### PR TITLE
Return length of data with kvstore reads, and avoid copying in writeString.

### DIFF
--- a/common/kvstore/KeyValueStore-emscripten.cc
+++ b/common/kvstore/KeyValueStore-emscripten.cc
@@ -36,11 +36,15 @@ void OwnedKeyValueStore::abort() const {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
+void OwnedKeyValueStore::writeInternal(string_view key, void *data, size_t len) {
+    throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
+}
+
 void OwnedKeyValueStore::write(string_view key, const vector<u1> &value) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-u1 *OwnedKeyValueStore::read(string_view key) const {
+KeyValueStoreValue OwnedKeyValueStore::read(string_view key) const {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 

--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -7,6 +7,11 @@ namespace sorbet {
 
 class OwnedKeyValueStore;
 
+struct KeyValueStoreValue {
+    u1 *data;
+    size_t len;
+};
+
 /**
  * A database with single writer and multiple readers. Must be owned by a particular thread (via `OwnedKeyValueStore`)
  * before it can be used.
@@ -60,6 +65,7 @@ class OwnedKeyValueStore final {
     const std::unique_ptr<TxnState> txnState;
     mutable absl::Mutex readers_mtx;
 
+    void writeInternal(std::string_view key, void *value, size_t len);
     void clear();
     void refreshMainTransaction();
     int commit();
@@ -70,7 +76,7 @@ public:
     ~OwnedKeyValueStore();
 
     /** returns nullptr if not found*/
-    u1 *read(std::string_view key) const;
+    KeyValueStoreValue read(std::string_view key) const;
     std::string_view readString(std::string_view key) const;
     void writeString(std::string_view key, std::string_view value);
     /** can only be called from owning thread */

--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -77,6 +77,8 @@ public:
 
     /** returns nullptr if not found*/
     KeyValueStoreValue read(std::string_view key) const;
+    /** Reads a string from the key value store. Lifetime of string is tied to the lifetime of the database. Returns an
+     * empty string_view if the key does not exist. */
     std::string_view readString(std::string_view key) const;
     void writeString(std::string_view key, std::string_view value);
     /** can only be called from owning thread */

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -93,9 +93,9 @@ unique_ptr<core::serialize::CachedFile> fetchFileFromCache(core::GlobalState &gs
     if (kvstore && fref.id() < gs.filesUsed()) {
         string fileHashKey = fileKey(file);
         auto maybeCached = kvstore->read(fileHashKey);
-        if (maybeCached) {
+        if (maybeCached.data != nullptr) {
             prodCounterInc("types.input.files.kvstore.hit");
-            auto cachedTree = core::serialize::Serializer::loadFile(gs, maybeCached);
+            auto cachedTree = core::serialize::Serializer::loadFile(gs, maybeCached.data);
             return make_unique<core::serialize::CachedFile>(move(cachedTree));
         } else {
             prodCounterInc("types.input.files.kvstore.miss");

--- a/test/cli/cache-dir-dne/cache-dir-dne.out
+++ b/test/cli/cache-dir-dne/cache-dir-dne.out
@@ -1,1 +1,1 @@
-'nope' does not exist. When using --cache-dir, create the directory before hand.
+'nope2' does not exist. When using --cache-dir, create the directory before hand.

--- a/test/cli/cache-dir-dne/cache-dir-dne.sh
+++ b/test/cli/cache-dir-dne/cache-dir-dne.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-main/sorbet --silence-dev-message --cache-dir=nope -e '0' 2>&1
+main/sorbet --silence-dev-message --cache-dir=nope2 -e '0' 2>&1

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -80,10 +80,10 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
         lspWrapper = nullptr;
 
         unique_ptr<const OwnedKeyValueStore> kvstore = realmain::cache::maybeCreateKeyValueStore(*opts);
-        CHECK_EQ(kvstore->read(updatedKey), nullptr);
+        CHECK_EQ(kvstore->read(updatedKey).data, nullptr);
 
         auto contents = kvstore->read(key);
-        REQUIRE_NE(contents, nullptr);
+        REQUIRE_NE(contents.data, nullptr);
 
         auto sink = std::make_shared<spdlog::sinks::null_sink_mt>();
         auto logger = std::make_shared<spdlog::logger>("null", sink);
@@ -93,7 +93,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
         // If caching fails, gs gets modified during payload creation.
         CHECK_FALSE(gs->wasModified());
 
-        auto cachedFile = core::serialize::Serializer::loadFile(*gs, contents);
+        auto cachedFile = core::serialize::Serializer::loadFile(*gs, contents.data);
         CHECK(cachedFile.file->cached);
         CHECK_EQ(cachedFile.file->path(), filePath);
         CHECK_EQ(cachedFile.file->source(), fileContents);
@@ -134,14 +134,14 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
         lspWrapper = nullptr;
         unique_ptr<const OwnedKeyValueStore> kvstore = realmain::cache::maybeCreateKeyValueStore(*opts);
         auto updatedFileData = kvstore->read(updatedKey);
-        REQUIRE_NE(updatedFileData, nullptr);
+        REQUIRE_NE(updatedFileData.data, nullptr);
 
         auto sink = std::make_shared<spdlog::sinks::null_sink_mt>();
         auto logger = std::make_shared<spdlog::logger>("null", sink);
         auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*logger, *logger));
         payload::createInitialGlobalState(gs, *opts, kvstore);
 
-        auto cachedFile = core::serialize::Serializer::loadFile(*gs, updatedFileData);
+        auto cachedFile = core::serialize::Serializer::loadFile(*gs, updatedFileData.data);
         CHECK(cachedFile.file->cached);
         CHECK_EQ(cachedFile.file->path(), filePath);
         CHECK_EQ(cachedFile.file->source(), updatedFileContents);
@@ -183,7 +183,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPDoesNotUseCacheIfModified") {
 
         unique_ptr<const OwnedKeyValueStore> kvstore = realmain::cache::maybeCreateKeyValueStore(*opts);
         auto contents = kvstore->read(key);
-        REQUIRE_NE(contents, nullptr);
+        REQUIRE_NE(contents.data, nullptr);
 
         auto gs = make_unique<core::GlobalState>((make_shared<core::ErrorQueue>(*nullLogger, *nullLogger)));
         payload::createInitialGlobalState(gs, *opts, kvstore);
@@ -191,7 +191,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPDoesNotUseCacheIfModified") {
         // If caching fails, gs gets modified during payload creation.
         CHECK_FALSE(gs->wasModified());
 
-        auto cachedFile = core::serialize::Serializer::loadFile(*gs, contents);
+        auto cachedFile = core::serialize::Serializer::loadFile(*gs, contents.data);
         CHECK(cachedFile.file->cached);
         CHECK_EQ(cachedFile.file->path(), filePath);
         CHECK_EQ(cachedFile.file->source(), fileContents);


### PR DESCRIPTION
Return length of data with kvstore reads, and avoid copying in writeString.

We were stashing the length of strings but we didn't have to.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

* Expose length of data. This is useful for my work on using compressed ASTs in LSP mode.
* Cleaner and faster code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests (see kvstore_test).
