### PR TITLE
WIP: Offload writing GlobalState to disk to a secondary thread.

### DIFF
--- a/main/cache/cache-orig.cc
+++ b/main/cache/cache-orig.cc
@@ -11,8 +11,9 @@ unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, uniqu
     return nullptr;
 }
 
-void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
-                                   core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> &indexed) {
+void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, shared_ptr<spdlog::logger> tracer,
+                                   const options::Options &opts, core::GlobalState &gs, WorkerPool &workers,
+                                   vector<ast::ParsedFile> &indexed) {
     return;
 }
 

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -1,5 +1,8 @@
 #include "main/cache/cache.h"
+#include "absl/synchronization/notification.h"
+#include "common/Random.h"
 #include "common/kvstore/KeyValueStore.h"
+#include "core/serialize/serialize.h"
 #include "main/options/options.h"
 #include "main/pipeline/pipeline.h"
 #include "payload/payload.h"
@@ -8,6 +11,40 @@
 using namespace std;
 
 namespace sorbet::realmain::cache {
+
+namespace {
+bool kvstoreUnchangedSinceGsCreation(const core::GlobalState &gs, const u1 *maybeGsBytes) {
+    const bool storedUidMatches =
+        maybeGsBytes && gs.kvstoreUuid == core::serialize::Serializer::loadGlobalStateUUID(gs, maybeGsBytes);
+    const bool noPreviouslyStoredUuid = !maybeGsBytes && gs.kvstoreUuid == 0;
+    return storedUidMatches || noPreviouslyStoredUuid;
+}
+
+/** Returns 'true' if the given GlobalState was originally created from the current contents of kvstore (e.g., kvstore
+ * has not since been modified). */
+bool kvstoreUnchangedSinceGsCreation(const core::GlobalState &gs, const unique_ptr<OwnedKeyValueStore> &kvstore) {
+    return kvstoreUnchangedSinceGsCreation(gs, kvstore->read(payload::GLOBAL_STATE_KEY).data);
+}
+
+/** Writes the GlobalState to kvstore, but only if kvstore hasn't been updated in the mean time. Returns 'true' if a
+ * write happens. */
+bool retainGlobalState(core::GlobalState &gs, const realmain::options::Options &options,
+                       const unique_ptr<OwnedKeyValueStore> &kvstore) {
+    ENFORCE_NO_TIMER(kvstore && gs.wasModified() && !gs.hadCriticalError());
+    auto maybeGsBytes = kvstore->read(payload::GLOBAL_STATE_KEY);
+    // Verify that no other GlobalState was written to kvstore between when we read GlobalState and wrote it
+    // into the databaase.
+    if (kvstoreUnchangedSinceGsCreation(gs, maybeGsBytes.data)) {
+        Timer timeit(gs.tracer(), "write_global_state.kvstore");
+        // Generate a new UUID, since this GS has changed since it was read.
+        gs.kvstoreUuid = Random::uniformU4();
+        kvstore->write(payload::GLOBAL_STATE_KEY, core::serialize::Serializer::storePayloadAndNameTable(gs));
+        return true;
+    }
+    return false;
+}
+} // namespace
+
 unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(const options::Options &opts) {
     if (opts.cacheDir.empty()) {
         return nullptr;
@@ -22,7 +59,7 @@ unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, uniqu
     }
 
     auto ownedKvstore = make_unique<OwnedKeyValueStore>(move(kvstore));
-    if (payload::kvstoreUnchangedSinceGsCreation(gs, ownedKvstore)) {
+    if (kvstoreUnchangedSinceGsCreation(gs, ownedKvstore)) {
         return ownedKvstore;
     }
 
@@ -30,23 +67,39 @@ unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, uniqu
     return nullptr;
 }
 
-void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
-                                   core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> &indexed) {
-    if (kvstore == nullptr) {
+void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, shared_ptr<spdlog::logger> tracer,
+                                   const options::Options &opts, core::GlobalState &gs, WorkerPool &workers,
+                                   vector<ast::ParsedFile> &indexed) {
+    if (kvstore == nullptr || !gs.wasModified() || gs.hadCriticalError()) {
         return;
     }
-    auto ownedKvstore = make_unique<OwnedKeyValueStore>(move(kvstore));
-    // TODO: Move these methods into this file.
-    auto wroteGlobalState = payload::retainGlobalState(gs, opts, ownedKvstore);
-    if (wroteGlobalState) {
-        // Only write changes to disk if GlobalState changed since the last time.
-        pipeline::cacheTreesAndFiles(gs, workers, indexed, ownedKvstore);
-        OwnedKeyValueStore::bestEffortCommit(gs.tracer(), move(ownedKvstore));
-        prodCounterInc("cache.committed");
-    } else {
-        prodCounterInc("cache.aborted");
-        OwnedKeyValueStore::abort(move(ownedKvstore));
-    }
+
+    auto writeBeginNotif = make_shared<absl::Notification>();
+    // We're going to try to commit the changed global state to disk.
+    // First, spawn off a new thread for this. kvstore only supports one thread writing to it, and we want to
+    // flush our writes to disk asynchronously from the rest of sorbet as it can take awhile on a large project.
+    runInAThread("cacheGlobalStateAndFiles",
+                 [&kvstore, &opts, &gs, writeBeginNotif, &workers, &indexed, tracer]() -> void {
+                     auto ownedKvstore = make_unique<OwnedKeyValueStore>(move(kvstore));
+                     auto wroteGlobalState = retainGlobalState(gs, opts, ownedKvstore);
+                     if (wroteGlobalState) {
+                         // Only write changes to disk if GlobalState changed since the last time.
+                         pipeline::cacheTreesAndFiles(gs, workers, indexed, ownedKvstore);
+                     }
+
+                     writeBeginNotif->Notify();
+                     // BELOW THIS POINT, WE CANNOT USE ANY REFERENCES TO OBJECTS IN THE
+                     // maybeCacheGlobalStateAndFiles STACK FRAME. Only use tracer and ownedKvstore.
+                     if (wroteGlobalState) {
+                         OwnedKeyValueStore::bestEffortCommit(*tracer, move(ownedKvstore));
+                         prodCounterInc("cache.committed");
+                     } else {
+                         prodCounterInc("cache.aborted");
+                         OwnedKeyValueStore::abort(move(ownedKvstore));
+                     }
+                 });
+    // Wait until the thread begins writing to kvstore before destroying the stack frame.
+    writeBeginNotif->WaitForNotification();
 }
 
 } // namespace sorbet::realmain::cache

--- a/main/cache/cache.h
+++ b/main/cache/cache.h
@@ -3,6 +3,10 @@
 
 #include <memory>
 
+namespace spdlog {
+class logger;
+}
+
 namespace sorbet {
 class KeyValueStore;
 class OwnedKeyValueStore;
@@ -19,6 +23,7 @@ struct Options;
 } // namespace sorbet
 
 namespace sorbet::realmain::cache {
+
 // If cacheDir is specified, creates a KeyValueStore. Otherwise, returns nullptr.
 std::unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(const options::Options &opts);
 
@@ -26,9 +31,10 @@ std::unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(const options::Opti
 std::unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, std::unique_ptr<KeyValueStore> kvstore);
 
 // If kvstore is not null, caches global state and the given files to disk if they have changed. Can silently fail to
-// cache
-void maybeCacheGlobalStateAndFiles(std::unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
-                                   core::GlobalState &gs, WorkerPool &workers, std::vector<ast::ParsedFile> &indexed);
+// cache. Asynchronously commits the kvstore to disk.
+void maybeCacheGlobalStateAndFiles(std::unique_ptr<KeyValueStore> kvstore, std::shared_ptr<spdlog::logger> tracer,
+                                   const options::Options &opts, core::GlobalState &gs, WorkerPool &workers,
+                                   std::vector<ast::ParsedFile> &indexed);
 } // namespace sorbet::realmain::cache
 
 #endif

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -183,8 +183,8 @@ void LSPIndexer::initialize(LSPFileUpdates &updates, WorkerPool &workers) {
         }
     }
 
-    cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(ownedKvstore)), config->opts, *initialGS,
-                                         workers, indexed);
+    cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(ownedKvstore)), config->logger, config->opts,
+                                         *initialGS, workers, indexed);
 
     ENFORCE_NO_TIMER(indexed.size() == initialGS->filesUsed());
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -546,7 +546,8 @@ int realmain(int argc, char *argv[]) {
                 gs->errorQueue->flushAllErrors(*gs);
             }
         }
-        cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, *workers, indexed);
+        cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), logger, opts, *gs, *workers,
+                                             indexed);
 
         if (gs->runningUnderAutogen) {
 #ifdef SORBET_REALMAIN_MIN

--- a/payload/payload.h
+++ b/payload/payload.h
@@ -7,16 +7,10 @@
 
 namespace sorbet::payload {
 
+constexpr std::string_view GLOBAL_STATE_KEY = "GlobalState";
+
 void createInitialGlobalState(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
                               const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
-
-/** Returns 'true' if the given GlobalState was originally created from the current contents of kvstore (e.g., kvstore
- * has not since been modified). */
-bool kvstoreUnchangedSinceGsCreation(const core::GlobalState &gs, const std::unique_ptr<OwnedKeyValueStore> &kvstore);
-
-/** Writes the GlobalState to kvstore, but only if it was modified. Returns 'true' if a write happens. */
-bool retainGlobalState(core::GlobalState &gs, const realmain::options::Options &options,
-                       const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
 } // namespace sorbet::payload
 #endif // RUBY_TYPER_PAYLOAD_H


### PR DESCRIPTION
Offload writing GlobalState to disk to a secondary thread.

Should take a decent amount of time off of the critical path in large projects when the cache is cold.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed++

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests. One test is currently failing; will fix if this works as expected.
