### PR TITLE
Faster cold cache LSP startup by re-using ASTs for hashing

### DIFF
--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -135,7 +135,7 @@ ExpressionPtr Substitute::run(core::MutableContext ctx, const core::GlobalSubsti
     return what;
 }
 
-ExpressionPtr Substitute::run(core::MutableContext ctx, core::LazyGlobalSubstitution &subst, TreePtr what) {
+ExpressionPtr Substitute::run(core::MutableContext ctx, core::LazyGlobalSubstitution &subst, ExpressionPtr what) {
     SubstWalk walk(subst);
     what = TreeMap::apply(ctx, walk, std::move(what));
     return what;

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -55,7 +55,7 @@ public:
 
     ExpressionPtr preTransformMethodDef(core::MutableContext ctx, ExpressionPtr tree) {
         auto &original = cast_tree_nonnull<MethodDef>(tree);
-        original.name = subst.substitute(original.name);
+        original.name = subst.substituteConstant(original.name);
         for (auto &arg : original.args) {
             arg = substArg(ctx, std::move(arg));
         }

--- a/ast/substitute/substitute.h
+++ b/ast/substitute/substitute.h
@@ -12,7 +12,7 @@ namespace sorbet::ast {
 class Substitute {
 public:
     static ExpressionPtr run(core::MutableContext ctx, const core::GlobalSubstitution &subst, ExpressionPtr what);
-    static ExpressionPtr run(core::MutableContext ctx, core::LazyGlobalSubstitution &subst, TreePtr what);
+    static ExpressionPtr run(core::MutableContext ctx, core::LazyGlobalSubstitution &subst, ExpressionPtr what);
 };
 } // namespace sorbet::ast
 #endif // SORBET_SUBSTITUTE_H

--- a/ast/substitute/substitute.h
+++ b/ast/substitute/substitute.h
@@ -4,10 +4,15 @@
 #include "ast/ast.h"
 #include "core/Context.h"
 
+namespace sorbet::core {
+class LazyGlobalSubstitution;
+};
+
 namespace sorbet::ast {
 class Substitute {
 public:
     static ExpressionPtr run(core::MutableContext ctx, const core::GlobalSubstitution &subst, ExpressionPtr what);
+    static ExpressionPtr run(core::MutableContext ctx, core::LazyGlobalSubstitution &subst, TreePtr what);
 };
 } // namespace sorbet::ast
 #endif // SORBET_SUBSTITUTE_H

--- a/core/GlobalSubstitution.cc
+++ b/core/GlobalSubstitution.cc
@@ -1,0 +1,43 @@
+#include "core/GlobalSubstitution.h"
+#include "core/GlobalState.h"
+#include "core/Names.h"
+using namespace std;
+namespace sorbet::core {
+
+LazyGlobalSubstitution::LazyGlobalSubstitution(const GlobalState &fromGS, GlobalState &toGS)
+    : fromGS(fromGS), toGS(toGS) {
+    // Pre-define an entry for the empty name.
+    nameSubstitution[core::NameRef()] = core::NameRef();
+};
+
+NameRef LazyGlobalSubstitution::defineName(NameRef from, bool allowSameFromTo) {
+    // Avoid failures in debug builds.
+    from = allowSameFromTo ? core::NameRef::fromRaw(fromGS, from.rawId()) : from;
+    NameRef to;
+    switch (from.kind()) {
+        case NameKind::UNIQUE: {
+            auto unique = from.dataUnique(fromGS);
+            to = this->toGS.freshNameUnique(unique->uniqueNameKind, substitute(unique->original), unique->num);
+            break;
+        }
+        case NameKind::UTF8: {
+            auto utf8 = from.dataUtf8(fromGS);
+            to = this->toGS.enterNameUTF8(utf8->utf8);
+            break;
+        }
+        case NameKind::CONSTANT: {
+            auto constant = from.dataCnst(fromGS);
+            to = this->toGS.enterNameConstant(substitute(constant->original));
+            break;
+        }
+    }
+    nameSubstitution[from] = to;
+    return to;
+}
+
+core::UsageHash LazyGlobalSubstitution::getAllNames() {
+    core::NameHash::sortAndDedupe(acc.sends);
+    core::NameHash::sortAndDedupe(acc.constants);
+    return move(acc);
+}
+} // namespace sorbet::core

--- a/core/GlobalSubstitution.cc
+++ b/core/GlobalSubstitution.cc
@@ -11,6 +11,8 @@ LazyGlobalSubstitution::LazyGlobalSubstitution(const GlobalState &fromGS, Global
 };
 
 NameRef LazyGlobalSubstitution::defineName(NameRef from, bool allowSameFromTo) {
+    ENFORCE_NO_TIMER(&fromGS != &toGS);
+
     // Avoid failures in debug builds.
     from = allowSameFromTo ? core::NameRef::fromRaw(fromGS, from.rawId()) : from;
     NameRef to;

--- a/core/GlobalSubstitution.h
+++ b/core/GlobalSubstitution.h
@@ -60,7 +60,9 @@ private:
 };
 
 /**
- * GlobalSubstitution, but lazily populates `nameSubstitution`.
+ * GlobalSubstitution, but lazily populates `nameSubstitution` _and_ builds up a UsageHash for the file.
+ * Used in the hashing package as a part of the AST hashing process, which rewrites ASTs from the main GlobalState into
+ * ASTs for new and empty GlobalStates.
  */
 class LazyGlobalSubstitution final {
     const core::GlobalState &fromGS;

--- a/core/GlobalSubstitution.h
+++ b/core/GlobalSubstitution.h
@@ -76,6 +76,10 @@ public:
     ~LazyGlobalSubstitution() = default;
 
     NameRef substitute(NameRef from, bool allowSameFromTo = false) {
+        if (&fromGS == &toGS) {
+            return from;
+        }
+
         auto it = nameSubstitution.find(from);
         if (it == nameSubstitution.end()) {
             return defineName(from, allowSameFromTo);

--- a/core/GlobalSubstitution.h
+++ b/core/GlobalSubstitution.h
@@ -37,7 +37,7 @@ public:
         }
     }
 
-    NameRef substituteConstant(NameRef from, bool allowSameFromTo = false) const {
+    NameRef substituteSymbolName(NameRef from, bool allowSameFromTo = false) const {
         return substitute(from, allowSameFromTo);
     }
 
@@ -89,7 +89,7 @@ public:
         return it->second;
     }
 
-    NameRef substituteConstant(NameRef from, bool allowSameFromTo = false) {
+    NameRef substituteSymbolName(NameRef from, bool allowSameFromTo = false) {
         acc.constants.emplace_back(fromGS, from);
         return substitute(from, allowSameFromTo);
     }

--- a/core/GlobalSubstitution.h
+++ b/core/GlobalSubstitution.h
@@ -10,6 +10,13 @@
 namespace sorbet::core {
 class GlobalState;
 
+/**
+ * With the ast::substitute pass, GlobalSubstitution makes it possible to rewrite ASTs from one GlobalState into ASTs
+ * from a second GlobalState.
+ *
+ * The constructor builds up a lookup table from every NameRef in `from` to an equivalent NameRef in `to`, inserting new
+ * names into `to` where needed. Then, that table can be used to rewrite multiple ASTs from `from`.
+ */
 class GlobalSubstitution {
 public:
     GlobalSubstitution(const GlobalState &from, GlobalState &to, const GlobalState *optionalCommonParent = nullptr);
@@ -63,6 +70,10 @@ private:
  * GlobalSubstitution, but lazily populates `nameSubstitution` _and_ builds up a UsageHash for the file.
  * Used in the hashing package as a part of the AST hashing process, which rewrites ASTs from the main GlobalState into
  * ASTs for new and empty GlobalStates.
+ *
+ * Unlike the GlobalSubstitution case, LazyGlobalSubstitution is intended to be used for rewriting a single AST. Hence,
+ * the `nameSubstitution` map is sparse and built up lazily, since a single AST will only reference a small subset of
+ * names in GlobalState.
  */
 class LazyGlobalSubstitution final {
     const core::GlobalState &fromGS;

--- a/hashing/BUILD
+++ b/hashing/BUILD
@@ -10,6 +10,7 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
+        "//ast/substitute",
         "//ast/treemap",
         "//common/concurrency",
         "//core",
@@ -30,6 +31,7 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
+        "//ast/substitute",
         "//ast/treemap",
         "//common/concurrency",
         "//core",

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -127,7 +127,7 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::Glob
     ENFORCE_NO_TIMER(asts.size() == files.size());
 
     // In parallel, rewrite ASTs to an empty GlobalState and use them for hashing.
-    shared_ptr<ConcurrentBoundedQueue<size_t>> fileq = make_shared<ConcurrentBoundedQueue<size_t>>(asts.size());
+    auto fileq = make_shared<ConcurrentBoundedQueue<size_t>>(asts.size());
     for (size_t i = 0; i < asts.size(); i++) {
         auto copy = i;
         fileq->push(move(copy), 1);

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -138,7 +138,7 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::Glob
     logger.debug("Computing state hashes for {} files", asts.size());
 
     const core::GlobalState &sharedGs = *gs;
-    shared_ptr<BlockingBoundedQueue<vector<pair<size_t, unique_ptr<const core::FileHash>>>>> resultq =
+    auto resultq =
         make_shared<BlockingBoundedQueue<vector<pair<size_t, unique_ptr<const core::FileHash>>>>>(asts.size());
     Timer timeit(logger, "computeFileHashes");
     workers.multiplexJob("lspStateHash", [fileq, resultq, &asts, &sharedGs, &logger]() {

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -206,6 +206,12 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
     // Ensure all files have hashes.
     computeFileHashes(edit.updates);
 
+    // TODO(jvilk): Use the new hashing package's new index and hash functionality here to avoid reparsing files twice.
+    // The challenge here is to update `canTakeFastPath` to take old hashes as an argument, since:
+    // - We need the _old_ and _new_ hashes to run `canTakeFastPath`
+    // - `canTakeFastPath` grabs the old hashes out of GlobalState
+    // - But the index and hash functionality updates the file hashes inside GlobalState.
+    // We can probably generalize the 'containsPendingTypecheckUpdate' parameter for this purpose.
     update.updatedFiles = move(edit.updates);
     update.canTakeFastPath = canTakeFastPath(update, /* containsPendingTypecheckUpdate */ false);
     update.cancellationExpected = edit.sorbetCancellationExpected;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -524,6 +524,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                cxxopts::value<string>()->default_value(empty.metricsRepo), "repo");
     options.add_options("dev")("metrics-extra-tags", "Extra tags to report, comma separated",
                                cxxopts::value<string>()->default_value(""), "key1=value1,key2=value2");
+    options.add_options("dev")(
+        "force-hashing", "Forces Sorbet to calculate file hashes when run from CLI. Useful for profiling purposes.");
 
     for (auto &provider : semanticExtensionProviders) {
         provider->injectOptions(options);
@@ -813,6 +815,7 @@ void readOptions(Options &opts,
         opts.noStdlib = raw["no-stdlib"].as<bool>();
         opts.stdoutHUPHack = raw["stdout-hup-hack"].as<bool>();
         opts.storeState = raw["store-state"].as<string>();
+        opts.forceHashing = raw["force-hashing"].as<bool>();
 
         opts.threads = (opts.runLSP || !opts.storeState.empty())
                            ? raw["max-threads"].as<int>()

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -145,6 +145,7 @@ struct Options {
     bool waitForDebugger = false;
     bool skipRewriterPasses = false;
     bool censorForSnapshotTests = false;
+    bool forceHashing = false;
     int threads = 0;
     int logLevel = 0; // number of time -v was passed
     int autogenVersion = 0;

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -80,4 +80,5 @@ TEST_CASE("DefaultConstructorMatchesReadOptions") {
     CHECK_EQ(empty.webTraceFile, opts.webTraceFile);
     CHECK_EQ(empty.stripeMode, opts.stripeMode);
     CHECK_EQ(empty.stripePackages, opts.stripePackages);
+    CHECK_EQ(empty.forceHashing, opts.forceHashing);
 }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -539,7 +539,7 @@ int realmain(int argc, char *argv[]) {
         }
 
         {
-            if (!opts.storeState.empty()) {
+            if (!opts.storeState.empty() || opts.forceHashing) {
                 // Calculate file hashes alongside indexing when --store-state is specified for LSP mode
                 indexed = hashing::Hashing::indexAndComputeFileHashes(gs, opts, *logger, inputFiles, *workers, kvstore);
             } else {

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -261,5 +261,7 @@ Usage:
       --metrics-extra-tags key1=value1,key2=value2
                                 Extra tags to report, comma separated
                                 (default: "")
+      --force-hashing           Forces Sorbet to calculate file hashes when
+                                run from CLI. Useful for profiling purposes.
 
 --------------------------------------------------------------------------


### PR DESCRIPTION
Faster cold cache LSP startup by re-using ASTs for hashing. Hashing is now ~44% faster. That does not mean cold cache startup is 44% faster, as hashing only forms one part of startup. I'm seeing ~15% improvements end-to-end. I have additional plans to make startup time faster.

The speed improvements come from:
* Files are only parsed _once_ at startup. The AST from pipeline::index is rewritten into an AST for an empty GlobalState which can be used for hashing purposes.
* The pass that rewrites the AST does double duty and collects sends and constant references (core::UsageHash), which removes the need for an extra full AST pass.

The main change involved adding a second type of `ast::substitute` pass that supports lazily adding new names to a GlobalState. (The existing pass is designed to re-use a lookup table constructed for all names in a GlobalState for many passes, whereas the lazy pass only cares about the subset of names in one particular AST.)

Measurements show that:
* Hashing the entire project is ~44% faster than before because the cost of the new logic is a small fraction of the cost of reparsing each file. On larger projects, that translates into substantial cold cache startup improvements.
  * With that said, cold cache startup is still appreciably slow; we haven't won yet!
* The new substitute pass is 70% slower than just copying an AST. That is, it's relatively cheap.

The new hashing procedure is not yet used once the LSP server is online. That is, edits by the user still incur two parses. That change is slightly riskier; I dropped a comment explaining why. I plan to tackle that change in the next PR.

In addition to the optimizations, I have added a new CLI parameter called `--force-hashing` that causes sorbet to run hashing over the codebase when run from the CLI. There is no reason why a user would ever need to use this option, but it will make it much easier for me to profile the hashing code.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
