### PR TITLE
Correctly report errors on undefined method for T.any

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -46,6 +46,16 @@ DispatchResult OrType::dispatchCall(const GlobalState &gs, const DispatchArgs &a
     categoryCounterInc("dispatch_call", "ortype");
     auto leftRet = left.dispatchCall(gs, args.withSelfRef(left));
     auto rightRet = right.dispatchCall(gs, args.withSelfRef(right));
+
+    auto leftOk = leftRet.main.method.exists();
+    auto rightOk = rightRet.main.method.exists();
+    // If only one side is missing the method, dispatch to that one to force an error
+    if (!leftOk && rightOk) {
+        return leftRet;
+    } else if (leftOk && !rightOk) {
+        return rightRet;
+    }
+
     DispatchResult ret{Types::any(gs, leftRet.returnType, rightRet.returnType), move(leftRet.main),
                        make_unique<DispatchResult>(move(rightRet)), DispatchResult::Combinator::OR};
     return ret;

--- a/test/testdata/infer/any_undefined_method.rb
+++ b/test/testdata/infer/any_undefined_method.rb
@@ -1,0 +1,40 @@
+# typed: true
+
+extend T::Sig
+
+class A
+  def foo; true; end
+end
+
+class B; end
+
+class C; end
+
+class D
+  def foo; true; end
+end
+
+sig {params(x: T.any(B, A, D)).returns(T::Boolean)}
+def bar_beginning(x)
+  x.foo
+# ^^^^^ error: Method `foo` does not exist on `B` component of `T.any(B, A, D)`
+end
+
+sig {params(x: T.any(A, B, D)).returns(T::Boolean)}
+def bar_middle(x)
+  x.foo
+# ^^^^^ error: Method `foo` does not exist on `B` component of `T.any(A, B, D)`
+end
+
+sig {params(x: T.any(A, D, B)).returns(T::Boolean)}
+def bar_end(x)
+  x.foo
+# ^^^^^ error: Method `foo` does not exist on `B` component of `T.any(A, D, B)`
+end
+
+sig {params(x: T.any(A, B, C, D)).returns(T::Boolean)}
+def bar_more_than_one(x)
+  x.foo
+# ^^^^^ error: Method `foo` does not exist on `B` component of `T.any(A, B, C, D)`
+# ^^^^^ error: Method `foo` does not exist on `C` component of `T.any(A, B, C, D)`
+end


### PR DESCRIPTION
Make sure that  we bubble up errors from undefined methods when dispatching a call to a `T.any` type.

Before this change, if the undefined method was on the  right-hand-side of a dispatching that  was not the last of the chain, it would be ignored.

### Motivation
Fixes #2373
Fixes #2813
Fixes #3910

### Test plan
- Added test cases in `test/testdata/infer/any_undefined_method.rb`
- Existing tests in `test/testdata/lsp/completion/union.rb`