### PR TITLE
Bump dependencies in advance of clang-10

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -36,6 +36,16 @@ def register_sorbet_dependencies():
         strip_prefix = "spdlog-c2b47430fb210c8822177407b9e4b82d4ef7455d",
     )
 
+    # We don't use this directly, but protobuf will skip defining its own
+    # `@zlib` if it's present.
+    http_archive(
+        name = "zlib",
+        urls = _github_public_urls("madler/zlib/archive/cacf7f1d4e3d44d871b605da3b647f07d718623f.zip"),
+        build_file = "@com_stripe_ruby_typer//third_party:zlib.BUILD",
+        sha256 = "1cce3828ec2ba80ff8a4cac0ab5aa03756026517154c4b450e617ede751d41bd",
+        strip_prefix = "zlib-cacf7f1d4e3d44d871b605da3b647f07d718623f",
+    )
+
     # proto_library, cc_proto_library, and java_proto_library rules implicitly
     # depend on @com_google_protobuf for protoc and proto runtimes.
     # This statement defines the @com_google_protobuf repo.

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -51,9 +51,9 @@ def register_sorbet_dependencies():
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
-        urls = _github_public_urls("protocolbuffers/protobuf/archive/v3.11.4.zip"),
-        sha256 = "9748c0d90e54ea09e5e75fb7fac16edce15d2028d4356f32211cfa3c0e956564",
-        strip_prefix = "protobuf-3.11.4",
+        urls = _github_public_urls("protocolbuffers/protobuf/archive/v3.14.0.zip"),
+        sha256 = "bf0e5070b4b99240183b29df78155eee335885e53a8af8683964579c214ad301",
+        strip_prefix = "protobuf-3.14.0",
     )
 
     http_archive(
@@ -82,10 +82,10 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "lizard",
-        urls = _github_public_urls("inikep/lizard/archive/dda3b335e92ecd5caceccc9c577b39dd4e3c9950.zip"),
-        sha256 = "1d4e8c17d40ec56b7ecad60bcf4a9065df73d7e5997f78e75dbe5fc662ce6aa8",
+        urls = _github_public_urls("sorbet/lizard/archive/3ea5729b2a337999772cb86998f202a718dd46fb.zip"),
+        sha256 = "f9f0f75264c160b7b19db936730282d28ef061bf7473cb339694b39ac2eb472e",
         build_file = "@com_stripe_ruby_typer//third_party:lizard.BUILD",
-        strip_prefix = "lizard-dda3b335e92ecd5caceccc9c577b39dd4e3c9950",
+        strip_prefix = "lizard-3ea5729b2a337999772cb86998f202a718dd46fb",
     )
 
     http_archive(
@@ -114,10 +114,10 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "statsd",
-        urls = _github_public_urls("romanbsd/statsd-c-client/archive/0caa5ef05d6a786bb4695394534a7182a3c94427.zip"),
-        sha256 = "0c67e994fb809ac9b0fd2216333b0dff5592401f81dc04fb7a0c2179d6b76dca",
+        urls = _github_public_urls("romanbsd/statsd-c-client/archive/08ecca678345f157e72a1db1446facb403cbeb65.zip"),
+        sha256 = "825395556fb553383173e47dbce98165981d100587993292ec9d174ec40a7ba1",
         build_file = "@com_stripe_ruby_typer//third_party:statsd.BUILD",
-        strip_prefix = "statsd-c-client-0caa5ef05d6a786bb4695394534a7182a3c94427",
+        strip_prefix = "statsd-c-client-08ecca678345f157e72a1db1446facb403cbeb65",
     )
 
     http_archive(

--- a/third_party/lizard.BUILD
+++ b/third_party/lizard.BUILD
@@ -7,6 +7,7 @@ cc_library(
         ],
     ),
     hdrs = glob(["lib/**/*.h"]),
+    copts = ["-Wno-implicit-fallthrough"],
     defines = ["LIZARD_NO_HUFFMAN"],
     linkstatic = select({
         "@com_stripe_ruby_typer//tools/config:linkshared": 0,

--- a/third_party/lmdb.BUILD
+++ b/third_party/lmdb.BUILD
@@ -10,6 +10,7 @@ cc_library(
         "libraries/liblmdb/lmdb.h",
         "libraries/liblmdb/midl.h",
     ],
+    copts = ["-Wno-implicit-fallthrough"],
     includes = [
         "libraries/liblmdb/",
     ],

--- a/third_party/statsd.BUILD
+++ b/third_party/statsd.BUILD
@@ -4,7 +4,7 @@ cc_library(
     hdrs = [
         "statsd-client.h",
     ],
-    copts = [],
+    copts = ["-Wno-implicit-fallthrough"],
     linkstatic = select({
         "@com_stripe_ruby_typer//tools/config:linkshared": 0,
         "//conditions:default": 1,

--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -1,0 +1,65 @@
+# Originally from https://github.com/protocolbuffers/protobuf/blob/2514f0bd7da7e2af1bed4c5d1b84f031c4d12c10/third_party/zlib.BUILD
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+licenses(["notice"])  # BSD/MIT-like license (for zlib)
+
+_ZLIB_HEADERS = [
+    "crc32.h",
+    "deflate.h",
+    "gzguts.h",
+    "inffast.h",
+    "inffixed.h",
+    "inflate.h",
+    "inftrees.h",
+    "trees.h",
+    "zconf.h",
+    "zlib.h",
+    "zutil.h",
+]
+
+_ZLIB_PREFIXED_HEADERS = ["zlib/include/" + hdr for hdr in _ZLIB_HEADERS]
+
+# In order to limit the damage from the `includes` propagation
+# via `:zlib`, copy the public headers to a subdirectory and
+# expose those.
+genrule(
+    name = "copy_public_headers",
+    srcs = _ZLIB_HEADERS,
+    outs = _ZLIB_PREFIXED_HEADERS,
+    cmd = "cp $(SRCS) $(@D)/zlib/include/",
+)
+
+cc_library(
+    name = "zlib",
+    srcs = [
+        "adler32.c",
+        "compress.c",
+        "crc32.c",
+        "deflate.c",
+        "gzclose.c",
+        "gzlib.c",
+        "gzread.c",
+        "gzwrite.c",
+        "infback.c",
+        "inffast.c",
+        "inflate.c",
+        "inftrees.c",
+        "trees.c",
+        "uncompr.c",
+        "zutil.c",
+        # Include the un-prefixed headers in srcs to work
+        # around the fact that zlib isn't consistent in its
+        # choice of <> or "" delimiter when including itself.
+    ] + _ZLIB_HEADERS,
+    hdrs = _ZLIB_PREFIXED_HEADERS,
+    copts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-Wno-unused-variable",
+            "-Wno-implicit-function-declaration",
+        ],
+    }) + ["-Wno-implicit-fallthrough"],
+    includes = ["zlib/include/"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Bumping dependencies for  clang-10 compatibility, and adding "-Wno-implicit-fallthrough" for the ones that fail with it enabled.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
