### PR TITLE
mark Command self.call as unimplemented

### DIFF
--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -83,6 +83,8 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
         ast::MK::SyntheticMethod(call->loc, call->loc, call->name, std::move(newArgs), ast::MK::UntypedNil(call->loc));
     auto &mdef = ast::cast_tree_nonnull<ast::MethodDef>(selfCall);
     mdef.flags.isSelfMethod = true;
+    // This method is only for type checking. It doesn't actually exist at runtime, and instead all
+    // Opus::Command subclasses inherit the `self.call` method from `Opus::Command` directly.
     mdef.flags.isUnimplemented = true;
 
     klass->rhs.insert(klass->rhs.begin() + i + 1, sig->deepCopy());

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -81,7 +81,9 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
 
     auto selfCall =
         ast::MK::SyntheticMethod(call->loc, call->loc, call->name, std::move(newArgs), ast::MK::UntypedNil(call->loc));
-    ast::cast_tree<ast::MethodDef>(selfCall)->flags.isSelfMethod = true;
+    auto &mdef = ast::cast_tree_nonnull<ast::MethodDef>(selfCall);
+    mdef.flags.isSelfMethod = true;
+    mdef.flags.isUnimplemented = true;
 
     klass->rhs.insert(klass->rhs.begin() + i + 1, sig->deepCopy());
     klass->rhs.insert(klass->rhs.begin() + i + 2, std::move(selfCall));

--- a/test/testdata/rewriter/command.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/command.rb.rewrite-tree.exp
@@ -21,8 +21,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :call, :normal)
-
-    ::Sorbet::Private::Static.keep_self_def(<self>, :call, :normal)
   end
 
   <emptyTree>::<C T>.assert_type!(<emptyTree>::<C MyCommand>.call(7), <emptyTree>::<C String>)
@@ -45,8 +43,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :call, :normal)
-
-    ::Sorbet::Private::Static.keep_self_def(<self>, :call, :normal)
   end
 
   <emptyTree>::<C T>.assert_type!(<emptyTree>::<C OtherCommand>.call("8"), <emptyTree>::<C Integer>)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Mark the synthesized `self.call` of the `Opus::Command` rewriter as unimplemented.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We don't need to keep this method around.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
