### PR TITLE
Docs: Clarify that sorbet-runtime only has partial support for generics

### DIFF
--- a/website/docs/stdlib-generics.md
+++ b/website/docs/stdlib-generics.md
@@ -6,7 +6,9 @@ sidebar_label: Arrays & Hashes
 
 > TODO: This page is still a fragment. Contributions welcome!
 
-Sorbet supports generic types. The syntax looks likes `MyClass[Elem]`. For user
+`sorbet-static` supports generic types. (`sorbet-runtime` has partial support, see below) 
+
+The syntax looks likes `MyClass[Elem]`. For user
 defined generic classes, it's possible to make this valid Ruby syntax.
 
 However, it's not possible to change the syntax for classes in the Ruby standard


### PR DESCRIPTION
`sorbet-runtime` only has partial support for generics.

```ruby
require 'sorbet-runtime'
T.let('1', Integer) # TypeError
T.let(['1', '2'], T::Array[Integer]) # No error
```

Should we make this more prominent [in the docs]?
