### PR TITLE
Type hashing: Avoid NameRef::hash.

### DIFF
--- a/core/types/hashing.cc
+++ b/core/types/hashing.cc
@@ -38,7 +38,7 @@ u4 LiteralType::hash(const GlobalState &gs) const {
     switch (literalKind) {
         case LiteralType::LiteralTypeKind::String:
         case LiteralType::LiteralTypeKind::Symbol:
-            return mix(result, asName(gs).hash(gs));
+            return mix(result, _hash(asName(gs).shortName(gs)));
         case LiteralType::LiteralTypeKind::Float:
             rawValue = absl::bit_cast<u8>(asFloat());
             break;


### PR DESCRIPTION
Type hashing: Avoid NameRef::hash.

NameRef::hash can use name IDs in hashing, which are not stable during hashing across file changes; it's impacted by the order in which names are encountered in an AST pass.

NameRef::hash still has use; it is safely used to quickly find a slot in GlobalState's name table. However, we cannot use it in file hashes.

I have replaced the only use of this in file hash routines with a hash of the name's shortname.

Note that it's possible that these namerefs are always of type "UTF8", in which case this is a no-op change; the ::hash of a UTF8 is its shortname. Still, I don't want code around that encourages the use of NameRef::hash in file hashes.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Prevent bugs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
