### PR TITLE
Add autocorrect for "Please use `T.unsafe` to cast"

### DIFF
--- a/test/cli/autocorrect-cast-untyped/autocorrect-cast-untyped.out
+++ b/test/cli/autocorrect-cast-untyped/autocorrect-cast-untyped.out
@@ -1,0 +1,78 @@
+autocorrect-cast-untyped.rb:3: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
+     3 |T.cast(nil, T.untyped)
+        ^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-cast-untyped.rb:3: Replaced with `T.unsafe(nil)`
+     3 |T.cast(nil, T.untyped)
+        ^^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-cast-untyped.rb:5: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
+     5 |_x = T.cast(nil, T.untyped)
+             ^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-cast-untyped.rb:5: Replaced with `T.unsafe(nil)`
+     5 |_x = T.cast(nil, T.untyped)
+             ^^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-cast-untyped.rb:9: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
+     9 |T.cast(
+    10 |  nil,
+    11 |  T.untyped)
+
+autocorrect-cast-untyped.rb:13: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
+    13 |_y = T.cast(
+    14 |  nil,
+    15 |  T.untyped)
+
+autocorrect-cast-untyped.rb:17: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
+    17 |T.cast(
+    18 |  nil,
+    19 |  T.untyped
+    20 |)
+
+autocorrect-cast-untyped.rb:22: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
+    22 |_z = T.cast(
+    23 |  nil,
+    24 |  T.untyped
+    25 |)
+
+autocorrect-cast-untyped.rb:27: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
+    27 |_w = T.cast(
+    28 |  nil, T.untyped)
+  Autocorrect: Done
+    autocorrect-cast-untyped.rb:27: Replaced with `T.unsafe(
+  nil)`
+    27 |_w = T.cast(
+    28 |  nil, T.untyped)
+Errors: 7
+
+--------------------------------------------------------------------------
+
+# typed: strict
+
+T.unsafe(nil)
+
+_x = T.unsafe(nil)
+
+# ----- multi-line is not handled unless it matches an unlikely pattern -----
+
+T.cast(
+  nil,
+  T.untyped)
+
+_y = T.cast(
+  nil,
+  T.untyped)
+
+T.cast(
+  nil,
+  T.untyped
+)
+
+_z = T.cast(
+  nil,
+  T.untyped
+)
+
+_w = T.unsafe(
+  nil)

--- a/test/cli/autocorrect-cast-untyped/autocorrect-cast-untyped.rb
+++ b/test/cli/autocorrect-cast-untyped/autocorrect-cast-untyped.rb
@@ -1,0 +1,28 @@
+# typed: strict
+
+T.cast(nil, T.untyped)
+
+_x = T.cast(nil, T.untyped)
+
+# ----- multi-line is not handled unless it matches an unlikely pattern -----
+
+T.cast(
+  nil,
+  T.untyped)
+
+_y = T.cast(
+  nil,
+  T.untyped)
+
+T.cast(
+  nil,
+  T.untyped
+)
+
+_z = T.cast(
+  nil,
+  T.untyped
+)
+
+_w = T.cast(
+  nil, T.untyped)

--- a/test/cli/autocorrect-cast-untyped/autocorrect-cast-untyped.sh
+++ b/test/cli/autocorrect-cast-untyped/autocorrect-cast-untyped.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tmp="$(mktemp -d)"
+infile="test/cli/autocorrect-cast-untyped/autocorrect-cast-untyped.rb"
+cp "$infile" "$tmp"
+
+cwd="$(pwd)"
+cd "$tmp"
+
+if "$cwd/main/sorbet" --silence-dev-message -a autocorrect-cast-untyped.rb 2>&1; then
+  echo "Expected failure, did not fail"
+  exit 1
+fi
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+cat autocorrect-cast-untyped.rb
+
+rm autocorrect-cast-untyped.rb
+rm "$tmp"

--- a/test/testdata/infer/casts.rb
+++ b/test/testdata/infer/casts.rb
@@ -17,7 +17,7 @@ class TestCasts
     s + 3 # error: Expected `String` but found `Integer(3)` for argument `arg0`
 
     s = T.cast(6, Integer) # error: `T.cast` is useless
-    s = T.cast(6, T.untyped) # error: Please use `T.unsafe(...)`
+    s = T.cast(6, T.untyped) # error: Please use `T.unsafe`
 
     s = T.cast(6, 7) # error: `T.cast` is useless
                 # ^ error: Unsupported literal in type syntax


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I didn't want to handle the multi-line case because it's kind of hard.

In particular, we don't have a convenient way to get a `Loc`
corresponding to just the first argument of the cast, so we have to use
some heuristics.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.