### PR TITLE
Fix hashing bug in indexAndComputeFileHashes + small code cleanups

### DIFF
--- a/core/NameHash.cc
+++ b/core/NameHash.cc
@@ -16,4 +16,7 @@ void NameHash::sortAndDedupe(std::vector<core::NameHash> &hashes) {
     hashes.resize(std::distance(hashes.begin(), std::unique(hashes.begin(), hashes.end())));
 }
 
+FileHash::FileHash(GlobalStateHash &&definitions, UsageHash &&usages)
+    : definitions(move(definitions)), usages(move(usages)) {}
+
 } // namespace sorbet::core

--- a/core/NameHash.h
+++ b/core/NameHash.h
@@ -53,6 +53,9 @@ struct UsageHash {
 struct FileHash {
     GlobalStateHash definitions;
     UsageHash usages;
+
+    FileHash() = default;
+    FileHash(GlobalStateHash &&definitions, UsageHash &&usages);
 };
 
 }; // namespace sorbet::core

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -28,8 +28,8 @@ pair<ast::ParsedFile, core::UsageHash> rewriteAST(const core::GlobalState &origi
     return make_pair<ast::ParsedFile, core::UsageHash>(move(rewritten), subst.getAllNames());
 }
 
-core::FileHash computeFileHashForAST(unique_ptr<core::GlobalState> &lgs, core::UsageHash usageHash,
-                                     ast::ParsedFile file) {
+unique_ptr<core::FileHash> computeFileHashForAST(unique_ptr<core::GlobalState> &lgs, core::UsageHash usageHash,
+                                                 ast::ParsedFile file) {
     vector<ast::ParsedFile> single;
     single.emplace_back(move(file));
 
@@ -37,7 +37,7 @@ core::FileHash computeFileHashForAST(unique_ptr<core::GlobalState> &lgs, core::U
     auto workers = WorkerPool::create(0, lgs->tracer());
     realmain::pipeline::resolve(lgs, move(single), opts(), *workers);
 
-    return {move(*lgs->hash()), move(usageHash)};
+    return make_unique<core::FileHash>(core::FileHash{move(*lgs->hash()), move(usageHash)});
 }
 
 // Note: lgs is an outparameter.
@@ -55,7 +55,7 @@ core::FileRef makeEmptyGlobalStateForFile(spdlog::logger &logger, shared_ptr<cor
     }
 }
 
-core::FileHash computeFileHashForFile(shared_ptr<core::File> forWhat, spdlog::logger &logger) {
+unique_ptr<core::FileHash> computeFileHashForFile(shared_ptr<core::File> forWhat, spdlog::logger &logger) {
     Timer timeit(logger, "computeFileHash");
     unique_ptr<core::GlobalState> lgs;
     core::FileRef fref = makeEmptyGlobalStateForFile(logger, move(forWhat), /* out param */ lgs);
@@ -73,20 +73,20 @@ core::FileHash computeFileHashForFile(shared_ptr<core::File> forWhat, spdlog::lo
 void Hashing::computeFileHashes(const vector<shared_ptr<core::File>> &files, spdlog::logger &logger,
                                 WorkerPool &workers) {
     Timer timeit(logger, "computeFileHashes");
-    shared_ptr<ConcurrentBoundedQueue<int>> fileq = make_shared<ConcurrentBoundedQueue<int>>(files.size());
-    for (int i = 0; i < files.size(); i++) {
+    auto fileq = make_shared<ConcurrentBoundedQueue<size_t>>(files.size());
+    for (size_t i = 0; i < files.size(); i++) {
         auto copy = i;
         fileq->push(move(copy), 1);
     }
 
     logger.debug("Computing state hashes for {} files", files.size());
 
-    shared_ptr<BlockingBoundedQueue<vector<pair<int, unique_ptr<const core::FileHash>>>>> resultq =
-        make_shared<BlockingBoundedQueue<vector<pair<int, unique_ptr<const core::FileHash>>>>>(files.size());
+    auto resultq =
+        make_shared<BlockingBoundedQueue<vector<pair<size_t, unique_ptr<const core::FileHash>>>>>(files.size());
     workers.multiplexJob("lspStateHash", [fileq, resultq, &files, &logger]() {
-        vector<pair<int, unique_ptr<const core::FileHash>>> threadResult;
+        vector<pair<size_t, unique_ptr<const core::FileHash>>> threadResult;
         int processedByThread = 0;
-        int job;
+        size_t job;
         {
             for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
                 if (result.gotItem()) {
@@ -96,8 +96,7 @@ void Hashing::computeFileHashes(const vector<shared_ptr<core::File>> &files, spd
                         continue;
                     }
 
-                    threadResult.emplace_back(job,
-                                              make_unique<core::FileHash>(computeFileHashForFile(files[job], logger)));
+                    threadResult.emplace_back(job, computeFileHashForFile(files[job], logger));
                 }
             }
         }
@@ -108,7 +107,7 @@ void Hashing::computeFileHashes(const vector<shared_ptr<core::File>> &files, spd
     });
 
     {
-        vector<pair<int, unique_ptr<const core::FileHash>>> threadResult;
+        vector<pair<size_t, unique_ptr<const core::FileHash>>> threadResult;
         for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger); !result.done();
              result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
             if (result.gotItem()) {
@@ -164,8 +163,7 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::Glob
                     auto newFref = makeEmptyGlobalStateForFile(logger, sharedGs.getFiles()[ast.file.id()], lgs);
                     auto [rewrittenAST, usageHash] = rewriteAST(sharedGs, *lgs, newFref, ast);
 
-                    threadResult.emplace_back(job, make_unique<core::FileHash>(computeFileHashForAST(
-                                                       lgs, move(usageHash), move(rewrittenAST))));
+                    threadResult.emplace_back(job, computeFileHashForAST(lgs, move(usageHash), move(rewrittenAST)));
                 }
             }
         }

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -37,7 +37,7 @@ unique_ptr<core::FileHash> computeFileHashForAST(unique_ptr<core::GlobalState> &
     auto workers = WorkerPool::create(0, lgs->tracer());
     realmain::pipeline::resolve(lgs, move(single), opts(), *workers);
 
-    return make_unique<core::FileHash>(core::FileHash{move(*lgs->hash()), move(usageHash)});
+    return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash));
 }
 
 // Note: lgs is an outparameter.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fix hashing bug + small code cleanups.

While working on using the new `indexAndComputeFileHashes` routine on the fast path, I uncovered a bug where files were getting the wrong hash. I realized that the cost assumed that the input files and ASTs were in the same order (FileRef order). This _happens to be true_ for all uses of the function now, but is _not true_ on the fast path. That is, this bug is not currently happening in Sorbet.

The fix is simple and cleaner: Use core::FileRef rather than indices to FileRefs for each unit of work.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This change will be covered by LSP tests once I modify the fast path to use this method.
