### PR TITLE
Vastly improve dead code error message

### DIFF
--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -58,6 +58,7 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                     bb->bexit.cond.variable = thenb->bexit.cond.variable;
                     bb->bexit.thenb = thenb->bexit.thenb;
                     bb->bexit.elseb = thenb->bexit.elseb;
+                    bb->bexit.loc = thenb->bexit.loc;
                     bb->bexit.thenb->backEdges.emplace_back(bb);
                     if (bb->bexit.thenb != bb->bexit.elseb) {
                         bb->bexit.elseb->backEdges.emplace_back(bb);
@@ -70,6 +71,7 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                     bb->bexit.cond.variable = thenb->bexit.cond.variable;
                     bb->bexit.thenb = thenb->bexit.thenb;
                     bb->bexit.elseb = thenb->bexit.elseb;
+                    bb->bexit.loc = thenb->bexit.loc;
                     thenb->backEdges.erase(remove(thenb->backEdges.begin(), thenb->backEdges.end(), bb),
                                            thenb->backEdges.end());
                     bb->bexit.thenb->backEdges.emplace_back(bb);

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -171,10 +171,6 @@ class Environment {
 
     bool getKnownTruthy(cfg::LocalRef var) const;
 
-    // NB: you can't call this function on vars in the first basic block since
-    // their type will be nullptr
-    const core::TypeAndOrigins &getTypeAndOrigin(core::Context ctx, cfg::LocalRef symbol) const;
-
     /* propagate knowledge on `to = from` */
     void propagateKnowledge(core::Context ctx, cfg::LocalRef to, cfg::LocalRef from, KnowledgeFilter &knowledgeFilter);
 
@@ -213,6 +209,10 @@ public:
     void setUninitializedVarsToNil(const core::Context &ctx, core::Loc origin);
 
     std::string toString(const core::GlobalState &gs, const cfg::CFG &cfg) const;
+
+    // NB: you can't call this function on vars in the first basic block since
+    // their type will be nullptr
+    const core::TypeAndOrigins &getTypeAndOrigin(core::Context ctx, cfg::LocalRef symbol) const;
 
     const core::TypeAndOrigins &getAndFillTypeAndOrigin(core::Context ctx, cfg::VariableUseSite &symbol) const;
 

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -184,6 +184,12 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
 
                         for (const auto &prevBasicBlock : bb->backEdges) {
                             const auto &prevEnv = outEnvironments[prevBasicBlock->id];
+                            if (prevEnv.isDead) {
+                                // This prevous block doesn't actually matter, because it was dead
+                                // (never got to evaluating its jump condition), so don't clutter
+                                // the error message.
+                                continue;
+                            }
 
                             const auto &cond = prevBasicBlock->bexit.cond;
                             if (cond.type == nullptr) {

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -183,6 +183,8 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                         e.setHeader("This code is unreachable");
 
                         for (const auto &prevBasicBlock : bb->backEdges) {
+                            const auto &prevEnv = outEnvironments[prevBasicBlock->id];
+
                             const auto &cond = prevBasicBlock->bexit.cond;
                             if (cond.type == nullptr) {
                                 // This previous block is actually a future block we haven't processed yet.
@@ -196,6 +198,9 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                             auto bexitLoc = core::Loc(ctx.file, prevBasicBlock->bexit.loc);
                             e.addErrorLine(bexitLoc, "This condition was always `{}` (`{}`)", alwaysWhat,
                                            cond.type.show(ctx));
+
+                            auto ty = prevEnv.getTypeAndOrigin(ctx, cond.variable);
+                            e.addErrorSection(ty.explainGot(ctx, prevEnv.locForUninitialized()));
                         }
                     }
                 }

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -199,6 +199,11 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                             e.addErrorLine(bexitLoc, "This condition was always `{}` (`{}`)", alwaysWhat,
                                            cond.type.show(ctx));
 
+                            if (ctx.state.suggestUnsafe.has_value() && bexitLoc.exists()) {
+                                e.replaceWith(fmt::format("Wrap in `{}`", *ctx.state.suggestUnsafe), bexitLoc, "{}({})",
+                                              *ctx.state.suggestUnsafe, bexitLoc.source(ctx));
+                            }
+
                             auto ty = prevEnv.getTypeAndOrigin(ctx, cond.variable);
                             e.addErrorSection(ty.explainGot(ctx, prevEnv.locForUninitialized()));
                         }

--- a/test/cli/suggest-sig/suggest-sig.out
+++ b/test/cli/suggest-sig/suggest-sig.out
@@ -160,14 +160,44 @@ suggest-sig.rb:79: This function does not have a `sig` https://srb.help/7017
 suggest-sig.rb:85: This code is unreachable https://srb.help/7006
     85 |  if true || qux || blah
                      ^^^
+    suggest-sig.rb:85: This condition was always `truthy` (`TrueClass`)
+    85 |  if true || qux || blah
+             ^^^^^^^^^^^
+  Got `TrueClass` originating from:
+    suggest-sig.rb:85:
+    85 |  if true || qux || blah
+             ^^^^
 
 suggest-sig.rb:85: This code is unreachable https://srb.help/7006
     85 |  if true || qux || blah
                             ^^^^
+    suggest-sig.rb:85: This condition was always `truthy` (`TrueClass`)
+    85 |  if true || qux || blah
+             ^^^^^^^^^^^^^^^^^^^
+  Got `TrueClass` originating from:
+    suggest-sig.rb:85:
+    85 |  if true || qux || blah
+             ^^^^
+    suggest-sig.rb:85:
+    85 |  if true || qux || blah
+             ^^^^^^^^^^^
 
 suggest-sig.rb:88: This code is unreachable https://srb.help/7006
     88 |    takesString(x)
             ^^^^^^^^^^^^^^
+    suggest-sig.rb:85: This condition was always `truthy` (`TrueClass`)
+    85 |  if true || qux || blah
+             ^^^^^^^^^^^^^^^^^^^
+  Got `TrueClass` originating from:
+    suggest-sig.rb:85:
+    85 |  if true || qux || blah
+             ^^^^
+    suggest-sig.rb:85:
+    85 |  if true || qux || blah
+             ^^^^^^^^^^^
+    suggest-sig.rb:85:
+    85 |  if true || qux || blah
+             ^^^^^^^^^^^^^^^^^^^
 
 suggest-sig.rb:84: This function does not have a `sig` https://srb.help/7017
     84 |def dead(x)

--- a/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.out
+++ b/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.out
@@ -1,47 +1,80 @@
 suggest_unsafe_dead.rb:24: This code is unreachable https://srb.help/7006
     24 |  x || do_something
                ^^^^^^^^^^^^
+    suggest_unsafe_dead.rb:24: This condition was always `truthy` (`Integer`)
+    24 |  x || do_something
+          ^
 
 suggest_unsafe_dead.rb:29: This code is unreachable https://srb.help/7006
     29 |  x && do_something
                ^^^^^^^^^^^^
+    suggest_unsafe_dead.rb:29: This condition was always `falsy` (`NilClass`)
+    29 |  x && do_something
+          ^
 
 suggest_unsafe_dead.rb:35: This code is unreachable https://srb.help/7006
     35 |  returns_integer || do_something
                              ^^^^^^^^^^^^
+    suggest_unsafe_dead.rb:35: This condition was always `truthy` (`Integer`)
+    35 |  returns_integer || do_something
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 suggest_unsafe_dead.rb:47: This code is unreachable https://srb.help/7006
     47 |    do_something
             ^^^^^^^^^^^^
+    suggest_unsafe_dead.rb:45: This condition was always `truthy` (`TrueClass`)
+    45 |  when String then puts 'str'
+               ^^^^^^
 
 suggest_unsafe_dead.rb:56: This code is unreachable https://srb.help/7006
     56 |    do_something
             ^^^^^^^^^^^^
+    suggest_unsafe_dead.rb:53: This condition was always `truthy` (`Integer`)
+    53 |  if returns_integer
+             ^^^^^^^^^^^^^^^
 
 suggest_unsafe_dead.rb:70: This code is unreachable https://srb.help/7006
     70 |    do_something
             ^^^^^^^^^^^^
+    suggest_unsafe_dead.rb:69: This condition was always `falsy` (`NilClass`)
+    69 |  elsif x
+                ^
 
 suggest_unsafe_dead.rb:98: This code is unreachable https://srb.help/7006
       98 |    begin
       99 |      puts 3
      100 |    end while T.unsafe(nil)
+    suggest_unsafe_dead.rb:96: This condition was always `falsy` (`FalseClass`)
+    96 |  if false
+             ^^^^^
 
 suggest_unsafe_dead.rb:15: This code is unreachable https://srb.help/7006
     15 |  puts x
           ^^^^^^
+    suggest_unsafe_dead.rb:14: This condition was always `truthy` (`Integer`)
+    14 |unless x
+               ^
 
 suggest_unsafe_dead.rb:19: This code is unreachable https://srb.help/7006
     19 |  puts y
           ^^^^^^
+    suggest_unsafe_dead.rb:18: This condition was always `falsy` (`NilClass`)
+    18 |if y
+           ^
 
 suggest_unsafe_dead.rb:81: This code is unreachable https://srb.help/7006
     81 |      do_something
               ^^^^^^^^^^^^
+    suggest_unsafe_dead.rb:80: This condition was always `truthy` (`A`)
+    80 |    unless self
+                   ^^^^
 
 suggest_unsafe_dead.rb:89: This code is unreachable https://srb.help/7006
     89 |      do_something
               ^^^^^^^^^^^^
+    suggest_unsafe_dead.rb:88: This condition was always `truthy` (`A`)
+    88 |    unless this
+                   ^^^^
 Errors: 11
 
 --------------------------------------------------------------------------

--- a/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.out
+++ b/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.out
@@ -1,0 +1,152 @@
+suggest_unsafe_dead.rb:24: This code is unreachable https://srb.help/7006
+    24 |  x || do_something
+               ^^^^^^^^^^^^
+
+suggest_unsafe_dead.rb:29: This code is unreachable https://srb.help/7006
+    29 |  x && do_something
+               ^^^^^^^^^^^^
+
+suggest_unsafe_dead.rb:35: This code is unreachable https://srb.help/7006
+    35 |  returns_integer || do_something
+                             ^^^^^^^^^^^^
+
+suggest_unsafe_dead.rb:47: This code is unreachable https://srb.help/7006
+    47 |    do_something
+            ^^^^^^^^^^^^
+
+suggest_unsafe_dead.rb:56: This code is unreachable https://srb.help/7006
+    56 |    do_something
+            ^^^^^^^^^^^^
+
+suggest_unsafe_dead.rb:70: This code is unreachable https://srb.help/7006
+    70 |    do_something
+            ^^^^^^^^^^^^
+
+suggest_unsafe_dead.rb:98: This code is unreachable https://srb.help/7006
+      98 |    begin
+      99 |      puts 3
+     100 |    end while T.unsafe(nil)
+
+suggest_unsafe_dead.rb:15: This code is unreachable https://srb.help/7006
+    15 |  puts x
+          ^^^^^^
+
+suggest_unsafe_dead.rb:19: This code is unreachable https://srb.help/7006
+    19 |  puts y
+          ^^^^^^
+
+suggest_unsafe_dead.rb:81: This code is unreachable https://srb.help/7006
+    81 |      do_something
+              ^^^^^^^^^^^^
+
+suggest_unsafe_dead.rb:89: This code is unreachable https://srb.help/7006
+    89 |      do_something
+              ^^^^^^^^^^^^
+Errors: 11
+
+--------------------------------------------------------------------------
+
+# typed: true
+extend T::Sig
+
+def do_something; end
+
+sig {returns(Integer)}
+def returns_integer
+  0
+end
+
+x = T.let(0, Integer)
+y = T.let(nil, NilClass)
+
+unless x
+  puts x
+end
+
+if y
+  puts y
+end
+
+sig {params(x: Integer).void}
+def test1_variable_or(x)
+  x || do_something
+end
+
+sig {params(x: NilClass).void}
+def test2_variable_and(x)
+  x && do_something
+end
+
+sig {void}
+def test3_method_or_method
+  # For some reason, this behaves different from when the LHS of `||` is a variable.
+  returns_integer || do_something
+end
+
+sig {params(x: T.any(Integer, String)).void}
+def test4_exhaustive_case(x)
+  # This test case points the blame back to the `when String` comparison, which
+  # is not "wrong" per se. Maybe the user was expecting to see the error blame
+  # to `case x`, or perhaps say something like "the case was exhaustive"
+  case x
+  when Integer then puts 'int'
+  when String then puts 'str'
+  else
+    do_something
+  end
+end
+
+sig {void}
+def test5_if_else
+  if returns_integer
+    do_something
+  else
+    do_something
+  end
+end
+
+
+sig {void}
+def test6_possibly_uninitialized
+  if T.unsafe(nil)
+    x = 1
+  end
+
+  if x
+    do_something
+  elsif x
+    do_something
+  end
+end
+
+# Can't write this test at the top level because at top level `self` is
+# `Object` which is possibly nil and thus possibly falsy 🙃
+class A
+  extend T::Sig
+  sig {void}
+  def test7_self
+    unless self
+      do_something
+    end
+  end
+
+  sig {void}
+  def test8_self_this
+    this = self
+    unless this
+      do_something
+    end
+  end
+end
+
+sig {void}
+def test8_cyclic_cfg
+  if false
+    # This begin/while is the way Ruby encodes do/while.
+    begin
+      puts 3
+    end while T.unsafe(nil)
+  end
+
+  puts 5
+end

--- a/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.out
+++ b/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.out
@@ -4,6 +4,10 @@ suggest_unsafe_dead.rb:24: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:24: This condition was always `truthy` (`Integer`)
     24 |  x || do_something
           ^
+  Autocorrect: Done
+    suggest_unsafe_dead.rb:24: Replaced with `T.unsafe(x)`
+    24 |  x || do_something
+          ^
   Got `Integer` originating from:
     suggest_unsafe_dead.rb:23:
     23 |def test1_variable_or(x)
@@ -13,6 +17,10 @@ suggest_unsafe_dead.rb:29: This code is unreachable https://srb.help/7006
     29 |  x && do_something
                ^^^^^^^^^^^^
     suggest_unsafe_dead.rb:29: This condition was always `falsy` (`NilClass`)
+    29 |  x && do_something
+          ^
+  Autocorrect: Done
+    suggest_unsafe_dead.rb:29: Replaced with `T.unsafe(x)`
     29 |  x && do_something
           ^
   Got `NilClass` originating from:
@@ -26,6 +34,10 @@ suggest_unsafe_dead.rb:35: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:35: This condition was always `truthy` (`Integer`)
     35 |  returns_integer || do_something
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest_unsafe_dead.rb:35: Replaced with `T.unsafe(returns_integer || do_something)`
+    35 |  returns_integer || do_something
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got `Integer` originating from:
     suggest_unsafe_dead.rb:35:
     35 |  returns_integer || do_something
@@ -35,6 +47,10 @@ suggest_unsafe_dead.rb:47: This code is unreachable https://srb.help/7006
     47 |    do_something
             ^^^^^^^^^^^^
     suggest_unsafe_dead.rb:45: This condition was always `truthy` (`TrueClass`)
+    45 |  when String then puts 'str'
+               ^^^^^^
+  Autocorrect: Done
+    suggest_unsafe_dead.rb:45: Replaced with `T.unsafe(String)`
     45 |  when String then puts 'str'
                ^^^^^^
   Got `TrueClass` originating from:
@@ -48,6 +64,10 @@ suggest_unsafe_dead.rb:56: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:53: This condition was always `truthy` (`Integer`)
     53 |  if returns_integer
              ^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest_unsafe_dead.rb:53: Replaced with `T.unsafe(returns_integer)`
+    53 |  if returns_integer
+             ^^^^^^^^^^^^^^^
   Got `Integer` originating from:
     suggest_unsafe_dead.rb:53:
     53 |  if returns_integer
@@ -57,6 +77,10 @@ suggest_unsafe_dead.rb:70: This code is unreachable https://srb.help/7006
     70 |    do_something
             ^^^^^^^^^^^^
     suggest_unsafe_dead.rb:69: This condition was always `falsy` (`NilClass`)
+    69 |  elsif x
+                ^
+  Autocorrect: Done
+    suggest_unsafe_dead.rb:69: Replaced with `T.unsafe(x)`
     69 |  elsif x
                 ^
   Got `NilClass` originating from:
@@ -74,6 +98,10 @@ suggest_unsafe_dead.rb:98: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:96: This condition was always `falsy` (`FalseClass`)
     96 |  if false
              ^^^^^
+  Autocorrect: Done
+    suggest_unsafe_dead.rb:96: Replaced with `T.unsafe(false)`
+    96 |  if false
+             ^^^^^
   Got `FalseClass` originating from:
     suggest_unsafe_dead.rb:96:
     96 |  if false
@@ -83,6 +111,10 @@ suggest_unsafe_dead.rb:15: This code is unreachable https://srb.help/7006
     15 |  puts x
           ^^^^^^
     suggest_unsafe_dead.rb:14: This condition was always `truthy` (`Integer`)
+    14 |unless x
+               ^
+  Autocorrect: Done
+    suggest_unsafe_dead.rb:14: Replaced with `T.unsafe(x)`
     14 |unless x
                ^
   Got `Integer` originating from:
@@ -96,6 +128,10 @@ suggest_unsafe_dead.rb:19: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:18: This condition was always `falsy` (`NilClass`)
     18 |if y
            ^
+  Autocorrect: Done
+    suggest_unsafe_dead.rb:18: Replaced with `T.unsafe(y)`
+    18 |if y
+           ^
   Got `NilClass` originating from:
     suggest_unsafe_dead.rb:12:
     12 |y = T.let(nil, NilClass)
@@ -107,12 +143,20 @@ suggest_unsafe_dead.rb:81: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:80: This condition was always `truthy` (`A`)
     80 |    unless self
                    ^^^^
+  Autocorrect: Done
+    suggest_unsafe_dead.rb:80: Replaced with `T.unsafe(self)`
+    80 |    unless self
+                   ^^^^
   Got `A` originating from:
 
 suggest_unsafe_dead.rb:89: This code is unreachable https://srb.help/7006
     89 |      do_something
               ^^^^^^^^^^^^
     suggest_unsafe_dead.rb:88: This condition was always `truthy` (`A`)
+    88 |    unless this
+                   ^^^^
+  Autocorrect: Done
+    suggest_unsafe_dead.rb:88: Replaced with `T.unsafe(this)`
     88 |    unless this
                    ^^^^
   Got `A` originating from:
@@ -133,28 +177,28 @@ end
 x = T.let(0, Integer)
 y = T.let(nil, NilClass)
 
-unless x
+unless T.unsafe(x)
   puts x
 end
 
-if y
+if T.unsafe(y)
   puts y
 end
 
 sig {params(x: Integer).void}
 def test1_variable_or(x)
-  x || do_something
+  T.unsafe(x) || do_something
 end
 
 sig {params(x: NilClass).void}
 def test2_variable_and(x)
-  x && do_something
+  T.unsafe(x) && do_something
 end
 
 sig {void}
 def test3_method_or_method
   # For some reason, this behaves different from when the LHS of `||` is a variable.
-  returns_integer || do_something
+  T.unsafe(returns_integer || do_something)
 end
 
 sig {params(x: T.any(Integer, String)).void}
@@ -164,7 +208,7 @@ def test4_exhaustive_case(x)
   # to `case x`, or perhaps say something like "the case was exhaustive"
   case x
   when Integer then puts 'int'
-  when String then puts 'str'
+  when T.unsafe(String) then puts 'str'
   else
     do_something
   end
@@ -172,7 +216,7 @@ end
 
 sig {void}
 def test5_if_else
-  if returns_integer
+  if T.unsafe(returns_integer)
     do_something
   else
     do_something
@@ -188,7 +232,7 @@ def test6_possibly_uninitialized
 
   if x
     do_something
-  elsif x
+  elsif T.unsafe(x)
     do_something
   end
 end
@@ -199,7 +243,7 @@ class A
   extend T::Sig
   sig {void}
   def test7_self
-    unless self
+    unless T.unsafe(self)
       do_something
     end
   end
@@ -207,7 +251,7 @@ class A
   sig {void}
   def test8_self_this
     this = self
-    unless this
+    unless T.unsafe(this)
       do_something
     end
   end
@@ -215,7 +259,7 @@ end
 
 sig {void}
 def test8_cyclic_cfg
-  if false
+  if T.unsafe(false)
     # This begin/while is the way Ruby encodes do/while.
     begin
       puts 3

--- a/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.out
+++ b/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.out
@@ -4,6 +4,10 @@ suggest_unsafe_dead.rb:24: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:24: This condition was always `truthy` (`Integer`)
     24 |  x || do_something
           ^
+  Got `Integer` originating from:
+    suggest_unsafe_dead.rb:23:
+    23 |def test1_variable_or(x)
+                              ^
 
 suggest_unsafe_dead.rb:29: This code is unreachable https://srb.help/7006
     29 |  x && do_something
@@ -11,6 +15,10 @@ suggest_unsafe_dead.rb:29: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:29: This condition was always `falsy` (`NilClass`)
     29 |  x && do_something
           ^
+  Got `NilClass` originating from:
+    suggest_unsafe_dead.rb:28:
+    28 |def test2_variable_and(x)
+                               ^
 
 suggest_unsafe_dead.rb:35: This code is unreachable https://srb.help/7006
     35 |  returns_integer || do_something
@@ -18,11 +26,19 @@ suggest_unsafe_dead.rb:35: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:35: This condition was always `truthy` (`Integer`)
     35 |  returns_integer || do_something
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `Integer` originating from:
+    suggest_unsafe_dead.rb:35:
+    35 |  returns_integer || do_something
+          ^^^^^^^^^^^^^^^
 
 suggest_unsafe_dead.rb:47: This code is unreachable https://srb.help/7006
     47 |    do_something
             ^^^^^^^^^^^^
     suggest_unsafe_dead.rb:45: This condition was always `truthy` (`TrueClass`)
+    45 |  when String then puts 'str'
+               ^^^^^^
+  Got `TrueClass` originating from:
+    suggest_unsafe_dead.rb:45:
     45 |  when String then puts 'str'
                ^^^^^^
 
@@ -32,6 +48,10 @@ suggest_unsafe_dead.rb:56: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:53: This condition was always `truthy` (`Integer`)
     53 |  if returns_integer
              ^^^^^^^^^^^^^^^
+  Got `Integer` originating from:
+    suggest_unsafe_dead.rb:53:
+    53 |  if returns_integer
+             ^^^^^^^^^^^^^^^
 
 suggest_unsafe_dead.rb:70: This code is unreachable https://srb.help/7006
     70 |    do_something
@@ -39,12 +59,23 @@ suggest_unsafe_dead.rb:70: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:69: This condition was always `falsy` (`NilClass`)
     69 |  elsif x
                 ^
+  Got `NilClass` originating from:
+    suggest_unsafe_dead.rb:67:
+    67 |  if x
+             ^
+    suggest_unsafe_dead.rb:62: Possibly uninitialized (`NilClass`) in:
+    62 |def test6_possibly_uninitialized
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 suggest_unsafe_dead.rb:98: This code is unreachable https://srb.help/7006
       98 |    begin
       99 |      puts 3
      100 |    end while T.unsafe(nil)
     suggest_unsafe_dead.rb:96: This condition was always `falsy` (`FalseClass`)
+    96 |  if false
+             ^^^^^
+  Got `FalseClass` originating from:
+    suggest_unsafe_dead.rb:96:
     96 |  if false
              ^^^^^
 
@@ -54,6 +85,10 @@ suggest_unsafe_dead.rb:15: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:14: This condition was always `truthy` (`Integer`)
     14 |unless x
                ^
+  Got `Integer` originating from:
+    suggest_unsafe_dead.rb:11:
+    11 |x = T.let(0, Integer)
+            ^^^^^^^^^^^^^^^^^
 
 suggest_unsafe_dead.rb:19: This code is unreachable https://srb.help/7006
     19 |  puts y
@@ -61,6 +96,10 @@ suggest_unsafe_dead.rb:19: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:18: This condition was always `falsy` (`NilClass`)
     18 |if y
            ^
+  Got `NilClass` originating from:
+    suggest_unsafe_dead.rb:12:
+    12 |y = T.let(nil, NilClass)
+            ^^^^^^^^^^^^^^^^^^^^
 
 suggest_unsafe_dead.rb:81: This code is unreachable https://srb.help/7006
     81 |      do_something
@@ -68,6 +107,7 @@ suggest_unsafe_dead.rb:81: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:80: This condition was always `truthy` (`A`)
     80 |    unless self
                    ^^^^
+  Got `A` originating from:
 
 suggest_unsafe_dead.rb:89: This code is unreachable https://srb.help/7006
     89 |      do_something
@@ -75,6 +115,7 @@ suggest_unsafe_dead.rb:89: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:88: This condition was always `truthy` (`A`)
     88 |    unless this
                    ^^^^
+  Got `A` originating from:
 Errors: 11
 
 --------------------------------------------------------------------------

--- a/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.rb
+++ b/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.rb
@@ -1,0 +1,104 @@
+# typed: true
+extend T::Sig
+
+def do_something; end
+
+sig {returns(Integer)}
+def returns_integer
+  0
+end
+
+x = T.let(0, Integer)
+y = T.let(nil, NilClass)
+
+unless x
+  puts x
+end
+
+if y
+  puts y
+end
+
+sig {params(x: Integer).void}
+def test1_variable_or(x)
+  x || do_something
+end
+
+sig {params(x: NilClass).void}
+def test2_variable_and(x)
+  x && do_something
+end
+
+sig {void}
+def test3_method_or_method
+  # For some reason, this behaves different from when the LHS of `||` is a variable.
+  returns_integer || do_something
+end
+
+sig {params(x: T.any(Integer, String)).void}
+def test4_exhaustive_case(x)
+  # This test case points the blame back to the `when String` comparison, which
+  # is not "wrong" per se. Maybe the user was expecting to see the error blame
+  # to `case x`, or perhaps say something like "the case was exhaustive"
+  case x
+  when Integer then puts 'int'
+  when String then puts 'str'
+  else
+    do_something
+  end
+end
+
+sig {void}
+def test5_if_else
+  if returns_integer
+    do_something
+  else
+    do_something
+  end
+end
+
+
+sig {void}
+def test6_possibly_uninitialized
+  if T.unsafe(nil)
+    x = 1
+  end
+
+  if x
+    do_something
+  elsif x
+    do_something
+  end
+end
+
+# Can't write this test at the top level because at top level `self` is
+# `Object` which is possibly nil and thus possibly falsy 🙃
+class A
+  extend T::Sig
+  sig {void}
+  def test7_self
+    unless self
+      do_something
+    end
+  end
+
+  sig {void}
+  def test8_self_this
+    this = self
+    unless this
+      do_something
+    end
+  end
+end
+
+sig {void}
+def test8_cyclic_cfg
+  if false
+    # This begin/while is the way Ruby encodes do/while.
+    begin
+      puts 3
+    end while T.unsafe(nil)
+  end
+
+  puts 5
+end

--- a/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.sh
+++ b/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+cwd="$(pwd)"
+infile="$cwd/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.rb"
+
+tmp="$(mktemp -d)"
+
+cp "$infile" "$tmp"
+
+cd "$tmp" || exit 1
+if "$cwd/main/sorbet" --silence-dev-message --suggest-unsafe -a suggest_unsafe_dead.rb 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+# Also cat the file, to make that the autocorrect applied
+cat suggest_unsafe_dead.rb
+
+rm suggest_unsafe_dead.rb
+
+rm -r "$tmp"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have #3903 which is a great PR fixing a long standing bug, but it introduces
almost a thousand new errors on Stripe's codebase.

On a more modest scale, my experiments to add better Shape typing are
introducing a bunch of dead code errors as well.

And last, the error for "This error is unreachable" is about as barren as an
error can get.

I fix all of these problems in this PR.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

**Before**

<img width="746" alt="Screen Shot 2021-01-23 at 11 45 17 PM" src="https://user-images.githubusercontent.com/5544532/105624944-8628b300-5dda-11eb-8f04-8f845858ed40.png">


**After**

<img width="737" alt="Screen Shot 2021-01-24 at 12 10 53 AM" src="https://user-images.githubusercontent.com/5544532/105624950-8b85fd80-5dda-11eb-96f8-45fe373b635c.png">


### Commit summary

Review by commit to see how the new test evolves.


- **pre-work: Fix bug when combining two basic blocks** (3f2f5ed22)

  We used to say that the `bexit.loc` of the two combined `BasicBlock`'s
  was the loc of the `BasicBlock` that unconditionally jumped into the
  second block, instead of loc of the second `BasicBlock` jumping out
  somewhere else.

  We don't actually have anywhere in the codebase that shows this Loc in
  an error message until this change.

- **Add failing test** (79bc84bc6)


- **Add ErrorLine on unconditional condition** (b7b4d1276)


- **Explain where type came from** (12f2d72d2)

  We have this fancy helper for explaining things, so I figured we may as
  well use it.

  It's also super handy that we keep all the environments around even
  after we're done typechecking a certain block, because technically all
  the conditions' variables that I want to be checking are only in scope
  in the previous environment.

  Also I had to change `getTypeAndOrigin` from private to public because I
  didn't want to use `getAndFillTypeAndOrigin` (public), which mutates the
  Environment and the VariableUseSite you give it.

- **Add autocorrect in --suggest-unsafe mode** (d98144a4c)

  This only applies in --suggest-unsafe mode because I figure that's the
  common case for dead code errors. It's usually "some codemod made
  something untyped into something typed" which causes a bunch of deadcode
  errors, because the revealed typing information wasn't actually good
  enough.

- **Skip dead backedges** (98c246cf8)

  This change makes sense intuitively, and I was definitely seeing cases
  that this code fixed. I could have sworn that I had a test case for it,
  but I can't find one anymore.

  Anyways, the intuition is in the comment. I figured it was harmless
  enough to include even though the test case it was needed to fix has
  been lost to time.