### PR TITLE
Introduce FieldRef, a reference type for fields and static fields

### DIFF
--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -100,7 +100,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
         core::SymbolRef global = kv.first;
         LocalRef local = kv.second;
         aliasesPrefix.emplace_back(local, core::LocOffsets::none(), make_unique<Alias>(global));
-        if (global.isField(ctx) || global.isStaticField(ctx)) {
+        if (global.isFieldOrStaticField()) {
             res->minLoops[local.id()] = CFG::MIN_LOOP_FIELD;
         } else {
             res->minLoops[local.id()] = CFG::MIN_LOOP_GLOBAL;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1180,7 +1180,7 @@ MethodRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, co
     return res;
 }
 
-SymbolRef GlobalState::enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
+FieldRef GlobalState::enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
     ENFORCE(name.exists());
 
     auto flags = Symbol::Flags::FIELD;
@@ -1191,7 +1191,7 @@ SymbolRef GlobalState::enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef
     if (store.exists()) {
         ENFORCE((store.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
         counterInc("symbols.hit");
-        return store;
+        return store.asFieldRef();
     }
 
     ENFORCE(!symbolTableFrozen);
@@ -1209,10 +1209,10 @@ SymbolRef GlobalState::enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef
     DEBUG_ONLY(categoryCounterInc("symbols", "field"));
     wasModified_ = true;
 
-    return result;
+    return result.asFieldRef();
 }
 
-SymbolRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
+FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
     ENFORCE(name.exists());
 
     SymbolData ownerScope = owner.dataAllowingNone(*this);
@@ -1223,7 +1223,7 @@ SymbolRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, N
     if (store.exists()) {
         ENFORCE((store.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
         counterInc("symbols.hit");
-        return store;
+        return store.asFieldRef();
     }
 
     ENFORCE(!symbolTableFrozen);
@@ -1241,7 +1241,7 @@ SymbolRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, N
     DEBUG_ONLY(categoryCounterInc("symbols", "static_field"));
     wasModified_ = true;
 
-    return ret;
+    return ret.asFieldRef();
 }
 
 ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRef name) {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -18,6 +18,7 @@ class Symbol;
 class SymbolRef;
 class ClassOrModuleRef;
 class MethodRef;
+class FieldRef;
 class GlobalSubstitution;
 class ErrorQueue;
 struct GlobalStateHash;
@@ -38,6 +39,7 @@ class GlobalState final {
     friend SymbolRef;
     friend ClassOrModuleRef;
     friend MethodRef;
+    friend FieldRef;
     friend File;
     friend FileRef;
     friend GlobalSubstitution;
@@ -91,8 +93,8 @@ public:
     MethodRef enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     MethodRef enterNewMethodOverload(Loc loc, MethodRef original, core::NameRef originalName, u4 num,
                                      const std::vector<bool> &argsToKeep);
-    SymbolRef enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
-    SymbolRef enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
+    FieldRef enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
+    FieldRef enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     ArgInfo &enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRef name);
 
     SymbolRef lookupSymbol(SymbolRef owner, NameRef name) const {
@@ -109,11 +111,11 @@ public:
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::METHOD, Symbols::noMethod()).asMethodRef();
     }
     MethodRef lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name, const std::vector<u4> &methodHash) const;
-    SymbolRef lookupStaticFieldSymbol(ClassOrModuleRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::STATIC_FIELD, Symbols::noField());
+    FieldRef lookupStaticFieldSymbol(ClassOrModuleRef owner, NameRef name) const {
+        return lookupSymbolWithFlags(owner, name, Symbol::Flags::STATIC_FIELD, Symbols::noField()).asFieldRef();
     }
-    SymbolRef lookupFieldSymbol(ClassOrModuleRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::FIELD, Symbols::noField());
+    FieldRef lookupFieldSymbol(ClassOrModuleRef owner, NameRef name) const {
+        return lookupSymbolWithFlags(owner, name, Symbol::Flags::FIELD, Symbols::noField()).asFieldRef();
     }
     SymbolRef findRenamedSymbol(SymbolRef owner, SymbolRef name) const;
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -104,6 +104,36 @@ public:
 };
 CheckSize(MethodRef, 4, 4);
 
+class FieldRef final {
+    u4 _id;
+
+public:
+    FieldRef() : _id(0){};
+    FieldRef(const GlobalState &from, u4 id);
+
+    u4 id() const {
+        return _id;
+    }
+
+    bool exists() const {
+        return _id != 0;
+    }
+
+    static FieldRef fromRaw(u4 id) {
+        FieldRef ref;
+        ref._id = id;
+        return ref;
+    }
+
+    SymbolData data(GlobalState &gs) const;
+    ConstSymbolData data(const GlobalState &gs) const;
+
+    bool operator==(const FieldRef &rhs) const;
+
+    bool operator!=(const FieldRef &rhs) const;
+};
+CheckSize(FieldRef, 4, 4);
+
 class SymbolRef final {
     friend class GlobalState;
     friend class Symbol;
@@ -192,6 +222,7 @@ public:
     // method arguments. This conversion is always safe and never throws.
     SymbolRef(ClassOrModuleRef kls);
     SymbolRef(MethodRef kls);
+    SymbolRef(FieldRef kls);
     SymbolRef() : _id(0){};
 
     // From experimentation, in the common case, methods typically have 2 or fewer arguments.
@@ -221,6 +252,11 @@ public:
     MethodRef asMethodRef() const {
         ENFORCE_NO_TIMER(kind() == Kind::Method);
         return MethodRef::fromRaw(unsafeTableIndex());
+    }
+
+    FieldRef asFieldRef() const {
+        ENFORCE_NO_TIMER(kind() == Kind::FieldOrStaticField);
+        return FieldRef::fromRaw(unsafeTableIndex());
     }
 
     SymbolData data(GlobalState &gs) const;
@@ -493,8 +529,8 @@ public:
         return MethodRef();
     }
 
-    static SymbolRef noField() {
-        return SymbolRef(nullptr, SymbolRef::Kind::FieldOrStaticField, 0);
+    static FieldRef noField() {
+        return FieldRef::fromRaw(0);
     }
 
     static SymbolRef noTypeArgument() {
@@ -522,8 +558,8 @@ public:
         return ClassOrModuleRef::fromRaw(59);
     }
 
-    static SymbolRef Magic_undeclaredFieldStub() {
-        return SymbolRef(nullptr, SymbolRef::Kind::FieldOrStaticField, 1);
+    static FieldRef Magic_undeclaredFieldStub() {
+        return FieldRef::fromRaw(1);
     }
 
     static MethodRef Sorbet_Private_Static_badAliasMethodStub() {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -45,6 +45,14 @@ bool MethodRef::operator!=(const MethodRef &rhs) const {
     return rhs._id != this->_id;
 }
 
+bool FieldRef::operator==(const FieldRef &rhs) const {
+    return rhs._id == this->_id;
+}
+
+bool FieldRef::operator!=(const FieldRef &rhs) const {
+    return rhs._id != this->_id;
+}
+
 vector<TypePtr> Symbol::selfTypeArgs(const GlobalState &gs) const {
     ENFORCE(isClassOrModule()); // should be removed when we have generic methods
     vector<TypePtr> targs;
@@ -266,6 +274,18 @@ ConstSymbolData MethodRef::data(const GlobalState &gs) const {
     return ConstSymbolData(gs.methods[_id], gs);
 }
 
+SymbolData FieldRef::data(GlobalState &gs) const {
+    ENFORCE_NO_TIMER(this->exists());
+    ENFORCE_NO_TIMER(_id < gs.fieldsUsed());
+    return SymbolData(gs.fields[_id], gs);
+}
+
+ConstSymbolData FieldRef::data(const GlobalState &gs) const {
+    ENFORCE_NO_TIMER(this->exists());
+    ENFORCE_NO_TIMER(_id < gs.fieldsUsed());
+    return ConstSymbolData(gs.fields[_id], gs);
+}
+
 bool SymbolRef::isSynthetic() const {
     switch (this->kind()) {
         case Kind::ClassOrModule:
@@ -301,9 +321,13 @@ SymbolRef::SymbolRef(ClassOrModuleRef kls) : SymbolRef(nullptr, SymbolRef::Kind:
 
 SymbolRef::SymbolRef(MethodRef kls) : SymbolRef(nullptr, SymbolRef::Kind::Method, kls.id()) {}
 
+SymbolRef::SymbolRef(FieldRef field) : SymbolRef(nullptr, SymbolRef::Kind::FieldOrStaticField, field.id()) {}
+
 ClassOrModuleRef::ClassOrModuleRef(const GlobalState &from, u4 id) : _id(id) {}
 
 MethodRef::MethodRef(const GlobalState &from, u4 id) : _id(id) {}
+
+FieldRef::FieldRef(const GlobalState &from, u4 id) : _id(id) {}
 
 string SymbolRef::showRaw(const GlobalState &gs) const {
     return dataAllowingNone(gs)->showRaw(gs);

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -58,9 +58,9 @@ public:
 
 class FieldResponse final {
 public:
-    FieldResponse(core::SymbolRef symbol, core::Loc termLoc, core::NameRef name, core::TypeAndOrigins retType)
+    FieldResponse(core::FieldRef symbol, core::Loc termLoc, core::NameRef name, core::TypeAndOrigins retType)
         : symbol(symbol), termLoc(termLoc), name(name), retType(std::move(retType)){};
-    const core::SymbolRef symbol;
+    const core::FieldRef symbol;
     const core::Loc termLoc;
     const core::NameRef name;
     const core::TypeAndOrigins retType;

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -67,12 +67,13 @@ ast::ExpressionPtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, 
 
         auto sym = klass.data(ctx)->findMemberTransitive(ctx, id.name);
         const core::lsp::Query &lspQuery = ctx.state.lspQuery;
-        if (sym.exists() && (lspQuery.matchesSymbol(sym) || lspQuery.matchesLoc(core::Loc(ctx.file, id.loc)))) {
+        if (sym.exists() && sym.isFieldOrStaticField() &&
+            (lspQuery.matchesSymbol(sym) || lspQuery.matchesLoc(core::Loc(ctx.file, id.loc)))) {
             core::TypeAndOrigins tp;
             tp.type = sym.data(ctx)->resultType;
             tp.origins.emplace_back(sym.data(ctx)->loc());
             core::lsp::QueryResponse::pushQueryResponse(
-                ctx, core::lsp::FieldResponse(sym, core::Loc(ctx.file, id.loc), id.name, tp));
+                ctx, core::lsp::FieldResponse(sym.asFieldRef(), core::Loc(ctx.file, id.loc), id.name, tp));
         }
     }
     return tree;

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -380,7 +380,7 @@ AccessorInfo LSPTask::getAccessorInfo(const core::GlobalState &gs, core::SymbolR
         if (!symbol.isField(gs)) {
             return info;
         }
-        info.fieldSymbol = symbol;
+        info.fieldSymbol = symbol.asFieldRef();
         baseName = string_view(symbolName).substr(1);
     } else if (absl::EndsWith(symbolName, "=")) {
         if (!symbol.data(gs)->isMethod()) {

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -18,7 +18,7 @@ enum class FieldAccessorType { None, Reader, Writer, Accessor };
 struct AccessorInfo {
     core::NameRef type;
     FieldAccessorType accessorType = FieldAccessorType::None;
-    core::SymbolRef fieldSymbol;
+    core::FieldRef fieldSymbol;
     core::MethodRef readerSymbol;
     core::MethodRef writerSymbol;
 };

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1235,7 +1235,7 @@ class SymbolDefiner {
         }
     }
 
-    core::SymbolRef insertStaticField(core::MutableContext ctx, const FoundStaticField &staticField) {
+    core::FieldRef insertStaticField(core::MutableContext ctx, const FoundStaticField &staticField) {
         // forbid dynamic constant definition
         auto ownerData = ctx.owner.data(ctx);
         if (!ownerData->isClassOrModule() && !ownerData->isRewriterSynthesized()) {
@@ -1265,7 +1265,7 @@ class SymbolDefiner {
         }
         sym = ctx.state.enterStaticFieldSymbol(core::Loc(ctx.file, staticField.lhsLoc), scope, name);
 
-        if (staticField.isTypeAlias && sym.isStaticField(ctx)) {
+        if (staticField.isTypeAlias) {
             sym.data(ctx)->setTypeAlias();
         }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1207,13 +1207,13 @@ class ResolveTypeMembersAndFieldsWalk {
     };
 
     struct ResolveSimpleStaticFieldItem {
-        core::SymbolRef sym;
+        core::FieldRef sym;
         core::TypePtr resultType;
     };
 
     struct ResolveStaticFieldItem {
         core::FileRef file;
-        core::SymbolRef sym;
+        core::FieldRef sym;
         ast::Assign *asgn;
     };
 
@@ -1392,7 +1392,7 @@ class ResolveTypeMembersAndFieldsWalk {
                 return;
             }
         }
-        core::SymbolRef var;
+        core::FieldRef var;
 
         if (uid->kind == ast::UnresolvedIdent::Kind::Class) {
             var = ctx.state.enterStaticFieldSymbol(core::Loc(job.file, uid->loc), scope, uid->name);
@@ -2184,10 +2184,11 @@ public:
 
             todoAssigns_.emplace_back(ResolveAssignItem{ctx.owner, sym, send, dependencies_, ctx.file});
         } else if (data->isStaticField()) {
-            ResolveStaticFieldItem job{ctx.file, sym, &asgn};
+            ResolveStaticFieldItem job{ctx.file, sym.asFieldRef(), &asgn};
             auto resultType = tryResolveStaticField(ctx, job);
             if (resultType != core::Types::todo()) {
-                todoResolveSimpleStaticFieldItems_.emplace_back(ResolveSimpleStaticFieldItem{sym, resultType});
+                todoResolveSimpleStaticFieldItems_.emplace_back(
+                    ResolveSimpleStaticFieldItem{sym.asFieldRef(), resultType});
             } else {
                 todoResolveStaticFieldItems_.emplace_back(move(job));
             }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Introduces `FieldRef`, a specialized `SymbolRef`-like class for fields and static fields.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Delurk usages of `SymbolRef::data()` so that we can ultimately have different `Symbol` classes per `Symbol` type.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
