### PR TITLE
Convert some `# error:` tests to `# ^^^ error:` tests

### DIFF
--- a/test/testdata/cfg/triple_eq.rb
+++ b/test/testdata/cfg/triple_eq.rb
@@ -1,2 +1,3 @@
 # typed: true
-Integer.===(1, 2) # error: Too many arguments provided for method `Module#===`. Expected: `1`, got: `2`
+  Integer.===(1, 2)
+# ^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `Module#===`. Expected: `1`, got: `2`

--- a/test/testdata/infer/arg_matching.rb
+++ b/test/testdata/infer/arg_matching.rb
@@ -13,7 +13,8 @@ class TestArgs
   def call_required
     required(1) # error: Not enough arguments
     required(1, 2)
-    required(1, 2, 3) # error: Expected: `2`, got: `3`
+    required(1, 2, 3)
+  # ^^^^^^^^^^^^^^^^^ error: Expected: `2`, got: `3`
   end
 
   def optional(a, b=1)
@@ -22,7 +23,8 @@ class TestArgs
   def call_optional
     optional(1)
     optional(1, 2)
-    optional(1, 2, 3) # error: Expected: `1..2`, got: `3`
+    optional(1, 2, 3)
+  # ^^^^^^^^^^^^^^^^^ error: Expected: `1..2`, got: `3`
   end
 
   sig do
@@ -37,16 +39,22 @@ class TestArgs
 
   def call_kwarg
     # "too many arguments" and "missing keyword argument b"
-    kwarg(1, 2) # error: Missing required keyword argument `b` for method `TestArgs#kwarg`
+    kwarg(1, 2)
   # ^^^^^^^^^^^ error: Too many positional arguments provided for method `TestArgs#kwarg`. Expected: `1`, got: `2`
-    kwarg(1) # error: Missing required keyword argument `b`
+  # ^^^^^^^^^^^ error: Missing required keyword argument `b` for method `TestArgs#kwarg`
+    kwarg(1)
+  # ^^^^^^^^ error: Missing required keyword argument `b`
 
     kwarg(1, b: 2)
-    kwarg(1, b: 2, c: 3) # error: Unrecognized keyword argument `c`
-    kwarg(1, {}) # error: Missing required keyword argument `b`
-    kwarg(1, b: "hi") # error: Expected `Integer` but found `String("hi")` for argument `b`
+    kwarg(1, b: 2, c: 3)
+  # ^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `c`
+    kwarg(1, {})
+  # ^^^^^^^^^^^^ error: Missing required keyword argument `b`
+    kwarg(1, b: "hi")
+    #        ^^^^^^^ error: Expected `Integer` but found `String("hi")` for argument `b`
     kwarg(1, any)
-    kwarg(1, a_hash) # error: Passing a hash where the specific keys are unknown
+    kwarg(1, a_hash)
+  # ^^^^^^^^^^^^^^^^ error: Passing a hash where the specific keys are unknown
   end
 
   sig do
@@ -61,11 +69,13 @@ class TestArgs
   def call_repeated
     repeated
     repeated(1, 2, 3)
-    repeated(1, "hi") # error: Expected `Integer` but found `String("hi")` for argument `x`
+    repeated(1, "hi")
+    #           ^^^^ error: Expected `Integer` but found `String("hi")` for argument `x`
 
     # We error on each incorrect argument
-    repeated("hi", "there") # error: Expected `Integer` but found `String("hi")` for argument `x`
-  #                ^^^^^^^ error: Expected `Integer` but found `String("there")` for argument `x`
+    repeated("hi", "there")
+    #        ^^^^ error: Expected `Integer` but found `String("hi")` for argument `x`
+    #              ^^^^^^^ error: Expected `Integer` but found `String("there")` for argument `x`
   end
 
   sig do
@@ -95,8 +105,10 @@ class TestArgs
   def call_optkw
     # There's ambiguity here about whether to report `u` or `x` as
     # missing; We follow Ruby in complaining about `u`.
-    optkw(u: 1) # error: Missing required keyword argument `u`
-    optkw(1, 2, 3) # error: Missing required keyword argument `u` for method `TestArgs#optkw`
+    optkw(u: 1)
+  # ^^^^^^^^^^^ error: Missing required keyword argument `u`
+    optkw(1, 2, 3)
+  # ^^^^^^^^^^^^^^ error: Missing required keyword argument `u` for method `TestArgs#optkw`
   # ^^^^^^^^^^^^^^ error: Too many positional arguments provided for method `TestArgs#optkw`. Expected: `1..2`, got: `3`
   end
 end

--- a/test/testdata/infer/arity.rb
+++ b/test/testdata/infer/arity.rb
@@ -9,11 +9,13 @@ class Test
   def test
     required() # error: Expected: `1`, got: `0`
     required(0)
-    required(0, 1) # error: Expected: `1`, got: `2`
+    required(0, 1)
+  # ^^^^^^^^^^^^^^ error: Expected: `1`, got: `2`
 
     optional() # error: Expected: `1..3`, got: `0`
     optional(0, 1)
-    optional(0, 1, 2, 3) # error: Expected: `1..3`, got: `4`
+    optional(0, 1, 2, 3)
+  # ^^^^^^^^^^^^^^^^^^^^ error: Expected: `1..3`, got: `4`
 
     repeated() # error: Expected: `1+`, got: `0`
   end

--- a/test/testdata/infer/flatten.rb
+++ b/test/testdata/infer/flatten.rb
@@ -39,7 +39,9 @@ T.reveal_type(xsss.flatten(2)) # error: Revealed type: `T::Array[Integer]`
 
 xs.flatten(1 + 1) # error: You must pass an Integer literal to specify a depth
 
-xs.flatten(true) # error: Expected `Integer` but found `TrueClass` for argument `depth`
-         # ^^^^ error: You must pass an Integer literal to specify a depth with Array#flatten
+xs.flatten(true)
+#          ^^^^ error: Expected `Integer` but found `TrueClass` for argument `depth`
+#          ^^^^ error: You must pass an Integer literal to specify a depth with Array#flatten
 
-xs.flatten(1, 1) # error: Too many arguments provided for method `Array#flatten`. Expected: `0..1`, got: `2`
+  xs.flatten(1, 1)
+# ^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `Array#flatten`. Expected: `0..1`, got: `2`

--- a/test/testdata/infer/kwargs.rb
+++ b/test/testdata/infer/kwargs.rb
@@ -12,5 +12,6 @@ class A
 end
 
 # Each repeated argument is checked as element type
-A.foo(x: 1, y: 2, z: '') # error: Expected `Integer` but found `String("")` for argument `kwargs`
+A.foo(x: 1, y: 2, z: '')
+#     ^^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `String("")` for argument `kwargs`
 A.foo(x: 1, y: 2, z: 3)

--- a/test/testdata/infer/kwargs_splat.rb
+++ b/test/testdata/infer/kwargs_splat.rb
@@ -30,6 +30,9 @@ f(3, **untyped_hash)
 g(3, **untyped_hash, w: 2.0)
 
 untyped_values_hash = T.let(shaped_hash, T::Hash[Symbol, T.untyped])
-f(3, untyped_values_hash) # error: Passing a hash where the specific keys are unknown to a method taking keyword arguments
-f(3, **untyped_values_hash) # error: Passing a hash where the specific keys are unknown to a method taking keyword arguments
-g(3, **untyped_values_hash, w: 2.0) # error: Passing a hash where the specific keys are unknown to a method taking keyword arguments
+  f(3, untyped_values_hash)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Passing a hash where the specific keys are unknown to a method taking keyword arguments
+  f(3, **untyped_values_hash)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Passing a hash where the specific keys are unknown to a method taking keyword arguments
+  g(3, **untyped_values_hash, w: 2.0)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Passing a hash where the specific keys are unknown to a method taking keyword arguments

--- a/test/testdata/infer/must.rb
+++ b/test/testdata/infer/must.rb
@@ -6,5 +6,6 @@ def test_must # error: does not have a `sig`
 
   T.must(x)
   T.must()  # error: Not enough arguments
-  T.must(x, 0)  # error: Expected: `1`, got: `2`
+  T.must(x, 0)
+# ^^^^^^^^^^^^ error: Expected: `1`, got: `2`
 end

--- a/test/testdata/infer/self_type_param.rb
+++ b/test/testdata/infer/self_type_param.rb
@@ -19,7 +19,8 @@ class GenricClass
   end
 
   def as_optional_hash
-    kwargs(return_type_member) # error: Too many positional arguments provided
+    kwargs(return_type_member)
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many positional arguments provided
   end
 
   def splat_expand

--- a/test/testdata/infer/star_star_args.rb
+++ b/test/testdata/infer/star_star_args.rb
@@ -31,24 +31,31 @@ class Main
         double_wild(a: 1, b: 2)
         one_required(a: 1)
         one_required(1, a: 1)
-        one_required(1, 2, a: 1) # error: Expected: `1`, got: `2`
+        one_required(1, 2, a: 1)
+      # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected: `1`, got: `2`
         one_kwarg(foo: 1)
         one_kwarg(foo: 1, a: "a")
 
-        one_kwarg(foo: "bad", a: "bad") # error: Expected `Integer` but found `String("bad")` for argument `foo`
-        one_kwarg(foo: 1, a: 1) # error: Expected `String` but found `Integer(1)` for argument `args`
-        one_kwarg(foo: "bad", a: 1) # error: Expected `Integer` but found `String("bad")` for argument `foo`
-      #           ^^^^^^^^^^^^^^^^ error: Expected `String` but found `Integer(1)` for argument `args`
+        one_kwarg(foo: "bad", a: "bad")
+        #         ^^^^^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `String("bad")` for argument `foo`
+        one_kwarg(foo: 1, a: 1)
+        #         ^^^^^^^^^^^^ error: Expected `String` but found `Integer(1)` for argument `args`
+        one_kwarg(foo: "bad", a: 1)
+        #         ^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `String("bad")` for argument `foo`
+        #         ^^^^^^^^^^^^^^^^ error: Expected `String` but found `Integer(1)` for argument `args`
         with_type
         with_type(a: 1)
-        with_type(a: "bad") # error: Expected `Integer` but found `String("bad")` for argument `args`
-        with_type(a: "bad", b: "bad2") # error: Expected `Integer` but found `String("bad")` for argument `args`
-      #           ^^^^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `String("bad2")` for argument `args`
+        with_type(a: "bad")
+        #         ^^^^^^^^ error: Expected `Integer` but found `String("bad")` for argument `args`
+        with_type(a: "bad", b: "bad2")
+        #         ^^^^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `String("bad")` for argument `args`
+        #         ^^^^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `String("bad2")` for argument `args`
 
         # This should assign `z`, instead of assigning `x={z: :foo}`,
         # which would happen with `y={}`
         opt_and_repeated_kw(z: :foo)
         opt_and_repeated_kw("hi")
-        opt_and_repeated_kw("hi", z: "foo") # error: Expected `Symbol` but found `String("foo")` for argument `y`
-    end
+        opt_and_repeated_kw("hi", z: "foo")
+        #                         ^^^^^^^^ error: Expected `Symbol` but found `String("foo")` for argument `y`
+  end
 end

--- a/test/testdata/rbi/float.rb
+++ b/test/testdata/rbi/float.rb
@@ -1,3 +1,4 @@
 # typed: true
 
-1.0.to_s(10) # error: Too many arguments provided for method `Float#to_s`. Expected: `0`, got: `1`
+  1.0.to_s(10)
+# ^^^^^^^^^^^^ error: Too many arguments provided for method `Float#to_s`. Expected: `0`, got: `1`

--- a/test/testdata/rbi/io.rb
+++ b/test/testdata/rbi/io.rb
@@ -12,5 +12,6 @@ def test_io_read_encoding(file_name)
   IO.read(file_name, encoding: "ASCII_8BIT")
   IO.read(file_name, encoding: Encoding::ASCII_8BIT)
   IO.read(file_name, encoding: Encoding::ASCII_8BIT.to_s)
-  IO.read(file_name, encoding: 42) # error: Expected `T.any(String, Encoding)` but found `Integer(42)` for argument `encoding`
+  IO.read(file_name, encoding: 42)
+  #                  ^^^^^^^^^^^^ error: Expected `T.any(String, Encoding)` but found `Integer(42)` for argument `encoding`
 end

--- a/test/testdata/rbi/t.rb
+++ b/test/testdata/rbi/t.rb
@@ -22,12 +22,15 @@ T.assert_type! # error: Not enough arguments provided for method `T.assert_type!
 T.cast # error: Not enough arguments provided for method `T.cast`. Expected: `2`, got: `0`
 T.unsafe # error: Not enough arguments provided for method `T.unsafe`. Expected: `1`, got: `0`
 T.nilable # error: Not enough arguments provided for method `T.nilable`. Expected: `1`, got: `0`
-T.proc(String) # error: Too many arguments provided for method `T.proc`. Expected: `0`, got: `1`
+  T.proc(String)
+# ^^^^^^^^^^^^^^ error: Too many arguments provided for method `T.proc`. Expected: `0`, got: `1`
 T.class_of # error: Not enough arguments provided for method `T.class_of`. Expected: `1`, got: `0`
-T.noreturn(String) # error: Too many arguments provided for method `T.noreturn`. Expected: `0`, got: `1`
+  T.noreturn(String)
+# ^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `T.noreturn`. Expected: `0`, got: `1`
 T.enum # error: Not enough arguments provided for method `T.enum`. Expected: `1`, got: `0`
 
-T.untyped(String) # error: Too many arguments provided for method `T.untyped`. Expected: `0`, got: `1`
+  T.untyped(String)
+# ^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `T.untyped`. Expected: `0`, got: `1`
 T.any # error: Not enough arguments provided for method `T.any`. Expected: `2+`, got: `0`
 T.all # error: Not enough arguments provided for method `T.all`. Expected: `2+`, got: `0`
 

--- a/test/testdata/resolver/missing_type_combinator_args.rb
+++ b/test/testdata/resolver/missing_type_combinator_args.rb
@@ -1,10 +1,12 @@
 # typed: true
 T.cast(nil, T.nilable) # error: Not enough arguments provided for method
-T.cast(nil, T.nilable(Integer, Integer)) # error: Too many arguments provided for method
+T.cast(nil, T.nilable(Integer, Integer))
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method
 T.cast(nil, T.any) # error: Not enough arguments provided for method
 T.cast(nil, T.all) # error: Not enough arguments provided for method
 T.must # error: Not enough arguments provided for method
 T.let(1) # error: Not enough arguments provided for method
 T.let(1, 2, 3) # error: Unsupported literal in type syntax
 T.reveal_type() # error: Not enough arguments provided for method
-T.reveal_type(1, 2) # error: Too many arguments provided for method
+  T.reveal_type(1, 2)
+# ^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method

--- a/test/testdata/resolver/proc.rb
+++ b/test/testdata/resolver/proc.rb
@@ -22,10 +22,11 @@ class TestProc
   sig do
     params(
       x: T.proc, # error: Malformed T.proc: You must specify a return type
-      y: T.proc(0).returns(Integer), # error: Too many arguments provided for method `T.proc`. Expected: `0`, got: `1`
+      y: T.proc(0).returns(Integer),
+      #  ^^^^^^^^^ error: Too many arguments provided for method `T.proc`. Expected: `0`, got: `1`
       z: T.proc.params({x: Integer}).returns(0),
-                                           # ^ error: Unsupported literal in type syntax
-       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `params` expects keyword arguments
+      #                                      ^ error: Unsupported literal in type syntax
+      #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `params` expects keyword arguments
       w: T.proc.params(x: :f).returns(Integer), # error: Unsupported literal in type syntax
     ).returns(NilClass)
   end

--- a/test/testdata/resolver/proc.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/proc.rb.symbol-table-raw.exp
@@ -1,19 +1,19 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/proc.rb start=3:1 end=44:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/proc.rb start=3:1 end=45:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/proc.rb start=??? end=???}
   class <C <U TestProc>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/proc.rb start=3:1 end=3:15}
-    method <C <U TestProc>><U bad> (x, y, z, w, <blk>) -> NilClass @ Loc {file=test/testdata/resolver/proc.rb start=32:3 end=32:22}
+    method <C <U TestProc>><U bad> (x, y, z, w, <blk>) -> NilClass @ Loc {file=test/testdata/resolver/proc.rb start=33:3 end=33:22}
       argument x<> -> T.proc.returns(T.untyped) @ Loc {file=test/testdata/resolver/proc.rb start=24:7 end=24:8}
       argument y<> -> T.proc.returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=25:7 end=25:8}
-      argument z<> -> T.proc.returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=26:7 end=26:8}
-      argument w<> -> T.proc.params(arg0: Symbol).returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=29:7 end=29:8}
+      argument z<> -> T.proc.returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=27:7 end=27:8}
+      argument w<> -> T.proc.params(arg0: Symbol).returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=30:7 end=30:8}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/proc.rb start=??? end=???}
-    method <C <U TestProc>><U foo> (x, <blk>) -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=36:3 end=36:13}
-      argument x<> -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=35:15 end=35:16}
+    method <C <U TestProc>><U foo> (x, <blk>) -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=37:3 end=37:13}
+      argument x<> -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=36:15 end=36:16}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/proc.rb start=??? end=???}
-    method <C <U TestProc>><U foo1> (x, <blk>) -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=43:3 end=43:14}
-      argument x<> -> T.proc.params(arg0: Integer).returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=40:7 end=40:8}
+    method <C <U TestProc>><U foo1> (x, <blk>) -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=44:3 end=44:14}
+      argument x<> -> T.proc.params(arg0: Integer).returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=41:7 end=41:8}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/proc.rb start=??? end=???}
     method <C <U TestProc>><U good1> (blk) -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=10:3 end=10:18}
       argument blk<block> -> T.proc.params(arg0: Integer).returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=7:12 end=7:15}
@@ -21,6 +21,6 @@ class <C <U <root>>> < <C <U Object>> ()
       argument blk<block> -> T.proc.params(arg0: T::Array[String]).returns(T::Array[Integer]) @ Loc {file=test/testdata/resolver/proc.rb start=15:12 end=15:15}
   class <S <C <U TestProc>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Sig>>) @ Loc {file=test/testdata/resolver/proc.rb start=3:7 end=3:15}
     type-member(+) <S <C <U TestProc>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U TestProc>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=TestProc) @ Loc {file=test/testdata/resolver/proc.rb start=3:7 end=3:15}
-    method <S <C <U TestProc>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/proc.rb start=3:1 end=44:4}
+    method <S <C <U TestProc>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/proc.rb start=3:1 end=45:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/proc.rb start=??? end=???}
 

--- a/test/testdata/resolver/sig_bad.rb
+++ b/test/testdata/resolver/sig_bad.rb
@@ -23,7 +23,8 @@ class A
       g: T.any(*[Integer, String]), # error: splats cannot be used in types
       h: T.junk, # error: Method `junk` does not exist on `T.class_of(T)`
        # ^^^^^^ error: Unsupported method `T.junk`
-      i: T.class_of(T1, T2), # error: Too many arguments provided for method `T.class_of`
+      i: T.class_of(T1, T2),
+      #  ^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `T.class_of`
       j: T.class_of(T.nilable(Integer)), # error: T.class_of needs a Class as its argument
       k: T.class_of(1), # error: T.class_of needs a Class as its argument
       l: {[] => String}, # error: Shape keys must be literals

--- a/test/testdata/resolver/sig_bad.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/sig_bad.rb.symbol-table-raw.exp
@@ -1,9 +1,9 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=2:1 end=39:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=2:1 end=40:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/sig_bad.rb start=??? end=???}
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/sig_bad.rb start=10:1 end=10:8}
-    method <C <U A>><U bad> (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, <blk>) -> T2 @ Loc {file=test/testdata/resolver/sig_bad.rb start=36:3 end=36:55}
+    method <C <U A>><U bad> (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, <blk>) -> T2 @ Loc {file=test/testdata/resolver/sig_bad.rb start=37:3 end=37:55}
       argument a<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=17:7 end=17:8}
       argument b<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=18:7 end=18:8}
       argument c<> -> Object @ Loc {file=test/testdata/resolver/sig_bad.rb start=19:7 end=19:8}
@@ -13,16 +13,16 @@ class <C <U <root>>> < <C <U Object>> ()
       argument g<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=23:7 end=23:8}
       argument h<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=24:7 end=24:8}
       argument i<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=26:7 end=26:8}
-      argument j<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=27:7 end=27:8}
-      argument k<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=28:7 end=28:8}
-      argument l<> -> {} @ Loc {file=test/testdata/resolver/sig_bad.rb start=29:7 end=29:8}
-      argument m<> -> {foo: Integer} @ Loc {file=test/testdata/resolver/sig_bad.rb start=30:7 end=30:8}
-      argument n<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=31:7 end=31:8}
-      argument o<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=32:7 end=32:8}
+      argument j<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=28:7 end=28:8}
+      argument k<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=29:7 end=29:8}
+      argument l<> -> {} @ Loc {file=test/testdata/resolver/sig_bad.rb start=30:7 end=30:8}
+      argument m<> -> {foo: Integer} @ Loc {file=test/testdata/resolver/sig_bad.rb start=31:7 end=31:8}
+      argument n<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=32:7 end=32:8}
+      argument o<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=33:7 end=33:8}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=??? end=???}
   class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Sig>>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=10:7 end=10:8}
     type-member(+) <S <C <U A>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/resolver/sig_bad.rb start=10:7 end=10:8}
-    method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=10:1 end=39:4}
+    method <S <C <U A>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=10:1 end=40:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/sig_bad.rb start=??? end=???}
     method <S <C <U A>> $1><U unsupported> (<blk>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=13:3 end=13:23}
       argument <blk><block> @ Loc {file=test/testdata/resolver/sig_bad.rb start=??? end=???}

--- a/test/testdata/rewriter/def_delegator.rb
+++ b/test/testdata/rewriter/def_delegator.rb
@@ -48,12 +48,18 @@ class IgnoredUsages
   not_def_delegator :thing, :foo # error: Method `not_def_delegator` does not exist
   def_delegator # error: Not enough arguments provided for method `Forwardable#def_delegator`
   def_delegator :thing # error: Not enough arguments provided for method `Forwardable#def_delegator`
-  def_delegator :thing, :foo, :bar, :baz # error: Too many arguments provided for method `Forwardable#def_delegator`
-  def_delegator :thing, :foo, :bar, kwarg: :thing # error: Too many arguments provided for method `Forwardable#def_delegator`
-  def_delegator :thing, kwarg: :thing # error: Expected `Symbol` but found `{kwarg: Symbol(:thing)}` for argument `method`
-  def_delegator :foo, kwarg1: :thing, kwarg2: local # error: Expected `Symbol` but found `{kwarg1: Symbol(:thing), kwarg2: Integer(0)}` for argument `method`
-  def_delegator :foo, local => :thing # error: Expected `Symbol` but found `{}` for argument `method`
-  def_delegator 234, :foo # error: Expected `T.any(Symbol, String)` but found `Integer(234)` for argument `accessor`
+  def_delegator :thing, :foo, :bar, :baz
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `Forwardable#def_delegator`
+  def_delegator :thing, :foo, :bar, kwarg: :thing
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `Forwardable#def_delegator`
+  def_delegator :thing, kwarg: :thing
+  #                     ^^^^^^^^^^^^^ error: Expected `Symbol` but found `{kwarg: Symbol(:thing)}` for argument `method`
+  def_delegator :foo, kwarg1: :thing, kwarg2: local
+  #                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{kwarg1: Symbol(:thing), kwarg2: Integer(0)}` for argument `method`
+  def_delegator :foo, local => :thing
+  #                   ^^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{}` for argument `method`
+  def_delegator 234, :foo
+  #             ^^^ error: Expected `T.any(Symbol, String)` but found `Integer(234)` for argument `accessor`
   def_delegator :thing => :foo # error: Not enough arguments provided for method `Forwardable#def_delegator
               # ^^^^^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `{thing: Symbol(:foo)}` for argument `accessor`
 end

--- a/test/testdata/rewriter/prop_skipped.rb
+++ b/test/testdata/rewriter/prop_skipped.rb
@@ -5,4 +5,5 @@ class A < T::Struct
   const :foo, T::Array[{foo: Integer}]
 end
 
-A.new(foo: []) # error: Too many arguments
+  A.new(foo: [])
+# ^^^^^^^^^^^^^^ error: Too many arguments

--- a/test/testdata/rewriter/struct.rb
+++ b/test/testdata/rewriter/struct.rb
@@ -57,22 +57,29 @@ class MixinStruct
     include MyMixin
     self.new.x
     self.new.foo
-    self.new(1, 2) # error: Too many positional arguments provided for method `MixinStruct::MyKeywordInitStruct#initialize`. Expected: `0`, got: `2`
-    self.new(giberish: 1) # error: Unrecognized keyword argument `giberish` passed for method `MixinStruct::MyKeywordInitStruct#initialize`
+    self.new(1, 2)
+  # ^^^^^^^^^^^^^^ error: Too many positional arguments provided for method `MixinStruct::MyKeywordInitStruct#initialize`. Expected: `0`, got: `2`
+    self.new(giberish: 1)
+  # ^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `giberish` passed for method `MixinStruct::MyKeywordInitStruct#initialize`
   end
 
-  MyKeywordInitStruct.new(1, 2) # error: Too many positional arguments provided for method `MixinStruct::MyKeywordInitStruct#initialize`. Expected: `0`, got: `2`
-  MyKeywordInitStruct.new(giberish: 1) # error: Unrecognized keyword argument `giberish` passed for method `MixinStruct::MyKeywordInitStruct#initialize`
+  MyKeywordInitStruct.new(1, 2)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many positional arguments provided for method `MixinStruct::MyKeywordInitStruct#initialize`. Expected: `0`, got: `2`
+  MyKeywordInitStruct.new(giberish: 1)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `giberish` passed for method `MixinStruct::MyKeywordInitStruct#initialize`
   MyStruct.new.x
   MyStruct.new.foo
 end
 
 class BadUsages
   A = Struct.new # error: Not enough arguments provided for method `Struct#initialize`. Expected: `1+`, got: `0`
-  B = Struct.new(giberish: 1) # error: Expected `T.any(Symbol, String)` but found `{giberish: Integer(1)}` for argument `arg0`
-  C = Struct.new(keyword_init: true) # error: Expected `T.any(Symbol, String)` but found `{keyword_init: TrueClass}` for argument `arg0`
+  B = Struct.new(giberish: 1)
+  #              ^^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `{giberish: Integer(1)}` for argument `arg0`
+  C = Struct.new(keyword_init: true)
+  #              ^^^^^^^^^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `{keyword_init: TrueClass}` for argument `arg0`
   local = true
-  D = Struct.new(keyword_init: local) # error: Expected `T.any(Symbol, String)` but found `{keyword_init: TrueClass}` for argument `arg0`
+  D = Struct.new(keyword_init: local)
+  #              ^^^^^^^^^^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `{keyword_init: TrueClass}` for argument `arg0`
   E = Struct.new(:a, keyword_init: local) # we run too early in to be able to support this
 end
 
@@ -93,7 +100,8 @@ class Main
         T.assert_type!(RealStruct::KeywordInit.new, RealStruct::KeywordInit)
         T.assert_type!(RealStruct::KeywordInit.new(foo: 1), RealStruct::KeywordInit)
         T.assert_type!(RealStruct::KeywordInit.new(foo: 2, bar: 3), RealStruct::KeywordInit)
-        RealStruct::KeywordInit.new(1, 2) # error: Too many positional arguments provided for method `RealStruct::KeywordInit#initialize`. Expected: `0`, got: `2`
+        RealStruct::KeywordInit.new(1, 2)
+      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many positional arguments provided for method `RealStruct::KeywordInit#initialize`. Expected: `0`, got: `2`
 
         T.assert_type!(RealStructDesugar::A.new(2, 3), RealStructDesugar::A)
     end

--- a/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=101:19}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=109:19}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U AccidentallyStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=37:1 end=37:25}
     class <C <U AccidentallyStruct>><C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
@@ -32,15 +32,15 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <C <U AccidentallyStruct>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U AccidentallyStruct>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AccidentallyStruct) @ Loc {file=test/testdata/rewriter/struct.rb start=37:7 end=37:25}
     method <S <C <U AccidentallyStruct>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=37:1 end=43:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-  class <C <U BadUsages>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=70:1 end=70:16}
-    static-field <C <U BadUsages>><C <U A>> @ Loc {file=test/testdata/rewriter/struct.rb start=71:3 end=71:4}
-    static-field <C <U BadUsages>><C <U B>> @ Loc {file=test/testdata/rewriter/struct.rb start=72:3 end=72:4}
-    static-field <C <U BadUsages>><C <U C>> @ Loc {file=test/testdata/rewriter/struct.rb start=73:3 end=73:4}
-    static-field <C <U BadUsages>><C <U D>> @ Loc {file=test/testdata/rewriter/struct.rb start=75:3 end=75:4}
-    static-field <C <U BadUsages>><C <U E>> @ Loc {file=test/testdata/rewriter/struct.rb start=76:3 end=76:4}
-  class <S <C <U BadUsages>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=70:7 end=70:16}
-    type-member(+) <S <C <U BadUsages>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U BadUsages>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=BadUsages) @ Loc {file=test/testdata/rewriter/struct.rb start=70:7 end=70:16}
-    method <S <C <U BadUsages>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=70:1 end=77:4}
+  class <C <U BadUsages>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=74:1 end=74:16}
+    static-field <C <U BadUsages>><C <U A>> @ Loc {file=test/testdata/rewriter/struct.rb start=75:3 end=75:4}
+    static-field <C <U BadUsages>><C <U B>> @ Loc {file=test/testdata/rewriter/struct.rb start=76:3 end=76:4}
+    static-field <C <U BadUsages>><C <U C>> @ Loc {file=test/testdata/rewriter/struct.rb start=78:3 end=78:4}
+    static-field <C <U BadUsages>><C <U D>> @ Loc {file=test/testdata/rewriter/struct.rb start=81:3 end=81:4}
+    static-field <C <U BadUsages>><C <U E>> @ Loc {file=test/testdata/rewriter/struct.rb start=83:3 end=83:4}
+  class <S <C <U BadUsages>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=74:7 end=74:16}
+    type-member(+) <S <C <U BadUsages>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U BadUsages>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=BadUsages) @ Loc {file=test/testdata/rewriter/struct.rb start=74:7 end=74:16}
+    method <S <C <U BadUsages>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=74:1 end=84:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   module <C <U Foo>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/rewriter/struct.rb start=4:1 end=4:11}
     class <C <U Foo>><C <U Struct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=5:5 end=5:17}
@@ -52,17 +52,17 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <C <U Foo>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo) @ Loc {file=test/testdata/rewriter/struct.rb start=4:8 end=4:11}
     method <S <C <U Foo>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=4:1 end=7:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-  class <C <U Main>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=79:1 end=79:11}
-    method <C <U Main>><U main> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=80:5 end=80:13}
+  class <C <U Main>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=86:1 end=86:11}
+    method <C <U Main>><U main> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=87:5 end=87:13}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-  class <S <C <U Main>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=79:7 end=79:11}
-    type-member(+) <S <C <U Main>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Main>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Main) @ Loc {file=test/testdata/rewriter/struct.rb start=79:7 end=79:11}
-    method <S <C <U Main>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=79:1 end=100:4}
+  class <S <C <U Main>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=86:7 end=86:11}
+    type-member(+) <S <C <U Main>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Main>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Main) @ Loc {file=test/testdata/rewriter/struct.rb start=86:7 end=86:11}
+    method <S <C <U Main>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=86:1 end=108:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U MixinStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=45:1 end=45:18}
-    class <C <U MixinStruct>><C <U MyKeywordInitStruct>> < <C <U Struct>> (<C <U MyMixin>>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
-      type-member(=) <C <U MixinStruct>><C <U MyKeywordInitStruct>><C <U Elem>> -> LambdaParam(<C <U MixinStruct>><C <U MyKeywordInitStruct>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
-      method <C <U MixinStruct>><C <U MyKeywordInitStruct>><U initialize> (x, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+    class <C <U MixinStruct>><C <U MyKeywordInitStruct>> < <C <U Struct>> (<C <U MyMixin>>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=64:6}
+      type-member(=) <C <U MixinStruct>><C <U MyKeywordInitStruct>><C <U Elem>> -> LambdaParam(<C <U MixinStruct>><C <U MyKeywordInitStruct>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=64:6}
+      method <C <U MixinStruct>><C <U MyKeywordInitStruct>><U initialize> (x, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=64:6}
         argument x<optional, keyword> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=56:37 end=56:38}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
       method <C <U MixinStruct>><C <U MyKeywordInitStruct>><U x> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:37 end=56:38}
@@ -72,7 +72,7 @@ class <C <U <root>>> < <C <U Object>> ()
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
     class <C <U MixinStruct>><S <C <U MyKeywordInitStruct>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=56:22}
       type-member(+) <C <U MixinStruct>><S <C <U MyKeywordInitStruct>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U MixinStruct>><S <C <U MyKeywordInitStruct>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U MixinStruct>><C <U MyKeywordInitStruct>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=56:22}
-      method <C <U MixinStruct>><S <C <U MyKeywordInitStruct>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=62:6}
+      method <C <U MixinStruct>><S <C <U MyKeywordInitStruct>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=56:3 end=64:6}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
     module <C <U MixinStruct>><C <U MyMixin>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/rewriter/struct.rb start=46:3 end=46:17}
       method <C <U MixinStruct>><C <U MyMixin>><U foo> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=47:5 end=47:12}
@@ -97,7 +97,7 @@ class <C <U <root>>> < <C <U Object>> ()
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <S <C <U MixinStruct>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=45:7 end=45:18}
     type-member(+) <S <C <U MixinStruct>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U MixinStruct>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=MixinStruct) @ Loc {file=test/testdata/rewriter/struct.rb start=45:7 end=45:18}
-    method <S <C <U MixinStruct>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=45:1 end=68:4}
+    method <S <C <U MixinStruct>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=45:1 end=72:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U NotStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=9:1 end=9:16}
     static-field <C <U NotStruct>><C <U B>> -> Foo::Struct @ Loc {file=test/testdata/rewriter/struct.rb start=10:5 end=10:6}

--- a/test/testdata/rewriter/t_enum_kwargs.rb
+++ b/test/testdata/rewriter/t_enum_kwargs.rb
@@ -13,8 +13,10 @@ class Test < T::Enum
     C = new(10, c: 20, d: 30)
     D = new(10, "bar", c: 20, d: 30)
 
-    E = new(10, "bar", c: 20, d: 30, f: "error") # error: Unrecognized keyword argument
-    F = new(1, "bar", 3, 4, c: 20) # error: Too many positional arguments
+    E = new(10, "bar", c: 20, d: 30, f: "error")
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument
+    F = new(1, "bar", 3, 4, c: 20)
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many positional arguments
   end
 
 end

--- a/test/testdata/rewriter/t_struct/default.rb
+++ b/test/testdata/rewriter/t_struct/default.rb
@@ -5,8 +5,10 @@ class Default < T::Struct
 end
 
 T.reveal_type(Default.new.foo) # error: Revealed type: `Integer`
-Default.new(foo: "no") # error: Expected `Integer` but found `String("no")` for argument `foo`
-Default.new(foo: 3, bar: 4) # error: Unrecognized keyword argument `bar` passed for method `Default#initialize`
+Default.new(foo: "no")
+#           ^^^^^^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
+  Default.new(foo: 3, bar: 4)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `bar` passed for method `Default#initialize`
 T.reveal_type(Default.new(foo: 3).foo) # error: Revealed type: `Integer`
 
 class Bad < T::Struct

--- a/test/testdata/rewriter/t_struct/nilable.rb
+++ b/test/testdata/rewriter/t_struct/nilable.rb
@@ -5,7 +5,9 @@ class Nilable < T::Struct
 end
 
 T.reveal_type(Nilable.new.foo) # error: Revealed type: `T.nilable(Integer)`
-Nilable.new(foo: "no") # error: Expected `T.nilable(Integer)` but found `String("no")` for argument `foo`
-Nilable.new(foo: 3, bar: 4) # error: Unrecognized keyword argument `bar` passed for method `Nilable#initialize`
+Nilable.new(foo: "no")
+#           ^^^^^^^^^ error: Expected `T.nilable(Integer)` but found `String("no")` for argument `foo`
+  Nilable.new(foo: 3, bar: 4)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `bar` passed for method `Nilable#initialize`
 T.reveal_type(Nilable.new(foo: 3).foo) # error: Revealed type: `T.nilable(Integer)`
 T.reveal_type(Nilable.new(foo: nil).foo) # error: Revealed type: `T.nilable(Integer)`

--- a/test/testdata/rewriter/t_struct/none.rb
+++ b/test/testdata/rewriter/t_struct/none.rb
@@ -3,4 +3,5 @@
 class None < T::Struct; end
 
 None.new
-None.new(foo: 3) # error: Too many arguments provided for method `None#initialize`. Expected: `0`, got: `1`
+  None.new(foo: 3)
+# ^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `None#initialize`. Expected: `0`, got: `1`

--- a/test/testdata/rewriter/t_struct/normal.rb
+++ b/test/testdata/rewriter/t_struct/normal.rb
@@ -5,6 +5,8 @@ class Normal < T::Struct
 end
 
 Normal.new # error: Missing required keyword argument `foo` for method `Normal#initialize`
-Normal.new(foo: "no") # error: Expected `Integer` but found `String("no")` for argument `foo`
-Normal.new(foo: 3, bar: 4) # error: Unrecognized keyword argument `bar` passed for method `Normal#initialize`
+Normal.new(foo: "no")
+#          ^^^^^^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
+  Normal.new(foo: 3, bar: 4)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `bar` passed for method `Normal#initialize`
 T.reveal_type(Normal.new(foo: 3).foo) # error: Revealed type: `Integer`

--- a/test/testdata/rewriter/t_struct/override.rb
+++ b/test/testdata/rewriter/t_struct/override.rb
@@ -15,6 +15,8 @@ class Override < T::Struct
 end
 
 Override.new # error: Missing required keyword argument `foo` for method `Override#initialize`
-Override.new(foo: "no") # error: Expected `Integer` but found `String("no")` for argument `foo`
-Override.new(foo: 3, bar: 4) # error: Unrecognized keyword argument `bar` passed for method `Override#initialize`
+Override.new(foo: "no")
+#            ^^^^^^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
+  Override.new(foo: 3, bar: 4)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `bar` passed for method `Override#initialize`
 T.reveal_type(Override.new(foo: 3).foo) # error: Revealed type: `String`

--- a/test/testdata/rewriter/t_struct/positional.rb
+++ b/test/testdata/rewriter/t_struct/positional.rb
@@ -7,4 +7,5 @@ class A < T::Struct
 
 end
 
-A.new(0) # error: Too many arguments
+  A.new(0)
+# ^^^^^^^^ error: Too many arguments

--- a/test/testdata/rewriter/t_struct/root.rb
+++ b/test/testdata/rewriter/t_struct/root.rb
@@ -5,6 +5,8 @@ class Root < ::T::Struct
 end
 
 Root.new # error: Missing required keyword argument `foo` for method `Root#initialize`
-Root.new(foo: "no") # error: Expected `Integer` but found `String("no")` for argument `foo`
-Root.new(foo: 3, bar: 4) # error: Unrecognized keyword argument `bar` passed for method `Root#initialize`
+Root.new(foo: "no")
+#        ^^^^^^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
+  Root.new(foo: 3, bar: 4)
+# ^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `bar` passed for method `Root#initialize`
 T.reveal_type(Root.new(foo: 3).foo) # error: Revealed type: `Integer`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I started today thinking that I would make the location information better for
keyword args errors.

I ended up realizing that I misunderstood how calls.cc handles keyword args,
and got discouraged after realizing that the problem wasn't quite as easy as I
thought it was.

In any case, I took the time to refactor these tests so that they capture the
inline location information, so that we'll know of any future changes to those
locations (intentional or unintentional).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

no-op test-only change