### PR TITLE
Fix the signature for BigDecimal

### DIFF
--- a/rbi/stdlib/bigdecimal.rbi
+++ b/rbi/stdlib/bigdecimal.rbi
@@ -1538,7 +1538,7 @@ class BigDecimal < Numeric
     params(
         arg0: Integer,
     )
-    .returns(Rational)
+    .returns(BigDecimal)
   end
   def truncate(arg0=T.unsafe(nil)); end
 


### PR DESCRIPTION
Change `truncate` to return `BigDecimal` instead of `Rationale`

### Motivation
According to the docs `truncate` should return `BigDecimal`

### Test plan
It's a part of Ruby core, didn't add the tests for the signatures here, since I didn't see this pattern being wildly used, but I can add if people feel like that is necessary
