### PR TITLE
Switch to sorbet/bazel-toolchain for clang

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -26,7 +26,7 @@ steps:
 
   - label: ":mac: test-static-sanitized.sh (master only)"
     command: .buildkite/test-static-sanitized.sh
-    branches: "master"
+    #branches: "master"
     artifact_paths: _out_/profile.json
     agents:
       os: mac
@@ -57,7 +57,7 @@ steps:
 
   - label: ":mac: build-static-release.sh (master only)"
     command: .buildkite/build-static-release.sh
-    branches: master
+    #branches: master
     artifact_paths: _out_/**/*
     agents:
       os: mac
@@ -81,7 +81,7 @@ steps:
     command: .buildkite/build-static-release-java.sh
     # this needs to be run when both linux & mac build-static-release
     # are done. at the moment, mac is only done on master branch
-    branches: master
+    #branches: master
     artifact_paths: _out_/**/*
     <<: *elastic
   - wait: ~

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -26,7 +26,7 @@ steps:
 
   - label: ":mac: test-static-sanitized.sh (master only)"
     command: .buildkite/test-static-sanitized.sh
-    #branches: "master"
+    branches: "master"
     artifact_paths: _out_/profile.json
     agents:
       os: mac
@@ -57,7 +57,7 @@ steps:
 
   - label: ":mac: build-static-release.sh (master only)"
     command: .buildkite/build-static-release.sh
-    #branches: master
+    branches: master
     artifact_paths: _out_/**/*
     agents:
       os: mac
@@ -81,7 +81,7 @@ steps:
     command: .buildkite/build-static-release-java.sh
     # this needs to be run when both linux & mac build-static-release
     # are done. at the moment, mac is only done on master branch
-    #branches: master
+    branches: master
     artifact_paths: _out_/**/*
     <<: *elastic
   - wait: ~

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,6 +4,10 @@ load("//third_party:externals.bzl", "register_sorbet_dependencies")
 
 register_sorbet_dependencies()
 
+load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+
+bazel_toolchain_dependencies()
+
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
 llvm_toolchain(

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -145,13 +145,12 @@ package(default_visibility = ["//visibility:public"])
         strip_prefix = "bazel-compilation-database-0ae6349c52700f060c9a87c5ed2b04b75f94a26f",
     )
 
-    # NOTE: using this branch:
-    # https://github.com/DarkDimius/bazel-toolchain/tree/dp-srb-now
+    # NOTE: we use the sorbet branch for development to keep our changes rebasable on grailio/bazel-toolchain
     http_archive(
         name = "com_grail_bazel_toolchain",
-        urls = _github_public_urls("DarkDimius/bazel-toolchain/archive/00214e00edc69982d9236782d5d0e4847eaf8827.zip"),
-        sha256 = "d7c8f74886e59ea407bfb5a53c4d9e6cc66976c2c3dd7ec788825f9f79462949",
-        strip_prefix = "bazel-toolchain-00214e00edc69982d9236782d5d0e4847eaf8827",
+        urls = _github_public_urls("sorbet/bazel-toolchain/archive/fd264c7296bfbb3375a1c0a6cbe64e2a90b8c807.zip"),
+        sha256 = "6736a188d0ea436e069c4a7e028da1ac08c65ae1c9723a76a49d51ef2aafb328",
+        strip_prefix = "bazel-toolchain-fd264c7296bfbb3375a1c0a6cbe64e2a90b8c807",
     )
 
     http_archive(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Take three of #3945 after sorting out static linking issues on OSX for sanitized and release builds.

Our [fork](https://github.com/DarkDimius/bazel-toolchain) of [grailio/bazel-toolchain](https://github.com/grailbio/bazel-toolchain) has diverged pretty substantially. This PR re-applies our changes to a fresh fork, and moves that fork to [sorbet/bazel-toolchain](https://github.com/sorbet/bazel-toolchain).

The new commits in sorbet/bazel-toolchain are:

* https://github.com/sorbet/bazel-toolchain/commit/ff5d0a7123bdbfb6186de57f46e478685fb55980 to support multiple mirrror_base values (`llvm_mirror_prefixes` in WORKSPACE)
* https://github.com/sorbet/bazel-toolchain/commit/919fdf95d068652f443c0bf0ccae8b6507840611 to change the `--hash-style` to `both` when linking on linux
* https://github.com/sorbet/bazel-toolchain/commit/fd264c7296bfbb3375a1c0a6cbe64e2a90b8c807 to support static linking libc++ and libc++abi on OSX


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This will make it easier for us to keep our changes rebased on top of the grailio toolchain, and ease upgrading to newer versions of clang.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

* [x] CI passes for linux and master-only OSX jobs
  * https://buildkite.com/sorbet/sorbet/builds/14587
* [x] `otool -L bazel-bin/main/sorbet` shows no references to system `libc++` or `libc++abi` with `--config=static-libs`
