### PR TITLE
Don't store file contents in the cache.

### DIFF
--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -884,19 +884,26 @@ u4 Serializer::loadGlobalStateUUID(const GlobalState &gs, const u1 *const data) 
     return SerializerImpl::unpickleGSUUID(p);
 }
 
-vector<u1> Serializer::storeFile(const core::File &file, ast::ParsedFile &tree) {
+vector<u1> Serializer::storeTree(const core::File &file, const ast::ParsedFile &tree) {
     Pickler p;
-    SerializerImpl::pickle(p, file);
+    // See comment in `serialize.h` above `loadTree`.
+    p.putU4(file.source().size());
+    SerializerImpl::pickle(p, file.getFileHash());
     SerializerImpl::pickle(p, tree.tree);
     return p.result();
 }
 
-CachedFile Serializer::loadFile(const core::GlobalState &gs, const u1 *const data) {
+ast::ExpressionPtr Serializer::loadTree(const core::GlobalState &gs, core::File &file, const u1 *const data) {
     UnPickler p(data, gs.tracer());
-    auto file = SerializerImpl::unpickleFile(p);
-    file->cached = true;
-    auto tree = SerializerImpl::unpickleExpr(p, gs);
-    return CachedFile{move(file), move(tree)};
+    u4 fileSrcLen = p.getU4();
+    if (file.source().size() < fileSrcLen) {
+        // See comment in `serialize.h` above `loadTree`.
+        // File is smaller than expected; bail.
+        return nullptr;
+    }
+    file.cached = true;
+    file.setFileHash(SerializerImpl::unpickleFileHash(p));
+    return SerializerImpl::unpickleExpr(p, gs);
 }
 
 void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -896,13 +896,14 @@ vector<u1> Serializer::storeTree(const core::File &file, const ast::ParsedFile &
 ast::ExpressionPtr Serializer::loadTree(const core::GlobalState &gs, core::File &file, const u1 *const data) {
     UnPickler p(data, gs.tracer());
     u4 fileSrcLen = p.getU4();
-    if (file.source().size() < fileSrcLen) {
+    if (file.source().size() != fileSrcLen) {
         // See comment in `serialize.h` above `loadTree`.
-        // File is smaller than expected; bail.
+        // File does not have expected size; bail.
         return nullptr;
     }
-    file.cached = true;
     file.setFileHash(SerializerImpl::unpickleFileHash(p));
+    // cached must be set _after_ setting the file hash, as setFileHash unsets the cached flag
+    file.cached = true;
     return SerializerImpl::unpickleExpr(p, gs);
 }
 

--- a/core/serialize/serialize.h
+++ b/core/serialize/serialize.h
@@ -32,7 +32,7 @@ public:
     // new file is smaller than the old file, Sorbet could encounter memory errors pretty printing `loc`s in error
     // messages as they will point to invalid offsets in the file's text.
     // To prevent that memory error entirely, we stash the file source's text into the `data` blob. If `loadTree`
-    // encounters a file with smaller-than-expected source text, it returns `nullptr`.
+    // encounters a file with a different sized source text, it returns `nullptr`.
     static ast::ExpressionPtr loadTree(const GlobalState &gs, core::File &file, const u1 *const data);
 };
 }; // namespace sorbet::core::serialize

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -93,7 +93,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
         // If caching fails, gs gets modified during payload creation.
         CHECK_FALSE(gs->wasModified());
 
-        auto cachedFile = core::serialize::Serializer::loadFile(*gs, contents.data);
+        auto tree = core::serialize::Serializer::loadTree(*gs, contents.data);
         CHECK(cachedFile.file->cached);
         CHECK_EQ(cachedFile.file->path(), filePath);
         CHECK_EQ(cachedFile.file->source(), fileContents);

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -101,9 +101,9 @@ UnorderedSet<string> knownExpectations = {"parse-tree",
 
 ast::ParsedFile testSerialize(core::GlobalState &gs, ast::ParsedFile expr) {
     auto &savedFile = expr.file.data(gs);
-    auto saved = core::serialize::Serializer::storeFile(savedFile, expr);
-    auto restored = core::serialize::Serializer::loadFile(gs, saved.data());
-    return {move(restored.tree), expr.file};
+    auto saved = core::serialize::Serializer::storeTree(savedFile, expr);
+    auto restored = core::serialize::Serializer::loadTree(gs, savedFile, saved.data());
+    return {move(restored), expr.file};
 }
 
 /** Converts a Sorbet Error object into an equivalent LSP Diagnostic object. */


### PR DESCRIPTION
Don't store file contents in the cache.

We don't actually need or use them, and they take a lot of space. On Stripe's codebase, it shrinks the cache by ~24% and speeds up typechecking by a little bit when the cache is cold.

### Background

The reason Sorbet stores file contents in the cache is to gracefully handle the situation when there is a hash collision on the contents of a single file. Sorbet stores ASTs for the file at path `P1` with contents `C1` at key `P1:SHA(C1)`. If Sorbet is later run on file `P1` with different contents `C2` such that `SHA(C1) == SHA(C2)` (hash collision), then it will reuse the AST for `C1` in the cache.

This situation, the same file having different contents across runs that hash to the same value, is vanishingly unlikely. The most immediate consequence of this action is that the user will observe typechecking results for the old version of the file, which is acceptable behavior for something so unlikely.

Now, why store the old version of the file? Why not store just the AST and use the new version of the file? The answer lies in locs, Sorbet's struct for location information. If a loc refers to a position in the source text that is beyond the size of the source text, pretty printing will try to print invalid memory, which is bad. (Unfortunately, there _are_ situations in the IDE case where Sorbet can end up with invalid locs like this, but that's another story...)

### This PR

We're already giving the user invalid typechecking results in this (very unlikely) situation. If we only care about crashes, we can just ensure that the file's new length is as long as expected (or is at least as long as was last encountered). The only change in behavior is that any errors pointing to locations in the new file may look garbled. That is exactly what this PR accomplishes.

The upside to this change is a smaller cache (so it reduces virtual memory usage a bit), faster compression/serialization into the cache, and faster cache flushes to disk -- which results in slightly faster typechecks/IDE startup when the cache is cold.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduce cache size and slightly speed up IDE startup w/ a cache.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
