### PR TITLE
make the error message for final method violations slightly clearer

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -129,6 +129,7 @@ module T::Private::Methods
           begin
             raise pretty_message
           rescue => e
+            T::Private::DeclState.current.reset!
             T::Configuration.sig_validation_error_handler(e, {})
           end
         end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -114,7 +114,7 @@ module T::Private::Methods
            final_method?(method_owner_and_name_to_key(ancestor, method_name))
           definition_file, definition_line = T::Private::Methods.signature_for_method(ancestor.instance_method(method_name)).method.source_location
           is_redefined = target == ancestor
-          caller_loc = caller_locations&.find {|l| !l.to_s.match?(%r{sorbet-runtime[^/]*/lib/types/private/methods/}) }
+          caller_loc = caller_locations&.find {|l| !l.to_s.match?(%r{sorbet-runtime[^/]*/lib/}) }
           extra_info = "\n"
           if caller_loc
             extra_info = (is_redefined ? "Redefined" : "Overriden") + " here: #{caller_loc.path}:#{caller_loc.lineno}\n"

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -117,7 +117,7 @@ module T::Private::Methods
           caller_loc = caller_locations&.find {|l| !l.to_s.match?(%r{sorbet-runtime[^/]*/lib/types/private/methods/}) }
           extra_info = "\n"
           if caller_loc
-            extra_info = "Overriden here: #{caller_loc.path}:#{caller_loc.lineno}\n"
+            extra_info = (is_redefined ? "Redefined" : "Overriden") + " here: #{caller_loc.path}:#{caller_loc.lineno}\n"
           end
 
           error_message = "The method `#{method_name}` on #{ancestor} was declared as final and cannot be " +

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -474,6 +474,12 @@ module T::Private::Methods
       return
     end
 
+    # See https://github.com/sorbet/sorbet/pull/3964 for an explanation of why this
+    # check (which theoretically should not be needed) is actually needed.
+    if !mod.is_a?(Module)
+      return
+    end
+
     if mod.singleton_class?
       mod.include(SingletonMethodHooks)
     else

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -126,7 +126,11 @@ module T::Private::Methods
                            "Made final here: #{definition_file}:#{definition_line}\n" \
                            "#{extra_info}"
 
-          T::Configuration.sig_validation_error_handler(pretty_message, {})
+          begin
+            raise pretty_message
+          rescue => e
+            T::Configuration.sig_validation_error_handler(e, {})
+          end
         end
       end
     end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -112,10 +112,16 @@ module T::Private::Methods
             ancestor.private_method_defined?(method_name) ||
             ancestor.protected_method_defined?(method_name)) &&
            final_method?(method_owner_and_name_to_key(ancestor, method_name))
-          raise(
-            "The method `#{method_name}` on #{ancestor} was declared as final and cannot be " +
-            (target == ancestor ? "redefined" : "overridden in #{target}")
-          )
+          caller_loc = T.must(caller_locations&.find {|l| !l.to_s.match?(%r{sorbet-runtime[^/]*/lib/types/private/methods/}) })
+          definition_file, definition_line = T::Private::Methods.signature_for_method(ancestor.instance_method(method_name)).method.source_location
+
+          error_message = "The method `#{method_name}` on #{ancestor} was declared as final and cannot be " +
+                          (target == ancestor ? "redefined" : "overriden in #{target}")
+          pretty_message = "#{error_message}\n" \
+                           "Made final here: #{definition_file}:#{definition_line}\n" \
+                           "Overriden here: #{caller_loc.path}:#{caller_loc.lineno}\n"
+
+          T::Configuration.sig_validation_error_handler(pretty_message, {})
         end
       end
     end
@@ -446,6 +452,10 @@ module T::Private::Methods
       # where we need to install the hooks are special.
       mod.extend(SingletonMethodHooks) # def self.foo; end (at top level)
       Object.extend(MethodHooks)       # def foo; end      (at top level)
+      return
+    end
+
+    if !mod.is_a?(Module)
       return
     end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -112,11 +112,12 @@ module T::Private::Methods
             ancestor.private_method_defined?(method_name) ||
             ancestor.protected_method_defined?(method_name)) &&
            final_method?(method_owner_and_name_to_key(ancestor, method_name))
-          caller_loc = T.must(caller_locations&.find {|l| !l.to_s.match?(%r{sorbet-runtime[^/]*/lib/types/private/methods/}) })
           definition_file, definition_line = T::Private::Methods.signature_for_method(ancestor.instance_method(method_name)).method.source_location
+          is_redefined = target == ancestor
+          caller_loc = T.must(caller_locations&.find {|l| !l.to_s.match?(%r{sorbet-runtime[^/]*/lib/types/private/methods/}) })
 
           error_message = "The method `#{method_name}` on #{ancestor} was declared as final and cannot be " +
-                          (target == ancestor ? "redefined" : "overriden in #{target}")
+                          (is_redefined ? "redefined" : "overriden in #{target}")
           pretty_message = "#{error_message}\n" \
                            "Made final here: #{definition_file}:#{definition_line}\n" \
                            "Overriden here: #{caller_loc.path}:#{caller_loc.lineno}\n"

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -114,13 +114,17 @@ module T::Private::Methods
            final_method?(method_owner_and_name_to_key(ancestor, method_name))
           definition_file, definition_line = T::Private::Methods.signature_for_method(ancestor.instance_method(method_name)).method.source_location
           is_redefined = target == ancestor
-          caller_loc = T.must(caller_locations&.find {|l| !l.to_s.match?(%r{sorbet-runtime[^/]*/lib/types/private/methods/}) })
+          caller_loc = caller_locations&.find {|l| !l.to_s.match?(%r{sorbet-runtime[^/]*/lib/types/private/methods/}) }
+          extra_info = "\n"
+          if caller_loc
+            extra_info = "Overriden here: #{caller_loc.path}:#{caller_loc.lineno}\n"
+          end
 
           error_message = "The method `#{method_name}` on #{ancestor} was declared as final and cannot be " +
                           (is_redefined ? "redefined" : "overriden in #{target}")
           pretty_message = "#{error_message}\n" \
                            "Made final here: #{definition_file}:#{definition_line}\n" \
-                           "Overriden here: #{caller_loc.path}:#{caller_loc.lineno}\n"
+                           "#{extra_info}"
 
           T::Configuration.sig_validation_error_handler(pretty_message, {})
         end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -117,11 +117,11 @@ module T::Private::Methods
           caller_loc = caller_locations&.find {|l| !l.to_s.match?(%r{sorbet-runtime[^/]*/lib/}) }
           extra_info = "\n"
           if caller_loc
-            extra_info = (is_redefined ? "Redefined" : "Overriden") + " here: #{caller_loc.path}:#{caller_loc.lineno}\n"
+            extra_info = (is_redefined ? "Redefined" : "Overridden") + " here: #{caller_loc.path}:#{caller_loc.lineno}\n"
           end
 
           error_message = "The method `#{method_name}` on #{ancestor} was declared as final and cannot be " +
-                          (is_redefined ? "redefined" : "overriden in #{target}")
+                          (is_redefined ? "redefined" : "overridden in #{target}")
           pretty_message = "#{error_message}\n" \
                            "Made final here: #{definition_file}:#{definition_line}\n" \
                            "#{extra_info}"

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -465,10 +465,6 @@ module T::Private::Methods
       return
     end
 
-    if !mod.is_a?(Module)
-      return
-    end
-
     if mod.singleton_class?
       mod.include(SingletonMethodHooks)
     else

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -163,6 +163,38 @@ module Opus::Types::Test
           assert_includes(ex.message, "was declared as final and cannot be redefined")
         end
       end
+
+      describe 'when overridden' do
+        before do
+          T::Configuration.sig_validation_error_handler = lambda do |*args|
+            CustomReceiver.receive(*args)
+          end
+        end
+
+        after do
+          T::Configuration.sig_validation_error_handler = nil
+        end
+
+        it 'handles a final method redefinition error' do
+          CustomReceiver.expects(:receive).once.with do |error, opts|
+            error.message.include?("was declared as final and cannot be redefined") &&
+              error.is_a?(RuntimeError) &&
+              opts.is_a?(Hash) &&
+              opts.empty?
+          end
+
+          @mod.sig(:final) {returns(Symbol)}
+          def @mod.final_method_redefined_ok
+            :bar
+          end
+          assert_equal(:bar, @mod.final_method_redefined_ok)
+          @mod.sig(:final) {returns(Symbol)}
+          def @mod.final_method_redefined_ok
+            :baz
+          end
+          assert_equal(:baz, @mod.final_method_redefined_ok)
+        end
+      end
     end
 
     describe 'call_validation_error_handler' do

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -147,6 +147,24 @@ module Opus::Types::Test
       end
     end
 
+    describe 'final_checks_on_hooks' do
+      describe 'when in default state' do
+        it 'raises an error' do
+          @mod.sig(:final) {returns(Symbol)}
+          def @mod.final_method_redefined_ko
+            :bar
+          end
+          ex = assert_raises(RuntimeError) do
+            @mod.sig(:final) {returns(Symbol)}
+            def @mod.final_method_redefined_ko
+              :baz
+            end
+          end
+          assert_includes(ex.message, "was declared as final and cannot be redefined")
+        end
+      end
+    end
+
     describe 'call_validation_error_handler' do
       describe 'when in default state' do
         it 'raises an error' do

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -15,22 +15,22 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   CLASS_CLASS_REGEX_STR = "#<Class:#<Class:0x[0-9a-f]+>>"
   MODULE_REGEX_STR = "#<Module:0x[0-9a-f]+>"
 
-  private def assert_msg_matches(regex, final_line, method_line, err)
+  private def assert_msg_matches(regex, final_line, method_line, explanation, err)
     lines = err.message.split("\n")
     assert_equal(3, lines.length)
     assert_match(regex, lines[0])
     assert_match(%r{Made final here: .*test.*/types/final_method.rb:#{final_line}}, lines[1])
-    assert_match(%r{Overriden here: .*test.*/types/final_method.rb:#{method_line}}, lines[2])
+    assert_match(%r{#{explanation} here: .*test.*/types/final_method.rb:#{method_line}}, lines[2])
   end
 
   private def assert_redefined_err(method_name, klass_str, final_line, method_line, err)
     regex = %r{The method `#{method_name}` on #{klass_str} was declared as final and cannot be redefined}
-    assert_msg_matches(regex, final_line, method_line, err)
+    assert_msg_matches(regex, final_line, method_line, "Redefined", err)
   end
 
   private def assert_overridden_err(method_name, klass_str, method_str, final_line, method_line, err)
     regex = %r{The method `#{method_name}` on #{klass_str} was declared as final and cannot be overriden in #{method_str}}
-    assert_msg_matches(regex, final_line, method_line, err)
+    assert_msg_matches(regex, final_line, method_line, "Overriden", err)
   end
 
   it "allows declaring an instance method as final" do

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -29,8 +29,8 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   private def assert_overridden_err(method_name, klass_str, method_str, final_line, method_line, err)
-    regex = %r{The method `#{method_name}` on #{klass_str} was declared as final and cannot be overriden in #{method_str}}
-    assert_msg_matches(regex, final_line, method_line, "Overriden", err)
+    regex = %r{The method `#{method_name}` on #{klass_str} was declared as final and cannot be overridden in #{method_str}}
+    assert_msg_matches(regex, final_line, method_line, "Overridden", err)
   end
 
   it "allows declaring an instance method as final" do

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -11,6 +11,28 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
     T::Configuration.reset_final_checks_on_hooks
   end
 
+  CLASS_REGEX_STR = "#<Class:0x[0-9a-f]+>"
+  CLASS_CLASS_REGEX_STR = "#<Class:#<Class:0x[0-9a-f]+>>"
+  MODULE_REGEX_STR = "#<Module:0x[0-9a-f]+>"
+
+  private def assert_msg_matches(regex, final_line, method_line, err)
+    lines = err.message.split("\n")
+    assert_equal(3, lines.length)
+    assert_match(regex, lines[0])
+    assert_match(%r{Made final here: .*test.*/types/final_method.rb:#{final_line}}, lines[1])
+    assert_match(%r{Overriden here: .*test.*/types/final_method.rb:#{method_line}}, lines[2])
+  end
+
+  private def assert_redefined_err(method_name, klass_str, final_line, method_line, err)
+    regex = %r{The method `#{method_name}` on #{klass_str} was declared as final and cannot be redefined}
+    assert_msg_matches(regex, final_line, method_line, err)
+  end
+
+  private def assert_overridden_err(method_name, klass_str, method_str, final_line, method_line, err)
+    regex = %r{The method `#{method_name}` on #{klass_str} was declared as final and cannot be overriden in #{method_str}}
+    assert_msg_matches(regex, final_line, method_line, err)
+  end
+
   it "allows declaring an instance method as final" do
     Class.new do
       extend T::Sig
@@ -37,7 +59,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_match(/^The method `foo` on #<Class:0x[0-9a-f]+> was declared as final and cannot be redefined$/, err.message)
+    assert_redefined_err('foo', CLASS_REGEX_STR, __LINE__ - 5, __LINE__ - 3, err)
   end
 
   it "forbids redefining a final class method with a final sig" do
@@ -50,7 +72,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def self.foo; end
       end
     end
-    assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be redefined$/, err.message)
+    assert_redefined_err('foo', CLASS_CLASS_REGEX_STR, __LINE__ - 5, __LINE__ - 3, err)
   end
 
   it "forbids redefining a final instance method with a regular sig" do
@@ -63,7 +85,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_match(/^The method `foo` on #<Class:0x[0-9a-f]+> was declared as final and cannot be redefined$/, err.message)
+    assert_redefined_err('foo', CLASS_REGEX_STR, __LINE__ - 5, __LINE__ - 3, err)
   end
 
   it "forbids redefining a final class method with a regular sig" do
@@ -76,7 +98,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def self.foo; end
       end
     end
-    assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be redefined$/, err.message)
+    assert_redefined_err('foo', CLASS_CLASS_REGEX_STR, __LINE__ - 5, __LINE__ - 3, err)
   end
 
   it "forbids redefining a final instance method with no sig" do
@@ -132,7 +154,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_match(/^The method `foo` on #<Class:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
+    assert_overridden_err('foo', CLASS_REGEX_STR, CLASS_REGEX_STR, __LINE__ - 7, __LINE__ - 3, err)
   end
 
   it "forbids overriding a final class method" do
@@ -146,7 +168,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def self.foo; end
       end
     end
-    assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be overridden in #<Class:#<Class:0x[0-9a-f]+>>$/, err.message)
+    assert_overridden_err('foo', CLASS_CLASS_REGEX_STR, CLASS_CLASS_REGEX_STR, __LINE__ - 7, __LINE__ - 3, err)
   end
 
   it "allows toggling a final method's visbility in the same class" do
@@ -180,19 +202,19 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         public :becomes_public
       end
     end
-    assert_match(/^The method `becomes_public` on #<Class:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
+    assert_overridden_err('becomes_public', CLASS_REGEX_STR, CLASS_REGEX_STR, __LINE__ - 13, __LINE__ - 3, err)
     err = assert_raises(RuntimeError) do
       Class.new(c) do
         private :becomes_private
       end
     end
-    assert_match(/^The method `becomes_private` on #<Class:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
+    assert_overridden_err('becomes_private', CLASS_REGEX_STR, CLASS_REGEX_STR, __LINE__ - 16, __LINE__ - 3, err)
     err = assert_raises(RuntimeError) do
       Class.new(c) do
         private :protected_becomes_private
       end
     end
-    assert_match(/^The method `protected_becomes_private` on #<Class:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
+    assert_overridden_err('protected_becomes_private', CLASS_REGEX_STR, CLASS_REGEX_STR, __LINE__ - 19, __LINE__ - 3, err)
   end
 
   it "forbids overriding a final method from an included module" do
@@ -207,7 +229,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_match(/^The method `foo` on #<Module:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
+    assert_overridden_err('foo', MODULE_REGEX_STR, CLASS_REGEX_STR, __LINE__ - 8, __LINE__ - 3, err)
   end
 
   it "forbids overriding a final method from an extended module" do
@@ -222,7 +244,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def self.foo; end
       end
     end
-    assert_match(/^The method `foo` on #<Module:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:#<Class:0x[0-9a-f]+>>$/, err.message)
+    assert_overridden_err('foo', MODULE_REGEX_STR, CLASS_CLASS_REGEX_STR, __LINE__ - 8, __LINE__ - 3, err)
   end
 
   it "forbids overriding a final method by including two modules" do
@@ -239,7 +261,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         include m2, m1
       end
     end
-    assert_match(/^The method `foo` on #<Module:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
+    assert_overridden_err('foo', MODULE_REGEX_STR, CLASS_REGEX_STR, __LINE__ - 10, __LINE__ - 3, err)
   end
 
   it "forbids overriding a final method by extending two modules" do
@@ -256,7 +278,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend m2, m1
       end
     end
-    assert_match(/^The method `foo` on #<Module:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
+    assert_overridden_err('foo', MODULE_REGEX_STR, CLASS_REGEX_STR, __LINE__ - 10, __LINE__ - 3, err)
   end
 
   it "allows calling final methods" do
@@ -337,7 +359,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_match(/^The method `foo` on #<Module:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
+    assert_overridden_err('foo', MODULE_REGEX_STR, CLASS_REGEX_STR, __LINE__ - 10, __LINE__ - 3, err)
   end
 
   it "forbids overriding through many levels of include" do
@@ -358,7 +380,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         def foo; end
       end
     end
-    assert_match(/^The method `foo` on #<Module:0x[0-9a-f]+> was declared as final and cannot be overridden in #<Class:0x[0-9a-f]+>$/, err.message)
+    assert_overridden_err('foo', MODULE_REGEX_STR, CLASS_REGEX_STR, __LINE__ - 14, __LINE__ - 3, err)
   end
 
   it "allows including modules again" do


### PR DESCRIPTION
We're very close to turning on final method errors in Stripe's codebase, and the current error message is not super-helpful.  This change at least points you to the definition of the final method and whatever caused the redefinition error to occur.  The latter is not necessarily the actual definition of the method, but is often an `include` or similar pulling in the actual class/module that redefines the method.  So there's still a bit of sleuthing required, but at least this message is more helpful than before.

### Motivation

More helpful error messages.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
