### PR TITLE
Remove NameRef::hash and inline it completely into GlobalState.cc.

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -28,6 +28,18 @@ using namespace std;
 
 namespace sorbet::core {
 
+namespace {
+// Hash functions used to determine position in namesByHash.
+
+inline unsigned int _hash_mix_unique(UniqueNameKind unk, unsigned int num, unsigned int rawId) {
+    return mix(mix(num, static_cast<u4>(unk)), rawId) * HASH_MULT2 + static_cast<u4>(NameKind::UNIQUE);
+}
+
+inline unsigned int _hash_mix_constant(unsigned int id) {
+    return id * HASH_MULT2 + static_cast<u4>(NameKind::CONSTANT);
+}
+} // namespace
+
 ClassOrModuleRef GlobalState::synthesizeClass(NameRef nameId, u4 superclass, bool isModule) {
     // This can't use enterClass since there is a chicken and egg problem.
     // These will be added to Symbols::root().members later.
@@ -1300,7 +1312,6 @@ NameRef GlobalState::enterNameUTF8(string_view nm) {
     bucket.second = name.rawId();
     utf8Names.emplace_back(UTF8Name{enterString(nm)});
 
-    ENFORCE(name.hash(*this) == hs);
     categoryCounterInc("names", "utf8");
 
     wasModified_ = true;
@@ -1311,7 +1322,7 @@ NameRef GlobalState::enterNameConstant(NameRef original) {
     ENFORCE(original.exists(), "making a constant name over non-existing name");
     ENFORCE(original.isValidConstantName(*this), "making a constant name over wrong name kind");
 
-    const auto hs = _hash_mix_constant(NameKind::CONSTANT, original.rawId());
+    const auto hs = _hash_mix_constant(original.rawId());
     unsigned int hashTableSize = namesByHash.size();
     unsigned int mask = hashTableSize - 1;
     auto bucketId = hs & mask;
@@ -1355,7 +1366,6 @@ NameRef GlobalState::enterNameConstant(NameRef original) {
     bucket.second = name.rawId();
 
     constantNames.emplace_back(ConstantName{original});
-    ENFORCE(name.hash(*this) == hs);
     wasModified_ = true;
     categoryCounterInc("names", "constant");
     return name;
@@ -1371,7 +1381,7 @@ NameRef GlobalState::lookupNameConstant(NameRef original) const {
     }
     ENFORCE(original.isValidConstantName(*this), "looking up a constant name over wrong name kind");
 
-    const auto hs = _hash_mix_constant(NameKind::CONSTANT, original.rawId());
+    const auto hs = _hash_mix_constant(original.rawId());
     unsigned int hashTableSize = namesByHash.size();
     unsigned int mask = hashTableSize - 1;
     auto bucketId = hs & mask;
@@ -1439,7 +1449,7 @@ void GlobalState::expandNames(u4 utf8NameSize, u4 constantNameSize, u4 uniqueNam
 
 NameRef GlobalState::lookupNameUnique(UniqueNameKind uniqueNameKind, NameRef original, u4 num) const {
     ENFORCE(num > 0, "num == 0, name overflow");
-    const auto hs = _hash_mix_unique((u2)uniqueNameKind, NameKind::UNIQUE, num, original.rawId());
+    const auto hs = _hash_mix_unique(uniqueNameKind, num, original.rawId());
     unsigned int hashTableSize = namesByHash.size();
     unsigned int mask = hashTableSize - 1;
     auto bucketId = hs & mask;
@@ -1465,7 +1475,7 @@ NameRef GlobalState::lookupNameUnique(UniqueNameKind uniqueNameKind, NameRef ori
 
 NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef original, u4 num) {
     ENFORCE(num > 0, "num == 0, name overflow");
-    const auto hs = _hash_mix_unique((u2)uniqueNameKind, NameKind::UNIQUE, num, original.rawId());
+    const auto hs = _hash_mix_unique(uniqueNameKind, num, original.rawId());
     unsigned int hashTableSize = namesByHash.size();
     unsigned int mask = hashTableSize - 1;
     auto bucketId = hs & mask;
@@ -1510,7 +1520,6 @@ NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef orig
     bucket.second = name.rawId();
 
     uniqueNames.emplace_back(UniqueName{original, num, uniqueNameKind});
-    ENFORCE(name.hash(*this) == hs);
     wasModified_ = true;
     categoryCounterInc("names", "unique");
     return name;
@@ -1703,7 +1712,22 @@ void GlobalState::sanityCheck() const {
         if (ent.second == 0) {
             continue;
         }
-        ENFORCE_NO_TIMER(ent.first == NameRef::fromRaw(*this, ent.second).hash(*this), "name hash table corruption");
+        auto nref = NameRef::fromRaw(*this, ent.second);
+        switch (nref.kind()) {
+            case NameKind::UTF8:
+                ENFORCE_NO_TIMER(ent.first == _hash(nref.shortName(*this)), "name hash table corruption");
+                break;
+            case NameKind::CONSTANT:
+                ENFORCE_NO_TIMER(ent.first == _hash_mix_constant(nref.dataCnst(*this)->original.rawId()),
+                                 "name hash table corruption");
+                break;
+            case NameKind::UNIQUE: {
+                auto data = nref.dataUnique(*this);
+                ENFORCE_NO_TIMER(ent.first == _hash_mix_unique(data->uniqueNameKind, data->num, data->original.rawId()),
+                                 "name hash table corruption");
+                break;
+            }
+        }
     }
 }
 

--- a/core/Hashing.h
+++ b/core/Hashing.h
@@ -11,14 +11,6 @@ inline unsigned int mix(unsigned int acc, unsigned int nw) {
     return nw + (acc << 6) + (acc << 16) - acc; // HASH_MULT in faster version
 }
 
-inline unsigned int _hash_mix_unique(unsigned int hash1, NameKind nk, unsigned int hash2, unsigned int hash3) {
-    return mix(mix(hash2, hash1), hash3) * HASH_MULT2 + _NameKind2Id_UNIQUE(nk);
-}
-
-inline unsigned int _hash_mix_constant(NameKind nk, unsigned int id) {
-    return id * HASH_MULT2 + _NameKind2Id_CONSTANT(nk);
-}
-
 inline unsigned int _hash(std::string_view utf8) {
     // TODO: replace with http://www.sanmayce.com/Fastest_Hash/, see https://www.strchr.com/hash_functions
     // and https://github.com/rurban/smhasher
@@ -32,7 +24,7 @@ inline unsigned int _hash(std::string_view utf8) {
         res = mix(res, *it - '!'); // "!" is the first printable letter in ASCII.
         // This will help Latin1 but may harm utf8 multibyte
     }
-    return res * HASH_MULT2 + _NameKind2Id_UTF8(NameKind::UTF8);
+    return res * HASH_MULT2 + static_cast<u4>(NameKind::UTF8);
 }
 } // namespace sorbet::core
 #endif // SORBET_HASHING_H

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -186,8 +186,6 @@ public:
 
     bool isValidConstantName(const GlobalState &gs) const;
 
-    u4 hash(const GlobalState &gs) const;
-
     std::string_view shortName(const GlobalState &gs) const;
     std::string showRaw(const GlobalState &gs) const;
     std::string toString(const GlobalState &gs) const;

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -26,22 +26,6 @@ NameRef::NameRef(const GlobalState &gs, NameRef ref)
     ENFORCE_NO_TIMER(this->unsafeTableIndex() <= ID_MASK);
 }
 
-unsigned int NameRef::hash(const GlobalState &gs) const {
-    // TODO: use https://github.com/Cyan4973/xxHash
-    // !!! keep this in sync with GlobalState.enter*
-    switch (kind()) {
-        case NameKind::UTF8:
-            return _hash(dataUtf8(gs)->utf8);
-        case NameKind::UNIQUE: {
-            auto unique = dataUnique(gs);
-            return _hash_mix_unique((u2)unique->uniqueNameKind, NameKind::UNIQUE, unique->num,
-                                    unique->original.rawId());
-        }
-        case NameKind::CONSTANT:
-            return _hash_mix_constant(NameKind::CONSTANT, dataCnst(gs)->original.rawId());
-    }
-}
-
 string NameRef::showRaw(const GlobalState &gs) const {
     switch (kind()) {
         case NameKind::UTF8: {

--- a/core/Names.h
+++ b/core/Names.h
@@ -11,21 +11,6 @@
 namespace sorbet::core {
 class GlobalState;
 
-inline int _NameKind2Id_UTF8(NameKind nm) {
-    ENFORCE(nm == NameKind::UTF8);
-    return 1;
-}
-
-inline int _NameKind2Id_UNIQUE(NameKind nm) {
-    ENFORCE(nm == NameKind::UNIQUE);
-    return 2;
-}
-
-inline int _NameKind2Id_CONSTANT(NameKind nm) {
-    ENFORCE(nm == NameKind::CONSTANT);
-    return 3;
-}
-
 struct UTF8Name final {
     std::string_view utf8;
 


### PR DESCRIPTION
Remove NameRef::hash and inline it completely into GlobalState.cc.

Some notes on this function:

* It _cannot_ be used like Symbol::hash because it encodes properties that are unstable across file hashes (name ID)
* The hash itself is intended for one very specific purpose: Determining the position of the name in `namesByHash`
* The hash itself is only ever used in GlobalState.cc.
* The implementation of the hash is distributed between Hashing.h, GlobalState.cc, and NameRef.cc.

I've also removed a function that converts the NameKind enum into an integer since we can just cast them (they have the same value as returned by that conversion function).

In a subsequent PR, I'll introduce a _new_ NameRef::hash that _can_ be used like Symbol::hash (but will not replace this very specific hash).

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Clean up the code and remove a footgun. If we were to depend on NameRef::hash in FileHash, we would have subtle fast path decision bugs where we take the slow path and don't have to.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
