### PR TITLE
wip: Correctly model merchant_prop w.r.t. foreign

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -98,8 +98,8 @@ public:
         return make_expression<ast::OptionalArg>(loc, std::move(inner), std::move(default_));
     }
 
-    static ExpressionPtr KeywordArg(core::LocOffsets loc, ExpressionPtr inner) {
-        return make_expression<ast::KeywordArg>(loc, std::move(inner));
+    static ExpressionPtr KeywordArg(core::LocOffsets loc, core::NameRef name) {
+        return make_expression<ast::KeywordArg>(loc, Local(loc, name));
     }
 
     static ExpressionPtr RestArg(core::LocOffsets loc, ExpressionPtr inner) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -202,6 +202,15 @@ public:
         return make_expression<UnresolvedConstantLit>(loc, std::move(scope), name);
     }
 
+    static ExpressionPtr UnresolvedConstantParts(core::LocOffsets loc, ExpressionPtr scope,
+                                                 const std::vector<core::NameRef> &parts) {
+        auto result = std::move(scope);
+        for (const auto part : parts) {
+            result = UnresolvedConstant(loc, std::move(result), part);
+        }
+        return result;
+    }
+
     static ExpressionPtr Int(core::LocOffsets loc, int64_t val) {
         return make_expression<ast::Literal>(loc, core::make_type<core::LiteralType>(val));
     }

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -102,6 +102,10 @@ public:
         return make_expression<ast::KeywordArg>(loc, Local(loc, name));
     }
 
+    static ExpressionPtr KeywordArgWithDefault(core::LocOffsets loc, core::NameRef name, ExpressionPtr default_) {
+        return OptionalArg(loc, KeywordArg(loc, name), std::move(default_));
+    }
+
     static ExpressionPtr RestArg(core::LocOffsets loc, ExpressionPtr inner) {
         return make_expression<ast::RestArg>(loc, std::move(inner));
     }
@@ -374,6 +378,11 @@ public:
 
     static ExpressionPtr Nilable(core::LocOffsets loc, ExpressionPtr arg) {
         return Send1(loc, T(loc), core::Names::nilable(), std::move(arg));
+    }
+
+    static ExpressionPtr T_Boolean(core::LocOffsets loc) {
+        return UnresolvedConstantParts(loc, EmptyTree(),
+                                       {core::Names::Constants::T(), core::Names::Constants::Boolean()});
     }
 
     static ExpressionPtr KeepForIDE(ExpressionPtr arg) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1219,11 +1219,11 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(res);
             },
             [&](parser::Kwrestarg *arg) {
-                ExpressionPtr res = MK::RestArg(loc, MK::KeywordArg(loc, MK::Local(loc, arg->name)));
+                ExpressionPtr res = MK::RestArg(loc, MK::KeywordArg(loc, arg->name));
                 result = std::move(res);
             },
             [&](parser::Kwarg *arg) {
-                ExpressionPtr res = MK::KeywordArg(loc, MK::Local(loc, arg->name));
+                ExpressionPtr res = MK::KeywordArg(loc, arg->name);
                 result = std::move(res);
             },
             [&](parser::Blockarg *arg) {
@@ -1231,8 +1231,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(res);
             },
             [&](parser::Kwoptarg *arg) {
-                ExpressionPtr res = MK::OptionalArg(loc, MK::KeywordArg(loc, MK::Local(arg->nameLoc, arg->name)),
-                                                    node2TreeImpl(dctx, std::move(arg->default_)));
+                ExpressionPtr res =
+                    MK::OptionalArg(loc, MK::KeywordArg(loc, arg->name), node2TreeImpl(dctx, std::move(arg->default_)));
                 result = std::move(res);
             },
             [&](parser::Optarg *arg) {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -192,6 +192,7 @@ NameDef names[] = {
     {"created"},
     {"merchant"},
     {"foreign"},
+    {"allowDirectMutation", "allow_direct_mutation"},
     {"ifunset"},
     {"withoutAccessors", "without_accessors"},
     {"instanceVariableGet", "instance_variable_get"},

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -176,6 +176,8 @@ NameDef names[] = {
     {"timestampedTokenProp", "timestamped_token_prop"},
     {"createdProp", "created_prop"},
     {"merchantProp", "merchant_prop"},
+    {"Merchant", "Merchant", true},
+    {"Account", "Account", true},
     {"encryptedProp", "encrypted_prop"},
     {"array"},
     {"defDelegator", "def_delegator"},

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -59,7 +59,7 @@ class LocalNameInserter {
             },
             [&](ast::KeywordArg &kw) {
                 named = nameArg(move(kw.expr));
-                named.expr = ast::MK::KeywordArg(arg.loc(), move(named.expr));
+                named.expr = ast::make_expression<ast::KeywordArg>(arg.loc(), move(named.expr));
                 named.flags.keyword = true;
             },
             [&](ast::OptionalArg &opt) {

--- a/rewriter/MixinEncryptedProp.cc
+++ b/rewriter/MixinEncryptedProp.cc
@@ -12,13 +12,13 @@ namespace sorbet::rewriter {
 namespace {
 
 ast::ExpressionPtr mkNilableEncryptedValue(core::MutableContext ctx, core::LocOffsets loc) {
-    auto opus = ast::MK::UnresolvedConstant(loc, ast::MK::EmptyTree(), core::Names::Constants::Opus());
-    auto db = ast::MK::UnresolvedConstant(loc, move(opus), core::Names::Constants::DB());
-    auto model = ast::MK::UnresolvedConstant(loc, move(db), core::Names::Constants::Model());
-    auto mixins = ast::MK::UnresolvedConstant(loc, move(model), core::Names::Constants::Mixins());
-    auto enc = ast::MK::UnresolvedConstant(loc, move(mixins), core::Names::Constants::Encryptable());
-    auto ev = ast::MK::UnresolvedConstant(loc, move(enc), core::Names::Constants::EncryptedValue());
-    return ASTUtil::mkNilable(loc, move(ev));
+    auto parts = vector<core::NameRef>{
+        core::Names::Constants::Opus(),        core::Names::Constants::DB(),
+        core::Names::Constants::Model(),       core::Names::Constants::Mixins(),
+        core::Names::Constants::Encryptable(), core::Names::Constants::EncryptedValue(),
+    };
+
+    return ASTUtil::mkNilable(loc, ast::MK::UnresolvedConstantParts(loc, ast::MK::EmptyTree(), parts));
 }
 
 ast::ExpressionPtr mkNilableString(core::LocOffsets loc) {

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -147,6 +147,10 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
                 core::LocOffsets{send->loc.beginPos(),
                                  send->loc.endPos() - 5}; // 5 is the difference between `merchant_prop` and `merchant`
             ret.type = ast::MK::Constant(send->loc, core::Symbols::String());
+            ret.foreign =
+                ast::MK::UnresolvedConstantParts(send->loc, ast::MK::EmptyTree(),
+                                                 {core::Names::Constants::Opus(), core::Names::Constants::Account(),
+                                                  core::Names::Constants::Model(), core::Names::Constants::Merchant()});
             break;
 
         default:

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -141,6 +141,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
             ret.type = ast::MK::Constant(send->loc, core::Symbols::Float());
             break;
         case core::Names::merchantProp().rawId():
+            // http://go/ps/blob/2adf5ea66d0e/lib/db/sharding/shard_by_merchant/shard_by_merchant.rb#L16
             ret.isImmutable = true;
             ret.name = core::Names::merchant();
             ret.nameLoc =

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -401,18 +401,17 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, 
             nonNilType = ASTUtil::dupType(ret.foreign);
         }
 
-        // sig {params(opts: T.untyped).returns(T.nilable($foreign))}
-        nodes.emplace_back(
-            ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, core::Names::opts()), ast::MK::Untyped(loc), std::move(type)));
+        // sig {params(allow_direct_mutation: T.nilable(T::Boolean)).returns(T.nilable($foreign))}
+        nodes.emplace_back(ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, core::Names::allowDirectMutation()),
+                                         ast::MK::Nilable(loc, ast::MK::T_Boolean(loc)), std::move(type)));
 
-        // def $fk_method(**opts)
+        // def $fk_method(allow_direct_mutation: nil)
         //  T.unsafe(nil)
         // end
 
         auto fkMethod = ctx.state.enterNameUTF8(name.show(ctx) + "_");
 
-        auto arg =
-            ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
+        auto arg = ast::MK::KeywordArgWithDefault(nameLoc, core::Names::allowDirectMutation(), ast::MK::Nil(loc));
         ast::MethodDef::Flags fkFlags;
         fkFlags.discardDef = true;
         auto fkMethodDef =
@@ -420,16 +419,15 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, 
         nodes.emplace_back(std::move(fkMethodDef));
 
         // sig {params(opts: T.untyped).returns($foreign)}
-        nodes.emplace_back(ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, core::Names::opts()), ast::MK::Untyped(loc),
-                                         std::move(nonNilType)));
+        nodes.emplace_back(ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, core::Names::allowDirectMutation()),
+                                         ast::MK::Nilable(loc, ast::MK::T_Boolean(loc)), std::move(nonNilType)));
 
         // def $fk_method_!(**opts)
         //  T.unsafe(nil)
         // end
 
         auto fkMethodBang = ctx.state.enterNameUTF8(name.show(ctx) + "_!");
-        auto arg2 =
-            ast::MK::RestArg(nameLoc, ast::MK::KeywordArg(nameLoc, ast::MK::Local(nameLoc, core::Names::opts())));
+        auto arg2 = ast::MK::KeywordArgWithDefault(nameLoc, core::Names::allowDirectMutation(), ast::MK::Nil(loc));
         ast::MethodDef::Flags fkBangFlags;
         fkBangFlags.discardDef = true;
         auto fkMethodDefBang = ast::MK::SyntheticMethod1(loc, loc, fkMethodBang, std::move(arg2),

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -489,7 +489,7 @@ vector<ast::ExpressionPtr> mkTypedInitialize(core::MutableContext ctx, core::Loc
             continue;
         }
         auto loc = prop.loc;
-        args.emplace_back(ast::MK::KeywordArg(loc, ast::MK::Local(loc, prop.name)));
+        args.emplace_back(ast::MK::KeywordArg(loc, prop.name));
         sigArgs.emplace_back(ast::MK::Symbol(loc, prop.name));
         sigArgs.emplace_back(prop.type.deepCopy());
     }
@@ -500,8 +500,7 @@ vector<ast::ExpressionPtr> mkTypedInitialize(core::MutableContext ctx, core::Loc
             continue;
         }
         auto loc = prop.loc;
-        args.emplace_back(ast::MK::OptionalArg(loc, ast::MK::KeywordArg(loc, ast::MK::Local(loc, prop.name)),
-                                               prop.default_.deepCopy()));
+        args.emplace_back(ast::MK::OptionalArg(loc, ast::MK::KeywordArg(loc, prop.name), prop.default_.deepCopy()));
         sigArgs.emplace_back(ast::MK::Symbol(loc, prop.name));
         sigArgs.emplace_back(prop.type.deepCopy());
     }

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -102,7 +102,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
         sigArgs.emplace_back(ast::MK::Constant(symLoc, core::Symbols::BasicObject()));
         auto argName = ast::MK::Local(symLoc, name);
         if (keywordInit) {
-            argName = ast::MK::KeywordArg(symLoc, move(argName));
+            argName = ast::make_expression<ast::KeywordArg>(symLoc, move(argName));
         }
         newArgs.emplace_back(ast::MK::OptionalArg(symLoc, move(argName), ast::MK::Nil(symLoc)));
 

--- a/test/testdata/rewriter/merchant_prop.rb
+++ b/test/testdata/rewriter/merchant_prop.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class MyModel
+  include T::Props
+  def self.merchant_prop(opts={}); end
+
+  # Opus::Account::Model::Merchant is in pay-server
+  merchant_prop # error: Unable to resolve constant `Account`
+end

--- a/test/testdata/rewriter/merchant_prop.rb
+++ b/test/testdata/rewriter/merchant_prop.rb
@@ -5,5 +5,7 @@ class MyModel
   def self.merchant_prop(opts={}); end
 
   # Opus::Account::Model::Merchant is in pay-server
-  merchant_prop # error: Unable to resolve constant `Account`
+  merchant_prop
+# ^^^^^^^^^^^^^ error: Unable to resolve constant `Account`
+# ^^^^^^^^^^^^^ error: Unable to resolve constant `Account`
 end

--- a/test/testdata/rewriter/prop.rb
+++ b/test/testdata/rewriter/prop.rb
@@ -77,6 +77,7 @@ class PropHelpers2
   created_prop(immutable: true)
 end
 
+class Opus::Account::Model::Merchant; end
 class ShardingProp
   include T::Props
   def self.merchant_prop(opts={}); end

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -7694,6 +7694,29 @@ ClassDef{
     ClassDef{
       kind = class
       name = UnresolvedConstantLit{
+        scope = UnresolvedConstantLit{
+          scope = UnresolvedConstantLit{
+            scope = UnresolvedConstantLit{
+              scope = EmptyTree
+              cnst = <C <U Opus>>
+            }
+            cnst = <C <U Account>>
+          }
+          cnst = <C <U Model>>
+        }
+        cnst = <C <U Merchant>>
+      }<<C <U <todo sym>>>>
+      ancestors = [ConstantLit{
+          orig = nullptr
+          symbol = (class ::<todo sym>)
+        }]
+      rhs = [
+      ]
+    }
+
+    ClassDef{
+      kind = class
+      name = UnresolvedConstantLit{
         scope = EmptyTree
         cnst = <C <U ShardingProp>>
       }<<C <U <todo sym>>>>

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -7840,6 +7840,209 @@ ClassDef{
         }
 
         Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = (module ::Sorbet::Private::Static)
+          }
+          fun = <U sig>
+          block = Block {
+            args = [
+            ]
+            body = Send{
+              recv = Send{
+                recv = Local{
+                  localVariable = <U <self>>
+                }
+                fun = <U params>
+                block = nullptr
+                pos_args = 0
+                args = [
+                  Literal{ value = :opts }
+                  Send{
+                    recv = ConstantLit{
+                      orig = nullptr
+                      symbol = (module ::T)
+                    }
+                    fun = <U untyped>
+                    block = nullptr
+                    pos_args = 0
+                    args = [
+                    ]
+                  }
+                ]
+              }
+              fun = <U returns>
+              block = nullptr
+              pos_args = 1
+              args = [
+                Send{
+                  recv = ConstantLit{
+                    orig = nullptr
+                    symbol = (module ::T)
+                  }
+                  fun = <U nilable>
+                  block = nullptr
+                  pos_args = 1
+                  args = [
+                    UnresolvedConstantLit{
+                      scope = UnresolvedConstantLit{
+                        scope = UnresolvedConstantLit{
+                          scope = UnresolvedConstantLit{
+                            scope = EmptyTree
+                            cnst = <C <U Opus>>
+                          }
+                          cnst = <C <U Account>>
+                        }
+                        cnst = <C <U Model>>
+                      }
+                      cnst = <C <U Merchant>>
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+          pos_args = 1
+          args = [
+            ConstantLit{
+              orig = nullptr
+              symbol = (module ::T::Sig::WithoutRuntime)
+            }
+          ]
+        }
+
+        MethodDef{
+          flags = {rewriter}
+          name = <U merchant_><<U <todo method>>>
+          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U opts>
+            } } }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Send{
+            recv = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = (module ::T)
+              }
+              fun = <U unsafe>
+              block = nullptr
+              pos_args = 1
+              args = [
+                ConstantLit{
+                  orig = nullptr
+                  symbol = (module ::Kernel)
+                }
+              ]
+            }
+            fun = <U raise>
+            block = nullptr
+            pos_args = 1
+            args = [
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
+            ]
+          }
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = (module ::Sorbet::Private::Static)
+          }
+          fun = <U sig>
+          block = Block {
+            args = [
+            ]
+            body = Send{
+              recv = Send{
+                recv = Local{
+                  localVariable = <U <self>>
+                }
+                fun = <U params>
+                block = nullptr
+                pos_args = 0
+                args = [
+                  Literal{ value = :opts }
+                  Send{
+                    recv = ConstantLit{
+                      orig = nullptr
+                      symbol = (module ::T)
+                    }
+                    fun = <U untyped>
+                    block = nullptr
+                    pos_args = 0
+                    args = [
+                    ]
+                  }
+                ]
+              }
+              fun = <U returns>
+              block = nullptr
+              pos_args = 1
+              args = [
+                UnresolvedConstantLit{
+                  scope = UnresolvedConstantLit{
+                    scope = UnresolvedConstantLit{
+                      scope = UnresolvedConstantLit{
+                        scope = EmptyTree
+                        cnst = <C <U Opus>>
+                      }
+                      cnst = <C <U Account>>
+                    }
+                    cnst = <C <U Model>>
+                  }
+                  cnst = <C <U Merchant>>
+                }
+              ]
+            }
+          }
+          pos_args = 1
+          args = [
+            ConstantLit{
+              orig = nullptr
+              symbol = (module ::T::Sig::WithoutRuntime)
+            }
+          ]
+        }
+
+        MethodDef{
+          flags = {rewriter}
+          name = <U merchant_!><<U <todo method>>>
+          args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U opts>
+            } } }, BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Send{
+            recv = Send{
+              recv = ConstantLit{
+                orig = nullptr
+                symbol = (module ::T)
+              }
+              fun = <U unsafe>
+              block = nullptr
+              pos_args = 1
+              args = [
+                ConstantLit{
+                  orig = nullptr
+                  symbol = (module ::Kernel)
+                }
+              ]
+            }
+            fun = <U raise>
+            block = nullptr
+            pos_args = 1
+            args = [
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
+            ]
+          }
+        }
+
+        Send{
           recv = Local{
             localVariable = <U <self>>
           }

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -827,6 +827,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:opts, ::T.untyped()).returns(::T.nilable(<emptyTree>::<C Opus>::<C Account>::<C Model>::<C Merchant>))
+    end
+
+    def merchant_<<todo method>>(*opts:, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:opts, ::T.untyped()).returns(<emptyTree>::<C Opus>::<C Account>::<C Model>::<C Merchant>)
+    end
+
+    def merchant_!<<todo method>>(*opts:, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
     <self>.include(<emptyTree>::<C T>::<C Props>)
 
     ::Sorbet::Private::Static.keep_self_def(<self>, :merchant_prop, :normal)

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -808,6 +808,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::Sorbet::Private::Static.keep_def(<self>, :created, :normal)
   end
 
+  class <emptyTree>::<C Opus>::<C Account>::<C Model>::<C Merchant><<C <todo sym>>> < (::<todo sym>)
+  end
+
   class <emptyTree>::<C ShardingProp><<C <todo sym>>> < (::<todo sym>)
     def self.merchant_prop<<todo method>>(opts = {}, &<blk>)
       <emptyTree>

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -197,6 +197,12 @@ class <C <U <root>>> < <C <U Object>> ()
   class <C <U ShardingProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=81:1 end=81:19}
     method <C <U ShardingProp>><U merchant> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=84:3 end=84:16}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <C <U ShardingProp>><U merchant_> (opts, <blk>) -> Opus::Account::Model::Merchant | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=84:3 end=84:16}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=84:3 end=84:11}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <C <U ShardingProp>><U merchant_!> (opts, <blk>) -> Opus::Account::Model::Merchant @ Loc {file=test/testdata/rewriter/prop.rb start=84:3 end=84:16}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=84:3 end=84:11}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <S <C <U ShardingProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=81:7 end=81:19}
     type-member(+) <S <C <U ShardingProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U ShardingProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=ShardingProp) @ Loc {file=test/testdata/rewriter/prop.rb start=81:7 end=81:19}
     method <S <C <U ShardingProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=81:1 end=85:4}

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=148:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=149:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U AdvancedODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=38:18}
     method <C <U AdvancedODM>><U array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
@@ -105,27 +105,27 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <C <U AdvancedODM>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U AdvancedODM>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AdvancedODM) @ Loc {file=test/testdata/rewriter/prop.rb start=38:7 end=38:18}
     method <S <C <U AdvancedODM>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=62:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U EncryptedProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=86:1 end=86:20}
-    method <C <U EncryptedProp>><U bar> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:56}
+  class <C <U EncryptedProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=87:20}
+    method <C <U EncryptedProp>><U bar> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=91:3 end=91:56}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U encrypted_bar> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:56}
+    method <C <U EncryptedProp>><U encrypted_bar> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=91:3 end=91:56}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U encrypted_foo> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=89:3 end=89:22}
+    method <C <U EncryptedProp>><U encrypted_foo> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U encrypted_foo=> (foo, <blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=89:3 end=89:22}
-      argument foo<> -> T.nilable(Opus::DB::Model::Mixins::Encryptable::EncryptedValue) @ Loc {file=test/testdata/rewriter/prop.rb start=89:19 end=89:22}
+    method <C <U EncryptedProp>><U encrypted_foo=> (foo, <blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:22}
+      argument foo<> -> T.nilable(Opus::DB::Model::Mixins::Encryptable::EncryptedValue) @ Loc {file=test/testdata/rewriter/prop.rb start=90:19 end=90:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U foo> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=89:3 end=89:22}
+    method <C <U EncryptedProp>><U foo> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U foo=> (foo, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=89:3 end=89:22}
-      argument foo<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=89:19 end=89:22}
+    method <C <U EncryptedProp>><U foo=> (foo, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:22}
+      argument foo<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=90:19 end=90:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U EncryptedProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=86:7 end=86:20}
-    type-member(+) <S <C <U EncryptedProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U EncryptedProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=EncryptedProp) @ Loc {file=test/testdata/rewriter/prop.rb start=86:7 end=86:20}
-    method <S <C <U EncryptedProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=86:1 end=91:4}
+  class <S <C <U EncryptedProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:7 end=87:20}
+    type-member(+) <S <C <U EncryptedProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U EncryptedProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=EncryptedProp) @ Loc {file=test/testdata/rewriter/prop.rb start=87:7 end=87:20}
+    method <S <C <U EncryptedProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=92:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <S <C <U EncryptedProp>> $1><U encrypted_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=88:3 end=88:35}
-      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=88:27 end=88:31}
+    method <S <C <U EncryptedProp>> $1><U encrypted_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=89:3 end=89:35}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=89:27 end=89:31}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U ForeignClass>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=35:1 end=35:19}
   class <S <C <U ForeignClass>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=35:7 end=35:19}
@@ -141,8 +141,20 @@ class <C <U <root>>> < <C <U Object>> ()
       argument args<repeated> @ Loc {file=test/testdata/rewriter/prop.rb start=3:20 end=3:24}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=93:1 end=93:9}
+    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=94:1 end=94:9}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+  module <C <U Opus>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> ()
+    module <C <U Opus>><C <U Account>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:20}
+      module <C <U Opus>><C <U Account>><C <U Model>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:27}
+        class <C <U Opus>><C <U Account>><C <U Model>><C <U Merchant>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=80:1 end=80:37}
+        class <C <U Opus>><C <U Account>><C <U Model>><S <C <U Merchant>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:37}
+          type-member(+) <C <U Opus>><C <U Account>><C <U Model>><S <C <U Merchant>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U Opus>><C <U Account>><C <U Model>><S <C <U Merchant>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Opus::Account::Model::Merchant) @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:37}
+          method <C <U Opus>><C <U Account>><C <U Model>><S <C <U Merchant>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=80:1 end=80:42}
+            argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+      class <C <U Opus>><C <U Account>><S <C <U Model>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:27}
+        type-member(+) <C <U Opus>><C <U Account>><S <C <U Model>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U Opus>><C <U Account>><S <C <U Model>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Opus::Account::Model) @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:27}
+    class <C <U Opus>><S <C <U Account>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:20}
+      type-member(+) <C <U Opus>><S <C <U Account>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U Opus>><S <C <U Account>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=Opus::Account) @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:20}
   class <C <U PropHelpers>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=64:1 end=64:18}
     method <C <U PropHelpers>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:15}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
@@ -182,15 +194,15 @@ class <C <U <root>>> < <C <U Object>> ()
     method <S <C <U PropHelpers2>> $1><U timestamped_token_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=74:3 end=74:43}
       argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=74:35 end=74:39}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U ShardingProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=80:1 end=80:19}
-    method <C <U ShardingProp>><U merchant> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=83:3 end=83:16}
+  class <C <U ShardingProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=81:1 end=81:19}
+    method <C <U ShardingProp>><U merchant> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=84:3 end=84:16}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U ShardingProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:19}
-    type-member(+) <S <C <U ShardingProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U ShardingProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=ShardingProp) @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:19}
-    method <S <C <U ShardingProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=80:1 end=84:4}
+  class <S <C <U ShardingProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=81:7 end=81:19}
+    type-member(+) <S <C <U ShardingProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U ShardingProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=ShardingProp) @ Loc {file=test/testdata/rewriter/prop.rb start=81:7 end=81:19}
+    method <S <C <U ShardingProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=81:1 end=85:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <S <C <U ShardingProp>> $1><U merchant_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=82:3 end=82:34}
-      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=82:26 end=82:30}
+    method <S <C <U ShardingProp>> $1><U merchant_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=83:3 end=83:34}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=83:26 end=83:30}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U SomeODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:1 end=23:14}
     method <C <U SomeODM>><U foo> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=27:5 end=27:22}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The current support for merchant_prop wasn't as good as it could be.

### Commit summary

I recommend reviewing the exp files commit by commit.

- **Add a helper for making constants** (c8faa6a93)


- **Pre-define Opus::Account::Model::Merchant** (3ada7862a)


- **Parse merchant_prop with `foreign:` annotation** (61f3c7a08)


- **tools/scripts/update_testdata_exp.sh test/testdata/rewriter/prop.rb** (297e985e4)


- **Add a test to make sure we error if Merchant is missing** (36921d91c)


- **Add a comment** (5505cfb92)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.