### PR TITLE
LocOffsets: Make sure begin/end are initialized

### DIFF
--- a/core/Loc.h
+++ b/core/Loc.h
@@ -13,8 +13,8 @@ class MutableContext;
 
 constexpr int INVALID_POS_LOC = 0xffffff;
 struct LocOffsets {
-    u4 beginLoc;
-    u4 endLoc;
+    u4 beginLoc = INVALID_POS_LOC;
+    u4 endLoc = INVALID_POS_LOC;
     u4 beginPos() const {
         return beginLoc;
     };


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I was running into some wonky behavior in development where
`locOffsets.exists()` was true when it shouldn't have, because someone
zero-initialized a `LocOffsets` and it ended up with some garbage data.

This change should make it so that in this case:

```cpp
LocOffsets loc;
```

this condition will hold: `loc.exists() == false`


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.

I managed to reproduce this by putting `loc.showRaw()` in a couple completely
random places while working.