### PR TITLE
Amend the message for 5013

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -339,9 +339,9 @@ end
 
 For how to fix, see [Type Annotations](type-annotations.md).
 
-If your intent was not to declare the type of the instance variable but was
-instead just to assign to it, you can assign to an intermediate variable to
-avoid this error:
+If your intent was not to declare the type of the instance variable but to check
+the type of the value being assigned to it, you can assign to an intermediate
+variable to avoid this error:
 
 ```ruby
 class A

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -339,9 +339,9 @@ end
 
 For how to fix, see [Type Annotations](type-annotations.md).
 
-If your intent was not to declare the type of the instance variable but to check
-the type of the value being assigned to it, you can assign to an intermediate
-variable to avoid this error:
+To instead use `T.cast` as a runtime-only type check (that is, neither as a
+statically-checked assertion nor as an instance variable declaration), assign
+the cast result to an intermediate variable:
 
 ```ruby
 class A

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -339,6 +339,17 @@ end
 
 For how to fix, see [Type Annotations](type-annotations.md).
 
+If your intent was not to declare the type of the instance variable but was
+instead just to assign to it, you can assign to an intermediate variable to
+avoid this error:
+
+```ruby
+class A
+  x = T.cast(10, Integer)
+  @@x = x
+end
+```
+
 ## 5014
 
 Given code like this:


### PR DESCRIPTION
Add an example of how to avoid the error when using `T.cast` to the docs for error 5013.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The error message for 5013 can be confusing if you're using `T.cast` as a runtime assertion and not intending to declare an instance/class variable.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
