### PR TITLE
Unify TypeAndOrigins-based error messages

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -767,6 +767,7 @@ public:
 
     std::vector<ErrorLine> origins2Explanations(const GlobalState &gs, Loc originForUninitialized) const;
 
+    static ErrorSection explainExpected(const GlobalState &gs, TypePtr type, Loc origin, const std::string &for_);
     ErrorSection explainGot(const GlobalState &gs, Loc originForUninitialized) const;
 
     ~TypeAndOrigins() noexcept;

--- a/core/Types.h
+++ b/core/Types.h
@@ -764,7 +764,11 @@ class TypeAndOrigins final {
 public:
     TypePtr type;
     InlinedVector<Loc, 1> origins;
+
     std::vector<ErrorLine> origins2Explanations(const GlobalState &gs, Loc originForUninitialized) const;
+
+    ErrorSection explainGot(const GlobalState &gs, Loc originForUninitialized) const;
+
     ~TypeAndOrigins() noexcept;
     TypeAndOrigins() = default;
     TypeAndOrigins(const TypeAndOrigins &) = default;

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -63,6 +63,12 @@ vector<ErrorLine> TypeAndOrigins::origins2Explanations(const GlobalState &gs, Lo
     return result;
 }
 
+ErrorSection TypeAndOrigins::explainGot(const GlobalState &gs, Loc originForUninitialized) const {
+    // TODO(jez) Make the type cyan
+    return ErrorSection("Got " + this->type.show(gs) + " originating from:",
+                        this->origins2Explanations(gs, originForUninitialized));
+}
+
 TypeAndOrigins::~TypeAndOrigins() noexcept {
     histogramInc("TypeAndOrigins.origins.size", origins.size());
 }

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -63,6 +63,11 @@ vector<ErrorLine> TypeAndOrigins::origins2Explanations(const GlobalState &gs, Lo
     return result;
 }
 
+ErrorSection TypeAndOrigins::explainExpected(const GlobalState &gs, TypePtr type, Loc origin, const string &for_) {
+    // TODO(jez) Make the type cyan
+    return ErrorSection("Expected " + type.show(gs) + " for " + for_ + ":", {ErrorLine{origin, ""}});
+}
+
 ErrorSection TypeAndOrigins::explainGot(const GlobalState &gs, Loc originForUninitialized) const {
     // TODO(jez) Make the type cyan
     return ErrorSection("Got " + this->type.show(gs) + " originating from:",

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -64,14 +64,13 @@ vector<ErrorLine> TypeAndOrigins::origins2Explanations(const GlobalState &gs, Lo
 }
 
 ErrorSection TypeAndOrigins::explainExpected(const GlobalState &gs, TypePtr type, Loc origin, const string &for_) {
-    // TODO(jez) Make the type cyan
-    return ErrorSection("Expected " + type.show(gs) + " for " + for_ + ":", {ErrorLine{origin, ""}});
+    auto header = ErrorColors::format("Expected `{}` for {}:", type.show(gs), for_);
+    return ErrorSection(header, {ErrorLine{origin, ""}});
 }
 
 ErrorSection TypeAndOrigins::explainGot(const GlobalState &gs, Loc originForUninitialized) const {
-    // TODO(jez) Make the type cyan
-    return ErrorSection("Got " + this->type.showWithMoreInfo(gs) + " originating from:",
-                        this->origins2Explanations(gs, originForUninitialized));
+    auto header = ErrorColors::format("Got `{}` originating from:", this->type.showWithMoreInfo(gs));
+    return ErrorSection(header, this->origins2Explanations(gs, originForUninitialized));
 }
 
 TypeAndOrigins::~TypeAndOrigins() noexcept {

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -70,7 +70,7 @@ ErrorSection TypeAndOrigins::explainExpected(const GlobalState &gs, TypePtr type
 
 ErrorSection TypeAndOrigins::explainGot(const GlobalState &gs, Loc originForUninitialized) const {
     // TODO(jez) Make the type cyan
-    return ErrorSection("Got " + this->type.show(gs) + " originating from:",
+    return ErrorSection("Got " + this->type.showWithMoreInfo(gs) + " originating from:",
                         this->origins2Explanations(gs, originForUninitialized));
 }
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1243,7 +1243,8 @@ public:
         auto ret = Types::approximateSubtract(gs, args.args[0]->type, Types::nilClass());
         if (ret == args.args[0]->type) {
             if (auto e = gs.beginError(loc, errors::Infer::InvalidCast)) {
-                e.setHeader("T.must(): Expected a `T.nilable` type, got: `{}`", args.args[0]->type.show(gs));
+                e.setHeader("`{}` called on `{}`, which is never `{}`", "T.must", args.args[0]->type.show(gs), "nil");
+                e.addErrorSection(args.args[0]->explainGot(gs, args.originForUninitialized));
                 const auto locWithoutTMust = Loc{loc.file(), loc.beginPos() + 7, loc.endPos() - 1};
                 e.replaceWith("Remove `T.must`", loc, "{}", locWithoutTMust.source(gs));
             }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1299,8 +1299,7 @@ public:
 
         if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::RevealType)) {
             e.setHeader("Revealed type: `{}`", args.args[0]->type.showWithMoreInfo(gs));
-            e.addErrorSection(
-                ErrorSection("From:", args.args[0]->origins2Explanations(gs, args.originForUninitialized)));
+            e.addErrorSection(args.args[0]->explainGot(gs, args.originForUninitialized));
         }
         res.returnType = args.args[0]->type;
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -196,10 +196,9 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
         } else {
             e.setHeader("Expected `{}` but found `{}` for argument `{}`", expectedType.show(gs), argTpe.type.show(gs),
                         argSym.argumentName(gs));
-            e.addErrorSection(ErrorSection({
-                ErrorLine::from(argSym.loc, "Method `{}` has specified `{}` as `{}`", method.data(gs)->show(gs),
-                                argSym.argumentName(gs), expectedType.show(gs)),
-            }));
+            auto for_ =
+                ErrorColors::format("argument `{}` of method `{}`", argSym.argumentName(gs), method.data(gs)->show(gs));
+            e.addErrorSection(TypeAndOrigins::explainExpected(gs, expectedType, argSym.loc, for_));
         }
         e.addErrorSection(argTpe.explainGot(gs, originForUninitialized));
         auto withoutNil = Types::approximateSubtract(gs, argTpe.type, Types::nilClass());

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1846,10 +1846,9 @@ private:
         ENFORCE(!methodArgs.empty());
         const auto &bspec = methodArgs.back();
         ENFORCE(bspec.flags.isBlock);
-        e.addErrorSection(ErrorSection({
-            ErrorLine::from(bspec.loc, "Method `{}` has specified `{}` as `{}`", dispatchComp.method.data(gs)->show(gs),
-                            bspec.argumentName(gs), blockType.show(gs)),
-        }));
+        auto for_ = ErrorColors::format("for block argument `{}` of method `{}`", bspec.argumentName(gs),
+                                        dispatchComp.method.data(gs)->show(gs));
+        e.addErrorSection(TypeAndOrigins::explainExpected(gs, blockType, bspec.loc, for_));
     }
 
     static void simulateCall(const GlobalState &gs, const TypeAndOrigins *receiver, const DispatchArgs &innerArgs,

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -201,8 +201,7 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
                                 argSym.argumentName(gs), expectedType.show(gs)),
             }));
         }
-        e.addErrorSection(ErrorSection("Got " + argTpe.type.show(gs) + " originating from:",
-                                       argTpe.origins2Explanations(gs, originForUninitialized)));
+        e.addErrorSection(argTpe.explainGot(gs, originForUninitialized));
         auto withoutNil = Types::approximateSubtract(gs, argTpe.type, Types::nilClass());
         if (!withoutNil.isBottom() &&
             Types::isSubTypeUnderConstraint(gs, constr, withoutNil, expectedType, UntypedMode::AlwaysCompatible)) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -802,9 +802,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                                 gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::UntypedSplat)) {
                             e.setHeader("Passing a hash where the specific keys are unknown to a method taking keyword "
                                         "arguments");
-                            e.addErrorSection(
-                                ErrorSection("Got " + kwSplatType.show(gs) + " originating from:",
-                                             kwSplatArg->origins2Explanations(gs, args.originForUninitialized)));
+                            auto kwSplatTPO = TypeAndOrigins{kwSplatType, kwSplatArg->origins};
+                            e.addErrorSection(kwSplatTPO.explainGot(gs, args.originForUninitialized));
                             result.main.errors.emplace_back(e.build());
                         }
                         kwargs = Types::untypedUntracked();

--- a/gems/sorbet/test/snapshot/partial/tc-with-error/expected/err.log
+++ b/gems/sorbet/test/snapshot/partial/tc-with-error/expected/err.log
@@ -7,7 +7,7 @@ or set SORBET_SILENCE_DEV_MESSAGE=1 in your shell environment.
 lib/test.rb:3: Revealed type: `Integer(10)` https://srb.help/7014
      3 |T.reveal_type(10)
         ^^^^^^^^^^^^^^^^^
-  From:
+  Got `Integer(10)` originating from:
     lib/test.rb:3:
      3 |T.reveal_type(10)
                       ^^

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1166,12 +1166,9 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         auto ownerData = ctx.owner.data(ctx);
                         e.setHeader("Expected `{}` but found `{}` for method result type", methodReturnType.show(ctx),
                                     typeAndOrigin.type.show(ctx));
-                        e.addErrorSection(core::ErrorSection(
-                            "Expected " + methodReturnType.show(ctx),
-                            {
-                                core::ErrorLine::from(ownerData->loc(), "Method `{}` has return type `{}`",
-                                                      ownerData->name.show(ctx), methodReturnType.show(ctx)),
-                            }));
+                        auto for_ = core::ErrorColors::format("result type of method `{}`", ownerData->name.show(ctx));
+                        e.addErrorSection(
+                            core::TypeAndOrigins::explainExpected(ctx, methodReturnType, ownerData->loc(), for_));
                         e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
                     }
                 }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1172,9 +1172,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                 core::ErrorLine::from(ownerData->loc(), "Method `{}` has return type `{}`",
                                                       ownerData->name.show(ctx), methodReturnType.show(ctx)),
                             }));
-                        e.addErrorSection(
-                            core::ErrorSection("Got " + typeAndOrigin.type.show(ctx) + " originating from:",
-                                               typeAndOrigin.origins2Explanations(ctx, ownerLoc)));
+                        e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
                     }
                 }
             },
@@ -1203,9 +1201,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     if (auto e = ctx.beginError(bind.loc, core::errors::Infer::ReturnTypeMismatch)) {
                         e.setHeader("Returning value that does not conform to block result type");
                         e.addErrorSection(core::ErrorSection("Expected " + expectedType.show(ctx)));
-                        e.addErrorSection(
-                            core::ErrorSection("Got " + typeAndOrigin.type.show(ctx) + " originating from:",
-                                               typeAndOrigin.origins2Explanations(ctx, ownerLoc)));
+                        e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
                     }
                 }
 
@@ -1270,8 +1266,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     if (c->cast == core::Names::assertType() && ty.type.isUntyped()) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
                             e.setHeader("The typechecker was unable to infer the type of the asserted value");
-                            e.addErrorSection(core::ErrorSection("Got " + ty.type.show(ctx) + " originating from:",
-                                                                 ty.origins2Explanations(ctx, ownerLoc)));
+                            e.addErrorSection(ty.explainGot(ctx, ownerLoc));
                             e.addErrorNote("You may need to add additional `{}` annotations", "sig");
                         }
                     } else if (!core::Types::isSubType(ctx, ty.type, castType)) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1283,8 +1283,9 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         }
                     } else if (!ty.type.isUntyped() && core::Types::isSubType(ctx, ty.type, castType)) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::InvalidCast)) {
-                            e.setHeader("Useless cast: inferred type `{}` is already a subtype of `{}`",
+                            e.setHeader("`{}` is useless because `{}` is already a subtype of `{}`", "T.cast",
                                         ty.type.show(ctx), castType.show(ctx));
+                            e.addErrorSection(ty.explainGot(ctx, ownerLoc));
                         }
                     }
                 }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1263,7 +1263,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 if (c->cast != core::Names::cast()) {
                     if (c->cast == core::Names::assertType() && ty.type.isUntyped()) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
-                            e.setHeader("The typechecker was unable to infer the type of the asserted value");
+                            e.setHeader("Expected a type but found `{}` for `{}`", "T.untyped", "T.assert_type!");
                             e.addErrorSection(ty.explainGot(ctx, ownerLoc));
                             e.addErrorNote("You may need to add additional `{}` annotations", "sig");
                         }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1227,8 +1227,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         e.setHeader("Control flow could reach `{}` because the type `{}` wasn't handled", "T.absurd",
                                     typeAndOrigin.type.show(ctx));
                     }
-                    e.addErrorSection(
-                        core::ErrorSection("Originating from:", typeAndOrigin.origins2Explanations(ctx, ownerLoc)));
+                    e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
                 }
 
                 tp.type = core::Types::bottom();

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1270,9 +1270,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     } else if (!core::Types::isSubType(ctx, ty.type, castType)) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
                             e.setHeader("Argument does not have asserted type `{}`", castType.show(ctx));
-                            e.addErrorSection(
-                                core::ErrorSection("Got " + ty.type.showWithMoreInfo(ctx) + " originating from:",
-                                                   ty.origins2Explanations(ctx, ownerLoc)));
+                            e.addErrorSection(ty.explainGot(ctx, ownerLoc));
                         }
                     }
                 } else if (!c->isSynthetic) {

--- a/test/cli/at/at.out
+++ b/test/cli/at/at.out
@@ -5,7 +5,7 @@ test/cli/at/at.rb:2: Expected `Integer` but found `String("s")` for argument `ar
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("s") originating from:
+  Got `String("s")` originating from:
     test/cli/at/at.rb:2:
      2 |1 + "s"
             ^^^

--- a/test/cli/at/at.out
+++ b/test/cli/at/at.out
@@ -1,7 +1,8 @@
 test/cli/at/at.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:

--- a/test/cli/autocorrect-case-meta-type/autocorrect-case-meta-type.out
+++ b/test/cli/autocorrect-case-meta-type/autocorrect-case-meta-type.out
@@ -11,7 +11,7 @@ autocorrect-case-meta-type.rb:9: Call to method `===` on `T::Array[Integer]` mis
 autocorrect-case-meta-type.rb:12: Control flow could reach `T.absurd` because the type `T::Array[Integer]` wasn't handled https://srb.help/7026
     12 |    T.absurd(input)
             ^^^^^^^^^^^^^^^
-  Originating from:
+  Got `T::Array[Integer]` originating from:
     autocorrect-case-meta-type.rb:5:
      5 |def get_value(input)
                       ^^^^^

--- a/test/cli/dedup_loc/dedup_loc.out
+++ b/test/cli/dedup_loc/dedup_loc.out
@@ -1,7 +1,7 @@
 test/cli/dedup_loc/dedup_loc.rb:5: Argument does not have asserted type `NilClass` https://srb.help/7007
      5 |    T.assert_type!(e, NilClass)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Got Exception originating from:
+  Got `Exception` originating from:
     test/cli/dedup_loc/dedup_loc.rb:4:
      4 |rescue Exception => e
      5 |    T.assert_type!(e, NilClass)

--- a/test/cli/error-blacklist/error-blacklist.out
+++ b/test/cli/error-blacklist/error-blacklist.out
@@ -1,7 +1,8 @@
 test/cli/error-blacklist/error-blacklist.rb:3: Expected `Integer` but found `String("1")` for argument `arg0` https://srb.help/7002
      3 |1 + "1"
             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("1") originating from:

--- a/test/cli/error-blacklist/error-blacklist.out
+++ b/test/cli/error-blacklist/error-blacklist.out
@@ -5,7 +5,7 @@ test/cli/error-blacklist/error-blacklist.rb:3: Expected `Integer` but found `Str
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("1") originating from:
+  Got `String("1")` originating from:
     test/cli/error-blacklist/error-blacklist.rb:3:
      3 |1 + "1"
             ^^^

--- a/test/cli/error-blacklist/error-blacklist.out
+++ b/test/cli/error-blacklist/error-blacklist.out
@@ -9,11 +9,19 @@ test/cli/error-blacklist/error-blacklist.rb:3: Expected `Integer` but found `Str
      3 |1 + "1"
             ^^^
 
-test/cli/error-blacklist/error-blacklist.rb:4: Useless cast: inferred type `Integer(1)` is already a subtype of `T.nilable(Integer)` https://srb.help/7015
+test/cli/error-blacklist/error-blacklist.rb:4: `T.cast` is useless because `Integer(1)` is already a subtype of `T.nilable(Integer)` https://srb.help/7015
      4 |T.cast(1, T.nilable(Integer))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `Integer(1)` originating from:
+    test/cli/error-blacklist/error-blacklist.rb:4:
+     4 |T.cast(1, T.nilable(Integer))
+               ^
 Errors: 2
-test/cli/error-blacklist/error-blacklist.rb:4: Useless cast: inferred type `Integer(1)` is already a subtype of `T.nilable(Integer)` https://srb.help/7015
+test/cli/error-blacklist/error-blacklist.rb:4: `T.cast` is useless because `Integer(1)` is already a subtype of `T.nilable(Integer)` https://srb.help/7015
      4 |T.cast(1, T.nilable(Integer))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `Integer(1)` originating from:
+    test/cli/error-blacklist/error-blacklist.rb:4:
+     4 |T.cast(1, T.nilable(Integer))
+               ^
 Errors: 1

--- a/test/cli/error-url/error-url.out
+++ b/test/cli/error-url/error-url.out
@@ -1,7 +1,7 @@
 test/cli/error-url/error-url.rb:5: Revealed type: `TrueClass` https://example.com/errors/?error=7014
      5 |T.reveal_type(true)
         ^^^^^^^^^^^^^^^^^^^
-  From:
+  Got `TrueClass` originating from:
     test/cli/error-url/error-url.rb:5:
      5 |T.reveal_type(true)
                       ^^^^
@@ -9,7 +9,7 @@ Errors: 1
 test/cli/error-url/error-url.rb:5: Revealed type: `TrueClass` https://example.com/error/7014
      5 |T.reveal_type(true)
         ^^^^^^^^^^^^^^^^^^^
-  From:
+  Got `TrueClass` originating from:
     test/cli/error-url/error-url.rb:5:
      5 |T.reveal_type(true)
                       ^^^^
@@ -17,7 +17,7 @@ Errors: 1
 test/cli/error-url/error-url.rb:5: Revealed type: `TrueClass` https://example.com/error#7014
      5 |T.reveal_type(true)
         ^^^^^^^^^^^^^^^^^^^
-  From:
+  Got `TrueClass` originating from:
     test/cli/error-url/error-url.rb:5:
      5 |T.reveal_type(true)
                       ^^^^

--- a/test/cli/errors/errors.out
+++ b/test/cli/errors/errors.out
@@ -16,7 +16,7 @@ test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2658:
     .. |        arg0: String,
                   ^^^^
-  Got Integer originating from:
+  Got `Integer` originating from:
     test/cli/errors/errors.rb:13:
     .. |  def foo(arg)
                   ^^^
@@ -28,7 +28,7 @@ test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for a
     test/cli/errors/errors.rb:12:
     .. |  sig {params(arg: Integer).returns(NilClass)}
                       ^^^
-  Got String("foo") originating from:
+  Got `String("foo")` originating from:
     test/cli/errors/errors.rb:19:
     .. |    foo("foo")
                 ^^^^^
@@ -40,7 +40,7 @@ test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` 
     test/cli/errors/errors.rb:36:
     .. |  sig {params(a: Integer).returns(Integer)}
                       ^
-  Got T.nilable(Integer) originating from:
+  Got `T.nilable(Integer)` originating from:
     test/cli/errors/errors.rb:29:
     .. |          nil
                   ^^^
@@ -73,7 +73,7 @@ test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2658:
     .. |        arg0: String,
                   ^^^^
-  Got Integer originating from:
+  Got `Integer` originating from:
     test/cli/errors/errors.rb:13:
     .. |  def foo(arg)
                   ^^^
@@ -85,7 +85,7 @@ test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for a
     test/cli/errors/errors.rb:12:
     .. |  sig {params(arg: Integer).returns(NilClass)}
                       ^^^
-  Got String("foo") originating from:
+  Got `String("foo")` originating from:
     test/cli/errors/errors.rb:19:
     .. |    foo("foo")
                 ^^^^^
@@ -97,7 +97,7 @@ test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` 
     test/cli/errors/errors.rb:36:
     .. |  sig {params(a: Integer).returns(Integer)}
                       ^
-  Got T.nilable(Integer) originating from:
+  Got `T.nilable(Integer)` originating from:
     test/cli/errors/errors.rb:29:
     .. |          nil
                   ^^^
@@ -130,7 +130,7 @@ test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2658:
     .. |        arg0: String,
                   ^^^^
-  Got Integer originating from:
+  Got `Integer` originating from:
     test/cli/errors/errors.rb:13:
     .. |  def foo(arg)
                   ^^^
@@ -142,7 +142,7 @@ test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for a
     test/cli/errors/errors.rb:12:
     .. |  sig {params(arg: Integer).returns(NilClass)}
                       ^^^
-  Got String("foo") originating from:
+  Got `String("foo")` originating from:
     test/cli/errors/errors.rb:19:
     .. |    foo("foo")
                 ^^^^^
@@ -154,7 +154,7 @@ test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` 
     test/cli/errors/errors.rb:36:
     .. |  sig {params(a: Integer).returns(Integer)}
                       ^
-  Got T.nilable(Integer) originating from:
+  Got `T.nilable(Integer)` originating from:
     test/cli/errors/errors.rb:29:
     .. |          nil
                   ^^^

--- a/test/cli/errors/errors.out
+++ b/test/cli/errors/errors.out
@@ -12,7 +12,8 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
 test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
     .. |    raise arg # raise is defined by stdlib
             ^^^^^^^^^
-    ...: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
+  Expected `String` for argument `arg0` of method `Kernel#raise (overload.1)`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2658:
     .. |        arg0: String,
                   ^^^^
   Got Integer originating from:
@@ -23,7 +24,8 @@ test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument
 test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for argument `arg` https://srb.help/7002
     .. |    foo("foo")
                 ^^^^^
-    test/cli/errors/errors.rb:12: Method `ComplexError#foo` has specified `arg` as `Integer`
+  Expected `Integer` for argument `arg` of method `ComplexError#foo`:
+    test/cli/errors/errors.rb:12:
     .. |  sig {params(arg: Integer).returns(NilClass)}
                       ^^^
   Got String("foo") originating from:
@@ -34,7 +36,8 @@ test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for a
 test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` for argument `a` https://srb.help/7002
     .. |    bar(a)
             ^^^^^^
-    test/cli/errors/errors.rb:36: Method `ErrorLines#bar` has specified `a` as `Integer`
+  Expected `Integer` for argument `a` of method `ErrorLines#bar`:
+    test/cli/errors/errors.rb:36:
     .. |  sig {params(a: Integer).returns(Integer)}
                       ^
   Got T.nilable(Integer) originating from:
@@ -66,7 +69,8 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
 test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
     .. |    raise arg # raise is defined by stdlib
             ^^^^^^^^^
-    ...: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
+  Expected `String` for argument `arg0` of method `Kernel#raise (overload.1)`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2658:
     .. |        arg0: String,
                   ^^^^
   Got Integer originating from:
@@ -77,7 +81,8 @@ test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument
 test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for argument `arg` https://srb.help/7002
     .. |    foo("foo")
                 ^^^^^
-    test/cli/errors/errors.rb:12: Method `ComplexError#foo` has specified `arg` as `Integer`
+  Expected `Integer` for argument `arg` of method `ComplexError#foo`:
+    test/cli/errors/errors.rb:12:
     .. |  sig {params(arg: Integer).returns(NilClass)}
                       ^^^
   Got String("foo") originating from:
@@ -88,7 +93,8 @@ test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for a
 test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` for argument `a` https://srb.help/7002
     .. |    bar(a)
             ^^^^^^
-    test/cli/errors/errors.rb:36: Method `ErrorLines#bar` has specified `a` as `Integer`
+  Expected `Integer` for argument `a` of method `ErrorLines#bar`:
+    test/cli/errors/errors.rb:36:
     .. |  sig {params(a: Integer).returns(Integer)}
                       ^
   Got T.nilable(Integer) originating from:
@@ -120,7 +126,8 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
 test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
     .. |    raise arg # raise is defined by stdlib
             ^^^^^^^^^
-    ...: Method `Kernel#raise (overload.1)` has specified `arg0` as `String`
+  Expected `String` for argument `arg0` of method `Kernel#raise (overload.1)`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2658:
     .. |        arg0: String,
                   ^^^^
   Got Integer originating from:
@@ -131,7 +138,8 @@ test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument
 test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for argument `arg` https://srb.help/7002
     .. |    foo("foo")
                 ^^^^^
-    test/cli/errors/errors.rb:12: Method `ComplexError#foo` has specified `arg` as `Integer`
+  Expected `Integer` for argument `arg` of method `ComplexError#foo`:
+    test/cli/errors/errors.rb:12:
     .. |  sig {params(arg: Integer).returns(NilClass)}
                       ^^^
   Got String("foo") originating from:
@@ -142,7 +150,8 @@ test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for a
 test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` for argument `a` https://srb.help/7002
     .. |    bar(a)
             ^^^^^^
-    test/cli/errors/errors.rb:36: Method `ErrorLines#bar` has specified `a` as `Integer`
+  Expected `Integer` for argument `a` of method `ErrorLines#bar`:
+    test/cli/errors/errors.rb:36:
     .. |  sig {params(a: Integer).returns(Integer)}
                       ^
   Got T.nilable(Integer) originating from:

--- a/test/cli/escaping/escaping.out
+++ b/test/cli/escaping/escaping.out
@@ -1,7 +1,8 @@
 test/cli/escaping/escaping.rb:10: Expected `Integer` but found `String("\n")` for argument `a` https://srb.help/7002
     10 |'
     11 |'
-    test/cli/escaping/escaping.rb:4: Method `Object#foo` has specified `a` as `Integer`
+  Expected `Integer` for argument `a` of method `Object#foo`:
+    test/cli/escaping/escaping.rb:4:
      4 |sig{params(a: Integer).void}
                    ^
   Got String("\n") originating from:

--- a/test/cli/escaping/escaping.out
+++ b/test/cli/escaping/escaping.out
@@ -5,7 +5,7 @@ test/cli/escaping/escaping.rb:10: Expected `Integer` but found `String("\n")` fo
     test/cli/escaping/escaping.rb:4:
      4 |sig{params(a: Integer).void}
                    ^
-  Got String("\n") originating from:
+  Got `String("\n")` originating from:
     test/cli/escaping/escaping.rb:10:
     10 |'
     11 |'

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -2,8 +2,8 @@ test/cli/expected-got/expected-got.rb:5: Expected `Integer` but found `NilClass`
      5 |def foo
      6 |
      7 |end
-  Expected Integer
-    test/cli/expected-got/expected-got.rb:11: Method `foo` has return type `Integer`
+  Expected Integer for result type of method `foo`:
+    test/cli/expected-got/expected-got.rb:11:
     11 |def foo
         ^^^^^^^
   Got NilClass originating from:
@@ -14,8 +14,8 @@ test/cli/expected-got/expected-got.rb:5: Expected `Integer` but found `NilClass`
 test/cli/expected-got/expected-got.rb:12: Expected `Integer` but found `NilClass` for method result type https://srb.help/7005
     12 |  nil
           ^^^
-  Expected Integer
-    test/cli/expected-got/expected-got.rb:11: Method `foo` has return type `Integer`
+  Expected Integer for result type of method `foo`:
+    test/cli/expected-got/expected-got.rb:11:
     11 |def foo
         ^^^^^^^
   Got NilClass originating from:

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -1,0 +1,140 @@
+test/cli/expected-got/expected-got.rb:5: Expected `Integer` but found `NilClass` for method result type https://srb.help/7005
+     5 |def foo
+     6 |
+     7 |end
+  Expected Integer
+    test/cli/expected-got/expected-got.rb:11: Method `foo` has return type `Integer`
+    11 |def foo
+        ^^^^^^^
+  Got NilClass originating from:
+    test/cli/expected-got/expected-got.rb:11: Possibly uninitialized (`NilClass`) in:
+    11 |def foo
+        ^^^^^^^
+
+test/cli/expected-got/expected-got.rb:12: Expected `Integer` but found `NilClass` for method result type https://srb.help/7005
+    12 |  nil
+          ^^^
+  Expected Integer
+    test/cli/expected-got/expected-got.rb:11: Method `foo` has return type `Integer`
+    11 |def foo
+        ^^^^^^^
+  Got NilClass originating from:
+    test/cli/expected-got/expected-got.rb:12:
+    12 |  nil
+          ^^^
+
+test/cli/expected-got/expected-got.rb:27: Expected `Integer` but found `T.any(String, Integer)` for argument `x` https://srb.help/7002
+    27 |  takes_integer(x)
+          ^^^^^^^^^^^^^^^^
+    test/cli/expected-got/expected-got.rb:15: Method `Object#takes_integer` has specified `x` as `Integer`
+    15 |sig {params(x: Integer).void}
+                    ^
+  Got T.any(String, Integer) originating from:
+    test/cli/expected-got/expected-got.rb:22:
+    22 |    x = ''
+                ^^
+    test/cli/expected-got/expected-got.rb:24:
+    24 |    x = 1
+                ^
+
+test/cli/expected-got/expected-got.rb:42: Expected `T.proc.returns(Integer)` but found `T.proc.returns(String)` for block argument https://srb.help/7002
+    42 |  takes_int_block(&blk)
+          ^^^^^^^^^^^^^^^^^^^^^
+    test/cli/expected-got/expected-got.rb:32: Method `Object#takes_int_block` has specified `blk` as `T.proc.returns(Integer)`
+    32 |sig {params(blk: T.proc.returns(Integer)).void}
+                    ^^^
+
+test/cli/expected-got/expected-got.rb:53: Control flow could reach `T.absurd` because the type `Integer` wasn't handled https://srb.help/7026
+    53 |  else T.absurd(x)
+               ^^^^^^^^^^^
+  Originating from:
+    test/cli/expected-got/expected-got.rb:50:
+    50 |def t_absurd(x)
+                     ^
+    test/cli/expected-got/expected-got.rb:52:
+    52 |  when String then 'string'
+               ^^^^^^
+
+test/cli/expected-got/expected-got.rb:30: T.must(): Expected a `T.nilable` type, got: `Integer(0)` https://srb.help/7015
+    30 |T.must(0)
+        ^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/expected-got/expected-got.rb:30: Replace with `0`
+    30 |T.must(0)
+        ^^^^^^^^^
+
+test/cli/expected-got/expected-got.rb:36: Returning value that does not conform to block result type https://srb.help/7005
+    36 |takes_int_block do
+    37 |  ''
+    38 |end
+  Expected Integer
+  Got String("") originating from:
+    test/cli/expected-got/expected-got.rb:37:
+    37 |  ''
+          ^^
+
+test/cli/expected-got/expected-got.rb:45: The typechecker was unable to infer the type of the asserted value https://srb.help/7007
+    45 |T.assert_type!(T.unsafe(nil), String)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got T.untyped originating from:
+    test/cli/expected-got/expected-got.rb:45:
+    45 |T.assert_type!(T.unsafe(nil), String)
+                       ^^^^^^^^^^^^^
+  Note:
+    You may need to add additional `sig` annotations
+
+test/cli/expected-got/expected-got.rb:47: Revealed type: `Integer(42)` https://srb.help/7014
+    47 |T.reveal_type(42)
+        ^^^^^^^^^^^^^^^^^
+  From:
+    test/cli/expected-got/expected-got.rb:47:
+    47 |T.reveal_type(42)
+                      ^^
+
+test/cli/expected-got/expected-got.rb:57: Used `&.` operator on a receiver which can never be nil https://srb.help/7034
+    57 |1&.even?
+        ^
+  Type of receiver is `Integer(1)`, from:
+    test/cli/expected-got/expected-got.rb:57:
+    57 |1&.even?
+        ^
+
+test/cli/expected-got/expected-got.rb:59: Method `top_level_does_not_exist` does not exist on `T.class_of(<root>)` https://srb.help/7003
+    59 |top_level_does_not_exist
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/expected-got/expected-got.rb:61: Argument does not have asserted type `Integer` https://srb.help/7007
+    61 |T.let(nil, Integer)
+        ^^^^^^^^^^^^^^^^^^^
+  Got NilClass originating from:
+    test/cli/expected-got/expected-got.rb:61:
+    61 |T.let(nil, Integer)
+              ^^^
+
+test/cli/expected-got/expected-got.rb:63: Useless cast: inferred type `Integer(1)` is already a subtype of `Integer` https://srb.help/7015
+    63 |T.cast(1, Integer)
+        ^^^^^^^^^^^^^^^^^^
+
+test/cli/expected-got/expected-got.rb:68: Can not call method `foo` on void type https://srb.help/7003
+    68 |returns_void.foo
+        ^^^^^^^^^^^^^^^^
+
+test/cli/expected-got/expected-got.rb:73: Expected `T::Array[Integer]` but found `[Integer(1), Integer(2), T.nilable(Integer)]` for argument `xs` https://srb.help/7002
+    73 |takes_int_array(xs)
+        ^^^^^^^^^^^^^^^^^^^
+    test/cli/expected-got/expected-got.rb:70: Method `Object#takes_int_array` has specified `xs` as `T::Array[Integer]`
+    70 |sig {params(xs: T::Array[Integer]).void}
+                    ^^
+  Got [Integer(1), Integer(2), T.nilable(Integer)] originating from:
+    test/cli/expected-got/expected-got.rb:72:
+    72 |xs = [1, 2, T.let(3, T.nilable(Integer))]
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/expected-got/expected-got.rb:74: Argument does not have asserted type `T::Array[Integer]` https://srb.help/7007
+    74 |T.let(xs, T::Array[Integer])
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got [Integer(1), Integer(2), T.nilable(Integer)] (3-tuple) originating from:
+    test/cli/expected-got/expected-got.rb:72:
+    72 |xs = [1, 2, T.let(3, T.nilable(Integer))]
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 16

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -41,7 +41,8 @@ test/cli/expected-got/expected-got.rb:27: Expected `Integer` but found `T.any(St
 test/cli/expected-got/expected-got.rb:42: Expected `T.proc.returns(Integer)` but found `T.proc.returns(String)` for block argument https://srb.help/7002
     42 |  takes_int_block(&blk)
           ^^^^^^^^^^^^^^^^^^^^^
-    test/cli/expected-got/expected-got.rb:32: Method `Object#takes_int_block` has specified `blk` as `T.proc.returns(Integer)`
+  Expected T.proc.returns(Integer) for for block argument `blk` of method `Object#takes_int_block`:
+    test/cli/expected-got/expected-got.rb:32:
     32 |sig {params(blk: T.proc.returns(Integer)).void}
                     ^^^
 

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -115,9 +115,13 @@ test/cli/expected-got/expected-got.rb:61: Argument does not have asserted type `
     61 |T.let(nil, Integer)
               ^^^
 
-test/cli/expected-got/expected-got.rb:63: Useless cast: inferred type `Integer(1)` is already a subtype of `Integer` https://srb.help/7015
+test/cli/expected-got/expected-got.rb:63: `T.cast` is useless because `Integer(1)` is already a subtype of `Integer` https://srb.help/7015
     63 |T.cast(1, Integer)
         ^^^^^^^^^^^^^^^^^^
+  Got Integer(1) originating from:
+    test/cli/expected-got/expected-got.rb:63:
+    63 |T.cast(1, Integer)
+               ^
 
 test/cli/expected-got/expected-got.rb:68: Can not call method `foo` on void type https://srb.help/7003
     68 |returns_void.foo

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -2,11 +2,11 @@ test/cli/expected-got/expected-got.rb:5: Expected `Integer` but found `NilClass`
      5 |def foo
      6 |
      7 |end
-  Expected Integer for result type of method `foo`:
+  Expected `Integer` for result type of method `foo`:
     test/cli/expected-got/expected-got.rb:11:
     11 |def foo
         ^^^^^^^
-  Got NilClass originating from:
+  Got `NilClass` originating from:
     test/cli/expected-got/expected-got.rb:11: Possibly uninitialized (`NilClass`) in:
     11 |def foo
         ^^^^^^^
@@ -14,11 +14,11 @@ test/cli/expected-got/expected-got.rb:5: Expected `Integer` but found `NilClass`
 test/cli/expected-got/expected-got.rb:12: Expected `Integer` but found `NilClass` for method result type https://srb.help/7005
     12 |  nil
           ^^^
-  Expected Integer for result type of method `foo`:
+  Expected `Integer` for result type of method `foo`:
     test/cli/expected-got/expected-got.rb:11:
     11 |def foo
         ^^^^^^^
-  Got NilClass originating from:
+  Got `NilClass` originating from:
     test/cli/expected-got/expected-got.rb:12:
     12 |  nil
           ^^^
@@ -26,11 +26,11 @@ test/cli/expected-got/expected-got.rb:12: Expected `Integer` but found `NilClass
 test/cli/expected-got/expected-got.rb:27: Expected `Integer` but found `T.any(String, Integer)` for argument `x` https://srb.help/7002
     27 |  takes_integer(x)
           ^^^^^^^^^^^^^^^^
-  Expected Integer for argument `x` of method `Object#takes_integer`:
+  Expected `Integer` for argument `x` of method `Object#takes_integer`:
     test/cli/expected-got/expected-got.rb:15:
     15 |sig {params(x: Integer).void}
                     ^
-  Got T.any(String, Integer) originating from:
+  Got `T.any(String, Integer)` originating from:
     test/cli/expected-got/expected-got.rb:22:
     22 |    x = ''
                 ^^
@@ -41,7 +41,7 @@ test/cli/expected-got/expected-got.rb:27: Expected `Integer` but found `T.any(St
 test/cli/expected-got/expected-got.rb:42: Expected `T.proc.returns(Integer)` but found `T.proc.returns(String)` for block argument https://srb.help/7002
     42 |  takes_int_block(&blk)
           ^^^^^^^^^^^^^^^^^^^^^
-  Expected T.proc.returns(Integer) for for block argument `blk` of method `Object#takes_int_block`:
+  Expected `T.proc.returns(Integer)` for for block argument `blk` of method `Object#takes_int_block`:
     test/cli/expected-got/expected-got.rb:32:
     32 |sig {params(blk: T.proc.returns(Integer)).void}
                     ^^^
@@ -49,7 +49,7 @@ test/cli/expected-got/expected-got.rb:42: Expected `T.proc.returns(Integer)` but
 test/cli/expected-got/expected-got.rb:53: Control flow could reach `T.absurd` because the type `Integer` wasn't handled https://srb.help/7026
     53 |  else T.absurd(x)
                ^^^^^^^^^^^
-  Got Integer originating from:
+  Got `Integer` originating from:
     test/cli/expected-got/expected-got.rb:50:
     50 |def t_absurd(x)
                      ^
@@ -60,7 +60,7 @@ test/cli/expected-got/expected-got.rb:53: Control flow could reach `T.absurd` be
 test/cli/expected-got/expected-got.rb:30: `T.must` called on `Integer(0)`, which is never `nil` https://srb.help/7015
     30 |T.must(0)
         ^^^^^^^^^
-  Got Integer(0) originating from:
+  Got `Integer(0)` originating from:
     test/cli/expected-got/expected-got.rb:30:
     30 |T.must(0)
                ^
@@ -73,11 +73,11 @@ test/cli/expected-got/expected-got.rb:36: Expected `Integer` but found `String("
     36 |takes_int_block do
     37 |  ''
     38 |end
-  Expected Integer for block result type:
+  Expected `Integer` for block result type:
     test/cli/expected-got/expected-got.rb:32:
     32 |sig {params(blk: T.proc.returns(Integer)).void}
                     ^^^
-  Got String("") originating from:
+  Got `String("")` originating from:
     test/cli/expected-got/expected-got.rb:37:
     37 |  ''
           ^^
@@ -85,7 +85,7 @@ test/cli/expected-got/expected-got.rb:36: Expected `Integer` but found `String("
 test/cli/expected-got/expected-got.rb:45: Expected a type but found `T.untyped` for `T.assert_type!` https://srb.help/7007
     45 |T.assert_type!(T.unsafe(nil), String)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Got T.untyped originating from:
+  Got `T.untyped` originating from:
     test/cli/expected-got/expected-got.rb:45:
     45 |T.assert_type!(T.unsafe(nil), String)
                        ^^^^^^^^^^^^^
@@ -95,7 +95,7 @@ test/cli/expected-got/expected-got.rb:45: Expected a type but found `T.untyped` 
 test/cli/expected-got/expected-got.rb:47: Revealed type: `Integer(42)` https://srb.help/7014
     47 |T.reveal_type(42)
         ^^^^^^^^^^^^^^^^^
-  Got Integer(42) originating from:
+  Got `Integer(42)` originating from:
     test/cli/expected-got/expected-got.rb:47:
     47 |T.reveal_type(42)
                       ^^
@@ -103,7 +103,7 @@ test/cli/expected-got/expected-got.rb:47: Revealed type: `Integer(42)` https://s
 test/cli/expected-got/expected-got.rb:57: Used `&.` operator on `Integer(1)`, which can never be nil https://srb.help/7034
     57 |1&.even?
         ^
-  Got Integer(1) originating from:
+  Got `Integer(1)` originating from:
     test/cli/expected-got/expected-got.rb:57:
     57 |1&.even?
         ^
@@ -115,7 +115,7 @@ test/cli/expected-got/expected-got.rb:59: Method `top_level_does_not_exist` does
 test/cli/expected-got/expected-got.rb:61: Argument does not have asserted type `Integer` https://srb.help/7007
     61 |T.let(nil, Integer)
         ^^^^^^^^^^^^^^^^^^^
-  Got NilClass originating from:
+  Got `NilClass` originating from:
     test/cli/expected-got/expected-got.rb:61:
     61 |T.let(nil, Integer)
               ^^^
@@ -123,7 +123,7 @@ test/cli/expected-got/expected-got.rb:61: Argument does not have asserted type `
 test/cli/expected-got/expected-got.rb:63: `T.cast` is useless because `Integer(1)` is already a subtype of `Integer` https://srb.help/7015
     63 |T.cast(1, Integer)
         ^^^^^^^^^^^^^^^^^^
-  Got Integer(1) originating from:
+  Got `Integer(1)` originating from:
     test/cli/expected-got/expected-got.rb:63:
     63 |T.cast(1, Integer)
                ^
@@ -135,11 +135,11 @@ test/cli/expected-got/expected-got.rb:68: Can not call method `foo` on void type
 test/cli/expected-got/expected-got.rb:73: Expected `T::Array[Integer]` but found `[Integer(1), Integer(2), T.nilable(Integer)]` for argument `xs` https://srb.help/7002
     73 |takes_int_array(xs)
         ^^^^^^^^^^^^^^^^^^^
-  Expected T::Array[Integer] for argument `xs` of method `Object#takes_int_array`:
+  Expected `T::Array[Integer]` for argument `xs` of method `Object#takes_int_array`:
     test/cli/expected-got/expected-got.rb:70:
     70 |sig {params(xs: T::Array[Integer]).void}
                     ^^
-  Got [Integer(1), Integer(2), T.nilable(Integer)] (3-tuple) originating from:
+  Got `[Integer(1), Integer(2), T.nilable(Integer)] (3-tuple)` originating from:
     test/cli/expected-got/expected-got.rb:72:
     72 |xs = [1, 2, T.let(3, T.nilable(Integer))]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -147,7 +147,7 @@ test/cli/expected-got/expected-got.rb:73: Expected `T::Array[Integer]` but found
 test/cli/expected-got/expected-got.rb:74: Argument does not have asserted type `T::Array[Integer]` https://srb.help/7007
     74 |T.let(xs, T::Array[Integer])
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Got [Integer(1), Integer(2), T.nilable(Integer)] (3-tuple) originating from:
+  Got `[Integer(1), Integer(2), T.nilable(Integer)] (3-tuple)` originating from:
     test/cli/expected-got/expected-got.rb:72:
     72 |xs = [1, 2, T.let(3, T.nilable(Integer))]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -91,10 +91,10 @@ test/cli/expected-got/expected-got.rb:47: Revealed type: `Integer(42)` https://s
     47 |T.reveal_type(42)
                       ^^
 
-test/cli/expected-got/expected-got.rb:57: Used `&.` operator on a receiver which can never be nil https://srb.help/7034
+test/cli/expected-got/expected-got.rb:57: Used `&.` operator on `Integer(1)`, which can never be nil https://srb.help/7034
     57 |1&.even?
         ^
-  Type of receiver is `Integer(1)`, from:
+  Got Integer(1) originating from:
     test/cli/expected-got/expected-got.rb:57:
     57 |1&.even?
         ^

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -67,11 +67,14 @@ test/cli/expected-got/expected-got.rb:30: `T.must` called on `Integer(0)`, which
     30 |T.must(0)
         ^^^^^^^^^
 
-test/cli/expected-got/expected-got.rb:36: Returning value that does not conform to block result type https://srb.help/7005
+test/cli/expected-got/expected-got.rb:36: Expected `Integer` but found `String("")` for block result type https://srb.help/7005
     36 |takes_int_block do
     37 |  ''
     38 |end
-  Expected Integer
+  Expected Integer for block result type:
+    test/cli/expected-got/expected-got.rb:32:
+    32 |sig {params(blk: T.proc.returns(Integer)).void}
+                    ^^^
   Got String("") originating from:
     test/cli/expected-got/expected-got.rb:37:
     37 |  ''

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -26,7 +26,8 @@ test/cli/expected-got/expected-got.rb:12: Expected `Integer` but found `NilClass
 test/cli/expected-got/expected-got.rb:27: Expected `Integer` but found `T.any(String, Integer)` for argument `x` https://srb.help/7002
     27 |  takes_integer(x)
           ^^^^^^^^^^^^^^^^
-    test/cli/expected-got/expected-got.rb:15: Method `Object#takes_integer` has specified `x` as `Integer`
+  Expected Integer for argument `x` of method `Object#takes_integer`:
+    test/cli/expected-got/expected-got.rb:15:
     15 |sig {params(x: Integer).void}
                     ^
   Got T.any(String, Integer) originating from:
@@ -133,7 +134,8 @@ test/cli/expected-got/expected-got.rb:68: Can not call method `foo` on void type
 test/cli/expected-got/expected-got.rb:73: Expected `T::Array[Integer]` but found `[Integer(1), Integer(2), T.nilable(Integer)]` for argument `xs` https://srb.help/7002
     73 |takes_int_array(xs)
         ^^^^^^^^^^^^^^^^^^^
-    test/cli/expected-got/expected-got.rb:70: Method `Object#takes_int_array` has specified `xs` as `T::Array[Integer]`
+  Expected T::Array[Integer] for argument `xs` of method `Object#takes_int_array`:
+    test/cli/expected-got/expected-got.rb:70:
     70 |sig {params(xs: T::Array[Integer]).void}
                     ^^
   Got [Integer(1), Integer(2), T.nilable(Integer)] originating from:

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -47,7 +47,7 @@ test/cli/expected-got/expected-got.rb:42: Expected `T.proc.returns(Integer)` but
 test/cli/expected-got/expected-got.rb:53: Control flow could reach `T.absurd` because the type `Integer` wasn't handled https://srb.help/7026
     53 |  else T.absurd(x)
                ^^^^^^^^^^^
-  Originating from:
+  Got Integer originating from:
     test/cli/expected-got/expected-got.rb:50:
     50 |def t_absurd(x)
                      ^

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -82,7 +82,7 @@ test/cli/expected-got/expected-got.rb:36: Expected `Integer` but found `String("
     37 |  ''
           ^^
 
-test/cli/expected-got/expected-got.rb:45: The typechecker was unable to infer the type of the asserted value https://srb.help/7007
+test/cli/expected-got/expected-got.rb:45: Expected a type but found `T.untyped` for `T.assert_type!` https://srb.help/7007
     45 |T.assert_type!(T.unsafe(nil), String)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got T.untyped originating from:

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -86,7 +86,7 @@ test/cli/expected-got/expected-got.rb:45: The typechecker was unable to infer th
 test/cli/expected-got/expected-got.rb:47: Revealed type: `Integer(42)` https://srb.help/7014
     47 |T.reveal_type(42)
         ^^^^^^^^^^^^^^^^^
-  From:
+  Got Integer(42) originating from:
     test/cli/expected-got/expected-got.rb:47:
     47 |T.reveal_type(42)
                       ^^

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -139,7 +139,7 @@ test/cli/expected-got/expected-got.rb:73: Expected `T::Array[Integer]` but found
     test/cli/expected-got/expected-got.rb:70:
     70 |sig {params(xs: T::Array[Integer]).void}
                     ^^
-  Got [Integer(1), Integer(2), T.nilable(Integer)] originating from:
+  Got [Integer(1), Integer(2), T.nilable(Integer)] (3-tuple) originating from:
     test/cli/expected-got/expected-got.rb:72:
     72 |xs = [1, 2, T.let(3, T.nilable(Integer))]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -55,9 +55,13 @@ test/cli/expected-got/expected-got.rb:53: Control flow could reach `T.absurd` be
     52 |  when String then 'string'
                ^^^^^^
 
-test/cli/expected-got/expected-got.rb:30: T.must(): Expected a `T.nilable` type, got: `Integer(0)` https://srb.help/7015
+test/cli/expected-got/expected-got.rb:30: `T.must` called on `Integer(0)`, which is never `nil` https://srb.help/7015
     30 |T.must(0)
         ^^^^^^^^^
+  Got Integer(0) originating from:
+    test/cli/expected-got/expected-got.rb:30:
+    30 |T.must(0)
+               ^
   Autocorrect: Use `-a` to autocorrect
     test/cli/expected-got/expected-got.rb:30: Replace with `0`
     30 |T.must(0)

--- a/test/cli/expected-got/expected-got.rb
+++ b/test/cli/expected-got/expected-got.rb
@@ -1,0 +1,74 @@
+# typed: strict
+extend T::Sig
+
+sig {returns(Integer)}
+def foo
+
+end
+
+
+sig {returns(Integer)}
+def foo
+  nil
+end
+
+sig {params(x: Integer).void}
+def takes_integer(x)
+end
+
+sig {void}
+def bar
+  if T.unsafe(nil)
+    x = ''
+  else
+    x = 1
+  end
+
+  takes_integer(x)
+end
+
+T.must(0)
+
+sig {params(blk: T.proc.returns(Integer)).void}
+def takes_int_block(&blk)
+end
+
+takes_int_block do
+  ''
+end
+
+sig {params(blk: T.proc.returns(String)).void}
+def takes_string_block(&blk)
+  takes_int_block(&blk)
+end
+
+T.assert_type!(T.unsafe(nil), String)
+
+T.reveal_type(42)
+
+sig {params(x: T.any(Integer, String)).void}
+def t_absurd(x)
+  case x
+  when String then 'string'
+  else T.absurd(x)
+  end
+end
+
+1&.even?
+
+top_level_does_not_exist
+
+T.let(nil, Integer)
+
+T.cast(1, Integer)
+
+sig {void}
+def returns_void; end
+
+returns_void.foo
+
+sig {params(xs: T::Array[Integer]).void}
+def takes_int_array(xs); end
+xs = [1, 2, T.let(3, T.nilable(Integer))]
+takes_int_array(xs)
+T.let(xs, T::Array[Integer])

--- a/test/cli/expected-got/expected-got.sh
+++ b/test/cli/expected-got/expected-got.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+main/sorbet --silence-dev-message test/cli/expected-got/expected-got.rb 2>&1

--- a/test/cli/folder-input-dir-and-file/folder-input-dir-and-file.out
+++ b/test/cli/folder-input-dir-and-file/folder-input-dir-and-file.out
@@ -5,7 +5,7 @@ test/cli/folder-input-dir-and-file/foo.rb:4: Expected `Integer` but found `Strin
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("foo.rb") originating from:
+  Got `String("foo.rb")` originating from:
     test/cli/folder-input-dir-and-file/foo.rb:4:
      4 |1 + "foo.rb"
             ^^^^^^^^
@@ -17,7 +17,7 @@ test/cli/folder-input-dir-and-file/input/subfolder/baz.rb:4: Expected `Integer` 
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("baz.rb") originating from:
+  Got `String("baz.rb")` originating from:
     test/cli/folder-input-dir-and-file/input/subfolder/baz.rb:4:
      4 |1 + "baz.rb"
             ^^^^^^^^
@@ -29,7 +29,7 @@ test/cli/folder-input-dir-and-file/input/bar.rb:3: Expected `Integer` but found 
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("bar.rb") originating from:
+  Got `String("bar.rb")` originating from:
     test/cli/folder-input-dir-and-file/input/bar.rb:3:
      3 |1 + "bar.rb"
             ^^^^^^^^

--- a/test/cli/folder-input-dir-and-file/folder-input-dir-and-file.out
+++ b/test/cli/folder-input-dir-and-file/folder-input-dir-and-file.out
@@ -1,7 +1,8 @@
 test/cli/folder-input-dir-and-file/foo.rb:4: Expected `Integer` but found `String("foo.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "foo.rb"
             ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("foo.rb") originating from:
@@ -12,7 +13,8 @@ test/cli/folder-input-dir-and-file/foo.rb:4: Expected `Integer` but found `Strin
 test/cli/folder-input-dir-and-file/input/subfolder/baz.rb:4: Expected `Integer` but found `String("baz.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "baz.rb"
             ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("baz.rb") originating from:
@@ -23,7 +25,8 @@ test/cli/folder-input-dir-and-file/input/subfolder/baz.rb:4: Expected `Integer` 
 test/cli/folder-input-dir-and-file/input/bar.rb:3: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      3 |1 + "bar.rb"
             ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("bar.rb") originating from:

--- a/test/cli/folder-input/folder-input.out
+++ b/test/cli/folder-input/folder-input.out
@@ -1,7 +1,8 @@
 test/cli/folder-input/foo.rb:4: Expected `Integer` but found `String("foo.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "foo.rb"
             ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("foo.rb") originating from:
@@ -12,7 +13,8 @@ test/cli/folder-input/foo.rb:4: Expected `Integer` but found `String("foo.rb")` 
 test/cli/folder-input/input/subfolder/baz.rb:4: Expected `Integer` but found `String("baz.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "baz.rb"
             ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("baz.rb") originating from:
@@ -23,7 +25,8 @@ test/cli/folder-input/input/subfolder/baz.rb:4: Expected `Integer` but found `St
 test/cli/folder-input/input/bar.rb:3: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      3 |1 + "bar.rb"
             ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("bar.rb") originating from:

--- a/test/cli/folder-input/folder-input.out
+++ b/test/cli/folder-input/folder-input.out
@@ -5,7 +5,7 @@ test/cli/folder-input/foo.rb:4: Expected `Integer` but found `String("foo.rb")` 
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("foo.rb") originating from:
+  Got `String("foo.rb")` originating from:
     test/cli/folder-input/foo.rb:4:
      4 |1 + "foo.rb"
             ^^^^^^^^
@@ -17,7 +17,7 @@ test/cli/folder-input/input/subfolder/baz.rb:4: Expected `Integer` but found `St
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("baz.rb") originating from:
+  Got `String("baz.rb")` originating from:
     test/cli/folder-input/input/subfolder/baz.rb:4:
      4 |1 + "baz.rb"
             ^^^^^^^^
@@ -29,7 +29,7 @@ test/cli/folder-input/input/bar.rb:3: Expected `Integer` but found `String("bar.
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("bar.rb") originating from:
+  Got `String("bar.rb")` originating from:
     test/cli/folder-input/input/bar.rb:3:
      3 |1 + "bar.rb"
             ^^^^^^^^

--- a/test/cli/ignore-slash/ignore-slash.out
+++ b/test/cli/ignore-slash/ignore-slash.out
@@ -1,7 +1,8 @@
 bar.rb:4: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "bar.rb"
             ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("bar.rb") originating from:

--- a/test/cli/ignore-slash/ignore-slash.out
+++ b/test/cli/ignore-slash/ignore-slash.out
@@ -5,7 +5,7 @@ bar.rb:4: Expected `Integer` but found `String("bar.rb")` for argument `arg0` ht
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("bar.rb") originating from:
+  Got `String("bar.rb")` originating from:
     bar.rb:4:
      4 |1 + "bar.rb"
             ^^^^^^^^

--- a/test/cli/ignore/ignore.out
+++ b/test/cli/ignore/ignore.out
@@ -5,7 +5,7 @@ subfolder2/subfolder/bar.rb:4: Expected `Integer` but found `String("subfolder2/
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("subfolder2/subfolder/bar.rb") originating from:
+  Got `String("subfolder2/subfolder/bar.rb")` originating from:
     subfolder2/subfolder/bar.rb:4:
      4 |1 + "subfolder2/subfolder/bar.rb"
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ bar.rb:4: Expected `Integer` but found `String("bar.rb")` for argument `arg0` ht
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("bar.rb") originating from:
+  Got `String("bar.rb")` originating from:
     bar.rb:4:
      4 |1 + "bar.rb"
             ^^^^^^^^

--- a/test/cli/ignore/ignore.out
+++ b/test/cli/ignore/ignore.out
@@ -1,7 +1,8 @@
 subfolder2/subfolder/bar.rb:4: Expected `Integer` but found `String("subfolder2/subfolder/bar.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "subfolder2/subfolder/bar.rb"
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("subfolder2/subfolder/bar.rb") originating from:
@@ -12,7 +13,8 @@ subfolder2/subfolder/bar.rb:4: Expected `Integer` but found `String("subfolder2/
 bar.rb:4: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "bar.rb"
             ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("bar.rb") originating from:

--- a/test/cli/kwarg-loc/kwarg-loc.out
+++ b/test/cli/kwarg-loc/kwarg-loc.out
@@ -5,7 +5,8 @@ kwarg-loc.rb:17: Expected `Integer` but found `String("1")` for argument `d` htt
     20 |  d: "1",
     21 |  e: 1,
     22 |  f: 1,
-    kwarg-loc.rb:8: Method `Object#foo` has specified `d` as `Integer`
+  Expected `Integer` for argument `d` of method `Object#foo`:
+    kwarg-loc.rb:8:
      8 |    d: Integer,
             ^
   Got String("1") originating from:
@@ -20,7 +21,8 @@ kwarg-loc.rb:17: Expected `Integer` but found `String("1")` for argument `d` htt
 kwarg-loc.rb:42: Expected `Integer` but found `String("1")` for argument `d` https://srb.help/7002
     42 |  "1",
           ^^^
-    kwarg-loc.rb:30: Method `Object#bar` has specified `d` as `Integer`
+  Expected `Integer` for argument `d` of method `Object#bar`:
+    kwarg-loc.rb:30:
     30 |    d: Integer,
             ^
   Got String("1") originating from:

--- a/test/cli/kwarg-loc/kwarg-loc.out
+++ b/test/cli/kwarg-loc/kwarg-loc.out
@@ -9,7 +9,7 @@ kwarg-loc.rb:17: Expected `Integer` but found `String("1")` for argument `d` htt
     kwarg-loc.rb:8:
      8 |    d: Integer,
             ^
-  Got String("1") originating from:
+  Got `String("1")` originating from:
     kwarg-loc.rb:17:
     17 |  a: 1,
     18 |  b: 1,
@@ -25,7 +25,7 @@ kwarg-loc.rb:42: Expected `Integer` but found `String("1")` for argument `d` htt
     kwarg-loc.rb:30:
     30 |    d: Integer,
             ^
-  Got String("1") originating from:
+  Got `String("1")` originating from:
     kwarg-loc.rb:42:
     42 |  "1",
           ^^^

--- a/test/cli/numbered_parameters/numbered_parameters.out
+++ b/test/cli/numbered_parameters/numbered_parameters.out
@@ -1,7 +1,7 @@
 test/cli/numbered_parameters/numbered_parameters.rb:12: Revealed type: `Integer` https://srb.help/7014
     12 |foo { T.reveal_type(_1) }
               ^^^^^^^^^^^^^^^^^
-  From:
+  Got `Integer` originating from:
     test/cli/numbered_parameters/numbered_parameters.rb:12:
     12 |foo { T.reveal_type(_1) }
                             ^^
@@ -9,7 +9,7 @@ test/cli/numbered_parameters/numbered_parameters.rb:12: Revealed type: `Integer`
 test/cli/numbered_parameters/numbered_parameters.rb:13: Revealed type: `String` https://srb.help/7014
     13 |foo do T.reveal_type(_2) end
                ^^^^^^^^^^^^^^^^^
-  From:
+  Got `String` originating from:
     test/cli/numbered_parameters/numbered_parameters.rb:13:
     13 |foo do T.reveal_type(_2) end
                              ^^
@@ -17,7 +17,7 @@ test/cli/numbered_parameters/numbered_parameters.rb:13: Revealed type: `String` 
 test/cli/numbered_parameters/numbered_parameters.rb:14: Revealed type: `T.untyped` https://srb.help/7014
     14 |-> { T.reveal_type(_1) }
              ^^^^^^^^^^^^^^^^^
-  From:
+  Got `T.untyped` originating from:
     test/cli/numbered_parameters/numbered_parameters.rb:14:
     14 |-> { T.reveal_type(_1) }
                            ^^
@@ -25,7 +25,7 @@ test/cli/numbered_parameters/numbered_parameters.rb:14: Revealed type: `T.untype
 test/cli/numbered_parameters/numbered_parameters.rb:15: Revealed type: `String` https://srb.help/7014
     15 |[''].each { T.reveal_type(_1) }
                     ^^^^^^^^^^^^^^^^^
-  From:
+  Got `String` originating from:
     test/cli/numbered_parameters/numbered_parameters.rb:15:
     15 |[''].each { T.reveal_type(_1) }
                                   ^^
@@ -33,7 +33,7 @@ test/cli/numbered_parameters/numbered_parameters.rb:15: Revealed type: `String` 
 test/cli/numbered_parameters/numbered_parameters.rb:21: Revealed type: `T.untyped` https://srb.help/7014
     21 |  T.reveal_type(_2)
           ^^^^^^^^^^^^^^^^^
-  From:
+  Got `T.untyped` originating from:
     test/cli/numbered_parameters/numbered_parameters.rb:18:
     18 |  1 + _2
               ^^
@@ -41,7 +41,7 @@ test/cli/numbered_parameters/numbered_parameters.rb:21: Revealed type: `T.untype
 test/cli/numbered_parameters/numbered_parameters.rb:22: Revealed type: `T.untyped` https://srb.help/7014
     22 |  T.reveal_type(_1)
           ^^^^^^^^^^^^^^^^^
-  From:
+  Got `T.untyped` originating from:
     test/cli/numbered_parameters/numbered_parameters.rb:19:
     19 |  puts _1
                ^^

--- a/test/cli/override-typed-bad/override-typed-bad.out
+++ b/test/cli/override-typed-bad/override-typed-bad.out
@@ -7,7 +7,7 @@ test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but foun
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("s") originating from:
+  Got `String("s")` originating from:
     test/cli/override-typed-bad/override-typed-bad.rb:2:
      2 |1 + "s"
             ^^^
@@ -20,7 +20,7 @@ test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but foun
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("s") originating from:
+  Got `String("s")` originating from:
     test/cli/override-typed-bad/override-typed-bad.rb:2:
      2 |1 + "s"
             ^^^
@@ -33,7 +33,7 @@ test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but foun
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("s") originating from:
+  Got `String("s")` originating from:
     test/cli/override-typed-bad/override-typed-bad.rb:2:
      2 |1 + "s"
             ^^^

--- a/test/cli/override-typed-bad/override-typed-bad.out
+++ b/test/cli/override-typed-bad/override-typed-bad.out
@@ -3,7 +3,8 @@ test/cli/override-typed-bad/override-typed-bad.rb: Useless override of strictnes
 test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:
@@ -15,7 +16,8 @@ Errors: 2
 test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:
@@ -27,7 +29,8 @@ Errors: 1
 test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:

--- a/test/cli/override-typed/override-typed.out
+++ b/test/cli/override-typed/override-typed.out
@@ -1,7 +1,8 @@
 test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      1 |1 + "s"
             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:
@@ -12,7 +13,8 @@ Errors: 1
 ./test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      1 |1 + "s"
             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:
@@ -23,7 +25,8 @@ Errors: 1
 test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      1 |1 + "s"
             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:

--- a/test/cli/override-typed/override-typed.out
+++ b/test/cli/override-typed/override-typed.out
@@ -5,7 +5,7 @@ test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `Strin
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("s") originating from:
+  Got `String("s")` originating from:
     test/cli/override-typed/override-typed.rb:1:
      1 |1 + "s"
             ^^^
@@ -17,7 +17,7 @@ Errors: 1
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("s") originating from:
+  Got `String("s")` originating from:
     ./test/cli/override-typed/override-typed.rb:1:
      1 |1 + "s"
             ^^^
@@ -29,7 +29,7 @@ test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `Strin
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("s") originating from:
+  Got `String("s")` originating from:
     test/cli/override-typed/override-typed.rb:1:
      1 |1 + "s"
             ^^^

--- a/test/cli/print-procs/print-procs.out
+++ b/test/cli/print-procs/print-procs.out
@@ -6,7 +6,7 @@ test/cli/print-procs/print-procs.rb:11: Malformed T.proc: Too many arguments (ma
 test/cli/print-procs/print-procs.rb:16: Revealed type: `T.proc.returns(T::Hash[Integer, String])` https://srb.help/7014
     16 |  T.reveal_type(a)
           ^^^^^^^^^^^^^^^^
-  From:
+  Got `T.proc.returns(T::Hash[Integer, String])` originating from:
     test/cli/print-procs/print-procs.rb:15:
     15 |def foo(a, b, c, d, e)
                 ^
@@ -14,7 +14,7 @@ test/cli/print-procs/print-procs.rb:16: Revealed type: `T.proc.returns(T::Hash[I
 test/cli/print-procs/print-procs.rb:17: Revealed type: `T.proc.params(arg0: String).returns(T::Hash[Integer, String])` https://srb.help/7014
     17 |  T.reveal_type(b)
           ^^^^^^^^^^^^^^^^
-  From:
+  Got `T.proc.params(arg0: String).returns(T::Hash[Integer, String])` originating from:
     test/cli/print-procs/print-procs.rb:15:
     15 |def foo(a, b, c, d, e)
                    ^
@@ -22,7 +22,7 @@ test/cli/print-procs/print-procs.rb:17: Revealed type: `T.proc.params(arg0: Stri
 test/cli/print-procs/print-procs.rb:18: Revealed type: `T.proc.params(arg0: String, arg1: Integer, arg2: Float).returns(T::Hash[Integer, String])` https://srb.help/7014
     18 |  T.reveal_type(c)
           ^^^^^^^^^^^^^^^^
-  From:
+  Got `T.proc.params(arg0: String, arg1: Integer, arg2: Float).returns(T::Hash[Integer, String])` originating from:
     test/cli/print-procs/print-procs.rb:15:
     15 |def foo(a, b, c, d, e)
                       ^
@@ -30,7 +30,7 @@ test/cli/print-procs/print-procs.rb:18: Revealed type: `T.proc.params(arg0: Stri
 test/cli/print-procs/print-procs.rb:19: Revealed type: `T.proc.params(arg0: String, arg1: Integer, arg2: Float, arg3: String, arg4: Integer, arg5: Float, arg6: String, arg7: Integer, arg8: Float, arg9: String).returns(T::Hash[Integer, String])` https://srb.help/7014
     19 |  T.reveal_type(d)
           ^^^^^^^^^^^^^^^^
-  From:
+  Got `T.proc.params(arg0: String, arg1: Integer, arg2: Float, arg3: String, arg4: Integer, arg5: Float, arg6: String, arg7: Integer, arg8: Float, arg9: String).returns(T::Hash[Integer, String])` originating from:
     test/cli/print-procs/print-procs.rb:15:
     15 |def foo(a, b, c, d, e)
                          ^
@@ -38,7 +38,7 @@ test/cli/print-procs/print-procs.rb:19: Revealed type: `T.proc.params(arg0: Stri
 test/cli/print-procs/print-procs.rb:20: Revealed type: `T.untyped` https://srb.help/7014
     20 |  T.reveal_type(e)
           ^^^^^^^^^^^^^^^^
-  From:
+  Got `T.untyped` originating from:
     test/cli/print-procs/print-procs.rb:15:
     15 |def foo(a, b, c, d, e)
                             ^

--- a/test/cli/remove-path-prefix-https/remove-path-prefix-https.out
+++ b/test/cli/remove-path-prefix-https/remove-path-prefix-https.out
@@ -5,7 +5,7 @@ test/cli/remove-path-prefix-https/remove-path-prefix-https.rb:2: Expected `Integ
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("s") originating from:
+  Got `String("s")` originating from:
     test/cli/remove-path-prefix-https/remove-path-prefix-https.rb:2:
      2 |1 + "s"
             ^^^

--- a/test/cli/remove-path-prefix-https/remove-path-prefix-https.out
+++ b/test/cli/remove-path-prefix-https/remove-path-prefix-https.out
@@ -1,7 +1,8 @@
 test/cli/remove-path-prefix-https/remove-path-prefix-https.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:

--- a/test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.out
+++ b/test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.out
@@ -1,7 +1,8 @@
 test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:

--- a/test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.out
+++ b/test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.out
@@ -5,7 +5,7 @@ test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.rb:2: Expected 
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("s") originating from:
+  Got `String("s")` originating from:
     test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.rb:2:
      2 |1 + "s"
             ^^^

--- a/test/cli/remove-path-prefix/remove-path-prefix.out
+++ b/test/cli/remove-path-prefix/remove-path-prefix.out
@@ -5,7 +5,7 @@ remove-path-prefix.rb:2: Expected `Integer` but found `String("s")` for argument
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
-  Got String("s") originating from:
+  Got `String("s")` originating from:
     remove-path-prefix.rb:2:
      2 |1 + "s"
             ^^^

--- a/test/cli/remove-path-prefix/remove-path-prefix.out
+++ b/test/cli/remove-path-prefix/remove-path-prefix.out
@@ -1,7 +1,8 @@
 remove-path-prefix.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148: Method `Integer#+` has specified `arg0` as `Integer`
+  Expected `Integer` for argument `arg0` of method `Integer#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
      148 |        arg0: Integer,
                   ^^^^
   Got String("s") originating from:

--- a/test/cli/suggest_t_must/suggest_t_must.out
+++ b/test/cli/suggest_t_must/suggest_t_must.out
@@ -13,7 +13,8 @@ test/cli/suggest_t_must/suggest_t_must.rb:4: Method `[]` does not exist on `NilC
 test/cli/suggest_t_must/suggest_t_must.rb:6: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
      6 |"hi" + foo
         ^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L58: Method `String#+` has specified `arg0` as `String`
+  Expected `String` for argument `arg0` of method `String#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L58:
     58 |        arg0: String,
                 ^^^^
   Got T.nilable(String) originating from:

--- a/test/cli/suggest_t_must/suggest_t_must.out
+++ b/test/cli/suggest_t_must/suggest_t_must.out
@@ -17,7 +17,7 @@ test/cli/suggest_t_must/suggest_t_must.rb:6: Expected `String` but found `T.nila
     https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L58:
     58 |        arg0: String,
                 ^^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     test/cli/suggest_t_must/suggest_t_must.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/uninitialized-explanation/uninitialized-explanation.out
+++ b/test/cli/uninitialized-explanation/uninitialized-explanation.out
@@ -5,7 +5,7 @@ test/cli/uninitialized-explanation/uninitialized.rb:15: Expected `Integer` but f
     test/cli/uninitialized-explanation/uninitialized.rb:5:
      5 |sig {params(x: Integer).void}
                     ^
-  Got T.nilable(Integer) originating from:
+  Got `T.nilable(Integer)` originating from:
     test/cli/uninitialized-explanation/uninitialized.rb:10:
     10 |    x = 1
                 ^

--- a/test/cli/uninitialized-explanation/uninitialized-explanation.out
+++ b/test/cli/uninitialized-explanation/uninitialized-explanation.out
@@ -1,7 +1,8 @@
 test/cli/uninitialized-explanation/uninitialized.rb:15: Expected `Integer` but found `T.nilable(Integer)` for argument `x` https://srb.help/7002
     15 |  takes_int(x)
           ^^^^^^^^^^^^
-    test/cli/uninitialized-explanation/uninitialized.rb:5: Method `Object#takes_int` has specified `x` as `Integer`
+  Expected `Integer` for argument `x` of method `Object#takes_int`:
+    test/cli/uninitialized-explanation/uninitialized.rb:5:
      5 |sig {params(x: Integer).void}
                     ^
   Got T.nilable(Integer) originating from:

--- a/test/testdata/cfg/return_type_of_nilable_blk_param.rb
+++ b/test/testdata/cfg/return_type_of_nilable_blk_param.rb
@@ -22,11 +22,11 @@ class A
 end
 
 def main
-  A.new.bar do |r| # error: Returning value that does not conform to block result type
+  A.new.bar do |r| # error: Expected `Integer` but found `String` for block result type
     r.to_s
   end
 
-  A.new.baz do |r| # error: Returning value that does not conform to block result type
+  A.new.baz do |r| # error: Expected `Integer` but found `String` for block result type
     r.to_s
   end
 

--- a/test/testdata/desugar/blockpass.rb
+++ b/test/testdata/desugar/blockpass.rb
@@ -45,7 +45,7 @@ def foo(&blk)
     calls_with_object(&HasToProc.new)
     calls_with_object {|*args| HasToProc.new.to_proc.call(*args)}
     CallsWithObject.calls_with_object(&:meth)
-    CallsWithObject&.calls_with_object(&:meth) # error: Used `&.` operator on a receiver which can never be nil
+    CallsWithObject&.calls_with_object(&:meth) # error: Used `&.` operator on `T.class_of(CallsWithObject)`, which can never be nil
     CallsWithObjectChild.calls_with_object(&:meth)
     calls_arg_with_object(HasMeth.new, &:meth)
     calls_arg_with_object(HasMeth.new) {|x| x.meth}

--- a/test/testdata/infer/block_arg.rb
+++ b/test/testdata/infer/block_arg.rb
@@ -23,9 +23,9 @@ class A
   def badnext
     yields do
       if _
-        4 # error: Returning value that does not conform to block result type
+        4 # error: Expected `String` but found `Integer(4)` for block result type
       else
-        next 5 # error: Returning value that does not conform to block result type
+        next 5 # error: Expected `String` but found `Integer(5)` for block result type
       end
     end
 

--- a/test/testdata/infer/casts.rb
+++ b/test/testdata/infer/casts.rb
@@ -3,7 +3,7 @@ class TestCasts
   def untyped; end # error: does not have a `sig`
 
   def test_casts # error: does not have a `sig`
-    t = T.assert_type!(untyped, Integer) # error: unable to infer the type
+    t = T.assert_type!(untyped, Integer) # error: found `T.untyped`
     t + 4
 
     t1 = T.assert_type!("hi", Integer) # error: does not have asserted type

--- a/test/testdata/infer/casts.rb
+++ b/test/testdata/infer/casts.rb
@@ -16,10 +16,10 @@ class TestCasts
     s + "hi"
     s + 3 # error: Expected `String` but found `Integer(3)` for argument `arg0`
 
-    s = T.cast(6, Integer) # error: Useless cast
+    s = T.cast(6, Integer) # error: `T.cast` is useless
     s = T.cast(6, T.untyped) # error: Please use `T.unsafe(...)`
 
-    s = T.cast(6, 7) # error: Useless cast
+    s = T.cast(6, 7) # error: `T.cast` is useless
                 # ^ error: Unsupported literal in type syntax
 
     # s ends up as `Integer`

--- a/test/testdata/infer/generics/class_less_than.rb
+++ b/test/testdata/infer/generics/class_less_than.rb
@@ -13,7 +13,7 @@ class Test
   sig {params(arg: T.any(T.class_of(A), T.class_of(Integer))).void}
   def test(arg)
     if arg < A
-      T.cast(arg, T.class_of(A)) # error: Useless cast
+      T.cast(arg, T.class_of(A)) # error: `T.cast` is useless
     end
   end
 end

--- a/test/testdata/infer/must.rb
+++ b/test/testdata/infer/must.rb
@@ -1,7 +1,7 @@
 # typed: strict
 
 def test_must # error: does not have a `sig`
-  x = T.cast(nil, T.nilable(String)) # error: Useless cast
+  x = T.cast(nil, T.nilable(String)) # error: `T.cast` is useless
   T.assert_type!(T.must(x), String)
 
   T.must(x)

--- a/test/testdata/infer/nil_safe_navigation.rb
+++ b/test/testdata/infer/nil_safe_navigation.rb
@@ -4,7 +4,7 @@ extend T::Sig
 
 sig {params(x: Integer, y: T.nilable(Integer)).void}
 def foo(x, y)
-  puts x&.to_s       # error: Used `&.` operator on a receiver which can never be nil
+  puts x&.to_s       # error: Used `&.` operator on `Integer`, which can never be nil
   puts x.to_s
 
   puts y&.to_s

--- a/test/testdata/infer/self_type_param_bounded.rb
+++ b/test/testdata/infer/self_type_param_bounded.rb
@@ -12,7 +12,7 @@ class A
 
   sig {params(x: T1).void}
   def test1(x)
-    T.cast(x, Animal) # error: Useless cast
+    T.cast(x, Animal) # error: `T.cast` is useless
   end
 end
 

--- a/test/testdata/lsp/hover_ampersand_operations.rb
+++ b/test/testdata/lsp/hover_ampersand_operations.rb
@@ -19,7 +19,7 @@ def main
 
   # Safenav
   dog = Dog.new
-  breed = dog&.breed # error: Used `&.` operator on a receiver which can never be nil
+  breed = dog&.breed # error: Used `&.` operator on `Dog`, which can never be nil
 # ^ hover: String
         # ^ hover: Dog
             # ^ hover: sig {returns(String)}

--- a/test/testdata/rbi/t.rb
+++ b/test/testdata/rbi/t.rb
@@ -1,7 +1,7 @@
 # typed: strict
 T.let("foo", String)
 T.assert_type!("foo", String)
-T.cast("foo", String) # error: Useless cast
+T.cast("foo", String) # error: `T.cast` is useless
 T.unsafe(String)
 T.nilable(String)
 T.proc

--- a/test/testdata/rewriter/prop_computed_by.rb
+++ b/test/testdata/rewriter/prop_computed_by.rb
@@ -12,7 +12,7 @@ class ComputingProps
 
   const :missing, Integer, computed_by: :compute_missing
                                       # ^^^^^^^^^^^^^^^^ error: Method `compute_missing` does not exist on `T.class_of(ComputingProps)`
-                                      # ^^^^^^^^^^^^^^^^ error: The typechecker was unable to infer the type of the asserted value
+                                      # ^^^^^^^^^^^^^^^^ error: Expected a type but found `T.untyped` for `T.assert_type!`
 
   const :num_wrong_value, Integer, computed_by: :compute_num_wrong_value
                                               # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Argument does not have asserted type `Integer`
@@ -35,7 +35,7 @@ class ComputingProps
                                                 # ^^^^^^^^^^^^^^^^^^ error: Value for `computed_by` must be a symbol literal
 
   const :num_unknown_type, Integer, computed_by: :compute_num_unknown_type
-                                               # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: The typechecker was unable to infer the type of the asserted value
+                                               # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected a type but found `T.untyped` for `T.assert_type!`
   def self.compute_num_unknown_type(inputs)
     T.untyped
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet tracks a wealth of location information, which is one of the main reasons
why people consider Sorbet to have good error messages.

But individual error messages make inconsistent usage of this information. In
particular, pretty much every error message that shows a type which is
influenced by control-flow sensitive typing should show the TypeAndOrigins data
structure on hand explaining how Sorbet arrived at that type.

This PR adds a couple helpers to make that process **super** easy (one short
line of code) so that people are highly encouraged to print such information
when adding new, similar kinds of errors.

Some of these errors look like trivial changes ("it's just duplicating information
present in the error") but in fact all of the `Got ...` sections will remember the
control flow path through a method resulting in Sorbet knowing a specific type.

### Commit summary

There are a lot of individual changes in this PR, but I've (almost excessively)
broken it up into small commits.

Each commit does only one thing.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

**Before**

<img width="960" alt="Screen Shot 2021-01-16 at 10 34 26 PM" src="https://user-images.githubusercontent.com/5544532/104833229-f6b85880-584b-11eb-9e78-1fa566f2ffe0.png">

**After**

<img width="963" alt="Screen Shot 2021-01-16 at 10 35 09 PM" src="https://user-images.githubusercontent.com/5544532/104833225-f3bd6800-584b-11eb-81d0-22ecbfcc4934.png">

Note:

- consistent error messages
- more colors
- more errors showing TypeAndOrigins information
