### PR TITLE
Remove references to Opus in favor of configuration callbacks

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -412,6 +412,19 @@ module T::Configuration
     @module_name_mangler = handler
   end
 
+  # Set to a PII handler function. This will be called with the `sensitivity:`
+  # annotations on things that use `T::Props` and can modify them ahead-of-time.
+  #
+  # @param [Lambda, Proc, nil] value Proc that takes a hash mapping symbols to the
+  # prop values. Pass nil to avoid changing `sensitivity:` annotations.
+  def self.normalize_sensitivity_and_pii_handler=(handler)
+    @sensitivity_and_pii_handler = handler
+  end
+
+  def self.normalize_sensitivity_and_pii_handler
+    @sensitivity_and_pii_handler
+  end
+
   # Temporarily disable ruby warnings while executing the given block. This is
   # useful when doing something that would normally cause a warning to be
   # emitted in Ruby verbose mode ($VERBOSE = true).

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -425,6 +425,19 @@ module T::Configuration
     @sensitivity_and_pii_handler
   end
 
+  # Set to a function which can get the 'owner' of a class. This is
+  # used in reporting deserialization errors
+  #
+  # @param [Lambda, Proc, nil] value Proc that takes a class and
+  # produces its owner, or `nil` if it does not have one.
+  def self.class_owner_finder=(handler)
+    @class_owner_finder = handler
+  end
+
+  def self.class_owner_finder
+    @class_owner_finder
+  end
+
   # Temporarily disable ruby warnings while executing the given block. This is
   # useful when doing something that would normally cause a warning to be
   # emitted in Ruby verbose mode ($VERBOSE = true).

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -306,8 +306,9 @@ class T::Props::Decorator
     type = T::Utils::Nilable.get_underlying_type(type)
 
     sensitivity_and_pii = {sensitivity: rules[:sensitivity]}
-    if defined?(Opus) && defined?(Opus::Sensitivity) && defined?(Opus::Sensitivity::Utils)
-      sensitivity_and_pii = Opus::Sensitivity::Utils.normalize_sensitivity_and_pii_annotation(sensitivity_and_pii)
+    normalize = T::Configuration.normalize_sensitivity_and_pii_handler
+    if normalize
+      sensitivity_and_pii = normalize.call(sensitivity_and_pii)
 
       # We check for Class so this is only applied on concrete
       # documents/models; We allow mixins containing props to not

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -246,11 +246,11 @@ module T::Props::Serializable::DecoratorMethods
 
     # Notify the model owner if it exists, and always notify the API owner.
     begin
-      if defined?(Opus) && defined?(Opus::Ownership) && decorated_class < Opus::Ownership
+      if T::Configuration.class_owner_finder && (owner = T::Configuration.class_owner_finder.call(decorated_class))
         T::Configuration.hard_assert_handler(
           msg,
           storytime: storytime,
-          project: decorated_class.get_owner
+          project: owner
         )
       end
     ensure

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -388,13 +388,20 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
   it 'applies the supplied sensitivity and PII handler' do
     begin
       T::Configuration.normalize_sensitivity_and_pii_handler = ->(meta) do
+        meta[:pii] = :set
         meta[:sensitivity] += 1
         meta
       end
       e = Class.new(T::Struct) do
+        # needs this annotation for the `:pii` field
+        def self.contains_pii?
+          true
+        end
+
         prop :foo, Integer, sensitivity: 5
       end
-      assert_equal(e.props[:foo][:sensitivity], 6)
+      assert_equal(6, e.props[:foo][:sensitivity])
+      assert_equal(:set, e.props[:foo][:pii])
     ensure
       T::Configuration.normalize_sensitivity_and_pii_handler = nil
     end

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -362,4 +362,19 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
     end
     assert_match(/has the word 'secret' in its name/, e.message)
   end
+
+  it 'applies the supplied sensitivity and PII handler' do
+    begin
+      T::Configuration.normalize_sensitivity_and_pii_handler = ->(meta) do
+        meta[:sensitivity] += 1
+        meta
+      end
+      e = Class.new(T::Struct) do
+        prop :foo, Integer, sensitivity: 5
+      end
+      assert_equal(e.props[:foo][:sensitivity], 6)
+    ensure
+      T::Configuration.normalize_sensitivity_and_pii_handler = nil
+    end
+  end
 end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -143,6 +143,10 @@ module T::Configuration
   def self.sig_validation_error_handler=(value); end
   def self.soft_assert_handler(str, extra); end
   def self.soft_assert_handler=(value); end
+  def self.normalize_sensitivity_and_pii_handler=(handler); end
+  def self.normalize_sensitivity_and_pii_handler; end
+  def self.class_owner_finder=(handler); end
+  def self.class_owner_finder; end
 end
 
 module T::Profile


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
We use `defined?(Opus)` in a few places in sorbet-runtime, which (especially with forthcoming package work) is brittle and also just bad style. Replace these with callbacks provided in `T::Configuration` so that we won't have `Opus` names hard-coded in the runtime any more.

Note that we're going to have to define these callbacks when we roll this out, but it should be pretty simple to do so.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added tests for each of the added configuration options.
