### PR TITLE
WIP: Introduce a ConcurrentTask abstraction to replace most uses of multiplexjob

### DIFF
--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -87,6 +87,11 @@ public:
     int sizeEstimate() const {
         return _queue.size_approx();
     }
+
+    // Used for ENFORCEs.
+    bool hasAllInput() {
+        return elementsLeftToPush.load() == 0;
+    }
 };
 
 template <class Elem>

--- a/common/concurrency/ConcurrentTask.h
+++ b/common/concurrency/ConcurrentTask.h
@@ -1,0 +1,82 @@
+#ifndef SORBET_CONCURRENTTASK_H
+#define SORBET_CONCURRENTTASK_H
+
+#include "absl/synchronization/barrier.h"
+#include "common/ConstExprStr.h"
+#include "common/concurrency/ConcurrentQueue.h"
+#include "common/concurrency/WorkerPool.h"
+
+namespace sorbet {
+template <typename I, typename WorkerState> class ConcurrentTask {
+    std::shared_ptr<ConcurrentBoundedQueue<I>> inputq;
+    ConstExprStr metricName;
+    ConstExprStr workerMetricName;
+    const size_t size;
+    spdlog::logger &tracer;
+    WorkerPool &workers;
+
+public:
+    ConcurrentTask(ConstExprStr metricName, ConstExprStr workerMetricName, size_t size, spdlog::logger &tracer,
+                   WorkerPool &workers)
+        : inputq(std::make_shared<ConcurrentBoundedQueue<I>>(size)), metricName(metricName),
+          workerMetricName(workerMetricName), size(size), tracer(tracer), workers(workers) {}
+
+    void enqueue(I &&input) {
+        inputq->push(std::move(input), 1);
+    }
+
+    void run(std::function<void(I &&, WorkerState &)> processTask, std::function<void(WorkerState &&)> combineOutput) {
+        ENFORCE_NO_TIMER(inputq->hasAllInput(), "Input queue is not filled; did you specify the wrong queue size?");
+        Timer timeit(tracer, metricName);
+
+        auto outputq = std::make_shared<BlockingBoundedQueue<WorkerState>>(size);
+
+        // Note: Cannot be stack allocated; see docs for absl::Barrier. The +1 is for the control thread.
+        auto workerBarrier = new absl::Barrier(workers.size() + 1);
+
+        // Note: We must copy `barrier` pointer into the lambda, as `delete barrier` races with the coordinator thread
+        // destroying the stack frame.
+        workers.multiplexJob(metricName.str, [&, barrier = workerBarrier]() {
+            {
+                Timer timeit(tracer, workerMetricName);
+                I input;
+                size_t count = 0;
+                WorkerState state;
+                for (auto result = inputq->try_pop(input); !result.done(); result = inputq->try_pop(input)) {
+                    if (result.gotItem()) {
+                        count++;
+                        processTask(std::move(input), state);
+                    }
+                }
+                if (count > 0) {
+                    outputq->push(std::move(state), count);
+                }
+            }
+            // Prevent deadlock with an empty workerpool, where all logic runs on one thread.
+            if (workers.size() > 0 && barrier->Block()) {
+                delete barrier;
+            }
+        });
+
+        {
+            WorkerState threadResult;
+            for (auto result = outputq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), tracer);
+                 !result.done(); result = outputq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), tracer)) {
+                if (result.gotItem()) {
+                    combineOutput(std::move(threadResult));
+                }
+            }
+        }
+
+        // Wait for all workers to complete before exiting. Prevents the scenario where this function completes before
+        // all worker threads, which causes a SEGFAULT as the thread tries to access deallocated objects.
+        // That scenario is possible if one thread isn't scheduled to run until after all other threads have finished
+        // processing work.
+        if (workerBarrier->Block()) {
+            delete workerBarrier;
+        }
+    }
+};
+} // namespace sorbet
+
+#endif

--- a/common/concurrency/ConcurrentTask.h
+++ b/common/concurrency/ConcurrentTask.h
@@ -53,6 +53,7 @@ public:
                 }
             }
             // Prevent deadlock with an empty workerpool, where all logic runs on one thread.
+            // After this LOC, it is no longer safe to use `this` or refer to any variables in the `run` stack frame.
             if (workers.size() > 0 && barrier->Block()) {
                 delete barrier;
             }

--- a/common/concurrency/ConcurrentTask.h
+++ b/common/concurrency/ConcurrentTask.h
@@ -42,7 +42,9 @@ public:
 
         // Note: We must copy `barrier` pointer into the lambda, as `delete barrier` races with the coordinator thread
         // destroying the stack frame.
-        workers.multiplexJob(metricName.str, [&, barrier = workerBarrier]() {
+        workers.multiplexJob(metricName.str, [&tracer = this->tracer, &workerMetricName = this->workerMetricName,
+                                              inputq = this->inputq, outputq, processTask, counters,
+                                              &workers = this->workers, barrier = workerBarrier]() {
             {
                 Timer timeit(tracer, workerMetricName);
                 I input;
@@ -64,7 +66,8 @@ public:
             }
 
             // Prevent deadlock with an empty workerpool, where all logic runs on one thread.
-            // After this LOC, it is no longer safe to use `this` or refer to any variables in the `run` stack frame.
+            // After this LOC, it is no longer safe to use `this` or refer to any variables in the `run` stack
+            // frame.
             if (workers.size() > 0 && barrier->Block()) {
                 delete barrier;
             }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -2,7 +2,7 @@
 #include "absl/synchronization/mutex.h"
 #include "absl/synchronization/notification.h"
 #include "ast/treemap/treemap.h"
-#include "common/concurrency/ConcurrentQueue.h"
+#include "common/concurrency/ConcurrentTask.h"
 #include "common/sort.h"
 #include "core/ErrorCollector.h"
 #include "core/ErrorQueue.h"
@@ -278,52 +278,31 @@ bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &i
                                  vector<ast::ParsedFile> &out) const {
     auto &logger = *config->logger;
     Timer timeit(logger, "slow_path.copy_indexes");
-    shared_ptr<ConcurrentBoundedQueue<int>> fileq = make_shared<ConcurrentBoundedQueue<int>>(indexed.size());
-    for (int i = 0; i < indexed.size(); i++) {
+    ConcurrentTask<size_t, vector<ast::ParsedFile>> task("copyParsedFiles", "copyParsedFilesWorker", indexed.size(),
+                                                         logger, workers);
+    for (size_t i = 0; i < indexed.size(); i++) {
         auto copy = i;
-        fileq->push(move(copy), 1);
+        task.enqueue(move(copy));
     }
 
     const auto &epochManager = *gs->epochManager;
-    shared_ptr<BlockingBoundedQueue<vector<ast::ParsedFile>>> resultq =
-        make_shared<BlockingBoundedQueue<vector<ast::ParsedFile>>>(indexed.size());
-    workers.multiplexJob("copyParsedFiles", [fileq, resultq, &indexed = this->indexed, &ignore, &epochManager]() {
-        vector<ast::ParsedFile> threadResult;
-        int processedByThread = 0;
-        int job;
-        {
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
-                if (result.gotItem()) {
-                    processedByThread++;
-
-                    // Stop if typechecking was canceled.
-                    if (!epochManager.wasTypecheckingCanceled()) {
-                        const auto &tree = indexed[job];
-                        // Note: indexed entries for payload files don't have any contents.
-                        if (tree.tree && !ignore.contains(tree.file.id())) {
-                            threadResult.emplace_back(ast::ParsedFile{tree.tree.deepCopy(), tree.file});
-                        }
-                    }
+    // TODO: Can add a runCanceled function.
+    task.run(
+        [&epochManager, &indexed = this->indexed, &ignore](size_t &&job, vector<ast::ParsedFile> &threadState) -> void {
+            // Stop if typechecking was canceled.
+            if (!epochManager.wasTypecheckingCanceled()) {
+                const auto &tree = indexed[job];
+                // Note: indexed entries for payload files don't have any contents.
+                if (tree.tree && !ignore.contains(tree.file.id())) {
+                    threadState.emplace_back(ast::ParsedFile{tree.tree.deepCopy(), tree.file});
                 }
             }
-        }
-
-        if (processedByThread > 0) {
-            resultq->push(move(threadResult), processedByThread);
-        }
-    });
-    {
-        vector<ast::ParsedFile> threadResult;
-        out.reserve(indexed.size());
-        for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger); !result.done();
-             result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
-            if (result.gotItem()) {
-                for (auto &copy : threadResult) {
-                    out.push_back(move(copy));
-                }
+        },
+        [&out](vector<ast::ParsedFile> &&threadState) -> void {
+            for (auto &copy : threadState) {
+                out.emplace_back(move(copy));
             }
-        }
-    }
+        });
     return !epochManager.wasTypecheckingCanceled();
 }
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -22,7 +22,7 @@
 #include "class_flatten/class_flatten.h"
 #include "common/FileOps.h"
 #include "common/Timer.h"
-#include "common/concurrency/ConcurrentQueue.h"
+#include "common/concurrency/ConcurrentTask.h"
 #include "common/crypto_hashing/crypto_hashing.h"
 #include "common/formatting.h"
 #include "common/sort.h"
@@ -1213,55 +1213,33 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, vector
     }
 
     Timer timeit(gs.tracer(), "pipeline::cacheTreesAndFiles");
-
     // Compress files in parallel.
-    auto fileq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile *>>(parsedFiles.size());
+    ConcurrentTask<ast::ParsedFile *, vector<pair<string, vector<u1>>>> task(
+        "compressTreesAndFiles", "compressTreesAndFilesWorker", parsedFiles.size(), gs.tracer(), workers);
+
     for (auto &parsedFile : parsedFiles) {
         auto ptr = &parsedFile;
-        fileq->push(move(ptr), 1);
+        task.enqueue(move(ptr));
     }
-
-    auto resultq = make_shared<BlockingBoundedQueue<vector<pair<string, vector<u1>>>>>(parsedFiles.size());
-    workers.multiplexJob("compressTreesAndFiles", [fileq, resultq, &gs]() {
-        vector<pair<string, vector<u1>>> threadResult;
-        int processedByThread = 0;
-        ast::ParsedFile *job = nullptr;
-        {
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
-                if (result.gotItem()) {
-                    processedByThread++;
-
-                    if (!job->file.exists()) {
-                        continue;
-                    }
-
-                    auto &file = job->file.data(gs);
-                    if (!file.cached && !file.hasParseErrors) {
-                        threadResult.emplace_back(fileKey(file), core::serialize::Serializer::storeFile(file, *job));
-                    }
-                }
-            }
-        }
-
-        if (processedByThread > 0) {
-            resultq->push(move(threadResult), processedByThread);
-        }
-    });
 
     bool written = false;
-    {
-        vector<pair<string, vector<u1>>> threadResult;
-        for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
-             !result.done();
-             result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
-            if (result.gotItem()) {
-                for (auto &a : threadResult) {
-                    kvstore->write(move(a.first), move(a.second));
-                    written = true;
-                }
+    task.run(
+        [&gs](ast::ParsedFile *job, vector<pair<string, vector<u1>>> &threadState) -> void {
+            if (!job->file.exists()) {
+                return;
             }
-        }
-    }
+
+            auto &file = job->file.data(gs);
+            if (!file.cached && !file.hasParseErrors) {
+                threadState.emplace_back(fileKey(file), core::serialize::Serializer::storeFile(file, *job));
+            }
+        },
+        [&written, &kvstore](vector<pair<string, vector<u1>>> &&threadState) -> void {
+            for (auto &a : threadState) {
+                kvstore->write(move(a.first), move(a.second));
+                written = true;
+            }
+        });
     return written;
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

WIP: Introduce a ConcurrentTask abstraction to replace most uses of multiplexjob. Net negative LOC PR since it's much easier to specify parallel tasks now.

Features:
* **Threadsafe handling of queues and stack frames.** Unlike our previous handrolled loops, `ConcurrentTask` uses a barrier to wait for all worker threads to finish before letting the coordinator thread proceed, which avoids nasty race conditions. This change fixes some possible-but-unlikely race conditions in the code.
  * Bonus: Fixing this bug should resolve some "queue depth" bugs that occur with WorkerPool, since the queue should never get deeper than 1 + non-concurrent-task-uses-of-workerpool.
* **Timers for coordinator + worker threads.** It "just happens".
* **Need to collect counters from worker threads? That's a template argument.** We don't collect counters all of the time because it's not completely free, and batching is good. (Perhaps this should just be its own ConcurrentTask sometime.)

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm tired of writing these by hand and hitting the same bugs over and over.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

CI + perf testing on Stripe's codebase.