### PR TITLE
Add T::Utils.signature_for_method

### DIFF
--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -52,6 +52,13 @@ module T::Utils
     end.uniq
   end
 
+  # Returns the signature for the `UnboundMethod`, or nil if it's not sig'd
+  #
+  # @example T::Utils.signature_for_method(x.method(:foo))
+  def self.signature_for_method(method)
+    T::Private::Methods.signature_for_method(method)
+  end
+
   # Returns the signature for the instance method on the supplied module, or nil if it's not found or not typed.
   #
   # @example T::Utils.signature_for_instance_method(MyClass, :my_method)

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -183,6 +183,7 @@ module T::Utils
   def self.coerce(val); end
   def self.resolve_alias(type); end
   def self.run_all_sig_blocks; end
+  def self.signature_for_method(method); end
   def self.signature_for_instance_method(mod, method_name); end
   def self.unwrap_nilable(type); end
   def self.wrap_method_with_call_validation_if_needed(mod, method_sig, original_method); end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There is already T::Utils.signature_for_instance_method, and
`T::Private:::Methods.signature_for_method` raises RuboCop warninngs on
Stripe's codebase for accessing `T::Private` outside of the private
namespace.

I considered just deleting `signature_for_method` but figured making it
a breaking change would involve a lot of needless toil.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is maybe not a great reason but there's no tests for `T::Utils.signature_for_instance_method` either and I didn't feel like writing tests. If you feel strongly I can add some.