### PR TITLE
Use ClassOrModuleRef / MethodRef in more places.

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -932,8 +932,9 @@ MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRe
 }
 
 // look up a symbol whose flags match the desired flags. This might look through mangled names to discover one whose
-// flags match. If no sych symbol exists, then it will return noSymbol.
-SymbolRef GlobalState::lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags) const {
+// flags match. If no sych symbol exists, then it will return defaultReturnValue.
+SymbolRef GlobalState::lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags,
+                                             SymbolRef defaultReturnValue) const {
     ENFORCE(owner.exists(), "looking up symbol from non-existing owner");
     ENFORCE(name.exists(), "looking up symbol with non-existing name");
     auto ownerScope = owner.dataAllowingNone(*this);
@@ -954,7 +955,7 @@ SymbolRef GlobalState::lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 f
         res = ownerScope->members().find(lookupName);
         unique++;
     }
-    return Symbols::noSymbol();
+    return defaultReturnValue;
 }
 
 SymbolRef GlobalState::findRenamedSymbol(SymbolRef owner, SymbolRef sym) const {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -792,17 +792,10 @@ void GlobalState::initEmpty() {
     int reservedCount = 0;
 
     // Set the correct resultTypes for all synthesized classes
-    // Does it in two passes since the singletonClass will go in the Symbols::root() members which will invalidate the
-    // iterator
-    vector<SymbolRef> needSingletons;
-    for (auto &sym : classAndModules) {
-        auto ref = sym.ref(*this);
-        if (ref.exists()) {
-            needSingletons.emplace_back(ref);
-        }
-    }
-    for (auto sym : needSingletons) {
-        sym.data(*this)->singletonClass(*this);
+    // Collect size prior to loop since singletons will cause vector to grow.
+    size_t classAndModulesSize = classAndModules.size();
+    for (u4 i = 1; i < classAndModulesSize; i++) {
+        classAndModules[i].singletonClass(*this);
     }
 
     // This fills in all the way up to MAX_SYNTHETIC_CLASS_SYMBOLS
@@ -910,7 +903,8 @@ void GlobalState::preallocateTables(u4 classAndModulesSize, u4 methodsSize, u4 f
 
 constexpr decltype(GlobalState::STRINGS_PAGE_SIZE) GlobalState::STRINGS_PAGE_SIZE;
 
-MethodRef GlobalState::lookupMethodSymbolWithHash(SymbolRef owner, NameRef name, const vector<u4> &methodHash) const {
+MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name,
+                                                  const vector<u4> &methodHash) const {
     ENFORCE(owner.exists(), "looking up symbol from non-existing owner");
     ENFORCE(name.exists(), "looking up symbol with non-existing name");
     auto ownerScope = owner.dataAllowingNone(*this);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -113,7 +113,7 @@ public:
             return sym.asMethodRef();
         }
     }
-    MethodRef lookupMethodSymbolWithHash(SymbolRef owner, NameRef name, const std::vector<u4> &methodHash) const;
+    MethodRef lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name, const std::vector<u4> &methodHash) const;
     SymbolRef lookupStaticFieldSymbol(SymbolRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::STATIC_FIELD);
     }

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -306,7 +306,6 @@ private:
 
     ClassOrModuleRef synthesizeClass(NameRef nameID, u4 superclass = Symbols::todo().id(), bool isModule = false);
 
-    SymbolRef lookupSymbolSuchThat(SymbolRef owner, NameRef name, std::function<bool(SymbolRef)> pred) const;
     SymbolRef lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags) const;
 
     std::string toStringWithOptions(bool showFull, bool showRaw) const;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -105,14 +105,14 @@ public:
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::CLASS_OR_MODULE, Symbols::noClassOrModule())
             .asClassOrModuleRef();
     }
-    MethodRef lookupMethodSymbol(SymbolRef owner, NameRef name) const {
+    MethodRef lookupMethodSymbol(ClassOrModuleRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::METHOD, Symbols::noMethod()).asMethodRef();
     }
     MethodRef lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name, const std::vector<u4> &methodHash) const;
-    SymbolRef lookupStaticFieldSymbol(SymbolRef owner, NameRef name) const {
+    SymbolRef lookupStaticFieldSymbol(ClassOrModuleRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::STATIC_FIELD, Symbols::noField());
     }
-    SymbolRef lookupFieldSymbol(SymbolRef owner, NameRef name) const {
+    SymbolRef lookupFieldSymbol(ClassOrModuleRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::FIELD, Symbols::noField());
     }
     SymbolRef findRenamedSymbol(SymbolRef owner, SymbolRef name) const;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -96,29 +96,24 @@ public:
     ArgInfo &enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRef name);
 
     SymbolRef lookupSymbol(SymbolRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, 0);
+        return lookupSymbolWithFlags(owner, name, 0, Symbols::noSymbol());
     }
     SymbolRef lookupTypeMemberSymbol(ClassOrModuleRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::TYPE_MEMBER);
+        return lookupSymbolWithFlags(owner, name, Symbol::Flags::TYPE_MEMBER, Symbols::noTypeMember());
     }
     ClassOrModuleRef lookupClassSymbol(ClassOrModuleRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::CLASS_OR_MODULE).asClassOrModuleRef();
+        return lookupSymbolWithFlags(owner, name, Symbol::Flags::CLASS_OR_MODULE, Symbols::noClassOrModule())
+            .asClassOrModuleRef();
     }
     MethodRef lookupMethodSymbol(SymbolRef owner, NameRef name) const {
-        // TODO: Maybe lookupSymbolWithFlags should accept a default symbol argument?
-        auto sym = lookupSymbolWithFlags(owner, name, Symbol::Flags::METHOD);
-        if (!sym.exists()) {
-            return Symbols::noMethod();
-        } else {
-            return sym.asMethodRef();
-        }
+        return lookupSymbolWithFlags(owner, name, Symbol::Flags::METHOD, Symbols::noMethod()).asMethodRef();
     }
     MethodRef lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name, const std::vector<u4> &methodHash) const;
     SymbolRef lookupStaticFieldSymbol(SymbolRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::STATIC_FIELD);
+        return lookupSymbolWithFlags(owner, name, Symbol::Flags::STATIC_FIELD, Symbols::noField());
     }
     SymbolRef lookupFieldSymbol(SymbolRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::FIELD);
+        return lookupSymbolWithFlags(owner, name, Symbol::Flags::FIELD, Symbols::noField());
     }
     SymbolRef findRenamedSymbol(SymbolRef owner, SymbolRef name) const;
 
@@ -306,7 +301,7 @@ private:
 
     ClassOrModuleRef synthesizeClass(NameRef nameID, u4 superclass = Symbols::todo().id(), bool isModule = false);
 
-    SymbolRef lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags) const;
+    SymbolRef lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags, SymbolRef defaultReturnValue) const;
 
     std::string toStringWithOptions(bool showFull, bool showRaw) const;
 };

--- a/core/Types.h
+++ b/core/Types.h
@@ -42,7 +42,7 @@ public:
     };
     ArgFlags flags;
     NameRef name;
-    SymbolRef rebind;
+    ClassOrModuleRef rebind;
     Loc loc;
     TypePtr type;
 
@@ -173,7 +173,7 @@ public:
     // Given a type, return a SymbolRef for the Ruby class that has that type, or no symbol if no such class exists.
     // This is an internal method for implementing intrinsics. In the future we should make all updateKnowledge methods
     // be intrinsics so that this can become an anonymous helper function in calls.cc.
-    static core::SymbolRef getRepresentedClass(const GlobalState &gs, const core::TypePtr &ty);
+    static core::ClassOrModuleRef getRepresentedClass(const GlobalState &gs, const core::TypePtr &ty);
 };
 
 struct Intrinsic {

--- a/core/Types.h
+++ b/core/Types.h
@@ -900,9 +900,9 @@ public:
 
 TYPE(UnresolvedAppliedType) final : public ClassType {
 public:
-    const core::SymbolRef klass;
+    const core::ClassOrModuleRef klass;
     const std::vector<TypePtr> targs;
-    UnresolvedAppliedType(SymbolRef klass, std::vector<TypePtr> targs)
+    UnresolvedAppliedType(ClassOrModuleRef klass, std::vector<TypePtr> targs)
         : ClassType(core::Symbols::untyped()), klass(klass), targs(std::move(targs)){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;

--- a/core/lsp/Query.cc
+++ b/core/lsp/Query.cc
@@ -27,7 +27,7 @@ Query Query::createVarQuery(core::SymbolRef owner, core::LocalVariable variable)
     return Query(Query::Kind::VAR, core::Loc::none(), owner, variable);
 }
 
-Query Query::createSuggestSigQuery(core::SymbolRef method) {
+Query Query::createSuggestSigQuery(core::MethodRef method) {
     ENFORCE(method.exists());
     return Query(Query::Kind::SUGGEST_SIG, core::Loc::none(), method, core::LocalVariable());
 }

--- a/core/lsp/Query.h
+++ b/core/lsp/Query.h
@@ -36,7 +36,7 @@ public:
     static Query createLocQuery(core::Loc loc);
     static Query createSymbolQuery(core::SymbolRef symbol);
     static Query createVarQuery(core::SymbolRef owner, core::LocalVariable variable);
-    static Query createSuggestSigQuery(core::SymbolRef method);
+    static Query createSuggestSigQuery(core::MethodRef method);
 
     bool matchesSymbol(const core::SymbolRef &symbol) const;
     bool matchesLoc(const core::Loc &loc) const;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -513,7 +513,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
 
 void SerializerImpl::pickle(Pickler &p, const ArgInfo &a) {
     p.putU4(a.name.rawId());
-    p.putU4(a.rebind.rawId());
+    p.putU4(a.rebind.id());
     pickle(p, a.loc);
     p.putU1(a.flags.toU1());
     pickle(p, a.type);
@@ -522,7 +522,7 @@ void SerializerImpl::pickle(Pickler &p, const ArgInfo &a) {
 ArgInfo SerializerImpl::unpickleArgInfo(UnPickler &p, const GlobalState *gs) {
     ArgInfo result;
     result.name = NameRef::fromRaw(*gs, p.getU4());
-    result.rebind = core::SymbolRef::fromRaw(p.getU4());
+    result.rebind = core::ClassOrModuleRef::fromRaw(p.getU4());
     result.loc = unpickleLoc(p);
     {
         u1 flags = p.getU1();

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -169,7 +169,7 @@ core::Loc smallestLocWithin(core::Loc callLoc, const core::TypeAndOrigins &argTp
 }
 
 unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Loc callLoc, Loc receiverLoc,
-                               ClassOrModuleRef inClass, SymbolRef method, const TypeAndOrigins &argTpe,
+                               ClassOrModuleRef inClass, MethodRef method, const TypeAndOrigins &argTpe,
                                const ArgInfo &argSym, const TypePtr &selfType, const vector<TypePtr> &targs, Loc loc,
                                Loc originForUninitialized, bool mayBeSetter = false) {
     TypePtr expectedType =
@@ -213,7 +213,7 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
     return nullptr;
 }
 
-unique_ptr<Error> missingArg(const GlobalState &gs, Loc callLoc, Loc receiverLoc, SymbolRef method,
+unique_ptr<Error> missingArg(const GlobalState &gs, Loc callLoc, Loc receiverLoc, MethodRef method,
                              const ArgInfo &arg) {
     if (auto e = gs.beginError(callLoc, errors::Infer::MethodArgumentCountMismatch)) {
         e.setHeader("Missing required keyword argument `{}` for method `{}`", arg.name.show(gs),
@@ -224,7 +224,7 @@ unique_ptr<Error> missingArg(const GlobalState &gs, Loc callLoc, Loc receiverLoc
 }
 }; // namespace
 
-int getArity(const GlobalState &gs, SymbolRef method) {
+int getArity(const GlobalState &gs, MethodRef method) {
     ENFORCE(!method.data(gs)->arguments().empty(), "Every method should have at least a block arg.");
     ENFORCE(method.data(gs)->arguments().back().flags.isBlock, "Last arg should be the block arg.");
 
@@ -309,7 +309,7 @@ MethodRef guessOverload(const GlobalState &gs, ClassOrModuleRef inClass, MethodR
 
     { // keep only candidates that have a block iff we are passing one
         for (auto it = leftCandidates.begin(); it != leftCandidates.end(); /* nothing*/) {
-            SymbolRef candidate = *it;
+            MethodRef candidate = *it;
             const auto &args = candidate.data(gs)->arguments();
             ENFORCE(!args.empty(), "Should at least have a block argument.");
             auto mentionsBlockArg = !args.back().isSyntheticBlockArgument();
@@ -325,11 +325,11 @@ MethodRef guessOverload(const GlobalState &gs, ClassOrModuleRef inClass, MethodR
         struct Comp {
             const GlobalState &gs;
 
-            bool operator()(SymbolRef s, int i) const {
+            bool operator()(MethodRef s, int i) const {
                 return getArity(gs, s) < i;
             }
 
-            bool operator()(int i, SymbolRef s) const {
+            bool operator()(int i, MethodRef s) const {
                 return i < getArity(gs, s);
             }
 
@@ -389,7 +389,7 @@ TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
     }
 
     if (auto *appType = cast_type<AppliedType>(tp)) {
-        SymbolRef attachedClass = appType->klass.data(gs)->attachedClass(gs);
+        ClassOrModuleRef attachedClass = appType->klass.data(gs)->attachedClass(gs);
         if (!attachedClass.exists()) {
             if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
                 e.setHeader("Unsupported usage of bare type");
@@ -423,7 +423,7 @@ TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
     return tp;
 }
 
-string prettyArity(const GlobalState &gs, SymbolRef method) {
+string prettyArity(const GlobalState &gs, MethodRef method) {
     int required = 0, optional = 0;
     bool repeated = false;
     for (const auto &arg : method.data(gs)->arguments()) {
@@ -446,7 +446,7 @@ string prettyArity(const GlobalState &gs, SymbolRef method) {
     }
 }
 
-bool extendsTHelpers(const GlobalState &gs, core::SymbolRef enclosingClass) {
+bool extendsTHelpers(const GlobalState &gs, core::ClassOrModuleRef enclosingClass) {
     ENFORCE(enclosingClass.exists());
     auto enclosingSingletonClass = enclosingClass.data(gs)->lookupSingletonClass(gs);
     ENFORCE(enclosingSingletonClass.exists());
@@ -456,8 +456,8 @@ bool extendsTHelpers(const GlobalState &gs, core::SymbolRef enclosingClass) {
 /**
  * Make an autocorrection for adding `extend T::Helpers`, when needed.
  */
-optional<core::AutocorrectSuggestion> maybeSuggestExtendTHelpers(const GlobalState &gs, core::SymbolRef enclosingClass,
-                                                                 const Loc &call) {
+optional<core::AutocorrectSuggestion>
+maybeSuggestExtendTHelpers(const GlobalState &gs, core::ClassOrModuleRef enclosingClass, const Loc &call) {
     if (extendsTHelpers(gs, enclosingClass)) {
         // No need to suggest here, because it already has 'extend T::Sig'
         return nullopt;
@@ -950,7 +950,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                     for (auto it = hash->keys.begin(); it != hash->keys.end(); ++it) {
                         auto key = cast_type_nonnull<LiteralType>(*it);
                         auto underlying = key.underlying(gs);
-                        SymbolRef klass = cast_type_nonnull<ClassType>(underlying).symbol;
+                        ClassOrModuleRef klass = cast_type_nonnull<ClassType>(underlying).symbol;
                         if (klass != Symbols::Symbol()) {
                             continue;
                         }
@@ -1007,7 +1007,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             for (auto &keyType : hash->keys) {
                 auto key = cast_type_nonnull<LiteralType>(keyType);
                 auto underlying = key.underlying(gs);
-                SymbolRef klass = cast_type_nonnull<ClassType>(underlying).symbol;
+                ClassOrModuleRef klass = cast_type_nonnull<ClassType>(underlying).symbol;
                 if (klass == Symbols::Symbol() && consumed.find(key.asName(gs)) != consumed.end()) {
                     continue;
                 }
@@ -1236,8 +1236,8 @@ DispatchResult MetaType::dispatchCall(const GlobalState &gs, const DispatchArgs 
 
 namespace {
 
-SymbolRef unwrapSymbol(const GlobalState &gs, const TypePtr &type) {
-    SymbolRef result;
+ClassOrModuleRef unwrapSymbol(const GlobalState &gs, const TypePtr &type) {
+    ClassOrModuleRef result;
     TypePtr typePtr = type;
     while (!result.exists()) {
         typecase(
@@ -1374,7 +1374,7 @@ public:
 class Object_class : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        SymbolRef self = unwrapSymbol(gs, args.thisType);
+        ClassOrModuleRef self = unwrapSymbol(gs, args.thisType);
         auto singleton = self.data(gs)->lookupSingletonClass(gs);
         if (singleton.exists()) {
             res.returnType = singleton.data(gs)->externalType();
@@ -1387,7 +1387,7 @@ public:
 class Class_new : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        SymbolRef self = unwrapSymbol(gs, args.thisType);
+        ClassOrModuleRef self = unwrapSymbol(gs, args.thisType);
 
         auto attachedClass = self.data(gs)->attachedClass(gs);
         if (!attachedClass.exists()) {
@@ -1433,7 +1433,7 @@ public:
     // Unfortunately, this means that some errors are double reported (once by resolver, and then
     // again by infer).
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        SymbolRef self = unwrapSymbol(gs, args.thisType);
+        ClassOrModuleRef self = unwrapSymbol(gs, args.thisType);
         auto attachedClass = self.data(gs)->attachedClass(gs);
 
         if (!attachedClass.exists()) {
@@ -2180,7 +2180,7 @@ public:
         }
 
         auto selfTy = *args.args[0];
-        SymbolRef self = unwrapSymbol(gs, selfTy.type);
+        ClassOrModuleRef self = unwrapSymbol(gs, selfTy.type);
 
         u2 numPosArgs = args.numPosArgs - 1;
 
@@ -2837,7 +2837,7 @@ public:
         }
         auto rc = Types::getRepresentedClass(gs, args.thisType);
         // in most cases, thisType is T.class_of(rc). see test/testdata/class_not_class_of.rb for an edge case.
-        if (rc == core::Symbols::noSymbol()) {
+        if (rc == core::Symbols::noClassOrModule()) {
             res.returnType = Types::Boolean();
             return;
         }

--- a/core/types/hashing.cc
+++ b/core/types/hashing.cc
@@ -20,7 +20,7 @@ u4 UnresolvedClassType::hash(const GlobalState &gs) const {
 
 u4 UnresolvedAppliedType::hash(const GlobalState &gs) const {
     u4 result = static_cast<u4>(TypePtr::Tag::UnresolvedAppliedType);
-    result = mix(result, this->klass.rawId());
+    result = mix(result, this->klass.id());
     for (auto &targ : targs) {
         result = mix(result, targ.hash(gs));
     }

--- a/core/types/hashing.cc
+++ b/core/types/hashing.cc
@@ -1,5 +1,4 @@
 #include "core/hashing/hashing.h"
-#include "core/SymbolRef.h"
 #include "core/Types.h"
 
 using namespace std;

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -124,7 +124,7 @@ string ShapeType::show(const GlobalState &gs) const {
             fmt::format_to(buf, ", ");
         }
         auto underlying = cast_type_nonnull<LiteralType>(key).underlying(gs);
-        SymbolRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
+        ClassOrModuleRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
         if (undSymbol == Symbols::Symbol()) {
             fmt::format_to(buf, "{}: {}", cast_type_nonnull<LiteralType>(key).asName(gs).show(gs),
                            (*valueIterator).show(gs));

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -184,7 +184,7 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, ClassO
             auto cdata = c.symbol.data(gs);
             if (c.symbol == core::Symbols::untyped()) {
                 result = from;
-            } else if (SymbolRef(c.symbol) == klass || c.derivesFrom(gs, klass)) {
+            } else if (c.symbol == klass || c.derivesFrom(gs, klass)) {
                 result = Types::bottom();
             } else if (c.symbol.data(gs)->isClassOrModuleClass() && klass.data(gs)->isClassOrModuleClass() &&
                        !klass.data(gs)->derivesFrom(gs, c.symbol)) {
@@ -750,18 +750,18 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
     return ret;
 }
 
-core::SymbolRef Types::getRepresentedClass(const GlobalState &gs, const TypePtr &ty) {
+core::ClassOrModuleRef Types::getRepresentedClass(const GlobalState &gs, const TypePtr &ty) {
     if (!ty.derivesFrom(gs, core::Symbols::Module())) {
-        return core::Symbols::noSymbol();
+        return core::Symbols::noClassOrModule();
     }
-    core::SymbolRef singleton;
+    core::ClassOrModuleRef singleton;
     if (isa_type<ClassType>(ty)) {
         auto s = cast_type_nonnull<ClassType>(ty);
         singleton = s.symbol;
     } else {
         auto *at = cast_type<AppliedType>(ty);
         if (at == nullptr) {
-            return core::Symbols::noSymbol();
+            return core::Symbols::noClassOrModule();
         }
 
         singleton = at->klass;

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -11,14 +11,14 @@ namespace sorbet::infer {
 
 namespace {
 
-bool extendsTSig(core::Context ctx, core::SymbolRef enclosingClass) {
+bool extendsTSig(core::Context ctx, core::ClassOrModuleRef enclosingClass) {
     ENFORCE(enclosingClass.exists());
     auto enclosingSingletonClass = enclosingClass.data(ctx)->lookupSingletonClass(ctx);
     ENFORCE(enclosingSingletonClass.exists());
     return enclosingSingletonClass.data(ctx)->derivesFrom(ctx, core::Symbols::T_Sig());
 }
 
-optional<core::AutocorrectSuggestion::Edit> maybeSuggestExtendTSig(core::Context ctx, core::SymbolRef methodSymbol) {
+optional<core::AutocorrectSuggestion::Edit> maybeSuggestExtendTSig(core::Context ctx, core::MethodRef methodSymbol) {
     auto method = methodSymbol.data(ctx);
 
     auto enclosingClass = method->enclosingClass(ctx).data(ctx)->topAttachedClass(ctx);
@@ -140,7 +140,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
     }
 }
 
-UnorderedMap<core::NameRef, core::TypePtr> guessArgumentTypes(core::Context ctx, core::SymbolRef methodSymbol,
+UnorderedMap<core::NameRef, core::TypePtr> guessArgumentTypes(core::Context ctx, core::MethodRef methodSymbol,
                                                               unique_ptr<cfg::CFG> &cfg) {
     // What variables by the end of basic block could plausibly contain what arguments.
     vector<UnorderedMap<cfg::LocalRef, InlinedVector<core::NameRef, 1>>> localsStoringArguments;
@@ -273,7 +273,7 @@ core::MethodRef closestOverridenMethod(core::Context ctx, core::ClassOrModuleRef
     }
 }
 
-bool childNeedsOverride(core::Context ctx, core::SymbolRef childSymbol, core::SymbolRef parentSymbol) {
+bool childNeedsOverride(core::Context ctx, core::MethodRef childSymbol, core::MethodRef parentSymbol) {
     return
         // We're overriding a method...
         parentSymbol.exists() &&
@@ -298,7 +298,7 @@ bool childNeedsOverride(core::Context ctx, core::SymbolRef childSymbol, core::Sy
 optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Context ctx, unique_ptr<cfg::CFG> &cfg,
                                                                      const core::TypePtr &methodReturnType,
                                                                      core::TypeConstraint &constr) {
-    core::SymbolRef methodSymbol = cfg->symbol;
+    core::MethodRef methodSymbol = cfg->symbol;
 
     bool guessedSomethingUseful = false;
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -479,7 +479,7 @@ namespace {
 // This is not the case for most other equality tests. e.g., x != 0 does not imply ¬ x : Integer.
 //
 // This powers (among other things) exhaustiveness checking for T::Enum.
-bool isSingleton(core::Context ctx, core::SymbolRef sym) {
+bool isSingleton(core::Context ctx, core::ClassOrModuleRef sym) {
     // Singletons that are built into the Ruby VM
     if (sym == core::Symbols::NilClass() || sym == core::Symbols::FalseClass() || sym == core::Symbols::TrueClass()) {
         return true;
@@ -563,7 +563,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         }
         auto &whoKnows = getKnowledge(local);
         auto &klassType = send->args[0].type;
-        core::SymbolRef klass = core::Types::getRepresentedClass(ctx, klassType);
+        core::ClassOrModuleRef klass = core::Types::getRepresentedClass(ctx, klassType);
         if (klass.exists()) {
             auto ty = klass.data(ctx)->externalType();
             if (!ty.isUntyped()) {
@@ -618,7 +618,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         const auto &recvType = send->recv.type;
 
         // `when` against class literal
-        core::SymbolRef representedClass = core::Types::getRepresentedClass(ctx, recvType);
+        core::ClassOrModuleRef representedClass = core::Types::getRepresentedClass(ctx, recvType);
         if (representedClass.exists()) {
             auto representedType = representedClass.data(ctx)->externalType();
             if (!representedType.isUntyped()) {

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -192,8 +192,8 @@ class LocalNameInserter {
         return args;
     }
 
-    core::SymbolRef methodOwner(core::MutableContext ctx) {
-        core::SymbolRef owner = ctx.owner.data(ctx)->enclosingClass(ctx);
+    core::ClassOrModuleRef methodOwner(core::MutableContext ctx) {
+        core::ClassOrModuleRef owner = ctx.owner.data(ctx)->enclosingClass(ctx);
         if (owner == core::Symbols::root()) {
             // Root methods end up going on object
             owner = core::Symbols::Object();

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -367,9 +367,10 @@ AccessorInfo LSPTask::getAccessorInfo(const core::GlobalState &gs, core::SymbolR
     AccessorInfo info;
 
     core::SymbolRef owner = symbol.data(gs)->owner;
-    if (!owner.exists()) {
+    if (!owner.exists() || !owner.isClassOrModule()) {
         return info;
     }
+    core::ClassOrModuleRef ownerCls = owner.asClassOrModuleRef();
 
     string_view baseName;
 
@@ -403,7 +404,7 @@ AccessorInfo LSPTask::getAccessorInfo(const core::GlobalState &gs, core::SymbolR
             // Field is not optional.
             return info;
         }
-        info.fieldSymbol = gs.lookupFieldSymbol(owner, fieldName);
+        info.fieldSymbol = gs.lookupFieldSymbol(ownerCls, fieldName);
         if (!info.fieldSymbol.exists()) {
             // field symbol does not exist, so `symbol` must not be an accessor.
             return info;
@@ -413,7 +414,7 @@ AccessorInfo LSPTask::getAccessorInfo(const core::GlobalState &gs, core::SymbolR
     if (!info.readerSymbol.exists()) {
         auto readerName = gs.lookupNameUTF8(baseName);
         if (readerName.exists()) {
-            info.readerSymbol = gs.lookupMethodSymbol(owner, readerName);
+            info.readerSymbol = gs.lookupMethodSymbol(ownerCls, readerName);
         }
     }
 
@@ -421,7 +422,7 @@ AccessorInfo LSPTask::getAccessorInfo(const core::GlobalState &gs, core::SymbolR
         auto writerNameStr = absl::StrCat(baseName, "=");
         auto writerName = gs.lookupNameUTF8(writerNameStr);
         if (writerName.exists()) {
-            info.writerSymbol = gs.lookupMethodSymbol(owner, writerName);
+            info.writerSymbol = gs.lookupMethodSymbol(ownerCls, writerName);
         }
     }
 

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -385,13 +385,13 @@ AccessorInfo LSPTask::getAccessorInfo(const core::GlobalState &gs, core::SymbolR
         if (!symbol.data(gs)->isMethod()) {
             return info;
         }
-        info.writerSymbol = symbol;
+        info.writerSymbol = symbol.asMethodRef();
         baseName = string_view(symbolName).substr(0, symbolName.length() - 1);
     } else {
         if (!symbol.data(gs)->isMethod()) {
             return info;
         }
-        info.readerSymbol = symbol;
+        info.readerSymbol = symbol.asMethodRef();
         baseName = symbolName;
     }
 

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -19,8 +19,8 @@ struct AccessorInfo {
     core::NameRef type;
     FieldAccessorType accessorType = FieldAccessorType::None;
     core::SymbolRef fieldSymbol;
-    core::SymbolRef readerSymbol;
-    core::SymbolRef writerSymbol;
+    core::MethodRef readerSymbol;
+    core::MethodRef writerSymbol;
 };
 
 /**

--- a/main/lsp/LocalVarFinder.h
+++ b/main/lsp/LocalVarFinder.h
@@ -11,7 +11,7 @@ class LocalVarFinder {
 
     // We go through the effort of keeping track of a method stack so as to not rely on trees having been
     // flattened at this point. (LSP code should try to make minimal assumptions to be robust to changes.)
-    std::vector<core::SymbolRef> methodStack;
+    std::vector<core::MethodRef> methodStack;
 
     std::vector<core::LocalVariable> result_;
 

--- a/main/lsp/NextMethodFinder.cc
+++ b/main/lsp/NextMethodFinder.cc
@@ -56,7 +56,7 @@ ast::ExpressionPtr NextMethodFinder::preTransformMethodDef(core::Context ctx, as
     }
 }
 
-const core::SymbolRef NextMethodFinder::result() const {
+const core::MethodRef NextMethodFinder::result() const {
     return this->result_;
 }
 

--- a/main/lsp/NextMethodFinder.h
+++ b/main/lsp/NextMethodFinder.h
@@ -8,14 +8,14 @@ namespace sorbet::realmain::lsp {
 class NextMethodFinder {
     const core::Loc queryLoc;
 
-    core::SymbolRef result_;
+    core::MethodRef result_;
 
 public:
-    NextMethodFinder(core::Loc queryLoc) : queryLoc(queryLoc), result_(core::Symbols::noSymbol()) {}
+    NextMethodFinder(core::Loc queryLoc) : queryLoc(queryLoc), result_(core::Symbols::noMethod()) {}
 
     ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr methodDef);
 
-    const core::SymbolRef result() const;
+    const core::MethodRef result() const;
 };
 }; // namespace sorbet::realmain::lsp
 

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -89,7 +89,7 @@ bool hasSimilarName(const core::GlobalState &gs, core::NameRef name, std::string
 bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym);
 std::unique_ptr<MarkupContent> formatRubyMarkup(MarkupKind markupKind, std::string_view rubyMarkup,
                                                 std::optional<std::string_view> explanation);
-std::string prettyTypeForMethod(const core::GlobalState &gs, core::SymbolRef method, const core::TypePtr &receiver,
+std::string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
                                 const core::TypePtr &retType, const core::TypeConstraint *constraint);
 std::string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant);
 core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &type, core::SymbolRef inWhat,

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -71,7 +71,7 @@ constexpr int MAX_PRETTY_SIG_ARGS = 4;
 // iff a `def` would be this wide or wider, expand it to be a multi-line def.
 constexpr int MAX_PRETTY_WIDTH = 80;
 
-string prettySigForMethod(const core::GlobalState &gs, core::SymbolRef method, const core::TypePtr &receiver,
+string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
                           core::TypePtr retType, const core::TypeConstraint *constraint) {
     ENFORCE(method.exists());
     ENFORCE(method.data(gs)->dealias(gs) == method);
@@ -136,7 +136,7 @@ string prettySigForMethod(const core::GlobalState &gs, core::SymbolRef method, c
     return fmt::format("{} do\n  {}{}{}\nend", sigCall, flagString, paramsString, methodReturnType);
 }
 
-string prettyDefForMethod(const core::GlobalState &gs, core::SymbolRef method) {
+string prettyDefForMethod(const core::GlobalState &gs, core::MethodRef method) {
     ENFORCE(method.exists());
     // handle this case anyways so that we don't crash in prod when this method is mis-used
     if (!method.exists()) {
@@ -213,10 +213,11 @@ string prettyDefForMethod(const core::GlobalState &gs, core::SymbolRef method) {
     return result;
 }
 
-string prettyTypeForMethod(const core::GlobalState &gs, core::SymbolRef method, const core::TypePtr &receiver,
+string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
                            const core::TypePtr &retType, const core::TypeConstraint *constraint) {
-    return fmt::format("{}\n{}", prettySigForMethod(gs, method.data(gs)->dealias(gs), receiver, retType, constraint),
-                       prettyDefForMethod(gs, method));
+    return fmt::format(
+        "{}\n{}", prettySigForMethod(gs, method.data(gs)->dealias(gs).asMethodRef(), receiver, retType, constraint),
+        prettyDefForMethod(gs, method));
 }
 
 string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant) {

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -15,7 +15,7 @@ class CompletionTask final : public LSPRequestTask {
 
     std::unique_ptr<CompletionItem> getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker,
                                                                core::DispatchResult &dispatchResult,
-                                                               core::SymbolRef what, const core::TypePtr &receiverType,
+                                                               core::MethodRef what, const core::TypePtr &receiverType,
                                                                const core::TypeConstraint *constraint,
                                                                core::Loc queryLoc, std::string_view prefix,
                                                                size_t sortIdx, u2 totalArgs) const;

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -98,7 +98,8 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
                 typeString = methodInfoString(gs, retType, *sendResp->dispatchResult, constraint);
             }
         } else if (auto defResp = resp->isDefinition()) {
-            typeString = prettyTypeForMethod(gs, defResp->symbol, nullptr, defResp->retType.type, nullptr);
+            typeString =
+                prettyTypeForMethod(gs, defResp->symbol.asMethodRef(), nullptr, defResp->retType.type, nullptr);
         } else if (auto constResp = resp->isConstant()) {
             typeString = prettyTypeForConstant(gs, constResp->symbol);
         } else {

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -6,7 +6,7 @@
 using namespace std;
 
 namespace sorbet::realmain::lsp {
-void addSignatureHelpItem(const core::GlobalState &gs, core::SymbolRef method,
+void addSignatureHelpItem(const core::GlobalState &gs, core::MethodRef method,
                           vector<unique_ptr<SignatureInformation>> &sigs, const core::lsp::SendResponse &resp,
                           int activeParameter) {
     // signature helps only exist for methods.

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -644,7 +644,7 @@ private:
     const int prohibitedLinesStart;
     const int prohibitedLinesEnd;
 
-    bool isWhiteListed(core::Context ctx, core::SymbolRef sym) {
+    bool isAllowListed(core::Context ctx, core::SymbolRef sym) {
         return sym.data(ctx)->name == core::Names::staticInit() ||
                sym.data(ctx)->name == core::Names::Constants::Root() ||
                sym.data(ctx)->name == core::Names::unresolvedAncestors();
@@ -657,7 +657,7 @@ private:
     }
 
     void checkSym(core::Context ctx, core::SymbolRef sym) {
-        if (isWhiteListed(ctx, sym)) {
+        if (isAllowListed(ctx, sym)) {
             return;
         }
         checkLoc(ctx, sym.data(ctx)->loc());

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -904,7 +904,7 @@ class SymbolDefiner {
         }
     }
 
-    bool paramsMatch(core::MutableContext ctx, core::SymbolRef method, const vector<ast::ParsedArg> &parsedArgs) {
+    bool paramsMatch(core::MutableContext ctx, core::MethodRef method, const vector<ast::ParsedArg> &parsedArgs) {
         auto sym = method.data(ctx)->dealias(ctx);
         if (sym.data(ctx)->arguments().size() != parsedArgs.size()) {
             return false;
@@ -1041,7 +1041,7 @@ class SymbolDefiner {
                 // if the symbol does exist, then we're running in incremental mode, and we need to compare it to
                 // the previously defined equivalent to re-report any errors
                 auto replacedSym = ctx.state.findRenamedSymbol(owner, matchingSym);
-                if (replacedSym.exists() && !paramsMatch(ctx, replacedSym, parsedArgs) &&
+                if (replacedSym.exists() && !paramsMatch(ctx, replacedSym.asMethodRef(), parsedArgs) &&
                     !isIntrinsic(replacedSym.data(ctx))) {
                     paramMismatchErrors(ctx.withOwner(replacedSym), declLoc, parsedArgs);
                 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3036,9 +3036,9 @@ ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vect
     trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), *workers);
     // NOTE: Linearization does not need to be recomputed as we do not mutate mixins() during incremental resolve.
     DEBUG_ONLY(for (auto i = 1; i < gs.classAndModulesUsed(); i++) {
-        core::SymbolRef sym(gs, core::SymbolRef::Kind::ClassOrModule, i);
+        core::ClassOrModuleRef sym(gs, i);
         // If class is not marked as 'linearization computed', then we added a mixin to it since the last slow path.
-        ENFORCE_NO_TIMER(sym.data(gs)->isClassOrModuleLinearizationComputed(), sym.toString(gs));
+        ENFORCE_NO_TIMER(sym.data(gs)->isClassOrModuleLinearizationComputed(), sym.data(gs)->toString(gs));
     })
     trees = ResolveTypeMembersAndFieldsWalk::run(gs, std::move(trees), *workers);
     auto result = resolveSigs(gs, std::move(trees), *workers);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -392,7 +392,7 @@ private:
 
     static bool resolveTypeAliasJob(core::MutableContext ctx, TypeAliasResolutionItem &job) {
         core::SymbolRef enclosingTypeMember;
-        core::SymbolRef enclosingClass = job.lhs.data(ctx)->enclosingClass(ctx);
+        core::ClassOrModuleRef enclosingClass = job.lhs.data(ctx)->enclosingClass(ctx);
         while (enclosingClass != core::Symbols::root()) {
             auto typeMembers = enclosingClass.data(ctx)->typeMembers();
             if (!typeMembers.empty()) {

--- a/resolver/type_syntax.h
+++ b/resolver/type_syntax.h
@@ -13,9 +13,9 @@ struct ParsedSig {
         core::Loc loc;
         core::NameRef name;
         core::TypePtr type;
-        core::SymbolRef rebind;
+        core::ClassOrModuleRef rebind;
     };
-    core::SymbolRef bind;
+    core::ClassOrModuleRef bind;
     std::vector<ArgSpec> argTypes;
     core::TypePtr returns;
 
@@ -75,7 +75,7 @@ public:
 
     struct ResultType {
         core::TypePtr type;
-        core::SymbolRef rebind;
+        core::ClassOrModuleRef rebind;
     };
     static ResultType getResultTypeAndBind(core::Context ctx, ast::ExpressionPtr &expr, const ParsedSig &,
                                            TypeSyntaxArgs args);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Use ClassOrModuleRef / MethodRef in more places.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduce usage of the general-purpose SymbolRef class so that `SymbolRef::data` is used in fewer places.

Next steps will be to define FieldRef, TypeArgumentRef, etc. Then we can make `.data()` on `SymbolRef` private and add general-purpose top-level methods on `SymbolRef` for common utilities (e.g., `toString()`). Then we can begin to define specialized `Symbol` classes!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
