### PR TITLE
more tightly bounded checks when searching for methods in ancestors

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -100,17 +100,15 @@ module T::Private::Methods
     if !module_with_final?(target)
       return
     end
-    # use reverse_each to check farther-up ancestors first, for better error messages. we could avoid this if we were on
-    # the version of ruby that adds the optional argument to method_defined? that allows you to exclude ancestors.
-    target_ancestors.reverse_each do |ancestor|
+    target_ancestors.each do |ancestor|
       source_method_names.each do |method_name|
         # the usage of method_owner_and_name_to_key(ancestor, method_name) instead of
         # method_to_key(ancestor.instance_method(method_name)) is not (just) an optimization, but also required for
         # correctness, since ancestor.method_defined?(method_name) may return true even if method_name is not defined
         # directly on ancestor but instead an ancestor of ancestor.
-        if (ancestor.method_defined?(method_name) ||
-            ancestor.private_method_defined?(method_name) ||
-            ancestor.protected_method_defined?(method_name)) &&
+        if (ancestor.method_defined?(method_name, false) ||
+            ancestor.private_method_defined?(method_name, false) ||
+            ancestor.protected_method_defined?(method_name, false)) &&
            final_method?(method_owner_and_name_to_key(ancestor, method_name))
           definition_file, definition_line = T::Private::Methods.signature_for_method(ancestor.instance_method(method_name)).method.source_location
           is_redefined = target == ancestor

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -103,9 +103,9 @@ module T::Private::Methods
     target_ancestors.each do |ancestor|
       source_method_names.each do |method_name|
         # the usage of method_owner_and_name_to_key(ancestor, method_name) instead of
-        # method_to_key(ancestor.instance_method(method_name)) is not (just) an optimization, but also required for
-        # correctness, since ancestor.method_defined?(method_name) may return true even if method_name is not defined
-        # directly on ancestor but instead an ancestor of ancestor.
+        # method_to_key(ancestor.instance_method(method_name)) is an optimization.
+        # If we were not limiting the defined? checks to ancestor only, it would be
+        # required for correctness.
         if (ancestor.method_defined?(method_name, false) ||
             ancestor.private_method_defined?(method_name, false) ||
             ancestor.protected_method_defined?(method_name, false)) &&


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Use the optional second arg to `method_defined?` and friends to bound ancestor chain searches.

### Motivation

In attempting to turn on `final` method checks for Stripe's codebase, we're seeing various timeouts when these checks are turned on.  I'm not 100% certain that this change solves things, but it does seem like a reasonable place to start.  By default, we're going to check the entire ancestor chain for each invocation of `method_defined?` for each ancestor we're examining.  This scales badly; we can do better by limiting the check to the specific ancestor we're looking at.  (It strikes me that we should also not be checking `protected_method_defined?`, since `method_defined?` is defined to examine public and protected methods, but that is a change for a separate PR, I think.)

This argument is a Ruby 2.6+ addition; I don't believe we support <= Ruby 2.5, but happy to hear otherwise.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I believe we already have tests that exercise this code, e.g.

https://github.com/sorbet/sorbet/blob/03f5d54c917f2371ba1ff304a3812a12257b4035/gems/sorbet-runtime/test/types/final_method.rb#L365-L384
