### PR TITLE
Add sha256 to get rid of bazel warning

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -291,6 +291,7 @@ package(default_visibility = ["//visibility:public"])
         name = "rubyfmt",
         build_file = "@com_stripe_ruby_typer//third_party/rubyfmt:rubyfmt.BUILD",
         urls = _github_public_urls("penelopezone/rubyfmt/releases/download/v0.5.0/rubyfmt-v0.5.0-sources.tar.gz"),
+        sha256 = "b2ac743da7c0a0d8dca9d452576d9731356be264fb308ee614bf5eff90a802dd",
     )
 
     http_archive(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

<https://buildkite.com/sorbet/sorbet/builds/14441#9256c3a9-f1ca-45b9-9331-29648cb82fbb/133-151>


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Check logs in CI