### PR TITLE
Support sigs inside class_methods blocks

### DIFF
--- a/test/testdata/rewriter/concern.rb
+++ b/test/testdata/rewriter/concern.rb
@@ -7,6 +7,9 @@ end
 module Foo
   extend ActiveSupport::Concern
   class_methods do
+    extend T::Sig
+
+    sig { void }
     def a_class_method
     end
   end
@@ -27,6 +30,9 @@ A.new.a_class_method # error: Method `a_class_method` does not exist on `A`
 module Bar
   extend ActiveSupport::Concern
   module ClassMethods
+    extend T::Sig
+
+    sig { void }
     def a_class_method
     end
 
@@ -56,6 +62,9 @@ module Baz
   end
 
   class_methods do
+    extend T::Sig
+
+    sig { void }
     def a_class_method_2
     end
   end

--- a/test/testdata/rewriter/concern.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/concern.rb.rewrite-tree.exp
@@ -8,9 +8,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     module <emptyTree>::<C ClassMethods><<C <todo sym>>> < ()
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
       def a_class_method<<todo method>>(&<blk>)
         <emptyTree>
       end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
       ::Sorbet::Private::Static.keep_def(<self>, :a_class_method, :normal)
     end
@@ -38,6 +44,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     module <emptyTree>::<C ClassMethods><<C <todo sym>>> < ()
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
       def a_class_method<<todo method>>(&<blk>)
         <emptyTree>
       end
@@ -45,6 +55,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       def another_class_method<<todo method>>(&<blk>)
         <emptyTree>
       end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
       ::Sorbet::Private::Static.keep_def(<self>, :a_class_method, :normal)
 
@@ -80,11 +92,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>
       end
 
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
       def a_class_method_2<<todo method>>(&<blk>)
         <emptyTree>
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :a_class_method, :normal)
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
       ::Sorbet::Private::Static.keep_def(<self>, :a_class_method_2, :normal)
     end


### PR DESCRIPTION
This PR supports usage of sigs inside `class_methods do; end` blocks which is used by the Concern rewriter.

This is done by copying over each statement within an `InsSeq` node instead of `block->body` as a whole as per @jez's recommendation.

### Motivation

Previous implementation of the Concern rewriter copied over the `body` of `class_methods do; end` block into a module called `ClassMethods`. Due to https://github.com/sorbet/sorbet/issues/3899 this resulted in `extend T::Sig` calls inside the block to not be reflected to the underlying `ClassMethods` module. As a result users were unable to use signatures.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
