### PR TITLE
rename Flags::isUnimplemented to Flags::discardDef, and make Flags more functional

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -220,34 +220,35 @@ public:
     }
 
     static ExpressionPtr Method(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                                MethodDef::ARGS_store args, ExpressionPtr rhs) {
+                                MethodDef::ARGS_store args, ExpressionPtr rhs,
+                                MethodDef::Flags flags = MethodDef::Flags()) {
         if (args.empty() || (!isa_tree<ast::Local>(args.back()) && !isa_tree<ast::BlockArg>(args.back()))) {
             auto blkLoc = core::LocOffsets::none();
             args.emplace_back(make_expression<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
         }
-        MethodDef::Flags flags;
         return make_expression<MethodDef>(loc, declLoc, core::Symbols::todoMethod(), name, std::move(args),
                                           std::move(rhs), flags);
     }
 
     static ExpressionPtr SyntheticMethod(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                                         MethodDef::ARGS_store args, ExpressionPtr rhs) {
-        auto mdef = Method(loc, declLoc, name, std::move(args), std::move(rhs));
-        cast_tree<MethodDef>(mdef)->flags.isRewriterSynthesized = true;
-        return mdef;
+                                         MethodDef::ARGS_store args, ExpressionPtr rhs,
+                                         MethodDef::Flags flags = MethodDef::Flags()) {
+        flags.isRewriterSynthesized = true;
+        return Method(loc, declLoc, name, std::move(args), std::move(rhs), flags);
     }
 
     static ExpressionPtr SyntheticMethod0(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                                          ExpressionPtr rhs) {
+                                          ExpressionPtr rhs, MethodDef::Flags flags = MethodDef::Flags()) {
         MethodDef::ARGS_store args;
-        return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs));
+        return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs), flags);
     }
 
     static ExpressionPtr SyntheticMethod1(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                                          ExpressionPtr arg0, ExpressionPtr rhs) {
+                                          ExpressionPtr arg0, ExpressionPtr rhs,
+                                          MethodDef::Flags flags = MethodDef::Flags()) {
         MethodDef::ARGS_store args;
         args.emplace_back(std::move(arg0));
-        return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs));
+        return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs), flags);
     }
 
     static ExpressionPtr ClassOrModule(core::LocOffsets loc, core::LocOffsets declLoc, ExpressionPtr name,

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -363,10 +363,10 @@ public:
         bool isSelfMethod : 1;
         bool isRewriterSynthesized : 1;
         bool isAttrReader : 1;
-        bool isUnimplemented : 1;
+        bool discardDef : 1;
 
         // In C++20 we can replace this with bit field initialzers
-        Flags() : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), isUnimplemented(false) {}
+        Flags() : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), discardDef(false) {}
     };
     CheckSize(Flags, 1, 1);
 

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -283,10 +283,11 @@ vector<ast::ExpressionPtr> AttrReader::run(core::MutableContext ctx, ast::Send *
                 }
             }
 
-            auto reader = ast::MK::SyntheticMethod0(loc, loc, name, ast::MK::Instance(argLoc, varName));
+            ast::MethodDef::Flags flags;
             if (sigIsUnchecked(ctx, sig)) {
-                ast::cast_tree_nonnull<ast::MethodDef>(reader).flags.isAttrReader = true;
+                flags.isAttrReader = true;
             }
+            auto reader = ast::MK::SyntheticMethod0(loc, loc, name, ast::MK::Instance(argLoc, varName), flags);
             stats.emplace_back(std::move(reader));
         }
     }

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -85,7 +85,7 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
     mdef.flags.isSelfMethod = true;
     // This method is only for type checking. It doesn't actually exist at runtime, and instead all
     // Opus::Command subclasses inherit the `self.call` method from `Opus::Command` directly.
-    mdef.flags.isUnimplemented = true;
+    mdef.flags.discardDef = true;
 
     klass->rhs.insert(klass->rhs.begin() + i + 1, sig->deepCopy());
     klass->rhs.insert(klass->rhs.begin() + i + 2, std::move(selfCall));

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -79,13 +79,13 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
         newArgs.emplace_back(arg.deepCopy());
     }
 
-    auto selfCall =
-        ast::MK::SyntheticMethod(call->loc, call->loc, call->name, std::move(newArgs), ast::MK::UntypedNil(call->loc));
-    auto &mdef = ast::cast_tree_nonnull<ast::MethodDef>(selfCall);
-    mdef.flags.isSelfMethod = true;
     // This method is only for type checking. It doesn't actually exist at runtime, and instead all
     // Opus::Command subclasses inherit the `self.call` method from `Opus::Command` directly.
-    mdef.flags.discardDef = true;
+    ast::MethodDef::Flags flags;
+    flags.isSelfMethod = true;
+    flags.discardDef = true;
+    auto selfCall = ast::MK::SyntheticMethod(call->loc, call->loc, call->name, std::move(newArgs),
+                                             ast::MK::UntypedNil(call->loc), flags);
 
     klass->rhs.insert(klass->rhs.begin() + i + 1, sig->deepCopy());
     klass->rhs.insert(klass->rhs.begin() + i + 2, std::move(selfCall));

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -369,10 +369,10 @@ public:
         auto keepName = methodDef.flags.isSelfMethod ? core::Names::keepSelfDef() : core::Names::keepDef();
 
         auto kind = methodDef.flags.isAttrReader ? core::Names::attrReader() : core::Names::normal();
-        auto unimplemented = methodDef.flags.isUnimplemented;
+        auto discardable = methodDef.flags.discardDef;
         methods.addExpr(*md, move(tree));
 
-        if (unimplemented) {
+        if (discardable) {
             return ast::MK::EmptyTree();
         } else {
             return ast::MK::Send3(loc, ast::MK::Constant(loc, core::Symbols::Sorbet_Private_Static()), keepName,

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -408,9 +408,10 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, 
 
         auto arg =
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
+        ast::MethodDef::Flags fkFlags;
+        fkFlags.discardDef = true;
         auto fkMethodDef =
-            ast::MK::SyntheticMethod1(loc, loc, fkMethod, std::move(arg), ast::MK::RaiseUnimplemented(loc));
-        ast::cast_tree_nonnull<ast::MethodDef>(fkMethodDef).flags.discardDef = true;
+            ast::MK::SyntheticMethod1(loc, loc, fkMethod, std::move(arg), ast::MK::RaiseUnimplemented(loc), fkFlags);
         nodes.emplace_back(std::move(fkMethodDef));
 
         // sig {params(opts: T.untyped).returns($foreign)}
@@ -424,9 +425,10 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, 
         auto fkMethodBang = ctx.state.enterNameUTF8(name.show(ctx) + "_!");
         auto arg2 =
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
-        auto fkMethodDefBang =
-            ast::MK::SyntheticMethod1(loc, loc, fkMethodBang, std::move(arg2), ast::MK::RaiseUnimplemented(loc));
-        ast::cast_tree_nonnull<ast::MethodDef>(fkMethodDefBang).flags.discardDef = true;
+        ast::MethodDef::Flags fkBangFlags;
+        fkBangFlags.discardDef = true;
+        auto fkMethodDefBang = ast::MK::SyntheticMethod1(loc, loc, fkMethodBang, std::move(arg2),
+                                                         ast::MK::RaiseUnimplemented(loc), fkBangFlags);
         nodes.emplace_back(std::move(fkMethodDefBang));
     }
 

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -410,7 +410,7 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, 
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
         auto fkMethodDef =
             ast::MK::SyntheticMethod1(loc, loc, fkMethod, std::move(arg), ast::MK::RaiseUnimplemented(loc));
-        ast::cast_tree_nonnull<ast::MethodDef>(fkMethodDef).flags.isUnimplemented = true;
+        ast::cast_tree_nonnull<ast::MethodDef>(fkMethodDef).flags.discardDef = true;
         nodes.emplace_back(std::move(fkMethodDef));
 
         // sig {params(opts: T.untyped).returns($foreign)}
@@ -426,7 +426,7 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, 
             ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
         auto fkMethodDefBang =
             ast::MK::SyntheticMethod1(loc, loc, fkMethodBang, std::move(arg2), ast::MK::RaiseUnimplemented(loc));
-        ast::cast_tree_nonnull<ast::MethodDef>(fkMethodDefBang).flags.isUnimplemented = true;
+        ast::cast_tree_nonnull<ast::MethodDef>(fkMethodDefBang).flags.discardDef = true;
         nodes.emplace_back(std::move(fkMethodDefBang));
     }
 


### PR DESCRIPTION
This is a change suggested by jez on #3976 (first commit) and a change that I thought I might as well implement while I was in the neighborhood: making `Flags` more functional so we don't have to keep casting to `MethodDef` to set things.

If folks don't like the latter change, I can just drop it.

### Motivation

Better naming is more better.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
