### PR TITLE
Implement a hash function on every Type

### DIFF
--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -186,7 +186,7 @@ public:
 
     bool isValidConstantName(const GlobalState &gs) const;
 
-    unsigned int hash(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
 
     std::string_view shortName(const GlobalState &gs) const;
     std::string showRaw(const GlobalState &gs) const;

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -322,8 +322,6 @@ u4 TypePtr::hash(const GlobalState &gs) const {
 #define HASH(T) return cast_type_nonnull<T>(*this).hash(gs);
     GENERATE_TAG_SWITCH(tag(), HASH)
 #undef HASH
-
-    return _hash(this->toString(gs)); // TODO: make something better
 }
 
 std::string TypePtr::show(const GlobalState &gs) const {

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -318,7 +318,11 @@ string TypePtr::toStringWithTabs(const GlobalState &gs, int tabs) const {
 #undef TO_STRING_WITH_TABS
 }
 
-unsigned int TypePtr::hash(const GlobalState &gs) const {
+u4 TypePtr::hash(const GlobalState &gs) const {
+#define HASH(T) return cast_type_nonnull<T>(*this).hash(gs);
+    GENERATE_TAG_SWITCH(tag(), HASH)
+#undef HASH
+
     return _hash(this->toString(gs)); // TODO: make something better
 }
 

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -318,9 +318,6 @@ public:
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
 
-    // Used in LSP's NameHash to determine the equivalence of types.
-    // Note: Types must not use any properties that are unstable across typechecking runs in this hash. Hashing must be
-    // deterministic.
     u4 hash(const GlobalState &gs) const;
 
     DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -318,7 +318,10 @@ public:
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
 
-    unsigned int hash(const GlobalState &gs) const;
+    // Used in LSP's NameHash to determine the equivalence of types.
+    // Note: Types must not use any properties that are unstable across typechecking runs in this hash. Hashing must be
+    // deterministic.
+    u4 hash(const GlobalState &gs) const;
 
     DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -330,6 +330,7 @@ public:
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
@@ -372,6 +373,7 @@ public:
     LambdaParam(SymbolRef definition, TypePtr lower, TypePtr upper);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
 
@@ -389,6 +391,7 @@ public:
     SelfTypeParam(const SymbolRef definition);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
 
@@ -411,6 +414,7 @@ public:
     AliasType(SymbolRef other);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
 
     const SymbolRef symbol;
@@ -441,6 +445,7 @@ public:
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
     std::string showValue(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
 
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
 
@@ -483,6 +488,7 @@ public:
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
     std::string showValue(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
 
     bool equals(const LiteralType &rhs) const;
     void _sanityCheck(const GlobalState &gs) const;
@@ -551,6 +557,7 @@ public:
     TypeVar(SymbolRef sym);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -567,6 +574,7 @@ public:
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -617,6 +625,7 @@ public:
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
@@ -659,6 +668,7 @@ public:
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
     std::string showWithMoreInfo(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
@@ -683,6 +693,7 @@ public:
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
     std::string showWithMoreInfo(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
@@ -705,6 +716,7 @@ public:
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
@@ -734,6 +746,7 @@ public:
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
 
@@ -879,6 +892,7 @@ public:
         : ClassType(core::Symbols::untyped()), scope(scope), names(names){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
 };
 
 TYPE(UnresolvedAppliedType) final : public ClassType {
@@ -889,6 +903,7 @@ public:
         : ClassType(core::Symbols::untyped()), klass(klass), targs(std::move(targs)){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
+    u4 hash(const GlobalState &gs) const;
 };
 
 } // namespace sorbet::core

--- a/core/types/hashing.cc
+++ b/core/types/hashing.cc
@@ -34,23 +34,23 @@ u4 LiteralType::hash(const GlobalState &gs) const {
     ClassOrModuleRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
     result = mix(result, undSymbol.id());
 
-    // Strings or numbers encode an extra value. True/False are completely represented by the class symbol.
-    // TODO: Casts are bad???
-    if (undSymbol == Symbols::String() || undSymbol == Symbols::Symbol()) {
-        result = mix(result, asName(gs).hash(gs));
-    } else if (undSymbol == Symbols::Integer()) {
-        u8 val = absl::bit_cast<u8>(asInteger());
-        u4 topBits = static_cast<u4>(val >> 32);
-        u4 bottomBits = static_cast<u4>(val & 0xFFFF);
-        result = mix(result, topBits);
-        result = mix(result, bottomBits);
-    } else if (undSymbol == Symbols::Float()) {
-        u8 val = absl::bit_cast<u8>(asFloat());
-        u4 topBits = static_cast<u4>(val >> 32);
-        u4 bottomBits = static_cast<u4>(val & 0xFFFF);
-        result = mix(result, topBits);
-        result = mix(result, bottomBits);
+    u8 rawValue;
+    switch (literalKind) {
+        case LiteralType::LiteralTypeKind::String:
+        case LiteralType::LiteralTypeKind::Symbol:
+            return mix(result, asName(gs).hash(gs));
+        case LiteralType::LiteralTypeKind::Float:
+            rawValue = absl::bit_cast<u8>(asFloat());
+            break;
+        case LiteralType::LiteralTypeKind::Integer:
+            rawValue = absl::bit_cast<u8>(asInteger());
+            break;
     }
+
+    u4 topBits = static_cast<u4>(rawValue >> 32);
+    u4 bottomBits = static_cast<u4>(rawValue & 0xFFFFFFFF);
+    result = mix(result, topBits);
+    result = mix(result, bottomBits);
     return result;
 }
 

--- a/core/types/hashing.cc
+++ b/core/types/hashing.cc
@@ -1,0 +1,128 @@
+#include "core/Hashing.h"
+#include "core/SymbolRef.h"
+#include "core/Types.h"
+
+using namespace std;
+
+namespace sorbet::core {
+u4 ClassType::hash(const GlobalState &gs) const {
+    u4 value = static_cast<u4>(TypePtr::Tag::ClassType);
+    return mix(value, this->symbol.id());
+}
+
+u4 UnresolvedClassType::hash(const GlobalState &gs) const {
+    u4 result = static_cast<u4>(TypePtr::Tag::UnresolvedClassType);
+    result = mix(result, this->scope.rawId());
+    for (auto name : this->names) {
+        result = mix(result, _hash(name.shortName(gs)));
+    }
+    return result;
+}
+
+u4 UnresolvedAppliedType::hash(const GlobalState &gs) const {
+    u4 result = static_cast<u4>(TypePtr::Tag::UnresolvedAppliedType);
+    result = mix(result, this->klass.rawId());
+    for (auto &targ : targs) {
+        result = mix(result, targ.hash(gs));
+    }
+    return result;
+}
+
+u4 LiteralType::hash(const GlobalState &gs) const {
+    u4 result = static_cast<u4>(TypePtr::Tag::LiteralType);
+    auto underlying = this->underlying(gs);
+    ClassOrModuleRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
+    result = mix(result, undSymbol.id());
+
+    // Strings or numbers encode an extra value. True/False are completely represented by the class symbol.
+    // TODO: Casts are bad???
+    if (undSymbol == Symbols::String() || undSymbol == Symbols::Symbol()) {
+        result = mix(result, asName(gs).hash(gs));
+    } else if (undSymbol == Symbols::Integer()) {
+        u8 val = absl::bit_cast<u8>(asInteger());
+        u4 topBits = static_cast<u4>(val >> 32);
+        u4 bottomBits = static_cast<u4>(val & 0xFFFF);
+        result = mix(result, topBits);
+        result = mix(result, bottomBits);
+    } else if (undSymbol == Symbols::Float()) {
+        u8 val = absl::bit_cast<u8>(asFloat());
+        u4 topBits = static_cast<u4>(val >> 32);
+        u4 bottomBits = static_cast<u4>(val & 0xFFFF);
+        result = mix(result, topBits);
+        result = mix(result, bottomBits);
+    }
+    return result;
+}
+
+u4 TupleType::hash(const GlobalState &gs) const {
+    u4 result = static_cast<u4>(TypePtr::Tag::TupleType);
+    for (auto &el : this->elems) {
+        result = mix(result, el.hash(gs));
+    }
+    return result;
+}
+
+u4 ShapeType::hash(const GlobalState &gs) const {
+    u4 result = static_cast<u4>(TypePtr::Tag::ShapeType);
+    for (auto &key : this->keys) {
+        result = mix(result, key.hash(gs));
+    }
+    return result;
+}
+
+u4 AliasType::hash(const GlobalState &gs) const {
+    u4 result = static_cast<u4>(TypePtr::Tag::AliasType);
+    return mix(result, this->symbol.rawId());
+}
+
+u4 AndType::hash(const GlobalState &gs) const {
+    u4 result = static_cast<u4>(TypePtr::Tag::AndType);
+    result = mix(result, this->left.hash(gs));
+    return mix(result, this->right.hash(gs));
+}
+
+u4 OrType::hash(const GlobalState &gs) const {
+    u4 result = static_cast<u4>(TypePtr::Tag::OrType);
+    result = mix(result, this->left.hash(gs));
+    return mix(result, this->right.hash(gs));
+}
+
+u4 TypeVar::hash(const GlobalState &gs) const {
+    u4 result = static_cast<u4>(TypePtr::Tag::TypeVar);
+    return mix(result, sym.rawId());
+}
+
+u4 AppliedType::hash(const GlobalState &gs) const {
+    u4 result = static_cast<u4>(TypePtr::Tag::AppliedType);
+    result = mix(result, this->klass.id());
+    for (auto &arg : targs) {
+        result = mix(result, arg.hash(gs));
+    }
+    return result;
+}
+
+u4 LambdaParam::hash(const GlobalState &gs) const {
+    u4 result = static_cast<u4>(TypePtr::Tag::LambdaParam);
+    result = mix(result, this->definition.rawId());
+    result = mix(result, this->upperBound.hash(gs));
+    // Lowerbound might not be set.
+    result = mix(result, this->lowerBound == nullptr ? 0 : this->lowerBound.hash(gs));
+    return result;
+}
+
+u4 SelfTypeParam::hash(const GlobalState &gs) const {
+    u4 result = static_cast<u4>(TypePtr::Tag::SelfTypeParam);
+    result = mix(result, this->definition.rawId());
+    return result;
+}
+
+u4 SelfType::hash(const GlobalState &gs) const {
+    return static_cast<u4>(TypePtr::Tag::SelfType);
+}
+
+u4 MetaType::hash(const GlobalState &gs) const {
+    u4 result = static_cast<u4>(TypePtr::Tag::MetaType);
+    return mix(result, this->wrapped.hash(gs));
+}
+
+} // namespace sorbet::core

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -58,7 +58,7 @@ string LiteralType::show(const GlobalState &gs) const {
 
 string LiteralType::showValue(const GlobalState &gs) const {
     auto underlying = this->underlying(gs);
-    SymbolRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
+    ClassOrModuleRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
     if (undSymbol == Symbols::String()) {
         return fmt::format("\"{}\"", absl::CEscape(asName(gs).show(gs)));
     } else if (undSymbol == Symbols::Symbol()) {


### PR DESCRIPTION
Implement a hash function on every Type

This change will substantially speed up Sorbet start-up in editor on a cold cache (up to ~50% on the hashing part of startup). Measured on Stripe's codebase, the effective hashing speedup is 40%.

When Sorbet starts up on a cold cache, it needs to hash every file in the project. This can take awhile on a large project. Hashing involves running resolver on the file's AST in an empty GlobalState and taking the hash of that GlobalState object.

Metrics show that ~50% of the hashing time spent in `computeFileHash` is in `TypePtr::hash`, which expensively hashes `TypePtr::toString()` (which allocates and formats strings -- with tabs! -- and often calls `Symbol::toString()`).

The new hashing routines use Symbol IDs and should overall be much cheaper to run.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed++

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
