### PR TITLE
WIP: Try using xxHash for hashing other name types.

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -32,11 +32,16 @@ namespace {
 // Hash functions used to determine position in namesByHash.
 
 inline unsigned int hashMixUnique(UniqueNameKind unk, unsigned int num, unsigned int rawId) {
-    return mix(mix(num, static_cast<u4>(unk)), rawId) * HASH_MULT2 + static_cast<u4>(NameKind::UNIQUE);
+    u4 unkAndKind = static_cast<u4>(unk) << 8;
+    unkAndKind |= static_cast<u4>(NameKind::UNIQUE);
+    return _hash(unkAndKind, num, rawId);
 }
 
 inline unsigned int hashMixConstant(unsigned int id) {
-    return id * HASH_MULT2 + static_cast<u4>(NameKind::CONSTANT);
+    u8 data = id;
+    data <<= 32;
+    data |= static_cast<u8>(NameKind::CONSTANT);
+    return _hash(data);
 }
 
 inline unsigned int hashNameRef(const GlobalState &gs, NameRef nref) {

--- a/core/hashing/hashing.cc
+++ b/core/hashing/hashing.cc
@@ -9,4 +9,13 @@ unsigned int _hash(std::string_view utf8) {
     return XXH32(utf8.data(), utf8.size(), /* seed */ 0);
 }
 
+unsigned int _hash(uint64_t num1) {
+    return XXH32(&num1, sizeof(num1), /* seed */ 0);
+}
+
+unsigned int _hash(uint32_t num1, uint32_t num2, uint32_t num3) {
+    uint32_t data[3] = {num1, num2, num3};
+    return XXH32(data, sizeof(uint32_t) * 3, /* seed */ 0);
+}
+
 } // namespace sorbet::core

--- a/core/hashing/hashing.h
+++ b/core/hashing/hashing.h
@@ -13,5 +13,9 @@ inline unsigned int mix(unsigned int acc, unsigned int nw) {
 
 unsigned int _hash(std::string_view utf8);
 
+unsigned int _hash(uint64_t num1);
+
+unsigned int _hash(uint32_t num1, uint32_t num2, uint32_t num3);
+
 } // namespace sorbet::core
 #endif // SORBET_HASHING_H


### PR DESCRIPTION
WIP: Try using xxHash for hashing other name types.

It's 3x-4x slower, but maybe there will be fewer collisions? Let's find out!

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Improve hashing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
