### PR TITLE
WIP: Speed up pickling/unpickling numbers with prefix varint packing.

### DIFF
--- a/core/serialize/pickler.h
+++ b/core/serialize/pickler.h
@@ -6,7 +6,6 @@
 namespace sorbet::core::serialize {
 class Pickler {
     std::vector<u1> data;
-    u1 zeroCounter = 0;
 
 public:
     void putU4(u4 u);
@@ -19,7 +18,6 @@ public:
 
 class UnPickler {
     int pos;
-    u1 zeroCounter = 0;
     std::vector<u1> data;
 
 public:


### PR DESCRIPTION
WIP: Speed up pickling and unpickling numbers with prefix varint packing.

Removes the zero special-case, although we can add it back in if it seems useful.

Intent is to _speed up_ encoding and decoding.

cc @froydnj who is looking at more complex SIMD-based approaches approaches

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Serialization and deserialization is still slower than I'd like. Maybe this will help?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
