### PR TITLE
Add LSP support for returning a useful definition for require_relative arguments

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -370,6 +370,7 @@ NameDef names[] = {
     {"staticInit", "<static-init>"},
 
     {"require"},
+    {"require_relative"},
     {"callWithSplat", "<call-with-splat>"},
     {"callWithBlock", "<call-with-block>"},
     {"callWithSplatAndBlock", "<call-with-splat-and-block>"},

--- a/main/lsp/requests/definition.h
+++ b/main/lsp/requests/definition.h
@@ -7,6 +7,8 @@ namespace sorbet::realmain::lsp {
 class TextDocumentPositionParams;
 class DefinitionTask final : public LSPRequestTask {
     std::unique_ptr<TextDocumentPositionParams> params;
+    core::Loc findRequireRelativeLoc(const core::GlobalState &gs,
+                                     const std::vector<std::unique_ptr<core::lsp::QueryResponse>> &responses);
 
 public:
     DefinitionTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<TextDocumentPositionParams> params);

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -421,6 +421,10 @@ TEST_CASE("LSPTest") {
         // (The first element of the pair is only ever TypeDefAssertions but we only ever care that they're
         // RangeAssertions, so rather than fiddle with up casting, we'll just make the whole vector RangeAssertions)
         UnorderedMap<string, pair<vector<shared_ptr<RangeAssertion>>, vector<shared_ptr<TypeAssertion>>>> typeDefMap;
+
+        // FileDefAssertion[]
+        vector<shared_ptr<FileDefAssertion>> fileDefAssertions;
+
         for (auto &assertion : assertions) {
             if (auto defAssertion = dynamic_pointer_cast<DefAssertion>(assertion)) {
                 auto &entry = defUsageMap[defAssertion->symbol];
@@ -441,6 +445,8 @@ TEST_CASE("LSPTest") {
             } else if (auto typeAssertion = dynamic_pointer_cast<TypeAssertion>(assertion)) {
                 auto &[_typeDefs, typeAssertions] = typeDefMap[typeAssertion->symbol];
                 typeAssertions.emplace_back(typeAssertion);
+            } else if (auto fileDefAssertion = dynamic_pointer_cast<FileDefAssertion>(assertion)) {
+                fileDefAssertions.emplace_back(fileDefAssertion);
             }
         }
 
@@ -473,7 +479,7 @@ TEST_CASE("LSPTest") {
                     symbol = usageAssertion->symbol;
                 }
 
-                vector<shared_ptr<DefAssertion>> defs;
+                vector<shared_ptr<BaseDefAssertion>> defs;
                 for (auto version : versions) {
                     auto entry = defAssertions.find(version);
                     if (entry != defAssertions.end()) {
@@ -498,7 +504,7 @@ TEST_CASE("LSPTest") {
 
                 auto queryLoc = assertion->getLocation(config);
                 // Check that a definition request at this location returns defs.
-                DefAssertion::check(test.sourceFileContents, *lspWrapper, nextId, *queryLoc, defs);
+                BaseDefAssertion::check(test.sourceFileContents, *lspWrapper, nextId, *queryLoc, defs);
                 // Check that a reference request at this location returns entryAssertions.
                 UsageAssertion::check(test.sourceFileContents, *lspWrapper, nextId, symbol, *queryLoc, entryAssertions);
                 // Check that a highlight request at this location returns all of the entryAssertions for the same
@@ -522,6 +528,14 @@ TEST_CASE("LSPTest") {
                 // Check that a type definition request at this location returns type-def.
                 TypeDefAssertion::check(test.sourceFileContents, *lspWrapper, nextId, symbol, *queryLoc, typeDefs);
             }
+        }
+
+        // Check file-def point to the right place
+        for (auto &fileDefAssertion : fileDefAssertions) {
+            // Where the request originates from
+            auto queryLoc = fileDefAssertion->getLocation(config);
+            // Check that a definition request lead to the location specified in the assertion
+            BaseDefAssertion::check(test.sourceFileContents, *lspWrapper, nextId, *queryLoc, {fileDefAssertion});
         }
     }
 

--- a/test/testdata/lsp/go_to_definition_require_relative.rb
+++ b/test/testdata/lsp/go_to_definition_require_relative.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+require_relative 'go_to_definition_require_relative__target'
+#                      ^ file-def: go_to_definition_require_relative__target.rb 0 0

--- a/test/testdata/lsp/go_to_definition_require_relative__target.rb
+++ b/test/testdata/lsp/go_to_definition_require_relative__target.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+class Target; end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
When detecting that a definition request is made against the pseudo-file path given to a `require_relative` the code will now simply construct a response linking to the relevant file.

![2021-02-01 17-13-44 2021-02-01 17_16_46](https://user-images.githubusercontent.com/104105/106524990-4c7a3b00-64b1-11eb-8032-8c924b547130.gif)


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Previously trying to navigate on the argument of `require_relative` would simply redirect to itself. This is not consistent with other languages behavior (like C/C++) which allows following relative includes for instance.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
