### PR TITLE
Merge dispatch results in OrType::dispatchCall

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -865,6 +865,9 @@ struct DispatchResult {
                    Combinator secondaryKind)
         : returnType(std::move(returnType)), main(std::move(comp)), secondary(std::move(secondary)),
           secondaryKind(secondaryKind){};
+
+    // Combine two dispatch results, preferring the left as the `main`.
+    static DispatchResult merge(TypePtr &&type, Combinator kind, DispatchResult &&left, DispatchResult &&right);
 };
 
 TYPE_INLINED(BlamedUntyped) final : public ClassType {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -46,9 +46,8 @@ DispatchResult OrType::dispatchCall(const GlobalState &gs, const DispatchArgs &a
     categoryCounterInc("dispatch_call", "ortype");
     auto leftRet = left.dispatchCall(gs, args.withSelfRef(left));
     auto rightRet = right.dispatchCall(gs, args.withSelfRef(right));
-    DispatchResult ret{Types::any(gs, leftRet.returnType, rightRet.returnType), move(leftRet.main),
-                       make_unique<DispatchResult>(move(rightRet)), DispatchResult::Combinator::OR};
-    return ret;
+    return DispatchResult::merge(Types::any(gs, leftRet.returnType, rightRet.returnType),
+                                 DispatchResult::Combinator::OR, std::move(leftRet), std::move(rightRet));
 }
 
 TypePtr OrType::getCallArguments(const GlobalState &gs, NameRef name) const {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -783,4 +783,24 @@ DispatchArgs DispatchArgs::withErrorsSuppressed() const {
     return DispatchArgs{name, locs, numPosArgs, args, selfType, fullType, thisType, block, originForUninitialized,
                         true};
 }
+
+DispatchResult DispatchResult::merge(TypePtr &&type, DispatchResult::Combinator kind, DispatchResult &&left,
+                                     DispatchResult &&right) {
+    DispatchResult res;
+
+    res.returnType = std::move(type);
+    res.main = std::move(left.main);
+    res.secondary = std::move(left.secondary);
+    res.secondaryKind = kind;
+
+    auto *it = &res;
+    while (it->secondary != nullptr) {
+        it = it->secondary.get();
+    }
+
+    it->secondary = make_unique<DispatchResult>(std::move(right));
+
+    return res;
+}
+
 } // namespace sorbet::core

--- a/test/testdata/infer/or_losing_errors.rb
+++ b/test/testdata/infer/or_losing_errors.rb
@@ -1,0 +1,40 @@
+# typed: true
+
+extend T::Sig
+
+class A
+  def foo; true; end
+end
+
+class B; end
+
+class C; end
+
+class D
+  def foo; true; end
+end
+
+sig {params(x: T.any(B, A, D)).returns(T::Boolean)}
+def bar_beginning(x)
+  x.foo
+# ^^^^^ error: Method `foo` does not exist on `B` component of `T.any(B, A, D)`
+end
+
+sig {params(x: T.any(A, B, D)).returns(T::Boolean)}
+def bar_middle(x)
+  x.foo
+# ^^^^^ error: Method `foo` does not exist on `B` component of `T.any(A, B, D)`
+end
+
+sig {params(x: T.any(A, D, B)).returns(T::Boolean)}
+def bar_end(x)
+  x.foo
+# ^^^^^ error: Method `foo` does not exist on `B` component of `T.any(A, D, B)`
+end
+
+sig {params(x: T.any(A, B, C, D)).returns(T::Boolean)}
+def bar_more_than_one(x)
+  x.foo
+# ^^^^^ error: Method `foo` does not exist on `B` component of `T.any(A, B, C, D)`
+# ^^^^^ error: Method `foo` does not exist on `C` component of `T.any(A, B, C, D)`
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
An alternate approach to #3952.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We were losing errors in some cases where `T.any` is used, as the `DispatchResult` constructed in `OrType::dispatchCall` was unconditionally throwing away the `secondary` value from the left side of the `OrType`.

Fixes #2373
Fixes #2813
Fixes #3910

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
