### PR TITLE
Only report dead code errors once

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -125,8 +125,8 @@ bool KnowledgeFilter::isNeeded(cfg::LocalRef var) {
     return used_vars[var.id()];
 }
 
-KnowledgeRef KnowledgeRef::under(core::Context ctx, const Environment &env, core::Loc loc, cfg::CFG &inWhat,
-                                 cfg::BasicBlock *bb, bool isNeeded) const {
+KnowledgeRef KnowledgeRef::under(core::Context ctx, const Environment &env, cfg::CFG &inWhat, cfg::BasicBlock *bb,
+                                 bool isNeeded) const {
     if (knowledge->yesTypeTests.empty() && !isNeeded) {
         return *this;
     }
@@ -760,8 +760,8 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef 
     }
 }
 
-void Environment::mergeWith(core::Context ctx, const Environment &other, core::Loc loc, cfg::CFG &inWhat,
-                            cfg::BasicBlock *bb, KnowledgeFilter &knowledgeFilter) {
+void Environment::mergeWith(core::Context ctx, const Environment &other, cfg::CFG &inWhat, cfg::BasicBlock *bb,
+                            KnowledgeFilter &knowledgeFilter) {
     this->isDead |= other.isDead;
     for (auto &pair : _vars) {
         auto var = pair.first;
@@ -789,9 +789,8 @@ void Environment::mergeWith(core::Context ctx, const Environment &other, core::L
 
         if (canBeTruthy) {
             auto &thisKnowledge = getKnowledge(var);
-            auto otherTruthy = other.getKnowledge(var, false)
-                                   .truthy()
-                                   .under(ctx, other, loc, inWhat, bb, knowledgeFilter.isNeeded(var));
+            auto otherTruthy =
+                other.getKnowledge(var, false).truthy().under(ctx, other, inWhat, bb, knowledgeFilter.isNeeded(var));
             if (!otherTruthy->isDead) {
                 if (!thisKnowledge.seenTruthyOption) {
                     thisKnowledge.seenTruthyOption = true;
@@ -804,9 +803,8 @@ void Environment::mergeWith(core::Context ctx, const Environment &other, core::L
 
         if (canBeFalsy) {
             auto &thisKnowledge = getKnowledge(var);
-            auto otherFalsy = other.getKnowledge(var, false)
-                                  .falsy()
-                                  .under(ctx, other, loc, inWhat, bb, knowledgeFilter.isNeeded(var));
+            auto otherFalsy =
+                other.getKnowledge(var, false).falsy().under(ctx, other, inWhat, bb, knowledgeFilter.isNeeded(var));
             if (!otherFalsy->isDead) {
                 if (!thisKnowledge.seenFalsyOption) {
                     thisKnowledge.seenFalsyOption = true;

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -79,7 +79,7 @@ public:
     /**
      * Computes all possible implications of this knowledge holding as an exit from environment env in block bb
      */
-    KnowledgeRef under(core::Context ctx, const Environment &env, core::Loc loc, cfg::CFG &inWhat, cfg::BasicBlock *bb,
+    KnowledgeRef under(core::Context ctx, const Environment &env, cfg::CFG &inWhat, cfg::BasicBlock *bb,
                        bool isNeeded) const;
 
     void removeReferencesToVar(cfg::LocalRef ref);
@@ -228,7 +228,7 @@ public:
     static const Environment &withCond(core::Context ctx, const Environment &env, Environment &copy, bool isTrue,
                                        const UnorderedMap<cfg::LocalRef, VariableState> &filter);
 
-    void mergeWith(core::Context ctx, const Environment &other, core::Loc loc, cfg::CFG &inWhat, cfg::BasicBlock *bb,
+    void mergeWith(core::Context ctx, const Environment &other, cfg::CFG &inWhat, cfg::BasicBlock *bb,
                    KnowledgeFilter &knowledgeFilter);
 
     void computePins(core::Context ctx, const std::vector<Environment> &envs, const cfg::CFG &inWhat,

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -111,8 +111,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                     Environment::withCond(ctx, outEnvironments[parent->id], tempEnv, isTrueBranch, current.vars());
                 if (!envAsSeenFromBranch.isDead) {
                     current.isDead = false;
-                    current.mergeWith(ctx, envAsSeenFromBranch, core::Loc(ctx.file, parent->bexit.loc), *cfg.get(), bb,
-                                      knowledgeFilter);
+                    current.mergeWith(ctx, envAsSeenFromBranch, *cfg.get(), bb, knowledgeFilter);
                 }
             }
         }

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -130,36 +130,40 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
             if (!bb->exprs.empty()) {
                 // This is a bit complicated:
                 //
-                //   1. If the block consists only of synthetic bindings or T.absurd, we don't
+                //   1. If this block is only dead because all jumps into this block are dead,
+                //      we already reported an error and don't want a duplicate.
+                //   2. If the block consists only of synthetic bindings or T.absurd, we don't
                 //      want to issue an error.
-                //   2. If the block contains a send of the form <Magic>.<nil-for-safe-navigation>(x),
+                //   3. If the block contains a send of the form <Magic>.<nil-for-safe-navigation>(x),
                 //      we want to issue an UnnecessarySafeNavigationError, extracting
                 //      type-and-origin info from x. (This magic form is inserted by the desugarer
                 //      for a "safe navigation" operation, e.g., `x&.foo`.)
-                //   3. Otherwise, we want to issue a DeadBranchInferencer error, taking the first
+                //   4. Otherwise, we want to issue a DeadBranchInferencer error, taking the first
                 //      (non-synthetic, non-"T.absurd") instruction in the block as the loc of the
                 //      error.
                 cfg::Instruction *unreachableInstruction = nullptr;
                 core::LocOffsets locForUnreachable;
                 bool dueToSafeNavigation = false;
 
-                for (auto &expr : bb->exprs) {
-                    if (expr.value->isSynthetic) {
-                        continue;
-                    }
-                    if (cfg::isa_instruction<cfg::TAbsurd>(expr.value.get())) {
-                        continue;
-                    }
+                if (absl::c_any_of(bb->backEdges, [&](const auto &bb) { return !outEnvironments[bb->id].isDead; })) {
+                    for (auto &expr : bb->exprs) {
+                        if (expr.value->isSynthetic) {
+                            continue;
+                        }
+                        if (cfg::isa_instruction<cfg::TAbsurd>(expr.value.get())) {
+                            continue;
+                        }
 
-                    auto send = cfg::cast_instruction<cfg::Send>(expr.value.get());
-                    if (send != nullptr && send->fun == core::Names::nilForSafeNavigation()) {
-                        unreachableInstruction = expr.value.get();
-                        locForUnreachable = expr.loc;
-                        dueToSafeNavigation = true;
-                        break;
-                    } else if (unreachableInstruction == nullptr) {
-                        unreachableInstruction = expr.value.get();
-                        locForUnreachable = expr.loc;
+                        auto send = cfg::cast_instruction<cfg::Send>(expr.value.get());
+                        if (send != nullptr && send->fun == core::Names::nilForSafeNavigation()) {
+                            unreachableInstruction = expr.value.get();
+                            locForUnreachable = expr.loc;
+                            dueToSafeNavigation = true;
+                            break;
+                        } else if (unreachableInstruction == nullptr) {
+                            unreachableInstruction = expr.value.get();
+                            locForUnreachable = expr.loc;
+                        }
                     }
                 }
 

--- a/test/testdata/cfg/override_bang.rb
+++ b/test/testdata/cfg/override_bang.rb
@@ -9,36 +9,49 @@ class C
   end
 end
 
+def test1
 if C.new
   puts
 else
   puts # error: This code is unreachable
 end
+end
 
+def test2
 if !C.new
   puts
 else
   puts # error: This code is unreachable
 end
+end
 
+def test3
 unless C.new
   puts # error: This code is unreachable
 else
   puts
 end
+end
 
+def test4
 unless !C.new
   puts # error: This code is unreachable
 else
   puts
 end
+end
 
+def test5
 until C.new
   puts # TODO this puts should be unreachable
 end
+puts # error: This code is unreachable
+end
 
+def test6
 until !C.new
-  #    ^ error: This code is unreachable
   # TODO this C.new should be reachable
   puts # error: This code is unreachable
+end
+puts
 end

--- a/test/testdata/cfg/override_bang.rb
+++ b/test/testdata/cfg/override_bang.rb
@@ -10,48 +10,48 @@ class C
 end
 
 def test1
-if C.new
-  puts
-else
-  puts # error: This code is unreachable
-end
+  if C.new
+    puts
+  else
+    puts # error: This code is unreachable
+  end
 end
 
 def test2
-if !C.new
-  puts
-else
-  puts # error: This code is unreachable
-end
+  if !C.new
+    puts
+  else
+    puts # error: This code is unreachable
+  end
 end
 
 def test3
-unless C.new
-  puts # error: This code is unreachable
-else
-  puts
-end
+  unless C.new
+    puts # error: This code is unreachable
+  else
+    puts
+  end
 end
 
 def test4
-unless !C.new
-  puts # error: This code is unreachable
-else
-  puts
-end
+  unless !C.new
+    puts # error: This code is unreachable
+  else
+    puts
+  end
 end
 
 def test5
-until C.new
-  puts # TODO this puts should be unreachable
-end
-puts # error: This code is unreachable
+  until C.new
+    puts # TODO this puts should be unreachable
+  end
+  puts # error: This code is unreachable
 end
 
 def test6
-until !C.new
-  # TODO this C.new should be reachable
-  puts # error: This code is unreachable
-end
-puts
+  until !C.new
+    # TODO this C.new should be reachable
+    puts # error: This code is unreachable
+  end
+  puts
 end

--- a/test/testdata/infer/case_exhaustive_union_type.rb
+++ b/test/testdata/infer/case_exhaustive_union_type.rb
@@ -62,7 +62,7 @@ def exhaustive_unreachable_when_after(x)
   when Integer
     x
   when Symbol # error: This code is unreachable
-    3 # error: This code is unreachable
+    3
   end
   T.reveal_type(ret) # error: Revealed type: `Integer`
   ret

--- a/test/testdata/infer/only_die_once.rb
+++ b/test/testdata/infer/only_die_once.rb
@@ -9,10 +9,10 @@ def test1
 
   if T.unsafe(nil)
   #  ^ error: This code is unreachable
-    do_something # error: This code is unreachable
+    do_something
   end
 
-  do_something # error: This code is unreachable
+  do_something
 end
 
 sig {params(x: T.any(Integer, String)).void}
@@ -39,8 +39,8 @@ def test3(x)
 
     if T.unsafe(nil)
     #  ^ error: This code is unreachable
-      do_something # error: This code is unreachable
+      do_something
     end
-    do_something # error: This code is unreachable
+    do_something
   end
 end

--- a/test/testdata/infer/only_die_once.rb
+++ b/test/testdata/infer/only_die_once.rb
@@ -1,0 +1,46 @@
+# typed: true
+extend T::Sig
+
+def do_something
+end
+
+def test1
+  raise
+
+  if T.unsafe(nil)
+  #  ^ error: This code is unreachable
+    do_something # error: This code is unreachable
+  end
+
+  do_something # error: This code is unreachable
+end
+
+sig {params(x: T.any(Integer, String)).void}
+def test2(x)
+  case x
+  when Integer then puts 'int'
+  when String then puts 'str'
+  else
+    T.absurd(x)
+    do_something
+  # ^^^^^^^^^^^^ error: This code is unreachable
+  end
+
+  do_something
+end
+
+sig {params(x: T.any(Integer, String)).void}
+def test3(x)
+  case x
+  when Integer then puts 'int'
+  when String then puts 'str'
+  else
+    T.absurd(x)
+
+    if T.unsafe(nil)
+    #  ^ error: This code is unreachable
+      do_something # error: This code is unreachable
+    end
+    do_something # error: This code is unreachable
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I want to introduce some autocorrects for dead code errors.

The current behavior is that if some piece of code causes one or more
blocks in a chain to become dead, we report a dead code error on the first
instruction inside every block.

That means we make multiple autocorrects to fix the deadcode error, when just
one is preferrable (the original point where something became dead).

With this change, if all the `backEdges` for the current block have already
been marked dead, we don't report an error for this block, because we
assume it means that a dead code error has already been reported.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See the commit history for a before-and-after of a new test I added.


### Commit summary

This change looks infinitely better ignoring whitespace and reviewing by
commit.

Some of the changes are entirely pre-work with no behavioral change, and I've
staged them first.


- **no-op prework: Remove unused Loc parameter** (66717594e)


- **no-op prework: Prevent crosstalk in override_bang** (3fe21b22d)

  The last test was behaving kind of weirdly because Sorbet could tell
  that `until C.new` is a forever loop, which leaked into the behavior
  that the next `until` loop was trying to test.

  By wrapping them all in their own methods, we can more easily see what's
  really being tested here.

- **no-op prework: Reindent to tidy up previous change** (bb5f6a915)


- **Add test failing die_only_once test** (9b90ff3c6)


- **Only report dead code errors once** (4c40ed240)

  Change looks infinitely better ignoring whitespace changes.

  The current behavior is that if some piece of code causes one or more
  blocks in a chain to become dead, we report a dead code error on the
  first instruction inside every block.

  With this change, if all the `backEdges` for the current block have
  already been marked dead, we don't report an error for this block,
  because we assume it means that a dead code error has already been
  reported.

- **Remove duplicate error from test suite** (8dc05aed1)

  This was the only place in the codebase where we were reporting two dead
  code errors and now only print one.
