### PR TITLE
fix ENFORCE when dealing with applied types in Array#zip

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2673,8 +2673,7 @@ public:
         for (auto arg : args.args) {
             auto argTyp = arg->type;
             if (auto *ap = cast_type<AppliedType>(argTyp)) {
-                ENFORCE(ap->klass == Symbols::Array() || ap->klass.data(gs)->derivesFrom(gs, Symbols::Array()) ||
-                        ap->klass == Symbols::Enumerable() ||
+                ENFORCE(ap->klass == Symbols::Enumerable() ||
                         ap->klass.data(gs)->derivesFrom(gs, Symbols::Enumerable()));
                 ENFORCE(!ap->targs.empty());
                 unwrappedElems.emplace_back(Types::any(gs, ap->targs.front(), Types::nilClass()));

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2673,7 +2673,9 @@ public:
         for (auto arg : args.args) {
             auto argTyp = arg->type;
             if (auto *ap = cast_type<AppliedType>(argTyp)) {
-                ENFORCE(ap->klass == Symbols::Array() || ap->klass.data(gs)->derivesFrom(gs, Symbols::Array()));
+                ENFORCE(ap->klass == Symbols::Array() || ap->klass.data(gs)->derivesFrom(gs, Symbols::Array()) ||
+                        ap->klass == Symbols::Enumerable() ||
+                        ap->klass.data(gs)->derivesFrom(gs, Symbols::Enumerable()));
                 ENFORCE(!ap->targs.empty());
                 unwrappedElems.emplace_back(Types::any(gs, ap->targs.front(), Types::nilClass()));
             } else if (auto *tuple = cast_type<TupleType>(argTyp)) {

--- a/test/testdata/core/array-zip.rb
+++ b/test/testdata/core/array-zip.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: true
+
+x = [1, 3, 5].cycle
+# We used to assume #zip only took Arrays and therefore Sorbet used to crash here.
+a = [2, 4, 6].zip(x)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Fix crash when `Array#zip` is used with non-`Array` types.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet should not crash.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
