### PR TITLE
Bump to clang-10

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,7 +12,7 @@ common:test --test_env=GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1
 ##
 ##  Custom toolchain.
 ##
-build --crosstool_top=@llvm_toolchain//:toolchain --copt=-D_LIBCPP_ENABLE_NODISCARD
+build --crosstool_top=@llvm_toolchain_10_0_0//:toolchain --copt=-D_LIBCPP_ENABLE_NODISCARD
 
 ##
 ##  Common build options across all build configurations
@@ -186,9 +186,9 @@ build:ubsan --define unsanitized=false
 build:ubsan --copt=-DHAS_SANITIZER
 
 # Bazel links C++ files with $CC, not $CXX, this breaks UBSan
-build:sanitize-linux --linkopt=external/llvm_toolchain/lib/clang/9.0.0/lib/linux/libclang_rt.asan_cxx-x86_64.a
-build:sanitize-linux --linkopt=external/llvm_toolchain/lib/clang/9.0.0/lib/linux/libclang_rt.ubsan_standalone_cxx-x86_64.a
-build:sanitize-linux --linkopt=external/llvm_toolchain/lib/clang/9.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a
+build:sanitize-linux --linkopt=external/llvm_toolchain_10_0_0/lib/clang/10.0.0/lib/linux/libclang_rt.asan_cxx-x86_64.a
+build:sanitize-linux --linkopt=external/llvm_toolchain_10_0_0/lib/clang/10.0.0/lib/linux/libclang_rt.ubsan_standalone_cxx-x86_64.a
+build:sanitize-linux --linkopt=external/llvm_toolchain_10_0_0/lib/clang/10.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a
 build:sanitize-linux --config=sanitize
 
 build:sanitize-mac --config=sanitize
@@ -237,7 +237,7 @@ build:webasm --compilation_mode=opt
 build:webasm --copt=-DNDEBUG --linkopt=-DNDEBUG # for some reason emscripten doesn't pass those when -O2\-Oz are specified
 build:webasm --copt=--llvm-lto --copt=3 --linkopt=--llvm-lto --linkopt=3
 # Specify a "sane" C++ toolchain for the host platform.
-build:webasm --host_crosstool_top=@llvm_toolchain//:toolchain
+build:webasm --host_crosstool_top=@llvm_toolchain_10_0_0//:toolchain
 
 ##
 ## Stripe's ci passes --config=ci, we need it to exist

--- a/.buildkite/coverage-static-sanitized.sh
+++ b/.buildkite/coverage-static-sanitized.sh
@@ -23,12 +23,12 @@ touch _tmp_/reports
     echo "bazel-testlogs/$path/coverage.dat" >> _tmp_/reports
 done
 
-find ./bazel-app/external/llvm_toolchain/
+find ./bazel-app/external/llvm_toolchain_10_0_0/
 
 rm -rf ./_tmp_/profdata_combined.profdata
 xargs .buildkite/tools/combine-coverage.sh < _tmp_/reports
 
-./bazel-app/external/llvm_toolchain/bin/llvm-cov show -instr-profile ./_tmp_/profdata_combined.profdata ./bazel-bin/test/test_corpus_sharded -object ./bazel-bin/main/sorbet > combined.coverage.txt
+./bazel-app/external/llvm_toolchain_10_0_0/bin/llvm-cov show -instr-profile ./_tmp_/profdata_combined.profdata ./bazel-bin/test/test_corpus_sharded -object ./bazel-bin/main/sorbet > combined.coverage.txt
 
 .buildkite/tools/codecov-bash -f combined.coverage.txt -X search
 

--- a/.buildkite/tools/combine-coverage.sh
+++ b/.buildkite/tools/combine-coverage.sh
@@ -3,9 +3,9 @@
 mkdir -p "_tmp_"
 OUT_FILE1=$(mktemp ./_tmp_/coverage.XXXXXX)
 if [ -f "./_tmp_/profdata_combined.profdata" ]; then
-  ./bazel-app/external/llvm_toolchain/bin/llvm-profdata merge -o="${OUT_FILE1}" ./_tmp_/profdata_combined.profdata "$@"
+  ./bazel-app/external/llvm_toolchain_10_0_0/bin/llvm-profdata merge -o="${OUT_FILE1}" ./_tmp_/profdata_combined.profdata "$@"
 else
-  ./bazel-app/external/llvm_toolchain/bin/llvm-profdata merge -o="${OUT_FILE1}" "$@"
+  ./bazel-app/external/llvm_toolchain_10_0_0/bin/llvm-profdata merge -o="${OUT_FILE1}" "$@"
 fi
 
 mv "${OUT_FILE1}" ./_tmp_/profdata_combined.profdata

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
   // Disable feature where Clangd auto-imports headers for missing references.
   // It inserts relative paths that we don't want.
   "clangd.arguments": ["--header-insertion=never"],
-  "clangd.path": "bazel-sorbet/external/llvm_toolchain/bin/clangd",
+  "clangd.path": "bazel-sorbet/external/llvm_toolchain_10_0_0/bin/clangd",
   "files.associations": {
     "*.rbi": "ruby",
     "*.rbupdated": "ruby",

--- a/README.md
+++ b/README.md
@@ -929,7 +929,7 @@ You are encouraged to play around with various clang-based tools which use the
 
     After successfully compiling Sorbet, point your editor to use the
     `clangd` executable located in
-    `bazel-sorbet/external/llvm_toolchain/bin/clangd`.
+    `bazel-sorbet/external/llvm_toolchain_10_0_0/bin/clangd`.
 
 -   [clang-format] -- Clang-based source code formatter
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,14 +11,14 @@ bazel_toolchain_dependencies()
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
 llvm_toolchain(
-    name = "llvm_toolchain",
+    name = "llvm_toolchain_10_0_0",
     absolute_paths = True,
     llvm_mirror_prefixes = [
         "https://sorbet-deps.s3-us-west-2.amazonaws.com/",
         "https://artifactory-content.stripe.build/artifactory/github-archives/llvm/llvm-project/releases/download/llvmorg-",
         "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     ],
-    llvm_version = "9.0.0",
+    llvm_version = "10.0.0",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/tools/clang.bzl
+++ b/tools/clang.bzl
@@ -30,6 +30,6 @@ _clang_tool = rule(
 def clang_tool(name):
     _clang_tool(
         name = name,
-        tool = "@llvm_toolchain//:bin/" + name,
+        tool = "@llvm_toolchain_10_0_0//:bin/" + name,
         visibility = ["//visibility:public"],
     )

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -28,7 +28,7 @@ echo "building $target"
 ./bazel build "//test/fuzz:$target" --config=fuzz -c opt
 
 # we want the bazel build command to run before this check so that bazel can download itself.
-export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain/bin"
+export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_10_0_0/bin"
 if ! command -v llvm-symbolizer >/dev/null; then
   echo "fatal: command not found: llvm-symbolizer"
   exit 1

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -72,7 +72,7 @@ handle_TERM() {
 trap handle_INT SIGINT
 trap handle_TERM SIGTERM
 
-export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain/bin"
+export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_10_0_0/bin"
 if ! command -v llvm-symbolizer >/dev/null; then
   echo "fatal: command not found: llvm-symbolizer"
   exit 1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Upgrade to clang-10.0.0. By renaming our llvm_toolchain package we avoid the problems that showed up in the clang-9 upgrade, but it does mean that any tooling that depended on `llvm_toolchain` paths in the sandbox will need to be updated to point to `llvm_toolchain_10_0_0` instead.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Upgrading clang for better c++20 support, as well as access to a better version of lldb that will segfault less frequently.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
