### PR TITLE
[WIP] serialize integers by grouping, rather than by individual varints

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,6 +33,7 @@ build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 # Developer laptops run skylake, devboxes run skylake-avx512
 # however some AWS instances in our fleet still run Sandy Bridge (Skylake predecessor)
 build --copt=-march=sandybridge
+build --host_copt=-march=sandybridge
 
 build --copt=-fno-omit-frame-pointer
 

--- a/core/serialize/pickler.h
+++ b/core/serialize/pickler.h
@@ -13,6 +13,9 @@ public:
     void putU1(const u1 u);
     void putS8(const int64_t i);
     void putStr(std::string_view s);
+
+    void putU4Group(u4, u4, u4, u4);
+
     std::vector<u1> result(int compressionDegree);
     Pickler() = default;
 };
@@ -27,6 +30,9 @@ public:
     u1 getU1();
     int64_t getS8();
     std::string_view getStr();
+
+    void getU4Group(u4*, u4*, u4*, u4*);
+
     explicit UnPickler(const u1 *const compressed, spdlog::logger &tracer);
 };
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1233,8 +1233,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
 
         case ast::Tag::UnresolvedConstantLit: {
             auto &a = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(what);
-            pickle(p, a.loc);
-            p.putU4(a.cnst.rawId());
+            serializeLocAndU4(a.loc, a.cnst.rawId());
             pickle(p, a.scope);
             break;
         }
@@ -1512,8 +1511,8 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             return ast::MK::If(loc, std::move(cond), std::move(thenp), std::move(elsep));
         }
         case ast::Tag::UnresolvedConstantLit: {
-            auto loc = unpickleLocOffsets(p);
-            NameRef cnst = unpickleNameRef(p, gs);
+            auto [loc, rawCnst] = unserializeLocAndU4(p);
+            NameRef cnst = NameRef::fromRaw(gs, rawCnst);
             auto scope = unpickleExpr(p, gs);
             return ast::MK::UnresolvedConstant(loc, std::move(scope), cnst);
         }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -954,7 +954,10 @@ Pickler SerializerImpl::pickle(const GlobalState &gs, bool payloadOnly) {
     }
 
     result.putU4(gs.namesByHash.size());
-    serializeGroupwise(result, gs.namesByHash, [](const auto &s) -> std::tuple<int, int> { return {s.first, s.second}; });
+    for (const auto &s : gs.namesByHash) {
+        result.putU4(s.first);
+        result.putU4(s.second);
+    }
     return result;
 }
 
@@ -1074,9 +1077,11 @@ void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
         Timer timeit(result.tracer(), "readNameTable");
         int namesByHashSize = p.getU4();
         namesByHash.reserve(namesByHashSize);
-        unserializeGroupwise(p, namesByHashSize, [&namesByHash](u4 hash, u4 value) {
+        for (int i = 0; i < namesByHashSize; i++) {
+            auto hash = p.getU4();
+            auto value = p.getU4();
             namesByHash.emplace_back(make_pair(hash, value));
-            });
+        }
     }
 
     UnorderedMap<string, FileRef> fileRefByPath;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1362,8 +1362,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
 
         case ast::Tag::Rescue: {
             auto &a = ast::cast_tree_nonnull<ast::Rescue>(what);
-            pickle(p, a.loc);
-            p.putU4(a.rescueCases.size());
+            serializeLocAndU4(p, a.loc, a.rescueCases.size());
             pickle(p, a.ensure);
             pickle(p, a.else_);
             pickle(p, a.body);
@@ -1655,8 +1654,7 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
                                                      std::move(ensure));
         }
         case ast::Tag::RescueCase: {
-            auto loc = unpickleLocOffsets(p);
-            auto exceptionsSize = p.getU4();
+            auto [loc, exceptionsSize] = unserializeLocAndU4(p);
             auto var = unpickleExpr(p, gs);
             auto body = unpickleExpr(p, gs);
             ast::RescueCase::EXCEPTION_store exceptions(exceptionsSize);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1309,8 +1309,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
 
         case ast::Tag::Cast: {
             auto &c = ast::cast_tree_nonnull<ast::Cast>(what);
-            pickle(p, c.loc);
-            p.putU4(c.cast.rawId());
+            serializeLocAndU4(p, c.loc, c.cast.rawId());
             pickle(p, c.type);
             pickle(p, c.arg);
             break;
@@ -1570,8 +1569,8 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             return ast::MK::Array(loc, std::move(elems));
         }
         case ast::Tag::Cast: {
-            auto loc = unpickleLocOffsets(p);
-            NameRef kind = NameRef::fromRaw(gs, p.getU4());
+            auto [loc, rawId] = unserializeLocAndU4(p);
+            NameRef kind = NameRef::fromRaw(gs, rawId);
             auto type = unpickleType(p, &gs);
             auto arg = unpickleExpr(p, gs);
             return ast::make_expression<ast::Cast>(loc, std::move(type), std::move(arg), kind);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1287,9 +1287,8 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
 
         case ast::Tag::Hash: {
             auto &h = ast::cast_tree_nonnull<ast::Hash>(what);
-            pickle(p, h.loc);
             ENFORCE(h.values.size() == h.keys.size());
-            p.putU4(h.values.size());
+            serializeLocAndU4(h.loc, h.values.size());
             for (auto &v : h.values) {
                 pickle(p, v);
             }
@@ -1551,8 +1550,7 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             return ast::make_expression<ast::Retry>(loc);
         }
         case ast::Tag::Hash: {
-            auto loc = unpickleLocOffsets(p);
-            auto sz = p.getU4();
+            auto [loc, sz] = unserializeLocAndU4(p);
             ast::Hash::ENTRY_store keys(sz);
             ast::Hash::ENTRY_store values(sz);
             for (auto &value : values) {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1301,8 +1301,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
 
         case ast::Tag::Array: {
             auto &a = ast::cast_tree_nonnull<ast::Array>(what);
-            pickle(p, a.loc);
-            p.putU4(a.elems.size());
+            serializeLocAndU4(p, a.loc, a.elems.size());
             for (auto &e : a.elems) {
                 pickle(p, e);
             }
@@ -1565,8 +1564,7 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             return ast::MK::Hash(loc, std::move(keys), std::move(values));
         }
         case ast::Tag::Array: {
-            auto loc = unpickleLocOffsets(p);
-            auto sz = p.getU4();
+            auto [loc, sz] = unserializeLocAndU4(p);
             ast::Array::ENTRY_store elems(sz);
             for (auto &elem : elems) {
                 elem = unpickleExpr(p, gs);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -940,10 +940,7 @@ Pickler SerializerImpl::pickle(const GlobalState &gs, bool payloadOnly) {
     }
 
     result.putU4(gs.namesByHash.size());
-    for (const auto &s : gs.namesByHash) {
-        result.putU4(s.first);
-        result.putU4(s.second);
-    }
+    serializeGroupwise(result, gs.namesByHash, [](const auto &s) -> std::tuple<int, int> { return {s.first, s.second}; });
     return result;
 }
 
@@ -1063,11 +1060,9 @@ void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
         Timer timeit(result.tracer(), "readNameTable");
         int namesByHashSize = p.getU4();
         namesByHash.reserve(namesByHashSize);
-        for (int i = 0; i < namesByHashSize; i++) {
-            auto hash = p.getU4();
-            auto value = p.getU4();
+        unserializeGroupwise(p, namesByHashSize, [&namesByHash](u4 hash, u4 value) {
             namesByHash.emplace_back(make_pair(hash, value));
-        }
+            });
     }
 
     UnorderedMap<string, FileRef> fileRefByPath;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1436,8 +1436,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
 
         case ast::Tag::ConstantLit: {
             auto &a = ast::cast_tree_nonnull<ast::ConstantLit>(what);
-            pickle(p, a.loc);
-            p.putU4(a.symbol.rawId());
+            serializeLocAndU4(p, a.loc, a.symbol.rawId());
             pickle(p, a.original);
             break;
         }
@@ -1703,8 +1702,8 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             return ast::make_expression<ast::UnresolvedIdent>(loc, kind, name);
         }
         case ast::Tag::ConstantLit: {
-            auto loc = unpickleLocOffsets(p);
-            auto sym = SymbolRef::fromRaw(p.getU4());
+            auto [loc, rawId] = unserializeLocAndU4(p);
+            auto sym = SymbolRef::fromRaw(rawId);
             auto orig = unpickleExpr(p, gs);
             return ast::make_expression<ast::ConstantLit>(loc, sym, std::move(orig));
         }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1240,9 +1240,8 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
 
         case ast::Tag::Local: {
             auto &a = ast::cast_tree_nonnull<ast::Local>(what);
-            pickle(p, a.loc);
+            serializeLocAndU4(p, a.loc, a.localVariable.unique());
             p.putU4(a.localVariable._name.rawId());
-            p.putU4(a.localVariable.unique);
             break;
         }
 
@@ -1511,9 +1510,8 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             return ast::MK::UnresolvedConstant(loc, std::move(scope), cnst);
         }
         case ast::Tag::Local: {
-            auto loc = unpickleLocOffsets(p);
+            auto [loc, unique] = unserializeLocAndU4(p);
             NameRef nm = unpickleNameRef(p, gs);
-            auto unique = p.getU4();
             LocalVariable lv(nm, unique);
             return ast::make_expression<ast::Local>(loc, lv);
         }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1256,8 +1256,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
 
         case ast::Tag::InsSeq: {
             auto &a = ast::cast_tree_nonnull<ast::InsSeq>(what);
-            pickle(p, a.loc);
-            p.putU4(a.stats.size());
+            serializeLocAndU4(p, a.loc, a.stats.size());
             pickle(p, a.expr);
             for (auto &st : a.stats) {
                 pickle(p, st);
@@ -1525,8 +1524,7 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             return ast::MK::Assign(loc, std::move(lhs), std::move(rhs));
         }
         case ast::Tag::InsSeq: {
-            auto loc = unpickleLocOffsets(p);
-            auto insSize = p.getU4();
+            auto [loc, insSize] = unserializeLocAndU4(p);
             auto expr = unpickleExpr(p, gs);
             ast::InsSeq::STATS_store stats(insSize);
             for (auto &stat : stats) {

--- a/core/serialize/test/serialize_test.cc
+++ b/core/serialize/test/serialize_test.cc
@@ -23,6 +23,24 @@ TEST_CASE("U4") { // NOLINT
     CHECK_EQ(u.getU4(), 4294967295);
 }
 
+TEST_CASE("U4GROUP") {
+    Pickler p;
+    p.putU4Group(257, 1, 76349, 17983207);
+    p.putU1(2);
+    p.putU4Group(257, 17983207, 1, 76349);
+    UnPickler u(p.result(Serializer::GLOBAL_STATE_COMPRESSION_DEGREE).data(), *logger);
+    u4 a, b, c, d;
+    u.getU4Group(&a, &b, &c, &d);
+    CHECK_EQ(a, 257);
+    CHECK_EQ(b, 1);
+    CHECK_EQ(c, 76349);
+    CHECK_EQ(d, 17983207);
+    CHECK_EQ(u.getU1(), 2);
+    u.getU4Group(&a, &b, &c, &d);
+    CHECK_EQ(a, 257);
+    CHECK_EQ(b, 17983207);
+    CHECK_EQ(c, 1);
+}
 TEST_CASE("U4U1") { // NOLINT
     Pickler p;
     p.putU4(0);


### PR DESCRIPTION
This was a weekend experiment to see how much better "group varint encoding" (https://github.com/facebook/folly/blob/master/folly/docs/GroupVarint.md) might work for Sorbet's serialization.  The above links to the original presentation of this idea which suggests decoding is ~2x faster; depending on the data, it might also be smaller as well.

Good news first: Sorbet's (uncompressed) payload gets ~2% smaller with these changes, with minimal changes to the compressed size.

There are a lot of known problems, and probably some unknown ones as well:

* No implementation for non-SSSE3 platforms (i.e. wasm)
* The SIMD bits were cut-and-pasted from Facebook's implementation (above) and need to be cleaned up
* The current implementation of decoding is almost certainly going to get flagged by sanitizers
* The groupings chosen are probably not optimal for some of the AST nodes (maybe even some of the payload-related things?)
* I would really like to know why 8d5e526 is such a loss
* No testing on whether this is actually a speed win or not
* Some of the names probably need to be cleaned up (e.g. `s/serialize/pickle/gi`)
* No idea how this does for the AST nodes

cc @jvilk-stripe

### Motivation

--space, ++speed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
