### PR TITLE
make string variables for versioning arrays, not pointers

### DIFF
--- a/sorbet_version/sorbet_version.c
+++ b/sorbet_version/sorbet_version.c
@@ -4,7 +4,7 @@
 #include <time.h>
 /**
  * This file is *MAGIC*
- * When we compile if from Bazel, we do magical substitutions to some variables defined in CAPS in this file.
+ * When we compile it from Bazel, we do magical substitutions to some variables defined in CAPS in this file.
  * See `sorbet_version/BUILD` for up-to-date list of substitutions.
  *
  *  This file takes them and packages them to a API that is more pleasant to work with.
@@ -30,8 +30,8 @@ const int sorbet_is_release_build = 0;
 #define Q(x) #x
 #define QUOTED(x) Q(x)
 
-const char *sorbet_build_scm_clean = STABLE_BUILD_SCM_CLEAN;
-const char *sorbet_build_scm_revision = STABLE_BUILD_SCM_REVISION;
+const char sorbet_build_scm_clean[] = STABLE_BUILD_SCM_CLEAN;
+const char sorbet_build_scm_revision[] = STABLE_BUILD_SCM_REVISION;
 const int sorbet_build_scm_commit_count = STABLE_BUILD_SCM_COMMIT_COUNT;
 const long sorbet_build_timestamp = BUILD_TIMESTAMP;
 
@@ -43,10 +43,10 @@ const int sorbet_is_with_debug_symbols = 1;
 const int sorbet_is_with_debug_symbols = 0;
 #endif
 
-const char *sorbet_version = "0.5"; // 0.01 alpha
-const char *sorbet_codename = "";   // We Try Furiously
+const char sorbet_version[] = "0.5"; // 0.01 alpha
+const char sorbet_codename[] = "";   // We Try Furiously
 
-const char *sorbet_full_version_string = SORBET_VERSION "." QUOTED(STABLE_BUILD_SCM_COMMIT_COUNT)
+const char sorbet_full_version_string[] = SORBET_VERSION "." QUOTED(STABLE_BUILD_SCM_COMMIT_COUNT)
 #if BUILD_RELEASE
     " git " STABLE_BUILD_SCM_REVISION
 #else

--- a/sorbet_version/sorbet_version.h
+++ b/sorbet_version/sorbet_version.h
@@ -44,13 +44,13 @@ constexpr bool fuzz_mode = true;
 #endif
 // ^^^ __cplusplus
 
-extern const char *sorbet_version;
-extern const char *sorbet_codename;
-extern const char *sorbet_build_scm_revision;
+extern const char sorbet_version[];
+extern const char sorbet_codename[];
+extern const char sorbet_build_scm_revision[];
 extern const int sorbet_build_scm_commit_count;
-extern const char *sorbet_build_scm_clean;
+extern const char sorbet_build_scm_clean[];
 extern const long sorbet_build_timestamp;
-extern const char *sorbet_full_version_string;
+extern const char sorbet_full_version_string[];
 extern const int sorbet_is_release_build;
 extern const int sorbet_is_with_debug_symbols;
 


### PR DESCRIPTION
This makes them take up slightly less space, since we're now only allocating space for the character array itself, not the character array + a pointer to the character array.  A nice side-effect is the removal of some read/write data, which can't be shared across processes.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Epsilon space savings.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
