### PR TITLE
Hashing spends ~15% of its time in GlobalState's constructor incrementing an atomic integer.

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -107,7 +107,7 @@ unique_ptr<GlobalState> GlobalState::makeEmptyGlobalStateForHashing(spdlog::logg
     // Note: Private constructor.
     unique_ptr<GlobalState> rv(
         new GlobalState(make_shared<core::ErrorQueue>(logger, logger, make_shared<core::NullFlusher>()),
-                        make_shared<lsp::TypecheckEpochManager>(), 999));
+                        make_shared<lsp::TypecheckEpochManager>(), -1));
     rv->initEmpty();
     rv->silenceErrors = true;
     return rv;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -49,9 +49,18 @@ class GlobalState final {
     friend class UnfreezeFileTable;
     friend struct NameRefDebugCheck;
 
+    // Private constructor that allows a specific globalStateId. Used in `makeEmptyGlobalStateForHashing` to avoid
+    // contention on the global state ID atomic.
+    GlobalState(std::shared_ptr<ErrorQueue> errorQueue, std::shared_ptr<lsp::TypecheckEpochManager> epochManager,
+                int globalStateId);
+
 public:
     GlobalState(std::shared_ptr<ErrorQueue> errorQueue);
     GlobalState(std::shared_ptr<ErrorQueue> errorQueue, std::shared_ptr<lsp::TypecheckEpochManager> epochManager);
+
+    // Creates an empty global state for hashing. Bypasses important sanity checks that are used for other types of
+    // global states.
+    static std::unique_ptr<GlobalState> makeEmptyGlobalStateForHashing(spdlog::logger &logger);
 
     // Empirically determined to be the smallest powers of two larger than the
     // values required by the payload. Enforced in payload.cc.

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -5,7 +5,6 @@
 #include "core/ErrorQueue.h"
 #include "core/GlobalSubstitution.h"
 #include "core/NameHash.h"
-#include "core/NullFlusher.h"
 #include "core/Unfreeze.h"
 #include "main/pipeline/pipeline.h"
 
@@ -44,10 +43,7 @@ unique_ptr<core::FileHash> computeFileHashForAST(unique_ptr<core::GlobalState> &
 core::FileRef makeEmptyGlobalStateForFile(spdlog::logger &logger, shared_ptr<core::File> forWhat,
                                           unique_ptr<core::GlobalState> &lgs,
                                           const realmain::options::Options &hashingOpts) {
-    lgs = make_unique<core::GlobalState>(
-        (make_shared<core::ErrorQueue>(logger, logger, make_shared<core::NullFlusher>())));
-    lgs->initEmpty();
-    lgs->silenceErrors = true;
+    lgs = core::GlobalState::makeEmptyGlobalStateForHashing(logger);
     lgs->requiresAncestorEnabled = hashingOpts.requiresAncestorEnabled;
     {
         core::UnfreezeFileTable fileTableAccess(*lgs);


### PR DESCRIPTION
Hashing spends ~15% of its time in GlobalState's constructor incrementing an atomic integer.

This integer corresponds to GlobalStateId, which is not semantically important for hashing... so let's not do that? :)

Introduces a new static method on GlobalState for creating empty GlobalStates for hashing.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed++.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
