### PR TITLE
Remove fileref param from unpickleExpr.

### DIFF
--- a/core/serialize/serialize.h
+++ b/core/serialize/serialize.h
@@ -33,8 +33,8 @@ public:
 
     static u4 loadGlobalStateUUID(const GlobalState &gs, const u1 *const data);
 
-    // Loads the given file and its AST. Overwrites file references in the AST with the given file ref.
-    static CachedFile loadFile(const GlobalState &gs, core::FileRef fref, const u1 *const data);
+    // Loads the given file and its AST.
+    static CachedFile loadFile(const GlobalState &gs, const u1 *const data);
 };
 }; // namespace sorbet::core::serialize
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -95,7 +95,7 @@ unique_ptr<core::serialize::CachedFile> fetchFileFromCache(core::GlobalState &gs
         auto maybeCached = kvstore->read(fileHashKey);
         if (maybeCached) {
             prodCounterInc("types.input.files.kvstore.hit");
-            auto cachedTree = core::serialize::Serializer::loadFile(gs, fref, maybeCached);
+            auto cachedTree = core::serialize::Serializer::loadFile(gs, maybeCached);
             return make_unique<core::serialize::CachedFile>(move(cachedTree));
         } else {
             prodCounterInc("types.input.files.kvstore.miss");

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -1,6 +1,5 @@
 #include "doctest.h"
 // has to go first as it violates our requirements
-#include "ProtocolTest.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_replace.h"
 #include "common/FileOps.h"
@@ -15,6 +14,7 @@
 #include "spdlog/sinks/null_sink.h"
 #include "test/helpers/CounterStateDatabase.h"
 #include "test/helpers/lsp.h"
+#include "test/lsp/ProtocolTest.h"
 #include <sys/wait.h>
 
 namespace sorbet::test::lsp {
@@ -93,7 +93,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
         // If caching fails, gs gets modified during payload creation.
         CHECK_FALSE(gs->wasModified());
 
-        auto cachedFile = core::serialize::Serializer::loadFile(*gs, core::FileRef{10}, contents);
+        auto cachedFile = core::serialize::Serializer::loadFile(*gs, contents);
         CHECK(cachedFile.file->cached);
         CHECK_EQ(cachedFile.file->path(), filePath);
         CHECK_EQ(cachedFile.file->source(), fileContents);
@@ -141,7 +141,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
         auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*logger, *logger));
         payload::createInitialGlobalState(gs, *opts, kvstore);
 
-        auto cachedFile = core::serialize::Serializer::loadFile(*gs, core::FileRef{10}, updatedFileData);
+        auto cachedFile = core::serialize::Serializer::loadFile(*gs, updatedFileData);
         CHECK(cachedFile.file->cached);
         CHECK_EQ(cachedFile.file->path(), filePath);
         CHECK_EQ(cachedFile.file->source(), updatedFileContents);
@@ -191,7 +191,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPDoesNotUseCacheIfModified") {
         // If caching fails, gs gets modified during payload creation.
         CHECK_FALSE(gs->wasModified());
 
-        auto cachedFile = core::serialize::Serializer::loadFile(*gs, core::FileRef{10}, contents);
+        auto cachedFile = core::serialize::Serializer::loadFile(*gs, contents);
         CHECK(cachedFile.file->cached);
         CHECK_EQ(cachedFile.file->path(), filePath);
         CHECK_EQ(cachedFile.file->source(), fileContents);

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -102,7 +102,7 @@ UnorderedSet<string> knownExpectations = {"parse-tree",
 ast::ParsedFile testSerialize(core::GlobalState &gs, ast::ParsedFile expr) {
     auto &savedFile = expr.file.data(gs);
     auto saved = core::serialize::Serializer::storeFile(savedFile, expr);
-    auto restored = core::serialize::Serializer::loadFile(gs, expr.file, saved.data());
+    auto restored = core::serialize::Serializer::loadFile(gs, saved.data());
     return {move(restored.tree), expr.file};
 }
 


### PR DESCRIPTION
Remove fileref param from unpickleExpr.

Expressions no longer encode file refs so this param is unused.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

CI.
