### PR TITLE
Typed Setters for raise_on_nil_write Props

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -190,6 +190,7 @@ NameDef names[] = {
     {"merchant"},
     {"foreign"},
     {"ifunset"},
+    {"raiseOnNilWrite", "raise_on_nil_write"},
     {"withoutAccessors", "without_accessors"},
     {"instanceVariableGet", "instance_variable_get"},
     {"instanceVariableSet", "instance_variable_set"},

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -44,4 +44,85 @@ class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest
       end
     end
   end
+
+  it "raises a TypeError setting nil on raise_on_nil_write prop" do
+    klass = Class.new(T::Struct) do
+      prop :foo, T.nilable(String), raise_on_nil_write: true
+    end
+    m = klass.new(foo: "baz")
+    assert_raises(TypeError) do
+      m.foo = nil
+    end
+  end
+
+  it "raises an error omitting raise_on_nil_write prop on initialization" do
+    klass = Class.new(T::Struct) do
+      prop :foo, T.nilable(String), raise_on_nil_write: true
+    end
+    assert_raises(ArgumentError) do
+      klass.new
+    end
+  end
+
+  it "raises an error explicitly setting nil on raise_on_nil_write prop on initialization" do
+    klass = Class.new(T::Struct) do
+      prop :foo, T.nilable(String), raise_on_nil_write: true
+    end
+    assert_raises(TypeError) do
+      klass.new(foo: nil)
+    end
+  end
+
+  # pre-existing behavior
+  it "allows explicit nil default for raise_on_nil_write prop" do
+    klass = Class.new(T::Struct) do
+      prop :foo, T.nilable(String), raise_on_nil_write: true, default: nil
+    end
+    m = klass.new
+    assert(m.foo.nil?)
+  end
+
+  it "does not allow setting nil with T.any(NilClass, U) with raise_on_nil_write props" do
+    klass = Class.new(T::Struct) do
+      prop :foo, T.any(NilClass, String), raise_on_nil_write: true
+    end
+    m = klass.new(foo: 'foo')
+    assert_raises(TypeError) do
+      m.foo = nil
+    end
+  end
+
+  it "allows setting non-nil values with T.any(NilClass, U) with raise_on_nil_write props" do
+    klass = Class.new(T::Struct) do
+      prop :foo, T.any(NilClass, String), raise_on_nil_write: true
+    end
+    m = klass.new(foo: 'foo')
+    m.foo = 'bar'
+  end
+
+  it "raises an error implicitly setting nil with T.any(NilClass, U) on raise_on_nil_write prop on initialization" do
+    klass = Class.new(T::Struct) do
+      prop :foo, T.any(NilClass, String), raise_on_nil_write: true
+    end
+    assert_raises(ArgumentError) do
+      klass.new
+    end
+  end
+
+  it "raises an error explicitly setting nil with T.any(NilClass, U) on raise_on_nil_write prop on initialization" do
+    klass = Class.new(T::Struct) do
+      prop :foo, T.any(NilClass, String), raise_on_nil_write: true
+    end
+    assert_raises(TypeError) do
+      klass.new(foo: nil)
+    end
+  end
+
+  it "allows setting nil values with T.nilable(NilClass) with raise_on_nil_write props, which is fine maybe?" do
+    klass = Class.new(T::Struct) do
+      prop :foo, T.nilable(NilClass), raise_on_nil_write: true
+    end
+    m = klass.new
+    m.foo = nil
+  end
 end

--- a/test/testdata/rewriter/prop_raise_on_nil_write.rb
+++ b/test/testdata/rewriter/prop_raise_on_nil_write.rb
@@ -1,0 +1,17 @@
+# typed: strict
+class Thing
+  include T::Props
+  prop :foo, T.nilable(String), raise_on_nil_write: true
+  prop :bar, T.any(NilClass, String), raise_on_nil_write: true
+end
+
+obj = Thing.new
+# this should be acceptable, but wouldn't normally be seen
+obj.bar = nil
+
+# this should be acceptable
+obj.foo = 'a string'
+
+# this should error, since the setter will not allow nil
+obj.foo = nil
+       #  ^^^ error: Assigning a value to `foo` that does not match expected type `String`

--- a/test/testdata/rewriter/prop_raise_on_nil_write.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_raise_on_nil_write.rewrite-tree.exp
@@ -1,0 +1,77 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Thing><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+    end
+
+    def foo<<todo method>>(&<blk>)
+      begin
+        arg2 = <self>.instance_variable_get(:@foo)
+        <self>.class().decorator().prop_get_logic(<self>, :foo, arg2)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
+    end
+
+    def foo=<<todo method>>(arg0, &<blk>)
+      begin
+        if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
+          ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :foo)
+        else
+          <emptyTree>
+        end
+        <self>.instance_variable_set(:@foo, arg0)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(<emptyTree>::<C T>.any(<emptyTree>::<C NilClass>, <emptyTree>::<C String>))
+    end
+
+    def bar<<todo method>>(&<blk>)
+      begin
+        arg2 = <self>.instance_variable_get(:@bar)
+        <self>.class().decorator().prop_get_logic(<self>, :bar, arg2)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, <emptyTree>::<C T>.any(<emptyTree>::<C NilClass>, <emptyTree>::<C String>)).returns(<emptyTree>::<C T>.any(<emptyTree>::<C NilClass>, <emptyTree>::<C String>))
+    end
+
+    def bar=<<todo method>>(arg0, &<blk>)
+      begin
+        if ::T::NonForcingConstants.non_forcing_is_a?(<self>, "::Chalk::ODM::Document")
+          ::Chalk::ODM::DocumentDecoratorHelper.soft_freeze_logic(<self>, :bar)
+        else
+          <emptyTree>
+        end
+        <self>.instance_variable_set(:@bar, arg0)
+      end
+    end
+
+    <self>.include(<emptyTree>::<C T>::<C Props>)
+
+    <self>.prop(:foo, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>), :raise_on_nil_write, true, :without_accessors, true)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :foo, :normal)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :foo=, :normal)
+
+    <self>.prop(:bar, <emptyTree>::<C T>.any(<emptyTree>::<C NilClass>, <emptyTree>::<C String>), :raise_on_nil_write, true, :without_accessors, true)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :bar, :normal)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :bar=, :normal)
+  end
+
+  obj = <emptyTree>::<C Thing>.new()
+
+  obj.bar=(nil)
+
+  obj.foo=("a string")
+
+  obj.foo=(nil)
+end

--- a/test/testdata/rewriter/prop_raise_on_nil_write.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop_raise_on_nil_write.symbol-table-raw.exp
@@ -1,0 +1,20 @@
+class <C <U <root>>> < <C <U Object>> ()
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=2:1 end=16:14}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=??? end=???}
+  class <C <U Thing>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=2:1 end=2:12}
+    method <C <U Thing>><U bar> (<blk>) -> NilClass | String @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=5:3 end=5:63}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=??? end=???}
+    method <C <U Thing>><U bar=> (bar, <blk>) -> NilClass | String @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=5:3 end=5:63}
+      argument bar<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=5:9 end=5:12}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=??? end=???}
+    method <C <U Thing>><U foo> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=4:3 end=4:57}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=??? end=???}
+    method <C <U Thing>><U foo=> (foo, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=4:3 end=4:57}
+      argument foo<> -> String @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=4:9 end=4:12}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=??? end=???}
+  class <S <C <U Thing>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=2:7 end=2:12}
+    type-member(+) <S <C <U Thing>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Thing>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Thing) @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=2:7 end=2:12}
+    method <S <C <U Thing>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=2:1 end=6:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop_raise_on_nil_write.rb start=??? end=???}
+

--- a/test/testdata/rewriter/prop_raise_on_nil_write_serialize.rb
+++ b/test/testdata/rewriter/prop_raise_on_nil_write_serialize.rb
@@ -1,0 +1,15 @@
+# typed: strict
+class Thing < T::Struct
+  prop :foo, T.nilable(String), raise_on_nil_write: true
+  prop :bar, String
+end
+
+obj = Thing.new(bar: 'bar!')
+
+obj.serialize
+
+# this should be acceptable
+obj.foo = 'a string'
+
+obj.foo = nil
+       #  ^^^ error: Assigning a value to `foo` that does not match expected type `String`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Make it so setters for raise_on_nil_write props no longer allow nil.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We currently enforce this via runtime checks, but it would be more helpful if the signature correctly implied the use case.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
