### PR TITLE
Add support for root scoped Struct definitions

### DIFF
--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -45,7 +45,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
         return empty;
     }
 
-    if (!ast::isa_tree<ast::EmptyTree>(recv->scope) || recv->cnst != core::Symbols::Struct().data(ctx)->name ||
+    if (!ast::MK::isRootScope(recv->scope) || recv->cnst != core::Symbols::Struct().data(ctx)->name ||
         send->fun != core::Names::new_() || send->args.empty()) {
         return empty;
     }

--- a/test/testdata/rewriter/struct.rb
+++ b/test/testdata/rewriter/struct.rb
@@ -107,3 +107,13 @@ class Main
     end
 end
 puts Main.new.main
+
+class FullyQualifiedStructUsages
+  Foo = Struct.new(:a)
+  Bar = ::Struct.new(:a)
+  Baz = ::Foo::Struct.new
+
+  Foo.new.a
+  Bar.new.a
+  Baz.new.a
+end

--- a/test/testdata/rewriter/struct.rb
+++ b/test/testdata/rewriter/struct.rb
@@ -115,5 +115,4 @@ class FullyQualifiedStructUsages
 
   Foo.new.a
   Bar.new.a
-  Baz.new.a
 end

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -407,7 +407,5 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C Foo>.new().a()
 
     <emptyTree>::<C Bar>.new().a()
-
-    <emptyTree>::<C Baz>.new().a()
   end
 end

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -348,4 +348,66 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   <self>.puts(<emptyTree>::<C Main>.new().main())
+
+  class <emptyTree>::<C FullyQualifiedStructUsages><<C <todo sym>>> < (::<todo sym>)
+    class <emptyTree>::<C Foo><<C <todo sym>>> < (::<root>::<C Struct>)
+      def a<<todo method>>(&<blk>)
+        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      def a=<<todo method>>(a, &<blk>)
+        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.params(:a, ::BasicObject).void()
+      end
+
+      def initialize<<todo method>>(a = nil, &<blk>)
+        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      ::Sorbet::Private::Static.keep_def(<self>, :a, :normal)
+
+      ::Sorbet::Private::Static.keep_def(<self>, :a=, :normal)
+
+      <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())
+
+      ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
+    end
+
+    class <emptyTree>::<C Bar><<C <todo sym>>> < (::<root>::<C Struct>)
+      def a<<todo method>>(&<blk>)
+        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      def a=<<todo method>>(a, &<blk>)
+        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.params(:a, ::BasicObject).void()
+      end
+
+      def initialize<<todo method>>(a = nil, &<blk>)
+        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      ::Sorbet::Private::Static.keep_def(<self>, :a, :normal)
+
+      ::Sorbet::Private::Static.keep_def(<self>, :a=, :normal)
+
+      <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())
+
+      ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
+    end
+
+    <emptyTree>::<C Baz> = ::<root>::<C Foo>::<C Struct>.new()
+
+    <emptyTree>::<C Foo>.new().a()
+
+    <emptyTree>::<C Bar>.new().a()
+
+    <emptyTree>::<C Baz>.new().a()
+  end
 end

--- a/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=109:19}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=119:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U AccidentallyStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=37:1 end=37:25}
     class <C <U AccidentallyStruct>><C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
@@ -51,6 +51,40 @@ class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U Foo>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/rewriter/struct.rb start=4:8 end=4:11}
     type-member(+) <S <C <U Foo>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo) @ Loc {file=test/testdata/rewriter/struct.rb start=4:8 end=4:11}
     method <S <C <U Foo>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=4:1 end=7:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <C <U FullyQualifiedStructUsages>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=111:1 end=111:33}
+    class <C <U FullyQualifiedStructUsages>><C <U Bar>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=113:3 end=113:25}
+      type-member(=) <C <U FullyQualifiedStructUsages>><C <U Bar>><C <U Elem>> -> LambdaParam(<C <U FullyQualifiedStructUsages>><C <U Bar>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=113:3 end=113:25}
+      method <C <U FullyQualifiedStructUsages>><C <U Bar>><U a> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=113:23 end=113:24}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U FullyQualifiedStructUsages>><C <U Bar>><U a=> (a, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=113:23 end=113:24}
+        argument a<> @ Loc {file=test/testdata/rewriter/struct.rb start=113:23 end=113:24}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U FullyQualifiedStructUsages>><C <U Bar>><U initialize> (a, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=113:3 end=113:25}
+        argument a<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=113:23 end=113:24}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U FullyQualifiedStructUsages>><S <C <U Bar>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=113:3 end=113:6}
+      type-member(+) <C <U FullyQualifiedStructUsages>><S <C <U Bar>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U FullyQualifiedStructUsages>><S <C <U Bar>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U FullyQualifiedStructUsages>><C <U Bar>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=113:3 end=113:6}
+      method <C <U FullyQualifiedStructUsages>><S <C <U Bar>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=113:3 end=113:25}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    static-field <C <U FullyQualifiedStructUsages>><C <U Baz>> @ Loc {file=test/testdata/rewriter/struct.rb start=114:3 end=114:6}
+    class <C <U FullyQualifiedStructUsages>><C <U Foo>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=112:3 end=112:23}
+      type-member(=) <C <U FullyQualifiedStructUsages>><C <U Foo>><C <U Elem>> -> LambdaParam(<C <U FullyQualifiedStructUsages>><C <U Foo>><C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=112:3 end=112:23}
+      method <C <U FullyQualifiedStructUsages>><C <U Foo>><U a> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=112:21 end=112:22}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U FullyQualifiedStructUsages>><C <U Foo>><U a=> (a, <blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=112:21 end=112:22}
+        argument a<> @ Loc {file=test/testdata/rewriter/struct.rb start=112:21 end=112:22}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+      method <C <U FullyQualifiedStructUsages>><C <U Foo>><U initialize> (a, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=112:3 end=112:23}
+        argument a<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=112:21 end=112:22}
+        argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    class <C <U FullyQualifiedStructUsages>><S <C <U Foo>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=112:3 end=112:6}
+      type-member(+) <C <U FullyQualifiedStructUsages>><S <C <U Foo>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U FullyQualifiedStructUsages>><S <C <U Foo>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U FullyQualifiedStructUsages>><C <U Foo>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=112:3 end=112:6}
+      method <C <U FullyQualifiedStructUsages>><S <C <U Foo>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=112:3 end=112:23}
+        argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <S <C <U FullyQualifiedStructUsages>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=111:7 end=111:33}
+    type-member(+) <S <C <U FullyQualifiedStructUsages>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U FullyQualifiedStructUsages>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=FullyQualifiedStructUsages) @ Loc {file=test/testdata/rewriter/struct.rb start=111:7 end=111:33}
+    method <S <C <U FullyQualifiedStructUsages>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=111:1 end=119:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U Main>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=86:1 end=86:11}
     method <C <U Main>><U main> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=87:5 end=87:13}

--- a/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=119:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=118:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U AccidentallyStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=37:1 end=37:25}
     class <C <U AccidentallyStruct>><C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
@@ -84,7 +84,7 @@ class <C <U <root>>> < <C <U Object>> ()
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <S <C <U FullyQualifiedStructUsages>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=111:7 end=111:33}
     type-member(+) <S <C <U FullyQualifiedStructUsages>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U FullyQualifiedStructUsages>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=FullyQualifiedStructUsages) @ Loc {file=test/testdata/rewriter/struct.rb start=111:7 end=111:33}
-    method <S <C <U FullyQualifiedStructUsages>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=111:1 end=119:4}
+    method <S <C <U FullyQualifiedStructUsages>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=111:1 end=118:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U Main>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=86:1 end=86:11}
     method <C <U Main>><U main> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=87:5 end=87:13}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

```ruby
# typed: true

Foo = Struct.new(:a)
Bar = ::Struct.new(:a)

Foo.new.a
Bar.new.a
```

Would produce

```ruby
class <emptyTree><<C <root>>> < (::<todo sym>)
  class <emptyTree>::<C Foo><<C <todo sym>>> < (::<root>::<C Struct>)
    def a<<todo method>>(&<blk>)
      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
    end

    def a=<<todo method>>(a, &<blk>)
      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
    end

    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
      <self>.params(:a, ::BasicObject).void()
    end

    def initialize<<todo method>>(a = nil, &<blk>)
      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
    end

    ::Sorbet::Private::Static.keep_def(<self>, :a, :normal)

    ::Sorbet::Private::Static.keep_def(<self>, :a=, :normal)

    <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())

    ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
  end

  <emptyTree>::<C Bar> = ::<root>::<C Struct>.new(:a)

  <emptyTree>::<C Foo>.new().a()

  <emptyTree>::<C Bar>.new().a()
end
```

where `::Struct.new(...)` was not correctly being rewritten. The following changes allow it to be correctly rewritten as

```
lass <emptyTree><<C <root>>> < (::<todo sym>)
  class <emptyTree>::<C Foo><<C <todo sym>>> < (::<root>::<C Struct>)
    def a<<todo method>>(&<blk>)
      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
    end

    def a=<<todo method>>(a, &<blk>)
      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
    end

    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
      <self>.params(:a, ::BasicObject).void()
    end

    def initialize<<todo method>>(a = nil, &<blk>)
      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
    end

    ::Sorbet::Private::Static.keep_def(<self>, :a, :normal)

    ::Sorbet::Private::Static.keep_def(<self>, :a=, :normal)

    <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())

    ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
  end

  class <emptyTree>::<C Bar><<C <todo sym>>> < (::<root>::<C Struct>)
    def a<<todo method>>(&<blk>)
      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
    end

    def a=<<todo method>>(a, &<blk>)
      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
    end

    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
      <self>.params(:a, ::BasicObject).void()
    end

    def initialize<<todo method>>(a = nil, &<blk>)
      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
    end

    ::Sorbet::Private::Static.keep_def(<self>, :a, :normal)

    ::Sorbet::Private::Static.keep_def(<self>, :a=, :normal)

    <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())

    ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
  end

  <emptyTree>::<C Foo>.new().a()

  <emptyTree>::<C Bar>.new().a()
end
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
