### PR TITLE
Create a Magic.mixes_in_class_methods method

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -659,6 +659,20 @@ void GlobalState::initEmpty() {
     }
     method.data(*this)->resultType = core::make_type<core::ClassType>(core::Symbols::Encoding());
 
+    // Synthesize <Magic>.mixes_in_class_methods(self: T.untyped, arg: T.untyped) => Void
+    method = enterMethodSymbol(Loc::none(), Symbols::MagicSingleton(), Names::mixesInClassMethods());
+    {
+        auto &argSelf = enterMethodArgumentSymbol(Loc::none(), method, Names::selfLocal());
+        argSelf.type = Types::untyped(*this, method);
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
+        arg.type = Types::untyped(*this, method);
+    }
+    method.data(*this)->resultType = Types::void_();
+    {
+        auto &arg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
+        arg.flags.isBlock = true;
+    }
+
     // Synthesize <DeclBuilderForProcs>.<params>(args: T.untyped) => DeclBuilderForProcs
     method = enterMethodSymbol(Loc::none(), Symbols::DeclBuilderForProcsSingleton(), Names::params());
     {

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -688,7 +688,7 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 200;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 34;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 35;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 3;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 3;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 97;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -567,6 +567,15 @@ private:
 
         auto encounteredError = false;
         for (auto &arg : send->args) {
+            auto self = ast::cast_tree<ast::Local>(arg);
+            if (self != nullptr && self->localVariable._name == core::Names::selfLocal()) {
+                auto recv = ast::cast_tree<ast::ConstantLit>(send->recv);
+                if (recv != nullptr && recv->symbol == core::Symbols::Magic()) {
+                    // This is the first argument of a Magic.mixes_in_class_methods() call
+                    continue;
+                }
+            }
+
             auto *id = ast::cast_tree<ast::ConstantLit>(arg);
 
             if (id == nullptr || !id->symbol.exists()) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -789,6 +789,13 @@ public:
         if (send.recv.isSelfReference() && send.fun == core::Names::mixesInClassMethods()) {
             auto item = ClassMethodsResolutionItem{ctx.file, ctx.owner, &send};
             this->todoClassMethods_.emplace_back(move(item));
+        } else {
+            auto recvAsConstantLit = ast::cast_tree<ast::ConstantLit>(send.recv);
+            if (recvAsConstantLit != nullptr && recvAsConstantLit->symbol == core::Symbols::Magic() &&
+                send.fun == core::Names::mixesInClassMethods()) {
+                auto item = ClassMethodsResolutionItem{ctx.file, ctx.owner, &send};
+                this->todoClassMethods_.emplace_back(move(item));
+            }
         }
         return tree;
     }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -567,8 +567,7 @@ private:
 
         auto encounteredError = false;
         for (auto &arg : send->args) {
-            auto self = ast::cast_tree<ast::Local>(arg);
-            if (self != nullptr && self->localVariable._name == core::Names::selfLocal()) {
+            if (arg.isSelfReference()) {
                 auto recv = ast::cast_tree<ast::ConstantLit>(send->recv);
                 if (recv != nullptr && recv->symbol == core::Symbols::Magic()) {
                     // This is the first argument of a Magic.mixes_in_class_methods() call


### PR DESCRIPTION
Created a `Magic.mixes_in_class_methods` method to be used with ActiveSupport::Concern rewriter https://github.com/sorbet/sorbet/pull/3468#issuecomment-771137943


### Motivation
We don't want to insert `extend T::Helpers` in the rewriter stage in order to use `mixes_in_class_methods` as it would cause runtime errors that wouldn't be caught in the static check. In the rewriter we can use this method instead to achieve the same result without `extend T::Helpers`


### Test plan

These diffs were tested as part of the rewriter logic in https://github.com/sorbet/sorbet/pull/3468. Did not add unit tests specific to this method but can add if necessary.
