### PR TITLE
Infer Array#flatten type taking into account #to_ary

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -30,6 +30,7 @@ NameDef names[] = {
     {"orOr", "||"},
     {"toS", "to_s"},
     {"toA", "to_a"},
+    {"toAry", "to_ary"},
     {"toH", "to_h"},
     {"toHash", "to_hash"},
     {"toProc", "to_proc"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2379,8 +2379,30 @@ class Shape_to_hash : public IntrinsicMethod {
 } Shape_to_hash;
 
 class Array_flatten : public IntrinsicMethod {
+    // If the element type supports the #to_ary method, then Ruby will implicitly call it when flattening. So here we
+    // dispatch #to_ary and recurse further down the result if it succeeds, otherwise we just return the type.
+    static TypePtr typeToAry(const GlobalState &gs, const DispatchArgs &args, const TypePtr &type, const int newDepth) {
+        NameRef toAry = core::Names::toAry();
+
+        InlinedVector<const TypeAndOrigins *, 2> sendArgs;
+        InlinedVector<LocOffsets, 2> sendArgLocs;
+        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.receiver, sendArgLocs};
+
+        DispatchArgs innerArgs{toAry,    sendLocs, 0,
+                               sendArgs, type,     {type, args.fullType.origins},
+                               type,     nullptr,  args.originForUninitialized};
+
+        auto dispatched = type.dispatchCall(gs, innerArgs);
+        if (dispatched.main.errors.empty()) {
+            return recursivelyFlattenArrays(gs, args, move(dispatched.returnType), newDepth);
+        }
+
+        return type;
+    }
+
     // Flattens a (nested) array all way down to its (inner) element type, stopping if we hit the depth limit first.
-    static TypePtr recursivelyFlattenArrays(const GlobalState &gs, const TypePtr &type, const int64_t depth) {
+    static TypePtr recursivelyFlattenArrays(const GlobalState &gs, const DispatchArgs &args, const TypePtr &type,
+                                            const int64_t depth) {
         ENFORCE(type != nullptr);
 
         if (depth == 0) {
@@ -2395,20 +2417,23 @@ class Array_flatten : public IntrinsicMethod {
             // This only shows up because t->elementType(gs) for tuples returns an OrType of all its elements.
             // So to properly handle nested tuples, we have to descend into the OrType's.
             [&](const OrType &o) {
-                result = Types::any(gs, recursivelyFlattenArrays(gs, o.left, newDepth),
-                                    recursivelyFlattenArrays(gs, o.right, newDepth));
+                result = Types::any(gs, recursivelyFlattenArrays(gs, args, o.left, newDepth),
+                                    recursivelyFlattenArrays(gs, args, o.right, newDepth));
             },
+
+            [&](const ClassType &c) { result = typeToAry(gs, args, type, newDepth); },
 
             [&](const AppliedType &a) {
-                if (a.klass != Symbols::Array()) {
-                    result = type;
+                if (a.klass == Symbols::Array()) {
+                    ENFORCE(a.targs.size() == 1);
+                    result = recursivelyFlattenArrays(gs, args, a.targs.front(), newDepth);
                     return;
                 }
-                ENFORCE(a.targs.size() == 1);
-                result = recursivelyFlattenArrays(gs, a.targs.front(), newDepth);
+
+                result = typeToAry(gs, args, type, newDepth);
             },
 
-            [&](const TupleType &t) { result = recursivelyFlattenArrays(gs, t.elementType(gs), newDepth); },
+            [&](const TupleType &t) { result = recursivelyFlattenArrays(gs, args, t.elementType(gs), newDepth); },
 
             [&](const TypePtr &t) { result = std::move(type); });
         return result;
@@ -2460,7 +2485,7 @@ public:
             return;
         }
 
-        res.returnType = Types::arrayOf(gs, recursivelyFlattenArrays(gs, element, depth));
+        res.returnType = Types::arrayOf(gs, recursivelyFlattenArrays(gs, args, element, depth));
     }
 } Array_flatten;
 

--- a/test/testdata/infer/flatten.rb
+++ b/test/testdata/infer/flatten.rb
@@ -22,6 +22,51 @@ xsss = T.let(
   T::Array[T::Array[T::Array[Integer]]],
 )
 
+class IntegerPair
+  extend T::Sig
+
+  sig { params(left: Integer, right: Integer).void }
+  def initialize(left, right)
+    @left = left
+    @right = right
+  end
+
+  sig { returns(T::Array[Integer]) }
+  def to_ary
+    [@left, @right]
+  end
+end
+
+class SuperPair < IntegerPair
+end
+
+class GenericPair
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member
+
+  sig { params(left: Elem, right: Elem).void }
+  def initialize(left, right)
+    @left = left
+    @right = right
+  end
+
+  sig { returns(T::Array[Elem]) }
+  def to_ary
+    [@left, @right]
+  end
+end
+
+integer_pairs = T.let([IntegerPair.new(1, 2), IntegerPair.new(3, 4)], T::Array[IntegerPair])
+super_pairs = T.let([SuperPair.new(1, 2)], T::Array[SuperPair])
+
+generic_pairs = T.let([GenericPair.new(1, 2), GenericPair.new(3, 4)], T::Array[GenericPair[Integer]])
+nested_generic_pairs = T.let(
+  [GenericPair.new(GenericPair.new(1, 2), GenericPair.new(3, 4))],
+  T::Array[GenericPair[GenericPair[Integer]]]
+)
+
 T.reveal_type(flat_tuple.flatten) # error: Revealed type: `T::Array[Integer]`
 T.reveal_type(nested_tuple.flatten) # error: Revealed type: `T::Array[Integer]`
 
@@ -36,6 +81,12 @@ T.reveal_type(xsss.flatten(-1)) # error: Revealed type: `T::Array[Integer]`
 T.reveal_type(xsss.flatten(0)) # error: Revealed type: `T::Array[T::Array[T::Array[Integer]]]`
 T.reveal_type(xsss.flatten(1)) # error: Revealed type: `T::Array[T::Array[Integer]]`
 T.reveal_type(xsss.flatten(2)) # error: Revealed type: `T::Array[Integer]`
+
+T.reveal_type(integer_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
+T.reveal_type(super_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
+T.reveal_type(generic_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
+T.reveal_type(nested_generic_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
+T.reveal_type(nested_generic_pairs.flatten(1)) # error: Revealed type: `T::Array[T::Array[GenericPair[Integer]]]`
 
 xs.flatten(1 + 1) # error: You must pass an Integer literal to specify a depth
 


### PR DESCRIPTION
When you call Array#flatten, Ruby will check if the object that's being flattened responds to #to_ary. If it does, then it will implicitly call it. So in order to correct infer the type, we need to mimic that behavior.

### Motivation

I was working on adding sorbet to a project that was flattening a list of ActiveRecord::Relation objects, and it was incorrectly inferring the result.

### Test plan

See included automated tests.


I haven't written C++ in a long time and this is my first time contributing, so apologies if I got literally all of this wrong. But I believe it works maybe?