### PR TITLE
Remove some extra code from call_validation fast paths

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -65,9 +65,9 @@ module T::Private::Methods::CallValidation
 
     T::Configuration.without_ruby_warnings do
       T::Private::DeclState.current.without_on_method_added do
-        if has_fixed_arity && has_simple_method_types && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
+        if has_fixed_arity && has_simple_method_types && !method_sig.bind && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
           create_validator_method_fast(mod, original_method, method_sig)
-        elsif has_fixed_arity && has_simple_procedure_types && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
+        elsif has_fixed_arity && has_simple_procedure_types && !method_sig.bind && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
           create_validator_procedure_fast(mod, original_method, method_sig)
         else
           create_validator_slow(mod, original_method, method_sig)
@@ -118,20 +118,6 @@ module T::Private::Methods::CallValidation
         T::Profile.typecheck_sample_attempts = T::Profile::SAMPLE_RATE
         T::Profile.typecheck_samples += 1
         t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      end
-
-      if method_sig.bind
-        message = method_sig.bind.error_message_for_obj(self)
-        if message
-          CallValidation.report_error(
-            method_sig,
-            message,
-            'Bind',
-            nil,
-            method_sig.bind,
-            self
-          )
-        end
       end
 
       if should_sample
@@ -191,20 +177,6 @@ module T::Private::Methods::CallValidation
         T::Profile.typecheck_sample_attempts = T::Profile::SAMPLE_RATE
         T::Profile.typecheck_samples += 1
         t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      end
-
-      if method_sig.bind
-        message = method_sig.bind.error_message_for_obj(self)
-        if message
-          CallValidation.report_error(
-            method_sig,
-            message,
-            'Bind',
-            nil,
-            method_sig.bind,
-            self
-          )
-        end
       end
 
       unless arg0.is_a?(arg0_type)
@@ -276,20 +248,6 @@ module T::Private::Methods::CallValidation
         T::Profile.typecheck_sample_attempts = T::Profile::SAMPLE_RATE
         T::Profile.typecheck_samples += 1
         t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      end
-
-      if method_sig.bind
-        message = method_sig.bind.error_message_for_obj(self)
-        if message
-          CallValidation.report_error(
-            method_sig,
-            message,
-            'Bind',
-            nil,
-            method_sig.bind,
-            self
-          )
-        end
       end
 
       unless arg0.is_a?(arg0_type)
@@ -373,20 +331,6 @@ module T::Private::Methods::CallValidation
         T::Profile.typecheck_sample_attempts = T::Profile::SAMPLE_RATE
         T::Profile.typecheck_samples += 1
         t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      end
-
-      if method_sig.bind
-        message = method_sig.bind.error_message_for_obj(self)
-        if message
-          CallValidation.report_error(
-            method_sig,
-            message,
-            'Bind',
-            nil,
-            method_sig.bind,
-            self
-          )
-        end
       end
 
       unless arg0.is_a?(arg0_type)
@@ -483,20 +427,6 @@ module T::Private::Methods::CallValidation
         T::Profile.typecheck_sample_attempts = T::Profile::SAMPLE_RATE
         T::Profile.typecheck_samples += 1
         t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      end
-
-      if method_sig.bind
-        message = method_sig.bind.error_message_for_obj(self)
-        if message
-          CallValidation.report_error(
-            method_sig,
-            message,
-            'Bind',
-            nil,
-            method_sig.bind,
-            self
-          )
-        end
       end
 
       unless arg0.is_a?(arg0_type)
@@ -634,20 +564,6 @@ module T::Private::Methods::CallValidation
         t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
 
-      if method_sig.bind
-        message = method_sig.bind.error_message_for_obj(self)
-        if message
-          CallValidation.report_error(
-            method_sig,
-            message,
-            'Bind',
-            nil,
-            method_sig.bind,
-            self
-          )
-        end
-      end
-
       if should_sample
         T::Profile.typecheck_duration += (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t1)
       end
@@ -685,20 +601,6 @@ module T::Private::Methods::CallValidation
         T::Profile.typecheck_sample_attempts = T::Profile::SAMPLE_RATE
         T::Profile.typecheck_samples += 1
         t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      end
-
-      if method_sig.bind
-        message = method_sig.bind.error_message_for_obj(self)
-        if message
-          CallValidation.report_error(
-            method_sig,
-            message,
-            'Bind',
-            nil,
-            method_sig.bind,
-            self
-          )
-        end
       end
 
       unless arg0.is_a?(arg0_type)
@@ -748,20 +650,6 @@ module T::Private::Methods::CallValidation
         T::Profile.typecheck_sample_attempts = T::Profile::SAMPLE_RATE
         T::Profile.typecheck_samples += 1
         t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      end
-
-      if method_sig.bind
-        message = method_sig.bind.error_message_for_obj(self)
-        if message
-          CallValidation.report_error(
-            method_sig,
-            message,
-            'Bind',
-            nil,
-            method_sig.bind,
-            self
-          )
-        end
       end
 
       unless arg0.is_a?(arg0_type)
@@ -824,20 +712,6 @@ module T::Private::Methods::CallValidation
         T::Profile.typecheck_sample_attempts = T::Profile::SAMPLE_RATE
         T::Profile.typecheck_samples += 1
         t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      end
-
-      if method_sig.bind
-        message = method_sig.bind.error_message_for_obj(self)
-        if message
-          CallValidation.report_error(
-            method_sig,
-            message,
-            'Bind',
-            nil,
-            method_sig.bind,
-            self
-          )
-        end
       end
 
       unless arg0.is_a?(arg0_type)
@@ -913,20 +787,6 @@ module T::Private::Methods::CallValidation
         T::Profile.typecheck_sample_attempts = T::Profile::SAMPLE_RATE
         T::Profile.typecheck_samples += 1
         t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      end
-
-      if method_sig.bind
-        message = method_sig.bind.error_message_for_obj(self)
-        if message
-          CallValidation.report_error(
-            method_sig,
-            message,
-            'Bind',
-            nil,
-            method_sig.bind,
-            self
-          )
-        end
       end
 
       unless arg0.is_a?(arg0_type)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

method_sig.bind is vanishingly uncommon, so we should not have it in the
fast path. This is a (tiny, like 10ns?) perf improvement, and also makes
it easier to get #4019 working.

Benchmark (lines interleaved):

    master:
    jez-no-bind:
    ❯ bex rake bench:typecheck
    ❯ bex rake bench:typecheck
    Vanilla Ruby method call: 19.999 ns
    Vanilla Ruby method call: 19.354 ns
    Vanilla Ruby is_a?: 27.14 ns
    Vanilla Ruby is_a?: 26.69 ns
    T::Types::Simple#valid?: 51.711 ns
    T::Types::Simple#valid?: 51.835 ns
    T::Types::Union#valid?: 176.806 ns
    T::Types::Union#valid?: 182.298 ns
    T.let(..., Integer): 497.604 ns
    T.let(..., Integer): 513.11 ns
    sig {params(x: Integer).void}: 578.055 ns
    sig {params(x: Integer).void}: 566.839 ns
    T.let(..., T.nilable(Integer)): 1.421 μs
    T.let(..., T.nilable(Integer)): 1.477 μs
    sig {params(x: T.nilable(Integer)).void}: 1.249 μs
    sig {params(x: T.nilable(Integer)).void}: 1.252 μs
    T.let(..., Example): 468.81 ns
    T.let(..., Example): 486.536 ns
    sig {params(x: Example).void}: 559.248 ns
    sig {params(x: Example).void}: 551.82 ns
    T.let(..., T.nilable(Example)): 1.435 μs
    T.let(..., T.nilable(Example)): 1.447 μs
    sig {params(x: T.nilable(Example)).void}: 1.222 μs
    sig {params(x: T.nilable(Example)).void}: 1.25 μs
    sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs): 2.251 μs
    sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs): 2.228 μs

For context, `method_sig.bind` is what you get if you write code like this:

```ruby
sig {bind(Kernel).void}
def foo
  puts 'hello'
end
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.