### PR TITLE
Adding T::Props::Plugin::ClassMethods to tprops.rbi

### DIFF
--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -90,6 +90,10 @@ end
 module T::Props::Plugin
   extend T::Helpers
   include T::Props
+  mixes_in_class_methods(T::Props::Plugin::ClassMethods)
+end
+
+module T::Props::Plugin::ClassMethods
 end
 
 module T::Props::Utils


### PR DESCRIPTION
Adding the missing `T::Props::Plugin::ClassMethods` module to tprops.rbi, and adding the `mixes_in_class_methods` call in the appropriate place. These are defined [here](https://github.com/sorbet/sorbet/blob/8e5db10c892a3afac86246cb82706405247a0370/gems/sorbet-runtime/lib/types/props/plugin.rb#L4).

### Motivation

These are parts of the APIs exposed by Sorbet so they should be declared by the rbis.


### Test plan

These are just declaring existing API types in the rbis.
