### PR TITLE
Handle missing parameter names for C Ruby methods

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -11,6 +11,10 @@ class T::Private::Methods::Signature
     # Using `Untyped` ensures we'll get an error if we ever try validation on these.
     not_typed = T::Private::Types::NotTyped.new
     raw_return_type = not_typed
+    # Map missing parameter names to "argN" positionally
+    parameters = parameters.each_with_index.map do |(param_kind, param_name), index|
+      [param_kind, param_name || "arg#{index}"]
+    end
     raw_arg_types = parameters.map do |_param_kind, param_name|
       [param_name, not_typed]
     end.to_h

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -186,6 +186,16 @@ module Opus::Types::Test
     end
 
     describe "validation" do
+      it "accepts built-in method overrides" do
+        klass = Class.new do
+          extend T::Sig
+          sig {params(m: Symbol, include_private: T::Boolean).returns(T::Boolean)}
+          def respond_to_missing?(m, include_private=false); true; end
+        end
+
+        klass.new.respond_to?(:foo)
+      end
+
       it "raises an error when the return value is the wrong type" do
         @mod.sig {returns(String)}
         def @mod.foo


### PR DESCRIPTION
This PR modifies the parameter list in the `T::Private::Methods::Signature.new_untyped` so that all missing parameter names are mapped to names of the format `argN`, where `N` is the positional offset of the parameter in the parameters array. This ensures that all parameters get checked appropriately when the validation step runs.

### Motivation

Fix #3939 

Ruby methods defined by CRuby generally have missing names for parameters. This creates a problem when constructing raw arg types when building a synthetic untyped signature for super methods that are Ruby methods defined by CRuby code. Missing names all get folded into a single hash key and when the validation time comes the arg count does not end up matching the parameter count.

### Test plan

See included automated tests.
