### PR TITLE
Stream out writes to kvstore to parallelize them with processing.

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1088,10 +1088,10 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, vector
                     if (!file.cached && !file.hasParseErrors) {
                         threadResult.emplace_back(fileKey(file), core::serialize::Serializer::storeFile(file, *job));
                         // Stream out compressed files so that writes happen in parallel with processing.
-                        if (processedByThread > 100) {
+                        /* if (processedByThread > 100) {
                             resultq->push(move(threadResult), processedByThread);
                             processedByThread = 0;
-                        }
+                        }*/
                     }
                 }
             }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1088,10 +1088,10 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, vector
                     if (!file.cached && !file.hasParseErrors) {
                         threadResult.emplace_back(fileKey(file), core::serialize::Serializer::storeFile(file, *job));
                         // Stream out compressed files so that writes happen in parallel with processing.
-                        /* if (processedByThread > 100) {
+                        if (processedByThread > 100) {
                             resultq->push(move(threadResult), processedByThread);
                             processedByThread = 0;
-                        }*/
+                        }
                     }
                 }
             }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1071,10 +1071,14 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, vector
         vector<pair<string, vector<u1>>> threadResult;
         int processedByThread = 0;
         ast::ParsedFile *job = nullptr;
+        unique_ptr<Timer> timeit;
         {
             for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
                 if (result.gotItem()) {
                     processedByThread++;
+                    if (timeit == nullptr) {
+                        timeit = make_unique<Timer>(gs.tracer(), "cacheTreesAndFilesWorker");
+                    }
 
                     if (!job->file.exists()) {
                         continue;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1083,6 +1083,11 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, vector
                     auto &file = job->file.data(gs);
                     if (!file.cached && !file.hasParseErrors) {
                         threadResult.emplace_back(fileKey(file), core::serialize::Serializer::storeFile(file, *job));
+                        // Stream out compressed files so that writes happen in parallel with processing.
+                        if (processedByThread > 100) {
+                            resultq->push(move(threadResult), processedByThread);
+                            processedByThread = 0;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Stream out writes to the cache to parallelize them with processing. Speeds up this method by ~25%.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed++.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
