### PR TITLE
LiteralType:showValue cleanup

### DIFF
--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -57,27 +57,21 @@ string LiteralType::show(const GlobalState &gs) const {
 }
 
 string LiteralType::showValue(const GlobalState &gs) const {
-    auto underlying = this->underlying(gs);
-    ClassOrModuleRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
-    if (undSymbol == Symbols::String()) {
-        return fmt::format("\"{}\"", absl::CEscape(asName(gs).show(gs)));
-    } else if (undSymbol == Symbols::Symbol()) {
-        auto shown = asName(gs).show(gs);
-        if (absl::StrContains(shown, " ")) {
-            return fmt::format(":\"{}\"", absl::CEscape(shown));
-        } else {
-            return fmt::format(":{}", shown);
+    switch (literalKind) {
+        case LiteralType::LiteralTypeKind::String:
+            return fmt::format("\"{}\"", absl::CEscape(asName(gs).show(gs)));
+        case LiteralType::LiteralTypeKind::Symbol: {
+            auto shown = asName(gs).show(gs);
+            if (absl::StrContains(shown, " ")) {
+                return fmt::format(":\"{}\"", absl::CEscape(shown));
+            } else {
+                return fmt::format(":{}", shown);
+            }
         }
-    } else if (undSymbol == Symbols::Integer()) {
-        return to_string(asInteger());
-    } else if (undSymbol == Symbols::Float()) {
-        return to_string(asFloat());
-    } else if (undSymbol == Symbols::TrueClass()) {
-        return "true";
-    } else if (undSymbol == Symbols::FalseClass()) {
-        return "false";
-    } else {
-        Exception::raise("should not be reachable");
+        case LiteralType::LiteralTypeKind::Integer:
+            return to_string(asInteger());
+        case LiteralType::LiteralTypeKind::Float:
+            return to_string(asFloat());
     }
 }
 


### PR DESCRIPTION
LiteralType:showValue cleanup. LiteralType can't be a boolean anymore. Also, we have a nice enum to switch over.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Clean up code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
