### PR TITLE
Add --suggest-unsafe option

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1785,6 +1785,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->ignoredForSuggestTypedErrorClasses = this->ignoredForSuggestTypedErrorClasses;
     result->suppressedErrorClasses = this->suppressedErrorClasses;
     result->onlyErrorClasses = this->onlyErrorClasses;
+    result->suggestUnsafe = this->suggestUnsafe;
     result->dslPlugins = this->dslPlugins;
     result->dslRubyExtraArgs = this->dslRubyExtraArgs;
     result->utf8Names.reserve(this->utf8Names.capacity());

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -247,6 +247,8 @@ public:
     void suppressErrorClass(int code);
     void onlyShowErrorClass(int code);
 
+    std::optional<std::string> suggestUnsafe;
+
     std::vector<std::string> dslRubyExtraArgs;
     void addDslPlugin(std::string_view method, std::string_view command);
     std::optional<std::string_view> findDslPlugin(NameRef method) const;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -501,6 +501,11 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
         options.add_options("dev")("suggest-sig", "Report typing candidates. Only supported in debug builds");
     }
     options.add_options("dev")("suggest-typed", "Suggest which typed: sigils to add or upgrade");
+    options.add_options("dev")("suggest-unsafe",
+                               "In as many errors as possible, suggest autocorrects to wrap problem code with "
+                               "<method>. Omit the =<method> to default to wrapping with T.unsafe. "
+                               "This supercedes certain autocorrects, especially T.must.",
+                               cxxopts::value<std::string>()->implicit_value("T.unsafe"), "<method>");
     options.add_options("dev")("statsd-prefix", "StatsD prefix",
                                cxxopts::value<string>()->default_value(empty.statsdPrefix), "prefix");
     options.add_options("dev")("statsd-port", "StatsD server port",
@@ -840,6 +845,9 @@ void readOptions(Options &opts,
         opts.skipRewriterPasses = raw["skip-rewriter-passes"].as<bool>();
         opts.storeState = raw["store-state"].as<string>();
         opts.suggestTyped = raw["suggest-typed"].as<bool>();
+        if (raw.count("suggest-unsafe") > 0) {
+            opts.suggestUnsafe = raw["suggest-unsafe"].as<string>();
+        }
         opts.waitForDebugger = raw["wait-for-dbg"].as<bool>();
         opts.stressIncrementalResolver = raw["stress-incremental-resolver"].as<bool>();
         opts.sleepInSlowPath = raw["sleep-in-slow-path"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -7,6 +7,7 @@
 #include "core/StrictLevel.h"
 #include "main/pipeline/semantic_extension/SemanticExtension.h"
 #include "spdlog/spdlog.h"
+#include <optional>
 
 namespace sorbet::realmain::options {
 
@@ -129,6 +130,7 @@ struct Options {
 
     bool showProgress = false;
     bool suggestTyped = false;
+    std::optional<std::string> suggestUnsafe = std::nullopt;
     bool silenceErrors = false;
     bool silenceDevMessage = false;
     bool suggestSig = false;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -488,6 +488,7 @@ int realmain(int argc, char *argv[]) {
             gs->ignoreErrorClassForSuggestTyped(core::errors::Namer::MultipleBehaviorDefs.code);
         }
     }
+    gs->suggestUnsafe = opts.suggestUnsafe;
 
     logger->trace("done building initial global state");
 

--- a/test/cli/autocorrect-helpers/autocorrect-helpers.sh
+++ b/test/cli/autocorrect-helpers/autocorrect-helpers.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 tmp="$(mktemp -d)"
 infile="test/cli/autocorrect-helpers/autocorrect-helpers.rb"
 cp "$infile" "$tmp"
@@ -5,13 +7,16 @@ cp "$infile" "$tmp"
 cwd="$(pwd)"
 cd "$tmp" || exit 1
 
-"$cwd/main/sorbet" --silence-dev-message -a autocorrect-helpers.rb 2>&1
+if "$cwd/main/sorbet" --silence-dev-message -a autocorrect-helpers.rb 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi
 
 echo
 echo --------------------------------------------------------------------------
 echo
 
-# Also cat the file, to make sure that 'extend' is only added once per class.
+# Also cat the file, to make that the autocorrect applied
 cat autocorrect-helpers.rb
 
 rm autocorrect-helpers.rb

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -237,6 +237,12 @@ Usage:
       --statsd-host host        StatsD sever hostname (default: "")
       --counters                Print all internal counters
       --suggest-typed           Suggest which typed: sigils to add or upgrade
+      --suggest-unsafe [=<method>(=T.unsafe)]
+                                In as many errors as possible, suggest
+                                autocorrects to wrap problem code with <method>.
+                                Omit the =<method> to default to wrapping with
+                                T.unsafe. This supercedes certain autocorrects,
+                                especially T.must.
       --statsd-prefix prefix    StatsD prefix (default: ruby_typer.unknown)
       --statsd-port port        StatsD server port (default: 8200)
       --metrics-file file       File to export metrics to (default: "")

--- a/test/cli/suggest_t_must/suggest_t_must.out
+++ b/test/cli/suggest_t_must/suggest_t_must.out
@@ -1,16 +1,16 @@
-test/cli/suggest_t_must/suggest_t_must.rb:4: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
+suggest_t_must.rb:4: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
      4 |foo[0]
         ^^^^^^
   Got T.nilable(String) originating from:
-    test/cli/suggest_t_must/suggest_t_must.rb:3:
+    suggest_t_must.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    test/cli/suggest_t_must/suggest_t_must.rb:4: Replace with `T.must(foo)`
+  Autocorrect: Done
+    suggest_t_must.rb:4: Replaced with `T.must(foo)`
      4 |foo[0]
         ^^^
 
-test/cli/suggest_t_must/suggest_t_must.rb:6: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
+suggest_t_must.rb:6: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
      6 |"hi" + foo
         ^^^^^^^^^^
   Expected `String` for argument `arg0` of method `String#+`:
@@ -18,11 +18,20 @@ test/cli/suggest_t_must/suggest_t_must.rb:6: Expected `String` but found `T.nila
     58 |        arg0: String,
                 ^^^^
   Got `T.nilable(String)` originating from:
-    test/cli/suggest_t_must/suggest_t_must.rb:3:
+    suggest_t_must.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    test/cli/suggest_t_must/suggest_t_must.rb:6: Replace with `T.must(foo)`
+  Autocorrect: Done
+    suggest_t_must.rb:6: Replaced with `T.must(foo)`
      6 |"hi" + foo
                ^^^
 Errors: 2
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+foo = T.let(nil, T.nilable(String))
+T.must(foo)[0]
+
+"hi" + T.must(foo)

--- a/test/cli/suggest_t_must/suggest_t_must.sh
+++ b/test/cli/suggest_t_must/suggest_t_must.sh
@@ -1,2 +1,23 @@
-#!/bin/bash
-main/sorbet --silence-dev-message test/cli/suggest_t_must/suggest_t_must.rb 2>&1
+#!/usr/bin/env bash
+
+tmp="$(mktemp -d)"
+infile="test/cli/suggest_t_must/suggest_t_must.rb"
+cp "$infile" "$tmp"
+
+cwd="$(pwd)"
+cd "$tmp" || exit 1
+
+if "$cwd/main/sorbet" --silence-dev-message -a suggest_t_must.rb 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+# Also cat the file, to make that the autocorrect applied
+cat suggest_t_must.rb
+
+rm suggest_t_must.rb
+rm "$tmp"

--- a/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
+++ b/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
@@ -1,37 +1,72 @@
-suggest_t_unsafe.rb:4: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
-     4 |foo[0]
+suggest_t_unsafe.rb:6: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
+     6 |foo[0]
         ^^^^^^
   Got T.nilable(String) originating from:
-    suggest_t_unsafe.rb:3:
-     3 |foo = T.let(nil, T.nilable(String))
+    suggest_t_unsafe.rb:5:
+     5 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest_t_unsafe.rb:4: Replaced with `T.unsafe(foo)`
-     4 |foo[0]
+    suggest_t_unsafe.rb:6: Replaced with `T.unsafe(foo)`
+     6 |foo[0]
         ^^^
 
-suggest_t_unsafe.rb:6: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
-     6 |"hi" + foo
+suggest_t_unsafe.rb:8: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
+     8 |"hi" + foo
         ^^^^^^^^^^
   Expected `String` for argument `arg0` of method `String#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L58:
     58 |        arg0: String,
                 ^^^^
   Got `T.nilable(String)` originating from:
-    suggest_t_unsafe.rb:3:
-     3 |foo = T.let(nil, T.nilable(String))
+    suggest_t_unsafe.rb:5:
+     5 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest_t_unsafe.rb:6: Replaced with `T.unsafe(foo)`
-     6 |"hi" + foo
+    suggest_t_unsafe.rb:8: Replaced with `T.unsafe(foo)`
+     8 |"hi" + foo
                ^^^
-Errors: 2
+
+suggest_t_unsafe.rb:11: Method `even?` does not exist on `String` component of `T.any(Integer, String)` https://srb.help/7003
+    11 |bar.even?
+        ^^^^^^^^^
+  Got T.any(Integer, String) originating from:
+    suggest_t_unsafe.rb:10:
+    10 |bar = T.let(1, T.any(Integer, String))
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest_t_unsafe.rb:11: Replaced with `T.unsafe(bar)`
+    11 |bar.even?
+        ^^^
+
+suggest_t_unsafe.rb:13: Expected `String` but found `Integer(1)` for argument `arg0` https://srb.help/7002
+    13 |"hi" + 1
+               ^
+  Expected `String` for argument `arg0` of method `String#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L58:
+    58 |        arg0: String,
+                ^^^^
+  Got `Integer(1)` originating from:
+    suggest_t_unsafe.rb:13:
+    13 |"hi" + 1
+               ^
+  Autocorrect: Done
+    suggest_t_unsafe.rb:13: Replaced with `T.unsafe(1)`
+    13 |"hi" + 1
+               ^
+Errors: 4
 
 --------------------------------------------------------------------------
 
 # typed: true
 
+def custom_wrapper(arg0); end
+
 foo = T.let(nil, T.nilable(String))
 T.unsafe(foo)[0]
 
 "hi" + T.unsafe(foo)
+
+bar = T.let(1, T.any(Integer, String))
+T.unsafe(bar).even?
+
+"hi" + T.unsafe(1)

--- a/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
+++ b/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
@@ -70,3 +70,78 @@ bar = T.let(1, T.any(Integer, String))
 T.unsafe(bar).even?
 
 "hi" + T.unsafe(1)
+
+--------------------------------------------------------------------------
+
+suggest_t_unsafe.rb:6: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
+     6 |foo[0]
+        ^^^^^^
+  Got T.nilable(String) originating from:
+    suggest_t_unsafe.rb:5:
+     5 |foo = T.let(nil, T.nilable(String))
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest_t_unsafe.rb:6: Replaced with `custom_wrapper(foo)`
+     6 |foo[0]
+        ^^^
+
+suggest_t_unsafe.rb:8: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
+     8 |"hi" + foo
+        ^^^^^^^^^^
+  Expected `String` for argument `arg0` of method `String#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L58:
+    58 |        arg0: String,
+                ^^^^
+  Got `T.nilable(String)` originating from:
+    suggest_t_unsafe.rb:5:
+     5 |foo = T.let(nil, T.nilable(String))
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest_t_unsafe.rb:8: Replaced with `custom_wrapper(foo)`
+     8 |"hi" + foo
+               ^^^
+
+suggest_t_unsafe.rb:11: Method `even?` does not exist on `String` component of `T.any(Integer, String)` https://srb.help/7003
+    11 |bar.even?
+        ^^^^^^^^^
+  Got T.any(Integer, String) originating from:
+    suggest_t_unsafe.rb:10:
+    10 |bar = T.let(1, T.any(Integer, String))
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest_t_unsafe.rb:11: Replaced with `custom_wrapper(bar)`
+    11 |bar.even?
+        ^^^
+
+suggest_t_unsafe.rb:13: Expected `String` but found `Integer(1)` for argument `arg0` https://srb.help/7002
+    13 |"hi" + 1
+               ^
+  Expected `String` for argument `arg0` of method `String#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L58:
+    58 |        arg0: String,
+                ^^^^
+  Got `Integer(1)` originating from:
+    suggest_t_unsafe.rb:13:
+    13 |"hi" + 1
+               ^
+  Autocorrect: Done
+    suggest_t_unsafe.rb:13: Replaced with `custom_wrapper(1)`
+    13 |"hi" + 1
+               ^
+Errors: 4
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+def custom_wrapper(arg0); end
+
+foo = T.let(nil, T.nilable(String))
+custom_wrapper(foo)[0]
+
+"hi" + custom_wrapper(foo)
+
+bar = T.let(1, T.any(Integer, String))
+custom_wrapper(bar).even?
+
+"hi" + custom_wrapper(1)

--- a/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
+++ b/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
@@ -1,0 +1,37 @@
+suggest_t_unsafe.rb:4: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
+     4 |foo[0]
+        ^^^^^^
+  Got T.nilable(String) originating from:
+    suggest_t_unsafe.rb:3:
+     3 |foo = T.let(nil, T.nilable(String))
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest_t_unsafe.rb:4: Replaced with `T.unsafe(foo)`
+     4 |foo[0]
+        ^^^
+
+suggest_t_unsafe.rb:6: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
+     6 |"hi" + foo
+        ^^^^^^^^^^
+  Expected `String` for argument `arg0` of method `String#+`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L58:
+    58 |        arg0: String,
+                ^^^^
+  Got `T.nilable(String)` originating from:
+    suggest_t_unsafe.rb:3:
+     3 |foo = T.let(nil, T.nilable(String))
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest_t_unsafe.rb:6: Replaced with `T.unsafe(foo)`
+     6 |"hi" + foo
+               ^^^
+Errors: 2
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+foo = T.let(nil, T.nilable(String))
+T.unsafe(foo)[0]
+
+"hi" + T.unsafe(foo)

--- a/test/cli/suggest_t_unsafe/suggest_t_unsafe.rb
+++ b/test/cli/suggest_t_unsafe/suggest_t_unsafe.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+foo = T.let(nil, T.nilable(String))
+foo[0]
+
+"hi" + foo

--- a/test/cli/suggest_t_unsafe/suggest_t_unsafe.rb
+++ b/test/cli/suggest_t_unsafe/suggest_t_unsafe.rb
@@ -1,6 +1,13 @@
 # typed: true
 
+def custom_wrapper(arg0); end
+
 foo = T.let(nil, T.nilable(String))
 foo[0]
 
 "hi" + foo
+
+bar = T.let(1, T.any(Integer, String))
+bar.even?
+
+"hi" + 1

--- a/test/cli/suggest_t_unsafe/suggest_t_unsafe.sh
+++ b/test/cli/suggest_t_unsafe/suggest_t_unsafe.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+tmp="$(mktemp -d)"
+infile="test/cli/suggest_t_unsafe/suggest_t_unsafe.rb"
+cp "$infile" "$tmp"
+
+cwd="$(pwd)"
+cd "$tmp" || exit 1
+
+if "$cwd/main/sorbet" --silence-dev-message --suggest-unsafe -a suggest_t_unsafe.rb 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+# Also cat the file, to make that the autocorrect applied
+cat suggest_t_unsafe.rb
+
+rm suggest_t_unsafe.rb
+rm "$tmp"

--- a/test/cli/suggest_t_unsafe/suggest_t_unsafe.sh
+++ b/test/cli/suggest_t_unsafe/suggest_t_unsafe.sh
@@ -1,23 +1,50 @@
 #!/usr/bin/env bash
 
-tmp="$(mktemp -d)"
-infile="test/cli/suggest_t_unsafe/suggest_t_unsafe.rb"
-cp "$infile" "$tmp"
-
 cwd="$(pwd)"
-cd "$tmp" || exit 1
+infile="$cwd/test/cli/suggest_t_unsafe/suggest_t_unsafe.rb"
 
-if "$cwd/main/sorbet" --silence-dev-message --suggest-unsafe -a suggest_t_unsafe.rb 2>&1; then
-  echo "Expected to fail!"
-  exit 1
-fi
+tmp="$(mktemp -d)"
+
+(
+  cp "$infile" "$tmp"
+
+  cd "$tmp" || exit 1
+  if "$cwd/main/sorbet" --silence-dev-message --suggest-unsafe -a suggest_t_unsafe.rb 2>&1; then
+    echo "Expected to fail!"
+    exit 1
+  fi
+
+  echo
+  echo --------------------------------------------------------------------------
+  echo
+
+  # Also cat the file, to make that the autocorrect applied
+  cat suggest_t_unsafe.rb
+
+  rm suggest_t_unsafe.rb
+)
 
 echo
 echo --------------------------------------------------------------------------
 echo
 
-# Also cat the file, to make that the autocorrect applied
-cat suggest_t_unsafe.rb
+(
+  cp "$infile" "$tmp"
 
-rm suggest_t_unsafe.rb
-rm "$tmp"
+  cd "$tmp" || exit 1
+  if "$cwd/main/sorbet" --silence-dev-message --suggest-unsafe=custom_wrapper -a suggest_t_unsafe.rb 2>&1; then
+    echo "Expected to fail!"
+    exit 1
+  fi
+
+  echo
+  echo --------------------------------------------------------------------------
+  echo
+
+  # Also cat the file, to make that the autocorrect applied
+  cat suggest_t_unsafe.rb
+
+  rm suggest_t_unsafe.rb
+)
+
+rm -r "$tmp"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is an option to make mass codemods easier.

Frequently, upgrading to a new Sorbet version is hard because either Sorbet
fixed a bug which was hiding untypedness, or Sorbet added type annotations to
it's standard library RBI definitions.

In almost all of these cases, it's better to burn in a few calls to `T.unsafe`
and upgrade, so that at least new code gains the advantages of the Sorbet
upgrade. In the meanwhile, people can go back through the newly-added calls to
`T.unsafe` manually to find and fix the sources of the errors. Frequently
people do this out of curiosity when they see a `T.unsafe` in the file they
have open.

This functionality is all behind an option that must be manually passed on the
command line. We might want to eventually write a Sorbet doc page like "tips
for doing codemods" that suggests how to use this option. I **do not** think
the default should be to show these `T.unsafe` autocorrects during normal
Sorbet usage, because I don't want to encourage people to sprinkle `T.unsafe`
to fix all their Sorbet problems.

I expect this to be the first of many such PRs. I have purposely kept this PR
small and only added two new autocorrects. Partly, this was because it was easy
to cargo cult the existing `T.must` autocorrects. But in general, I think that
there are **many** errors in Sorbet that can be fixed with a particular usage
of `T.unsafe`, and over time we should introduce these into as many places as
possible (where it's not possible to add another, better autocorrect).

### Commit summary

I did some minor test cleanups while I was looking at this code.

- **Add --suggest-unsafe option, thread into GlobalState** (bd131b0f0)


- **Hijack some T.must autocorrects** (230617894)


- **Reword the helpers test because I keep copying it** (9660c5294)


- **Make the T.must cli test better** (e85a602cf)


- **Add new test** (03d99d3c0)




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I have included a CLI test showing two examples.