### PR TITLE
Change wording in `T.must` error message

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1288,7 +1288,12 @@ public:
         auto ret = Types::approximateSubtract(gs, args.args[0]->type, Types::nilClass());
         if (ret == args.args[0]->type) {
             if (auto e = gs.beginError(loc, errors::Infer::InvalidCast)) {
-                e.setHeader("`{}` called on `{}`, which is never `{}`", "T.must", args.args[0]->type.show(gs), "nil");
+                if (args.args[0]->type.isUntyped()) {
+                    e.setHeader("`{}` called on `{}`, which is redundant", "T.must", args.args[0]->type.show(gs));
+                } else {
+                    e.setHeader("`{}` called on `{}`, which is never `{}`", "T.must", args.args[0]->type.show(gs),
+                                "nil");
+                }
                 e.addErrorSection(args.args[0]->explainGot(gs, args.originForUninitialized));
                 const auto locWithoutTMust = Loc{loc.file(), loc.beginPos() + 7, loc.endPos() - 1};
                 e.replaceWith("Remove `T.must`", loc, "{}", locWithoutTMust.source(gs));

--- a/test/testdata/infer/must_untyped.rb
+++ b/test/testdata/infer/must_untyped.rb
@@ -1,3 +1,3 @@
 # typed: strict
 
-T.must(T.unsafe(nil)) # error: `T.must` called on `T.untyped`, which is never `nil`
+T.must(T.unsafe(nil)) # error: `T.must` called on `T.untyped`, which is redundant

--- a/test/testdata/infer/must_untyped.rb
+++ b/test/testdata/infer/must_untyped.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+T.must(T.unsafe(nil)) # error: `T.must` called on `T.untyped`, which is never `nil`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I changed this error message in #3902 but I didn't realize that I made it become
technically nonsensical. It used to say:

    T.must(): Expected a `T.nilable` type, got: ...

which, while ugly, was at least never wrong.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Review by commit to see the diff to the tests.