### PR TITLE
WIP: Use compressed ASTs when in LSP mode

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -227,6 +227,11 @@ struct ParsedFile {
     core::FileRef file;
 };
 
+struct CompressedParsedFile {
+    std::unique_ptr<std::vector<u1>> tree;
+    core::FileRef file;
+};
+
 /**
  * Stores a vector of `ParsedFile`s. May be empty if pass was canceled or encountered an error.
  * TODO: Modify to store reason if we ever have multiple reasons for a pass to stop. Currently, it's only empty if the

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -886,19 +886,40 @@ u4 Serializer::loadGlobalStateUUID(const GlobalState &gs, const u1 *const data) 
     return SerializerImpl::unpickleGSUUID(p);
 }
 
-vector<u1> Serializer::storeFile(const core::File &file, ast::ParsedFile &tree) {
+vector<u1> Serializer::storeFile(const core::File &file) {
     Pickler p;
     SerializerImpl::pickle(p, file);
+    return p.result(FILE_COMPRESSION_DEGREE);
+}
+
+vector<u1> Serializer::storeAST(const ast::ParsedFile &tree) {
+    Pickler p;
     SerializerImpl::pickle(p, tree.tree);
     return p.result(FILE_COMPRESSION_DEGREE);
 }
 
-CachedFile Serializer::loadFile(const core::GlobalState &gs, const u1 *const data) {
+shared_ptr<core::File> Serializer::loadFile(const core::GlobalState &gs, const u1 *const data) {
     UnPickler p(data, gs.tracer());
     auto file = SerializerImpl::unpickleFile(p);
     file->cached = true;
-    auto tree = SerializerImpl::unpickleExpr(p, gs);
-    return CachedFile{move(file), move(tree)};
+    return file;
+}
+
+ast::ExpressionPtr Serializer::loadAST(const GlobalState &gs, const u1 *const data) {
+    UnPickler p(data, gs.tracer());
+    return SerializerImpl::unpickleExpr(p, gs);
+}
+
+unique_ptr<vector<u1>> copyCompressedDataIntoVector(const u1 *const data) {
+    int compressedSize;
+    memcpy(&compressedSize, data, SIZE_BYTES);
+
+    // Data contains two sizes (uncompressed + compressed) followed by compressed data.
+    auto totalSize = compressedSize + 2 * SIZE_BYTES;
+
+    auto ret = make_unique<vector<u1>>(totalSize);
+    memcpy(ret->data(), data, totalSize);
+    return ret;
 }
 
 void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -910,18 +910,6 @@ ast::ExpressionPtr Serializer::loadAST(const GlobalState &gs, const u1 *const da
     return SerializerImpl::unpickleExpr(p, gs);
 }
 
-unique_ptr<vector<u1>> copyCompressedDataIntoVector(const u1 *const data) {
-    int compressedSize;
-    memcpy(&compressedSize, data, SIZE_BYTES);
-
-    // Data contains two sizes (uncompressed + compressed) followed by compressed data.
-    auto totalSize = compressedSize + 2 * SIZE_BYTES;
-
-    auto ret = make_unique<vector<u1>>(totalSize);
-    memcpy(ret->data(), data, totalSize);
-    return ret;
-}
-
 void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
     if (what == nullptr) {
         p.putU4(0);

--- a/core/serialize/serialize.h
+++ b/core/serialize/serialize.h
@@ -32,8 +32,6 @@ public:
     static std::shared_ptr<core::File> loadFile(const GlobalState &gs, const u1 *const data);
 
     static ast::ExpressionPtr loadAST(const GlobalState &gs, const u1 *const data);
-
-    static std::unique_ptr<std::vector<u1>> copyCompressedDataIntoVector(const u1 *const data);
 };
 }; // namespace sorbet::core::serialize
 

--- a/core/serialize/serialize.h
+++ b/core/serialize/serialize.h
@@ -4,11 +4,6 @@
 #include "core/core.h"
 
 namespace sorbet::core::serialize {
-struct CachedFile {
-    std::shared_ptr<core::File> file;
-    ast::ExpressionPtr tree;
-};
-
 class Serializer {
 public:
     static const u4 VERSION = 5;
@@ -26,15 +21,19 @@ public:
     // individual cached files, which can be loaded independently.
     static std::vector<u1> storePayloadAndNameTable(GlobalState &gs);
 
-    // Serializes a file and its AST.
-    static std::vector<u1> storeFile(const core::File &file, ast::ParsedFile &tree);
+    static std::vector<u1> storeFile(const core::File &file);
+
+    static std::vector<u1> storeAST(const ast::ParsedFile &tree);
 
     static void loadGlobalState(GlobalState &gs, const u1 *const data);
 
     static u4 loadGlobalStateUUID(const GlobalState &gs, const u1 *const data);
 
-    // Loads the given file and its AST.
-    static CachedFile loadFile(const GlobalState &gs, const u1 *const data);
+    static std::shared_ptr<core::File> loadFile(const GlobalState &gs, const u1 *const data);
+
+    static ast::ExpressionPtr loadAST(const GlobalState &gs, const u1 *const data);
+
+    static std::unique_ptr<std::vector<u1>> copyCompressedDataIntoVector(const u1 *const data);
 };
 }; // namespace sorbet::core::serialize
 

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -189,4 +189,11 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::Glob
     return asts;
 }
 
+static std::vector<ast::CompressedParsedFile>
+indexCompressAndComputeFileHashes(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &opts,
+                                  spdlog::logger &logger, std::vector<core::FileRef> &files, WorkerPool &workers,
+                                  const std::unique_ptr<const OwnedKeyValueStore> &kvstore) {
+    // nooo.
+}
+
 } // namespace sorbet::hashing

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -7,6 +7,7 @@
 #include "core/NameHash.h"
 #include "core/NullFlusher.h"
 #include "core/Unfreeze.h"
+#include "core/serialize/serialize.h"
 #include "main/pipeline/pipeline.h"
 
 using namespace std;
@@ -68,6 +69,146 @@ unique_ptr<core::FileHash> computeFileHashForFile(shared_ptr<core::File> forWhat
     ast.tree = ast::Substitute::run(ctx, subst, move(ast.tree));
     return computeFileHashForAST(lgs, subst.getAllNames(), move(ast));
 }
+
+struct FileHashJob {
+    bool compressed;
+    size_t index;
+};
+
+void computeFileHashesFromIndexResult(realmain::pipeline::IndexResult &indexResult, spdlog::logger &logger,
+                                      WorkerPool &workers, const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+    // Rewrite ASTs to an empty GlobalState and use them for hashing.
+    auto fileq =
+        make_shared<ConcurrentBoundedQueue<FileHashJob>>(indexResult.trees.size() + indexResult.compressedTrees.size());
+    for (size_t i = 0; i < indexResult.trees.size(); i++) {
+        fileq->push(FileHashJob{false, i}, 1);
+    }
+    for (size_t i = 0; i < indexResult.compressedTrees.size(); i++) {
+        fileq->push(FileHashJob{true, i}, 1);
+    }
+
+    logger.debug("Computing state hashes for {} files", indexResult.trees.size() + indexResult.compressedTrees.size());
+
+    const core::GlobalState &sharedGs = *indexResult.gs;
+    const vector<ast::ParsedFile> &trees = indexResult.trees;
+    const vector<ast::CompressedParsedFile> &compressedTrees = indexResult.compressedTrees;
+    auto resultq = make_shared<BlockingBoundedQueue<vector<pair<core::FileRef, unique_ptr<const core::FileHash>>>>>(
+        indexResult.trees.size() + indexResult.compressedTrees.size());
+    Timer timeit(logger, "computeFileHashes");
+    workers.multiplexJob("lspStateHash", [fileq, resultq, &trees, &compressedTrees, &sharedGs, &logger]() {
+        unique_ptr<Timer> timeit;
+        vector<pair<core::FileRef, unique_ptr<const core::FileHash>>> threadResult;
+        int processedByThread = 0;
+        FileHashJob job;
+        {
+            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
+                if (result.gotItem()) {
+                    if (timeit == nullptr) {
+                        timeit = make_unique<Timer>(logger, "computeFileHashesWorker");
+                    }
+                    processedByThread++;
+
+                    ast::ParsedFile temp;
+                    const ast::ParsedFile *ast;
+                    if (job.compressed) {
+                        const auto &compressed = compressedTrees[job.index];
+                        if (!compressed.file.exists() || compressed.file.data(sharedGs).getFileHash() != nullptr) {
+                            continue;
+                        }
+
+                        // Decompress and hash. This is expected to be an uncommon case, as 1) all compressedFiles
+                        // are cached and 2) LSP caches files, ASTs, _and_ their hashes. However, if a user runs Sorbet
+                        // on the CLI, it will cache files and ASTs but no hashes, so we need to handle this case.
+                        temp = ast::ParsedFile{core::serialize::Serializer::loadAST(sharedGs, compressed.tree->data()),
+                                               compressed.file};
+                        ast = &temp;
+                    } else {
+                        ast = &trees[job.index];
+
+                        if (!ast->file.exists() || ast->file.data(sharedGs).getFileHash() != nullptr) {
+                            continue;
+                        }
+                    }
+
+                    unique_ptr<core::GlobalState> lgs;
+                    auto newFref = makeEmptyGlobalStateForFile(logger, sharedGs.getFiles()[ast->file.id()], lgs);
+                    auto [rewrittenAST, usageHash] = rewriteAST(sharedGs, *lgs, newFref, *ast);
+
+                    threadResult.emplace_back(ast->file,
+                                              computeFileHashForAST(lgs, move(usageHash), move(rewrittenAST)));
+                }
+            }
+        }
+
+        if (processedByThread > 0) {
+            resultq->push(move(threadResult), processedByThread);
+        }
+    });
+
+    {
+        vector<pair<core::FileRef, unique_ptr<const core::FileHash>>> threadResult;
+        for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger); !result.done();
+             result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
+            if (result.gotItem()) {
+                for (auto &a : threadResult) {
+                    a.first.data(*indexResult.gs).setFileHash(move(a.second));
+                }
+            }
+        }
+    }
+}
+
+vector<ast::CompressedParsedFile> compressTrees(spdlog::logger &logger, vector<ast::ParsedFile> trees,
+                                                WorkerPool &workers) {
+    Timer timeit(logger, "Hashing::compressTrees");
+    // Compress files in parallel.
+    auto fileq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(trees.size());
+    vector<ast::CompressedParsedFile> output;
+    output.reserve(trees.size());
+    for (auto &tree : trees) {
+        fileq->push(move(tree), 1);
+    }
+
+    auto resultq = make_shared<BlockingBoundedQueue<vector<ast::CompressedParsedFile>>>(trees.size());
+    trees.clear();
+    workers.multiplexJob("compressTreesAndFiles", [fileq, resultq]() {
+        vector<ast::CompressedParsedFile> threadResult;
+        int processedByThread = 0;
+        ast::ParsedFile job;
+        {
+            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
+                if (result.gotItem()) {
+                    processedByThread++;
+
+                    if (!job.file.exists()) {
+                        continue;
+                    }
+
+                    threadResult.emplace_back(ast::CompressedParsedFile{
+                        make_unique<vector<u1>>(core::serialize::Serializer::storeAST(job)), job.file});
+                }
+            }
+        }
+
+        if (processedByThread > 0) {
+            resultq->push(move(threadResult), processedByThread);
+        }
+    });
+
+    {
+        vector<ast::CompressedParsedFile> threadResult;
+        for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger); !result.done();
+             result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
+            if (result.gotItem()) {
+                for (auto &compressed : threadResult) {
+                    output.emplace_back(move(compressed));
+                }
+            }
+        }
+    }
+    return output;
+}
+
 }; // namespace
 
 void Hashing::computeFileHashes(const vector<shared_ptr<core::File>> &files, spdlog::logger &logger,
@@ -124,76 +265,33 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::Glob
                                                            spdlog::logger &logger, vector<core::FileRef> &files,
                                                            WorkerPool &workers,
                                                            const unique_ptr<const OwnedKeyValueStore> &kvstore) {
-    auto asts = realmain::pipeline::index(gs, files, opts, workers, kvstore);
-    ENFORCE_NO_TIMER(asts.size() == files.size());
-
-    // Below, we rewrite ASTs to an empty GlobalState and use them for hashing.
-    auto fileq = make_shared<ConcurrentBoundedQueue<size_t>>(asts.size());
-    for (size_t i = 0; i < asts.size(); i++) {
-        auto copy = i;
-        fileq->push(move(copy), 1);
-    }
-
-    logger.debug("Computing state hashes for {} files", asts.size());
-
-    const core::GlobalState &sharedGs = *gs;
-    auto resultq =
-        make_shared<BlockingBoundedQueue<vector<pair<core::FileRef, unique_ptr<const core::FileHash>>>>>(asts.size());
-    Timer timeit(logger, "computeFileHashes");
-    workers.multiplexJob("lspStateHash", [fileq, resultq, &asts, &sharedGs, &logger]() {
-        unique_ptr<Timer> timeit;
-        vector<pair<core::FileRef, unique_ptr<const core::FileHash>>> threadResult;
-        int processedByThread = 0;
-        size_t job;
-        {
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
-                if (result.gotItem()) {
-                    if (timeit == nullptr) {
-                        timeit = make_unique<Timer>(logger, "computeFileHashesWorker");
-                    }
-                    processedByThread++;
-
-                    const auto &ast = asts[job];
-
-                    if (!ast.file.exists() || ast.file.data(sharedGs).getFileHash() != nullptr) {
-                        continue;
-                    }
-
-                    unique_ptr<core::GlobalState> lgs;
-                    auto newFref = makeEmptyGlobalStateForFile(logger, sharedGs.getFiles()[ast.file.id()], lgs);
-                    auto [rewrittenAST, usageHash] = rewriteAST(sharedGs, *lgs, newFref, ast);
-
-                    threadResult.emplace_back(ast.file,
-                                              computeFileHashForAST(lgs, move(usageHash), move(rewrittenAST)));
-                }
-            }
-        }
-
-        if (processedByThread > 0) {
-            resultq->push(move(threadResult), processedByThread);
-        }
-    });
-
-    {
-        vector<pair<core::FileRef, unique_ptr<const core::FileHash>>> threadResult;
-        for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger); !result.done();
-             result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
-            if (result.gotItem()) {
-                for (auto &a : threadResult) {
-                    a.first.data(*gs).setFileHash(move(a.second));
-                }
-            }
-        }
-    }
-
-    return asts;
+    realmain::pipeline::IndexResult result{nullptr, {}, {}};
+    result.trees = realmain::pipeline::index(gs, files, opts, workers, kvstore);
+    ENFORCE_NO_TIMER(result.trees.size() == files.size());
+    result.gs = move(gs);
+    computeFileHashesFromIndexResult(result, logger, workers, kvstore);
+    gs = move(result.gs);
+    return move(result.trees);
 }
 
-static std::vector<ast::CompressedParsedFile>
-indexCompressAndComputeFileHashes(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &opts,
-                                  spdlog::logger &logger, std::vector<core::FileRef> &files, WorkerPool &workers,
-                                  const std::unique_ptr<const OwnedKeyValueStore> &kvstore) {
-    // nooo.
+vector<ast::CompressedParsedFile>
+indexCompressAndComputeFileHashes(unique_ptr<core::GlobalState> &gs, const realmain::options::Options &opts,
+                                  spdlog::logger &logger, vector<core::FileRef> &files, WorkerPool &workers,
+                                  const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+    auto result = realmain::pipeline::indexWithNoDecompression(move(gs), files, opts, workers, kvstore);
+
+    ENFORCE_NO_TIMER(result.compressedTrees.size() + result.trees.size() == files.size());
+    computeFileHashesFromIndexResult(result, logger, workers, kvstore);
+    gs = move(result.gs);
+
+    if (!result.trees.empty()) {
+        auto compressed = compressTrees(logger, move(result.trees), workers);
+        result.compressedTrees.reserve(result.compressedTrees.size() + compressed.size());
+        result.compressedTrees.insert(result.compressedTrees.end(), make_move_iterator(compressed.begin()),
+                                      make_move_iterator(compressed.end()));
+    }
+
+    return move(result.compressedTrees);
 }
 
 } // namespace sorbet::hashing

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -275,9 +275,9 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::Glob
 }
 
 vector<ast::CompressedParsedFile>
-indexCompressAndComputeFileHashes(unique_ptr<core::GlobalState> &gs, const realmain::options::Options &opts,
-                                  spdlog::logger &logger, vector<core::FileRef> &files, WorkerPool &workers,
-                                  const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+Hashing::indexCompressAndComputeFileHashes(unique_ptr<core::GlobalState> &gs, const realmain::options::Options &opts,
+                                           spdlog::logger &logger, vector<core::FileRef> &files, WorkerPool &workers,
+                                           const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     auto result = realmain::pipeline::indexWithNoDecompression(move(gs), files, opts, workers, kvstore);
 
     ENFORCE_NO_TIMER(result.compressedTrees.size() + result.trees.size() == files.size());

--- a/hashing/hashing.h
+++ b/hashing/hashing.h
@@ -11,7 +11,8 @@ class OwnedKeyValueStore;
 
 namespace sorbet::ast {
 struct ParsedFile;
-}
+struct CompressedParsedFile;
+} // namespace sorbet::ast
 
 namespace sorbet::realmain::options {
 struct Options;
@@ -52,6 +53,14 @@ public:
     indexAndComputeFileHashes(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &opts,
                               spdlog::logger &logger, std::vector<core::FileRef> &files, WorkerPool &workers,
                               const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
+
+    /**
+     * Same as indexAndComputeFileHashes, but it returns compressed files.
+     */
+    static std::vector<ast::CompressedParsedFile>
+    indexCompressAndComputeFileHashes(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &opts,
+                                      spdlog::logger &logger, std::vector<core::FileRef> &files, WorkerPool &workers,
+                                      const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
 };
 } // namespace sorbet::hashing
 

--- a/main/cache/cache-orig.cc
+++ b/main/cache/cache-orig.cc
@@ -12,7 +12,8 @@ unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, uniqu
 }
 
 void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
-                                   core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> &indexed) {
+                                   core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> &indexed,
+                                   vector<ast::CompressedParsedFile> &indexedCompressed) {
     return;
 }
 

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -31,7 +31,8 @@ unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, uniqu
 }
 
 void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
-                                   core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> &indexed) {
+                                   core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> &indexed,
+                                   vector<ast::CompressedParsedFile> &indexedCompressed) {
     if (kvstore == nullptr) {
         return;
     }
@@ -40,7 +41,7 @@ void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const opti
     auto wroteGlobalState = payload::retainGlobalState(gs, opts, ownedKvstore);
     if (wroteGlobalState) {
         // Only write changes to disk if GlobalState changed since the last time.
-        pipeline::cacheTreesAndFiles(gs, workers, indexed, ownedKvstore);
+        pipeline::cacheTreesAndFiles(gs, workers, indexed, indexedCompressed, ownedKvstore);
         OwnedKeyValueStore::bestEffortCommit(gs.tracer(), move(ownedKvstore));
         prodCounterInc("cache.committed");
     } else {

--- a/main/cache/cache.h
+++ b/main/cache/cache.h
@@ -9,7 +9,8 @@ class OwnedKeyValueStore;
 class WorkerPool;
 namespace ast {
 struct ParsedFile;
-}
+struct CompressedParsedFile;
+} // namespace ast
 namespace core {
 class GlobalState;
 }
@@ -28,7 +29,8 @@ std::unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, 
 // If kvstore is not null, caches global state and the given files to disk if they have changed. Can silently fail to
 // cache
 void maybeCacheGlobalStateAndFiles(std::unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
-                                   core::GlobalState &gs, WorkerPool &workers, std::vector<ast::ParsedFile> &indexed);
+                                   core::GlobalState &gs, WorkerPool &workers, std::vector<ast::ParsedFile> &indexed,
+                                   std::vector<ast::CompressedParsedFile> &indexedCompressed);
 } // namespace sorbet::realmain::cache
 
 #endif

--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -29,8 +29,7 @@ void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
         encountered.emplace(f->path());
         updatedFiles.push_back(f);
         auto &ast = older.updatedFileIndexes[i];
-        vector<u1> tree = *ast.tree;
-        updatedFileIndexes.push_back(ast::CompressedParsedFile{make_unique<vector<u1>>(move(tree)), ast.file});
+        updatedFileIndexes.push_back(ast::ParsedFile{ast.tree.deepCopy(), ast.file});
     }
     canTakeFastPath = false;
 }
@@ -47,8 +46,7 @@ LSPFileUpdates LSPFileUpdates::copy() const {
     copy.preemptionsExpected = preemptionsExpected;
     for (auto &ast : updatedFileIndexes) {
         // TODO: Make this a shared_ptr to reduce copying.
-        vector<u1> tree = *ast.tree;
-        copy.updatedFileIndexes.push_back(ast::CompressedParsedFile{make_unique<vector<u1>>(move(tree)), ast.file});
+        copy.updatedFileIndexes.push_back(ast::ParsedFile{ast.tree.deepCopy(), ast.file});
     }
     return copy;
 }

--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -29,7 +29,8 @@ void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
         encountered.emplace(f->path());
         updatedFiles.push_back(f);
         auto &ast = older.updatedFileIndexes[i];
-        updatedFileIndexes.push_back(ast::ParsedFile{ast.tree.deepCopy(), ast.file});
+        vector<u1> tree = *ast.tree;
+        updatedFileIndexes.push_back(ast::CompressedParsedFile{make_unique<vector<u1>>(move(tree)), ast.file});
     }
     canTakeFastPath = false;
 }
@@ -45,7 +46,9 @@ LSPFileUpdates LSPFileUpdates::copy() const {
     copy.cancellationExpected = cancellationExpected;
     copy.preemptionsExpected = preemptionsExpected;
     for (auto &ast : updatedFileIndexes) {
-        copy.updatedFileIndexes.push_back(ast::ParsedFile{ast.tree.deepCopy(), ast.file});
+        // TODO: Make this a shared_ptr to reduce copying.
+        vector<u1> tree = *ast.tree;
+        copy.updatedFileIndexes.push_back(ast::CompressedParsedFile{make_unique<vector<u1>>(move(tree)), ast.file});
     }
     return copy;
 }

--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -29,7 +29,8 @@ void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
         encountered.emplace(f->path());
         updatedFiles.push_back(f);
         auto &ast = older.updatedFileIndexes[i];
-        updatedFileIndexes.push_back(ast::ParsedFile{ast.tree.deepCopy(), ast.file});
+        vector<u1> tree = *ast.tree;
+        updatedFileIndexes.push_back(ast::CompressedParsedFile{make_unique<vector<u1>>(move(tree)), ast.file});
     }
     canTakeFastPath = false;
 }
@@ -46,7 +47,8 @@ LSPFileUpdates LSPFileUpdates::copy() const {
     copy.preemptionsExpected = preemptionsExpected;
     for (auto &ast : updatedFileIndexes) {
         // TODO: Make this a shared_ptr to reduce copying.
-        copy.updatedFileIndexes.push_back(ast::ParsedFile{ast.tree.deepCopy(), ast.file});
+        vector<u1> tree = *ast.tree;
+        copy.updatedFileIndexes.push_back(ast::CompressedParsedFile{make_unique<vector<u1>>(move(tree)), ast.file});
     }
     return copy;
 }

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -19,7 +19,7 @@ public:
     u4 committedEditCount = 0;
 
     std::vector<std::shared_ptr<core::File>> updatedFiles;
-    std::vector<ast::ParsedFile> updatedFileIndexes;
+    std::vector<ast::CompressedParsedFile> updatedFileIndexes;
 
     bool canTakeFastPath = false;
     // Indicates that this update contains a new file. Is a hack for determining if combining two updates can take the
@@ -28,7 +28,7 @@ public:
     // If true, this update caused a slow path to be canceled.
     bool canceledSlowPath = false;
     // Updated on typechecking thread. Contains indexes processed with typechecking global state.
-    std::vector<ast::ParsedFile> updatedFinalGSFileIndexes;
+    std::vector<ast::CompressedParsedFile> updatedFinalGSFileIndexes;
     // (Optional) Updated global state object to use to typecheck this update.
     std::optional<std::unique_ptr<core::GlobalState>> updatedGS;
     // (Used in tests) Ensures that a slow path typecheck on these updates waits until it gets cancelled.

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -19,7 +19,7 @@ public:
     u4 committedEditCount = 0;
 
     std::vector<std::shared_ptr<core::File>> updatedFiles;
-    std::vector<ast::CompressedParsedFile> updatedFileIndexes;
+    std::vector<ast::ParsedFile> updatedFileIndexes;
 
     bool canTakeFastPath = false;
     // Indicates that this update contains a new file. Is a hack for determining if combining two updates can take the
@@ -28,7 +28,7 @@ public:
     // If true, this update caused a slow path to be canceled.
     bool canceledSlowPath = false;
     // Updated on typechecking thread. Contains indexes processed with typechecking global state.
-    std::vector<ast::CompressedParsedFile> updatedFinalGSFileIndexes;
+    std::vector<ast::ParsedFile> updatedFinalGSFileIndexes;
     // (Optional) Updated global state object to use to typecheck this update.
     std::optional<std::unique_ptr<core::GlobalState>> updatedGS;
     // (Used in tests) Ensures that a slow path typecheck on these updates waits until it gets cancelled.

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -162,7 +162,7 @@ void LSPIndexer::initialize(LSPFileUpdates &updates, WorkerPool &workers) {
     initialGS->errorQueue = make_shared<core::ErrorQueue>(savedErrorQueue->logger, savedErrorQueue->tracer,
                                                           make_shared<core::NullFlusher>());
 
-    vector<ast::CompressedParsedFile> indexed;
+    vector<ast::ParsedFile> indexed;
     Timer timeit(config->logger, "initial_index");
     ShowOperation op(*config, ShowOperation::Kind::Indexing);
     vector<core::FileRef> inputFiles;

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -162,7 +162,7 @@ void LSPIndexer::initialize(LSPFileUpdates &updates, WorkerPool &workers) {
     initialGS->errorQueue = make_shared<core::ErrorQueue>(savedErrorQueue->logger, savedErrorQueue->tracer,
                                                           make_shared<core::NullFlusher>());
 
-    vector<ast::ParsedFile> indexed;
+    vector<ast::CompressedParsedFile> indexed;
     Timer timeit(config->logger, "initial_index");
     ShowOperation op(*config, ShowOperation::Kind::Indexing);
     vector<core::FileRef> inputFiles;

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -38,9 +38,9 @@ class LSPTypechecker final {
      * instance, actively consume and replace GlobalState. */
     mutable std::unique_ptr<core::GlobalState> gs;
     /** Trees that have been indexed (with initialGS) and can be reused between different runs */
-    std::vector<ast::ParsedFile> indexed;
+    std::vector<ast::CompressedParsedFile> indexed;
     /** Trees that have been indexed (with finalGS) and can be reused between different runs */
-    UnorderedMap<int, ast::ParsedFile> indexedFinalGS;
+    UnorderedMap<int, ast::CompressedParsedFile> indexedFinalGS;
     /** Set only when typechecking is happening on the slow path. Contains all of the state needed to restore
      * LSPTypechecker to its pre-slow-path state. Can be null, which indicates that no slow path is currently running */
     std::unique_ptr<UndoState> cancellationUndoState;
@@ -106,7 +106,7 @@ public:
     /**
      * Returns the parsed file for the given file, up to the index passes (does not include resolver passes).
      */
-    const ast::ParsedFile &getIndexed(core::FileRef fref) const;
+    ast::ParsedFile getIndexed(core::FileRef fref) const;
 
     /**
      * Returns the parsed files for the given files, including resolver.
@@ -167,7 +167,7 @@ public:
     /**
      * Returns the parsed file for the given file, up to the index passes (does not include resolver passes).
      */
-    const ast::ParsedFile &getIndexed(core::FileRef fref) const;
+    ast::ParsedFile getIndexed(core::FileRef fref) const;
 
     /**
      * Returns the parsed files for the given files, including resolver.

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -8,11 +8,11 @@
 using namespace std;
 
 namespace sorbet::realmain::lsp {
-UndoState::UndoState(unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS,
-                     u4 epoch)
+UndoState::UndoState(unique_ptr<core::GlobalState> evictedGs,
+                     UnorderedMap<int, ast::CompressedParsedFile> evictedIndexedFinalGS, u4 epoch)
     : evictedGs(move(evictedGs)), evictedIndexedFinalGS(std::move(evictedIndexedFinalGS)), epoch(epoch) {}
 
-void UndoState::recordEvictedState(ast::ParsedFile evictedIndexTree) {
+void UndoState::recordEvictedState(ast::CompressedParsedFile evictedIndexTree) {
     const auto id = evictedIndexTree.file.id();
     // The first time a file gets evicted, it's an index tree from the old global state.
     // Subsequent times it is evicting old index trees from the new global state, and we don't care.
@@ -22,8 +22,8 @@ void UndoState::recordEvictedState(ast::ParsedFile evictedIndexTree) {
     }
 }
 
-void UndoState::restore(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> &indexed,
-                        UnorderedMap<int, ast::ParsedFile> &indexedFinalGS) {
+void UndoState::restore(unique_ptr<core::GlobalState> &gs, vector<ast::CompressedParsedFile> &indexed,
+                        UnorderedMap<int, ast::CompressedParsedFile> &indexedFinalGS) {
     // Replace evicted index trees.
     for (auto &entry : evictedIndexed) {
         indexed[entry.first] = move(entry.second);

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -15,9 +15,9 @@ class UndoState final {
     // Stores the pre-slow-path global state.
     std::unique_ptr<core::GlobalState> evictedGs;
     // Stores index trees containing data stored in `gs` that have been evicted during the slow path operation.
-    UnorderedMap<int, ast::ParsedFile> evictedIndexed;
+    UnorderedMap<int, ast::CompressedParsedFile> evictedIndexed;
     // Stores the index trees stored in `gs` that were evicted because the slow path operation replaced `gs`.
-    UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS;
+    UnorderedMap<int, ast::CompressedParsedFile> evictedIndexedFinalGS;
     // Stores the list of files that had errors before the slow path began.
     std::vector<core::FileRef> evictedFilesThatHaveErrors;
 
@@ -25,19 +25,19 @@ public:
     // Epoch of the running slow path
     const u4 epoch;
 
-    UndoState(std::unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS,
-              u4 epoch);
+    UndoState(std::unique_ptr<core::GlobalState> evictedGs,
+              UnorderedMap<int, ast::CompressedParsedFile> evictedIndexedFinalGS, u4 epoch);
 
     /**
      * Records that the given items were evicted from LSPTypechecker following a typecheck run.
      */
-    void recordEvictedState(ast::ParsedFile evictedIndexTree);
+    void recordEvictedState(ast::CompressedParsedFile evictedIndexTree);
 
     /**
      * Undoes the slow path changes represented by this class.
      */
-    void restore(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> &indexed,
-                 UnorderedMap<int, ast::ParsedFile> &indexedFinalGS);
+    void restore(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::CompressedParsedFile> &indexed,
+                 UnorderedMap<int, ast::CompressedParsedFile> &indexedFinalGS);
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -546,6 +546,9 @@ IndexResult indexSuppliedFiles(const shared_ptr<core::GlobalState> &baseGs, vect
 IndexResult indexWithNoDecompression(std::unique_ptr<core::GlobalState> gs, std::vector<core::FileRef> &files,
                                      const options::Options &opts, WorkerPool &workers,
                                      const std::unique_ptr<const OwnedKeyValueStore> &kvstore) {
+    if (files.empty()) {
+        return IndexResult{move(gs), {}, {}};
+    }
     return indexSuppliedFiles(move(gs), files, opts, workers, kvstore, /* decompressAllTrees */ false);
 }
 
@@ -1096,7 +1099,15 @@ ast::ParsedFilesOrCancelled typecheck(unique_ptr<core::GlobalState> &gs, vector<
     }
 }
 
+namespace {
+struct CacheTreeJob {
+    bool compressed;
+    size_t index;
+};
+} // namespace
+
 bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> &parsedFiles,
+                        vector<ast::CompressedParsedFile> &compressedParsedFiles,
                         const unique_ptr<OwnedKeyValueStore> &kvstore) {
     if (kvstore == nullptr) {
         return false;
@@ -1105,30 +1116,42 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, vector
     Timer timeit(gs.tracer(), "pipeline::cacheTreesAndFiles");
 
     // Compress files in parallel.
-    auto fileq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile *>>(parsedFiles.size());
-    for (auto &parsedFile : parsedFiles) {
-        auto ptr = &parsedFile;
-        fileq->push(move(ptr), 1);
+    auto fileq = make_shared<ConcurrentBoundedQueue<CacheTreeJob>>(parsedFiles.size() + compressedParsedFiles.size());
+    for (size_t i = 0; i < parsedFiles.size(); i++) {
+        fileq->push(CacheTreeJob{false, i}, 1);
+    }
+    for (size_t i = 0; i < compressedParsedFiles.size(); i++) {
+        fileq->push(CacheTreeJob{true, i}, 1);
     }
 
     auto resultq = make_shared<BlockingBoundedQueue<vector<pair<string, vector<u1>>>>>(parsedFiles.size());
-    workers.multiplexJob("compressTreesAndFiles", [fileq, resultq, &gs]() {
+    workers.multiplexJob("compressTreesAndFiles", [fileq, resultq, &parsedFiles, &compressedParsedFiles, &gs]() {
         vector<pair<string, vector<u1>>> threadResult;
         int processedByThread = 0;
-        ast::ParsedFile *job = nullptr;
+        CacheTreeJob job;
         {
             for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
                 if (result.gotItem()) {
                     processedByThread++;
 
-                    if (!job->file.exists()) {
+                    core::FileRef fref;
+                    if (job.compressed) {
+                        fref = compressedParsedFiles[job.index].file;
+                    } else {
+                        fref = parsedFiles[job.index].file;
+                    }
+
+                    if (!fref.exists()) {
                         continue;
                     }
 
-                    auto &file = job->file.data(gs);
+                    auto &file = fref.data(gs);
                     if (!file.cached && !file.hasParseErrors) {
                         threadResult.emplace_back(fileKey(file), core::serialize::Serializer::storeFile(file));
-                        threadResult.emplace_back(treeKey(file), core::serialize::Serializer::storeAST(*job));
+                        if (!job.compressed) {
+                            auto &ast = parsedFiles[job.index];
+                            threadResult.emplace_back(treeKey(file), core::serialize::Serializer::storeAST(ast));
+                        }
                     }
                 }
             }
@@ -1142,6 +1165,11 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, vector
     bool written = false;
     {
         vector<pair<string, vector<u1>>> threadResult;
+        // Before processing work from workers, we can write the compressed ASTs.
+        for (auto &compressed : compressedParsedFiles) {
+            kvstore->write(treeKey(compressed.file.data(gs)), *compressed.tree);
+        }
+
         for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
              !result.done();
              result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -78,25 +78,32 @@ public:
     }
 };
 
-string fileKey(const core::File &file) {
+FileKeys fileKeys(const core::File &file) {
     auto path = file.path();
-    string key(path.begin(), path.end());
-    key += "//";
     auto hashBytes = sorbet::crypto_hashing::hash64(file.source());
-    key += absl::BytesToHexString(string_view{(char *)hashBytes.data(), size(hashBytes)});
-    return key;
+    auto base =
+        absl::StrCat(path, "//", absl::BytesToHexString(string_view{(char *)hashBytes.data(), size(hashBytes)}));
+
+    return {absl::StrCat(base, "//file"), absl::StrCat(base, "//tree")};
 }
 
-unique_ptr<core::serialize::CachedFile> fetchFileFromCache(core::GlobalState &gs, core::FileRef fref,
-                                                           const core::File &file,
-                                                           const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+struct CachedFile {
+    shared_ptr<core::File> file;
+    ast::ExpressionPtr tree;
+};
+
+unique_ptr<CachedFile> fetchFileAndTreeFromCache(core::GlobalState &gs, core::FileRef fref, const core::File &file,
+                                                 const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     if (kvstore && fref.id() < gs.filesUsed()) {
-        string fileHashKey = fileKey(file);
-        auto maybeCached = kvstore->read(fileHashKey);
-        if (maybeCached.data != nullptr) {
+        auto fileHashKey = fileKeys(file);
+        auto maybeCachedFile = kvstore->read(fileHashKey.file);
+        auto maybeCachedAST = kvstore->read(fileHashKey.tree);
+        if (maybeCachedFile && maybeCachedAST) {
             prodCounterInc("types.input.files.kvstore.hit");
-            auto cachedTree = core::serialize::Serializer::loadFile(gs, maybeCached.data);
-            return make_unique<core::serialize::CachedFile>(move(cachedTree));
+            auto rv = make_unique<CachedFile>();
+            rv->file = core::serialize::Serializer::loadFile(gs, maybeCachedFile);
+            rv->tree = core::serialize::Serializer::loadAST(gs, maybeCachedAST);
+            return rv;
         } else {
             prodCounterInc("types.input.files.kvstore.miss");
         }
@@ -104,11 +111,27 @@ unique_ptr<core::serialize::CachedFile> fetchFileFromCache(core::GlobalState &gs
     return nullptr;
 }
 
-ast::ExpressionPtr fetchTreeFromCache(core::GlobalState &gs, core::FileRef fref, const core::File &file,
-                                      const unique_ptr<const OwnedKeyValueStore> &kvstore) {
-    auto cachedFile = fetchFileFromCache(gs, fref, file, kvstore);
-    if (cachedFile) {
-        return move(cachedFile->tree);
+struct CachedFileCompressedAST {
+    shared_ptr<core::File> file;
+    unique_ptr<vector<u1>> compressedTree;
+};
+
+unique_ptr<CachedFileCompressedAST>
+fetchFileAndCompressedTreeFromCache(core::GlobalState &gs, core::FileRef fref, const core::File &file,
+                                    const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+    if (kvstore && fref.id() < gs.filesUsed()) {
+        auto fileHashKey = fileKeys(file);
+        auto maybeCachedFile = kvstore->read(fileHashKey.file);
+        auto maybeCachedAST = kvstore->read(fileHashKey.tree);
+        if (maybeCachedFile && maybeCachedAST) {
+            prodCounterInc("types.input.files.kvstore.hit");
+            auto rv = make_unique<CachedFileCompressedAST>();
+            rv->file = core::serialize::Serializer::loadFile(gs, maybeCachedFile);
+            rv->compressedTree = core::serialize::Serializer::copyCompressedDataIntoVector(maybeCachedAST);
+            return rv;
+        } else {
+            prodCounterInc("types.input.files.kvstore.miss");
+        }
     }
     return nullptr;
 }
@@ -396,7 +419,7 @@ ast::ExpressionPtr readFileWithStrictnessOverrides(unique_ptr<core::GlobalState>
         core::UnfreezeFileTable unfreezeFiles(*gs);
         auto fileObj =
             make_shared<core::File>(string(fileName.begin(), fileName.end()), move(src), core::File::Type::Normal);
-        if (auto maybeCached = fetchFileFromCache(*gs, file, *fileObj, kvstore)) {
+        if (auto maybeCached = fetchFileAndTreeFromCache(*gs, file, *fileObj, kvstore)) {
             fileObj = move(maybeCached->file);
             ast = move(maybeCached->tree);
         }
@@ -1082,7 +1105,9 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, vector
 
                     auto &file = job->file.data(gs);
                     if (!file.cached && !file.hasParseErrors) {
-                        threadResult.emplace_back(fileKey(file), core::serialize::Serializer::storeFile(file, *job));
+                        auto keys = fileKeys(file);
+                        threadResult.emplace_back(keys.file, core::serialize::Serializer::storeFile(file));
+                        threadResult.emplace_back(keys.tree, core::serialize::Serializer::storeAST(*job));
                     }
                 }
             }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -99,9 +99,9 @@ shared_ptr<core::File> fetchFileFromCache(core::GlobalState &gs, core::FileRef f
     if (kvstore && fref.id() < gs.filesUsed()) {
         auto fileHashKey = fileKey(file);
         auto maybeCachedFile = kvstore->read(fileHashKey);
-        if (maybeCachedFile) {
+        if (maybeCachedFile.data != nullptr) {
             prodCounterInc("types.input.files.kvstore.file.hit");
-            return core::serialize::Serializer::loadFile(gs, maybeCachedFile);
+            return core::serialize::Serializer::loadFile(gs, maybeCachedFile.data);
         } else {
             prodCounterInc("types.input.files.kvstore.file.miss");
         }
@@ -109,14 +109,14 @@ shared_ptr<core::File> fetchFileFromCache(core::GlobalState &gs, core::FileRef f
     return nullptr;
 }
 
-ast::ExpressionPtr fetchTreeFromCache(core::GlobalState &gs, core::FileRef fref, const core::File &file,
+ast::ExpressionPtr fetchTreeFromCache(core::GlobalState &gs, core::FileRef fref,
                                       const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     if (kvstore && fref.id() < gs.filesUsed()) {
-        auto treeHashKey = treeKey(file);
+        auto treeHashKey = treeKey(fref.data(gs));
         auto maybeCachedAST = kvstore->read(treeHashKey);
-        if (maybeCachedAST) {
+        if (maybeCachedAST.data != nullptr) {
             prodCounterInc("types.input.files.kvstore.tree.hit");
-            return core::serialize::Serializer::loadAST(gs, maybeCachedAST);
+            return core::serialize::Serializer::loadAST(gs, maybeCachedAST.data);
         } else {
             prodCounterInc("types.input.files.kvstore.tree.miss");
         }
@@ -124,14 +124,16 @@ ast::ExpressionPtr fetchTreeFromCache(core::GlobalState &gs, core::FileRef fref,
     return nullptr;
 }
 
-vector<u1> fetchCompressedTreeFromCache(core::GlobalState &gs, core::FileRef fref, const core::File &file,
-                                        const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+unique_ptr<vector<u1>> fetchCompressedTreeFromCache(core::GlobalState &gs, core::FileRef fref,
+                                                    const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     if (kvstore && fref.id() < gs.filesUsed()) {
-        auto treeHashKey = treeKey(file);
+        auto treeHashKey = treeKey(fref.data(gs));
         auto maybeCachedAST = kvstore->read(treeHashKey);
-        if (maybeCachedAST) {
+        if (maybeCachedAST.data != nullptr) {
             prodCounterInc("types.input.files.kvstore.tree.hit");
-            return core::serialize::Serializer::loadAST(gs, maybeCachedAST);
+            auto compressedAST = make_unique<vector<u1>>(maybeCachedAST.len);
+            memcpy(compressedAST->data(), maybeCachedAST.data, maybeCachedAST.len);
+            return compressedAST;
         } else {
             prodCounterInc("types.input.files.kvstore.tree.miss");
         }
@@ -196,52 +198,47 @@ ast::ParsedFile emptyParsedFile(core::FileRef file) {
     return {ast::MK::EmptyTree(), file};
 }
 
-ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
-                         ast::ExpressionPtr tree) {
+ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file) {
     auto &print = opts.print;
-    ast::ParsedFile rewriten{nullptr, file};
+    ast::ParsedFile rewritten{nullptr, file};
 
     Timer timeit(lgs.tracer(), "indexOne");
     try {
-        if (!tree) {
-            // tree isn't cached. Need to start from parser
-            if (file.data(lgs).strictLevel == core::StrictLevel::Ignore) {
-                return emptyParsedFile(file);
-            }
-            auto parseTree = runParser(lgs, file, print);
-            if (opts.stopAfterPhase == options::Phase::PARSER) {
-                return emptyParsedFile(file);
-            }
-            tree = runDesugar(lgs, file, move(parseTree), print);
-            if (opts.stopAfterPhase == options::Phase::DESUGARER) {
-                return emptyParsedFile(file);
-            }
-            if (!opts.skipRewriterPasses) {
-                tree = runRewriter(lgs, file, move(tree));
-            }
-            if (print.RewriterTree.enabled) {
-                print.RewriterTree.fmt("{}\n", tree.toStringWithTabs(lgs, 0));
-            }
-            if (print.RewriterTreeRaw.enabled) {
-                print.RewriterTreeRaw.fmt("{}\n", tree.showRaw(lgs));
-            }
-            tree = runLocalVars(lgs, ast::ParsedFile{move(tree), file}).tree;
-            if (opts.stopAfterPhase == options::Phase::LOCAL_VARS) {
-                return emptyParsedFile(file);
-            }
+        if (file.data(lgs).strictLevel == core::StrictLevel::Ignore) {
+            return emptyParsedFile(file);
+        }
+        auto parseTree = runParser(lgs, file, print);
+        if (opts.stopAfterPhase == options::Phase::PARSER) {
+            return emptyParsedFile(file);
+        }
+        rewritten.tree = runDesugar(lgs, file, move(parseTree), print);
+        if (opts.stopAfterPhase == options::Phase::DESUGARER) {
+            return emptyParsedFile(file);
+        }
+        if (!opts.skipRewriterPasses) {
+            rewritten.tree = runRewriter(lgs, file, move(rewritten.tree));
+        }
+        if (print.RewriterTree.enabled) {
+            print.RewriterTree.fmt("{}\n", rewritten.tree.toStringWithTabs(lgs, 0));
+        }
+        if (print.RewriterTreeRaw.enabled) {
+            print.RewriterTreeRaw.fmt("{}\n", rewritten.tree.showRaw(lgs));
+        }
+        rewritten.tree = runLocalVars(lgs, ast::ParsedFile{move(rewritten.tree), file}).tree;
+        if (opts.stopAfterPhase == options::Phase::LOCAL_VARS) {
+            return emptyParsedFile(file);
         }
         if (print.IndexTree.enabled) {
-            print.IndexTree.fmt("{}\n", tree.toStringWithTabs(lgs, 0));
+            print.IndexTree.fmt("{}\n", rewritten.tree.toStringWithTabs(lgs, 0));
         }
         if (print.IndexTreeRaw.enabled) {
-            print.IndexTreeRaw.fmt("{}\n", tree.showRaw(lgs));
+            print.IndexTreeRaw.fmt("{}\n", rewritten.tree.showRaw(lgs));
         }
         if (opts.stopAfterPhase == options::Phase::REWRITER) {
             return emptyParsedFile(file);
         }
 
-        rewriten.tree = move(tree);
-        return rewriten;
+        return rewritten;
     } catch (SorbetException &) {
         Exception::failInFuzzer();
         if (auto e = lgs.beginError(sorbet::core::Loc::none(file), core::errors::Internal::InternalError)) {
@@ -396,12 +393,11 @@ void incrementStrictLevelCounter(core::StrictLevel level) {
 }
 
 // Returns a non-null ast::Expression if kvstore contains the AST.
-ast::ExpressionPtr readFileWithStrictnessOverrides(unique_ptr<core::GlobalState> &gs, core::FileRef file,
-                                                   const options::Options &opts,
-                                                   const unique_ptr<const OwnedKeyValueStore> &kvstore) {
-    ast::ExpressionPtr ast;
+void readFileWithStrictnessOverrides(unique_ptr<core::GlobalState> &gs, core::FileRef file,
+                                     const options::Options &opts,
+                                     const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     if (file.dataAllowingUnsafe(*gs).sourceType != core::File::Type::NotYetRead) {
-        return ast;
+        return;
     }
     auto fileName = file.dataAllowingUnsafe(*gs).path();
     Timer timeit(gs->tracer(), "readFileWithStrictnessOverrides", {{"file", (string)fileName}});
@@ -422,9 +418,8 @@ ast::ExpressionPtr readFileWithStrictnessOverrides(unique_ptr<core::GlobalState>
         core::UnfreezeFileTable unfreezeFiles(*gs);
         auto fileObj =
             make_shared<core::File>(string(fileName.begin(), fileName.end()), move(src), core::File::Type::Normal);
-        if (auto maybeCached = fetchFileAndTreeFromCache(*gs, file, *fileObj, kvstore)) {
-            fileObj = move(maybeCached->file);
-            ast = move(maybeCached->tree);
+        if (auto maybeCached = fetchFileFromCache(*gs, file, *fileObj, kvstore)) {
+            fileObj = move(maybeCached);
         }
 
         auto entered = gs->enterNewFileAt(move(fileObj), file);
@@ -448,12 +443,14 @@ ast::ExpressionPtr readFileWithStrictnessOverrides(unique_ptr<core::GlobalState>
     auto level = decideStrictLevel(*gs, file, opts);
     fileData.strictLevel = level;
     incrementStrictLevelCounter(level);
-    return ast;
 }
 
 struct IndexResult {
     unique_ptr<core::GlobalState> gs;
     vector<ast::ParsedFile> trees;
+    // Note: Compressed trees were fetched from kvstore, and don't need to have their namerefs rewritten because they
+    // were created w/ the base gs.
+    vector<ast::CompressedParsedFile> compressedTrees;
 };
 
 struct IndexThreadResultPack {
@@ -463,7 +460,7 @@ struct IndexThreadResultPack {
 
 IndexResult mergeIndexResults(const shared_ptr<core::GlobalState> cgs, const options::Options &opts,
                               shared_ptr<BlockingBoundedQueue<IndexThreadResultPack>> input,
-                              const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+                              const unique_ptr<const OwnedKeyValueStore> &kvstore, bool compressAllTrees) {
     ProgressIndicator progress(opts.showProgress, "Indexing", input->bound);
     Timer timeit(cgs->tracer(), "mergeIndexResults");
     IndexThreadResultPack threadResult;
@@ -476,6 +473,7 @@ IndexResult mergeIndexResults(const shared_ptr<core::GlobalState> cgs, const opt
                 ret.gs = move(threadResult.res.gs);
                 ENFORCE(ret.trees.empty());
                 ret.trees = move(threadResult.res.trees);
+                ret.compressedTrees = move(threadResult.res.compressedTrees);
             } else {
                 core::GlobalSubstitution substitution(*threadResult.res.gs, *ret.gs, cgs.get());
                 {
@@ -490,16 +488,24 @@ IndexResult mergeIndexResults(const shared_ptr<core::GlobalState> cgs, const opt
                 }
                 ret.trees.insert(ret.trees.end(), make_move_iterator(threadResult.res.trees.begin()),
                                  make_move_iterator(threadResult.res.trees.end()));
+                ret.compressedTrees.insert(ret.compressedTrees.end(),
+                                           make_move_iterator(threadResult.res.compressedTrees.begin()),
+                                           make_move_iterator(threadResult.res.compressedTrees.end()));
             }
             progress.reportProgress(input->doneEstimate());
         }
     }
+
+    if (compressAllTrees && !ret.trees.empty()) {
+        // Compress trees!
+    }
+
     return ret;
 }
 
 IndexResult indexSuppliedFiles(const shared_ptr<core::GlobalState> &baseGs, vector<core::FileRef> &files,
                                const options::Options &opts, WorkerPool &workers,
-                               const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+                               const unique_ptr<const OwnedKeyValueStore> &kvstore, bool compressAllTrees) {
     Timer timeit(baseGs->tracer(), "indexSuppliedFiles");
     auto resultq = make_shared<BlockingBoundedQueue<IndexThreadResultPack>>(files.size());
     auto fileq = make_shared<ConcurrentBoundedQueue<core::FileRef>>(files.size());
@@ -507,7 +513,7 @@ IndexResult indexSuppliedFiles(const shared_ptr<core::GlobalState> &baseGs, vect
         fileq->push(move(file), 1);
     }
 
-    workers.multiplexJob("indexSuppliedFiles", [baseGs, &opts, fileq, resultq, &kvstore]() {
+    workers.multiplexJob("indexSuppliedFiles", [baseGs, &opts, fileq, resultq, &kvstore, compressAllTrees]() {
         Timer timeit(baseGs->tracer(), "indexSuppliedFilesWorker");
         unique_ptr<core::GlobalState> localGs = baseGs->deepCopy();
         IndexThreadResultPack threadResult;
@@ -517,8 +523,20 @@ IndexResult indexSuppliedFiles(const shared_ptr<core::GlobalState> &baseGs, vect
             for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
                 if (result.gotItem()) {
                     core::FileRef file = job;
-                    auto cachedTree = readFileWithStrictnessOverrides(localGs, file, opts, kvstore);
-                    auto parsedFile = indexOne(opts, *localGs, file, move(cachedTree));
+                    readFileWithStrictnessOverrides(localGs, file, opts, kvstore);
+                    if (compressAllTrees) {
+                        if (auto tree = fetchCompressedTreeFromCache(*localGs, file, kvstore)) {
+                            threadResult.res.compressedTrees.emplace_back(ast::CompressedParsedFile{move(tree), file});
+                            continue;
+                        }
+                    } else if (auto tree = fetchTreeFromCache(*localGs, file, kvstore)) {
+                        threadResult.res.trees.emplace_back(ast::ParsedFile{move(tree), file});
+                        continue;
+                    }
+
+                    // Tree not in cache; needs to be indexed.
+                    // N.B.: If `compressAllTrees` is `true`, then this tree will be compressed in `mergeIndexResults`.
+                    auto parsedFile = indexOne(opts, *localGs, file);
                     threadResult.res.trees.emplace_back(move(parsedFile));
                 }
             }
@@ -532,7 +550,7 @@ IndexResult indexSuppliedFiles(const shared_ptr<core::GlobalState> &baseGs, vect
         }
     });
 
-    return mergeIndexResults(baseGs, opts, resultq, kvstore);
+    return mergeIndexResults(baseGs, opts, resultq, kvstore, compressAllTrees);
 }
 
 vector<ast::ParsedFile> index(unique_ptr<core::GlobalState> &gs, vector<core::FileRef> files,
@@ -551,13 +569,53 @@ vector<ast::ParsedFile> index(unique_ptr<core::GlobalState> &gs, vector<core::Fi
     if (files.size() < 3) {
         // Run singlethreaded if only using 2 files
         for (auto file : files) {
-            auto tree = readFileWithStrictnessOverrides(gs, file, opts, kvstore);
-            auto parsedFile = indexOne(opts, *gs, file, move(tree));
-            ret.emplace_back(move(parsedFile));
+            readFileWithStrictnessOverrides(gs, file, opts, kvstore);
+            if (auto tree = fetchTreeFromCache(*gs, file, kvstore)) {
+                ret.emplace_back(ast::ParsedFile{move(tree), file});
+            } else {
+                auto parsedFile = indexOne(opts, *gs, file);
+                ret.emplace_back(move(parsedFile));
+            }
         }
         ENFORCE(files.size() == ret.size());
     } else {
         auto pass = indexSuppliedFiles(move(gs), files, opts, workers, kvstore);
+        gs = move(pass.gs);
+        ret = move(pass.trees);
+        ENFORCE_NO_TIMER(pass.compressedTrees.empty());
+    }
+
+    fast_sort(ret, [](ast::ParsedFile const &a, ast::ParsedFile const &b) { return a.file < b.file; });
+    return ret;
+}
+
+vector<ast::CompressedParsedFile> indexAndCompress(unique_ptr<core::GlobalState> &gs, vector<core::FileRef> files,
+                                                   const options::Options &opts, WorkerPool &workers,
+                                                   const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+    Timer timeit(gs->tracer(), "index");
+    vector<ast::CompressedParsedFile> ret;
+
+    if (opts.stopAfterPhase == options::Phase::INIT) {
+        return ret;
+    }
+
+    gs->sanityCheck();
+
+    if (files.size() < 3) {
+        // Run singlethreaded if only using 2 files
+        for (auto file : files) {
+            readFileWithStrictnessOverrides(gs, file, opts, kvstore);
+            if (auto tree = fetchCompressedTreeFromCache(*gs, file, kvstore)) {
+                ret.emplace_back(ast::CompressedParsedFile{move(tree), file});
+            } else {
+                auto parsedFile = indexOne(opts, *gs, file);
+                auto compressedTree = make_unique<vector<u1>>(core::serialize::Serializer::storeAST(parsedFile));
+                ret.emplace_back(ast::CompressedParsedFile{move(compressedTree), file});
+            }
+        }
+        ENFORCE(files.size() == ret.size());
+    } else {
+        auto pass = indexSuppliedFiles(move(gs), files, opts, workers, kvstore /* compressAllTrees */ true);
         gs = move(pass.gs);
         ret = move(pass.trees);
     }
@@ -1108,9 +1166,8 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, vector
 
                     auto &file = job->file.data(gs);
                     if (!file.cached && !file.hasParseErrors) {
-                        auto keys = fileKeys(file);
-                        threadResult.emplace_back(keys.file, core::serialize::Serializer::storeFile(file));
-                        threadResult.emplace_back(keys.tree, core::serialize::Serializer::storeAST(*job));
+                        threadResult.emplace_back(fileKey(file), core::serialize::Serializer::storeFile(file));
+                        threadResult.emplace_back(treeKey(file), core::serialize::Serializer::storeAST(*job));
                     }
                 }
             }

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -23,6 +23,16 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
 
 std::vector<core::FileRef> reserveFiles(std::unique_ptr<core::GlobalState> &gs, const std::vector<std::string> &files);
 
+/**
+ * This routine is optimized for the editor/LSP use case, which keeps trees compressed in-memory:
+ * - If an AST is in the cache, appends the tree to IndexResult.compressedTrees.
+ * - Otherwise, it indexes the file and stores the raw AST into trees.
+ * In the common case, ~all ASTs are in the cache so this function ends up doing a bunch of memcpys.
+ */
+IndexResult indexWithNoDecompression(std::unique_ptr<core::GlobalState> gs, std::vector<core::FileRef> &files,
+                                     const options::Options &opts, WorkerPool &workers,
+                                     const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
+
 std::vector<ast::ParsedFile> index(std::unique_ptr<core::GlobalState> &gs, std::vector<core::FileRef> files,
                                    const options::Options &opts, WorkerPool &workers,
                                    const std::unique_ptr<const OwnedKeyValueStore> &kvstore);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -12,6 +12,13 @@ class PreemptionTaskManager;
 }
 
 namespace sorbet::realmain::pipeline {
+
+struct IndexResult {
+    std::unique_ptr<core::GlobalState> gs;
+    std::vector<ast::ParsedFile> trees;
+    std::vector<ast::CompressedParsedFile> compressedTrees;
+};
+
 ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file);
 
 std::vector<core::FileRef> reserveFiles(std::unique_ptr<core::GlobalState> &gs, const std::vector<std::string> &files);
@@ -19,13 +26,6 @@ std::vector<core::FileRef> reserveFiles(std::unique_ptr<core::GlobalState> &gs, 
 std::vector<ast::ParsedFile> index(std::unique_ptr<core::GlobalState> &gs, std::vector<core::FileRef> files,
                                    const options::Options &opts, WorkerPool &workers,
                                    const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
-
-// Index the given files and compress them. Used in LSP mode to reduce memory consumption as we keep all ASTs in memory.
-// Also reduces startup time when the cache is in-use as we can grab compressed ASTs from the cache.
-std::vector<ast::CompressedParsedFile> indexAndCompress(std::unique_ptr<core::GlobalState> &gs,
-                                                        std::vector<core::FileRef> files, const options::Options &opts,
-                                                        WorkerPool &workers,
-                                                        const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
 
 std::vector<ast::ParsedFile> package(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                      const options::Options &opts, WorkerPool &workers);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -49,13 +49,9 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
 bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, std::vector<ast::ParsedFile> &parsedFiles,
                         const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
-struct FileKeys {
-    std::string file;
-    std::string tree;
-};
-
 // Exported for tests only.
-FileKeys fileKey(const core::File &file);
+std::string fileKey(const core::File &file);
+std::string treeKey(const core::File &file);
 
 } // namespace sorbet::realmain::pipeline
 #endif // RUBY_TYPER_PIPELINE_H

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -49,8 +49,13 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
 bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, std::vector<ast::ParsedFile> &parsedFiles,
                         const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
+struct FileKeys {
+    std::string file;
+    std::string tree;
+};
+
 // Exported for tests only.
-std::string fileKey(const core::File &file);
+FileKeys fileKey(const core::File &file);
 
 } // namespace sorbet::realmain::pipeline
 #endif // RUBY_TYPER_PIPELINE_H

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -63,6 +63,7 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
 
 // Caches any uncached trees and files. Returns true if it modifies kvstore.
 bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, std::vector<ast::ParsedFile> &parsedFiles,
+                        std::vector<ast::CompressedParsedFile> &compressedParsedFiles,
                         const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
 // Exported for tests only.

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -12,14 +12,20 @@ class PreemptionTaskManager;
 }
 
 namespace sorbet::realmain::pipeline {
-ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
-                         ast::ExpressionPtr cachedTree = nullptr);
+ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file);
 
 std::vector<core::FileRef> reserveFiles(std::unique_ptr<core::GlobalState> &gs, const std::vector<std::string> &files);
 
 std::vector<ast::ParsedFile> index(std::unique_ptr<core::GlobalState> &gs, std::vector<core::FileRef> files,
                                    const options::Options &opts, WorkerPool &workers,
                                    const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
+
+// Index the given files and compress them. Used in LSP mode to reduce memory consumption as we keep all ASTs in memory.
+// Also reduces startup time when the cache is in-use as we can grab compressed ASTs from the cache.
+std::vector<ast::CompressedParsedFile> indexAndCompress(std::unique_ptr<core::GlobalState> &gs,
+                                                        std::vector<core::FileRef> files, const options::Options &opts,
+                                                        WorkerPool &workers,
+                                                        const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
 
 std::vector<ast::ParsedFile> package(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                      const options::Options &opts, WorkerPool &workers);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -544,7 +544,9 @@ int realmain(int argc, char *argv[]) {
                 gs->errorQueue->flushAllErrors(*gs);
             }
         }
-        cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, *workers, indexed);
+        vector<ast::CompressedParsedFile> compressed;
+        cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, *workers, indexed,
+                                             compressed);
 
         if (gs->runningUnderAutogen) {
 #ifdef SORBET_REALMAIN_MIN

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -100,10 +100,9 @@ UnorderedSet<string> knownExpectations = {"parse-tree",
                                           "document-formatting-rubyfmt"};
 
 ast::ParsedFile testSerialize(core::GlobalState &gs, ast::ParsedFile expr) {
-    auto &savedFile = expr.file.data(gs);
-    auto saved = core::serialize::Serializer::storeFile(savedFile, expr);
-    auto restored = core::serialize::Serializer::loadFile(gs, saved.data());
-    return {move(restored.tree), expr.file};
+    auto saved = core::serialize::Serializer::storeAST(expr);
+    auto restored = core::serialize::Serializer::loadAST(gs, saved.data());
+    return {move(restored), expr.file};
 }
 
 /** Converts a Sorbet Error object into an equivalent LSP Diagnostic object. */


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

WIP: Use compressed ASTs when in LSP mode.

Because parsing is expensive, Sorbet's LSP server stores an AST for every file in your project in-memory. For large projects, this can take up a fair bit of memory. When you make a change in-editor that causes Sorbet to retypecheck the world, it:
* Deep copies each AST in the project. ASTs are trees constructed with pointers, so there's a fair bit of pointer chasing involved.
* Runs those ASTs through Sorbet's various passes, which mutates the AST (which is why we had to copy them).

There's also an interesting situation when you use `--cache-dir`. The on-disk cache contains compressed ASTs, so at startup Sorbet has to retrieve these and decompress them -- which seems a bit wasteful.

This PR changes Sorbet to keep around compressed ASTs in memory. Retypechecking the world involves _decompressing_ the AST and inflating it into a tree, which I believe will be cheaper (or at least as expensive) as copying them. When you start up Sorbet with a warm cache, it can grab and memcpy ASTs directly from the cache without doing further work.

There is one scenario where performance will regress slightly. For folks using Sorbet in LSP mode without a cache, Sorbet will spend a little extra time at startup compressing the ASTs. However, I believe the benefits are worth this slight regression. Folks who care about editor performance should use `--cache-dir`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Lower memory consumption and (hopefully) improve speed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

CI.
