### PR TITLE
TreePtr -> ExpressionPtr

### DIFF
--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -8,7 +8,7 @@ using namespace std;
 namespace sorbet::ast {
 
 namespace {
-ParsedArg parseArg(const ast::TreePtr &arg) {
+ParsedArg parseArg(const ast::ExpressionPtr &arg) {
     ParsedArg parsedArg;
 
     typecase(
@@ -41,8 +41,8 @@ ParsedArg parseArg(const ast::TreePtr &arg) {
     return parsedArg;
 }
 
-TreePtr getDefaultValue(TreePtr arg) {
-    TreePtr default_;
+ExpressionPtr getDefaultValue(ExpressionPtr arg) {
+    ExpressionPtr default_;
     typecase(
         arg, [&](ast::RestArg &rest) { default_ = getDefaultValue(move(rest.expr)); },
         [&](ast::KeywordArg &kw) { default_ = getDefaultValue(move(kw.expr)); },
@@ -98,7 +98,7 @@ std::vector<u4> ArgParsing::hashArgs(core::Context ctx, const std::vector<Parsed
     return result;
 }
 
-TreePtr ArgParsing::getDefault(const ParsedArg &parsedArg, TreePtr arg) {
+ExpressionPtr ArgParsing::getDefault(const ParsedArg &parsedArg, ExpressionPtr arg) {
     if (!parsedArg.flags.isDefault) {
         return nullptr;
     }

--- a/ast/ArgParsing.h
+++ b/ast/ArgParsing.h
@@ -12,7 +12,7 @@ public:
     static std::vector<ParsedArg> parseArgs(const ast::MethodDef::ARGS_store &args);
     static std::vector<u4> hashArgs(core::Context ctx, const std::vector<ParsedArg> &args);
     // Returns the default argument value for the given argument, or nullptr if not specified. Mutates arg.
-    static TreePtr getDefault(const ParsedArg &parsedArg, TreePtr arg);
+    static ExpressionPtr getDefault(const ParsedArg &parsedArg, ExpressionPtr arg);
 };
 }; // namespace sorbet::ast
 

--- a/ast/Helpers.cc
+++ b/ast/Helpers.cc
@@ -4,7 +4,7 @@ using namespace std;
 
 namespace sorbet::ast {
 
-bool definesBehavior(const TreePtr &expr) {
+bool definesBehavior(const ExpressionPtr &expr) {
     if (BehaviorHelpers::checkEmptyDeep(expr)) {
         return false;
     }
@@ -45,11 +45,11 @@ bool definesBehavior(const TreePtr &expr) {
         [&](const ast::MethodDef &methodDef) { result = !methodDef.flags.isRewriterSynthesized; },
         [&](const ast::Literal &methodDef) { result = false; },
 
-        [&](const TreePtr &klass) { result = true; });
+        [&](const ExpressionPtr &klass) { result = true; });
     return result;
 }
 
-bool BehaviorHelpers::checkClassDefinesBehavior(const TreePtr &expr) {
+bool BehaviorHelpers::checkClassDefinesBehavior(const ExpressionPtr &expr) {
     auto *klass = ast::cast_tree<ast::ClassDef>(expr);
     ENFORCE(klass);
     return BehaviorHelpers::checkClassDefinesBehavior(*klass);
@@ -71,7 +71,7 @@ bool BehaviorHelpers::checkClassDefinesBehavior(const ast::ClassDef &klass) {
     return absl::c_any_of(klass.rhs, [](auto &tree) { return definesBehavior(tree); });
 }
 
-bool BehaviorHelpers::checkEmptyDeep(const TreePtr &expr) {
+bool BehaviorHelpers::checkEmptyDeep(const ExpressionPtr &expr) {
     bool result = false;
 
     typecase(
@@ -90,7 +90,7 @@ bool BehaviorHelpers::checkEmptyDeep(const TreePtr &expr) {
                      checkEmptyDeep(seq.expr);
         },
 
-        [&](const TreePtr &klass) { result = false; });
+        [&](const ExpressionPtr &klass) { result = false; });
     return result;
 }
 

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -10,11 +10,11 @@ namespace sorbet::ast {
 class MK {
 public:
     static ExpressionPtr EmptyTree() {
-        return make_tree<ast::EmptyTree>();
+        return make_expression<ast::EmptyTree>();
     }
 
     static ExpressionPtr Block(core::LocOffsets loc, ExpressionPtr body, MethodDef::ARGS_store args) {
-        return make_tree<ast::Block>(loc, std::move(args), std::move(body));
+        return make_expression<ast::Block>(loc, std::move(args), std::move(body));
     }
 
     static ExpressionPtr Block0(core::LocOffsets loc, ExpressionPtr body) {
@@ -36,7 +36,7 @@ public:
 
     static ExpressionPtr Send(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, u2 numPosArgs,
                               Send::ARGS_store args, Send::Flags flags = {}, ExpressionPtr blk = nullptr) {
-        auto send = make_tree<ast::Send>(loc, std::move(recv), fun, numPosArgs, std::move(args), std::move(blk), flags);
+        auto send = make_expression<ast::Send>(loc, std::move(recv), fun, numPosArgs, std::move(args), std::move(blk), flags);
         return send;
     }
 
@@ -65,63 +65,63 @@ public:
     }
 
     static ExpressionPtr Literal(core::LocOffsets loc, const core::TypePtr &tpe) {
-        return make_tree<ast::Literal>(loc, tpe);
+        return make_expression<ast::Literal>(loc, tpe);
     }
 
     static ExpressionPtr Return(core::LocOffsets loc, ExpressionPtr expr) {
-        return make_tree<ast::Return>(loc, std::move(expr));
+        return make_expression<ast::Return>(loc, std::move(expr));
     }
 
     static ExpressionPtr Next(core::LocOffsets loc, ExpressionPtr expr) {
-        return make_tree<ast::Next>(loc, std::move(expr));
+        return make_expression<ast::Next>(loc, std::move(expr));
     }
 
     static ExpressionPtr Break(core::LocOffsets loc, ExpressionPtr expr) {
-        return make_tree<ast::Break>(loc, std::move(expr));
+        return make_expression<ast::Break>(loc, std::move(expr));
     }
 
     static ExpressionPtr Nil(core::LocOffsets loc) {
-        return make_tree<ast::Literal>(loc, core::Types::nilClass());
+        return make_expression<ast::Literal>(loc, core::Types::nilClass());
     }
 
     static ExpressionPtr Constant(core::LocOffsets loc, core::SymbolRef symbol) {
         ENFORCE(symbol.exists());
-        return make_tree<ConstantLit>(loc, symbol, nullptr);
+        return make_expression<ConstantLit>(loc, symbol, nullptr);
     }
 
     static ExpressionPtr Local(core::LocOffsets loc, core::NameRef name) {
-        return make_tree<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Local, name);
+        return make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Local, name);
     }
 
     static ExpressionPtr OptionalArg(core::LocOffsets loc, ExpressionPtr inner, ExpressionPtr default_) {
-        return make_tree<ast::OptionalArg>(loc, std::move(inner), std::move(default_));
+        return make_expression<ast::OptionalArg>(loc, std::move(inner), std::move(default_));
     }
 
     static ExpressionPtr KeywordArg(core::LocOffsets loc, ExpressionPtr inner) {
-        return make_tree<ast::KeywordArg>(loc, std::move(inner));
+        return make_expression<ast::KeywordArg>(loc, std::move(inner));
     }
 
     static ExpressionPtr RestArg(core::LocOffsets loc, ExpressionPtr inner) {
-        return make_tree<ast::RestArg>(loc, std::move(inner));
+        return make_expression<ast::RestArg>(loc, std::move(inner));
     }
 
     static ExpressionPtr BlockArg(core::LocOffsets loc, ExpressionPtr inner) {
-        return make_tree<ast::BlockArg>(loc, std::move(inner));
+        return make_expression<ast::BlockArg>(loc, std::move(inner));
     }
 
     static ExpressionPtr ShadowArg(core::LocOffsets loc, ExpressionPtr inner) {
-        return make_tree<ast::ShadowArg>(loc, std::move(inner));
+        return make_expression<ast::ShadowArg>(loc, std::move(inner));
     }
 
     static ExpressionPtr Instance(core::LocOffsets loc, core::NameRef name) {
-        return make_tree<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Instance, name);
+        return make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Instance, name);
     }
 
     static ExpressionPtr cpRef(ExpressionPtr &name) {
         if (auto *nm = cast_tree<UnresolvedIdent>(name)) {
-            return make_tree<UnresolvedIdent>(nm->loc, nm->kind, nm->name);
+            return make_expression<UnresolvedIdent>(nm->loc, nm->kind, nm->name);
         } else if (auto *nm = cast_tree<ast::Local>(name)) {
-            return make_tree<ast::Local>(nm->loc, nm->localVariable);
+            return make_expression<ast::Local>(nm->loc, nm->localVariable);
         }
         Exception::notImplemented();
     }
@@ -147,7 +147,7 @@ public:
         }
 
         // otherwise, just assign to it!
-        return make_tree<ast::Assign>(loc, std::move(lhs), std::move(rhs));
+        return make_expression<ast::Assign>(loc, std::move(lhs), std::move(rhs));
     }
 
     static ExpressionPtr Assign(core::LocOffsets loc, core::NameRef name, ExpressionPtr rhs) {
@@ -155,20 +155,20 @@ public:
     }
 
     static ExpressionPtr If(core::LocOffsets loc, ExpressionPtr cond, ExpressionPtr thenp, ExpressionPtr elsep) {
-        return make_tree<ast::If>(loc, std::move(cond), std::move(thenp), std::move(elsep));
+        return make_expression<ast::If>(loc, std::move(cond), std::move(thenp), std::move(elsep));
     }
 
     static ExpressionPtr While(core::LocOffsets loc, ExpressionPtr cond, ExpressionPtr body) {
-        return make_tree<ast::While>(loc, std::move(cond), std::move(body));
+        return make_expression<ast::While>(loc, std::move(cond), std::move(body));
     }
 
     static ExpressionPtr Self(core::LocOffsets loc) {
-        return make_tree<ast::Local>(loc, core::LocalVariable::selfVariable());
+        return make_expression<ast::Local>(loc, core::LocalVariable::selfVariable());
     }
 
     static ExpressionPtr InsSeq(core::LocOffsets loc, InsSeq::STATS_store stats, ExpressionPtr expr) {
         if (!stats.empty()) {
-            return make_tree<ast::InsSeq>(loc, std::move(stats), std::move(expr));
+            return make_expression<ast::InsSeq>(loc, std::move(stats), std::move(expr));
         }
         return expr;
     }
@@ -191,41 +191,41 @@ public:
     }
 
     static ExpressionPtr True(core::LocOffsets loc) {
-        return make_tree<ast::Literal>(loc, core::Types::trueClass());
+        return make_expression<ast::Literal>(loc, core::Types::trueClass());
     }
 
     static ExpressionPtr False(core::LocOffsets loc) {
-        return make_tree<ast::Literal>(loc, core::Types::falseClass());
+        return make_expression<ast::Literal>(loc, core::Types::falseClass());
     }
 
     static ExpressionPtr UnresolvedConstant(core::LocOffsets loc, ExpressionPtr scope, core::NameRef name) {
-        return make_tree<UnresolvedConstantLit>(loc, std::move(scope), name);
+        return make_expression<UnresolvedConstantLit>(loc, std::move(scope), name);
     }
 
     static ExpressionPtr Int(core::LocOffsets loc, int64_t val) {
-        return make_tree<ast::Literal>(loc, core::make_type<core::LiteralType>(val));
+        return make_expression<ast::Literal>(loc, core::make_type<core::LiteralType>(val));
     }
 
     static ExpressionPtr Float(core::LocOffsets loc, double val) {
-        return make_tree<ast::Literal>(loc, core::make_type<core::LiteralType>(val));
+        return make_expression<ast::Literal>(loc, core::make_type<core::LiteralType>(val));
     }
 
     static ExpressionPtr Symbol(core::LocOffsets loc, core::NameRef name) {
-        return make_tree<ast::Literal>(loc, core::make_type<core::LiteralType>(core::Symbols::Symbol(), name));
+        return make_expression<ast::Literal>(loc, core::make_type<core::LiteralType>(core::Symbols::Symbol(), name));
     }
 
     static ExpressionPtr String(core::LocOffsets loc, core::NameRef value) {
-        return make_tree<ast::Literal>(loc, core::make_type<core::LiteralType>(core::Symbols::String(), value));
+        return make_expression<ast::Literal>(loc, core::make_type<core::LiteralType>(core::Symbols::String(), value));
     }
 
     static ExpressionPtr Method(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
                                 MethodDef::ARGS_store args, ExpressionPtr rhs) {
         if (args.empty() || (!isa_tree<ast::Local>(args.back()) && !isa_tree<ast::BlockArg>(args.back()))) {
             auto blkLoc = core::LocOffsets::none();
-            args.emplace_back(make_tree<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
+            args.emplace_back(make_expression<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
         }
         MethodDef::Flags flags;
-        return make_tree<MethodDef>(loc, declLoc, core::Symbols::todoMethod(), name, std::move(args), std::move(rhs),
+        return make_expression<MethodDef>(loc, declLoc, core::Symbols::todoMethod(), name, std::move(args), std::move(rhs),
                                     flags);
     }
 
@@ -252,7 +252,7 @@ public:
     static ExpressionPtr ClassOrModule(core::LocOffsets loc, core::LocOffsets declLoc, ExpressionPtr name,
                                        ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs,
                                        ClassDef::Kind kind) {
-        return make_tree<ClassDef>(loc, declLoc, core::Symbols::todo(), std::move(name), std::move(ancestors),
+        return make_expression<ClassDef>(loc, declLoc, core::Symbols::todo(), std::move(name), std::move(ancestors),
                                    std::move(rhs), kind);
     }
 
@@ -269,11 +269,11 @@ public:
     }
 
     static ExpressionPtr Array(core::LocOffsets loc, Array::ENTRY_store entries) {
-        return make_tree<ast::Array>(loc, std::move(entries));
+        return make_expression<ast::Array>(loc, std::move(entries));
     }
 
     static ExpressionPtr Hash(core::LocOffsets loc, Hash::ENTRY_store keys, Hash::ENTRY_store values) {
-        return make_tree<ast::Hash>(loc, std::move(keys), std::move(values));
+        return make_expression<ast::Hash>(loc, std::move(keys), std::move(values));
     }
 
     static ExpressionPtr Hash0(core::LocOffsets loc) {
@@ -379,7 +379,7 @@ public:
     }
 
     static ExpressionPtr ZSuper(core::LocOffsets loc) {
-        return Send1(loc, Self(loc), core::Names::super(), make_tree<ast::ZSuperArgs>(loc));
+        return Send1(loc, Self(loc), core::Names::super(), make_expression<ast::ZSuperArgs>(loc));
     }
 
     static ExpressionPtr SelfNew(core::LocOffsets loc, int numPosArgs, ast::Send::ARGS_store args,

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -34,8 +34,8 @@ public:
         return store;
     }
 
-    static ExpressionPtr Send(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, u2 numPosArgs, Send::ARGS_store args,
-                        Send::Flags flags = {}, ExpressionPtr blk = nullptr) {
+    static ExpressionPtr Send(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, u2 numPosArgs,
+                              Send::ARGS_store args, Send::Flags flags = {}, ExpressionPtr blk = nullptr) {
         auto send = make_tree<ast::Send>(loc, std::move(recv), fun, numPosArgs, std::move(args), std::move(blk), flags);
         return send;
     }
@@ -54,12 +54,13 @@ public:
         return Send(loc, std::move(recv), fun, 1, SendArgs(std::move(arg1)));
     }
 
-    static ExpressionPtr Send2(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, ExpressionPtr arg1, ExpressionPtr arg2) {
+    static ExpressionPtr Send2(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, ExpressionPtr arg1,
+                               ExpressionPtr arg2) {
         return Send(loc, std::move(recv), fun, 2, SendArgs(std::move(arg1), std::move(arg2)));
     }
 
-    static ExpressionPtr Send3(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, ExpressionPtr arg1, ExpressionPtr arg2,
-                         ExpressionPtr arg3) {
+    static ExpressionPtr Send3(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, ExpressionPtr arg1,
+                               ExpressionPtr arg2, ExpressionPtr arg3) {
         return Send(loc, std::move(recv), fun, 3, SendArgs(std::move(arg1), std::move(arg2), std::move(arg3)));
     }
 
@@ -177,7 +178,8 @@ public:
         return Send1(loc, Constant(loc, core::Symbols::Magic()), core::Names::splat(), std::move(to_a));
     }
 
-    static ExpressionPtr CallWithSplat(core::LocOffsets loc, ExpressionPtr recv, core::NameRef name, ExpressionPtr args) {
+    static ExpressionPtr CallWithSplat(core::LocOffsets loc, ExpressionPtr recv, core::NameRef name,
+                                       ExpressionPtr args) {
         return Send3(loc, Constant(loc, core::Symbols::Magic()), core::Names::callWithSplat(), std::move(recv),
                      MK::Symbol(loc, name), std::move(args));
     }
@@ -217,7 +219,7 @@ public:
     }
 
     static ExpressionPtr Method(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                          MethodDef::ARGS_store args, ExpressionPtr rhs) {
+                                MethodDef::ARGS_store args, ExpressionPtr rhs) {
         if (args.empty() || (!isa_tree<ast::Local>(args.back()) && !isa_tree<ast::BlockArg>(args.back()))) {
             auto blkLoc = core::LocOffsets::none();
             args.emplace_back(make_tree<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
@@ -228,38 +230,40 @@ public:
     }
 
     static ExpressionPtr SyntheticMethod(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                                   MethodDef::ARGS_store args, ExpressionPtr rhs) {
+                                         MethodDef::ARGS_store args, ExpressionPtr rhs) {
         auto mdef = Method(loc, declLoc, name, std::move(args), std::move(rhs));
         cast_tree<MethodDef>(mdef)->flags.isRewriterSynthesized = true;
         return mdef;
     }
 
-    static ExpressionPtr SyntheticMethod0(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name, ExpressionPtr rhs) {
+    static ExpressionPtr SyntheticMethod0(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
+                                          ExpressionPtr rhs) {
         MethodDef::ARGS_store args;
         return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs));
     }
 
-    static ExpressionPtr SyntheticMethod1(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name, ExpressionPtr arg0,
-                                    ExpressionPtr rhs) {
+    static ExpressionPtr SyntheticMethod1(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
+                                          ExpressionPtr arg0, ExpressionPtr rhs) {
         MethodDef::ARGS_store args;
         args.emplace_back(std::move(arg0));
         return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs));
     }
 
     static ExpressionPtr ClassOrModule(core::LocOffsets loc, core::LocOffsets declLoc, ExpressionPtr name,
-                                 ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs, ClassDef::Kind kind) {
+                                       ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs,
+                                       ClassDef::Kind kind) {
         return make_tree<ClassDef>(loc, declLoc, core::Symbols::todo(), std::move(name), std::move(ancestors),
                                    std::move(rhs), kind);
     }
 
     static ExpressionPtr Class(core::LocOffsets loc, core::LocOffsets declLoc, ExpressionPtr name,
-                         ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs) {
+                               ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs) {
         return MK::ClassOrModule(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
                                  ClassDef::Kind::Class);
     }
 
     static ExpressionPtr Module(core::LocOffsets loc, core::LocOffsets declLoc, ExpressionPtr name,
-                          ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs) {
+                                ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs) {
         return MK::ClassOrModule(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
                                  ClassDef::Kind::Module);
     }
@@ -378,8 +382,8 @@ public:
         return Send1(loc, Self(loc), core::Names::super(), make_tree<ast::ZSuperArgs>(loc));
     }
 
-    static ExpressionPtr SelfNew(core::LocOffsets loc, int numPosArgs, ast::Send::ARGS_store args, Send::Flags flags = {},
-                           ExpressionPtr block = nullptr) {
+    static ExpressionPtr SelfNew(core::LocOffsets loc, int numPosArgs, ast::Send::ARGS_store args,
+                                 Send::Flags flags = {}, ExpressionPtr block = nullptr) {
         auto magic = Constant(loc, core::Symbols::Magic());
         return Send(loc, std::move(magic), core::Names::selfNew(), numPosArgs, std::move(args), flags,
                     std::move(block));

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -36,7 +36,8 @@ public:
 
     static ExpressionPtr Send(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, u2 numPosArgs,
                               Send::ARGS_store args, Send::Flags flags = {}, ExpressionPtr blk = nullptr) {
-        auto send = make_expression<ast::Send>(loc, std::move(recv), fun, numPosArgs, std::move(args), std::move(blk), flags);
+        auto send =
+            make_expression<ast::Send>(loc, std::move(recv), fun, numPosArgs, std::move(args), std::move(blk), flags);
         return send;
     }
 
@@ -225,8 +226,8 @@ public:
             args.emplace_back(make_expression<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
         }
         MethodDef::Flags flags;
-        return make_expression<MethodDef>(loc, declLoc, core::Symbols::todoMethod(), name, std::move(args), std::move(rhs),
-                                    flags);
+        return make_expression<MethodDef>(loc, declLoc, core::Symbols::todoMethod(), name, std::move(args),
+                                          std::move(rhs), flags);
     }
 
     static ExpressionPtr SyntheticMethod(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
@@ -253,7 +254,7 @@ public:
                                        ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs,
                                        ClassDef::Kind kind) {
         return make_expression<ClassDef>(loc, declLoc, core::Symbols::todo(), std::move(name), std::move(ancestors),
-                                   std::move(rhs), kind);
+                                         std::move(rhs), kind);
     }
 
     static ExpressionPtr Class(core::LocOffsets loc, core::LocOffsets declLoc, ExpressionPtr name,

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -9,20 +9,20 @@ namespace sorbet::ast {
 
 class MK {
 public:
-    static TreePtr EmptyTree() {
+    static ExpressionPtr EmptyTree() {
         return make_tree<ast::EmptyTree>();
     }
 
-    static TreePtr Block(core::LocOffsets loc, TreePtr body, MethodDef::ARGS_store args) {
+    static ExpressionPtr Block(core::LocOffsets loc, ExpressionPtr body, MethodDef::ARGS_store args) {
         return make_tree<ast::Block>(loc, std::move(args), std::move(body));
     }
 
-    static TreePtr Block0(core::LocOffsets loc, TreePtr body) {
+    static ExpressionPtr Block0(core::LocOffsets loc, ExpressionPtr body) {
         MethodDef::ARGS_store args;
         return Block(loc, std::move(body), std::move(args));
     }
 
-    static TreePtr Block1(core::LocOffsets loc, TreePtr body, TreePtr arg1) {
+    static ExpressionPtr Block1(core::LocOffsets loc, ExpressionPtr body, ExpressionPtr arg1) {
         MethodDef::ARGS_store args;
         args.emplace_back(std::move(arg1));
         return Block(loc, std::move(body), std::move(args));
@@ -34,89 +34,89 @@ public:
         return store;
     }
 
-    static TreePtr Send(core::LocOffsets loc, TreePtr recv, core::NameRef fun, u2 numPosArgs, Send::ARGS_store args,
-                        Send::Flags flags = {}, TreePtr blk = nullptr) {
+    static ExpressionPtr Send(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, u2 numPosArgs, Send::ARGS_store args,
+                        Send::Flags flags = {}, ExpressionPtr blk = nullptr) {
         auto send = make_tree<ast::Send>(loc, std::move(recv), fun, numPosArgs, std::move(args), std::move(blk), flags);
         return send;
     }
 
-    static TreePtr Send0(core::LocOffsets loc, TreePtr recv, core::NameRef fun) {
+    static ExpressionPtr Send0(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun) {
         Send::ARGS_store nargs;
         return Send(loc, std::move(recv), fun, 0, std::move(nargs));
     }
 
-    static TreePtr Send0Block(core::LocOffsets loc, TreePtr recv, core::NameRef fun, TreePtr blk) {
+    static ExpressionPtr Send0Block(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, ExpressionPtr blk) {
         Send::ARGS_store nargs;
         return Send(loc, std::move(recv), fun, 0, std::move(nargs), {}, std::move(blk));
     }
 
-    static TreePtr Send1(core::LocOffsets loc, TreePtr recv, core::NameRef fun, TreePtr arg1) {
+    static ExpressionPtr Send1(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, ExpressionPtr arg1) {
         return Send(loc, std::move(recv), fun, 1, SendArgs(std::move(arg1)));
     }
 
-    static TreePtr Send2(core::LocOffsets loc, TreePtr recv, core::NameRef fun, TreePtr arg1, TreePtr arg2) {
+    static ExpressionPtr Send2(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, ExpressionPtr arg1, ExpressionPtr arg2) {
         return Send(loc, std::move(recv), fun, 2, SendArgs(std::move(arg1), std::move(arg2)));
     }
 
-    static TreePtr Send3(core::LocOffsets loc, TreePtr recv, core::NameRef fun, TreePtr arg1, TreePtr arg2,
-                         TreePtr arg3) {
+    static ExpressionPtr Send3(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, ExpressionPtr arg1, ExpressionPtr arg2,
+                         ExpressionPtr arg3) {
         return Send(loc, std::move(recv), fun, 3, SendArgs(std::move(arg1), std::move(arg2), std::move(arg3)));
     }
 
-    static TreePtr Literal(core::LocOffsets loc, const core::TypePtr &tpe) {
+    static ExpressionPtr Literal(core::LocOffsets loc, const core::TypePtr &tpe) {
         return make_tree<ast::Literal>(loc, tpe);
     }
 
-    static TreePtr Return(core::LocOffsets loc, TreePtr expr) {
+    static ExpressionPtr Return(core::LocOffsets loc, ExpressionPtr expr) {
         return make_tree<ast::Return>(loc, std::move(expr));
     }
 
-    static TreePtr Next(core::LocOffsets loc, TreePtr expr) {
+    static ExpressionPtr Next(core::LocOffsets loc, ExpressionPtr expr) {
         return make_tree<ast::Next>(loc, std::move(expr));
     }
 
-    static TreePtr Break(core::LocOffsets loc, TreePtr expr) {
+    static ExpressionPtr Break(core::LocOffsets loc, ExpressionPtr expr) {
         return make_tree<ast::Break>(loc, std::move(expr));
     }
 
-    static TreePtr Nil(core::LocOffsets loc) {
+    static ExpressionPtr Nil(core::LocOffsets loc) {
         return make_tree<ast::Literal>(loc, core::Types::nilClass());
     }
 
-    static TreePtr Constant(core::LocOffsets loc, core::SymbolRef symbol) {
+    static ExpressionPtr Constant(core::LocOffsets loc, core::SymbolRef symbol) {
         ENFORCE(symbol.exists());
         return make_tree<ConstantLit>(loc, symbol, nullptr);
     }
 
-    static TreePtr Local(core::LocOffsets loc, core::NameRef name) {
+    static ExpressionPtr Local(core::LocOffsets loc, core::NameRef name) {
         return make_tree<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Local, name);
     }
 
-    static TreePtr OptionalArg(core::LocOffsets loc, TreePtr inner, TreePtr default_) {
+    static ExpressionPtr OptionalArg(core::LocOffsets loc, ExpressionPtr inner, ExpressionPtr default_) {
         return make_tree<ast::OptionalArg>(loc, std::move(inner), std::move(default_));
     }
 
-    static TreePtr KeywordArg(core::LocOffsets loc, TreePtr inner) {
+    static ExpressionPtr KeywordArg(core::LocOffsets loc, ExpressionPtr inner) {
         return make_tree<ast::KeywordArg>(loc, std::move(inner));
     }
 
-    static TreePtr RestArg(core::LocOffsets loc, TreePtr inner) {
+    static ExpressionPtr RestArg(core::LocOffsets loc, ExpressionPtr inner) {
         return make_tree<ast::RestArg>(loc, std::move(inner));
     }
 
-    static TreePtr BlockArg(core::LocOffsets loc, TreePtr inner) {
+    static ExpressionPtr BlockArg(core::LocOffsets loc, ExpressionPtr inner) {
         return make_tree<ast::BlockArg>(loc, std::move(inner));
     }
 
-    static TreePtr ShadowArg(core::LocOffsets loc, TreePtr inner) {
+    static ExpressionPtr ShadowArg(core::LocOffsets loc, ExpressionPtr inner) {
         return make_tree<ast::ShadowArg>(loc, std::move(inner));
     }
 
-    static TreePtr Instance(core::LocOffsets loc, core::NameRef name) {
+    static ExpressionPtr Instance(core::LocOffsets loc, core::NameRef name) {
         return make_tree<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Instance, name);
     }
 
-    static TreePtr cpRef(TreePtr &name) {
+    static ExpressionPtr cpRef(ExpressionPtr &name) {
         if (auto *nm = cast_tree<UnresolvedIdent>(name)) {
             return make_tree<UnresolvedIdent>(nm->loc, nm->kind, nm->name);
         } else if (auto *nm = cast_tree<ast::Local>(name)) {
@@ -125,7 +125,7 @@ public:
         Exception::notImplemented();
     }
 
-    static TreePtr Assign(core::LocOffsets loc, TreePtr lhs, TreePtr rhs) {
+    static ExpressionPtr Assign(core::LocOffsets loc, ExpressionPtr lhs, ExpressionPtr rhs) {
         if (auto *s = cast_tree<ast::Send>(lhs)) {
             // the LHS might be a send of the form x.y=(), in which case we add the RHS to the arguments list and get
             // x.y=(rhs)
@@ -149,75 +149,75 @@ public:
         return make_tree<ast::Assign>(loc, std::move(lhs), std::move(rhs));
     }
 
-    static TreePtr Assign(core::LocOffsets loc, core::NameRef name, TreePtr rhs) {
+    static ExpressionPtr Assign(core::LocOffsets loc, core::NameRef name, ExpressionPtr rhs) {
         return Assign(loc, Local(loc, name), std::move(rhs));
     }
 
-    static TreePtr If(core::LocOffsets loc, TreePtr cond, TreePtr thenp, TreePtr elsep) {
+    static ExpressionPtr If(core::LocOffsets loc, ExpressionPtr cond, ExpressionPtr thenp, ExpressionPtr elsep) {
         return make_tree<ast::If>(loc, std::move(cond), std::move(thenp), std::move(elsep));
     }
 
-    static TreePtr While(core::LocOffsets loc, TreePtr cond, TreePtr body) {
+    static ExpressionPtr While(core::LocOffsets loc, ExpressionPtr cond, ExpressionPtr body) {
         return make_tree<ast::While>(loc, std::move(cond), std::move(body));
     }
 
-    static TreePtr Self(core::LocOffsets loc) {
+    static ExpressionPtr Self(core::LocOffsets loc) {
         return make_tree<ast::Local>(loc, core::LocalVariable::selfVariable());
     }
 
-    static TreePtr InsSeq(core::LocOffsets loc, InsSeq::STATS_store stats, TreePtr expr) {
+    static ExpressionPtr InsSeq(core::LocOffsets loc, InsSeq::STATS_store stats, ExpressionPtr expr) {
         if (!stats.empty()) {
             return make_tree<ast::InsSeq>(loc, std::move(stats), std::move(expr));
         }
         return expr;
     }
 
-    static TreePtr Splat(core::LocOffsets loc, TreePtr arg) {
+    static ExpressionPtr Splat(core::LocOffsets loc, ExpressionPtr arg) {
         auto to_a = Send0(loc, std::move(arg), core::Names::toA());
         return Send1(loc, Constant(loc, core::Symbols::Magic()), core::Names::splat(), std::move(to_a));
     }
 
-    static TreePtr CallWithSplat(core::LocOffsets loc, TreePtr recv, core::NameRef name, TreePtr args) {
+    static ExpressionPtr CallWithSplat(core::LocOffsets loc, ExpressionPtr recv, core::NameRef name, ExpressionPtr args) {
         return Send3(loc, Constant(loc, core::Symbols::Magic()), core::Names::callWithSplat(), std::move(recv),
                      MK::Symbol(loc, name), std::move(args));
     }
 
-    static TreePtr InsSeq1(core::LocOffsets loc, TreePtr stat, TreePtr expr) {
+    static ExpressionPtr InsSeq1(core::LocOffsets loc, ExpressionPtr stat, ExpressionPtr expr) {
         InsSeq::STATS_store stats;
         stats.emplace_back(std::move(stat));
         return InsSeq(loc, std::move(stats), std::move(expr));
     }
 
-    static TreePtr True(core::LocOffsets loc) {
+    static ExpressionPtr True(core::LocOffsets loc) {
         return make_tree<ast::Literal>(loc, core::Types::trueClass());
     }
 
-    static TreePtr False(core::LocOffsets loc) {
+    static ExpressionPtr False(core::LocOffsets loc) {
         return make_tree<ast::Literal>(loc, core::Types::falseClass());
     }
 
-    static TreePtr UnresolvedConstant(core::LocOffsets loc, TreePtr scope, core::NameRef name) {
+    static ExpressionPtr UnresolvedConstant(core::LocOffsets loc, ExpressionPtr scope, core::NameRef name) {
         return make_tree<UnresolvedConstantLit>(loc, std::move(scope), name);
     }
 
-    static TreePtr Int(core::LocOffsets loc, int64_t val) {
+    static ExpressionPtr Int(core::LocOffsets loc, int64_t val) {
         return make_tree<ast::Literal>(loc, core::make_type<core::LiteralType>(val));
     }
 
-    static TreePtr Float(core::LocOffsets loc, double val) {
+    static ExpressionPtr Float(core::LocOffsets loc, double val) {
         return make_tree<ast::Literal>(loc, core::make_type<core::LiteralType>(val));
     }
 
-    static TreePtr Symbol(core::LocOffsets loc, core::NameRef name) {
+    static ExpressionPtr Symbol(core::LocOffsets loc, core::NameRef name) {
         return make_tree<ast::Literal>(loc, core::make_type<core::LiteralType>(core::Symbols::Symbol(), name));
     }
 
-    static TreePtr String(core::LocOffsets loc, core::NameRef value) {
+    static ExpressionPtr String(core::LocOffsets loc, core::NameRef value) {
         return make_tree<ast::Literal>(loc, core::make_type<core::LiteralType>(core::Symbols::String(), value));
     }
 
-    static TreePtr Method(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                          MethodDef::ARGS_store args, TreePtr rhs) {
+    static ExpressionPtr Method(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
+                          MethodDef::ARGS_store args, ExpressionPtr rhs) {
         if (args.empty() || (!isa_tree<ast::Local>(args.back()) && !isa_tree<ast::BlockArg>(args.back()))) {
             auto blkLoc = core::LocOffsets::none();
             args.emplace_back(make_tree<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
@@ -227,58 +227,58 @@ public:
                                     flags);
     }
 
-    static TreePtr SyntheticMethod(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                                   MethodDef::ARGS_store args, TreePtr rhs) {
+    static ExpressionPtr SyntheticMethod(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
+                                   MethodDef::ARGS_store args, ExpressionPtr rhs) {
         auto mdef = Method(loc, declLoc, name, std::move(args), std::move(rhs));
         cast_tree<MethodDef>(mdef)->flags.isRewriterSynthesized = true;
         return mdef;
     }
 
-    static TreePtr SyntheticMethod0(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name, TreePtr rhs) {
+    static ExpressionPtr SyntheticMethod0(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name, ExpressionPtr rhs) {
         MethodDef::ARGS_store args;
         return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs));
     }
 
-    static TreePtr SyntheticMethod1(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name, TreePtr arg0,
-                                    TreePtr rhs) {
+    static ExpressionPtr SyntheticMethod1(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name, ExpressionPtr arg0,
+                                    ExpressionPtr rhs) {
         MethodDef::ARGS_store args;
         args.emplace_back(std::move(arg0));
         return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs));
     }
 
-    static TreePtr ClassOrModule(core::LocOffsets loc, core::LocOffsets declLoc, TreePtr name,
+    static ExpressionPtr ClassOrModule(core::LocOffsets loc, core::LocOffsets declLoc, ExpressionPtr name,
                                  ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs, ClassDef::Kind kind) {
         return make_tree<ClassDef>(loc, declLoc, core::Symbols::todo(), std::move(name), std::move(ancestors),
                                    std::move(rhs), kind);
     }
 
-    static TreePtr Class(core::LocOffsets loc, core::LocOffsets declLoc, TreePtr name,
+    static ExpressionPtr Class(core::LocOffsets loc, core::LocOffsets declLoc, ExpressionPtr name,
                          ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs) {
         return MK::ClassOrModule(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
                                  ClassDef::Kind::Class);
     }
 
-    static TreePtr Module(core::LocOffsets loc, core::LocOffsets declLoc, TreePtr name,
+    static ExpressionPtr Module(core::LocOffsets loc, core::LocOffsets declLoc, ExpressionPtr name,
                           ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs) {
         return MK::ClassOrModule(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
                                  ClassDef::Kind::Module);
     }
 
-    static TreePtr Array(core::LocOffsets loc, Array::ENTRY_store entries) {
+    static ExpressionPtr Array(core::LocOffsets loc, Array::ENTRY_store entries) {
         return make_tree<ast::Array>(loc, std::move(entries));
     }
 
-    static TreePtr Hash(core::LocOffsets loc, Hash::ENTRY_store keys, Hash::ENTRY_store values) {
+    static ExpressionPtr Hash(core::LocOffsets loc, Hash::ENTRY_store keys, Hash::ENTRY_store values) {
         return make_tree<ast::Hash>(loc, std::move(keys), std::move(values));
     }
 
-    static TreePtr Hash0(core::LocOffsets loc) {
+    static ExpressionPtr Hash0(core::LocOffsets loc) {
         Hash::ENTRY_store keys;
         Hash::ENTRY_store values;
         return Hash(loc, std::move(keys), std::move(values));
     }
 
-    static TreePtr Hash1(core::LocOffsets loc, TreePtr key, TreePtr value) {
+    static ExpressionPtr Hash1(core::LocOffsets loc, ExpressionPtr key, ExpressionPtr value) {
         Hash::ENTRY_store keys;
         Hash::ENTRY_store values;
         keys.emplace_back(std::move(key));
@@ -287,7 +287,7 @@ public:
     }
 
 private:
-    static TreePtr Params(core::LocOffsets loc, TreePtr recv, Send::ARGS_store args) {
+    static ExpressionPtr Params(core::LocOffsets loc, ExpressionPtr recv, Send::ARGS_store args) {
         ENFORCE(args.size() % 2 == 0, "Sig params must be arg name/type pairs");
 
         if (args.size() > 0) {
@@ -298,7 +298,7 @@ private:
     }
 
 public:
-    static TreePtr Sig(core::LocOffsets loc, Send::ARGS_store args, TreePtr ret) {
+    static ExpressionPtr Sig(core::LocOffsets loc, Send::ARGS_store args, ExpressionPtr ret) {
         auto params = Params(loc, Self(loc), std::move(args));
         auto returns = Send1(loc, std::move(params), core::Names::returns(), std::move(ret));
         auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(),
@@ -309,7 +309,7 @@ public:
         return sig;
     }
 
-    static TreePtr SigVoid(core::LocOffsets loc, Send::ARGS_store args) {
+    static ExpressionPtr SigVoid(core::LocOffsets loc, Send::ARGS_store args) {
         auto params = Params(loc, Self(loc), std::move(args));
         auto void_ = Send0(loc, std::move(params), core::Names::void_());
         auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(),
@@ -320,7 +320,7 @@ public:
         return sig;
     }
 
-    static TreePtr Sig0(core::LocOffsets loc, TreePtr ret) {
+    static ExpressionPtr Sig0(core::LocOffsets loc, ExpressionPtr ret) {
         auto returns = Send1(loc, Self(loc), core::Names::returns(), std::move(ret));
         auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(),
                          Constant(loc, core::Symbols::T_Sig_WithoutRuntime()));
@@ -330,62 +330,62 @@ public:
         return sig;
     }
 
-    static TreePtr Sig1(core::LocOffsets loc, TreePtr key, TreePtr value, TreePtr ret) {
+    static ExpressionPtr Sig1(core::LocOffsets loc, ExpressionPtr key, ExpressionPtr value, ExpressionPtr ret) {
         return Sig(loc, SendArgs(std::move(key), std::move(value)), std::move(ret));
     }
 
-    static TreePtr T(core::LocOffsets loc) {
+    static ExpressionPtr T(core::LocOffsets loc) {
         return Constant(loc, core::Symbols::T());
     }
 
-    static TreePtr Let(core::LocOffsets loc, TreePtr value, TreePtr type) {
+    static ExpressionPtr Let(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
         return Send2(loc, T(loc), core::Names::let(), std::move(value), std::move(type));
     }
 
-    static TreePtr AssertType(core::LocOffsets loc, TreePtr value, TreePtr type) {
+    static ExpressionPtr AssertType(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
         return Send2(loc, T(loc), core::Names::assertType(), std::move(value), std::move(type));
     }
 
-    static TreePtr Unsafe(core::LocOffsets loc, TreePtr inner) {
+    static ExpressionPtr Unsafe(core::LocOffsets loc, ExpressionPtr inner) {
         return Send1(loc, T(loc), core::Names::unsafe(), std::move(inner));
     }
 
-    static TreePtr Untyped(core::LocOffsets loc) {
+    static ExpressionPtr Untyped(core::LocOffsets loc) {
         return Send0(loc, T(loc), core::Names::untyped());
     }
 
-    static TreePtr UntypedNil(core::LocOffsets loc) {
+    static ExpressionPtr UntypedNil(core::LocOffsets loc) {
         return Unsafe(loc, Nil(loc));
     }
 
-    static TreePtr Nilable(core::LocOffsets loc, TreePtr arg) {
+    static ExpressionPtr Nilable(core::LocOffsets loc, ExpressionPtr arg) {
         return Send1(loc, T(loc), core::Names::nilable(), std::move(arg));
     }
 
-    static TreePtr KeepForIDE(TreePtr arg) {
+    static ExpressionPtr KeepForIDE(ExpressionPtr arg) {
         auto loc = core::LocOffsets::none();
         return Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::keepForIde(),
                      std::move(arg));
     }
 
-    static TreePtr KeepForTypechecking(TreePtr arg) {
+    static ExpressionPtr KeepForTypechecking(ExpressionPtr arg) {
         auto loc = core::LocOffsets::none();
         return Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::keepForTypechecking(),
                      std::move(arg));
     }
 
-    static TreePtr ZSuper(core::LocOffsets loc) {
+    static ExpressionPtr ZSuper(core::LocOffsets loc) {
         return Send1(loc, Self(loc), core::Names::super(), make_tree<ast::ZSuperArgs>(loc));
     }
 
-    static TreePtr SelfNew(core::LocOffsets loc, int numPosArgs, ast::Send::ARGS_store args, Send::Flags flags = {},
-                           TreePtr block = nullptr) {
+    static ExpressionPtr SelfNew(core::LocOffsets loc, int numPosArgs, ast::Send::ARGS_store args, Send::Flags flags = {},
+                           ExpressionPtr block = nullptr) {
         auto magic = Constant(loc, core::Symbols::Magic());
         return Send(loc, std::move(magic), core::Names::selfNew(), numPosArgs, std::move(args), flags,
                     std::move(block));
     }
 
-    static TreePtr DefineTopClassOrModule(core::LocOffsets loc, core::ClassOrModuleRef klass) {
+    static ExpressionPtr DefineTopClassOrModule(core::LocOffsets loc, core::ClassOrModuleRef klass) {
         auto magic = Constant(loc, core::Symbols::Magic());
         Send::Flags flags;
         flags.isRewriterSynthesized = true;
@@ -394,7 +394,7 @@ public:
                     core::Names::defineTopClassOrModule(), 1, SendArgs(Constant(loc, klass)), flags);
     }
 
-    static TreePtr RaiseUnimplemented(core::LocOffsets loc) {
+    static ExpressionPtr RaiseUnimplemented(core::LocOffsets loc) {
         auto kernel = Constant(loc, core::Symbols::Kernel());
         auto msg = String(loc, core::Names::rewriterRaiseUnimplemented());
         // T.unsafe so that Sorbet doesn't know this unconditionally raises (avoids introducing dead code errors)
@@ -403,7 +403,7 @@ public:
         return ret;
     }
 
-    static bool isRootScope(const ast::TreePtr &scope) {
+    static bool isRootScope(const ast::ExpressionPtr &scope) {
         if (ast::isa_tree<ast::EmptyTree>(scope)) {
             return true;
         }
@@ -411,7 +411,7 @@ public:
         return root != nullptr && root->symbol == core::Symbols::root();
     }
 
-    static bool isMagicClass(TreePtr &expr) {
+    static bool isMagicClass(ExpressionPtr &expr) {
         if (auto *recv = cast_tree<ConstantLit>(expr)) {
             return recv->symbol == core::Symbols::Magic();
         } else {
@@ -427,7 +427,7 @@ public:
         return isMagicClass(send->recv);
     }
 
-    static ast::Local const *arg2Local(const ast::TreePtr &arg) {
+    static ast::Local const *arg2Local(const ast::ExpressionPtr &arg) {
         auto *cursor = &arg;
         while (true) {
             if (auto *local = ast::cast_tree<ast::Local>(*cursor)) {
@@ -444,7 +444,7 @@ public:
                 [&](const class ShadowArg &shadow) { cursor = &shadow.expr; },
                 // ENFORCES are last so that we don't pay the price of casting in the fast path.
                 [&](const UnresolvedIdent &opt) { ENFORCE(false, "Namer should have created a Local for this arg."); },
-                [&](const TreePtr &expr) { ENFORCE(false, "Unexpected node type in argument position."); });
+                [&](const ExpressionPtr &expr) { ENFORCE(false, "Unexpected node type in argument position."); });
         }
     }
 };
@@ -452,7 +452,7 @@ public:
 class BehaviorHelpers final {
 public:
     // Recursively check if all children of an expression are EmptyTree's or InsSeq's that only contain EmptyTree's
-    static bool checkEmptyDeep(const TreePtr &);
+    static bool checkEmptyDeep(const ExpressionPtr &);
 
     // Does a class/module definition define "behavior"? A class definition that only serves as a
     // namespace for inner-definitions is not considered to have behavior.
@@ -463,7 +463,7 @@ public:
     //     def m; end <-- Behavior in A::B
     //   end
     // end
-    static bool checkClassDefinesBehavior(const TreePtr &);
+    static bool checkClassDefinesBehavior(const ExpressionPtr &);
     static bool checkClassDefinesBehavior(const ast::ClassDef &);
 };
 

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -7,7 +7,7 @@ namespace sorbet::ast {
 
 namespace {
 
-TreePtr deepCopy(const void *avoid, const TreePtr &tree, bool root = false);
+ExpressionPtr deepCopy(const void *avoid, const ExpressionPtr &tree, bool root = false);
 
 template <class T> T deepCopyVec(const void *avoid, const T &origin) {
     T copy;
@@ -20,7 +20,7 @@ template <class T> T deepCopyVec(const void *avoid, const T &origin) {
 
 class DeepCopyError {};
 
-TreePtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool root) {
+ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool root) {
     if (!root && tree == avoid) {
         throw DeepCopyError();
     }
@@ -159,7 +159,7 @@ TreePtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool root) 
 
         case Tag::ConstantLit: {
             auto *exp = reinterpret_cast<const ConstantLit *>(tree);
-            TreePtr originalC;
+            ExpressionPtr originalC;
             if (exp->original) {
                 originalC = deepCopy(avoid, exp->original);
             }
@@ -183,7 +183,7 @@ TreePtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool root) 
     }
 }
 
-TreePtr deepCopy(const void *avoid, const TreePtr &tree, bool root) {
+ExpressionPtr deepCopy(const void *avoid, const ExpressionPtr &tree, bool root) {
     ENFORCE(tree != nullptr);
 
     return deepCopy(avoid, tree.tag(), tree.get(), root);
@@ -191,7 +191,7 @@ TreePtr deepCopy(const void *avoid, const TreePtr &tree, bool root) {
 
 } // namespace
 
-TreePtr TreePtr::deepCopy() const {
+ExpressionPtr ExpressionPtr::deepCopy() const {
     try {
         return sorbet::ast::deepCopy(get(), tag(), get(), true);
     } catch (DeepCopyError &e) {
@@ -200,7 +200,7 @@ TreePtr TreePtr::deepCopy() const {
 }
 
 #define COPY_IMPL(name)                                                             \
-    TreePtr name::deepCopy() const {                                                \
+    ExpressionPtr name::deepCopy() const {                                                \
         try {                                                                       \
             return sorbet::ast::deepCopy(this, TreeToTag<name>::value, this, true); \
         } catch (DeepCopyError & e) {                                               \

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -32,26 +32,27 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
         case Tag::Send: {
             auto *exp = reinterpret_cast<const Send *>(tree);
             return make_expression<Send>(exp->loc, deepCopy(avoid, exp->recv), exp->fun, exp->numPosArgs,
-                                   deepCopyVec(avoid, exp->args),
-                                   exp->block == nullptr ? nullptr : deepCopy(avoid, exp->block), exp->flags);
+                                         deepCopyVec(avoid, exp->args),
+                                         exp->block == nullptr ? nullptr : deepCopy(avoid, exp->block), exp->flags);
         }
 
         case Tag::ClassDef: {
             auto *exp = reinterpret_cast<const ClassDef *>(tree);
             return make_expression<ClassDef>(exp->loc, exp->declLoc, exp->symbol, deepCopy(avoid, exp->name),
-                                       deepCopyVec(avoid, exp->ancestors), deepCopyVec(avoid, exp->rhs), exp->kind);
+                                             deepCopyVec(avoid, exp->ancestors), deepCopyVec(avoid, exp->rhs),
+                                             exp->kind);
         }
 
         case Tag::MethodDef: {
             auto *exp = reinterpret_cast<const MethodDef *>(tree);
-            return make_expression<MethodDef>(exp->loc, exp->declLoc, exp->symbol, exp->name, deepCopyVec(avoid, exp->args),
-                                        deepCopy(avoid, exp->rhs), exp->flags);
+            return make_expression<MethodDef>(exp->loc, exp->declLoc, exp->symbol, exp->name,
+                                              deepCopyVec(avoid, exp->args), deepCopy(avoid, exp->rhs), exp->flags);
         }
 
         case Tag::If: {
             auto *exp = reinterpret_cast<const If *>(tree);
             return make_expression<If>(exp->loc, deepCopy(avoid, exp->cond), deepCopy(avoid, exp->thenp),
-                                 deepCopy(avoid, exp->elsep));
+                                       deepCopy(avoid, exp->elsep));
         }
 
         case Tag::While: {
@@ -82,14 +83,14 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
         case Tag::RescueCase: {
             auto *exp = reinterpret_cast<const RescueCase *>(tree);
             return make_expression<RescueCase>(exp->loc, deepCopyVec(avoid, exp->exceptions), deepCopy(avoid, exp->var),
-                                         deepCopy(avoid, exp->body));
+                                               deepCopy(avoid, exp->body));
         }
 
         case Tag::Rescue: {
             auto *exp = reinterpret_cast<const Rescue *>(tree);
             return make_expression<Rescue>(exp->loc, deepCopy(avoid, exp->body),
-                                     deepCopyVec<Rescue::RESCUE_CASE_store>(avoid, exp->rescueCases),
-                                     deepCopy(avoid, exp->else_), deepCopy(avoid, exp->ensure));
+                                           deepCopyVec<Rescue::RESCUE_CASE_store>(avoid, exp->rescueCases),
+                                           deepCopy(avoid, exp->else_), deepCopy(avoid, exp->ensure));
         }
 
         case Tag::Local: {
@@ -199,13 +200,13 @@ ExpressionPtr ExpressionPtr::deepCopy() const {
     }
 }
 
-#define COPY_IMPL(name)                                                             \
-    ExpressionPtr name::deepCopy() const {                                          \
-        try {                                                                       \
+#define COPY_IMPL(name)                                                                   \
+    ExpressionPtr name::deepCopy() const {                                                \
+        try {                                                                             \
             return sorbet::ast::deepCopy(this, ExpressionToTag<name>::value, this, true); \
-        } catch (DeepCopyError & e) {                                               \
-            return nullptr;                                                         \
-        }                                                                           \
+        } catch (DeepCopyError & e) {                                                     \
+            return nullptr;                                                               \
+        }                                                                                 \
     }
 
 COPY_IMPL(EmptyTree);

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -200,7 +200,7 @@ ExpressionPtr ExpressionPtr::deepCopy() const {
 }
 
 #define COPY_IMPL(name)                                                             \
-    ExpressionPtr name::deepCopy() const {                                                \
+    ExpressionPtr name::deepCopy() const {                                          \
         try {                                                                       \
             return sorbet::ast::deepCopy(this, TreeToTag<name>::value, this, true); \
         } catch (DeepCopyError & e) {                                               \

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -202,7 +202,7 @@ ExpressionPtr ExpressionPtr::deepCopy() const {
 #define COPY_IMPL(name)                                                             \
     ExpressionPtr name::deepCopy() const {                                          \
         try {                                                                       \
-            return sorbet::ast::deepCopy(this, TreeToTag<name>::value, this, true); \
+            return sorbet::ast::deepCopy(this, ExpressionToTag<name>::value, this, true); \
         } catch (DeepCopyError & e) {                                               \
             return nullptr;                                                         \
         }                                                                           \

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -27,134 +27,134 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
 
     switch (tag) {
         case Tag::EmptyTree:
-            return make_tree<EmptyTree>();
+            return make_expression<EmptyTree>();
 
         case Tag::Send: {
             auto *exp = reinterpret_cast<const Send *>(tree);
-            return make_tree<Send>(exp->loc, deepCopy(avoid, exp->recv), exp->fun, exp->numPosArgs,
+            return make_expression<Send>(exp->loc, deepCopy(avoid, exp->recv), exp->fun, exp->numPosArgs,
                                    deepCopyVec(avoid, exp->args),
                                    exp->block == nullptr ? nullptr : deepCopy(avoid, exp->block), exp->flags);
         }
 
         case Tag::ClassDef: {
             auto *exp = reinterpret_cast<const ClassDef *>(tree);
-            return make_tree<ClassDef>(exp->loc, exp->declLoc, exp->symbol, deepCopy(avoid, exp->name),
+            return make_expression<ClassDef>(exp->loc, exp->declLoc, exp->symbol, deepCopy(avoid, exp->name),
                                        deepCopyVec(avoid, exp->ancestors), deepCopyVec(avoid, exp->rhs), exp->kind);
         }
 
         case Tag::MethodDef: {
             auto *exp = reinterpret_cast<const MethodDef *>(tree);
-            return make_tree<MethodDef>(exp->loc, exp->declLoc, exp->symbol, exp->name, deepCopyVec(avoid, exp->args),
+            return make_expression<MethodDef>(exp->loc, exp->declLoc, exp->symbol, exp->name, deepCopyVec(avoid, exp->args),
                                         deepCopy(avoid, exp->rhs), exp->flags);
         }
 
         case Tag::If: {
             auto *exp = reinterpret_cast<const If *>(tree);
-            return make_tree<If>(exp->loc, deepCopy(avoid, exp->cond), deepCopy(avoid, exp->thenp),
+            return make_expression<If>(exp->loc, deepCopy(avoid, exp->cond), deepCopy(avoid, exp->thenp),
                                  deepCopy(avoid, exp->elsep));
         }
 
         case Tag::While: {
             auto *exp = reinterpret_cast<const While *>(tree);
-            return make_tree<While>(exp->loc, deepCopy(avoid, exp->cond), deepCopy(avoid, exp->body));
+            return make_expression<While>(exp->loc, deepCopy(avoid, exp->cond), deepCopy(avoid, exp->body));
         }
 
         case Tag::Break: {
             auto *exp = reinterpret_cast<const Break *>(tree);
-            return make_tree<Break>(exp->loc, deepCopy(avoid, exp->expr));
+            return make_expression<Break>(exp->loc, deepCopy(avoid, exp->expr));
         }
 
         case Tag::Retry: {
             auto *exp = reinterpret_cast<const Retry *>(tree);
-            return make_tree<Retry>(exp->loc);
+            return make_expression<Retry>(exp->loc);
         }
 
         case Tag::Next: {
             auto *exp = reinterpret_cast<const Next *>(tree);
-            return make_tree<Next>(exp->loc, deepCopy(avoid, exp->expr));
+            return make_expression<Next>(exp->loc, deepCopy(avoid, exp->expr));
         }
 
         case Tag::Return: {
             auto *exp = reinterpret_cast<const Return *>(tree);
-            return make_tree<Return>(exp->loc, deepCopy(avoid, exp->expr));
+            return make_expression<Return>(exp->loc, deepCopy(avoid, exp->expr));
         }
 
         case Tag::RescueCase: {
             auto *exp = reinterpret_cast<const RescueCase *>(tree);
-            return make_tree<RescueCase>(exp->loc, deepCopyVec(avoid, exp->exceptions), deepCopy(avoid, exp->var),
+            return make_expression<RescueCase>(exp->loc, deepCopyVec(avoid, exp->exceptions), deepCopy(avoid, exp->var),
                                          deepCopy(avoid, exp->body));
         }
 
         case Tag::Rescue: {
             auto *exp = reinterpret_cast<const Rescue *>(tree);
-            return make_tree<Rescue>(exp->loc, deepCopy(avoid, exp->body),
+            return make_expression<Rescue>(exp->loc, deepCopy(avoid, exp->body),
                                      deepCopyVec<Rescue::RESCUE_CASE_store>(avoid, exp->rescueCases),
                                      deepCopy(avoid, exp->else_), deepCopy(avoid, exp->ensure));
         }
 
         case Tag::Local: {
             auto *exp = reinterpret_cast<const Local *>(tree);
-            return make_tree<Local>(exp->loc, exp->localVariable);
+            return make_expression<Local>(exp->loc, exp->localVariable);
         }
 
         case Tag::UnresolvedIdent: {
             auto *exp = reinterpret_cast<const UnresolvedIdent *>(tree);
-            return make_tree<UnresolvedIdent>(exp->loc, exp->kind, exp->name);
+            return make_expression<UnresolvedIdent>(exp->loc, exp->kind, exp->name);
         }
 
         case Tag::RestArg: {
             auto *exp = reinterpret_cast<const RestArg *>(tree);
-            return make_tree<RestArg>(exp->loc, deepCopy(avoid, exp->expr));
+            return make_expression<RestArg>(exp->loc, deepCopy(avoid, exp->expr));
         }
 
         case Tag::KeywordArg: {
             auto *exp = reinterpret_cast<const KeywordArg *>(tree);
-            return make_tree<KeywordArg>(exp->loc, deepCopy(avoid, exp->expr));
+            return make_expression<KeywordArg>(exp->loc, deepCopy(avoid, exp->expr));
         }
 
         case Tag::OptionalArg: {
             auto *exp = reinterpret_cast<const OptionalArg *>(tree);
-            return make_tree<OptionalArg>(exp->loc, deepCopy(avoid, exp->expr), deepCopy(avoid, exp->default_));
+            return make_expression<OptionalArg>(exp->loc, deepCopy(avoid, exp->expr), deepCopy(avoid, exp->default_));
         }
 
         case Tag::BlockArg: {
             auto *exp = reinterpret_cast<const BlockArg *>(tree);
-            return make_tree<BlockArg>(exp->loc, deepCopy(avoid, exp->expr));
+            return make_expression<BlockArg>(exp->loc, deepCopy(avoid, exp->expr));
         }
 
         case Tag::ShadowArg: {
             auto *exp = reinterpret_cast<const ShadowArg *>(tree);
-            return make_tree<ShadowArg>(exp->loc, deepCopy(avoid, exp->expr));
+            return make_expression<ShadowArg>(exp->loc, deepCopy(avoid, exp->expr));
         }
 
         case Tag::Assign: {
             auto *exp = reinterpret_cast<const Assign *>(tree);
-            return make_tree<Assign>(exp->loc, deepCopy(avoid, exp->lhs), deepCopy(avoid, exp->rhs));
+            return make_expression<Assign>(exp->loc, deepCopy(avoid, exp->lhs), deepCopy(avoid, exp->rhs));
         }
 
         case Tag::Cast: {
             auto *exp = reinterpret_cast<const Cast *>(tree);
-            return make_tree<Cast>(exp->loc, exp->type, deepCopy(avoid, exp->arg), exp->cast);
+            return make_expression<Cast>(exp->loc, exp->type, deepCopy(avoid, exp->arg), exp->cast);
         }
 
         case Tag::Hash: {
             auto *exp = reinterpret_cast<const Hash *>(tree);
-            return make_tree<Hash>(exp->loc, deepCopyVec(avoid, exp->keys), deepCopyVec(avoid, exp->values));
+            return make_expression<Hash>(exp->loc, deepCopyVec(avoid, exp->keys), deepCopyVec(avoid, exp->values));
         }
 
         case Tag::Array: {
             auto *exp = reinterpret_cast<const Array *>(tree);
-            return make_tree<Array>(exp->loc, deepCopyVec(avoid, exp->elems));
+            return make_expression<Array>(exp->loc, deepCopyVec(avoid, exp->elems));
         }
 
         case Tag::Literal: {
             auto *exp = reinterpret_cast<const Literal *>(tree);
-            return make_tree<Literal>(exp->loc, exp->value);
+            return make_expression<Literal>(exp->loc, exp->value);
         }
 
         case Tag::UnresolvedConstantLit: {
             auto *exp = reinterpret_cast<const UnresolvedConstantLit *>(tree);
-            return make_tree<UnresolvedConstantLit>(exp->loc, deepCopy(avoid, exp->scope), exp->cnst);
+            return make_expression<UnresolvedConstantLit>(exp->loc, deepCopy(avoid, exp->scope), exp->cnst);
         }
 
         case Tag::ConstantLit: {
@@ -163,22 +163,22 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
             if (exp->original) {
                 originalC = deepCopy(avoid, exp->original);
             }
-            return make_tree<ConstantLit>(exp->loc, exp->symbol, move(originalC));
+            return make_expression<ConstantLit>(exp->loc, exp->symbol, move(originalC));
         }
 
         case Tag::ZSuperArgs: {
             auto *exp = reinterpret_cast<const ZSuperArgs *>(tree);
-            return make_tree<ZSuperArgs>(exp->loc);
+            return make_expression<ZSuperArgs>(exp->loc);
         }
 
         case Tag::Block: {
             auto *exp = reinterpret_cast<const Block *>(tree);
-            return make_tree<Block>(exp->loc, deepCopyVec(avoid, exp->args), deepCopy(avoid, exp->body));
+            return make_expression<Block>(exp->loc, deepCopyVec(avoid, exp->args), deepCopy(avoid, exp->body));
         }
 
         case Tag::InsSeq: {
             auto *exp = reinterpret_cast<const InsSeq *>(tree);
-            return make_tree<InsSeq>(exp->loc, deepCopyVec(avoid, exp->stats), deepCopy(avoid, exp->expr));
+            return make_expression<InsSeq>(exp->loc, deepCopyVec(avoid, exp->stats), deepCopy(avoid, exp->expr));
         }
     }
 }

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -5,7 +5,7 @@ using namespace std;
 
 namespace sorbet::ast {
 
-void TreePtr::_sanityCheck() const {
+void ExpressionPtr::_sanityCheck() const {
     auto *ptr = get();
     ENFORCE(ptr != nullptr);
 

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -232,7 +232,8 @@ RescueCase::RescueCase(core::LocOffsets loc, EXCEPTION_store exceptions, Express
     _sanityCheck();
 }
 
-Rescue::Rescue(core::LocOffsets loc, ExpressionPtr body, RESCUE_CASE_store rescueCases, ExpressionPtr else_, ExpressionPtr ensure)
+Rescue::Rescue(core::LocOffsets loc, ExpressionPtr body, RESCUE_CASE_store rescueCases, ExpressionPtr else_,
+               ExpressionPtr ensure)
     : loc(loc), body(std::move(body)), rescueCases(std::move(rescueCases)), else_(std::move(else_)),
       ensure(std::move(ensure)) {
     categoryCounterInc("trees", "rescue");
@@ -252,13 +253,14 @@ UnresolvedIdent::UnresolvedIdent(core::LocOffsets loc, Kind kind, core::NameRef 
     _sanityCheck();
 }
 
-Assign::Assign(core::LocOffsets loc, ExpressionPtr lhs, ExpressionPtr rhs) : loc(loc), lhs(std::move(lhs)), rhs(std::move(rhs)) {
+Assign::Assign(core::LocOffsets loc, ExpressionPtr lhs, ExpressionPtr rhs)
+    : loc(loc), lhs(std::move(lhs)), rhs(std::move(rhs)) {
     categoryCounterInc("trees", "assign");
     _sanityCheck();
 }
 
-Send::Send(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, u2 numPosArgs, Send::ARGS_store args, ExpressionPtr block,
-           Flags flags)
+Send::Send(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, u2 numPosArgs, Send::ARGS_store args,
+           ExpressionPtr block, Flags flags)
     : loc(loc), fun(fun), flags(flags), numPosArgs(numPosArgs), recv(std::move(recv)), args(std::move(args)),
       block(std::move(block)) {
     categoryCounterInc("trees", "send");

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -389,7 +389,7 @@ EmptyTree singletonEmptyTree{};
 
 } // namespace
 
-template <> ExpressionPtr make_tree<EmptyTree>() {
+template <> ExpressionPtr make_expression<EmptyTree>() {
     ExpressionPtr result = nullptr;
     result.reset(&singletonEmptyTree);
     return result;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -217,6 +217,8 @@ public:
         return toStringWithTabs(gs);
     }
 };
+// TODO(jez) Remove this once this lands on master (prevent merge races)
+using TreePtr = ExpressionPtr;
 
 template <class E, typename... Args> ExpressionPtr make_expression(Args &&... args) {
     return ExpressionPtr(ExpressionToTag<E>::value, new E(std::forward<Args>(args)...));

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -61,7 +61,7 @@ enum class Tag {
 };
 
 // A mapping from tree type to its corresponding tag.
-template <typename T> struct TreeToTag;
+template <typename T> struct ExpressionToTag;
 
 class ExpressionPtr {
 public:
@@ -166,7 +166,7 @@ public:
     }
 
     template <typename T> void reset(T *expr = nullptr) noexcept {
-        resetTagged(tagPtr(TreeToTag<T>::value, expr));
+        resetTagged(tagPtr(ExpressionToTag<T>::value, expr));
     }
 
     Tag tag() const noexcept {
@@ -219,7 +219,7 @@ public:
 };
 
 template <class E, typename... Args> ExpressionPtr make_tree(Args &&... args) {
-    return ExpressionPtr(TreeToTag<E>::value, new E(std::forward<Args>(args)...));
+    return ExpressionPtr(ExpressionToTag<E>::value, new E(std::forward<Args>(args)...));
 }
 
 struct ParsedFile {
@@ -245,7 +245,7 @@ public:
 };
 
 template <class To> bool isa_tree(const ExpressionPtr &what) {
-    return what != nullptr && what.tag() == TreeToTag<To>::value;
+    return what != nullptr && what.tag() == ExpressionToTag<To>::value;
 }
 
 bool isa_reference(const ExpressionPtr &what);
@@ -306,7 +306,7 @@ template <> inline const ExpressionPtr &ExpressionPtr::cast<ExpressionPtr>(const
 
 #define TREE(name)                                                                  \
     class name;                                                                     \
-    template <> struct TreeToTag<name> { static constexpr Tag value = Tag::name; }; \
+    template <> struct ExpressionToTag<name> { static constexpr Tag value = Tag::name; }; \
     class __attribute__((aligned(8))) name final
 
 TREE(ClassDef) {

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -305,7 +305,7 @@ template <> inline const ExpressionPtr &ExpressionPtr::cast<ExpressionPtr>(const
 }
 
 #define EXPRESSION(name)                                                                  \
-    class name;                                                                     \
+    class name;                                                                           \
     template <> struct ExpressionToTag<name> { static constexpr Tag value = Tag::name; }; \
     class __attribute__((aligned(8))) name final
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -531,7 +531,8 @@ public:
     ExpressionPtr else_;
     ExpressionPtr ensure;
 
-    Rescue(core::LocOffsets loc, ExpressionPtr body, RESCUE_CASE_store rescueCases, ExpressionPtr else_, ExpressionPtr ensure);
+    Rescue(core::LocOffsets loc, ExpressionPtr body, RESCUE_CASE_store rescueCases, ExpressionPtr else_,
+           ExpressionPtr ensure);
 
     ExpressionPtr deepCopy() const;
 
@@ -741,8 +742,8 @@ public:
 
     ExpressionPtr block; // null if no block passed
 
-    Send(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, u2 numPosArgs, ARGS_store args, ExpressionPtr block = nullptr,
-         Flags flags = {});
+    Send(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, u2 numPosArgs, ARGS_store args,
+         ExpressionPtr block = nullptr, Flags flags = {});
 
     ExpressionPtr deepCopy() const;
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -82,7 +82,7 @@ private:
 
     tagged_storage ptr;
 
-    template <typename E, typename... Args> friend ExpressionPtr make_tree(Args &&...);
+    template <typename E, typename... Args> friend ExpressionPtr make_expression(Args &&...);
 
     static tagged_storage tagPtr(Tag tag, void *expr) {
         // Store the tag in the lower 16 bits of the pointer, regardless of size.
@@ -218,7 +218,7 @@ public:
     }
 };
 
-template <class E, typename... Args> ExpressionPtr make_tree(Args &&... args) {
+template <class E, typename... Args> ExpressionPtr make_expression(Args &&... args) {
     return ExpressionPtr(ExpressionToTag<E>::value, new E(std::forward<Args>(args)...));
 }
 
@@ -983,8 +983,8 @@ public:
 };
 CheckSize(EmptyTree, 8, 8);
 
-// This specialization of make_tree exists to ensure that we only ever create one empty tree.
-template <> ExpressionPtr make_tree<EmptyTree>();
+// This specialization of make_expression exists to ensure that we only ever create one empty tree.
+template <> ExpressionPtr make_expression<EmptyTree>();
 
 /** https://git.corp.stripe.com/gist/nelhage/51564501674174da24822e60ad770f64
  *

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -304,12 +304,12 @@ template <> inline const ExpressionPtr &ExpressionPtr::cast<ExpressionPtr>(const
     return tree;
 }
 
-#define TREE(name)                                                                  \
+#define EXPRESSION(name)                                                                  \
     class name;                                                                     \
     template <> struct ExpressionToTag<name> { static constexpr Tag value = Tag::name; }; \
     class __attribute__((aligned(8))) name final
 
-TREE(ClassDef) {
+EXPRESSION(ClassDef) {
 public:
     const core::LocOffsets loc;
     core::LocOffsets declLoc;
@@ -346,7 +346,7 @@ public:
 };
 CheckSize(ClassDef, 120, 8);
 
-TREE(MethodDef) {
+EXPRESSION(MethodDef) {
 public:
     const core::LocOffsets loc;
     core::LocOffsets declLoc;
@@ -384,7 +384,7 @@ public:
 };
 CheckSize(MethodDef, 64, 8);
 
-TREE(If) {
+EXPRESSION(If) {
 public:
     const core::LocOffsets loc;
 
@@ -404,7 +404,7 @@ public:
 };
 CheckSize(If, 32, 8);
 
-TREE(While) {
+EXPRESSION(While) {
 public:
     const core::LocOffsets loc;
 
@@ -423,7 +423,7 @@ public:
 };
 CheckSize(While, 24, 8);
 
-TREE(Break) {
+EXPRESSION(Break) {
 public:
     const core::LocOffsets loc;
 
@@ -441,7 +441,7 @@ public:
 };
 CheckSize(Break, 16, 8);
 
-TREE(Retry) {
+EXPRESSION(Retry) {
 public:
     const core::LocOffsets loc;
 
@@ -457,7 +457,7 @@ public:
 };
 CheckSize(Retry, 8, 8);
 
-TREE(Next) {
+EXPRESSION(Next) {
 public:
     const core::LocOffsets loc;
 
@@ -475,7 +475,7 @@ public:
 };
 CheckSize(Next, 16, 8);
 
-TREE(Return) {
+EXPRESSION(Return) {
 public:
     const core::LocOffsets loc;
 
@@ -493,7 +493,7 @@ public:
 };
 CheckSize(Return, 16, 8);
 
-TREE(RescueCase) {
+EXPRESSION(RescueCase) {
 public:
     const core::LocOffsets loc;
 
@@ -519,7 +519,7 @@ public:
 };
 CheckSize(RescueCase, 48, 8);
 
-TREE(Rescue) {
+EXPRESSION(Rescue) {
 public:
     const core::LocOffsets loc;
 
@@ -544,7 +544,7 @@ public:
 };
 CheckSize(Rescue, 56, 8);
 
-TREE(Local) {
+EXPRESSION(Local) {
 public:
     const core::LocOffsets loc;
 
@@ -562,7 +562,7 @@ public:
 };
 CheckSize(Local, 16, 8);
 
-TREE(UnresolvedIdent) {
+EXPRESSION(UnresolvedIdent) {
 public:
     const core::LocOffsets loc;
 
@@ -587,7 +587,7 @@ public:
 };
 CheckSize(UnresolvedIdent, 16, 8);
 
-TREE(RestArg) {
+EXPRESSION(RestArg) {
 public:
     const core::LocOffsets loc;
 
@@ -605,7 +605,7 @@ public:
 };
 CheckSize(RestArg, 16, 8);
 
-TREE(KeywordArg) {
+EXPRESSION(KeywordArg) {
 public:
     const core::LocOffsets loc;
 
@@ -623,7 +623,7 @@ public:
 };
 CheckSize(KeywordArg, 16, 8);
 
-TREE(OptionalArg) {
+EXPRESSION(OptionalArg) {
 public:
     const core::LocOffsets loc;
 
@@ -642,7 +642,7 @@ public:
 };
 CheckSize(OptionalArg, 24, 8);
 
-TREE(BlockArg) {
+EXPRESSION(BlockArg) {
 public:
     const core::LocOffsets loc;
 
@@ -660,7 +660,7 @@ public:
 };
 CheckSize(BlockArg, 16, 8);
 
-TREE(ShadowArg) {
+EXPRESSION(ShadowArg) {
 public:
     const core::LocOffsets loc;
 
@@ -678,7 +678,7 @@ public:
 };
 CheckSize(ShadowArg, 16, 8);
 
-TREE(Assign) {
+EXPRESSION(Assign) {
 public:
     const core::LocOffsets loc;
 
@@ -697,7 +697,7 @@ public:
 };
 CheckSize(Assign, 24, 8);
 
-TREE(Send) {
+EXPRESSION(Send) {
 public:
     const core::LocOffsets loc;
 
@@ -774,7 +774,7 @@ public:
 };
 CheckSize(Send, 56, 8);
 
-TREE(Cast) {
+EXPRESSION(Cast) {
 public:
     const core::LocOffsets loc;
 
@@ -796,7 +796,7 @@ public:
 };
 CheckSize(Cast, 40, 8);
 
-TREE(Hash) {
+EXPRESSION(Hash) {
 public:
     const core::LocOffsets loc;
 
@@ -818,7 +818,7 @@ public:
 };
 CheckSize(Hash, 56, 8);
 
-TREE(Array) {
+EXPRESSION(Array) {
 public:
     const core::LocOffsets loc;
 
@@ -839,7 +839,7 @@ public:
 };
 CheckSize(Array, 48, 8);
 
-TREE(Literal) {
+EXPRESSION(Literal) {
 public:
     const core::LocOffsets loc;
 
@@ -864,7 +864,7 @@ public:
 };
 CheckSize(Literal, 24, 8);
 
-TREE(UnresolvedConstantLit) {
+EXPRESSION(UnresolvedConstantLit) {
 public:
     const core::LocOffsets loc;
 
@@ -883,7 +883,7 @@ public:
 };
 CheckSize(UnresolvedConstantLit, 24, 8);
 
-TREE(ConstantLit) {
+EXPRESSION(ConstantLit) {
 public:
     const core::LocOffsets loc;
 
@@ -908,7 +908,7 @@ public:
 };
 CheckSize(ConstantLit, 48, 8);
 
-TREE(ZSuperArgs) {
+EXPRESSION(ZSuperArgs) {
 public:
     const core::LocOffsets loc;
 
@@ -925,7 +925,7 @@ public:
 };
 CheckSize(ZSuperArgs, 8, 8);
 
-TREE(Block) {
+EXPRESSION(Block) {
 public:
     const core::LocOffsets loc;
 
@@ -943,7 +943,7 @@ public:
 };
 CheckSize(Block, 40, 8);
 
-TREE(InsSeq) {
+EXPRESSION(InsSeq) {
 public:
     const core::LocOffsets loc;
 
@@ -967,7 +967,7 @@ public:
 };
 CheckSize(InsSeq, 56, 8);
 
-TREE(EmptyTree) {
+EXPRESSION(EmptyTree) {
 public:
     const core::LocOffsets loc;
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -128,7 +128,7 @@ pair<MethodDef::ARGS_store, InsSeq::STATS_store> desugarArgs(DesugarContext dctx
 }
 
 ExpressionPtr desugarBody(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> &bodynode,
-                    InsSeq::STATS_store destructures) {
+                          InsSeq::STATS_store destructures) {
     auto body = node2TreeImpl(dctx, std::move(bodynode));
     if (!destructures.empty()) {
         auto bodyLoc = body.loc();
@@ -142,8 +142,8 @@ ExpressionPtr desugarBody(DesugarContext dctx, core::LocOffsets loc, unique_ptr<
 }
 
 ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocOffsets blockLoc,
-                     unique_ptr<parser::Node> &blockSend, unique_ptr<parser::Node> &blockArgs,
-                     unique_ptr<parser::Node> &blockBody) {
+                           unique_ptr<parser::Node> &blockSend, unique_ptr<parser::Node> &blockArgs,
+                           unique_ptr<parser::Node> &blockBody) {
     blockSend->loc = loc;
     auto recv = node2TreeImpl(dctx, std::move(blockSend));
     Send *send;
@@ -179,7 +179,8 @@ bool isStringLit(DesugarContext dctx, ExpressionPtr &expr) {
     return (lit = cast_tree<Literal>(expr)) && lit->isString(dctx.ctx);
 }
 
-ExpressionPtr mergeStrings(DesugarContext dctx, core::LocOffsets loc, InlinedVector<ExpressionPtr, 4> stringsAccumulated) {
+ExpressionPtr mergeStrings(DesugarContext dctx, core::LocOffsets loc,
+                           InlinedVector<ExpressionPtr, 4> stringsAccumulated) {
     if (stringsAccumulated.size() == 1) {
         return move(stringsAccumulated[0]);
     } else {
@@ -298,7 +299,7 @@ ExpressionPtr validateRBIBody(DesugarContext dctx, ExpressionPtr body) {
 }
 
 ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                    unique_ptr<parser::Node> &argnode, unique_ptr<parser::Node> &body, bool isSelf) {
+                          unique_ptr<parser::Node> &argnode, unique_ptr<parser::Node> &body, bool isSelf) {
     // Reset uniqueCounter within this scope (to keep numbers small)
     u4 uniqueCounter = 1;
     DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockArg, declLoc, name);
@@ -1125,8 +1126,9 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     loc, make_unique<parser::LVar>(recvLoc, tempRecv), csend->method, std::move(csend->args));
                 auto send = node2TreeImpl(dctx, std::move(sendNode));
 
-                ExpressionPtr nil = MK::Send1(zeroLengthRecvLoc, ast::MK::Constant(zeroLengthLoc, core::Symbols::Magic()),
-                                        core::Names::nilForSafeNavigation(), MK::Local(zeroLengthRecvLoc, tempRecv));
+                ExpressionPtr nil =
+                    MK::Send1(zeroLengthRecvLoc, ast::MK::Constant(zeroLengthLoc, core::Symbols::Magic()),
+                              core::Names::nilForSafeNavigation(), MK::Local(zeroLengthRecvLoc, tempRecv));
                 auto iff = MK::If(zeroLengthLoc, std::move(cond), std::move(nil), std::move(send));
                 auto res = MK::InsSeq1(zeroLengthLoc, std::move(assgn), std::move(iff));
                 result = std::move(res);
@@ -1182,8 +1184,9 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             [&](parser::Module *module) {
                 ClassDef::RHS_store body = scopeNodeToBody(dctx, std::move(module->body));
                 ClassDef::ANCESTORS_store ancestors;
-                ExpressionPtr res = MK::Module(module->loc, module->declLoc, node2TreeImpl(dctx, std::move(module->name)),
-                                         std::move(ancestors), std::move(body));
+                ExpressionPtr res =
+                    MK::Module(module->loc, module->declLoc, node2TreeImpl(dctx, std::move(module->name)),
+                               std::move(ancestors), std::move(body));
                 result = std::move(res);
             },
             [&](parser::Class *claz) {
@@ -1195,7 +1198,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     ancestors.emplace_back(node2TreeImpl(dctx, std::move(claz->superclass)));
                 }
                 ExpressionPtr res = MK::Class(claz->loc, claz->declLoc, node2TreeImpl(dctx, std::move(claz->name)),
-                                        std::move(ancestors), std::move(body));
+                                              std::move(ancestors), std::move(body));
                 result = std::move(res);
             },
             [&](parser::Arg *arg) {
@@ -1220,12 +1223,12 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             },
             [&](parser::Kwoptarg *arg) {
                 ExpressionPtr res = MK::OptionalArg(loc, MK::KeywordArg(loc, MK::Local(arg->nameLoc, arg->name)),
-                                              node2TreeImpl(dctx, std::move(arg->default_)));
+                                                    node2TreeImpl(dctx, std::move(arg->default_)));
                 result = std::move(res);
             },
             [&](parser::Optarg *arg) {
                 ExpressionPtr res = MK::OptionalArg(loc, MK::Local(arg->nameLoc, arg->name),
-                                              node2TreeImpl(dctx, std::move(arg->default_)));
+                                                    node2TreeImpl(dctx, std::move(arg->default_)));
                 result = std::move(res);
             },
             [&](parser::Shadowarg *arg) {
@@ -1266,10 +1269,11 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
 
                 ClassDef::RHS_store body = scopeNodeToBody(dctx, std::move(sclass->body));
                 ClassDef::ANCESTORS_store emptyAncestors;
-                ExpressionPtr res = MK::Class(sclass->loc, sclass->declLoc,
-                                        make_tree<UnresolvedIdent>(sclass->expr->loc, UnresolvedIdent::Kind::Class,
-                                                                   core::Names::singleton()),
-                                        std::move(emptyAncestors), std::move(body));
+                ExpressionPtr res =
+                    MK::Class(sclass->loc, sclass->declLoc,
+                              make_tree<UnresolvedIdent>(sclass->expr->loc, UnresolvedIdent::Kind::Class,
+                                                         core::Names::singleton()),
+                              std::move(emptyAncestors), std::move(body));
                 result = std::move(res);
             },
             [&](parser::Block *block) {
@@ -1290,14 +1294,15 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 auto body = node2TreeImpl(dctx, std::move(wl->body));
                 // TODO using bang (aka !) is not semantically correct because it can be overridden by the user.
                 ExpressionPtr res = isKwbegin ? doUntil(dctx, loc, MK::Send0(loc, std::move(cond), core::Names::bang()),
-                                                  std::move(body))
-                                        : MK::While(loc, std::move(cond), std::move(body));
+                                                        std::move(body))
+                                              : MK::While(loc, std::move(cond), std::move(body));
                 result = std::move(res);
             },
             [&](parser::Until *wl) {
                 auto cond = node2TreeImpl(dctx, std::move(wl->cond));
                 auto body = node2TreeImpl(dctx, std::move(wl->body));
-                ExpressionPtr res = MK::While(loc, MK::Send0(loc, std::move(cond), core::Names::bang()), std::move(body));
+                ExpressionPtr res =
+                    MK::While(loc, MK::Send0(loc, std::move(cond), core::Names::bang()), std::move(body));
                 result = std::move(res);
             },
             // This is the same as WhilePost, but the cond negation is in the other branch.
@@ -1344,7 +1349,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             },
             [&](parser::NthRef *var) {
                 ExpressionPtr res = make_tree<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Global,
-                                                         dctx.ctx.state.enterNameUTF8(to_string(var->ref)));
+                                                               dctx.ctx.state.enterNameUTF8(to_string(var->ref)));
                 result = std::move(res);
             },
             [&](parser::Assign *asgn) {
@@ -1773,8 +1778,9 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     cases.emplace_back(node2TreeImpl(dctx, std::move(node)));
                     ENFORCE(isa_tree<RescueCase>(cases.back()), "node2TreeImpl failed to produce a rescue case");
                 }
-                ExpressionPtr res = make_tree<Rescue>(loc, node2TreeImpl(dctx, std::move(rescue->body)), std::move(cases),
-                                                node2TreeImpl(dctx, std::move(rescue->else_)), MK::EmptyTree());
+                ExpressionPtr res =
+                    make_tree<Rescue>(loc, node2TreeImpl(dctx, std::move(rescue->body)), std::move(cases),
+                                      node2TreeImpl(dctx, std::move(rescue->else_)), MK::EmptyTree());
                 result = std::move(res);
             },
             [&](parser::Resbody *resbody) {
@@ -1835,7 +1841,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 } else {
                     Rescue::RESCUE_CASE_store cases;
                     ExpressionPtr res = make_tree<Rescue>(loc, std::move(bodyExpr), std::move(cases), MK::EmptyTree(),
-                                                    std::move(ensureExpr));
+                                                          std::move(ensureExpr));
                     result = std::move(res);
                 }
             },

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1272,7 +1272,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 ExpressionPtr res =
                     MK::Class(sclass->loc, sclass->declLoc,
                               make_expression<UnresolvedIdent>(sclass->expr->loc, UnresolvedIdent::Kind::Class,
-                                                         core::Names::singleton()),
+                                                               core::Names::singleton()),
                               std::move(emptyAncestors), std::move(body));
                 result = std::move(res);
             },
@@ -1349,7 +1349,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             },
             [&](parser::NthRef *var) {
                 ExpressionPtr res = make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Global,
-                                                               dctx.ctx.state.enterNameUTF8(to_string(var->ref)));
+                                                                     dctx.ctx.state.enterNameUTF8(to_string(var->ref)));
                 result = std::move(res);
             },
             [&](parser::Assign *asgn) {
@@ -1780,7 +1780,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 }
                 ExpressionPtr res =
                     make_expression<Rescue>(loc, node2TreeImpl(dctx, std::move(rescue->body)), std::move(cases),
-                                      node2TreeImpl(dctx, std::move(rescue->else_)), MK::EmptyTree());
+                                            node2TreeImpl(dctx, std::move(rescue->else_)), MK::EmptyTree());
                 result = std::move(res);
             },
             [&](parser::Resbody *resbody) {
@@ -1840,8 +1840,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     result = std::move(bodyExpr);
                 } else {
                     Rescue::RESCUE_CASE_store cases;
-                    ExpressionPtr res = make_expression<Rescue>(loc, std::move(bodyExpr), std::move(cases), MK::EmptyTree(),
-                                                          std::move(ensureExpr));
+                    ExpressionPtr res = make_expression<Rescue>(loc, std::move(bodyExpr), std::move(cases),
+                                                                MK::EmptyTree(), std::move(ensureExpr));
                     result = std::move(res);
                 }
             },
@@ -2064,8 +2064,8 @@ ExpressionPtr liftTopLevel(DesugarContext dctx, core::LocOffsets loc, Expression
     } else {
         rhs.emplace_back(std::move(what));
     }
-    return make_expression<ClassDef>(loc, loc, core::Symbols::root(), MK::EmptyTree(), std::move(ancestors), std::move(rhs),
-                               ClassDef::Kind::Class);
+    return make_expression<ClassDef>(loc, loc, core::Symbols::root(), MK::EmptyTree(), std::move(ancestors),
+                                     std::move(rhs), ClassDef::Kind::Class);
 }
 } // namespace
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1271,7 +1271,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 ClassDef::ANCESTORS_store emptyAncestors;
                 ExpressionPtr res =
                     MK::Class(sclass->loc, sclass->declLoc,
-                              make_tree<UnresolvedIdent>(sclass->expr->loc, UnresolvedIdent::Kind::Class,
+                              make_expression<UnresolvedIdent>(sclass->expr->loc, UnresolvedIdent::Kind::Class,
                                                          core::Names::singleton()),
                               std::move(emptyAncestors), std::move(body));
                 result = std::move(res);
@@ -1320,15 +1320,15 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(res);
             },
             [&](parser::IVar *var) {
-                ExpressionPtr res = make_tree<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Instance, var->name);
+                ExpressionPtr res = make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Instance, var->name);
                 result = std::move(res);
             },
             [&](parser::GVar *var) {
-                ExpressionPtr res = make_tree<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Global, var->name);
+                ExpressionPtr res = make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Global, var->name);
                 result = std::move(res);
             },
             [&](parser::CVar *var) {
-                ExpressionPtr res = make_tree<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Class, var->name);
+                ExpressionPtr res = make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Class, var->name);
                 result = std::move(res);
             },
             [&](parser::LVarLhs *var) {
@@ -1336,19 +1336,19 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(res);
             },
             [&](parser::GVarLhs *var) {
-                ExpressionPtr res = make_tree<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Global, var->name);
+                ExpressionPtr res = make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Global, var->name);
                 result = std::move(res);
             },
             [&](parser::CVarLhs *var) {
-                ExpressionPtr res = make_tree<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Class, var->name);
+                ExpressionPtr res = make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Class, var->name);
                 result = std::move(res);
             },
             [&](parser::IVarLhs *var) {
-                ExpressionPtr res = make_tree<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Instance, var->name);
+                ExpressionPtr res = make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Instance, var->name);
                 result = std::move(res);
             },
             [&](parser::NthRef *var) {
-                ExpressionPtr res = make_tree<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Global,
+                ExpressionPtr res = make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Global,
                                                                dctx.ctx.state.enterNameUTF8(to_string(var->ref)));
                 result = std::move(res);
             },
@@ -1738,7 +1738,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 }
             },
             [&](parser::Retry *ret) {
-                ExpressionPtr res = make_tree<Retry>(loc);
+                ExpressionPtr res = make_expression<Retry>(loc);
                 result = std::move(res);
             },
             [&](parser::Yield *ret) {
@@ -1779,7 +1779,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     ENFORCE(isa_tree<RescueCase>(cases.back()), "node2TreeImpl failed to produce a rescue case");
                 }
                 ExpressionPtr res =
-                    make_tree<Rescue>(loc, node2TreeImpl(dctx, std::move(rescue->body)), std::move(cases),
+                    make_expression<Rescue>(loc, node2TreeImpl(dctx, std::move(rescue->body)), std::move(cases),
                                       node2TreeImpl(dctx, std::move(rescue->else_)), MK::EmptyTree());
                 result = std::move(res);
             },
@@ -1828,7 +1828,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 }
 
                 ExpressionPtr res =
-                    make_tree<RescueCase>(loc, std::move(exceptions), MK::Local(varLoc, var), std::move(body));
+                    make_expression<RescueCase>(loc, std::move(exceptions), MK::Local(varLoc, var), std::move(body));
                 result = std::move(res);
             },
             [&](parser::Ensure *ensure) {
@@ -1840,7 +1840,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     result = std::move(bodyExpr);
                 } else {
                     Rescue::RESCUE_CASE_store cases;
-                    ExpressionPtr res = make_tree<Rescue>(loc, std::move(bodyExpr), std::move(cases), MK::EmptyTree(),
+                    ExpressionPtr res = make_expression<Rescue>(loc, std::move(bodyExpr), std::move(cases), MK::EmptyTree(),
                                                           std::move(ensureExpr));
                     result = std::move(res);
                 }
@@ -2064,7 +2064,7 @@ ExpressionPtr liftTopLevel(DesugarContext dctx, core::LocOffsets loc, Expression
     } else {
         rhs.emplace_back(std::move(what));
     }
-    return make_tree<ClassDef>(loc, loc, core::Symbols::root(), MK::EmptyTree(), std::move(ancestors), std::move(rhs),
+    return make_expression<ClassDef>(loc, loc, core::Symbols::root(), MK::EmptyTree(), std::move(ancestors), std::move(rhs),
                                ClassDef::Kind::Class);
 }
 } // namespace

--- a/ast/desugar/Desugar.h
+++ b/ast/desugar/Desugar.h
@@ -7,7 +7,7 @@
 
 namespace sorbet::ast::desugar {
 
-TreePtr node2Tree(core::MutableContext ctx, std::unique_ptr<parser::Node> what);
+ExpressionPtr node2Tree(core::MutableContext ctx, std::unique_ptr<parser::Node> what);
 } // namespace sorbet::ast::desugar
 
 #endif // SORBET_DESUGAR_H

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -22,7 +22,7 @@ private:
         auto scope = substClassName(ctx, std::move(constLit->scope));
         auto cnst = subst.substitute(constLit->cnst);
 
-        return make_tree<UnresolvedConstantLit>(constLit->loc, std::move(scope), cnst);
+        return make_expression<UnresolvedConstantLit>(constLit->loc, std::move(scope), cnst);
     }
 
     ExpressionPtr substArg(core::MutableContext ctx, ExpressionPtr argp) {

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -10,7 +10,7 @@ class SubstWalk {
 private:
     const core::GlobalSubstitution &subst;
 
-    TreePtr substClassName(core::MutableContext ctx, TreePtr node) {
+    ExpressionPtr substClassName(core::MutableContext ctx, ExpressionPtr node) {
         auto *constLit = cast_tree<UnresolvedConstantLit>(node);
         if (constLit == nullptr) { // uncommon case. something is strange
             if (isa_tree<EmptyTree>(node)) {
@@ -25,8 +25,8 @@ private:
         return make_tree<UnresolvedConstantLit>(constLit->loc, std::move(scope), cnst);
     }
 
-    TreePtr substArg(core::MutableContext ctx, TreePtr argp) {
-        TreePtr *arg = &argp;
+    ExpressionPtr substArg(core::MutableContext ctx, ExpressionPtr argp) {
+        ExpressionPtr *arg = &argp;
         while (arg != nullptr) {
             typecase(
                 *arg, [&](RestArg &rest) { arg = &rest.expr; }, [&](KeywordArg &kw) { arg = &kw.expr; },
@@ -44,7 +44,7 @@ private:
 public:
     SubstWalk(const core::GlobalSubstitution &subst) : subst(subst) {}
 
-    TreePtr preTransformClassDef(core::MutableContext ctx, TreePtr tree) {
+    ExpressionPtr preTransformClassDef(core::MutableContext ctx, ExpressionPtr tree) {
         auto *original = cast_tree<ClassDef>(tree);
         original->name = substClassName(ctx, std::move(original->name));
         for (auto &anc : original->ancestors) {
@@ -53,7 +53,7 @@ public:
         return tree;
     }
 
-    TreePtr preTransformMethodDef(core::MutableContext ctx, TreePtr tree) {
+    ExpressionPtr preTransformMethodDef(core::MutableContext ctx, ExpressionPtr tree) {
         auto *original = cast_tree<MethodDef>(tree);
         original->name = subst.substitute(original->name);
         for (auto &arg : original->args) {
@@ -62,7 +62,7 @@ public:
         return tree;
     }
 
-    TreePtr preTransformBlock(core::MutableContext ctx, TreePtr tree) {
+    ExpressionPtr preTransformBlock(core::MutableContext ctx, ExpressionPtr tree) {
         auto *original = cast_tree<Block>(tree);
         for (auto &arg : original->args) {
             arg = substArg(ctx, std::move(arg));
@@ -70,22 +70,22 @@ public:
         return tree;
     }
 
-    TreePtr postTransformUnresolvedIdent(core::MutableContext ctx, TreePtr original) {
+    ExpressionPtr postTransformUnresolvedIdent(core::MutableContext ctx, ExpressionPtr original) {
         cast_tree<UnresolvedIdent>(original)->name = subst.substitute(cast_tree<UnresolvedIdent>(original)->name);
         return original;
     }
 
-    TreePtr postTransformLocal(core::MutableContext ctx, TreePtr local) {
+    ExpressionPtr postTransformLocal(core::MutableContext ctx, ExpressionPtr local) {
         cast_tree<Local>(local)->localVariable._name = subst.substitute(cast_tree<Local>(local)->localVariable._name);
         return local;
     }
 
-    TreePtr preTransformSend(core::MutableContext ctx, TreePtr original) {
+    ExpressionPtr preTransformSend(core::MutableContext ctx, ExpressionPtr original) {
         cast_tree<Send>(original)->fun = subst.substitute(cast_tree<Send>(original)->fun);
         return original;
     }
 
-    TreePtr postTransformLiteral(core::MutableContext ctx, TreePtr tree) {
+    ExpressionPtr postTransformLiteral(core::MutableContext ctx, ExpressionPtr tree) {
         auto *original = cast_tree<Literal>(tree);
         if (original->isString(ctx)) {
             auto nameRef = original->asString(ctx);
@@ -112,7 +112,7 @@ public:
         return tree;
     }
 
-    TreePtr postTransformUnresolvedConstantLit(core::MutableContext ctx, TreePtr tree) {
+    ExpressionPtr postTransformUnresolvedConstantLit(core::MutableContext ctx, ExpressionPtr tree) {
         auto *original = cast_tree<UnresolvedConstantLit>(tree);
         original->cnst = subst.substitute(original->cnst);
         original->scope = substClassName(ctx, std::move(original->scope));
@@ -121,7 +121,7 @@ public:
 };
 } // namespace
 
-TreePtr Substitute::run(core::MutableContext ctx, const core::GlobalSubstitution &subst, TreePtr what) {
+ExpressionPtr Substitute::run(core::MutableContext ctx, const core::GlobalSubstitution &subst, ExpressionPtr what) {
     if (subst.useFastPath()) {
         return what;
     }

--- a/ast/substitute/substitute.h
+++ b/ast/substitute/substitute.h
@@ -7,7 +7,7 @@
 namespace sorbet::ast {
 class Substitute {
 public:
-    static TreePtr run(core::MutableContext ctx, const core::GlobalSubstitution &subst, TreePtr what);
+    static ExpressionPtr run(core::MutableContext ctx, const core::GlobalSubstitution &subst, ExpressionPtr what);
 };
 } // namespace sorbet::ast
 #endif // SORBET_SUBSTITUTE_H

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -18,62 +18,62 @@ public:
     // Not including the member will skip the branch
     // you may return the same pointer that you are given
     // caller is responsible to handle it
-    TreePtr preTransformClassDef(core::MutableContext ctx, ClassDef *original);
-    TreePtr postTransformClassDef(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr preTransformClassDef(core::MutableContext ctx, ClassDef *original);
+    ExpressionPtr postTransformClassDef(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr preTransformMethodDef(core::MutableContext ctx, TreePtr original);
-    TreePtr postTransformMethodDef(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr preTransformMethodDef(core::MutableContext ctx, ExpressionPtr original);
+    ExpressionPtr postTransformMethodDef(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr preTransformIf(core::MutableContext ctx, TreePtr original);
-    TreePtr postTransformIf(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr preTransformIf(core::MutableContext ctx, ExpressionPtr original);
+    ExpressionPtr postTransformIf(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr preTransformWhile(core::MutableContext ctx, TreePtr original);
-    TreePtr postTransformWhile(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr preTransformWhile(core::MutableContext ctx, ExpressionPtr original);
+    ExpressionPtr postTransformWhile(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr postTransformBreak(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr postTransformBreak(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr postTransformRetry(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr postTransformRetry(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr postTransformNext(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr postTransformNext(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr preTransformReturn(core::MutableContext ctx, TreePtr original);
-    TreePtr postTransformReturn(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr preTransformReturn(core::MutableContext ctx, ExpressionPtr original);
+    ExpressionPtr postTransformReturn(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr preTransformRescueCase(core::MutableContext ctx, TreePtr original);
-    TreePtr postTransformRescueCase(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr preTransformRescueCase(core::MutableContext ctx, ExpressionPtr original);
+    ExpressionPtr postTransformRescueCase(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr preTransformRescue(core::MutableContext ctx, TreePtr original);
-    TreePtr postTransformRescue(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr preTransformRescue(core::MutableContext ctx, ExpressionPtr original);
+    ExpressionPtr postTransformRescue(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr postTransformUnresolvedIdent(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr postTransformUnresolvedIdent(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr preTransformAssign(core::MutableContext ctx, TreePtr original);
-    TreePtr postTransformAssign(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr preTransformAssign(core::MutableContext ctx, ExpressionPtr original);
+    ExpressionPtr postTransformAssign(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr preTransformSend(core::MutableContext ctx, TreePtr original);
-    TreePtr postTransformSend(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr preTransformSend(core::MutableContext ctx, ExpressionPtr original);
+    ExpressionPtr postTransformSend(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr preTransformHash(core::MutableContext ctx, TreePtr original);
-    TreePtr postTransformHash(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr preTransformHash(core::MutableContext ctx, ExpressionPtr original);
+    ExpressionPtr postTransformHash(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr preTransformArray(core::MutableContext ctx, TreePtr original);
-    TreePtr postransformArray(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr preTransformArray(core::MutableContext ctx, ExpressionPtr original);
+    ExpressionPtr postransformArray(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr postTransformConstantLit(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr postTransformConstantLit(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr postTransformUnresolvedConstantLit(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr postTransformUnresolvedConstantLit(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr preTransformBlock(core::MutableContext ctx, TreePtr original);
-    TreePtr postTransformBlock(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr preTransformBlock(core::MutableContext ctx, ExpressionPtr original);
+    ExpressionPtr postTransformBlock(core::MutableContext ctx, ExpressionPtr original);
 
-    TreePtr preTransformInsSeq(core::MutableContext ctx, TreePtr original);
-    TreePtr postTransformInsSeq(core::MutableContext ctx, TreePtr original);
+    ExpressionPtr preTransformInsSeq(core::MutableContext ctx, ExpressionPtr original);
+    ExpressionPtr postTransformInsSeq(core::MutableContext ctx, ExpressionPtr original);
 };
 
 // NOTE: Implementations must use a context type parameter that `MutableContext` is convertable to.
 // That is, either `Context` or `MutableContext`.
 #define GENERATE_HAS_MEMBER_VISITOR(X) \
-    GENERATE_HAS_MEMBER(X, std::declval<core::MutableContext>(), std::declval<TreePtr>())
+    GENERATE_HAS_MEMBER(X, std::declval<core::MutableContext>(), std::declval<ExpressionPtr>())
 
 // used to check for ABSENCE of method
 GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedIdent);
@@ -84,11 +84,11 @@ GENERATE_HAS_MEMBER_VISITOR(preTransformLiteral);
 
 #define GENERATE_POSTPONE_PRECLASS(X)                                                                            \
     GENERATE_CALL_MEMBER(preTransform##X, Exception::raise("should never be called. Incorrect use of TreeMap?"); \
-                         return nullptr, std::declval<core::MutableContext>(), std::declval<TreePtr>())
+                         return nullptr, std::declval<core::MutableContext>(), std::declval<ExpressionPtr>())
 
 #define GENERATE_POSTPONE_POSTCLASS(X)                                                                            \
     GENERATE_CALL_MEMBER(postTransform##X, Exception::raise("should never be called. Incorrect use of TreeMap?"); \
-                         return nullptr, std::declval<core::MutableContext>(), std::declval<TreePtr>())
+                         return nullptr, std::declval<core::MutableContext>(), std::declval<ExpressionPtr>())
 
 GENERATE_POSTPONE_PRECLASS(Expression);
 GENERATE_POSTPONE_PRECLASS(ClassDef);
@@ -158,7 +158,7 @@ private:
 
     TreeMapper(FUNC &func) : func(func) {}
 
-    TreePtr mapClassDef(TreePtr v, CTX ctx) {
+    ExpressionPtr mapClassDef(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformClassDef<FUNC>()) {
             v = CALL_MEMBER_preTransformClassDef<FUNC>::call(func, ctx, std::move(v));
         }
@@ -175,7 +175,7 @@ private:
         return v;
     }
 
-    TreePtr mapMethodDef(TreePtr v, CTX ctx) {
+    ExpressionPtr mapMethodDef(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformMethodDef<FUNC>()) {
             v = CALL_MEMBER_preTransformMethodDef<FUNC>::call(func, ctx, std::move(v));
         }
@@ -196,7 +196,7 @@ private:
         return v;
     }
 
-    TreePtr mapIf(TreePtr v, CTX ctx) {
+    ExpressionPtr mapIf(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformIf<FUNC>()) {
             v = CALL_MEMBER_preTransformIf<FUNC>::call(func, ctx, std::move(v));
         }
@@ -210,7 +210,7 @@ private:
         return v;
     }
 
-    TreePtr mapWhile(TreePtr v, CTX ctx) {
+    ExpressionPtr mapWhile(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformWhile<FUNC>()) {
             v = CALL_MEMBER_preTransformWhile<FUNC>::call(func, ctx, std::move(v));
         }
@@ -223,7 +223,7 @@ private:
         return v;
     }
 
-    TreePtr mapBreak(TreePtr v, CTX ctx) {
+    ExpressionPtr mapBreak(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformBreak<FUNC>()) {
             return CALL_MEMBER_preTransformBreak<FUNC>::call(func, ctx, std::move(v));
         }
@@ -235,14 +235,14 @@ private:
         }
         return v;
     }
-    TreePtr mapRetry(TreePtr v, CTX ctx) {
+    ExpressionPtr mapRetry(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_postTransformRetry<FUNC>()) {
             return CALL_MEMBER_postTransformRetry<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
-    TreePtr mapNext(TreePtr v, CTX ctx) {
+    ExpressionPtr mapNext(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformNext<FUNC>()) {
             return CALL_MEMBER_preTransformNext<FUNC>::call(func, ctx, std::move(v));
         }
@@ -255,7 +255,7 @@ private:
         return v;
     }
 
-    TreePtr mapReturn(TreePtr v, CTX ctx) {
+    ExpressionPtr mapReturn(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformReturn<FUNC>()) {
             v = CALL_MEMBER_preTransformReturn<FUNC>::call(func, ctx, std::move(v));
         }
@@ -268,7 +268,7 @@ private:
         return v;
     }
 
-    TreePtr mapRescueCase(TreePtr v, CTX ctx) {
+    ExpressionPtr mapRescueCase(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformRescueCase<FUNC>()) {
             v = CALL_MEMBER_preTransformRescueCase<FUNC>::call(func, ctx, std::move(v));
         }
@@ -287,7 +287,7 @@ private:
 
         return v;
     }
-    TreePtr mapRescue(TreePtr v, CTX ctx) {
+    ExpressionPtr mapRescue(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformRescue<FUNC>()) {
             v = CALL_MEMBER_preTransformRescue<FUNC>::call(func, ctx, std::move(v));
         }
@@ -310,14 +310,14 @@ private:
         return v;
     }
 
-    TreePtr mapUnresolvedIdent(TreePtr v, CTX ctx) {
+    ExpressionPtr mapUnresolvedIdent(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_postTransformUnresolvedIdent<FUNC>()) {
             return CALL_MEMBER_postTransformUnresolvedIdent<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
-    TreePtr mapAssign(TreePtr v, CTX ctx) {
+    ExpressionPtr mapAssign(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformAssign<FUNC>()) {
             v = CALL_MEMBER_preTransformAssign<FUNC>::call(func, ctx, std::move(v));
         }
@@ -332,7 +332,7 @@ private:
         return v;
     }
 
-    TreePtr mapSend(TreePtr v, CTX ctx) {
+    ExpressionPtr mapSend(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformSend<FUNC>()) {
             v = CALL_MEMBER_preTransformSend<FUNC>::call(func, ctx, std::move(v));
         }
@@ -355,7 +355,7 @@ private:
         return v;
     }
 
-    TreePtr mapHash(TreePtr v, CTX ctx) {
+    ExpressionPtr mapHash(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformHash<FUNC>()) {
             v = CALL_MEMBER_preTransformHash<FUNC>::call(func, ctx, std::move(v));
         }
@@ -373,7 +373,7 @@ private:
         return v;
     }
 
-    TreePtr mapArray(TreePtr v, CTX ctx) {
+    ExpressionPtr mapArray(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformArray<FUNC>()) {
             v = CALL_MEMBER_preTransformArray<FUNC>::call(func, ctx, std::move(v));
         }
@@ -387,28 +387,28 @@ private:
         return v;
     }
 
-    TreePtr mapLiteral(TreePtr v, CTX ctx) {
+    ExpressionPtr mapLiteral(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_postTransformLiteral<FUNC>()) {
             return CALL_MEMBER_postTransformLiteral<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
-    TreePtr mapUnresolvedConstantLit(TreePtr v, CTX ctx) {
+    ExpressionPtr mapUnresolvedConstantLit(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>()) {
             return CALL_MEMBER_postTransformUnresolvedConstantLit<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
-    TreePtr mapConstantLit(TreePtr v, CTX ctx) {
+    ExpressionPtr mapConstantLit(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_postTransformConstantLit<FUNC>()) {
             return CALL_MEMBER_postTransformConstantLit<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
-    TreePtr mapBlock(TreePtr v, CTX ctx) {
+    ExpressionPtr mapBlock(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformBlock<FUNC>()) {
             v = CALL_MEMBER_preTransformBlock<FUNC>::call(func, ctx, std::move(v));
         }
@@ -427,7 +427,7 @@ private:
         return v;
     }
 
-    TreePtr mapInsSeq(TreePtr v, CTX ctx) {
+    ExpressionPtr mapInsSeq(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformInsSeq<FUNC>()) {
             v = CALL_MEMBER_preTransformInsSeq<FUNC>::call(func, ctx, std::move(v));
         }
@@ -445,14 +445,14 @@ private:
         return v;
     }
 
-    TreePtr mapLocal(TreePtr v, CTX ctx) {
+    ExpressionPtr mapLocal(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_postTransformLocal<FUNC>()) {
             return CALL_MEMBER_postTransformLocal<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
-    TreePtr mapCast(TreePtr v, CTX ctx) {
+    ExpressionPtr mapCast(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformCast<FUNC>()) {
             v = CALL_MEMBER_preTransformCast<FUNC>::call(func, ctx, std::move(v));
         }
@@ -465,7 +465,7 @@ private:
         return v;
     }
 
-    TreePtr mapIt(TreePtr what, CTX ctx) {
+    ExpressionPtr mapIt(ExpressionPtr what, CTX ctx) {
         if (what == nullptr) {
             return what;
         }
@@ -582,7 +582,7 @@ private:
 
 class TreeMap {
 public:
-    template <typename CTX, typename FUNC> static TreePtr apply(CTX ctx, FUNC &func, TreePtr to) {
+    template <typename CTX, typename FUNC> static ExpressionPtr apply(CTX ctx, FUNC &func, ExpressionPtr to) {
         TreeMapper<FUNC, CTX> walker(func);
         try {
             return walker.mapIt(std::move(to), ctx);
@@ -616,7 +616,7 @@ private:
 
     ShallowMapper(FUNC &func) : func(func) {}
 
-    TreePtr mapClassDef(TreePtr v, CTX ctx) {
+    ExpressionPtr mapClassDef(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformClassDef<FUNC>()) {
             v = CALL_MEMBER_preTransformClassDef<FUNC>::call(func, ctx, std::move(v));
         }
@@ -633,7 +633,7 @@ private:
         return v;
     }
 
-    TreePtr mapMethodDef(TreePtr v, CTX ctx) {
+    ExpressionPtr mapMethodDef(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformMethodDef<FUNC>()) {
             v = CALL_MEMBER_preTransformMethodDef<FUNC>::call(func, ctx, std::move(v));
         }
@@ -653,7 +653,7 @@ private:
         return v;
     }
 
-    TreePtr mapIf(TreePtr v, CTX ctx) {
+    ExpressionPtr mapIf(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformIf<FUNC>()) {
             v = CALL_MEMBER_preTransformIf<FUNC>::call(func, ctx, std::move(v));
         }
@@ -667,7 +667,7 @@ private:
         return v;
     }
 
-    TreePtr mapWhile(TreePtr v, CTX ctx) {
+    ExpressionPtr mapWhile(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformWhile<FUNC>()) {
             v = CALL_MEMBER_preTransformWhile<FUNC>::call(func, ctx, std::move(v));
         }
@@ -680,7 +680,7 @@ private:
         return v;
     }
 
-    TreePtr mapBreak(TreePtr v, CTX ctx) {
+    ExpressionPtr mapBreak(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformBreak<FUNC>()) {
             return CALL_MEMBER_preTransformBreak<FUNC>::call(func, ctx, std::move(v));
         }
@@ -692,14 +692,14 @@ private:
         }
         return v;
     }
-    TreePtr mapRetry(TreePtr v, CTX ctx) {
+    ExpressionPtr mapRetry(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_postTransformRetry<FUNC>()) {
             return CALL_MEMBER_postTransformRetry<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
-    TreePtr mapNext(TreePtr v, CTX ctx) {
+    ExpressionPtr mapNext(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformNext<FUNC>()) {
             return CALL_MEMBER_preTransformNext<FUNC>::call(func, ctx, std::move(v));
         }
@@ -712,7 +712,7 @@ private:
         return v;
     }
 
-    TreePtr mapReturn(TreePtr v, CTX ctx) {
+    ExpressionPtr mapReturn(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformReturn<FUNC>()) {
             v = CALL_MEMBER_preTransformReturn<FUNC>::call(func, ctx, std::move(v));
         }
@@ -725,7 +725,7 @@ private:
         return v;
     }
 
-    TreePtr mapRescueCase(TreePtr v, CTX ctx) {
+    ExpressionPtr mapRescueCase(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformRescueCase<FUNC>()) {
             v = CALL_MEMBER_preTransformRescueCase<FUNC>::call(func, ctx, std::move(v));
         }
@@ -744,7 +744,7 @@ private:
 
         return v;
     }
-    TreePtr mapRescue(TreePtr v, CTX ctx) {
+    ExpressionPtr mapRescue(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformRescue<FUNC>()) {
             v = CALL_MEMBER_preTransformRescue<FUNC>::call(func, ctx, std::move(v));
         }
@@ -767,14 +767,14 @@ private:
         return v;
     }
 
-    TreePtr mapUnresolvedIdent(TreePtr v, CTX ctx) {
+    ExpressionPtr mapUnresolvedIdent(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_postTransformUnresolvedIdent<FUNC>()) {
             return CALL_MEMBER_postTransformUnresolvedIdent<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
-    TreePtr mapAssign(TreePtr v, CTX ctx) {
+    ExpressionPtr mapAssign(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformAssign<FUNC>()) {
             v = CALL_MEMBER_preTransformAssign<FUNC>::call(func, ctx, std::move(v));
         }
@@ -789,7 +789,7 @@ private:
         return v;
     }
 
-    TreePtr mapSend(TreePtr v, CTX ctx) {
+    ExpressionPtr mapSend(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformSend<FUNC>()) {
             v = CALL_MEMBER_preTransformSend<FUNC>::call(func, ctx, std::move(v));
         }
@@ -812,7 +812,7 @@ private:
         return v;
     }
 
-    TreePtr mapHash(TreePtr v, CTX ctx) {
+    ExpressionPtr mapHash(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformHash<FUNC>()) {
             v = CALL_MEMBER_preTransformHash<FUNC>::call(func, ctx, std::move(v));
         }
@@ -830,7 +830,7 @@ private:
         return v;
     }
 
-    TreePtr mapArray(TreePtr v, CTX ctx) {
+    ExpressionPtr mapArray(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformArray<FUNC>()) {
             v = CALL_MEMBER_preTransformArray<FUNC>::call(func, ctx, std::move(v));
         }
@@ -844,28 +844,28 @@ private:
         return v;
     }
 
-    TreePtr mapLiteral(TreePtr v, CTX ctx) {
+    ExpressionPtr mapLiteral(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_postTransformLiteral<FUNC>()) {
             return CALL_MEMBER_postTransformLiteral<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
-    TreePtr mapUnresolvedConstantLit(TreePtr v, CTX ctx) {
+    ExpressionPtr mapUnresolvedConstantLit(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>()) {
             return CALL_MEMBER_postTransformUnresolvedConstantLit<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
-    TreePtr mapConstantLit(TreePtr v, CTX ctx) {
+    ExpressionPtr mapConstantLit(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_postTransformConstantLit<FUNC>()) {
             return CALL_MEMBER_postTransformConstantLit<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
-    TreePtr mapBlock(TreePtr v, CTX ctx) {
+    ExpressionPtr mapBlock(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformBlock<FUNC>()) {
             v = CALL_MEMBER_preTransformBlock<FUNC>::call(func, ctx, std::move(v));
         }
@@ -884,7 +884,7 @@ private:
         return v;
     }
 
-    TreePtr mapInsSeq(TreePtr v, CTX ctx) {
+    ExpressionPtr mapInsSeq(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformInsSeq<FUNC>()) {
             v = CALL_MEMBER_preTransformInsSeq<FUNC>::call(func, ctx, std::move(v));
         }
@@ -902,14 +902,14 @@ private:
         return v;
     }
 
-    TreePtr mapLocal(TreePtr v, CTX ctx) {
+    ExpressionPtr mapLocal(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_postTransformLocal<FUNC>()) {
             return CALL_MEMBER_postTransformLocal<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
-    TreePtr mapCast(TreePtr v, CTX ctx) {
+    ExpressionPtr mapCast(ExpressionPtr v, CTX ctx) {
         if constexpr (HAS_MEMBER_preTransformCast<FUNC>()) {
             v = CALL_MEMBER_preTransformCast<FUNC>::call(func, ctx, std::move(v));
         }
@@ -922,7 +922,7 @@ private:
         return v;
     }
 
-    TreePtr mapIt(TreePtr what, CTX ctx) {
+    ExpressionPtr mapIt(ExpressionPtr what, CTX ctx) {
         if (what == nullptr) {
             return what;
         }
@@ -1039,7 +1039,7 @@ private:
 
 class ShallowMap {
 public:
-    template <typename CTX, typename FUNC> static TreePtr apply(CTX ctx, FUNC &func, TreePtr to) {
+    template <typename CTX, typename FUNC> static ExpressionPtr apply(CTX ctx, FUNC &func, ExpressionPtr to) {
         ShallowMapper<FUNC, CTX> walker(func);
         try {
             return walker.mapIt(std::move(to), ctx);

--- a/ast/verifier/Verifier.cc
+++ b/ast/verifier/Verifier.cc
@@ -8,7 +8,7 @@ class VerifierWalker {
     u4 methodDepth = 0;
 
 public:
-    TreePtr preTransformExpression(core::Context ctx, TreePtr original) {
+    ExpressionPtr preTransformExpression(core::Context ctx, ExpressionPtr original) {
         if (!isa_tree<EmptyTree>(original)) {
             ENFORCE(original.loc().exists(), "location is unset");
         }
@@ -18,17 +18,17 @@ public:
         return original;
     }
 
-    TreePtr preTransformMethodDef(core::Context ctx, TreePtr original) {
+    ExpressionPtr preTransformMethodDef(core::Context ctx, ExpressionPtr original) {
         methodDepth++;
         return original;
     }
 
-    TreePtr postTransformMethodDef(core::Context ctx, TreePtr original) {
+    ExpressionPtr postTransformMethodDef(core::Context ctx, ExpressionPtr original) {
         methodDepth--;
         return original;
     }
 
-    TreePtr postTransformAssign(core::Context ctx, TreePtr original) {
+    ExpressionPtr postTransformAssign(core::Context ctx, ExpressionPtr original) {
         auto *assign = cast_tree<Assign>(original);
         if (ast::isa_tree<ast::UnresolvedConstantLit>(assign->lhs)) {
             ENFORCE(methodDepth == 0, "Found constant definition inside method definition");
@@ -36,13 +36,13 @@ public:
         return original;
     }
 
-    TreePtr preTransformBlock(core::Context ctx, TreePtr original) {
+    ExpressionPtr preTransformBlock(core::Context ctx, ExpressionPtr original) {
         original._sanityCheck();
         return original;
     }
 };
 
-TreePtr Verifier::run(core::Context ctx, TreePtr node) {
+ExpressionPtr Verifier::run(core::Context ctx, ExpressionPtr node) {
     if (!debug_mode) {
         return node;
     }

--- a/ast/verifier/verifier.h
+++ b/ast/verifier/verifier.h
@@ -4,7 +4,7 @@ namespace sorbet::ast {
 
 class Verifier {
 public:
-    static TreePtr run(core::Context ctx, TreePtr node);
+    static ExpressionPtr run(core::Context ctx, ExpressionPtr node);
 };
 
 } // namespace sorbet::ast

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -10,7 +10,7 @@ public:
     static std::unique_ptr<CFG> buildFor(core::Context ctx, ast::MethodDef &md);
 
 private:
-    static BasicBlock *walk(CFGContext cctx, ast::TreePtr &what, BasicBlock *current);
+    static BasicBlock *walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlock *current);
     static void fillInTopoSorts(core::Context ctx, CFG &cfg);
     static void dealias(core::Context ctx, CFG &cfg);
     static void simplify(core::Context ctx, CFG &cfg);
@@ -29,7 +29,7 @@ private:
     static BasicBlock *walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method);
     static std::tuple<LocalRef, BasicBlock *, BasicBlock *>
     walkDefault(CFGContext cctx, int argIndex, const core::ArgInfo &argInfo, LocalRef argLocal, core::LocOffsets argLoc,
-                ast::TreePtr &def, BasicBlock *presentCont, BasicBlock *defaultCont);
+                ast::ExpressionPtr &def, BasicBlock *presentCont, BasicBlock *defaultCont);
     static BasicBlock *joinBlocks(CFGContext cctx, BasicBlock *a, BasicBlock *b);
 };
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -146,7 +146,7 @@ BasicBlock *CFGBuilder::joinBlocks(CFGContext cctx, BasicBlock *a, BasicBlock *b
 
 tuple<LocalRef, BasicBlock *, BasicBlock *> CFGBuilder::walkDefault(CFGContext cctx, int argIndex,
                                                                     const core::ArgInfo &argInfo, LocalRef argLocal,
-                                                                    core::LocOffsets argLoc, ast::TreePtr &def,
+                                                                    core::LocOffsets argLoc, ast::ExpressionPtr &def,
                                                                     BasicBlock *presentCont, BasicBlock *defaultCont) {
     auto defLoc = def.loc();
 
@@ -179,7 +179,7 @@ tuple<LocalRef, BasicBlock *, BasicBlock *> CFGBuilder::walkDefault(CFGContext c
 /** Convert `what` into a cfg, by starting to evaluate it in `current` inside method defined by `inWhat`.
  * store result of evaluation into `target`. Returns basic block in which evaluation should proceed.
  */
-BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::TreePtr &what, BasicBlock *current) {
+BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlock *current) {
     /** Try to pay additional attention not to duplicate any part of tree.
      * Though this may lead to more effictient and a better CFG if it was to be actually compiled into code
      * This will lead to duplicate typechecking and may lead to exponential explosion of typechecking time
@@ -775,7 +775,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::TreePtr &what, BasicBlock *cu
             [&](const ast::ClassDef &c) { Exception::raise("Should have been removed by FlattenWalk"); },
             [&](const ast::MethodDef &c) { Exception::raise("Should have been removed by FlattenWalk"); },
 
-            [&](const ast::TreePtr &n) { Exception::raise("Unimplemented AST Node: {}", what.nodeName()); });
+            [&](const ast::ExpressionPtr &n) { Exception::raise("Unimplemented AST Node: {}", what.nodeName()); });
 
         // For, Rescue,
         // Symbol, Array,

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -110,7 +110,7 @@ public:
         args.emplace_back(ast::make_expression<ast::Local>(blkLoc, blkLocalVar));
 
         auto init = ast::make_expression<ast::MethodDef>(loc.offsets(), loc.offsets(), sym, core::Names::staticInit(),
-                                                   std::move(args), std::move(inits), ast::MethodDef::Flags());
+                                                         std::move(args), std::move(inits), ast::MethodDef::Flags());
         ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isRewriterSynthesized = false;
         ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isSelfMethod = true;
 

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -107,9 +107,9 @@ public:
         auto blkLoc = core::LocOffsets::none();
         core::LocalVariable blkLocalVar(core::Names::blkArg(), 0);
         ast::MethodDef::ARGS_store args;
-        args.emplace_back(ast::make_tree<ast::Local>(blkLoc, blkLocalVar));
+        args.emplace_back(ast::make_expression<ast::Local>(blkLoc, blkLocalVar));
 
-        auto init = ast::make_tree<ast::MethodDef>(loc.offsets(), loc.offsets(), sym, core::Names::staticInit(),
+        auto init = ast::make_expression<ast::MethodDef>(loc.offsets(), loc.offsets(), sym, core::Names::staticInit(),
                                                    std::move(args), std::move(inits), ast::MethodDef::Flags());
         ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isRewriterSynthesized = false;
         ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isSelfMethod = true;

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -11,7 +11,7 @@ using namespace std;
 
 namespace sorbet::class_flatten {
 
-bool shouldExtract(core::Context ctx, const ast::TreePtr &what) {
+bool shouldExtract(core::Context ctx, const ast::ExpressionPtr &what) {
     if (ast::isa_tree<ast::MethodDef>(what)) {
         return false;
     }
@@ -32,7 +32,7 @@ bool shouldExtract(core::Context ctx, const ast::TreePtr &what) {
 // pull all the non-definitions (i.e. anything that's not a method definition, a class definition, or a constant
 // defintion) from a class or file into their own instruction sequence (or, if there is only one, simply move it out of
 // the class body and return it.)
-ast::TreePtr extractClassInit(core::Context ctx, ast::ClassDef *klass) {
+ast::ExpressionPtr extractClassInit(core::Context ctx, ast::ClassDef *klass) {
     ast::InsSeq::STATS_store inits;
 
     for (auto it = klass->rhs.begin(); it != klass->rhs.end(); /* nothing */) {
@@ -61,14 +61,14 @@ public:
         ENFORCE(classStack.empty());
     }
 
-    ast::TreePtr preTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         classStack.emplace_back(classes.size());
         classes.emplace_back();
 
         return tree;
     }
 
-    ast::TreePtr postTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         ENFORCE(!classStack.empty());
         ENFORCE(classes.size() > classStack.back());
         ENFORCE(classes[classStack.back()] == nullptr);
@@ -78,7 +78,7 @@ public:
 
         core::MethodRef sym;
         auto loc = core::Loc(ctx.file, classDef->declLoc);
-        ast::TreePtr replacement;
+        ast::ExpressionPtr replacement;
         if (classDef->symbol == core::Symbols::root()) {
             // Every file may have its own top-level code, so uniqify the names.
             //
@@ -122,7 +122,7 @@ public:
         return replacement;
     };
 
-    ast::TreePtr addClasses(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr addClasses(core::Context ctx, ast::ExpressionPtr tree) {
         if (classes.empty()) {
             ENFORCE(sortedClasses().empty());
             return tree;
@@ -148,7 +148,7 @@ public:
     }
 
 private:
-    vector<ast::TreePtr> sortedClasses() {
+    vector<ast::ExpressionPtr> sortedClasses() {
         ENFORCE(classStack.empty());
         auto ret = std::move(classes);
         classes.clear();
@@ -164,7 +164,7 @@ private:
     // would result in an "bottom-up" ordering, so instead we store a stack of
     // "where does the next definition belong" into `classStack`
     // which we push onto in the `preTransform* hook, and pop from in the `postTransform` hook.
-    vector<ast::TreePtr> classes;
+    vector<ast::ExpressionPtr> classes;
     vector<int> classStack;
 };
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -34,7 +34,7 @@ public:
     static void pickle(Pickler &p, const TypePtr &what);
     static void pickle(Pickler &p, const ArgInfo &a);
     static void pickle(Pickler &p, const Symbol &what);
-    static void pickle(Pickler &p, const ast::TreePtr &what);
+    static void pickle(Pickler &p, const ast::ExpressionPtr &what);
     static void pickle(Pickler &p, core::LocOffsets loc);
     static void pickle(Pickler &p, core::Loc loc);
     static void pickle(Pickler &p, shared_ptr<const FileHash> fh);
@@ -50,7 +50,7 @@ public:
     static u4 unpickleGSUUID(UnPickler &p);
     static LocOffsets unpickleLocOffsets(UnPickler &p);
     static Loc unpickleLoc(UnPickler &p);
-    static ast::TreePtr unpickleExpr(UnPickler &p, const GlobalState &, FileRef file);
+    static ast::ExpressionPtr unpickleExpr(UnPickler &p, const GlobalState &, FileRef file);
     static NameRef unpickleNameRef(UnPickler &p, const GlobalState &);
     static NameRef unpickleNameRef(UnPickler &p, GlobalState &);
     static unique_ptr<const FileHash> unpickleFileHash(UnPickler &p);
@@ -901,7 +901,7 @@ CachedFile Serializer::loadFile(const core::GlobalState &gs, core::FileRef fref,
     return CachedFile{move(file), move(tree)};
 }
 
-void SerializerImpl::pickle(Pickler &p, const ast::TreePtr &what) {
+void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
     if (what == nullptr) {
         p.putU4(0);
         return;
@@ -1193,7 +1193,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::TreePtr &what) {
     }
 }
 
-ast::TreePtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const GlobalState &gs, FileRef file) {
+ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const GlobalState &gs, FileRef file) {
     auto kind = p.getU4();
     if (kind == 0) {
         return nullptr;
@@ -1212,7 +1212,7 @@ ast::TreePtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const GlobalS
             auto argsSize = p.getU4();
             auto recv = unpickleExpr(p, gs, file);
             auto blkt = unpickleExpr(p, gs, file);
-            ast::TreePtr blk;
+            ast::ExpressionPtr blk;
             if (blkt) {
                 blk.reset(static_cast<ast::Block *>(blkt.release()));
             }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1266,7 +1266,7 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             NameRef nm = unpickleNameRef(p, gs);
             auto unique = p.getU4();
             LocalVariable lv(nm, unique);
-            return ast::make_tree<ast::Local>(loc, lv);
+            return ast::make_expression<ast::Local>(loc, lv);
         }
         case ast::Tag::Assign: {
             auto loc = unpickleLocOffsets(p);
@@ -1296,7 +1296,7 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
         }
         case ast::Tag::Retry: {
             auto loc = unpickleLocOffsets(p);
-            return ast::make_tree<ast::Retry>(loc);
+            return ast::make_expression<ast::Retry>(loc);
         }
         case ast::Tag::Hash: {
             auto loc = unpickleLocOffsets(p);
@@ -1325,7 +1325,7 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             NameRef kind = NameRef::fromRaw(gs, p.getU4());
             auto type = unpickleType(p, &gs);
             auto arg = unpickleExpr(p, gs, file);
-            return ast::make_tree<ast::Cast>(loc, std::move(type), std::move(arg), kind);
+            return ast::make_expression<ast::Cast>(loc, std::move(type), std::move(arg), kind);
         }
         case ast::Tag::EmptyTree:
             return ast::MK::EmptyTree();
@@ -1396,7 +1396,7 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
                 auto t = unpickleExpr(p, gs, file);
                 case_.reset(static_cast<ast::RescueCase *>(t.release()));
             }
-            return ast::make_tree<ast::Rescue>(loc, std::move(body_), std::move(cases), std::move(else_),
+            return ast::make_expression<ast::Rescue>(loc, std::move(body_), std::move(cases), std::move(else_),
                                                std::move(ensure));
         }
         case ast::Tag::RescueCase: {
@@ -1408,27 +1408,27 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             for (auto &ex : exceptions) {
                 ex = unpickleExpr(p, gs, file);
             }
-            return ast::make_tree<ast::RescueCase>(loc, std::move(exceptions), std::move(var), std::move(body));
+            return ast::make_expression<ast::RescueCase>(loc, std::move(exceptions), std::move(var), std::move(body));
         }
         case ast::Tag::RestArg: {
             auto loc = unpickleLocOffsets(p);
             auto ref = unpickleExpr(p, gs, file);
-            return ast::make_tree<ast::RestArg>(loc, std::move(ref));
+            return ast::make_expression<ast::RestArg>(loc, std::move(ref));
         }
         case ast::Tag::KeywordArg: {
             auto loc = unpickleLocOffsets(p);
             auto ref = unpickleExpr(p, gs, file);
-            return ast::make_tree<ast::KeywordArg>(loc, std::move(ref));
+            return ast::make_expression<ast::KeywordArg>(loc, std::move(ref));
         }
         case ast::Tag::ShadowArg: {
             auto loc = unpickleLocOffsets(p);
             auto ref = unpickleExpr(p, gs, file);
-            return ast::make_tree<ast::ShadowArg>(loc, std::move(ref));
+            return ast::make_expression<ast::ShadowArg>(loc, std::move(ref));
         }
         case ast::Tag::BlockArg: {
             auto loc = unpickleLocOffsets(p);
             auto ref = unpickleExpr(p, gs, file);
-            return ast::make_tree<ast::BlockArg>(loc, std::move(ref));
+            return ast::make_expression<ast::BlockArg>(loc, std::move(ref));
         }
         case ast::Tag::OptionalArg: {
             auto loc = unpickleLocOffsets(p);
@@ -1438,19 +1438,19 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
         }
         case ast::Tag::ZSuperArgs: {
             auto loc = unpickleLocOffsets(p);
-            return ast::make_tree<ast::ZSuperArgs>(loc);
+            return ast::make_expression<ast::ZSuperArgs>(loc);
         }
         case ast::Tag::UnresolvedIdent: {
             auto loc = unpickleLocOffsets(p);
             auto kind = (ast::UnresolvedIdent::Kind)p.getU1();
             NameRef name = unpickleNameRef(p, gs);
-            return ast::make_tree<ast::UnresolvedIdent>(loc, kind, name);
+            return ast::make_expression<ast::UnresolvedIdent>(loc, kind, name);
         }
         case ast::Tag::ConstantLit: {
             auto loc = unpickleLocOffsets(p);
             auto sym = SymbolRef::fromRaw(p.getU4());
             auto orig = unpickleExpr(p, gs, file);
-            return ast::make_tree<ast::ConstantLit>(loc, sym, std::move(orig));
+            return ast::make_expression<ast::ConstantLit>(loc, sym, std::move(orig));
         }
     }
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1397,7 +1397,7 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
                 case_.reset(static_cast<ast::RescueCase *>(t.release()));
             }
             return ast::make_expression<ast::Rescue>(loc, std::move(body_), std::move(cases), std::move(else_),
-                                               std::move(ensure));
+                                                     std::move(ensure));
         }
         case ast::Tag::RescueCase: {
             auto loc = unpickleLocOffsets(p);

--- a/core/serialize/serialize.h
+++ b/core/serialize/serialize.h
@@ -6,7 +6,7 @@
 namespace sorbet::core::serialize {
 struct CachedFile {
     std::shared_ptr<core::File> file;
-    ast::TreePtr tree;
+    ast::ExpressionPtr tree;
 };
 
 class Serializer {

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -589,7 +589,7 @@ private:
     }
 
 public:
-    ast::TreePtr preTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &classDef = ast::cast_tree_nonnull<ast::ClassDef>(tree);
         auto sym = classDef.symbol;
         auto singleton = sym.data(ctx)->lookupSingletonClass(ctx);
@@ -605,7 +605,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr preTransformMethodDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         auto methodData = methodDef.symbol.data(ctx);
         auto ownerData = methodData->owner.data(ctx);

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -35,13 +35,13 @@ class LocalNameInserter {
         core::NameRef name;
         core::LocalVariable local;
         core::LocOffsets loc;
-        ast::TreePtr expr;
+        ast::ExpressionPtr expr;
         ArgFlags flags;
     };
 
     // Map through the reference structure, naming the locals, and preserving
     // the outer structure for the namer proper.
-    NamedArg nameArg(ast::TreePtr arg) {
+    NamedArg nameArg(ast::ExpressionPtr arg) {
         NamedArg named;
 
         typecase(
@@ -202,17 +202,17 @@ class LocalNameInserter {
     }
 
 public:
-    ast::TreePtr preTransformClassDef(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr tree) {
         enterClass();
         return tree;
     }
 
-    ast::TreePtr postTransformClassDef(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr tree) {
         exitScope();
         return tree;
     }
 
-    ast::TreePtr preTransformMethodDef(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformMethodDef(core::MutableContext ctx, ast::ExpressionPtr tree) {
         enterMethod();
 
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(tree);
@@ -220,12 +220,12 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformMethodDef(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformMethodDef(core::MutableContext ctx, ast::ExpressionPtr tree) {
         exitScope();
         return tree;
     }
 
-    ast::TreePtr postTransformSend(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformSend(core::MutableContext ctx, ast::ExpressionPtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::Send>(tree);
         if (original.args.size() == 1 && ast::isa_tree<ast::ZSuperArgs>(original.args[0])) {
             original.numPosArgs = 0;
@@ -260,7 +260,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr preTransformBlock(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformBlock(core::MutableContext ctx, ast::ExpressionPtr tree) {
         auto &blk = ast::cast_tree_nonnull<ast::Block>(tree);
         auto outerArgs = scopeStack.back().args;
         auto &frame = enterBlock();
@@ -279,12 +279,12 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformBlock(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformBlock(core::MutableContext ctx, ast::ExpressionPtr tree) {
         exitScope();
         return tree;
     }
 
-    ast::TreePtr postTransformUnresolvedIdent(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformUnresolvedIdent(core::MutableContext ctx, ast::ExpressionPtr tree) {
         auto &nm = ast::cast_tree_nonnull<ast::UnresolvedIdent>(tree);
         if (nm.kind == ast::UnresolvedIdent::Kind::Local) {
             auto &frame = scopeStack.back();

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -50,7 +50,7 @@ class LocalNameInserter {
                 named.name = nm.name;
                 named.local = enterLocal(named.name);
                 named.loc = arg.loc();
-                named.expr = ast::make_tree<ast::Local>(arg.loc(), named.local);
+                named.expr = ast::make_expression<ast::Local>(arg.loc(), named.local);
             },
             [&](ast::RestArg &rest) {
                 named = nameArg(move(rest.expr));
@@ -80,7 +80,7 @@ class LocalNameInserter {
                 named.name = local.localVariable._name;
                 named.local = enterLocal(named.name);
                 named.loc = arg.loc();
-                named.expr = ast::make_tree<ast::Local>(local.loc, named.local);
+                named.expr = ast::make_expression<ast::Local>(local.loc, named.local);
             });
 
         return named;
@@ -235,12 +235,12 @@ public:
                 for (auto arg : scopeStack.back().args) {
                     if (arg.flags.isPositional()) {
                         ENFORCE(!seenKeywordArgs, "Saw positional arg after keyword arg");
-                        original.args.emplace_back(ast::make_tree<ast::Local>(original.loc, arg.arg));
+                        original.args.emplace_back(ast::make_expression<ast::Local>(original.loc, arg.arg));
                         ++original.numPosArgs;
                     } else if (arg.flags.isKeyword()) {
                         seenKeywordArgs = true;
                         original.args.emplace_back(ast::MK::Symbol(original.loc, arg.arg._name));
-                        original.args.emplace_back(ast::make_tree<ast::Local>(original.loc, arg.arg));
+                        original.args.emplace_back(ast::make_expression<ast::Local>(original.loc, arg.arg));
                     } else if (arg.flags.repeated || arg.flags.block) {
                         // Explicitly skip for now.
                         // Involves synthesizing a call to callWithSplat, callWithBlock, or callWithSplatAndBlock
@@ -293,7 +293,7 @@ public:
                 cur = enterLocal(nm.name);
                 frame.locals[nm.name] = cur;
             }
-            return ast::make_tree<ast::Local>(nm.loc, cur);
+            return ast::make_expression<ast::Local>(nm.loc, cur);
         } else {
             return tree;
         }

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -57,7 +57,7 @@ public:
         nesting.emplace_back(def.id);
     }
 
-    ast::TreePtr preTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::ClassDef>(tree);
 
         if (!ast::isa_tree<ast::ConstantLit>(original.name)) {
@@ -150,7 +150,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::ClassDef>(tree);
 
         if (!ast::isa_tree<ast::ConstantLit>(original.name)) {
@@ -166,12 +166,12 @@ public:
         return tree;
     }
 
-    ast::TreePtr preTransformBlock(core::Context ctx, ast::TreePtr block) {
+    ast::ExpressionPtr preTransformBlock(core::Context ctx, ast::ExpressionPtr block) {
         scopeTypes.emplace_back(ScopeType::Block);
         return block;
     }
 
-    ast::TreePtr postTransformBlock(core::Context ctx, ast::TreePtr block) {
+    ast::ExpressionPtr postTransformBlock(core::Context ctx, ast::ExpressionPtr block) {
         scopeTypes.pop_back();
         return block;
     }
@@ -188,7 +188,7 @@ public:
         return false;
     }
 
-    ast::TreePtr postTransformConstantLit(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformConstantLit(core::Context ctx, ast::ExpressionPtr tree) {
         auto *original = ast::cast_tree<ast::ConstantLit>(tree);
 
         if (!ignoring.empty()) {
@@ -239,7 +239,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformAssign(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformAssign(core::Context ctx, ast::ExpressionPtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::Assign>(tree);
 
         // autogen only cares about constant assignments/definitions, so bail otherwise
@@ -281,7 +281,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr preTransformSend(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformSend(core::Context ctx, ast::ExpressionPtr tree) {
         auto *original = ast::cast_tree<ast::Send>(tree);
 
         bool inBlock = !scopeTypes.empty() && scopeTypes.back() == ScopeType::Block;
@@ -303,7 +303,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformSend(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformSend(core::Context ctx, ast::ExpressionPtr tree) {
         auto *original = ast::cast_tree<ast::Send>(tree);
         // if this send was something we were ignoring (i.e. a `keepForIde` or an `include` or `require`) then pop this
         if (!ignoring.empty() && ignoring.back() == original) {

--- a/main/autogen/packages.cc
+++ b/main/autogen/packages.cc
@@ -27,7 +27,7 @@ class PackageWalk {
     }
 
 public:
-    ast::TreePtr preTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &classDef = ast::cast_tree_nonnull<ast::ClassDef>(tree);
         if (classDef.symbol == core::Symbols::root() || classDef.ancestors.size() != 1 ||
             classDef.kind != ast::ClassDef::Kind::Class) {
@@ -42,7 +42,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformSend(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformSend(core::Context ctx, ast::ExpressionPtr tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
         // we're not going to report errors about ill-formed things here: those errors should get reported elsewhere,
         // and instead we'll bail if things don't look like we expect

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -6,7 +6,7 @@
 using namespace std;
 namespace sorbet::realmain::lsp {
 
-ast::TreePtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::TreePtr tree) {
+ast::ExpressionPtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
     auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
     const core::lsp::Query &lspQuery = ctx.state.lspQuery;
@@ -49,7 +49,7 @@ ast::TreePtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::TreePtr
     return tree;
 }
 
-ast::TreePtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, ast::TreePtr tree) {
+ast::ExpressionPtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, ast::ExpressionPtr tree) {
     auto &id = ast::cast_tree_nonnull<ast::UnresolvedIdent>(tree);
     if (id.kind == ast::UnresolvedIdent::Kind::Instance || id.kind == ast::UnresolvedIdent::Kind::Class) {
         core::ClassOrModuleRef klass;
@@ -111,7 +111,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
     }
 }
 
-ast::TreePtr DefLocSaver::postTransformConstantLit(core::Context ctx, ast::TreePtr tree) {
+ast::ExpressionPtr DefLocSaver::postTransformConstantLit(core::Context ctx, ast::ExpressionPtr tree) {
     auto &lit = ast::cast_tree_nonnull<ast::ConstantLit>(tree);
     const core::lsp::Query &lspQuery = ctx.state.lspQuery;
     auto symbol = lit.symbol.data(ctx)->dealias(ctx);

--- a/main/lsp/DefLocSaver.h
+++ b/main/lsp/DefLocSaver.h
@@ -7,11 +7,11 @@ namespace sorbet::realmain::lsp {
 class DefLocSaver {
 public:
     // Handles loc and symbol requests for method definitions.
-    ast::TreePtr postTransformMethodDef(core::Context ctx, ast::TreePtr methodDef);
+    ast::ExpressionPtr postTransformMethodDef(core::Context ctx, ast::ExpressionPtr methodDef);
     // Handles loc and symbol requests for instance variables.
-    ast::TreePtr postTransformUnresolvedIdent(core::Context ctx, ast::TreePtr id);
+    ast::ExpressionPtr postTransformUnresolvedIdent(core::Context ctx, ast::ExpressionPtr id);
 
     // Handles loc and symbol requests for constants.
-    ast::TreePtr postTransformConstantLit(core::Context ctx, ast::TreePtr lit);
+    ast::ExpressionPtr postTransformConstantLit(core::Context ctx, ast::ExpressionPtr lit);
 };
 }; // namespace sorbet::realmain::lsp

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -6,7 +6,7 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 
-ast::TreePtr LocalVarFinder::postTransformAssign(core::Context ctx, ast::TreePtr tree) {
+ast::ExpressionPtr LocalVarFinder::postTransformAssign(core::Context ctx, ast::ExpressionPtr tree) {
     ENFORCE(!methodStack.empty());
 
     auto &assign = ast::cast_tree_nonnull<ast::Assign>(tree);
@@ -23,7 +23,7 @@ ast::TreePtr LocalVarFinder::postTransformAssign(core::Context ctx, ast::TreePtr
     return tree;
 }
 
-ast::TreePtr LocalVarFinder::preTransformMethodDef(core::Context ctx, ast::TreePtr tree) {
+ast::ExpressionPtr LocalVarFinder::preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
     auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
     ENFORCE(methodDef.symbol.exists());
@@ -43,12 +43,12 @@ ast::TreePtr LocalVarFinder::preTransformMethodDef(core::Context ctx, ast::TreeP
     return tree;
 }
 
-ast::TreePtr LocalVarFinder::postTransformMethodDef(core::Context ctx, ast::TreePtr tree) {
+ast::ExpressionPtr LocalVarFinder::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
     this->methodStack.pop_back();
     return tree;
 }
 
-ast::TreePtr LocalVarFinder::preTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+ast::ExpressionPtr LocalVarFinder::preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
     auto &classDef = ast::cast_tree_nonnull<ast::ClassDef>(tree);
     ENFORCE(classDef.symbol.exists());
     ENFORCE(classDef.symbol != core::Symbols::todo());
@@ -62,7 +62,7 @@ ast::TreePtr LocalVarFinder::preTransformClassDef(core::Context ctx, ast::TreePt
     return tree;
 }
 
-ast::TreePtr LocalVarFinder::postTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+ast::ExpressionPtr LocalVarFinder::postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
     this->methodStack.pop_back();
     return tree;
 }

--- a/main/lsp/LocalVarFinder.h
+++ b/main/lsp/LocalVarFinder.h
@@ -18,11 +18,11 @@ class LocalVarFinder {
 public:
     LocalVarFinder(core::MethodRef targetMethod) : targetMethod(targetMethod) {}
 
-    ast::TreePtr postTransformAssign(core::Context ctx, ast::TreePtr assign);
-    ast::TreePtr preTransformMethodDef(core::Context ctx, ast::TreePtr methodDef);
-    ast::TreePtr postTransformMethodDef(core::Context ctx, ast::TreePtr methodDef);
-    ast::TreePtr preTransformClassDef(core::Context ctx, ast::TreePtr classDef);
-    ast::TreePtr postTransformClassDef(core::Context ctx, ast::TreePtr classDef);
+    ast::ExpressionPtr postTransformAssign(core::Context ctx, ast::ExpressionPtr assign);
+    ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr methodDef);
+    ast::ExpressionPtr postTransformMethodDef(core::Context ctx, ast::ExpressionPtr methodDef);
+    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr classDef);
+    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr classDef);
 
     const std::vector<core::LocalVariable> &result() const;
 };

--- a/main/lsp/LocalVarSaver.cc
+++ b/main/lsp/LocalVarSaver.cc
@@ -5,7 +5,7 @@
 using namespace std;
 
 namespace sorbet::realmain::lsp {
-ast::TreePtr LocalVarSaver::postTransformLocal(core::Context ctx, ast::TreePtr tree) {
+ast::ExpressionPtr LocalVarSaver::postTransformLocal(core::Context ctx, ast::ExpressionPtr tree) {
     auto &local = ast::cast_tree_nonnull<ast::Local>(tree);
 
     core::MethodRef enclosingMethod;
@@ -29,7 +29,7 @@ ast::TreePtr LocalVarSaver::postTransformLocal(core::Context ctx, ast::TreePtr t
     return tree;
 }
 
-ast::TreePtr LocalVarSaver::postTransformMethodDef(core::Context ctx, ast::TreePtr tree) {
+ast::ExpressionPtr LocalVarSaver::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
     auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
     // Check args.

--- a/main/lsp/LocalVarSaver.h
+++ b/main/lsp/LocalVarSaver.h
@@ -9,8 +9,8 @@ namespace sorbet::realmain::lsp {
 
 class LocalVarSaver {
 public:
-    ast::TreePtr postTransformLocal(core::Context ctx, ast::TreePtr local);
-    ast::TreePtr postTransformMethodDef(core::Context ctx, ast::TreePtr methodDef);
+    ast::ExpressionPtr postTransformLocal(core::Context ctx, ast::ExpressionPtr local);
+    ast::ExpressionPtr postTransformMethodDef(core::Context ctx, ast::ExpressionPtr methodDef);
 };
 }; // namespace sorbet::realmain::lsp
 

--- a/main/lsp/NextMethodFinder.cc
+++ b/main/lsp/NextMethodFinder.cc
@@ -5,7 +5,7 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 
-ast::TreePtr NextMethodFinder::preTransformMethodDef(core::Context ctx, ast::TreePtr tree) {
+ast::ExpressionPtr NextMethodFinder::preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
     auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
     ENFORCE(methodDef.symbol.exists());
     ENFORCE(methodDef.symbol != core::Symbols::todoMethod());

--- a/main/lsp/NextMethodFinder.h
+++ b/main/lsp/NextMethodFinder.h
@@ -13,7 +13,7 @@ class NextMethodFinder {
 public:
     NextMethodFinder(core::Loc queryLoc) : queryLoc(queryLoc), result_(core::Symbols::noSymbol()) {}
 
-    ast::TreePtr preTransformMethodDef(core::Context ctx, ast::TreePtr methodDef);
+    ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr methodDef);
 
     const core::SymbolRef result() const;
 };

--- a/main/lsp/test/lsp_file_updates_test.cc
+++ b/main/lsp/test/lsp_file_updates_test.cc
@@ -21,7 +21,7 @@ unique_ptr<core::FileHash> getFileHash() {
 }
 
 ast::ParsedFile getParsedFile(core::FileRef fref) {
-    auto lit = ast::make_tree<ast::Literal>(core::LocOffsets{0, 1}, core::Types::Integer());
+    auto lit = ast::make_expression<ast::Literal>(core::LocOffsets{0, 1}, core::Types::Integer());
     return ast::ParsedFile{move(lit), fref};
 }
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -110,7 +110,7 @@ unique_ptr<core::serialize::CachedFile> fetchFileFromCache(core::GlobalState &gs
 }
 
 ast::ExpressionPtr fetchTreeFromCache(core::GlobalState &gs, core::FileRef fref, const core::File &file,
-                                const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+                                      const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     auto cachedFile = fetchFileFromCache(gs, fref, file, kvstore);
     if (cachedFile) {
         return move(cachedFile->tree);
@@ -141,7 +141,7 @@ unique_ptr<parser::Node> runParser(core::GlobalState &gs, core::FileRef file, co
 }
 
 ast::ExpressionPtr runDesugar(core::GlobalState &gs, core::FileRef file, unique_ptr<parser::Node> parseTree,
-                        const options::Printers &print) {
+                              const options::Printers &print) {
     Timer timeit(gs.tracer(), "runDesugar", {{"file", (string)file.data(gs).path()}});
     ast::ExpressionPtr ast;
     core::MutableContext ctx(gs, core::Symbols::root(), file);
@@ -175,7 +175,8 @@ ast::ParsedFile emptyParsedFile(core::FileRef file) {
     return {ast::MK::EmptyTree(), file};
 }
 
-ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file, ast::ExpressionPtr tree) {
+ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
+                         ast::ExpressionPtr tree) {
     auto &print = opts.print;
     ast::ParsedFile rewriten{nullptr, file};
     ENFORCE(file.data(lgs).strictLevel == decideStrictLevel(lgs, file, opts));
@@ -442,8 +443,8 @@ void incrementStrictLevelCounter(core::StrictLevel level) {
 
 // Returns a non-null ast::Expression if kvstore contains the AST.
 ast::ExpressionPtr readFileWithStrictnessOverrides(unique_ptr<core::GlobalState> &gs, core::FileRef file,
-                                             const options::Options &opts,
-                                             const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+                                                   const options::Options &opts,
+                                                   const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     ast::ExpressionPtr ast;
     if (file.dataAllowingUnsafe(*gs).sourceType != core::File::Type::NotYetRead) {
         return ast;

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -13,11 +13,11 @@ class PreemptionTaskManager;
 
 namespace sorbet::realmain::pipeline {
 ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
-                         ast::TreePtr cachedTree = nullptr);
+                         ast::ExpressionPtr cachedTree = nullptr);
 
 std::pair<ast::ParsedFile, std::vector<std::shared_ptr<core::File>>>
 indexOneWithPlugins(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
-                    ast::TreePtr cachedTree = nullptr);
+                    ast::ExpressionPtr cachedTree = nullptr);
 
 std::vector<core::FileRef> reserveFiles(std::unique_ptr<core::GlobalState> &gs, const std::vector<std::string> &files);
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1470,7 +1470,7 @@ class TreeSymbolizer {
         // NameInserter should have created this symbol.
         ENFORCE(existing.exists());
 
-        node = ast::make_tree<ast::ConstantLit>(constLit->loc, existing, std::move(node));
+        node = ast::make_expression<ast::ConstantLit>(constLit->loc, existing, std::move(node));
         return existing;
     }
 
@@ -1480,7 +1480,7 @@ class TreeSymbolizer {
     }
 
     ast::ExpressionPtr arg2Symbol(core::Context ctx, int pos, ast::ParsedArg parsedArg, ast::ExpressionPtr arg) {
-        ast::ExpressionPtr localExpr = ast::make_tree<ast::Local>(parsedArg.loc, parsedArg.local);
+        ast::ExpressionPtr localExpr = ast::make_expression<ast::Local>(parsedArg.loc, parsedArg.local);
         if (parsedArg.flags.isDefault) {
             localExpr =
                 ast::MK::OptionalArg(parsedArg.loc, move(localExpr), ast::ArgParsing::getDefault(parsedArg, move(arg)));
@@ -1661,7 +1661,7 @@ public:
             auto localVariable = arg.local;
 
             if (arg.flags.isShadow) {
-                auto localExpr = ast::make_tree<ast::Local>(arg.loc, localVariable);
+                auto localExpr = ast::make_expression<ast::Local>(arg.loc, localVariable);
                 args.emplace_back(move(localExpr));
             } else {
                 ENFORCE(i < oldArgs.size());
@@ -1706,7 +1706,7 @@ public:
         core::SymbolRef cnst = ctx.state.lookupStaticFieldSymbol(scope, lhs.cnst);
         ENFORCE(cnst.exists());
         auto loc = lhs.loc;
-        asgn.lhs = ast::make_tree<ast::ConstantLit>(loc, cnst, std::move(asgn.lhs));
+        asgn.lhs = ast::make_expression<ast::ConstantLit>(loc, cnst, std::move(asgn.lhs));
 
         return tree;
     }
@@ -1730,7 +1730,7 @@ public:
             auto send = ast::MK::Send0Block(asgn.loc, ast::MK::T(asgn.loc), core::Names::typeAlias(),
                                             ast::MK::Block0(asgn.loc, ast::MK::Untyped(asgn.loc)));
 
-            return handleAssignment(ctx, ast::make_tree<ast::Assign>(asgn.loc, std::move(asgn.lhs), std::move(send)));
+            return handleAssignment(ctx, ast::make_expression<ast::Assign>(asgn.loc, std::move(asgn.lhs), std::move(send)));
         }
 
         if (!send->args.empty()) {
@@ -1742,7 +1742,7 @@ public:
                 auto send = ast::MK::Send1(asgn.loc, ast::MK::T(asgn.loc), core::Names::typeAlias(),
                                            ast::MK::Untyped(asgn.loc));
                 return handleAssignment(ctx,
-                                        ast::make_tree<ast::Assign>(asgn.loc, std::move(asgn.lhs), std::move(send)));
+                                        ast::make_expression<ast::Assign>(asgn.loc, std::move(asgn.lhs), std::move(send)));
             }
 
             bool isTypeTemplate = send->fun == core::Names::typeTemplate();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1431,7 +1431,8 @@ public:
 class TreeSymbolizer {
     friend class Namer;
 
-    core::SymbolRef squashNamesInner(core::Context ctx, core::SymbolRef owner, ast::ExpressionPtr &node, bool firstName) {
+    core::SymbolRef squashNamesInner(core::Context ctx, core::SymbolRef owner, ast::ExpressionPtr &node,
+                                     bool firstName) {
         auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(node);
         if (constLit == nullptr) {
             if (auto *id = ast::cast_tree<ast::ConstantLit>(node)) {
@@ -1711,7 +1712,7 @@ public:
     }
 
     ast::ExpressionPtr handleTypeMemberDefinition(core::Context ctx, ast::Send *send, ast::ExpressionPtr tree,
-                                            const ast::UnresolvedConstantLit *typeName) {
+                                                  const ast::UnresolvedConstantLit *typeName) {
         auto &asgn = ast::cast_tree_nonnull<ast::Assign>(tree);
 
         ENFORCE(asgn.lhs.get() == typeName &&

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1730,7 +1730,8 @@ public:
             auto send = ast::MK::Send0Block(asgn.loc, ast::MK::T(asgn.loc), core::Names::typeAlias(),
                                             ast::MK::Block0(asgn.loc, ast::MK::Untyped(asgn.loc)));
 
-            return handleAssignment(ctx, ast::make_expression<ast::Assign>(asgn.loc, std::move(asgn.lhs), std::move(send)));
+            return handleAssignment(ctx,
+                                    ast::make_expression<ast::Assign>(asgn.loc, std::move(asgn.lhs), std::move(send)));
         }
 
         if (!send->args.empty()) {
@@ -1741,8 +1742,8 @@ public:
                 }
                 auto send = ast::MK::Send1(asgn.loc, ast::MK::T(asgn.loc), core::Names::typeAlias(),
                                            ast::MK::Untyped(asgn.loc));
-                return handleAssignment(ctx,
-                                        ast::make_expression<ast::Assign>(asgn.loc, std::move(asgn.lhs), std::move(send)));
+                return handleAssignment(
+                    ctx, ast::make_expression<ast::Assign>(asgn.loc, std::move(asgn.lhs), std::move(send)));
             }
 
             bool isTypeTemplate = send->fun == core::Names::typeTemplate();

--- a/plugin/SubprocessTextPlugin.cc
+++ b/plugin/SubprocessTextPlugin.cc
@@ -131,7 +131,8 @@ struct SpawningWalker {
     }
 };
 
-pair<ast::ExpressionPtr, vector<shared_ptr<core::File>>> SubprocessTextPlugin::run(core::Context ctx, ast::ExpressionPtr tree) {
+pair<ast::ExpressionPtr, vector<shared_ptr<core::File>>> SubprocessTextPlugin::run(core::Context ctx,
+                                                                                   ast::ExpressionPtr tree) {
     if (!ctx.state.hasAnyDslPlugin()) {
         vector<shared_ptr<core::File>> empty;
         return {move(tree), empty};

--- a/plugin/SubprocessTextPlugin.cc
+++ b/plugin/SubprocessTextPlugin.cc
@@ -13,7 +13,7 @@ struct Namespace {
     Type type;
     InlinedVector<core::NameRef, 3> components;
 
-    Namespace(ast::TreePtr &tree) {
+    Namespace(ast::ExpressionPtr &tree) {
         auto *klass = ast::cast_tree<ast::ClassDef>(tree);
         type = (klass->kind == ast::ClassDef::Kind::Module ? Namespace::Type::Module : Namespace::Type::Class);
         fillComponents(klass->name);
@@ -22,7 +22,7 @@ struct Namespace {
     Namespace(Namespace &&) = default;
 
 private:
-    void fillComponents(ast::TreePtr &constant) {
+    void fillComponents(ast::ExpressionPtr &constant) {
         auto *cursor = &constant;
         while (cursor) {
             if (auto unresolved = ast::cast_tree<ast::UnresolvedConstantLit>(*cursor)) {
@@ -49,7 +49,7 @@ struct SpawningWalker {
 
     SpawningWalker() {}
 
-    ast::TreePtr preTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto *klass = ast::cast_tree<ast::ClassDef>(tree);
         if (klass->symbol == core::Symbols::root()) {
             return tree;
@@ -123,7 +123,7 @@ struct SpawningWalker {
         return tree;
     }
 
-    ast::TreePtr postTransformClassDef(core::Context ctx, ast::TreePtr klass) {
+    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr klass) {
         if (ast::cast_tree<ast::ClassDef>(klass)->symbol != core::Symbols::root()) {
             nesting.pop_back();
         }
@@ -131,7 +131,7 @@ struct SpawningWalker {
     }
 };
 
-pair<ast::TreePtr, vector<shared_ptr<core::File>>> SubprocessTextPlugin::run(core::Context ctx, ast::TreePtr tree) {
+pair<ast::ExpressionPtr, vector<shared_ptr<core::File>>> SubprocessTextPlugin::run(core::Context ctx, ast::ExpressionPtr tree) {
     if (!ctx.state.hasAnyDslPlugin()) {
         vector<shared_ptr<core::File>> empty;
         return {move(tree), empty};

--- a/plugin/SubprocessTextPlugin.h
+++ b/plugin/SubprocessTextPlugin.h
@@ -6,7 +6,8 @@ namespace sorbet::plugin {
 
 class SubprocessTextPlugin final {
 public:
-    static std::pair<ast::ExpressionPtr, std::vector<std::shared_ptr<core::File>>> run(core::Context ctx, ast::ExpressionPtr tree);
+    static std::pair<ast::ExpressionPtr, std::vector<std::shared_ptr<core::File>>> run(core::Context ctx,
+                                                                                       ast::ExpressionPtr tree);
 
     SubprocessTextPlugin() = delete;
 };

--- a/plugin/SubprocessTextPlugin.h
+++ b/plugin/SubprocessTextPlugin.h
@@ -6,7 +6,7 @@ namespace sorbet::plugin {
 
 class SubprocessTextPlugin final {
 public:
-    static std::pair<ast::TreePtr, std::vector<std::shared_ptr<core::File>>> run(core::Context ctx, ast::TreePtr tree);
+    static std::pair<ast::ExpressionPtr, std::vector<std::shared_ptr<core::File>>> run(core::Context ctx, ast::ExpressionPtr tree);
 
     SubprocessTextPlugin() = delete;
 };

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -676,7 +676,7 @@ private:
             auto loc = ancestor.loc();
             auto enclosingClass = ctx.owner.data(ctx)->enclosingClass(ctx);
             auto nw = ast::MK::UnresolvedConstant(loc, std::move(ancestor), enclosingClass.data(ctx)->name);
-            auto out = ast::make_tree<ast::ConstantLit>(loc, enclosingClass, std::move(nw));
+            auto out = ast::make_expression<ast::ConstantLit>(loc, enclosingClass, std::move(nw));
             job.ancestor = ast::cast_tree<ast::ConstantLit>(out);
             ancestor = std::move(out);
         } else if (ast::isa_tree<ast::EmptyTree>(ancestor)) {
@@ -702,7 +702,7 @@ public:
             c.scope = postTransformUnresolvedConstantLit(ctx, std::move(c.scope));
         }
         auto loc = c.loc;
-        auto out = ast::make_tree<ast::ConstantLit>(loc, core::Symbols::noSymbol(), std::move(tree));
+        auto out = ast::make_expression<ast::ConstantLit>(loc, core::Symbols::noSymbol(), std::move(tree));
         ResolutionItem job{nesting_, ctx.file, ast::cast_tree<ast::ConstantLit>(out)};
         if (resolveJob(ctx, job)) {
             categoryCounterInc("resolve.constants.nonancestor", "firstpass");
@@ -1975,7 +1975,7 @@ public:
 
                     auto typeExpr = ast::MK::KeepForTypechecking(std::move(send.args[1]));
                     auto expr = std::move(send.args[0]);
-                    auto cast = ast::make_tree<ast::Cast>(send.loc, core::Types::todo(), std::move(expr), send.fun);
+                    auto cast = ast::make_expression<ast::Cast>(send.loc, core::Types::todo(), std::move(expr), send.fun);
                     item.cast = ast::cast_tree<ast::Cast>(cast);
                     item.typeArg = &ast::cast_tree_nonnull<ast::Send>(typeExpr).args[0];
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1975,7 +1975,8 @@ public:
 
                     auto typeExpr = ast::MK::KeepForTypechecking(std::move(send.args[1]));
                     auto expr = std::move(send.args[0]);
-                    auto cast = ast::make_expression<ast::Cast>(send.loc, core::Types::todo(), std::move(expr), send.fun);
+                    auto cast =
+                        ast::make_expression<ast::Cast>(send.loc, core::Types::todo(), std::move(expr), send.fun);
                     item.cast = ast::cast_tree<ast::Cast>(cast);
                     item.typeArg = &ast::cast_tree_nonnull<ast::Send>(typeExpr).args[0];
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -639,8 +639,8 @@ private:
         ancestorSym.data(ctx)->recordSealedSubclass(ctx, job.klass);
     }
 
-    void transformAncestor(core::Context ctx, core::ClassOrModuleRef klass, ast::ExpressionPtr &ancestor, bool isInclude,
-                           bool isSuperclass = false) {
+    void transformAncestor(core::Context ctx, core::ClassOrModuleRef klass, ast::ExpressionPtr &ancestor,
+                           bool isInclude, bool isSuperclass = false) {
         if (auto *constScope = ast::cast_tree<ast::UnresolvedConstantLit>(ancestor)) {
             auto scopeTmp = nesting_;
             if (isSuperclass) {
@@ -2587,8 +2587,8 @@ private:
 
         processLeftoverSigs(ctx, lastSigs);
 
-        auto toRemove =
-            remove_if(klass.rhs.begin(), klass.rhs.end(), [](ast::ExpressionPtr &stat) -> bool { return stat == nullptr; });
+        auto toRemove = remove_if(klass.rhs.begin(), klass.rhs.end(),
+                                  [](ast::ExpressionPtr &stat) -> bool { return stat == nullptr; });
         klass.rhs.erase(toRemove, klass.rhs.end());
     }
 
@@ -2607,8 +2607,8 @@ private:
 
         processLeftoverSigs(classCtx, lastSigs);
 
-        auto toRemove =
-            remove_if(seq.stats.begin(), seq.stats.end(), [](ast::ExpressionPtr &stat) -> bool { return stat == nullptr; });
+        auto toRemove = remove_if(seq.stats.begin(), seq.stats.end(),
+                                  [](ast::ExpressionPtr &stat) -> bool { return stat == nullptr; });
         seq.stats.erase(toRemove, seq.stats.end());
     }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -149,7 +149,7 @@ private:
     struct TypeAliasResolutionItem {
         core::SymbolRef lhs;
         core::FileRef file;
-        ast::TreePtr *rhs;
+        ast::ExpressionPtr *rhs;
 
         TypeAliasResolutionItem(TypeAliasResolutionItem &&) noexcept = default;
         TypeAliasResolutionItem &operator=(TypeAliasResolutionItem &&rhs) noexcept = default;
@@ -205,16 +205,16 @@ private:
     public:
         bool seenUnresolved = false;
 
-        ast::TreePtr postTransformConstantLit(core::Context ctx, ast::TreePtr tree) {
+        ast::ExpressionPtr postTransformConstantLit(core::Context ctx, ast::ExpressionPtr tree) {
             auto &original = ast::cast_tree_nonnull<ast::ConstantLit>(tree);
             seenUnresolved |= !isAlreadyResolved(ctx, original);
             return tree;
         };
     };
 
-    static bool isFullyResolved(core::Context ctx, const ast::TreePtr &expression) {
+    static bool isFullyResolved(core::Context ctx, const ast::ExpressionPtr &expression) {
         ResolutionChecker checker;
-        ast::TreePtr dummy(expression.getTagged());
+        ast::ExpressionPtr dummy(expression.getTagged());
         dummy = ast::TreeMap::apply(ctx, checker, std::move(dummy));
         ENFORCE(dummy == expression);
         dummy.release();
@@ -639,7 +639,7 @@ private:
         ancestorSym.data(ctx)->recordSealedSubclass(ctx, job.klass);
     }
 
-    void transformAncestor(core::Context ctx, core::ClassOrModuleRef klass, ast::TreePtr &ancestor, bool isInclude,
+    void transformAncestor(core::Context ctx, core::ClassOrModuleRef klass, ast::ExpressionPtr &ancestor, bool isInclude,
                            bool isSuperclass = false) {
         if (auto *constScope = ast::cast_tree<ast::UnresolvedConstantLit>(ancestor)) {
             auto scopeTmp = nesting_;
@@ -691,12 +691,12 @@ private:
 public:
     ResolveConstantsWalk() : nesting_(nullptr) {}
 
-    ast::TreePtr preTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         nesting_ = make_unique<Nesting>(std::move(nesting_), ast::cast_tree_nonnull<ast::ClassDef>(tree).symbol);
         return tree;
     }
 
-    ast::TreePtr postTransformUnresolvedConstantLit(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformUnresolvedConstantLit(core::Context ctx, ast::ExpressionPtr tree) {
         auto &c = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(tree);
         if (ast::isa_tree<ast::UnresolvedConstantLit>(c.scope)) {
             c.scope = postTransformUnresolvedConstantLit(ctx, std::move(c.scope));
@@ -712,7 +712,7 @@ public:
         return out;
     }
 
-    ast::TreePtr postTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::ClassDef>(tree);
 
         auto klass = original.symbol;
@@ -735,7 +735,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformAssign(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformAssign(core::Context ctx, ast::ExpressionPtr tree) {
         auto &asgn = ast::cast_tree_nonnull<ast::Assign>(tree);
 
         auto *id = ast::cast_tree<ast::ConstantLit>(asgn.lhs);
@@ -784,7 +784,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformSend(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformSend(core::Context ctx, ast::ExpressionPtr tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
         if (send.recv.isSelfReference() && send.fun == core::Names::mixesInClassMethods()) {
             auto item = ClassMethodsResolutionItem{ctx.file, ctx.owner, &send};
@@ -1101,7 +1101,7 @@ class ResolveTypeMembersAndFieldsWalk {
     struct ResolveCastItem {
         core::FileRef file;
         core::SymbolRef owner;
-        ast::TreePtr *typeArg;
+        ast::ExpressionPtr *typeArg;
         ast::Cast *cast;
     };
 
@@ -1167,7 +1167,7 @@ class ResolveTypeMembersAndFieldsWalk {
         }
     }
 
-    static bool isT(const ast::TreePtr &expr) {
+    static bool isT(const ast::ExpressionPtr &expr) {
         auto *tMod = ast::cast_tree<ast::ConstantLit>(expr);
         return tMod && tMod->symbol == core::Symbols::T();
     }
@@ -1316,7 +1316,7 @@ class ResolveTypeMembersAndFieldsWalk {
     //
     // We don't handle array or hash literals, because intuiting the element
     // type (once we have generics) will be nontrivial.
-    [[nodiscard]] static core::TypePtr resolveConstantType(core::Context ctx, const ast::TreePtr &expr) {
+    [[nodiscard]] static core::TypePtr resolveConstantType(core::Context ctx, const ast::ExpressionPtr &expr) {
         core::TypePtr result;
         typecase(
             expr, [&](const ast::Literal &a) { result = a.value; },
@@ -1333,7 +1333,7 @@ class ResolveTypeMembersAndFieldsWalk {
                 result = cast.type;
             },
             [&](const ast::InsSeq &outer) { result = resolveConstantType(ctx, outer.expr); },
-            [&](const ast::TreePtr &expr) {});
+            [&](const ast::ExpressionPtr &expr) {});
         return result;
     }
 
@@ -1832,7 +1832,7 @@ public:
         nestedBlockCounts.emplace_back(0);
     }
 
-    ast::TreePtr preTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         nestedBlockCounts.emplace_back(0);
 
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(tree);
@@ -1847,34 +1847,34 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         nestedBlockCounts.pop_back();
         return tree;
     }
 
-    ast::TreePtr preTransformMethodDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
         nestedBlockCounts.emplace_back(0);
         return tree;
     }
 
-    ast::TreePtr postTransformMethodDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
         nestedBlockCounts.pop_back();
         return tree;
     }
 
-    ast::TreePtr preTransformBlock(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformBlock(core::Context ctx, ast::ExpressionPtr tree) {
         ENFORCE_NO_TIMER(!nestedBlockCounts.empty());
         nestedBlockCounts.back() += 1;
         return tree;
     }
 
-    ast::TreePtr postTransformBlock(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformBlock(core::Context ctx, ast::ExpressionPtr tree) {
         ENFORCE_NO_TIMER(!nestedBlockCounts.empty());
         nestedBlockCounts.back() -= 1;
         return tree;
     }
 
-    ast::TreePtr preTransformSend(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformSend(core::Context ctx, ast::ExpressionPtr tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
         switch (send.fun.rawId()) {
             case core::Names::typeAlias().rawId():
@@ -1901,7 +1901,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformConstantLit(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformConstantLit(core::Context ctx, ast::ExpressionPtr tree) {
         auto &lit = ast::cast_tree_nonnull<ast::ConstantLit>(tree);
 
         if (trackDependencies_) {
@@ -1934,7 +1934,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformSend(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformSend(core::Context ctx, ast::ExpressionPtr tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
 
         switch (send.fun.rawId()) {
@@ -2054,7 +2054,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformAssign(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformAssign(core::Context ctx, ast::ExpressionPtr tree) {
         auto &asgn = ast::cast_tree_nonnull<ast::Assign>(tree);
         if (handleFieldDeclaration(ctx, asgn)) {
             return tree;
@@ -2588,7 +2588,7 @@ private:
         processLeftoverSigs(ctx, lastSigs);
 
         auto toRemove =
-            remove_if(klass.rhs.begin(), klass.rhs.end(), [](ast::TreePtr &stat) -> bool { return stat == nullptr; });
+            remove_if(klass.rhs.begin(), klass.rhs.end(), [](ast::ExpressionPtr &stat) -> bool { return stat == nullptr; });
         klass.rhs.erase(toRemove, klass.rhs.end());
     }
 
@@ -2608,7 +2608,7 @@ private:
         processLeftoverSigs(classCtx, lastSigs);
 
         auto toRemove =
-            remove_if(seq.stats.begin(), seq.stats.end(), [](ast::TreePtr &stat) -> bool { return stat == nullptr; });
+            remove_if(seq.stats.begin(), seq.stats.end(), [](ast::ExpressionPtr &stat) -> bool { return stat == nullptr; });
         seq.stats.erase(toRemove, seq.stats.end());
     }
 
@@ -2620,7 +2620,7 @@ private:
                                     TypeSyntaxArgs{allowSelfType, allowRebind, allowTypeMember, mdef.symbol});
     }
 
-    void processStatement(core::Context ctx, ast::TreePtr &stat, InlinedVector<ast::Send *, 1> &lastSigs) {
+    void processStatement(core::Context ctx, ast::ExpressionPtr &stat, InlinedVector<ast::Send *, 1> &lastSigs) {
         typecase(
             stat,
 
@@ -2735,7 +2735,7 @@ private:
 
             [&](const ast::EmptyTree &e) { stat.reset(nullptr); },
 
-            [&](const ast::TreePtr &e) {});
+            [&](const ast::ExpressionPtr &e) {});
     }
 
 public:
@@ -2778,13 +2778,13 @@ public:
         handleAbstractMethod(ctx, mdef);
     }
 
-    ast::TreePtr postTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(tree);
         processClassBody(ctx.withOwner(klass.symbol), klass);
         return tree;
     }
 
-    ast::TreePtr postTransformInsSeq(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformInsSeq(core::Context ctx, ast::ExpressionPtr tree) {
         processInSeq(ctx, ast::cast_tree_nonnull<ast::InsSeq>(tree));
         return tree;
     }
@@ -2792,7 +2792,7 @@ public:
 
 class ResolveSanityCheckWalk {
 public:
-    ast::TreePtr postTransformClassDef(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::ClassDef>(tree);
         ENFORCE(original.symbol != core::Symbols::todo(), "These should have all been resolved: {}",
                 tree.toString(ctx));
@@ -2803,23 +2803,23 @@ public:
         }
         return tree;
     }
-    ast::TreePtr postTransformMethodDef(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformMethodDef(core::MutableContext ctx, ast::ExpressionPtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         ENFORCE(original.symbol != core::Symbols::todoMethod(), "These should have all been resolved: {}",
                 tree.toString(ctx));
         return tree;
     }
-    ast::TreePtr postTransformUnresolvedConstantLit(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformUnresolvedConstantLit(core::MutableContext ctx, ast::ExpressionPtr tree) {
         ENFORCE(false, "These should have all been removed: {}", tree.toString(ctx));
         return tree;
     }
-    ast::TreePtr postTransformUnresolvedIdent(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformUnresolvedIdent(core::MutableContext ctx, ast::ExpressionPtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::UnresolvedIdent>(tree);
         ENFORCE(original.kind != ast::UnresolvedIdent::Kind::Local, "{} should have been removed by local_vars",
                 tree.toString(ctx));
         return tree;
     }
-    ast::TreePtr postTransformConstantLit(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformConstantLit(core::MutableContext ctx, ast::ExpressionPtr tree) {
         auto &original = ast::cast_tree_nonnull<ast::ConstantLit>(tree);
         ENFORCE(ResolveConstantsWalk::isAlreadyResolved(ctx, original));
         return tree;

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -13,10 +13,10 @@ namespace sorbet::resolver {
 // Forward declarations for the local versions of getResultType, getResultTypeAndBind, and parseSig that skolemize type
 // members.
 namespace {
-core::TypePtr getResultTypeWithSelfTypeParams(core::Context ctx, const ast::TreePtr &expr,
+core::TypePtr getResultTypeWithSelfTypeParams(core::Context ctx, const ast::ExpressionPtr &expr,
                                               const ParsedSig &sigBeingParsed, TypeSyntaxArgs args);
 
-TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx, const ast::TreePtr &expr,
+TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx, const ast::ExpressionPtr &expr,
                                                               const ParsedSig &sigBeingParsed, TypeSyntaxArgs args);
 
 ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend, const ParsedSig *parent,
@@ -38,24 +38,24 @@ ParsedSig TypeSyntax::parseSig(core::Context ctx, const ast::Send &sigSend, cons
     return result;
 }
 
-core::TypePtr TypeSyntax::getResultType(core::Context ctx, ast::TreePtr &expr, const ParsedSig &sigBeingParsed,
+core::TypePtr TypeSyntax::getResultType(core::Context ctx, ast::ExpressionPtr &expr, const ParsedSig &sigBeingParsed,
                                         TypeSyntaxArgs args) {
     return core::Types::unwrapSelfTypeParam(
         ctx, getResultTypeWithSelfTypeParams(ctx, expr, sigBeingParsed, args.withoutRebind()));
 }
 
-TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::Context ctx, ast::TreePtr &expr,
+TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::Context ctx, ast::ExpressionPtr &expr,
                                                         const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
     auto result = getResultTypeAndBindWithSelfTypeParams(ctx, expr, sigBeingParsed, args);
     result.type = core::Types::unwrapSelfTypeParam(ctx, result.type);
     return result;
 }
 
-core::TypePtr getResultLiteral(core::Context ctx, const ast::TreePtr &expr) {
+core::TypePtr getResultLiteral(core::Context ctx, const ast::ExpressionPtr &expr) {
     core::TypePtr result;
     typecase(
         expr, [&](const ast::Literal &lit) { result = lit.value; },
-        [&](const ast::TreePtr &e) {
+        [&](const ast::ExpressionPtr &e) {
             if (auto e = ctx.beginError(expr.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Unsupported type literal");
             }
@@ -622,12 +622,12 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
     }
 }
 
-core::TypePtr getResultTypeWithSelfTypeParams(core::Context ctx, const ast::TreePtr &expr,
+core::TypePtr getResultTypeWithSelfTypeParams(core::Context ctx, const ast::ExpressionPtr &expr,
                                               const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
     return getResultTypeAndBindWithSelfTypeParams(ctx, expr, sigBeingParsed, args.withoutRebind()).type;
 }
 
-TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx, const ast::TreePtr &expr,
+TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx, const ast::ExpressionPtr &expr,
                                                               const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
     // Ensure that we only check types from a class context
     auto ctxOwnerData = ctx.owner.data(ctx);
@@ -1011,7 +1011,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             }
             result.type = underlying;
         },
-        [&](const ast::TreePtr &e) {
+        [&](const ast::ExpressionPtr &e) {
             if (auto e = ctx.beginError(expr.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Unsupported type syntax");
             }

--- a/resolver/type_syntax.h
+++ b/resolver/type_syntax.h
@@ -77,9 +77,9 @@ public:
         core::TypePtr type;
         core::SymbolRef rebind;
     };
-    static ResultType getResultTypeAndBind(core::Context ctx, ast::TreePtr &expr, const ParsedSig &,
+    static ResultType getResultTypeAndBind(core::Context ctx, ast::ExpressionPtr &expr, const ParsedSig &,
                                            TypeSyntaxArgs args);
-    static core::TypePtr getResultType(core::Context ctx, ast::TreePtr &expr, const ParsedSig &, TypeSyntaxArgs args);
+    static core::TypePtr getResultType(core::Context ctx, ast::ExpressionPtr &expr, const ParsedSig &, TypeSyntaxArgs args);
 
     TypeSyntax() = delete;
 };

--- a/resolver/type_syntax.h
+++ b/resolver/type_syntax.h
@@ -79,7 +79,8 @@ public:
     };
     static ResultType getResultTypeAndBind(core::Context ctx, ast::ExpressionPtr &expr, const ParsedSig &,
                                            TypeSyntaxArgs args);
-    static core::TypePtr getResultType(core::Context ctx, ast::ExpressionPtr &expr, const ParsedSig &, TypeSyntaxArgs args);
+    static core::TypePtr getResultType(core::Context ctx, ast::ExpressionPtr &expr, const ParsedSig &,
+                                       TypeSyntaxArgs args);
 
     TypeSyntax() = delete;
 };

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -15,7 +15,7 @@ namespace sorbet::rewriter {
 
 namespace {
 
-pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::TreePtr &name) {
+pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::ExpressionPtr &name) {
     core::LocOffsets loc;
     core::NameRef res;
     if (auto *lit = ast::cast_tree<ast::Literal>(name)) {
@@ -51,7 +51,7 @@ pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Tre
 // these helpers work on a purely syntactic level. for instance, this function determines if an expression is `T`,
 // either with no scope or with the root scope (i.e. `::T`). this might not actually refer to the `T` that we define for
 // users, but we don't know that information in the Rewriter passes.
-bool isT(const ast::TreePtr &expr) {
+bool isT(const ast::ExpressionPtr &expr) {
     auto *t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     if (t == nullptr || t->cnst != core::Names::Constants::T()) {
         return false;
@@ -59,7 +59,7 @@ bool isT(const ast::TreePtr &expr) {
     return ast::MK::isRootScope(t->scope);
 }
 
-bool isTNilableOrUntyped(const ast::TreePtr &expr) {
+bool isTNilableOrUntyped(const ast::ExpressionPtr &expr) {
     auto *send = ast::cast_tree<ast::Send>(expr);
     return send != nullptr && (send->fun == core::Names::nilable() || send->fun == core::Names::untyped()) &&
            isT(send->recv);
@@ -78,7 +78,7 @@ ast::Send *findSendReturns(ast::Send *sharedSig) {
     return body->fun == core::Names::returns() ? body : nullptr;
 }
 
-bool hasNilableOrUntypedReturns(ast::TreePtr &sharedSig) {
+bool hasNilableOrUntypedReturns(ast::ExpressionPtr &sharedSig) {
     ENFORCE(ASTUtil::castSig(sharedSig), "We weren't given a send node that's a valid signature");
 
     auto *body = findSendReturns(ASTUtil::castSig(sharedSig));
@@ -90,7 +90,7 @@ bool hasNilableOrUntypedReturns(ast::TreePtr &sharedSig) {
     return isTNilableOrUntyped(body->args[0]);
 }
 
-ast::TreePtr dupReturnsType(ast::Send *sharedSig) {
+ast::ExpressionPtr dupReturnsType(ast::Send *sharedSig) {
     ENFORCE(ASTUtil::castSig(sharedSig), "We weren't given a send node that's a valid signature");
 
     auto *body = findSendReturns(ASTUtil::castSig(sharedSig));
@@ -165,11 +165,11 @@ bool sigIsUnchecked(core::MutableContext ctx, ast::Send *sig) {
 
 // To convert a sig into a writer sig with argument `name`, we copy the `returns(...)`
 // value into the `sig {params(...)}` using whatever name we have for the setter.
-ast::TreePtr toWriterSigForName(ast::Send *sharedSig, const core::NameRef name, core::LocOffsets nameLoc) {
+ast::ExpressionPtr toWriterSigForName(ast::Send *sharedSig, const core::NameRef name, core::LocOffsets nameLoc) {
     ENFORCE(ASTUtil::castSig(sharedSig), "We weren't given a send node that's a valid signature");
 
     // There's a bit of work here because deepCopy gives us back an Expression when we know it's a Send.
-    ast::TreePtr sigExpr = sharedSig->deepCopy();
+    ast::ExpressionPtr sigExpr = sharedSig->deepCopy();
     auto *sig = ast::cast_tree<ast::Send>(sigExpr);
     ENFORCE(sig != nullptr, "Just deep copied this, so it should be non-null");
 
@@ -179,7 +179,7 @@ ast::TreePtr toWriterSigForName(ast::Send *sharedSig, const core::NameRef name, 
     if (body->args.size() != 1) {
         return nullptr;
     }
-    ast::TreePtr resultType = body->args[0].deepCopy();
+    ast::ExpressionPtr resultType = body->args[0].deepCopy();
     ast::Send *cur = body;
     while (cur != nullptr) {
         auto recv = ast::cast_tree<ast::ConstantLit>(cur->recv);
@@ -227,8 +227,8 @@ ast::TreePtr toWriterSigForName(ast::Send *sharedSig, const core::NameRef name, 
 // Also note that the burden is on the user to provide an accurate type signature.
 // All attr_accessor's should probably have `T.nilable(...)` to account for a
 // read-before-write.
-vector<ast::TreePtr> AttrReader::run(core::MutableContext ctx, ast::Send *send, ast::TreePtr *prevStat) {
-    vector<ast::TreePtr> empty;
+vector<ast::ExpressionPtr> AttrReader::run(core::MutableContext ctx, ast::Send *send, ast::ExpressionPtr *prevStat) {
+    vector<ast::ExpressionPtr> empty;
 
     if (ctx.state.runningUnderAutogen) {
         return empty;
@@ -248,7 +248,7 @@ vector<ast::TreePtr> AttrReader::run(core::MutableContext ctx, ast::Send *send, 
     }
 
     auto loc = send->loc;
-    vector<ast::TreePtr> stats;
+    vector<ast::ExpressionPtr> stats;
 
     ast::Send *sig = nullptr;
     if (prevStat) {
@@ -313,7 +313,7 @@ vector<ast::TreePtr> AttrReader::run(core::MutableContext ctx, ast::Send *send, 
                 }
             }
 
-            ast::TreePtr body;
+            ast::ExpressionPtr body;
             if (declareIvars) {
                 body = ast::MK::Assign(loc, ast::MK::Instance(argLoc, varName),
                                        ast::MK::Let(loc, ast::MK::Local(loc, name), dupReturnsType(sig)));

--- a/rewriter/AttrReader.h
+++ b/rewriter/AttrReader.h
@@ -26,7 +26,7 @@ namespace sorbet::rewriter {
  */
 class AttrReader final {
 public:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, ast::Send *send, ast::TreePtr *prevStat);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Send *send, ast::ExpressionPtr *prevStat);
 
     AttrReader() = delete;
 };

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -10,8 +10,8 @@ using namespace std;
 
 namespace sorbet::rewriter {
 
-vector<ast::TreePtr> ClassNew::run(core::MutableContext ctx, ast::Assign *asgn) {
-    vector<ast::TreePtr> empty;
+vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *asgn) {
+    vector<ast::ExpressionPtr> empty;
     auto loc = asgn->loc;
 
     if (ctx.state.runningUnderAutogen) {
@@ -77,7 +77,7 @@ vector<ast::TreePtr> ClassNew::run(core::MutableContext ctx, ast::Assign *asgn) 
         ancestors.emplace_back(ast::MK::Constant(send->loc, core::Symbols::todo()));
     }
 
-    vector<ast::TreePtr> stats;
+    vector<ast::ExpressionPtr> stats;
     stats.emplace_back(ast::MK::Class(loc, loc, std::move(asgn->lhs), std::move(ancestors), std::move(body)));
     return stats;
 }

--- a/rewriter/ClassNew.h
+++ b/rewriter/ClassNew.h
@@ -19,7 +19,7 @@ namespace sorbet::rewriter {
  */
 class ClassNew final {
 public:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, ast::Assign *asgn);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Assign *asgn);
 
     ClassNew() = delete;
 };

--- a/rewriter/Cleanup.cc
+++ b/rewriter/Cleanup.cc
@@ -12,7 +12,7 @@ namespace sorbet::rewriter {
 // pass, specifically by removing EmptyTree nodes in places where they can be safely removed (i.e. as part of longer
 // sequences of expressions where they are not a return value)
 struct CleanupWalk {
-    ast::TreePtr postTransformInsSeq(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformInsSeq(core::Context ctx, ast::ExpressionPtr tree) {
         auto &insSeq = ast::cast_tree_nonnull<ast::InsSeq>(tree);
 
         ast::InsSeq::STATS_store newStore;
@@ -28,7 +28,7 @@ struct CleanupWalk {
         return tree;
     }
 
-    ast::TreePtr postTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &classDef = ast::cast_tree_nonnull<ast::ClassDef>(tree);
 
         ast::ClassDef::RHS_store newStore;
@@ -42,7 +42,7 @@ struct CleanupWalk {
     }
 };
 
-ast::TreePtr Cleanup::run(core::Context ctx, ast::TreePtr tree) {
+ast::ExpressionPtr Cleanup::run(core::Context ctx, ast::ExpressionPtr tree) {
     CleanupWalk cleanup;
     return ast::TreeMap::apply(ctx, cleanup, std::move(tree));
 }

--- a/rewriter/Cleanup.h
+++ b/rewriter/Cleanup.h
@@ -6,7 +6,7 @@ namespace sorbet::rewriter {
 
 class Cleanup final {
 public:
-    static ast::TreePtr run(core::Context ctx, ast::TreePtr tree);
+    static ast::ExpressionPtr run(core::Context ctx, ast::ExpressionPtr tree);
 
     Cleanup() = delete;
 };

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -18,8 +18,8 @@ using namespace std;
 //
 
 namespace sorbet::rewriter {
-vector<ast::TreePtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *send) {
-    vector<ast::TreePtr> empty;
+vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *send) {
+    vector<ast::ExpressionPtr> empty;
 
     if (ctx.state.runningUnderAutogen) {
         return empty;
@@ -29,7 +29,7 @@ vector<ast::TreePtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *send) 
     bool implied = false;
     bool skipGetter = false;
     bool skipSetter = false;
-    ast::TreePtr type;
+    ast::ExpressionPtr type;
     core::NameRef name;
 
     if (send->fun == core::Names::dslOptional()) {
@@ -56,7 +56,7 @@ vector<ast::TreePtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *send) 
         return empty;
     }
 
-    ast::TreePtr optsTree = ASTUtil::mkKwArgsHash(send);
+    ast::ExpressionPtr optsTree = ASTUtil::mkKwArgsHash(send);
     if (auto *opts = ast::cast_tree<ast::Hash>(optsTree)) {
         if (ASTUtil::hasHashValue(ctx, *opts, core::Names::default_())) {
             nilable = false;
@@ -74,7 +74,7 @@ vector<ast::TreePtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *send) 
 
     auto loc = send->loc;
 
-    vector<ast::TreePtr> stats;
+    vector<ast::ExpressionPtr> stats;
 
     // def self.<prop>
     if (!skipSetter) {

--- a/rewriter/DSLBuilder.h
+++ b/rewriter/DSLBuilder.h
@@ -22,7 +22,7 @@ namespace sorbet::rewriter {
  */
 class DSLBuilder final {
 public:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, ast::Send *send);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Send *send);
 
     DSLBuilder() = delete;
 };

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -57,7 +57,7 @@ vector<ast::ExpressionPtr> DefDelegator::run(core::MutableContext ctx, const ast
     // def $methodName(*arg0, &blk); end
     ast::MethodDef::ARGS_store args;
     args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
-    args.emplace_back(ast::make_tree<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
+    args.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
     methodStubs.push_back(
         ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::RaiseUnimplemented(loc)));

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -8,8 +8,8 @@ using namespace std;
 
 namespace sorbet::rewriter {
 
-vector<ast::TreePtr> DefDelegator::run(core::MutableContext ctx, const ast::Send *send) {
-    vector<ast::TreePtr> methodStubs;
+vector<ast::ExpressionPtr> DefDelegator::run(core::MutableContext ctx, const ast::Send *send) {
+    vector<ast::ExpressionPtr> methodStubs;
     auto loc = send->loc;
 
     if (send->fun != core::Names::defDelegator()) {

--- a/rewriter/DefDelegator.h
+++ b/rewriter/DefDelegator.h
@@ -25,7 +25,7 @@ namespace sorbet::rewriter {
  */
 class DefDelegator final {
 public:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, const ast::Send *send);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, const ast::Send *send);
 
     DefDelegator() = delete;
 };

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -119,7 +119,7 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
         // def $methodName(*arg0, &blk); end
         ast::MethodDef::ARGS_store args;
         args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
-        args.emplace_back(ast::make_tree<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
+        args.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
         methodStubs.push_back(ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree()));
     }

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -8,21 +8,21 @@ using namespace std;
 
 namespace sorbet::rewriter {
 
-static bool literalSymbolEqual(const core::GlobalState &gs, const ast::TreePtr &node, core::NameRef name) {
+static bool literalSymbolEqual(const core::GlobalState &gs, const ast::ExpressionPtr &node, core::NameRef name) {
     if (auto lit = ast::cast_tree<ast::Literal>(node)) {
         return lit->isSymbol(gs) && lit->asSymbol(gs) == name;
     }
     return false;
 }
 
-static bool isLiteralTrue(const core::GlobalState &gs, const ast::TreePtr &node) {
+static bool isLiteralTrue(const core::GlobalState &gs, const ast::ExpressionPtr &node) {
     if (auto lit = ast::cast_tree<ast::Literal>(node)) {
         return lit->isTrue(gs);
     }
     return false;
 }
 
-static optional<core::NameRef> stringOrSymbolNameRef(const core::GlobalState &gs, const ast::TreePtr &node) {
+static optional<core::NameRef> stringOrSymbolNameRef(const core::GlobalState &gs, const ast::ExpressionPtr &node) {
     auto lit = ast::cast_tree<ast::Literal>(node);
     if (!lit) {
         return nullopt;
@@ -36,8 +36,8 @@ static optional<core::NameRef> stringOrSymbolNameRef(const core::GlobalState &gs
     }
 }
 
-vector<ast::TreePtr> Delegate::run(core::MutableContext ctx, const ast::Send *send) {
-    vector<ast::TreePtr> empty;
+vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Send *send) {
+    vector<ast::ExpressionPtr> empty;
     auto loc = send->loc;
 
     if (send->fun != core::Names::delegate()) {
@@ -59,7 +59,7 @@ vector<ast::TreePtr> Delegate::run(core::MutableContext ctx, const ast::Send *se
         return empty;
     }
 
-    ast::TreePtr const *prefixNode = nullptr;
+    ast::ExpressionPtr const *prefixNode = nullptr;
     core::NameRef toName;
     {
         optional<core::NameRef> to;
@@ -92,7 +92,7 @@ vector<ast::TreePtr> Delegate::run(core::MutableContext ctx, const ast::Send *se
         }
     }
 
-    vector<ast::TreePtr> methodStubs;
+    vector<ast::ExpressionPtr> methodStubs;
     for (int i = 0; i < send->numPosArgs; i++) {
         auto *lit = ast::cast_tree<ast::Literal>(send->args[i]);
         if (!lit || !lit->isSymbol(ctx)) {

--- a/rewriter/Delegate.h
+++ b/rewriter/Delegate.h
@@ -24,7 +24,7 @@ namespace sorbet::rewriter {
  */
 class Delegate final {
 public:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, const ast::Send *send);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, const ast::Send *send);
 
     Delegate() = delete;
 };

--- a/rewriter/Flatfiles.cc
+++ b/rewriter/Flatfiles.cc
@@ -26,7 +26,7 @@ optional<core::NameRef> getFieldName(core::MutableContext ctx, ast::Send &send) 
     return nullopt;
 }
 
-ast::Send *asFlatfileDo(ast::TreePtr &stat) {
+ast::Send *asFlatfileDo(ast::ExpressionPtr &stat) {
     auto *send = ast::cast_tree<ast::Send>(stat);
     if (send != nullptr && send->block != nullptr && send->fun == core::Names::flatfile()) {
         return send;
@@ -35,7 +35,7 @@ ast::Send *asFlatfileDo(ast::TreePtr &stat) {
     }
 }
 
-void handleFieldDefinition(core::MutableContext ctx, ast::TreePtr &stat, vector<ast::TreePtr> &methods) {
+void handleFieldDefinition(core::MutableContext ctx, ast::ExpressionPtr &stat, vector<ast::ExpressionPtr> &methods) {
     if (auto send = ast::cast_tree<ast::Send>(stat)) {
         if ((send->fun != core::Names::from() && send->fun != core::Names::field() &&
              send->fun != core::Names::pattern()) ||
@@ -63,7 +63,7 @@ void Flatfiles::run(core::MutableContext ctx, ast::ClassDef *klass) {
         return;
     }
 
-    vector<ast::TreePtr> methods;
+    vector<ast::ExpressionPtr> methods;
     for (auto &stat : klass->rhs) {
         if (auto flatfileBlock = asFlatfileDo(stat)) {
             auto &block = ast::cast_tree_nonnull<ast::Block>(flatfileBlock->block);

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -280,7 +280,7 @@ class FlattenWalk {
         // generate the nested `class << self` blocks as needed and add them to the class
         for (auto &body : nestedClassBodies) {
             auto classDef = ast::MK::Class(loc, loc,
-                                           ast::make_tree<ast::UnresolvedIdent>(core::LocOffsets::none(),
+                                           ast::make_expression<ast::UnresolvedIdent>(core::LocOffsets::none(),
                                                                                 ast::UnresolvedIdent::Kind::Class,
                                                                                 core::Names::singleton()),
                                            {}, std::move(body));
@@ -390,7 +390,7 @@ public:
         auto insSeq = ast::cast_tree<ast::InsSeq>(tree);
         if (insSeq == nullptr) {
             ast::InsSeq::STATS_store stats;
-            tree = ast::make_tree<ast::InsSeq>(tree.loc(), std::move(stats), std::move(tree));
+            tree = ast::make_expression<ast::InsSeq>(tree.loc(), std::move(stats), std::move(tree));
             return addTopLevelMethods(ctx, std::move(tree));
         }
 

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -93,9 +93,9 @@ class FlattenWalk {
     // can reconstruct the preorder traversal)'static' it should be: i.e. whether it should have a `self.` qualifier and
     // whether it should be in a `class << self` block.
     struct MovedItem {
-        ast::TreePtr expr;
+        ast::ExpressionPtr expr;
         u4 staticLevel;
-        MovedItem(ast::TreePtr expr, u4 staticLevel) : expr(move(expr)), staticLevel(staticLevel){};
+        MovedItem(ast::ExpressionPtr expr, u4 staticLevel) : expr(move(expr)), staticLevel(staticLevel){};
         MovedItem() = default;
     };
 
@@ -138,7 +138,7 @@ class FlattenWalk {
         }
 
         // this moves an expression to the already-allocated space
-        void addExpr(MethodData md, ast::TreePtr expr) {
+        void addExpr(MethodData md, ast::ExpressionPtr expr) {
             ENFORCE(md.targetLocation);
             int idx = *md.targetLocation;
             ENFORCE(moveQueue.size() > idx);
@@ -253,7 +253,7 @@ class FlattenWalk {
             targets.emplace_back(&target);
         }
 
-        vector<vector<ast::TreePtr>> expressionsToBePutInTargets;
+        vector<vector<ast::ExpressionPtr>> expressionsToBePutInTargets;
         // This makes each element be a length-0 vector
         expressionsToBePutInTargets.resize(targets.size());
 
@@ -298,7 +298,7 @@ public:
         ENFORCE(classScopes.empty());
     }
 
-    ast::TreePtr preTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         if (!curMethodSet().stack.empty()) {
             curMethodSet().pushScope(computeScopeInfo(ScopeType::InstanceMethodScope));
         }
@@ -306,7 +306,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformClassDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &classDef = ast::cast_tree_nonnull<ast::ClassDef>(tree);
         classDef.rhs = addClassDefMethods(ctx, std::move(classDef.rhs), classDef.loc);
         auto &methods = curMethodSet();
@@ -321,7 +321,7 @@ public:
         return ast::MK::EmptyTree();
     };
 
-    ast::TreePtr preTransformSend(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformSend(core::Context ctx, ast::ExpressionPtr tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
         // we might want to move sigs, so we mostly use the same logic that we use for methods. The one exception is
         // that we don't know the 'staticness level' of a sig, as it depends on the method that follows it (whether that
@@ -333,7 +333,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformSend(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformSend(core::Context ctx, ast::ExpressionPtr tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
         auto &methods = curMethodSet();
         // if it's not a send, then we didn't make a stack frame for it
@@ -348,7 +348,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr preTransformMethodDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         // add a new scope for this method def
         curMethodSet().pushScope(computeScopeInfo(methodDef.flags.isSelfMethod ? ScopeType::StaticMethodScope
@@ -356,7 +356,7 @@ public:
         return tree;
     }
 
-    ast::TreePtr postTransformMethodDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         auto &methods = curMethodSet();
         // if we get a MethodData back, then we need to move this and replace it
@@ -375,7 +375,7 @@ public:
                               ast::MK::Self(loc), ast::MK::Symbol(loc, name), ast::MK::Symbol(loc, kind));
     };
 
-    ast::TreePtr addTopLevelMethods(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr addTopLevelMethods(core::Context ctx, ast::ExpressionPtr tree) {
         auto &methods = curMethodSet().moveQueue;
         if (methods.empty()) {
             ENFORCE(popCurMethodDefs().empty());
@@ -383,7 +383,7 @@ public:
         }
         if (methods.size() == 1 && ast::isa_tree<ast::EmptyTree>(tree)) {
             // It was only 1 method to begin with, put it back
-            ast::TreePtr methodDef = std::move(popCurMethodDefs()[0].expr);
+            ast::ExpressionPtr methodDef = std::move(popCurMethodDefs()[0].expr);
             return methodDef;
         }
 
@@ -402,7 +402,7 @@ public:
     }
 };
 
-ast::TreePtr Flatten::run(core::Context ctx, ast::TreePtr tree) {
+ast::ExpressionPtr Flatten::run(core::Context ctx, ast::ExpressionPtr tree) {
     FlattenWalk flatten;
     tree = ast::TreeMap::apply(ctx, flatten, std::move(tree));
     tree = flatten.addTopLevelMethods(ctx, std::move(tree));

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -281,8 +281,8 @@ class FlattenWalk {
         for (auto &body : nestedClassBodies) {
             auto classDef = ast::MK::Class(loc, loc,
                                            ast::make_expression<ast::UnresolvedIdent>(core::LocOffsets::none(),
-                                                                                ast::UnresolvedIdent::Kind::Class,
-                                                                                core::Names::singleton()),
+                                                                                      ast::UnresolvedIdent::Kind::Class,
+                                                                                      core::Names::singleton()),
                                            {}, std::move(body));
             rhs.emplace_back(std::move(classDef));
         }

--- a/rewriter/Flatten.h
+++ b/rewriter/Flatten.h
@@ -6,7 +6,7 @@ namespace sorbet::rewriter {
 
 class Flatten final {
 public:
-    static ast::TreePtr run(core::Context ctx, ast::TreePtr tree);
+    static ast::ExpressionPtr run(core::Context ctx, ast::ExpressionPtr tree);
 
     Flatten() = delete;
 };

--- a/rewriter/Initializer.h
+++ b/rewriter/Initializer.h
@@ -32,7 +32,7 @@ namespace sorbet::rewriter {
 
 class Initializer final {
 public:
-    static void run(core::MutableContext ctx, ast::MethodDef *methodDef, ast::TreePtr *prevStat);
+    static void run(core::MutableContext ctx, ast::MethodDef *methodDef, ast::ExpressionPtr *prevStat);
 
     Initializer() = delete;
 };

--- a/rewriter/InterfaceWrapper.cc
+++ b/rewriter/InterfaceWrapper.cc
@@ -11,7 +11,7 @@
 using namespace std;
 
 namespace sorbet::rewriter {
-ast::TreePtr InterfaceWrapper::run(core::MutableContext ctx, ast::Send *send) {
+ast::ExpressionPtr InterfaceWrapper::run(core::MutableContext ctx, ast::Send *send) {
     if (ctx.state.runningUnderAutogen) {
         return nullptr;
     }

--- a/rewriter/InterfaceWrapper.h
+++ b/rewriter/InterfaceWrapper.h
@@ -22,7 +22,7 @@ namespace sorbet::rewriter {
  */
 class InterfaceWrapper final {
 public:
-    static ast::TreePtr run(core::MutableContext ctx, ast::Send *send);
+    static ast::ExpressionPtr run(core::MutableContext ctx, ast::Send *send);
 
     InterfaceWrapper() = delete;
 };

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -7,21 +7,21 @@ using namespace std;
 
 namespace sorbet::rewriter {
 
-static bool literalSymbolEqual(const core::GlobalState &gs, const ast::TreePtr &node, core::NameRef name) {
+static bool literalSymbolEqual(const core::GlobalState &gs, const ast::ExpressionPtr &node, core::NameRef name) {
     if (auto lit = ast::cast_tree<ast::Literal>(node)) {
         return lit->isSymbol(gs) && lit->asSymbol(gs) == name;
     }
     return false;
 }
 
-static bool isLiteralFalse(const core::GlobalState &gs, const ast::TreePtr &node) {
+static bool isLiteralFalse(const core::GlobalState &gs, const ast::ExpressionPtr &node) {
     if (auto lit = ast::cast_tree<ast::Literal>(node)) {
         return lit->isFalse(gs);
     }
     return false;
 }
 
-static void addInstanceCounterPart(vector<ast::TreePtr> &sink, const ast::TreePtr &sig, const ast::TreePtr &def) {
+static void addInstanceCounterPart(vector<ast::ExpressionPtr> &sink, const ast::ExpressionPtr &sig, const ast::ExpressionPtr &def) {
     sink.emplace_back(sig.deepCopy());
     auto instanceDef = def.deepCopy();
     ENFORCE(ast::isa_tree<ast::MethodDef>(def));
@@ -30,8 +30,8 @@ static void addInstanceCounterPart(vector<ast::TreePtr> &sink, const ast::TreePt
     sink.emplace_back(move(instanceDef));
 }
 
-vector<ast::TreePtr> Mattr::run(core::MutableContext ctx, const ast::Send *send, ast::ClassDef::Kind classDefKind) {
-    vector<ast::TreePtr> empty;
+vector<ast::ExpressionPtr> Mattr::run(core::MutableContext ctx, const ast::Send *send, ast::ClassDef::Kind classDefKind) {
+    vector<ast::ExpressionPtr> empty;
     bool doReaders = false;
     bool doWriters = false;
     bool doPredicates = false;
@@ -84,7 +84,7 @@ vector<ast::TreePtr> Mattr::run(core::MutableContext ctx, const ast::Send *send,
         return empty;
     }
 
-    vector<ast::TreePtr> result;
+    vector<ast::ExpressionPtr> result;
     for (int i = 0; i < symbolArgsBound; i++) {
         auto *lit = ast::cast_tree<ast::Literal>(send->args[i]);
         if (!lit || !lit->isSymbol(ctx)) {

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -21,7 +21,8 @@ static bool isLiteralFalse(const core::GlobalState &gs, const ast::ExpressionPtr
     return false;
 }
 
-static void addInstanceCounterPart(vector<ast::ExpressionPtr> &sink, const ast::ExpressionPtr &sig, const ast::ExpressionPtr &def) {
+static void addInstanceCounterPart(vector<ast::ExpressionPtr> &sink, const ast::ExpressionPtr &sig,
+                                   const ast::ExpressionPtr &def) {
     sink.emplace_back(sig.deepCopy());
     auto instanceDef = def.deepCopy();
     ENFORCE(ast::isa_tree<ast::MethodDef>(def));
@@ -30,7 +31,8 @@ static void addInstanceCounterPart(vector<ast::ExpressionPtr> &sink, const ast::
     sink.emplace_back(move(instanceDef));
 }
 
-vector<ast::ExpressionPtr> Mattr::run(core::MutableContext ctx, const ast::Send *send, ast::ClassDef::Kind classDefKind) {
+vector<ast::ExpressionPtr> Mattr::run(core::MutableContext ctx, const ast::Send *send,
+                                      ast::ClassDef::Kind classDefKind) {
     vector<ast::ExpressionPtr> empty;
     bool doReaders = false;
     bool doWriters = false;

--- a/rewriter/Mattr.h
+++ b/rewriter/Mattr.h
@@ -31,7 +31,7 @@ namespace sorbet::rewriter {
 class Mattr final {
 public:
     static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, const ast::Send *send,
-                                         ast::ClassDef::Kind classDefKind);
+                                               ast::ClassDef::Kind classDefKind);
 
     Mattr() = delete;
 };

--- a/rewriter/Mattr.h
+++ b/rewriter/Mattr.h
@@ -30,7 +30,7 @@ namespace sorbet::rewriter {
  */
 class Mattr final {
 public:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, const ast::Send *send,
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, const ast::Send *send,
                                          ast::ClassDef::Kind classDefKind);
 
     Mattr() = delete;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -179,7 +179,7 @@ ast::ExpressionPtr getIteratee(ast::ExpressionPtr &exp) {
 // this applies to each statement contained within a `test_each`: if it's an `it`-block, then convert it appropriately,
 // otherwise flag an error about it
 ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName, ast::ExpressionPtr stmt,
-                          ast::MethodDef::ARGS_store &args, ast::ExpressionPtr &iteratee) {
+                                ast::MethodDef::ARGS_store &args, ast::ExpressionPtr &iteratee) {
     // this statement must be a send
     if (auto *send = ast::cast_tree<ast::Send>(stmt)) {
         // the send must be a call to `it` with a single argument (the test name) and a block with no arguments
@@ -217,7 +217,7 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
 
 // this just walks the body of a `test_each` and tries to transform every statement
 ast::ExpressionPtr prepareTestEachBody(core::MutableContext ctx, core::NameRef eachName, ast::ExpressionPtr body,
-                                 ast::MethodDef::ARGS_store &args, ast::ExpressionPtr &iteratee) {
+                                       ast::MethodDef::ARGS_store &args, ast::ExpressionPtr &iteratee) {
     auto *bodySeq = ast::cast_tree<ast::InsSeq>(body);
     if (bodySeq) {
         for (auto &exp : bodySeq->stats) {

--- a/rewriter/Minitest.h
+++ b/rewriter/Minitest.h
@@ -32,7 +32,7 @@ namespace sorbet::rewriter {
  */
 class Minitest final {
 public:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, ast::Send *send);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Send *send);
 
     Minitest() = delete;
 };

--- a/rewriter/MixinEncryptedProp.cc
+++ b/rewriter/MixinEncryptedProp.cc
@@ -11,7 +11,7 @@ namespace sorbet::rewriter {
 
 namespace {
 
-ast::TreePtr mkNilableEncryptedValue(core::MutableContext ctx, core::LocOffsets loc) {
+ast::ExpressionPtr mkNilableEncryptedValue(core::MutableContext ctx, core::LocOffsets loc) {
     auto opus = ast::MK::UnresolvedConstant(loc, ast::MK::EmptyTree(), core::Names::Constants::Opus());
     auto db = ast::MK::UnresolvedConstant(loc, move(opus), core::Names::Constants::DB());
     auto model = ast::MK::UnresolvedConstant(loc, move(db), core::Names::Constants::Model());
@@ -21,14 +21,14 @@ ast::TreePtr mkNilableEncryptedValue(core::MutableContext ctx, core::LocOffsets 
     return ASTUtil::mkNilable(loc, move(ev));
 }
 
-ast::TreePtr mkNilableString(core::LocOffsets loc) {
+ast::ExpressionPtr mkNilableString(core::LocOffsets loc) {
     return ASTUtil::mkNilable(loc, ast::MK::Constant(loc, core::Symbols::String()));
 }
 
 } // namespace
 
-vector<ast::TreePtr> MixinEncryptedProp::run(core::MutableContext ctx, ast::Send *send) {
-    vector<ast::TreePtr> empty;
+vector<ast::ExpressionPtr> MixinEncryptedProp::run(core::MutableContext ctx, ast::Send *send) {
+    vector<ast::ExpressionPtr> empty;
 
     if (ctx.state.runningUnderAutogen) {
         return empty;
@@ -56,7 +56,7 @@ vector<ast::TreePtr> MixinEncryptedProp::run(core::MutableContext ctx, ast::Send
     auto nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};
     enc_name = name.prepend(ctx, "encrypted_");
 
-    ast::TreePtr rules;
+    ast::ExpressionPtr rules;
     if (!send->args.empty()) {
         rules = ASTUtil::mkKwArgsHash(send);
     }
@@ -67,7 +67,7 @@ vector<ast::TreePtr> MixinEncryptedProp::run(core::MutableContext ctx, ast::Send
         }
     }
 
-    vector<ast::TreePtr> stats;
+    vector<ast::ExpressionPtr> stats;
 
     // Compute the getters
 

--- a/rewriter/MixinEncryptedProp.h
+++ b/rewriter/MixinEncryptedProp.h
@@ -32,7 +32,7 @@ namespace sorbet::rewriter {
  */
 class MixinEncryptedProp final {
 public:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, ast::Send *send);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Send *send);
 
     MixinEncryptedProp() = delete;
 };

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -15,8 +15,8 @@ namespace sorbet::rewriter {
 void ModuleFunction::run(core::MutableContext ctx, ast::ClassDef *cdef) {
     // once we see a bare `module_function`, we should replace every subsequent definition
     bool moduleFunctionActive = false;
-    ast::TreePtr *prevStat = nullptr;
-    UnorderedMap<void *, vector<ast::TreePtr>> replaceNodes;
+    ast::ExpressionPtr *prevStat = nullptr;
+    UnorderedMap<void *, vector<ast::ExpressionPtr>> replaceNodes;
     for (auto &stat : cdef->rhs) {
         if (auto send = ast::cast_tree<ast::Send>(stat)) {
             // we only care about sends if they're `module_function`
@@ -27,7 +27,7 @@ void ModuleFunction::run(core::MutableContext ctx, ast::ClassDef *cdef) {
                     moduleFunctionActive = true;
                     // putting in an empty statement list, which means we remove this statement when we get around to
                     // updating the statement list
-                    vector<ast::TreePtr> empty;
+                    vector<ast::ExpressionPtr> empty;
                     replaceNodes[stat.get()] = move(empty);
                 } else {
                     // if we do have arguments, then we can rewrite them appropriately
@@ -68,9 +68,9 @@ void ModuleFunction::run(core::MutableContext ctx, ast::ClassDef *cdef) {
     }
 }
 
-vector<ast::TreePtr> ModuleFunction::rewriteDefn(core::MutableContext ctx, const ast::TreePtr &expr,
-                                                 const ast::TreePtr *prevStat) {
-    vector<ast::TreePtr> stats;
+vector<ast::ExpressionPtr> ModuleFunction::rewriteDefn(core::MutableContext ctx, const ast::ExpressionPtr &expr,
+                                                 const ast::ExpressionPtr *prevStat) {
+    vector<ast::ExpressionPtr> stats;
     auto mdef = ast::cast_tree<ast::MethodDef>(expr);
     // only do this rewrite to method defs that aren't self methods
     if (mdef == nullptr || mdef->flags.isSelfMethod) {
@@ -102,8 +102,8 @@ vector<ast::TreePtr> ModuleFunction::rewriteDefn(core::MutableContext ctx, const
     return stats;
 }
 
-vector<ast::TreePtr> ModuleFunction::run(core::MutableContext ctx, ast::Send *send, const ast::TreePtr *prevStat) {
-    vector<ast::TreePtr> stats;
+vector<ast::ExpressionPtr> ModuleFunction::run(core::MutableContext ctx, ast::Send *send, const ast::ExpressionPtr *prevStat) {
+    vector<ast::ExpressionPtr> stats;
 
     if (send->fun != core::Names::moduleFunction()) {
         return stats;

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -135,7 +135,7 @@ vector<ast::ExpressionPtr> ModuleFunction::run(core::MutableContext ctx, ast::Se
             stats.emplace_back(ast::MK::Send1(loc, ast::MK::Self(loc), core::Names::private_(), lit->deepCopy()));
             ast::MethodDef::ARGS_store args;
             args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
-            args.emplace_back(ast::make_tree<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
+            args.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
             auto methodDef = ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree());
             ast::cast_tree_nonnull<ast::MethodDef>(methodDef).flags.isSelfMethod = true;
             stats.emplace_back(std::move(methodDef));

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -69,7 +69,7 @@ void ModuleFunction::run(core::MutableContext ctx, ast::ClassDef *cdef) {
 }
 
 vector<ast::ExpressionPtr> ModuleFunction::rewriteDefn(core::MutableContext ctx, const ast::ExpressionPtr &expr,
-                                                 const ast::ExpressionPtr *prevStat) {
+                                                       const ast::ExpressionPtr *prevStat) {
     vector<ast::ExpressionPtr> stats;
     auto mdef = ast::cast_tree<ast::MethodDef>(expr);
     // only do this rewrite to method defs that aren't self methods
@@ -102,7 +102,8 @@ vector<ast::ExpressionPtr> ModuleFunction::rewriteDefn(core::MutableContext ctx,
     return stats;
 }
 
-vector<ast::ExpressionPtr> ModuleFunction::run(core::MutableContext ctx, ast::Send *send, const ast::ExpressionPtr *prevStat) {
+vector<ast::ExpressionPtr> ModuleFunction::run(core::MutableContext ctx, ast::Send *send,
+                                               const ast::ExpressionPtr *prevStat) {
     vector<ast::ExpressionPtr> stats;
 
     if (send->fun != core::Names::moduleFunction()) {

--- a/rewriter/ModuleFunction.h
+++ b/rewriter/ModuleFunction.h
@@ -34,10 +34,11 @@ public:
     ModuleFunction() = delete;
 
 private:
-    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Send *send, const ast::ExpressionPtr *prevStat);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Send *send,
+                                               const ast::ExpressionPtr *prevStat);
 
     static std::vector<ast::ExpressionPtr> rewriteDefn(core::MutableContext ctx, const ast::ExpressionPtr &expr,
-                                                 const ast::ExpressionPtr *prevStat);
+                                                       const ast::ExpressionPtr *prevStat);
 };
 
 } // namespace sorbet::rewriter

--- a/rewriter/ModuleFunction.h
+++ b/rewriter/ModuleFunction.h
@@ -34,10 +34,10 @@ public:
     ModuleFunction() = delete;
 
 private:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, ast::Send *send, const ast::TreePtr *prevStat);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Send *send, const ast::ExpressionPtr *prevStat);
 
-    static std::vector<ast::TreePtr> rewriteDefn(core::MutableContext ctx, const ast::TreePtr &expr,
-                                                 const ast::TreePtr *prevStat);
+    static std::vector<ast::ExpressionPtr> rewriteDefn(core::MutableContext ctx, const ast::ExpressionPtr &expr,
+                                                 const ast::ExpressionPtr *prevStat);
 };
 
 } // namespace sorbet::rewriter

--- a/rewriter/Private.cc
+++ b/rewriter/Private.cc
@@ -11,8 +11,8 @@ using namespace std;
 
 namespace sorbet::rewriter {
 
-vector<ast::TreePtr> Private::run(core::MutableContext ctx, ast::Send *send) {
-    vector<ast::TreePtr> empty;
+vector<ast::ExpressionPtr> Private::run(core::MutableContext ctx, ast::Send *send) {
+    vector<ast::ExpressionPtr> empty;
 
     if (send->args.size() != 1) {
         return empty;

--- a/rewriter/Private.h
+++ b/rewriter/Private.h
@@ -16,7 +16,7 @@ namespace sorbet::rewriter {
  */
 class Private final {
 public:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, ast::Send *send);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Send *send);
 
     Private() = delete;
 };

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -466,7 +466,7 @@ ast::ExpressionPtr ensureWithoutAccessors(const PropInfo &prop, const ast::Send 
 }
 
 vector<ast::ExpressionPtr> mkTypedInitialize(core::MutableContext ctx, core::LocOffsets klassLoc,
-                                       core::LocOffsets klassDeclLoc, const vector<PropInfo> &props) {
+                                             core::LocOffsets klassDeclLoc, const vector<PropInfo> &props) {
     ast::MethodDef::ARGS_store args;
     ast::Send::ARGS_store sigArgs;
     args.reserve(props.size());

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -15,27 +15,27 @@ namespace {
 // these helpers work on a purely syntactic level. for instance, this function determines if an expression is `T`,
 // either with no scope or with the root scope (i.e. `::T`). this might not actually refer to the `T` that we define for
 // users, but we don't know that information in the Rewriter passes.
-bool isT(ast::TreePtr &expr) {
+bool isT(ast::ExpressionPtr &expr) {
     auto *t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     return t != nullptr && t->cnst == core::Names::Constants::T() && ast::MK::isRootScope(t->scope);
 }
 
-bool isTNilable(ast::TreePtr &expr) {
+bool isTNilable(ast::ExpressionPtr &expr) {
     auto *nilable = ast::cast_tree<ast::Send>(expr);
     return nilable != nullptr && nilable->fun == core::Names::nilable() && isT(nilable->recv);
 }
 
-bool isTStruct(ast::TreePtr &expr) {
+bool isTStruct(ast::ExpressionPtr &expr) {
     auto *struct_ = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     return struct_ != nullptr && struct_->cnst == core::Names::Constants::Struct() && isT(struct_->scope);
 }
 
-bool isTInexactStruct(ast::TreePtr &expr) {
+bool isTInexactStruct(ast::ExpressionPtr &expr) {
     auto *struct_ = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     return struct_ != nullptr && struct_->cnst == core::Names::Constants::InexactStruct() && isT(struct_->scope);
 }
 
-bool isChalkODMDocument(ast::TreePtr &expr) {
+bool isChalkODMDocument(ast::ExpressionPtr &expr) {
     auto *document = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     if (document == nullptr || document->cnst != core::Names::Constants::Document()) {
         return false;
@@ -99,17 +99,17 @@ struct PropInfo {
     bool hasWithoutAccessors = false;
     core::NameRef name;
     core::LocOffsets nameLoc;
-    ast::TreePtr type;
-    ast::TreePtr default_;
+    ast::ExpressionPtr type;
+    ast::ExpressionPtr default_;
     core::NameRef computedByMethodName;
     core::LocOffsets computedByMethodNameLoc;
-    ast::TreePtr foreign;
-    ast::TreePtr enum_;
-    ast::TreePtr ifunset;
+    ast::ExpressionPtr foreign;
+    ast::ExpressionPtr enum_;
+    ast::ExpressionPtr ifunset;
 };
 
 struct NodesAndPropInfo {
-    vector<ast::TreePtr> nodes;
+    vector<ast::ExpressionPtr> nodes;
     PropInfo propInfo;
 };
 
@@ -198,7 +198,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
 
     // Deep copy the rules hash so that we can destruct it at will to parse things,
     // without having to worry about whether we stole things from the tree.
-    ast::TreePtr rulesTree = ASTUtil::mkKwArgsHash(send);
+    ast::ExpressionPtr rulesTree = ASTUtil::mkKwArgsHash(send);
     if (rulesTree == nullptr && send->numPosArgs >= expectedPosArgs) {
         // No rules, but 3 args including name and type. Also not a T::Props
         return std::nullopt;
@@ -268,8 +268,8 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
     return ret;
 }
 
-vector<ast::TreePtr> processProp(core::MutableContext ctx, PropInfo &ret, PropContext propContext) {
-    vector<ast::TreePtr> nodes;
+vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, PropContext propContext) {
+    vector<ast::ExpressionPtr> nodes;
 
     const auto loc = ret.loc;
     const auto name = ret.name;
@@ -385,8 +385,8 @@ vector<ast::TreePtr> processProp(core::MutableContext ctx, PropInfo &ret, PropCo
 
     // Compute the `_` foreign accessor
     if (ret.foreign) {
-        ast::TreePtr type;
-        ast::TreePtr nonNilType;
+        ast::ExpressionPtr type;
+        ast::ExpressionPtr nonNilType;
         if (ASTUtil::dupType(ret.foreign) == nullptr) {
             // If it's not a valid type, just use untyped
             type = ast::MK::Untyped(loc);
@@ -406,7 +406,7 @@ vector<ast::TreePtr> processProp(core::MutableContext ctx, PropInfo &ret, PropCo
 
         auto fkMethod = ctx.state.enterNameUTF8(name.show(ctx) + "_");
 
-        ast::TreePtr arg =
+        ast::ExpressionPtr arg =
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
         nodes.emplace_back(
             ast::MK::SyntheticMethod1(loc, loc, fkMethod, std::move(arg), ast::MK::RaiseUnimplemented(loc)));
@@ -420,7 +420,7 @@ vector<ast::TreePtr> processProp(core::MutableContext ctx, PropInfo &ret, PropCo
         // end
 
         auto fkMethodBang = ctx.state.enterNameUTF8(name.show(ctx) + "_!");
-        ast::TreePtr arg2 =
+        ast::ExpressionPtr arg2 =
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
         nodes.emplace_back(
             ast::MK::SyntheticMethod1(loc, loc, fkMethodBang, std::move(arg2), ast::MK::RaiseUnimplemented(loc)));
@@ -429,8 +429,8 @@ vector<ast::TreePtr> processProp(core::MutableContext ctx, PropInfo &ret, PropCo
     return nodes;
 }
 
-ast::TreePtr ensureWithoutAccessors(const PropInfo &prop, const ast::Send *send) {
-    ast::TreePtr result = send->deepCopy();
+ast::ExpressionPtr ensureWithoutAccessors(const PropInfo &prop, const ast::Send *send) {
+    ast::ExpressionPtr result = send->deepCopy();
 
     if (prop.hasWithoutAccessors) {
         return result;
@@ -465,7 +465,7 @@ ast::TreePtr ensureWithoutAccessors(const PropInfo &prop, const ast::Send *send)
     return result;
 }
 
-vector<ast::TreePtr> mkTypedInitialize(core::MutableContext ctx, core::LocOffsets klassLoc,
+vector<ast::ExpressionPtr> mkTypedInitialize(core::MutableContext ctx, core::LocOffsets klassLoc,
                                        core::LocOffsets klassDeclLoc, const vector<PropInfo> &props) {
     ast::MethodDef::ARGS_store args;
     ast::Send::ARGS_store sigArgs;
@@ -504,7 +504,7 @@ vector<ast::TreePtr> mkTypedInitialize(core::MutableContext ctx, core::LocOffset
     }
     auto body = ast::MK::InsSeq(klassLoc, std::move(stats), ast::MK::ZSuper(klassDeclLoc));
 
-    vector<ast::TreePtr> result;
+    vector<ast::ExpressionPtr> result;
     result.emplace_back(ast::MK::SigVoid(klassDeclLoc, std::move(sigArgs)));
     result.emplace_back(
         ast::MK::SyntheticMethod(klassLoc, klassDeclLoc, core::Names::initialize(), std::move(args), std::move(body)));
@@ -529,7 +529,7 @@ void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
         }
     }
     auto propContext = PropContext{syntacticSuperClass, klass->kind};
-    UnorderedMap<void *, vector<ast::TreePtr>> replaceNodes;
+    UnorderedMap<void *, vector<ast::ExpressionPtr>> replaceNodes;
     replaceNodes.reserve(klass->rhs.size());
     vector<PropInfo> props;
     for (auto &stat : klass->rhs) {
@@ -544,7 +544,7 @@ void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
         auto processed = processProp(ctx, propInfo.value(), propContext);
         ENFORCE(!processed.empty(), "if parseProp completed successfully, processProp must complete too");
 
-        vector<ast::TreePtr> nodes;
+        vector<ast::ExpressionPtr> nodes;
         nodes.emplace_back(ensureWithoutAccessors(propInfo.value(), send));
         nodes.insert(nodes.end(), make_move_iterator(processed.begin()), make_move_iterator(processed.end()));
         replaceNodes[stat.get()] = std::move(nodes);

--- a/rewriter/Regexp.cc
+++ b/rewriter/Regexp.cc
@@ -10,7 +10,7 @@ using namespace std;
 
 namespace sorbet::rewriter {
 
-vector<ast::TreePtr> Regexp::run(core::MutableContext ctx, ast::Assign *asgn) {
+vector<ast::ExpressionPtr> Regexp::run(core::MutableContext ctx, ast::Assign *asgn) {
     auto lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn->lhs);
     if (lhs == nullptr) {
         return {};
@@ -26,7 +26,7 @@ vector<ast::TreePtr> Regexp::run(core::MutableContext ctx, ast::Assign *asgn) {
         return {};
     }
 
-    vector<ast::TreePtr> stats;
+    vector<ast::ExpressionPtr> stats;
     auto type = ast::MK::Constant(send->loc, core::Symbols::Regexp());
     auto newRhs = ast::MK::Let(send->loc, std::move(asgn->rhs), std::move(type));
     stats.emplace_back(ast::MK::Assign(asgn->loc, std::move(asgn->lhs), std::move(newRhs)));

--- a/rewriter/Regexp.h
+++ b/rewriter/Regexp.h
@@ -16,7 +16,7 @@ namespace sorbet::rewriter {
  */
 class Regexp final {
 public:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, ast::Assign *asgn);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Assign *asgn);
 
     Regexp() = delete;
 };

--- a/rewriter/SelfNew.cc
+++ b/rewriter/SelfNew.cc
@@ -5,7 +5,7 @@
 
 namespace sorbet::rewriter {
 
-ast::TreePtr SelfNew::run(core::MutableContext ctx, ast::Send *send) {
+ast::ExpressionPtr SelfNew::run(core::MutableContext ctx, ast::Send *send) {
     if (send->fun != core::Names::new_() || !send->recv.isSelfReference()) {
         return nullptr;
     }

--- a/rewriter/SelfNew.h
+++ b/rewriter/SelfNew.h
@@ -19,7 +19,7 @@ namespace sorbet::rewriter {
  */
 class SelfNew final {
 public:
-    static ast::TreePtr run(core::MutableContext ctx, ast::Send *send);
+    static ast::ExpressionPtr run(core::MutableContext ctx, ast::Send *send);
     SelfNew() = delete;
 };
 

--- a/rewriter/SigRewriter.cc
+++ b/rewriter/SigRewriter.cc
@@ -7,7 +7,7 @@ namespace sorbet::rewriter {
 
 namespace {
 
-bool isTSigWithoutRuntime(ast::TreePtr &expr) {
+bool isTSigWithoutRuntime(ast::ExpressionPtr &expr) {
     if (auto *cnst = ast::cast_tree<ast::ConstantLit>(expr)) {
         return cnst->symbol == core::Symbols::T_Sig_WithoutRuntime();
     } else {

--- a/rewriter/Singleton.cc
+++ b/rewriter/Singleton.cc
@@ -11,7 +11,7 @@ namespace sorbet::rewriter {
 
 namespace {
 
-bool isFinal(const ast::TreePtr &stmt) {
+bool isFinal(const ast::ExpressionPtr &stmt) {
     auto *send = ast::cast_tree<ast::Send>(stmt);
     if (send == nullptr) {
         return false;
@@ -32,7 +32,7 @@ bool isFinal(const ast::TreePtr &stmt) {
     return true;
 }
 
-bool isIncludeSingleton(const ast::TreePtr &stmt) {
+bool isIncludeSingleton(const ast::ExpressionPtr &stmt) {
     const auto *send = ast::cast_tree<ast::Send>(stmt);
     if (send == nullptr) {
         return false;

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -14,7 +14,7 @@ namespace sorbet::rewriter {
 
 namespace {
 
-bool isKeywordInitKey(const core::GlobalState &gs, const ast::TreePtr &node) {
+bool isKeywordInitKey(const core::GlobalState &gs, const ast::ExpressionPtr &node) {
     if (auto *lit = ast::cast_tree<ast::Literal>(node)) {
         return lit->isSymbol(gs) && lit->asSymbol(gs) == core::Names::keywordInit();
     }
@@ -23,8 +23,8 @@ bool isKeywordInitKey(const core::GlobalState &gs, const ast::TreePtr &node) {
 
 } // namespace
 
-vector<ast::TreePtr> Struct::run(core::MutableContext ctx, ast::Assign *asgn) {
-    vector<ast::TreePtr> empty;
+vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *asgn) {
+    vector<ast::ExpressionPtr> empty;
 
     if (ctx.state.runningUnderAutogen) {
         return empty;
@@ -145,7 +145,7 @@ vector<ast::TreePtr> Struct::run(core::MutableContext ctx, ast::Assign *asgn) {
     ancestors.emplace_back(ast::MK::UnresolvedConstant(loc, ast::MK::Constant(loc, core::Symbols::root()),
                                                        core::Names::Constants::Struct()));
 
-    vector<ast::TreePtr> stats;
+    vector<ast::ExpressionPtr> stats;
     stats.emplace_back(ast::MK::Class(loc, loc, std::move(asgn->lhs), std::move(ancestors), std::move(body)));
     return stats;
 }

--- a/rewriter/Struct.h
+++ b/rewriter/Struct.h
@@ -24,7 +24,7 @@ namespace sorbet::rewriter {
  */
 class Struct final {
 public:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, ast::Assign *asgn);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Assign *asgn);
 
     Struct() = delete;
 };

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -58,7 +58,7 @@ vector<ast::ExpressionPtr> badConst(core::MutableContext ctx, core::LocOffsets h
 }
 
 vector<ast::ExpressionPtr> processStat(core::MutableContext ctx, ast::ClassDef *klass, ast::ExpressionPtr &stat,
-                                 FromWhere fromWhere) {
+                                       FromWhere fromWhere) {
     auto *asgn = ast::cast_tree<ast::Assign>(stat);
     if (asgn == nullptr) {
         return {};

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -5,8 +5,8 @@
 
 namespace sorbet::rewriter {
 
-std::vector<ast::TreePtr> TestCase::run(core::MutableContext ctx, ast::Send *send) {
-    std::vector<ast::TreePtr> stats;
+std::vector<ast::ExpressionPtr> TestCase::run(core::MutableContext ctx, ast::Send *send) {
+    std::vector<ast::ExpressionPtr> stats;
     if (ctx.state.runningUnderAutogen) {
         return stats;
     }

--- a/rewriter/TestCase.h
+++ b/rewriter/TestCase.h
@@ -23,7 +23,7 @@ namespace sorbet::rewriter {
  */
 class TestCase final {
 public:
-    static std::vector<ast::TreePtr> run(core::MutableContext ctx, ast::Send *send);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Send *send);
 
     TestCase() = delete;
 };

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -58,7 +58,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
         if (ident->original && !orig) {
             return nullptr;
         }
-        return ast::make_tree<ast::ConstantLit>(ident->loc, ident->symbol, std::move(orig));
+        return ast::make_expression<ast::ConstantLit>(ident->loc, ident->symbol, std::move(orig));
     }
 
     auto *cons = ast::cast_tree<ast::UnresolvedConstantLit>(orig);

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -8,7 +8,7 @@ using namespace std;
 
 namespace sorbet::rewriter {
 
-ast::TreePtr ASTUtil::dupType(const ast::TreePtr &orig) {
+ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
     auto send = ast::cast_tree<ast::Send>(orig);
     if (send) {
         ast::Send::ARGS_store args;
@@ -115,7 +115,7 @@ bool ASTUtil::hasTruthyHashValue(core::MutableContext ctx, const ast::Hash &hash
     return false;
 }
 
-pair<ast::TreePtr, ast::TreePtr> ASTUtil::extractHashValue(core::MutableContext ctx, ast::Hash &hash,
+pair<ast::ExpressionPtr, ast::ExpressionPtr> ASTUtil::extractHashValue(core::MutableContext ctx, ast::Hash &hash,
                                                            core::NameRef name) {
     int i = -1;
     for (auto &keyExpr : hash.keys) {
@@ -132,7 +132,7 @@ pair<ast::TreePtr, ast::TreePtr> ASTUtil::extractHashValue(core::MutableContext 
     return make_pair(nullptr, nullptr);
 }
 
-ast::Send *ASTUtil::castSig(ast::TreePtr &expr) {
+ast::Send *ASTUtil::castSig(ast::ExpressionPtr &expr) {
     auto *send = ast::cast_tree<ast::Send>(expr);
     if (send == nullptr) {
         return nullptr;
@@ -171,7 +171,7 @@ ast::Send *ASTUtil::castSig(ast::Send *send) {
     }
 }
 
-ast::TreePtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
+ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
     if (send->args.empty()) {
         return nullptr;
     }
@@ -204,26 +204,26 @@ ast::TreePtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
     }
 }
 
-ast::TreePtr ASTUtil::mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::TreePtr rhs,
+ast::ExpressionPtr ASTUtil::mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::ExpressionPtr rhs,
                             bool isAttrReader) {
     auto ret = ast::MK::SyntheticMethod0(loc, loc, name, move(rhs));
     ast::cast_tree_nonnull<ast::MethodDef>(ret).flags.isAttrReader = isAttrReader;
     return ret;
 }
 
-ast::TreePtr ASTUtil::mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name, core::LocOffsets argLoc,
-                            ast::TreePtr rhs) {
+ast::ExpressionPtr ASTUtil::mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name, core::LocOffsets argLoc,
+                            ast::ExpressionPtr rhs) {
     return ast::MK::SyntheticMethod1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs));
 }
 
-ast::TreePtr ASTUtil::mkNilable(core::LocOffsets loc, ast::TreePtr type) {
+ast::ExpressionPtr ASTUtil::mkNilable(core::LocOffsets loc, ast::ExpressionPtr type) {
     return ast::MK::Send1(loc, ast::MK::T(loc), core::Names::nilable(), move(type));
 }
 
 namespace {
 
 // Returns `true` when the expression passed is an UnresolvedConstantLit with the name `Kernel` and no additional scope.
-bool isKernel(const ast::TreePtr &expr) {
+bool isKernel(const ast::ExpressionPtr &expr) {
     if (auto *constRecv = ast::cast_tree<ast::UnresolvedConstantLit>(expr)) {
         return ast::isa_tree<ast::EmptyTree>(constRecv->scope) && constRecv->cnst == core::Names::Constants::Kernel();
     }
@@ -232,7 +232,7 @@ bool isKernel(const ast::TreePtr &expr) {
 
 } // namespace
 
-ast::TreePtr ASTUtil::thunkBody(core::MutableContext ctx, ast::TreePtr &node) {
+ast::ExpressionPtr ASTUtil::thunkBody(core::MutableContext ctx, ast::ExpressionPtr &node) {
     auto *send = ast::cast_tree<ast::Send>(node);
     if (send == nullptr) {
         return nullptr;

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -116,7 +116,7 @@ bool ASTUtil::hasTruthyHashValue(core::MutableContext ctx, const ast::Hash &hash
 }
 
 pair<ast::ExpressionPtr, ast::ExpressionPtr> ASTUtil::extractHashValue(core::MutableContext ctx, ast::Hash &hash,
-                                                           core::NameRef name) {
+                                                                       core::NameRef name) {
     int i = -1;
     for (auto &keyExpr : hash.keys) {
         i++;
@@ -205,14 +205,14 @@ ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
 }
 
 ast::ExpressionPtr ASTUtil::mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::ExpressionPtr rhs,
-                            bool isAttrReader) {
+                                  bool isAttrReader) {
     auto ret = ast::MK::SyntheticMethod0(loc, loc, name, move(rhs));
     ast::cast_tree_nonnull<ast::MethodDef>(ret).flags.isAttrReader = isAttrReader;
     return ret;
 }
 
 ast::ExpressionPtr ASTUtil::mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name, core::LocOffsets argLoc,
-                            ast::ExpressionPtr rhs) {
+                                  ast::ExpressionPtr rhs) {
     return ast::MK::SyntheticMethod1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs));
 }
 

--- a/rewriter/Util.h
+++ b/rewriter/Util.h
@@ -14,7 +14,7 @@ public:
 
     /** Removes the key, value matching key with symbol `name` from hash and returns it */
     static std::pair<ast::ExpressionPtr, ast::ExpressionPtr> extractHashValue(core::MutableContext ctx, ast::Hash &hash,
-                                                                  core::NameRef name);
+                                                                              core::NameRef name);
 
     static ast::Send *castSig(ast::ExpressionPtr &expr);
     static ast::Send *castSig(ast::Send *expr);
@@ -22,10 +22,10 @@ public:
     static ast::ExpressionPtr mkKwArgsHash(const ast::Send *send);
 
     static ast::ExpressionPtr mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::ExpressionPtr rhs,
-                              bool isAttrReader = false);
+                                    bool isAttrReader = false);
 
-    static ast::ExpressionPtr mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name, core::LocOffsets argLoc,
-                              ast::ExpressionPtr rhs);
+    static ast::ExpressionPtr mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name,
+                                    core::LocOffsets argLoc, ast::ExpressionPtr rhs);
 
     static ast::ExpressionPtr mkNilable(core::LocOffsets loc, ast::ExpressionPtr type);
 

--- a/rewriter/Util.h
+++ b/rewriter/Util.h
@@ -8,28 +8,28 @@
 namespace sorbet::rewriter {
 class ASTUtil {
 public:
-    static ast::TreePtr dupType(const ast::TreePtr &orig);
+    static ast::ExpressionPtr dupType(const ast::ExpressionPtr &orig);
     static bool hasHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name);
     static bool hasTruthyHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name);
 
     /** Removes the key, value matching key with symbol `name` from hash and returns it */
-    static std::pair<ast::TreePtr, ast::TreePtr> extractHashValue(core::MutableContext ctx, ast::Hash &hash,
+    static std::pair<ast::ExpressionPtr, ast::ExpressionPtr> extractHashValue(core::MutableContext ctx, ast::Hash &hash,
                                                                   core::NameRef name);
 
-    static ast::Send *castSig(ast::TreePtr &expr);
+    static ast::Send *castSig(ast::ExpressionPtr &expr);
     static ast::Send *castSig(ast::Send *expr);
 
-    static ast::TreePtr mkKwArgsHash(const ast::Send *send);
+    static ast::ExpressionPtr mkKwArgsHash(const ast::Send *send);
 
-    static ast::TreePtr mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::TreePtr rhs,
+    static ast::ExpressionPtr mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::ExpressionPtr rhs,
                               bool isAttrReader = false);
 
-    static ast::TreePtr mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name, core::LocOffsets argLoc,
-                              ast::TreePtr rhs);
+    static ast::ExpressionPtr mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name, core::LocOffsets argLoc,
+                              ast::ExpressionPtr rhs);
 
-    static ast::TreePtr mkNilable(core::LocOffsets loc, ast::TreePtr type);
+    static ast::ExpressionPtr mkNilable(core::LocOffsets loc, ast::ExpressionPtr type);
 
-    static ast::TreePtr thunkBody(core::MutableContext ctx, ast::TreePtr &node);
+    static ast::ExpressionPtr thunkBody(core::MutableContext ctx, ast::ExpressionPtr &node);
 
     ASTUtil() = delete;
 };

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -38,7 +38,7 @@ class Rewriterer {
     friend class Rewriter;
 
 public:
-    ast::TreePtr postTransformClassDef(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr tree) {
         auto *classDef = ast::cast_tree<ast::ClassDef>(tree);
 
         Command::run(ctx, classDef);
@@ -53,13 +53,13 @@ public:
             extension->run(ctx, classDef);
         }
 
-        ast::TreePtr *prevStat = nullptr;
-        UnorderedMap<void *, vector<ast::TreePtr>> replaceNodes;
+        ast::ExpressionPtr *prevStat = nullptr;
+        UnorderedMap<void *, vector<ast::ExpressionPtr>> replaceNodes;
         for (auto &stat : classDef->rhs) {
             typecase(
                 stat,
                 [&](ast::Assign &assign) {
-                    vector<ast::TreePtr> nodes;
+                    vector<ast::ExpressionPtr> nodes;
 
                     nodes = Struct::run(ctx, &assign);
                     if (!nodes.empty()) {
@@ -81,7 +81,7 @@ public:
                 },
 
                 [&](ast::Send &send) {
-                    vector<ast::TreePtr> nodes;
+                    vector<ast::ExpressionPtr> nodes;
 
                     nodes = MixinEncryptedProp::run(ctx, &send);
                     if (!nodes.empty()) {
@@ -142,7 +142,7 @@ public:
 
                 [&](ast::MethodDef &mdef) { Initializer::run(ctx, &mdef, prevStat); },
 
-                [&](const ast::TreePtr &e) {});
+                [&](const ast::ExpressionPtr &e) {});
 
             prevStat = &stat;
         }
@@ -172,7 +172,7 @@ public:
 
     // NOTE: this case differs from the `Send` typecase branch in `postTransformClassDef` above, as it will apply to all
     // sends, not just those that are present in the RHS of a `ClassDef`.
-    ast::TreePtr postTransformSend(core::MutableContext ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr postTransformSend(core::MutableContext ctx, ast::ExpressionPtr tree) {
         auto *send = ast::cast_tree<ast::Send>(tree);
 
         if (auto expr = InterfaceWrapper::run(ctx, send)) {
@@ -194,7 +194,7 @@ private:
     Rewriterer() = default;
 };
 
-ast::TreePtr Rewriter::run(core::MutableContext ctx, ast::TreePtr tree) {
+ast::ExpressionPtr Rewriter::run(core::MutableContext ctx, ast::ExpressionPtr tree) {
     auto ast = std::move(tree);
 
     Rewriterer rewriter;

--- a/rewriter/rewriter.h
+++ b/rewriter/rewriter.h
@@ -7,7 +7,7 @@ namespace sorbet::rewriter {
 
 class Rewriter final {
 public:
-    static ast::TreePtr run(core::MutableContext ctx, ast::TreePtr tree);
+    static ast::ExpressionPtr run(core::MutableContext ctx, ast::ExpressionPtr tree);
 
     Rewriter() = delete;
 };

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -43,86 +43,86 @@ TEST_CASE("CountTrees") {
     class Counter {
     public:
         int count = 0;
-        ast::TreePtr preTransformClassDef(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr preTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
-        ast::TreePtr preTransformMethodDef(core::MutableContext ctx, ast::TreePtr original) {
-            count++;
-            return original;
-        }
-
-        ast::TreePtr preTransformIf(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr preTransformMethodDef(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr preTransformWhile(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr preTransformIf(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr postTransformBreak(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr preTransformWhile(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr postTransformNext(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr postTransformBreak(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr preTransformReturn(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr postTransformNext(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr preTransformRescue(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr preTransformReturn(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr postTransformConstantLit(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr preTransformRescue(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr preTransformAssign(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr postTransformConstantLit(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr preTransformSend(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr preTransformAssign(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr preTransformHash(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr preTransformSend(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr preTransformArray(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr preTransformHash(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr postTransformLiteral(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr preTransformArray(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr postTransformUnresolvedConstantLit(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr postTransformLiteral(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr preTransformBlock(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr postTransformUnresolvedConstantLit(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }
 
-        ast::TreePtr preTransformInsSeq(core::MutableContext ctx, ast::TreePtr original) {
+        ast::ExpressionPtr preTransformBlock(core::MutableContext ctx, ast::ExpressionPtr original) {
+            count++;
+            return original;
+        }
+
+        ast::ExpressionPtr preTransformInsSeq(core::MutableContext ctx, ast::ExpressionPtr original) {
             count++;
             return original;
         }

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -148,19 +148,19 @@ TEST_CASE("CountTrees") {
     auto empty = vector<core::SymbolRef>();
     auto argumentSym = core::LocalVariable(name, 0);
     auto rhs(ast::MK::Int(loc.offsets(), 5));
-    auto arg = ast::make_tree<ast::Local>(loc.offsets(), argumentSym);
+    auto arg = ast::make_expression<ast::Local>(loc.offsets(), argumentSym);
     ast::MethodDef::ARGS_store args;
     args.emplace_back(std::move(arg));
 
     ast::MethodDef::Flags flags;
-    auto methodDef = ast::make_tree<ast::MethodDef>(loc.offsets(), loc.offsets(), methodSym, name, std::move(args),
+    auto methodDef = ast::make_expression<ast::MethodDef>(loc.offsets(), loc.offsets(), methodSym, name, std::move(args),
                                                     std::move(rhs), flags);
     auto emptyTree = ast::MK::EmptyTree();
-    auto cnst = ast::make_tree<ast::UnresolvedConstantLit>(loc.offsets(), std::move(emptyTree), name);
+    auto cnst = ast::make_expression<ast::UnresolvedConstantLit>(loc.offsets(), std::move(emptyTree), name);
 
     ast::ClassDef::RHS_store classrhs;
     classrhs.emplace_back(std::move(methodDef));
-    auto tree = ast::make_tree<ast::ClassDef>(loc.offsets(), loc.offsets(), classSym, std::move(cnst),
+    auto tree = ast::make_expression<ast::ClassDef>(loc.offsets(), loc.offsets(), classSym, std::move(cnst),
                                               ast::ClassDef::ANCESTORS_store(), std::move(classrhs),
                                               ast::ClassDef::Kind::Class);
     Counter c;

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -153,16 +153,16 @@ TEST_CASE("CountTrees") {
     args.emplace_back(std::move(arg));
 
     ast::MethodDef::Flags flags;
-    auto methodDef = ast::make_expression<ast::MethodDef>(loc.offsets(), loc.offsets(), methodSym, name, std::move(args),
-                                                    std::move(rhs), flags);
+    auto methodDef = ast::make_expression<ast::MethodDef>(loc.offsets(), loc.offsets(), methodSym, name,
+                                                          std::move(args), std::move(rhs), flags);
     auto emptyTree = ast::MK::EmptyTree();
     auto cnst = ast::make_expression<ast::UnresolvedConstantLit>(loc.offsets(), std::move(emptyTree), name);
 
     ast::ClassDef::RHS_store classrhs;
     classrhs.emplace_back(std::move(methodDef));
     auto tree = ast::make_expression<ast::ClassDef>(loc.offsets(), loc.offsets(), classSym, std::move(cnst),
-                                              ast::ClassDef::ANCESTORS_store(), std::move(classrhs),
-                                              ast::ClassDef::Kind::Class);
+                                                    ast::ClassDef::ANCESTORS_store(), std::move(classrhs),
+                                                    ast::ClassDef::Kind::Class);
     Counter c;
     sorbet::core::MutableContext ctx(cb, core::Symbols::root(), loc.file());
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -56,7 +56,7 @@ string singleTest;
 class CFGCollectorAndTyper {
 public:
     vector<unique_ptr<cfg::CFG>> cfgs;
-    ast::TreePtr preTransformMethodDef(core::Context ctx, ast::TreePtr tree) {
+    ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &m = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
         if (m.symbol.data(ctx)->isOverloaded()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have multiple kinds of "tree"'s in Sorbet (parser::Node, core::Type, etc.).

`TreePtr` used to be called `unique_ptr<ast::Expression>` and I think we should
recover that naming.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

**Review by commit** for a good summary of the changes.