### PR TITLE
Use DispatchResult::merge in AndType::dispatchCall

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -867,7 +867,7 @@ struct DispatchResult {
           secondaryKind(secondaryKind){};
 
     // Combine two dispatch results, preferring the left as the `main`.
-    static DispatchResult merge(TypePtr &&type, Combinator kind, DispatchResult &&left, DispatchResult &&right);
+    static DispatchResult merge(const GlobalState &gs, Combinator kind, DispatchResult &&left, DispatchResult &&right);
 };
 
 TYPE_INLINED(BlamedUntyped) final : public ClassType {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -46,9 +46,7 @@ DispatchResult OrType::dispatchCall(const GlobalState &gs, const DispatchArgs &a
     categoryCounterInc("dispatch_call", "ortype");
     auto leftRet = left.dispatchCall(gs, args.withSelfRef(left));
     auto rightRet = right.dispatchCall(gs, args.withSelfRef(right));
-    auto resultType = Types::any(gs, leftRet.returnType, rightRet.returnType);
-    return DispatchResult::merge(std::move(resultType), DispatchResult::Combinator::OR, std::move(leftRet),
-                                 std::move(rightRet));
+    return DispatchResult::merge(gs, DispatchResult::Combinator::OR, std::move(leftRet), std::move(rightRet));
 }
 
 TypePtr OrType::getCallArguments(const GlobalState &gs, NameRef name) const {
@@ -95,8 +93,7 @@ DispatchResult AndType::dispatchCall(const GlobalState &gs, const DispatchArgs &
     }
 
     auto resultType = Types::all(gs, leftRet.returnType, rightRet.returnType);
-    return DispatchResult::merge(std::move(resultType), DispatchResult::Combinator::AND, std::move(leftRet),
-                                 std::move(rightRet));
+    return DispatchResult::merge(gs, DispatchResult::Combinator::AND, std::move(leftRet), std::move(rightRet));
 }
 
 TypePtr AndType::getCallArguments(const GlobalState &gs, NameRef name) const {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -46,8 +46,9 @@ DispatchResult OrType::dispatchCall(const GlobalState &gs, const DispatchArgs &a
     categoryCounterInc("dispatch_call", "ortype");
     auto leftRet = left.dispatchCall(gs, args.withSelfRef(left));
     auto rightRet = right.dispatchCall(gs, args.withSelfRef(right));
-    return DispatchResult::merge(Types::any(gs, leftRet.returnType, rightRet.returnType),
-                                 DispatchResult::Combinator::OR, std::move(leftRet), std::move(rightRet));
+    auto resultType = Types::any(gs, leftRet.returnType, rightRet.returnType);
+    return DispatchResult::merge(std::move(resultType), DispatchResult::Combinator::OR, std::move(leftRet),
+                                 std::move(rightRet));
 }
 
 TypePtr OrType::getCallArguments(const GlobalState &gs, NameRef name) const {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -93,12 +93,10 @@ DispatchResult AndType::dispatchCall(const GlobalState &gs, const DispatchArgs &
         leftRet = left.dispatchCall(gs, args.withThisRef(left));
         rightRet = right.dispatchCall(gs, args.withThisRef(right));
     }
-    DispatchResult ret{Types::all(gs, leftRet.returnType, rightRet.returnType), move(leftRet.main),
-                       make_unique<DispatchResult>(move(rightRet)),
 
-                       DispatchResult::Combinator::AND};
-
-    return ret;
+    auto resultType = Types::all(gs, leftRet.returnType, rightRet.returnType);
+    return DispatchResult::merge(std::move(resultType), DispatchResult::Combinator::AND, std::move(leftRet),
+                                 std::move(rightRet));
 }
 
 TypePtr AndType::getCallArguments(const GlobalState &gs, NameRef name) const {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -784,11 +784,20 @@ DispatchArgs DispatchArgs::withErrorsSuppressed() const {
                         true};
 }
 
-DispatchResult DispatchResult::merge(TypePtr &&type, DispatchResult::Combinator kind, DispatchResult &&left,
+DispatchResult DispatchResult::merge(const GlobalState &gs, DispatchResult::Combinator kind, DispatchResult &&left,
                                      DispatchResult &&right) {
     DispatchResult res;
 
-    res.returnType = std::move(type);
+    switch (kind) {
+        case DispatchResult::Combinator::OR:
+            res.returnType = Types::any(gs, left.returnType, right.returnType);
+            break;
+
+        case DispatchResult::Combinator::AND:
+            res.returnType = Types::all(gs, left.returnType, right.returnType);
+            break;
+    }
+
     res.main = std::move(left.main);
     res.secondary = std::move(left.secondary);
     res.secondaryKind = kind;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Like #3974, `AndType::dispatchCall` was losing the `secondary` value from the left side of the tree.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Avoid potentially losing errors with `T.all` dispatch.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
