### PR TITLE
Fix Array#flatten when the element is T.untyped

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2572,6 +2572,11 @@ class Array_flatten : public IntrinsicMethod {
     // If the element type supports the #to_ary method, then Ruby will implicitly call it when flattening. So here we
     // dispatch #to_ary and recurse further down the result if it succeeds, otherwise we just return the type.
     static TypePtr typeToAry(const GlobalState &gs, const DispatchArgs &args, const TypePtr &type, const int newDepth) {
+
+        if (type.isUntyped()) {
+            return type;
+        }
+
         NameRef toAry = core::Names::toAry();
 
         InlinedVector<const TypeAndOrigins *, 2> sendArgs;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2572,7 +2572,6 @@ class Array_flatten : public IntrinsicMethod {
     // If the element type supports the #to_ary method, then Ruby will implicitly call it when flattening. So here we
     // dispatch #to_ary and recurse further down the result if it succeeds, otherwise we just return the type.
     static TypePtr typeToAry(const GlobalState &gs, const DispatchArgs &args, const TypePtr &type, const int newDepth) {
-
         if (type.isUntyped()) {
             return type;
         }

--- a/test/testdata/infer/array_flatten_T.untyped.rb
+++ b/test/testdata/infer/array_flatten_T.untyped.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+a = [1, 2, []]
+a.flatten


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Terminating the recursion of the `Array#flatten` intrinsic when the elements of the array are `T.untyped`.

Fixes #4033

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.