### PR TITLE
Rename UsageHash::constants to symbolNames.

### DIFF
--- a/core/GlobalSubstitution.cc
+++ b/core/GlobalSubstitution.cc
@@ -39,7 +39,7 @@ NameRef LazyGlobalSubstitution::defineName(NameRef from, bool allowSameFromTo) {
 
 core::UsageHash LazyGlobalSubstitution::getAllNames() {
     core::NameHash::sortAndDedupe(acc.sends);
-    core::NameHash::sortAndDedupe(acc.constants);
+    core::NameHash::sortAndDedupe(acc.symbolNames);
     return move(acc);
 }
 } // namespace sorbet::core

--- a/core/GlobalSubstitution.cc
+++ b/core/GlobalSubstitution.cc
@@ -39,7 +39,7 @@ NameRef LazyGlobalSubstitution::defineName(NameRef from, bool allowSameFromTo) {
 
 core::UsageHash LazyGlobalSubstitution::getAllNames() {
     core::NameHash::sortAndDedupe(acc.sends);
-    core::NameHash::sortAndDedupe(acc.symbolNames);
+    core::NameHash::sortAndDedupe(acc.symbols);
     return move(acc);
 }
 } // namespace sorbet::core

--- a/core/GlobalSubstitution.h
+++ b/core/GlobalSubstitution.h
@@ -101,7 +101,7 @@ public:
     }
 
     NameRef substituteSymbolName(NameRef from, bool allowSameFromTo = false) {
-        acc.symbolNames.emplace_back(fromGS, from);
+        acc.symbols.emplace_back(fromGS, from);
         return substitute(from, allowSameFromTo);
     }
 

--- a/core/GlobalSubstitution.h
+++ b/core/GlobalSubstitution.h
@@ -101,7 +101,7 @@ public:
     }
 
     NameRef substituteSymbolName(NameRef from, bool allowSameFromTo = false) {
-        acc.constants.emplace_back(fromGS, from);
+        acc.symbolNames.emplace_back(fromGS, from);
         return substitute(from, allowSameFromTo);
     }
 

--- a/core/NameHash.h
+++ b/core/NameHash.h
@@ -47,7 +47,7 @@ struct GlobalStateHash {
 
 struct UsageHash {
     std::vector<core::NameHash> sends;
-    std::vector<core::NameHash> constants;
+    std::vector<core::NameHash> symbolNames;
 };
 
 struct FileHash {

--- a/core/NameHash.h
+++ b/core/NameHash.h
@@ -47,7 +47,7 @@ struct GlobalStateHash {
 
 struct UsageHash {
     std::vector<core::NameHash> sends;
-    std::vector<core::NameHash> symbolNames;
+    std::vector<core::NameHash> symbols;
 };
 
 struct FileHash {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -241,8 +241,8 @@ void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
         p.putU4(key._hashValue);
         p.putU4(value);
     }
-    p.putU4(fh->usages.symbolNames.size());
-    for (const auto &e : fh->usages.symbolNames) {
+    p.putU4(fh->usages.symbols.size());
+    for (const auto &e : fh->usages.symbols) {
         p.putU4(e._hashValue);
     }
     p.putU4(fh->usages.sends.size());
@@ -267,11 +267,11 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
         ret.definitions.methodHashes.emplace_back(key, p.getU4());
     }
     auto constantsSize = p.getU4();
-    ret.usages.symbolNames.reserve(constantsSize);
+    ret.usages.symbols.reserve(constantsSize);
     for (int it = 0; it < constantsSize; it++) {
         NameHash key;
         key._hashValue = p.getU4();
-        ret.usages.symbolNames.emplace_back(key);
+        ret.usages.symbols.emplace_back(key);
     }
     auto sendsSize = p.getU4();
     ret.usages.sends.reserve(sendsSize);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -241,8 +241,8 @@ void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
         p.putU4(key._hashValue);
         p.putU4(value);
     }
-    p.putU4(fh->usages.constants.size());
-    for (const auto &e : fh->usages.constants) {
+    p.putU4(fh->usages.symbolNames.size());
+    for (const auto &e : fh->usages.symbolNames) {
         p.putU4(e._hashValue);
     }
     p.putU4(fh->usages.sends.size());
@@ -267,11 +267,11 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
         ret.definitions.methodHashes.emplace_back(key, p.getU4());
     }
     auto constantsSize = p.getU4();
-    ret.usages.constants.reserve(constantsSize);
+    ret.usages.symbolNames.reserve(constantsSize);
     for (int it = 0; it < constantsSize; it++) {
         NameHash key;
         key._hashValue = p.getU4();
-        ret.usages.constants.emplace_back(key);
+        ret.usages.symbolNames.emplace_back(key);
     }
     auto sendsSize = p.getU4();
     ret.usages.sends.reserve(sendsSize);

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -168,14 +168,14 @@ LSPQueryResult LSPTask::queryBySymbol(LSPTypecheckerDelegate &typechecker, core:
         ENFORCE(file->getFileHash() != nullptr);
         const auto &hash = *file->getFileHash();
         const auto &usedSends = hash.usages.sends;
-        const auto &usedConstants = hash.usages.constants;
+        const auto &usedSymbolNames = hash.usages.symbolNames;
         auto ref = core::FileRef(i);
 
         const bool fileIsValid = ref.exists() && (ref.data(gs).sourceType == core::File::Type::Normal ||
                                                   ref.data(gs).sourceType == core::File::Type::Package);
         if (fileIsValid &&
             (std::find(usedSends.begin(), usedSends.end(), symNameHash) != usedSends.end() ||
-             std::find(usedConstants.begin(), usedConstants.end(), symNameHash) != usedConstants.end())) {
+             std::find(usedSymbolNames.begin(), usedSymbolNames.end(), symNameHash) != usedSymbolNames.end())) {
             frefs.emplace_back(ref);
         }
     }

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -168,7 +168,7 @@ LSPQueryResult LSPTask::queryBySymbol(LSPTypecheckerDelegate &typechecker, core:
         ENFORCE(file->getFileHash() != nullptr);
         const auto &hash = *file->getFileHash();
         const auto &usedSends = hash.usages.sends;
-        const auto &usedSymbolNames = hash.usages.symbolNames;
+        const auto &usedSymbolNames = hash.usages.symbols;
         auto ref = core::FileRef(i);
 
         const bool fileIsValid = ref.exists() && (ref.data(gs).sourceType == core::File::Type::Normal ||


### PR DESCRIPTION
Rename UsageHash::constants to symbolNames.

We put _all_ symbol names here, not just constants.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Follow-up from https://github.com/sorbet/sorbet/pull/3946

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavior change.
