### PR TITLE
Bump the sorbet/bazel-toolchain dependency

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -148,9 +148,9 @@ package(default_visibility = ["//visibility:public"])
     # NOTE: we use the sorbet branch for development to keep our changes rebasable on grailio/bazel-toolchain
     http_archive(
         name = "com_grail_bazel_toolchain",
-        urls = _github_public_urls("sorbet/bazel-toolchain/archive/fd264c7296bfbb3375a1c0a6cbe64e2a90b8c807.zip"),
-        sha256 = "6736a188d0ea436e069c4a7e028da1ac08c65ae1c9723a76a49d51ef2aafb328",
-        strip_prefix = "bazel-toolchain-fd264c7296bfbb3375a1c0a6cbe64e2a90b8c807",
+        urls = _github_public_urls("sorbet/bazel-toolchain/archive/ff9ded642e9d8eb2a329f59adcaa3fa5bdb3249c.zip"),
+        sha256 = "a99293bea4549e3ddd1cc0a3307822c719c5ef482707d192be2060051d4505b3",
+        strip_prefix = "bazel-toolchain-ff9ded642e9d8eb2a329f59adcaa3fa5bdb3249c",
     )
 
     http_archive(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Bump the dependency on https://github.com/sorbet/bazel-toolchain to include a [fix to url construction](https://github.com/sorbet/bazel-toolchain/commit/c24dca5952d6d7a3dadbb98f219573a887c109f0). Re-forking and applying our changes to master lost a change to the url construction to stop putting a `/` between the mirror base and url suffix. We rely on this internally for artifactory mirroring.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fix the build in stripe.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I logged the urls that were being constructed, and inspected that the artifactory one is correct now.