### PR TITLE
externalType: Never return nullptr.

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -72,6 +72,12 @@ TypePtr Symbol::selfType(const GlobalState &gs) const {
 
 TypePtr Symbol::externalType() const {
     ENFORCE_NO_TIMER(resultType);
+    if (!resultType) {
+        // Don't return nullptr in prod builds, which would cause a disruptive crash
+        // Emit a metric and return untyped instead.
+        prodCounterInc("symbol.externalType.nullptr");
+        return Types::untypedUntracked();
+    }
     return resultType;
 }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -72,7 +72,7 @@ TypePtr Symbol::selfType(const GlobalState &gs) const {
 
 TypePtr Symbol::externalType() const {
     ENFORCE_NO_TIMER(resultType);
-    if (!resultType) {
+    if (resultType == nullptr) {
         // Don't return nullptr in prod builds, which would cause a disruptive crash
         // Emit a metric and return untyped instead.
         prodCounterInc("symbol.externalType.nullptr");


### PR DESCRIPTION
externalType: Never return nullptr.

Proactively prevent crashes in prod builds due to bugs.

At the same time, emit a metric when this occurs so we can track when this is happening.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We've been observing many Sorbet crashes in IDE at Stripe. I isolated one (after great effort!) to externalType returning `nullptr`, and fixed it by disabling the configatron pass. However, I can't be certain that I've found all of these cases.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

If we had a test that triggered this code path, then we would have a bug to fix.
