### PR TITLE
Avoid crash when autocorrect has origin pointing to payload

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1386,7 +1386,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                 e.addErrorSection(core::ErrorSection(core::ErrorColors::format(
                                     "Attempting to change type to: `{}`\n", tp.type.show(ctx))));
 
-                                if (cur.origins.size() == 1 && cur.origins[0].exists()) {
+                                if (cur.origins.size() == 1 && cur.origins[0].exists() &&
+                                    !cur.origins[0].file().data(ctx).isPayload()) {
                                     // NOTE(nelhage): We assume that if there is
                                     // a single definition location, that
                                     // corresponds to an initial

--- a/test/cli/autocorrect-payload/autocorrect-payload.out
+++ b/test/cli/autocorrect-payload/autocorrect-payload.out
@@ -1,0 +1,12 @@
+# typed: true
+
+T.let(FOO, T.nilable(Integer)) = 10 # TODO Also fix this autocorrect
+
+a = FOO
+[].each { |i| a = nil }
+
+b = Float::INFINITY
+[].each { |i| b = nil }
+
+c = T.let(10, T.nilable(Integer))
+[].each { |i| c = nil }

--- a/test/cli/autocorrect-payload/autocorrect-payload.rb
+++ b/test/cli/autocorrect-payload/autocorrect-payload.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+FOO = 10 # TODO Also fix this autocorrect
+
+a = FOO
+[].each { |i| a = nil }
+
+b = Float::INFINITY
+[].each { |i| b = nil }
+
+c = 10
+[].each { |i| c = nil }

--- a/test/cli/autocorrect-payload/autocorrect-payload.sh
+++ b/test/cli/autocorrect-payload/autocorrect-payload.sh
@@ -1,0 +1,4 @@
+tmp=$(mktemp -d)
+cp test/cli/autocorrect-payload/*.rb "$tmp"
+main/sorbet --silence-dev-message -a "$tmp"/*.rb 2>/dev/null
+cat "$tmp"/*.rb


### PR DESCRIPTION
### Motivation

Origins seem messed up for constant references when applying autocorrect for 7001 errors:

```rb
FOO = 10

a = FOO
[].each { |i| a = nil } # Error: changing the type of a variable in a loop
```

Is autocorrected as 

```rb
T.let(FOO, T.nilable(Integer)) = 10

a = FOO
[].each { |i| a = nil }
```

There are a few issues about this already: https://github.com/sorbet/sorbet/issues/3497,  https://github.com/sorbet/sorbet/issues/3190, https://github.com/sorbet/sorbet/issues/1848.

One side effect of this problem is when the constant used comes from the payload:

```rb
b = Float::INFINITY
[].each { |i| b = nil } # Error: changing the type of a variable in a loop
```

The autocorrect will try to write the payload file and sorbet will crash.

While I'm not sure how to fix the original problem, I can at least make it so it doesn't try to write the payload and doesn't crash. When you try to fix hundreds of errors thanks to the autocorrect, a few bad ones are better than a crash that produce no correction at all.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
