### PR TITLE
Bump bazel-toolchain for sanizer support with clang-10+

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -158,9 +158,9 @@ package(default_visibility = ["//visibility:public"])
     # NOTE: we use the sorbet branch for development to keep our changes rebasable on grailio/bazel-toolchain
     http_archive(
         name = "com_grail_bazel_toolchain",
-        urls = _github_public_urls("sorbet/bazel-toolchain/archive/ff9ded642e9d8eb2a329f59adcaa3fa5bdb3249c.zip"),
-        sha256 = "a99293bea4549e3ddd1cc0a3307822c719c5ef482707d192be2060051d4505b3",
-        strip_prefix = "bazel-toolchain-ff9ded642e9d8eb2a329f59adcaa3fa5bdb3249c",
+        urls = _github_public_urls("sorbet/bazel-toolchain/archive/0c3130d83ed918d7a51490ea4dd814cb2cc68a85.zip"),
+        sha256 = "4d23f1e8b6ec0e8f612d47ae6189eb00e01461c8ad37cc6c0a41c0e9d5727084",
+        strip_prefix = "bazel-toolchain-0c3130d83ed918d7a51490ea4dd814cb2cc68a85",
     )
 
     http_archive(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We needed to add the share directory to the include dirs in the toolchain definition for the sanitizers to work in clang-10+. The relevant commit in our bazel-toolchain fork is https://github.com/sorbet/bazel-toolchain/commit/0c3130d83ed918d7a51490ea4dd814cb2cc68a85.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
