### PR TITLE
Hash and index at the same time on the fast path.

### DIFF
--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -82,7 +82,8 @@ public:
     }
 
     ExpressionPtr postTransformLocal(core::MutableContext ctx, ExpressionPtr local) {
-        cast_tree<Local>(local)->localVariable._name = subst.substitute(cast_tree<Local>(local)->localVariable._name);
+        cast_tree_nonnull<Local>(local).localVariable._name =
+            subst.substitute(cast_tree_nonnull<Local>(local).localVariable._name);
         return local;
     }
 
@@ -92,9 +93,9 @@ public:
     }
 
     ExpressionPtr postTransformLiteral(core::MutableContext ctx, ExpressionPtr tree) {
-        auto *original = cast_tree<Literal>(tree);
-        if (original->isString(ctx)) {
-            auto nameRef = original->asString(ctx);
+        auto &original = cast_tree_nonnull<Literal>(tree);
+        if (original.isString(ctx)) {
+            auto nameRef = original.asString(ctx);
             // The 'from' and 'to' GlobalState in this substitution will always be the same,
             // because the newly created nameRef reuses our current GlobalState id
             bool allowSameFromTo = true;
@@ -102,10 +103,10 @@ public:
             if (newName == nameRef) {
                 return tree;
             }
-            return MK::String(original->loc, newName);
+            return MK::String(original.loc, newName);
         }
-        if (original->isSymbol(ctx)) {
-            auto nameRef = original->asSymbol(ctx);
+        if (original.isSymbol(ctx)) {
+            auto nameRef = original.asSymbol(ctx);
             // The 'from' and 'to' GlobalState in this substitution will always be the same,
             // because the newly created nameRef reuses our current GlobalState id
             bool allowSameFromTo = true;
@@ -113,15 +114,15 @@ public:
             if (newName == nameRef) {
                 return tree;
             }
-            return MK::Symbol(original->loc, newName);
+            return MK::Symbol(original.loc, newName);
         }
         return tree;
     }
 
     ExpressionPtr postTransformUnresolvedConstantLit(core::MutableContext ctx, ExpressionPtr tree) {
-        auto *original = cast_tree<UnresolvedConstantLit>(tree);
-        original->cnst = subst.substituteSymbolName(original->cnst);
-        original->scope = substClassName(ctx, std::move(original->scope));
+        auto &original = cast_tree_nonnull<UnresolvedConstantLit>(tree);
+        original.cnst = subst.substituteSymbolName(original.cnst);
+        original.scope = substClassName(ctx, std::move(original.scope));
         return tree;
     }
 };


### PR DESCRIPTION
Hash and index at the same time on the fast path.

Also stop using fref.id() in maps.

Also convert a few remaining cast_tree => cast_tree_nonnull.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed improvements. We now only have to parse file changes once when they occur in the common case.

There's one scenario where we may still need to parse files twice: If the slow path is running and we need to check if an edit can preempt. In order to do this, we need to hash the file changes _before_ scheduling them to be commited to LSPIndexer. However, this is an edge case, and the "cost" involved is much much lower than restarting the slow path.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests (which surfaced the bug I fixed in #3955).
