### PR TITLE
Run --store-state with multiple threads

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -805,9 +805,11 @@ void readOptions(Options &opts,
         opts.noErrorCount = raw["no-error-count"].as<bool>();
         opts.noStdlib = raw["no-stdlib"].as<bool>();
         opts.stdoutHUPHack = raw["stdout-hup-hack"].as<bool>();
+        opts.storeState = raw["store-state"].as<string>();
 
-        opts.threads = opts.runLSP ? raw["max-threads"].as<int>()
-                                   : min(raw["max-threads"].as<int>(), int(opts.inputFileNames.size() / 2));
+        opts.threads = (opts.runLSP || !opts.storeState.empty())
+                           ? raw["max-threads"].as<int>()
+                           : min(raw["max-threads"].as<int>(), int(opts.inputFileNames.size() / 2));
 
         if (raw["h"].as<bool>()) {
             logger->info("{}", options.help({""}));
@@ -838,7 +840,6 @@ void readOptions(Options &opts,
             opts.configatronFiles = raw["configatron-file"].as<vector<string>>();
         }
         opts.skipRewriterPasses = raw["skip-rewriter-passes"].as<bool>();
-        opts.storeState = raw["store-state"].as<string>();
         opts.suggestTyped = raw["suggest-typed"].as<bool>();
         opts.waitForDebugger = raw["wait-for-dbg"].as<bool>();
         opts.stressIncrementalResolver = raw["stress-incremental-resolver"].as<bool>();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There are about 150 RBI files in Sorbet's payload.
Right now it processes them entirely serially.
This PR allows processing them with max hardware parallelism.

This leads to a slight (but not mindblowing speedup) on my machine for the
`generate-state-payload-raw` step.

This only affects builds that run with `--store-state`, which is what we pass to
`sorbet-orig` to generate the binary payload data in `payload/binary/BUILD`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Ran a bunch of rebuilds where I changed nothing but adding whitespace to
`rbi/core/kernel.rbi` and ran `bazel build --config=dbg //main:sorbet`.

Three such rebuilds on an already-cached master: ~17s start to finish

Three such rebuilds after building once to cache this branch: ~12s start to finish.