### PR TITLE
don't check non-final modules for final method violations

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -103,6 +103,7 @@ module T::Private::Methods
     # use reverse_each to check farther-up ancestors first, for better error messages. we could avoid this if we were on
     # the version of ruby that adds the optional argument to method_defined? that allows you to exclude ancestors.
     target_ancestors.reverse_each do |ancestor|
+      next if !module_with_final?(ancestor)
       source_method_names.each do |method_name|
         # the usage of method_owner_and_name_to_key(ancestor, method_name) instead of
         # method_to_key(ancestor.instance_method(method_name)) is not (just) an optimization, but also required for


### PR DESCRIPTION
`sorbet-runtime` maintains a set of all modules that contain at least one final method.  If we are checking the ancestor chain, we only need to check modules that are in this set for potential final method violations.  This removes an entire inner loop's worth of checks.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  Something is not quite right, though: the tests pass, but this changes the number of final method violations reported in Stripe's codebase, so we must be doing something not quite right here.
