### PR TITLE
Introduce TypeArgumentRef and TypeMemberRef.

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -19,6 +19,8 @@ class SymbolRef;
 class ClassOrModuleRef;
 class MethodRef;
 class FieldRef;
+class TypeArgumentRef;
+class TypeMemberRef;
 class GlobalSubstitution;
 class ErrorQueue;
 struct GlobalStateHash;
@@ -39,6 +41,8 @@ class GlobalState final {
     friend SymbolRef;
     friend ClassOrModuleRef;
     friend MethodRef;
+    friend TypeMemberRef;
+    friend TypeArgumentRef;
     friend FieldRef;
     friend File;
     friend FileRef;
@@ -88,8 +92,8 @@ public:
     ~GlobalState() = default;
 
     ClassOrModuleRef enterClassSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
-    SymbolRef enterTypeMember(Loc loc, ClassOrModuleRef owner, NameRef name, Variance variance);
-    SymbolRef enterTypeArgument(Loc loc, MethodRef owner, NameRef name, Variance variance);
+    TypeMemberRef enterTypeMember(Loc loc, ClassOrModuleRef owner, NameRef name, Variance variance);
+    TypeArgumentRef enterTypeArgument(Loc loc, MethodRef owner, NameRef name, Variance variance);
     MethodRef enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     MethodRef enterNewMethodOverload(Loc loc, MethodRef original, core::NameRef originalName, u4 num,
                                      const std::vector<bool> &argsToKeep);
@@ -100,8 +104,9 @@ public:
     SymbolRef lookupSymbol(SymbolRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, 0, Symbols::noSymbol());
     }
-    SymbolRef lookupTypeMemberSymbol(ClassOrModuleRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::TYPE_MEMBER, Symbols::noTypeMember());
+    TypeMemberRef lookupTypeMemberSymbol(ClassOrModuleRef owner, NameRef name) const {
+        return lookupSymbolWithFlags(owner, name, Symbol::Flags::TYPE_MEMBER, Symbols::noTypeMember())
+            .asTypeMemberRef();
     }
     ClassOrModuleRef lookupClassSymbol(ClassOrModuleRef owner, NameRef name) const {
         return lookupSymbolWithFlags(owner, name, Symbol::Flags::CLASS_OR_MODULE, Symbols::noClassOrModule())

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -134,6 +134,66 @@ public:
 };
 CheckSize(FieldRef, 4, 4);
 
+class TypeMemberRef final {
+    u4 _id;
+
+public:
+    TypeMemberRef() : _id(0){};
+    TypeMemberRef(const GlobalState &from, u4 id);
+
+    u4 id() const {
+        return _id;
+    }
+
+    bool exists() const {
+        return _id != 0;
+    }
+
+    static TypeMemberRef fromRaw(u4 id) {
+        TypeMemberRef ref;
+        ref._id = id;
+        return ref;
+    }
+
+    SymbolData data(GlobalState &gs) const;
+    ConstSymbolData data(const GlobalState &gs) const;
+
+    bool operator==(const TypeMemberRef &rhs) const;
+
+    bool operator!=(const TypeMemberRef &rhs) const;
+};
+CheckSize(TypeMemberRef, 4, 4);
+
+class TypeArgumentRef final {
+    u4 _id;
+
+public:
+    TypeArgumentRef() : _id(0){};
+    TypeArgumentRef(const GlobalState &from, u4 id);
+
+    u4 id() const {
+        return _id;
+    }
+
+    bool exists() const {
+        return _id != 0;
+    }
+
+    static TypeArgumentRef fromRaw(u4 id) {
+        TypeArgumentRef ref;
+        ref._id = id;
+        return ref;
+    }
+
+    SymbolData data(GlobalState &gs) const;
+    ConstSymbolData data(const GlobalState &gs) const;
+
+    bool operator==(const TypeArgumentRef &rhs) const;
+
+    bool operator!=(const TypeArgumentRef &rhs) const;
+};
+CheckSize(TypeArgumentRef, 4, 4);
+
 class SymbolRef final {
     friend class GlobalState;
     friend class Symbol;
@@ -223,6 +283,8 @@ public:
     SymbolRef(ClassOrModuleRef kls);
     SymbolRef(MethodRef kls);
     SymbolRef(FieldRef kls);
+    SymbolRef(TypeMemberRef kls);
+    SymbolRef(TypeArgumentRef kls);
     SymbolRef() : _id(0){};
 
     // From experimentation, in the common case, methods typically have 2 or fewer arguments.
@@ -257,6 +319,16 @@ public:
     FieldRef asFieldRef() const {
         ENFORCE_NO_TIMER(kind() == Kind::FieldOrStaticField);
         return FieldRef::fromRaw(unsafeTableIndex());
+    }
+
+    TypeMemberRef asTypeMemberRef() const {
+        ENFORCE_NO_TIMER(kind() == Kind::TypeMember);
+        return TypeMemberRef::fromRaw(unsafeTableIndex());
+    }
+
+    TypeArgumentRef asTypeArgumentRef() const {
+        ENFORCE_NO_TIMER(kind() == Kind::TypeArgument);
+        return TypeArgumentRef::fromRaw(unsafeTableIndex());
     }
 
     SymbolData data(GlobalState &gs) const;
@@ -533,25 +605,30 @@ public:
         return FieldRef::fromRaw(0);
     }
 
-    static SymbolRef noTypeArgument() {
-        return SymbolRef(nullptr, SymbolRef::Kind::TypeArgument, 0);
+    static TypeArgumentRef noTypeArgument() {
+        return TypeArgumentRef::fromRaw(0);
     }
 
-    static SymbolRef noTypeMember() {
-        return SymbolRef(nullptr, SymbolRef::Kind::TypeMember, 0);
+    static TypeMemberRef noTypeMember() {
+        return TypeMemberRef::fromRaw(0);
     }
 
     static MethodRef Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder() {
         return MethodRef::fromRaw(1);
     }
 
-    static SymbolRef
+    static TypeArgumentRef
     Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_contravariant() {
-        return SymbolRef(nullptr, SymbolRef::Kind::TypeArgument, 1);
+        return TypeArgumentRef::fromRaw(1);
     }
 
-    static SymbolRef Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_covariant() {
-        return SymbolRef(nullptr, SymbolRef::Kind::TypeArgument, 2);
+    static TypeArgumentRef
+    Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_covariant() {
+        return TypeArgumentRef::fromRaw(2);
+    }
+
+    static TypeArgumentRef todoTypeArgument() {
+        return TypeArgumentRef::fromRaw(3);
     }
 
     static ClassOrModuleRef T_Sig() {
@@ -727,7 +804,7 @@ public:
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 200;
     static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 36;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 3;
-    static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 3;
+    static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 97;
 };
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -53,6 +53,22 @@ bool FieldRef::operator!=(const FieldRef &rhs) const {
     return rhs._id != this->_id;
 }
 
+bool TypeMemberRef::operator==(const TypeMemberRef &rhs) const {
+    return rhs._id == this->_id;
+}
+
+bool TypeMemberRef::operator!=(const TypeMemberRef &rhs) const {
+    return rhs._id != this->_id;
+}
+
+bool TypeArgumentRef::operator==(const TypeArgumentRef &rhs) const {
+    return rhs._id == this->_id;
+}
+
+bool TypeArgumentRef::operator!=(const TypeArgumentRef &rhs) const {
+    return rhs._id != this->_id;
+}
+
 vector<TypePtr> Symbol::selfTypeArgs(const GlobalState &gs) const {
     ENFORCE(isClassOrModule()); // should be removed when we have generic methods
     vector<TypePtr> targs;
@@ -286,6 +302,30 @@ ConstSymbolData FieldRef::data(const GlobalState &gs) const {
     return ConstSymbolData(gs.fields[_id], gs);
 }
 
+SymbolData TypeMemberRef::data(GlobalState &gs) const {
+    ENFORCE_NO_TIMER(this->exists());
+    ENFORCE_NO_TIMER(_id < gs.typeMembersUsed());
+    return SymbolData(gs.typeMembers[_id], gs);
+}
+
+ConstSymbolData TypeMemberRef::data(const GlobalState &gs) const {
+    ENFORCE_NO_TIMER(this->exists());
+    ENFORCE_NO_TIMER(_id < gs.typeMembersUsed());
+    return ConstSymbolData(gs.typeMembers[_id], gs);
+}
+
+SymbolData TypeArgumentRef::data(GlobalState &gs) const {
+    ENFORCE_NO_TIMER(this->exists());
+    ENFORCE_NO_TIMER(_id < gs.typeArgumentsUsed());
+    return SymbolData(gs.typeArguments[_id], gs);
+}
+
+ConstSymbolData TypeArgumentRef::data(const GlobalState &gs) const {
+    ENFORCE_NO_TIMER(this->exists());
+    ENFORCE_NO_TIMER(_id < gs.typeArgumentsUsed());
+    return ConstSymbolData(gs.typeArguments[_id], gs);
+}
+
 bool SymbolRef::isSynthetic() const {
     switch (this->kind()) {
         case Kind::ClassOrModule:
@@ -323,11 +363,19 @@ SymbolRef::SymbolRef(MethodRef kls) : SymbolRef(nullptr, SymbolRef::Kind::Method
 
 SymbolRef::SymbolRef(FieldRef field) : SymbolRef(nullptr, SymbolRef::Kind::FieldOrStaticField, field.id()) {}
 
+SymbolRef::SymbolRef(TypeMemberRef typeMember) : SymbolRef(nullptr, SymbolRef::Kind::TypeMember, typeMember.id()) {}
+
+SymbolRef::SymbolRef(TypeArgumentRef typeArg) : SymbolRef(nullptr, SymbolRef::Kind::TypeArgument, typeArg.id()) {}
+
 ClassOrModuleRef::ClassOrModuleRef(const GlobalState &from, u4 id) : _id(id) {}
 
 MethodRef::MethodRef(const GlobalState &from, u4 id) : _id(id) {}
 
 FieldRef::FieldRef(const GlobalState &from, u4 id) : _id(id) {}
+
+TypeMemberRef::TypeMemberRef(const GlobalState &from, u4 id) : _id(id) {}
+
+TypeArgumentRef::TypeArgumentRef(const GlobalState &from, u4 id) : _id(id) {}
 
 string SymbolRef::showRaw(const GlobalState &gs) const {
     return dataAllowingNone(gs)->showRaw(gs);

--- a/core/TypeConstraint.cc
+++ b/core/TypeConstraint.cc
@@ -137,7 +137,7 @@ bool TypeConstraint::isAlreadyASubType(const GlobalState &gs, const TypePtr &t1,
     }
 }
 
-TypePtr TypeConstraint::getInstantiation(SymbolRef sym) const {
+TypePtr TypeConstraint::getInstantiation(TypeArgumentRef sym) const {
     ENFORCE(wasSolved);
     return findSolution(sym);
 }
@@ -157,7 +157,7 @@ TypeConstraint TypeConstraint::makeEmptyFrozenConstraint() {
 
 TypeConstraint TypeConstraint::EmptyFrozenConstraint(makeEmptyFrozenConstraint());
 
-bool TypeConstraint::hasUpperBound(SymbolRef forWhat) const {
+bool TypeConstraint::hasUpperBound(TypeArgumentRef forWhat) const {
     for (auto &entry : this->upperBounds) {
         if (entry.first == forWhat) {
             return true;
@@ -166,7 +166,7 @@ bool TypeConstraint::hasUpperBound(SymbolRef forWhat) const {
     return false;
 }
 
-bool TypeConstraint::hasLowerBound(SymbolRef forWhat) const {
+bool TypeConstraint::hasLowerBound(TypeArgumentRef forWhat) const {
     for (auto &entry : this->lowerBounds) {
         if (entry.first == forWhat) {
             return true;
@@ -175,7 +175,7 @@ bool TypeConstraint::hasLowerBound(SymbolRef forWhat) const {
     return false;
 }
 
-TypePtr &TypeConstraint::findUpperBound(SymbolRef forWhat) {
+TypePtr &TypeConstraint::findUpperBound(TypeArgumentRef forWhat) {
     for (auto &entry : this->upperBounds) {
         if (entry.first == forWhat) {
             return entry.second;
@@ -186,7 +186,7 @@ TypePtr &TypeConstraint::findUpperBound(SymbolRef forWhat) {
     return inserted.second;
 }
 
-TypePtr &TypeConstraint::findLowerBound(SymbolRef forWhat) {
+TypePtr &TypeConstraint::findLowerBound(TypeArgumentRef forWhat) {
     for (auto &entry : this->lowerBounds) {
         if (entry.first == forWhat) {
             return entry.second;
@@ -197,7 +197,7 @@ TypePtr &TypeConstraint::findLowerBound(SymbolRef forWhat) {
     return inserted.second;
 }
 
-TypePtr &TypeConstraint::findSolution(SymbolRef forWhat) {
+TypePtr &TypeConstraint::findSolution(TypeArgumentRef forWhat) {
     for (auto &entry : this->solution) {
         if (entry.first == forWhat) {
             return entry.second;
@@ -208,7 +208,7 @@ TypePtr &TypeConstraint::findSolution(SymbolRef forWhat) {
     return inserted.second;
 }
 
-TypePtr TypeConstraint::findUpperBound(SymbolRef forWhat) const {
+TypePtr TypeConstraint::findUpperBound(TypeArgumentRef forWhat) const {
     for (auto &entry : this->upperBounds) {
         if (entry.first == forWhat) {
             return entry.second;
@@ -217,7 +217,7 @@ TypePtr TypeConstraint::findUpperBound(SymbolRef forWhat) const {
     Exception::raise("should never happen");
 }
 
-TypePtr TypeConstraint::findLowerBound(SymbolRef forWhat) const {
+TypePtr TypeConstraint::findLowerBound(TypeArgumentRef forWhat) const {
     for (auto &entry : this->lowerBounds) {
         if (entry.first == forWhat) {
             return entry.second;
@@ -226,7 +226,7 @@ TypePtr TypeConstraint::findLowerBound(SymbolRef forWhat) const {
     Exception::raise("should never happen");
 }
 
-TypePtr TypeConstraint::findSolution(SymbolRef forWhat) const {
+TypePtr TypeConstraint::findSolution(TypeArgumentRef forWhat) const {
     for (auto &entry : this->solution) {
         if (entry.first == forWhat) {
             return entry.second;
@@ -244,17 +244,17 @@ InlinedVector<SymbolRef, 4> TypeConstraint::getDomain() const {
     return ret;
 }
 
-UnorderedMap<SymbolRef, std::pair<TypePtr, TypePtr>> TypeConstraint::collateBounds(const GlobalState &gs) const {
-    auto collated = UnorderedMap<SymbolRef, pair<TypePtr, TypePtr>>{};
+UnorderedMap<TypeArgumentRef, std::pair<TypePtr, TypePtr>> TypeConstraint::collateBounds(const GlobalState &gs) const {
+    auto collated = UnorderedMap<TypeArgumentRef, pair<TypePtr, TypePtr>>{};
 
     for (const auto &[sym, lowerBound] : this->lowerBounds) {
         auto &[lowerRef, _upperRef] = collated[sym];
-        ENFORCE(lowerRef == nullptr, "{} in lowerBounds twice?", sym.show(gs));
+        ENFORCE(lowerRef == nullptr, "{} in lowerBounds twice?", sym.data(gs)->show(gs));
         lowerRef = lowerBound;
     }
     for (const auto &[sym, upperBound] : this->upperBounds) {
         auto &[_lowerRef, upperRef] = collated[sym];
-        ENFORCE(upperRef == nullptr, "{} in upperBounds twice?", sym.show(gs));
+        ENFORCE(upperRef == nullptr, "{} in upperBounds twice?", sym.data(gs)->show(gs));
         upperRef = upperBound;
     }
 
@@ -277,7 +277,7 @@ string TypeConstraint::toString(const core::GlobalState &gs) const {
     fmt::format_to(buf, "solution: [{}]\n",
                    fmt::map_join(
                        this->solution.begin(), this->solution.end(), ", ", [&gs](auto pair) -> auto {
-                           return fmt::format("{}: {}", pair.first.show(gs), pair.second.show(gs));
+                           return fmt::format("{}: {}", pair.first.data(gs)->show(gs), pair.second.show(gs));
                        }));
     return to_string(buf);
 }

--- a/core/TypeConstraint.h
+++ b/core/TypeConstraint.h
@@ -8,27 +8,27 @@ namespace sorbet::core {
 
 class TypeConstraint {
     static TypeConstraint makeEmptyFrozenConstraint();
-    std::vector<std::pair<SymbolRef, TypePtr>> upperBounds;
-    std::vector<std::pair<SymbolRef, TypePtr>> lowerBounds;
-    std::vector<std::pair<SymbolRef, TypePtr>> solution;
+    std::vector<std::pair<TypeArgumentRef, TypePtr>> upperBounds;
+    std::vector<std::pair<TypeArgumentRef, TypePtr>> lowerBounds;
+    std::vector<std::pair<TypeArgumentRef, TypePtr>> solution;
     bool wasSolved = false;
     bool cantSolve = false;
-    TypePtr &findUpperBound(SymbolRef forWhat);
-    TypePtr &findLowerBound(SymbolRef forWhat);
-    TypePtr &findSolution(SymbolRef forWhat);
+    TypePtr &findUpperBound(TypeArgumentRef forWhat);
+    TypePtr &findLowerBound(TypeArgumentRef forWhat);
+    TypePtr &findSolution(TypeArgumentRef forWhat);
 
-    UnorderedMap<SymbolRef, std::pair<TypePtr, TypePtr>> collateBounds(const GlobalState &gs) const;
+    UnorderedMap<TypeArgumentRef, std::pair<TypePtr, TypePtr>> collateBounds(const GlobalState &gs) const;
 
 public:
     TypeConstraint() = default;
     TypeConstraint(const TypeConstraint &) = delete;
     TypeConstraint(TypeConstraint &&) = default;
     void defineDomain(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &typeParams);
-    bool hasUpperBound(SymbolRef forWhat) const;
-    bool hasLowerBound(SymbolRef forWhat) const;
-    TypePtr findSolution(SymbolRef forWhat) const;
-    TypePtr findUpperBound(SymbolRef forWhat) const;
-    TypePtr findLowerBound(SymbolRef forWhat) const;
+    bool hasUpperBound(TypeArgumentRef forWhat) const;
+    bool hasLowerBound(TypeArgumentRef forWhat) const;
+    TypePtr findSolution(TypeArgumentRef forWhat) const;
+    TypePtr findUpperBound(TypeArgumentRef forWhat) const;
+    TypePtr findLowerBound(TypeArgumentRef forWhat) const;
 
     bool isEmpty() const;
     inline bool isSolved() const {
@@ -42,7 +42,7 @@ public:
     bool isAlreadyASubType(const GlobalState &gs, const TypePtr &, const TypePtr &) const;
     // returns true if was successfully solved
     bool solve(const GlobalState &gs);
-    TypePtr getInstantiation(SymbolRef) const;
+    TypePtr getInstantiation(TypeArgumentRef) const;
     std::unique_ptr<TypeConstraint> deepCopy() const;
     InlinedVector<SymbolRef, 4> getDomain() const;
     static TypeConstraint EmptyFrozenConstraint;

--- a/core/Types.h
+++ b/core/Types.h
@@ -363,14 +363,14 @@ template <> inline ClassType cast_type_nonnull<ClassType>(const TypePtr &what) {
  */
 TYPE(LambdaParam) final {
 public:
-    SymbolRef definition;
+    TypeMemberRef definition;
 
     // The type bounds provided in the definition of the type_member or
     // type_template.
     TypePtr lowerBound;
     TypePtr upperBound;
 
-    LambdaParam(SymbolRef definition, TypePtr lower, TypePtr upper);
+    LambdaParam(TypeMemberRef definition, TypePtr lower, TypePtr upper);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
     u4 hash(const GlobalState &gs) const;
@@ -553,8 +553,8 @@ template <> inline LiteralType cast_type_nonnull<LiteralType>(const TypePtr &wha
  */
 TYPE(TypeVar) final {
 public:
-    SymbolRef sym;
-    TypeVar(SymbolRef sym);
+    TypeArgumentRef sym;
+    TypeVar(TypeArgumentRef sym);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
     u4 hash(const GlobalState &gs) const;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -401,7 +401,7 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
             auto &lp = cast_type_nonnull<LambdaParam>(what);
             pickle(p, lp.lowerBound);
             pickle(p, lp.upperBound);
-            p.putU4(lp.definition.rawId());
+            p.putU4(lp.definition.id());
             break;
         }
         case TypePtr::Tag::AppliedType: {
@@ -415,7 +415,7 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
         }
         case TypePtr::Tag::TypeVar: {
             auto &tp = cast_type_nonnull<TypeVar>(what);
-            p.putU4(tp.sym.rawId());
+            p.putU4(tp.sym.id());
             break;
         }
         case TypePtr::Tag::SelfType: {
@@ -487,7 +487,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
         case TypePtr::Tag::LambdaParam: {
             auto lower = unpickleType(p, gs);
             auto upper = unpickleType(p, gs);
-            return make_type<LambdaParam>(SymbolRef::fromRaw(p.getU4()), lower, upper);
+            return make_type<LambdaParam>(TypeMemberRef::fromRaw(p.getU4()), lower, upper);
         }
         case TypePtr::Tag::AppliedType: {
             auto klass = ClassOrModuleRef::fromRaw(p.getU4());
@@ -499,7 +499,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
             return make_type<AppliedType>(klass, move(targs));
         }
         case TypePtr::Tag::TypeVar: {
-            auto sym = SymbolRef::fromRaw(p.getU4());
+            auto sym = TypeArgumentRef::fromRaw(p.getU4());
             return make_type<TypeVar>(sym);
         }
         case TypePtr::Tag::SelfType: {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -419,6 +419,7 @@ NameDef names[] = {
     {"Module", "Module", true},
     {"Todo", "<todo sym>", true},
     {"TodoMethod", "<todo method>", false},
+    {"TodoTypeArgument", "<todo typeargument>", true},
     {"NoSymbol", "<none>", true},
     {"noFieldOrStaticField", "<no-field-or-static-field>", false},
     {"noMethod", "<no-method>", false},

--- a/core/types/hashing.cc
+++ b/core/types/hashing.cc
@@ -88,7 +88,7 @@ u4 OrType::hash(const GlobalState &gs) const {
 
 u4 TypeVar::hash(const GlobalState &gs) const {
     u4 result = static_cast<u4>(TypePtr::Tag::TypeVar);
-    return mix(result, sym.rawId());
+    return mix(result, sym.id());
 }
 
 u4 AppliedType::hash(const GlobalState &gs) const {
@@ -102,7 +102,7 @@ u4 AppliedType::hash(const GlobalState &gs) const {
 
 u4 LambdaParam::hash(const GlobalState &gs) const {
     u4 result = static_cast<u4>(TypePtr::Tag::LambdaParam);
-    result = mix(result, this->definition.rawId());
+    result = mix(result, this->definition.id());
     result = mix(result, this->upperBound.hash(gs));
     // Lowerbound might not be set.
     result = mix(result, this->lowerBound == nullptr ? 0 : this->lowerBound.hash(gs));

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -571,7 +571,7 @@ bool TypeVar::derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const {
     Exception::raise("should never happen. You're missing a call to either Types::approximate or Types::instantiate");
 }
 
-TypeVar::TypeVar(SymbolRef sym) : sym(sym) {
+TypeVar::TypeVar(TypeArgumentRef sym) : sym(sym) {
     categoryCounterInc("types.allocated", "typevar");
 }
 
@@ -597,7 +597,7 @@ bool AppliedType::derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) con
     return und.derivesFrom(gs, klass);
 }
 
-LambdaParam::LambdaParam(const SymbolRef definition, TypePtr lowerBound, TypePtr upperBound)
+LambdaParam::LambdaParam(const TypeMemberRef definition, TypePtr lowerBound, TypePtr upperBound)
     : definition(definition), lowerBound(lowerBound), upperBound(upperBound) {
     categoryCounterInc("types.allocated", "lambdatypeparam");
 }

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -138,9 +138,6 @@ private:
             // This is where the actual variance checks are done.
             [&](const core::LambdaParam &param) {
                 auto paramData = param.definition.data(ctx);
-
-                ENFORCE(paramData->isTypeMember());
-
                 auto paramVariance = paramData->variance();
 
                 if (!hasCompatibleVariance(polarity, paramVariance)) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1304,7 +1304,7 @@ class SymbolDefiner {
             }
         }
 
-        core::SymbolRef sym;
+        core::TypeMemberRef sym;
         auto existingTypeMember = ctx.state.lookupTypeMemberSymbol(onSymbol, typeMember.name);
         if (existingTypeMember.exists()) {
             // if we already have a type member but it was constructed in a different file from the one we're
@@ -1359,7 +1359,7 @@ class SymbolDefiner {
                 }
                 auto alias =
                     ctx.state.enterStaticFieldSymbol(core::Loc(ctx.file, typeMember.asgnLoc), context, typeMember.name);
-                alias.data(ctx)->resultType = core::make_type<core::AliasType>(sym);
+                alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(sym));
             }
         }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -391,12 +391,12 @@ private:
     }
 
     static bool resolveTypeAliasJob(core::MutableContext ctx, TypeAliasResolutionItem &job) {
-        core::SymbolRef enclosingTypeMember;
+        core::TypeMemberRef enclosingTypeMember;
         core::ClassOrModuleRef enclosingClass = job.lhs.data(ctx)->enclosingClass(ctx);
         while (enclosingClass != core::Symbols::root()) {
             auto typeMembers = enclosingClass.data(ctx)->typeMembers();
             if (!typeMembers.empty()) {
-                enclosingTypeMember = typeMembers[0];
+                enclosingTypeMember = typeMembers[0].asTypeMemberRef();
                 break;
             }
             enclosingClass = enclosingClass.data(ctx)->owner.data(ctx)->enclosingClass(ctx);
@@ -1475,7 +1475,7 @@ class ResolveTypeMembersAndFieldsWalk {
         return data->resultType;
     }
 
-    static void resolveTypeMember(core::MutableContext ctx, core::SymbolRef lhs, ast::Send *rhs,
+    static void resolveTypeMember(core::MutableContext ctx, core::TypeMemberRef lhs, ast::Send *rhs,
                                   vector<bool> &resolvedAttachedClasses) {
         auto data = lhs.data(ctx);
         auto owner = data->owner;
@@ -1656,7 +1656,7 @@ class ResolveTypeMembersAndFieldsWalk {
                 return false;
             }
 
-            resolveTypeMember(ctx.withOwner(job.owner), job.lhs, job.rhs, resolvedAttachedClasses);
+            resolveTypeMember(ctx.withOwner(job.owner), job.lhs.asTypeMemberRef(), job.rhs, resolvedAttachedClasses);
         } else {
             resolveTypeAlias(ctx.withOwner(job.owner), job.lhs, job.rhs);
         }
@@ -2332,7 +2332,8 @@ public:
                     auto data = job.lhs.data(gs);
 
                     if (data->isTypeMember()) {
-                        data->resultType = core::make_type<core::LambdaParam>(job.lhs, core::Types::untypedUntracked(),
+                        data->resultType = core::make_type<core::LambdaParam>(job.lhs.asTypeMemberRef(),
+                                                                              core::Types::untypedUntracked(),
                                                                               core::Types::untypedUntracked());
                     } else {
                         data->resultType = core::Types::untypedUntracked();

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -168,7 +168,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                                                 name.show(ctx));
                                 }
                             }
-                            typeArgSpec.type = core::make_type<core::TypeVar>(core::Symbols::todo());
+                            typeArgSpec.type = core::make_type<core::TypeVar>(core::Symbols::todoTypeArgument());
                             typeArgSpec.loc = core::Loc(ctx.file, arg.loc());
                         } else {
                             if (auto e = ctx.beginError(arg.loc(), core::errors::Resolver::InvalidMethodSignature)) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Introduce TypeArgumentRef and TypeMemberRef.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduce usage of SymbolRef::data() so we can eventually specialize Symbol classes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
