### PR TITLE
Revert "Infer Array#flatten type taking into account #to_ary"

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -30,7 +30,6 @@ NameDef names[] = {
     {"orOr", "||"},
     {"toS", "to_s"},
     {"toA", "to_a"},
-    {"toAry", "to_ary"},
     {"toH", "to_h"},
     {"toHash", "to_hash"},
     {"toProc", "to_proc"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2569,30 +2569,8 @@ class Shape_to_hash : public IntrinsicMethod {
 } Shape_to_hash;
 
 class Array_flatten : public IntrinsicMethod {
-    // If the element type supports the #to_ary method, then Ruby will implicitly call it when flattening. So here we
-    // dispatch #to_ary and recurse further down the result if it succeeds, otherwise we just return the type.
-    static TypePtr typeToAry(const GlobalState &gs, const DispatchArgs &args, const TypePtr &type, const int newDepth) {
-        NameRef toAry = core::Names::toAry();
-
-        InlinedVector<const TypeAndOrigins *, 2> sendArgs;
-        InlinedVector<LocOffsets, 2> sendArgLocs;
-        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.receiver, sendArgLocs};
-
-        DispatchArgs innerArgs{toAry,    sendLocs, 0,
-                               sendArgs, type,     {type, args.fullType.origins},
-                               type,     nullptr,  args.originForUninitialized};
-
-        auto dispatched = type.dispatchCall(gs, innerArgs);
-        if (dispatched.main.errors.empty()) {
-            return recursivelyFlattenArrays(gs, args, move(dispatched.returnType), newDepth);
-        }
-
-        return type;
-    }
-
     // Flattens a (nested) array all way down to its (inner) element type, stopping if we hit the depth limit first.
-    static TypePtr recursivelyFlattenArrays(const GlobalState &gs, const DispatchArgs &args, const TypePtr &type,
-                                            const int64_t depth) {
+    static TypePtr recursivelyFlattenArrays(const GlobalState &gs, const TypePtr &type, const int64_t depth) {
         ENFORCE(type != nullptr);
 
         if (depth == 0) {
@@ -2607,23 +2585,20 @@ class Array_flatten : public IntrinsicMethod {
             // This only shows up because t->elementType(gs) for tuples returns an OrType of all its elements.
             // So to properly handle nested tuples, we have to descend into the OrType's.
             [&](const OrType &o) {
-                result = Types::any(gs, recursivelyFlattenArrays(gs, args, o.left, newDepth),
-                                    recursivelyFlattenArrays(gs, args, o.right, newDepth));
+                result = Types::any(gs, recursivelyFlattenArrays(gs, o.left, newDepth),
+                                    recursivelyFlattenArrays(gs, o.right, newDepth));
             },
-
-            [&](const ClassType &c) { result = typeToAry(gs, args, type, newDepth); },
 
             [&](const AppliedType &a) {
-                if (a.klass == Symbols::Array()) {
-                    ENFORCE(a.targs.size() == 1);
-                    result = recursivelyFlattenArrays(gs, args, a.targs.front(), newDepth);
+                if (a.klass != Symbols::Array()) {
+                    result = type;
                     return;
                 }
-
-                result = typeToAry(gs, args, type, newDepth);
+                ENFORCE(a.targs.size() == 1);
+                result = recursivelyFlattenArrays(gs, a.targs.front(), newDepth);
             },
 
-            [&](const TupleType &t) { result = recursivelyFlattenArrays(gs, args, t.elementType(gs), newDepth); },
+            [&](const TupleType &t) { result = recursivelyFlattenArrays(gs, t.elementType(gs), newDepth); },
 
             [&](const TypePtr &t) { result = std::move(type); });
         return result;
@@ -2675,7 +2650,7 @@ public:
             return;
         }
 
-        res.returnType = Types::arrayOf(gs, recursivelyFlattenArrays(gs, args, element, depth));
+        res.returnType = Types::arrayOf(gs, recursivelyFlattenArrays(gs, element, depth));
     }
 } Array_flatten;
 

--- a/test/testdata/infer/flatten.rb
+++ b/test/testdata/infer/flatten.rb
@@ -22,51 +22,6 @@ xsss = T.let(
   T::Array[T::Array[T::Array[Integer]]],
 )
 
-class IntegerPair
-  extend T::Sig
-
-  sig { params(left: Integer, right: Integer).void }
-  def initialize(left, right)
-    @left = left
-    @right = right
-  end
-
-  sig { returns(T::Array[Integer]) }
-  def to_ary
-    [@left, @right]
-  end
-end
-
-class SuperPair < IntegerPair
-end
-
-class GenericPair
-  extend T::Sig
-  extend T::Generic
-
-  Elem = type_member
-
-  sig { params(left: Elem, right: Elem).void }
-  def initialize(left, right)
-    @left = left
-    @right = right
-  end
-
-  sig { returns(T::Array[Elem]) }
-  def to_ary
-    [@left, @right]
-  end
-end
-
-integer_pairs = T.let([IntegerPair.new(1, 2), IntegerPair.new(3, 4)], T::Array[IntegerPair])
-super_pairs = T.let([SuperPair.new(1, 2)], T::Array[SuperPair])
-
-generic_pairs = T.let([GenericPair.new(1, 2), GenericPair.new(3, 4)], T::Array[GenericPair[Integer]])
-nested_generic_pairs = T.let(
-  [GenericPair.new(GenericPair.new(1, 2), GenericPair.new(3, 4))],
-  T::Array[GenericPair[GenericPair[Integer]]]
-)
-
 T.reveal_type(flat_tuple.flatten) # error: Revealed type: `T::Array[Integer]`
 T.reveal_type(nested_tuple.flatten) # error: Revealed type: `T::Array[Integer]`
 
@@ -81,12 +36,6 @@ T.reveal_type(xsss.flatten(-1)) # error: Revealed type: `T::Array[Integer]`
 T.reveal_type(xsss.flatten(0)) # error: Revealed type: `T::Array[T::Array[T::Array[Integer]]]`
 T.reveal_type(xsss.flatten(1)) # error: Revealed type: `T::Array[T::Array[Integer]]`
 T.reveal_type(xsss.flatten(2)) # error: Revealed type: `T::Array[Integer]`
-
-T.reveal_type(integer_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
-T.reveal_type(super_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
-T.reveal_type(generic_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
-T.reveal_type(nested_generic_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
-T.reveal_type(nested_generic_pairs.flatten(1)) # error: Revealed type: `T::Array[T::Array[GenericPair[Integer]]]`
 
 xs.flatten(1 + 1) # error: You must pass an Integer literal to specify a depth
 


### PR DESCRIPTION
Reverts sorbet/sorbet#4025

This caused the bug reported in #4033.

cc @kddeisz the issue linked contains a reproducer, which you should be able to use to find and fix the problem in the code.

#4025 was not a priority for us, so this will likely stay reverted until you have time to fix it.

Thanks!