### PR TITLE
Allow Linuxbrew path for autoconf

### DIFF
--- a/third_party/jemalloc.BUILD
+++ b/third_party/jemalloc.BUILD
@@ -20,6 +20,7 @@ JEMALLOC_BUILD_COMMAND = """
    echo "$$path"
   }
   export PATH="/usr/local/bin:$$PATH" # find autoconf on mac
+  export PATH="/home/linuxbrew/.linuxbrew/bin:$$PATH" # find autoconf on linux using Linuxbrew
   export CC=$$(absolutize $(CC))
   export CXX=$$(absolutize $(CC))
   [ "$$(uname)" = "Linux" ] && export AR=$$(absolutize $(AR))


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This lets me run `--config=release-linux` without having to install
`autoconf` via `apt`.

Eventually we probably want to provide `autoconf` via Bazel, rather than relying
on the user having it installed on their system.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I ran

```
bazel build //main:sorbet --config=release-linux
```

on my personal desktop