### PR TITLE
Fix bugs in advance of clang-10

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -124,8 +124,8 @@ string DefTree::show(const core::GlobalState &gs, int level) const {
 }
 
 string DefTree::fullName(const core::GlobalState &gs) const {
-    return fmt::format(
-        "{}", fmt::map_join(qname.nameParts, "::", [&](core::NameRef nr) -> string_view { return nr.show(gs); }));
+    return fmt::format("{}",
+                       fmt::map_join(qname.nameParts, "::", [&](core::NameRef nr) -> string { return nr.show(gs); }));
 }
 
 string join(string path, string file) {

--- a/third_party/parser/include/ruby_parser/pool.hh
+++ b/third_party/parser/include/ruby_parser/pool.hh
@@ -1,6 +1,7 @@
 #ifndef RUBY_PARSER_POOL_HH
 #define RUBY_PARSER_POOL_HH
 
+#include <cassert>
 #include <type_traits>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
* `pool.hh` in the parser was missing `#include <cassert>` for a use of `assert`
* clang-10 identified a place where we were returning a string_view from a string intermediate

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
