### PR TITLE
[WIP] Checked annotation for structs

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/_props.rb
+++ b/gems/sorbet-runtime/lib/types/props/_props.rb
@@ -119,6 +119,11 @@ module T::Props
       decorator.validate_prop_value(prop, val)
     end
 
+    # Allows allows configuring the runtime type checking behavior of the struct.
+    def checked(level)
+      decorator.set_check_level(level)
+    end
+
     # Needs to be documented
     def plugin(mod)
       decorator.plugin(mod)

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -29,6 +29,16 @@ class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest
     end
   end
 
+  it "allows disabling tests in tests" do
+    c = Class.new(T::Struct) do
+      checked(:tests)
+      prop :arr, T::Array[String]
+      const :other, T::Array[Integer]
+    end
+    c = c.new(arr: ["foo, bar"], other: ["foo", "bar"]) # doesn't throw
+    c.arr = [1, 2] # doesn't throw
+  end
+
   it "errors when using string typed props" do
     assert_raises(TypeError) do
       Class.new(T::Struct) do


### PR DESCRIPTION
This introduces the ability to write `checked(:tests)` on `T::Struct` definitions to avoid potentially expensive recursive type checking on struct fields at runtime:

```
class Foo < T::Struct
   checked(:tests)
   prop :foo, String
end

f = Foo.new(foo: 12) # only throws in tests
f.foo = 43 # only throws in tests
```

### Motivation
We profiled some of our code and found that adding `checked(:tests)` to `sig`s still resulted in lot's of runtime type checks. The code in question makes heavy use of structs, hence this PR.

### Test plan
I included some automated tests, let me know if I need to add more elsewhere.
