### PR TITLE
Fix crash in pinning autocorrect

### DIFF
--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -267,6 +267,7 @@ string Loc::filePosToString(const GlobalState &gs, bool showFull) const {
 }
 
 string Loc::source(const GlobalState &gs) const {
+    ENFORCE(exists(), "Can't take source of Loc that doesn't exist");
     auto source = this->file().data(gs).source();
     return string(source.substr(beginPos(), endPos() - beginPos()));
 }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1388,7 +1388,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                 e.addErrorSection(core::ErrorSection(core::ErrorColors::format(
                                     "Attempting to change type to: `{}`\n", tp.type.show(ctx))));
 
-                                if (cur.origins.size() == 1) {
+                                if (cur.origins.size() == 1 && cur.origins[0].exists()) {
                                     // NOTE(nelhage): We assume that if there is
                                     // a single definition location, that
                                     // corresponds to an initial

--- a/test/testdata/infer/suggest_t_let_self.rb
+++ b/test/testdata/infer/suggest_t_let_self.rb
@@ -3,5 +3,5 @@
 x = self
 
 1.times do
-  x = 10
+  x = 10 # error: Changing the type of a variable in a loop is not permitted
 end

--- a/test/testdata/infer/suggest_t_let_self.rb
+++ b/test/testdata/infer/suggest_t_let_self.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+x = self
+
+1.times do
+  x = 10
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fix the error reported in #3922, which was caused by the changes in #3876.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


In defense of #3876, the old behavior was this:

<img width="644" alt="Screen Shot 2021-01-23 at 1 16 31 PM" src="https://user-images.githubusercontent.com/5544532/105614268-37006500-5d7d-11eb-8a41-1699bacf129a.png">

because we were using the Loc of the whole method definition as the origin of `self`.

I'd argue that it's better to say "I don't have a Loc" than it is to say "the Loc is the entire method body" because then we can at least detect when we shouldn't be suggesting an autocorrect, rather than suggesting a terrible autocorrect.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

