### PR TITLE
Switch to sorbet/bazel-toolchain for clang

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,6 +4,10 @@ load("//third_party:externals.bzl", "register_sorbet_dependencies")
 
 register_sorbet_dependencies()
 
+load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+
+bazel_toolchain_dependencies()
+
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
 llvm_toolchain(

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -145,13 +145,12 @@ package(default_visibility = ["//visibility:public"])
         strip_prefix = "bazel-compilation-database-0ae6349c52700f060c9a87c5ed2b04b75f94a26f",
     )
 
-    # NOTE: using this branch:
-    # https://github.com/DarkDimius/bazel-toolchain/tree/dp-srb-now
+    # NOTE: we use the sorbet branch for development to keep our changes rebasable on grailio/bazel-toolchain
     http_archive(
         name = "com_grail_bazel_toolchain",
-        urls = _github_public_urls("DarkDimius/bazel-toolchain/archive/00214e00edc69982d9236782d5d0e4847eaf8827.zip"),
-        sha256 = "d7c8f74886e59ea407bfb5a53c4d9e6cc66976c2c3dd7ec788825f9f79462949",
-        strip_prefix = "bazel-toolchain-00214e00edc69982d9236782d5d0e4847eaf8827",
+        urls = _github_public_urls("sorbet/bazel-toolchain/archive/da7bda80fd801fab782f5638e09d3d03ff035a68.zip"),
+        sha256 = "ac81c959a4d3880c14d38ff26db0166e4df425b1e356b92c739f60f2e766c6f4",
+        strip_prefix = "bazel-toolchain-da7bda80fd801fab782f5638e09d3d03ff035a68",
     )
 
     http_archive(

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -148,9 +148,9 @@ package(default_visibility = ["//visibility:public"])
     # NOTE: we use the sorbet branch for development to keep our changes rebasable on grailio/bazel-toolchain
     http_archive(
         name = "com_grail_bazel_toolchain",
-        urls = _github_public_urls("sorbet/bazel-toolchain/archive/da7bda80fd801fab782f5638e09d3d03ff035a68.zip"),
-        sha256 = "ac81c959a4d3880c14d38ff26db0166e4df425b1e356b92c739f60f2e766c6f4",
-        strip_prefix = "bazel-toolchain-da7bda80fd801fab782f5638e09d3d03ff035a68",
+        urls = _github_public_urls("sorbet/bazel-toolchain/archive/93c64ca0cda13752e7644b01a2534a7c82e366ab.zip"),
+        sha256 = "d01e4e1606ca41b4279019293fc7b1fa724b905bcd71ca254c6e023d7e229f18",
+        strip_prefix = "bazel-toolchain-93c64ca0cda13752e7644b01a2534a7c82e366ab",
     )
 
     http_archive(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Take two of #3945 after sorting out static linking issues on OSX.

Our [fork](https://github.com/DarkDimius/bazel-toolchain) of [grailio/bazel-toolchain](https://github.com/grailbio/bazel-toolchain) has diverged pretty substantially. This PR re-applies our changes to a fresh fork, and moves that fork to [sorbet/bazel-toolchain](https://github.com/sorbet/bazel-toolchain).

The new commits in sorbet/bazel-toolchain are:

* https://github.com/sorbet/bazel-toolchain/commit/ff5d0a7123bdbfb6186de57f46e478685fb55980 to support multiple mirrror_base values (`llvm_mirror_prefixes` in WORKSPACE)
* https://github.com/sorbet/bazel-toolchain/commit/ac975538acfea274ec8ae4f072e7dcb182a7fe36 and https://github.com/sorbet/bazel-toolchain/commit/da7bda80fd801fab782f5638e09d3d03ff035a68 to support static linking libc++ and libc++abi on OSX
* https://github.com/sorbet/bazel-toolchain/commit/567ba00e632e3c334ac1e2148f736b1d41752e23 to change the `--hash-style` to `both` when linking on linux

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This will make it easier for us to keep our changes rebased on top of the grailio toolchain, and ease upgrading to newer versions of clang.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

CI has passed on linux, and I have run a full build and test locally. I verified that we're still linking libc++ and libc++abi statically on osx by running `otool -L` on the binary produced by `bazel build //main:sorbet`.
