### PR TITLE
add early filtering of final method names for final method checking

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -104,7 +104,7 @@ module T::Private::Methods
       return
     end
     source_method_names.filter! do |method_name|
-      self.was_ever_final?(method_name)
+      was_ever_final?(method_name)
     end
     if source_method_names.empty?
       return

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -11,6 +11,9 @@ module T::Private::Methods
   # - they are done possibly before any sig block has run.
   # - they are done even if the method being defined doesn't have a sig.
   @final_methods = Set.new
+  # stores method names that were declared final without regard for where.
+  # enables early rejection of names that we know can't induce final method violations.
+  @was_ever_final_names = Set.new
   # a non-singleton is a module for which at least one of the following is true:
   # - is declared final
   # - defines a method that is declared final
@@ -100,6 +103,12 @@ module T::Private::Methods
     if !module_with_final?(target)
       return
     end
+    source_method_names.filter! do |method_name|
+      self.was_ever_final?(method_name)
+    end
+    if source_method_names.empty?
+      return
+    end
     # use reverse_each to check farther-up ancestors first, for better error messages. we could avoid this if we were on
     # the version of ruby that adds the optional argument to method_defined? that allows you to exclude ancestors.
     target_ancestors.reverse_each do |ancestor|
@@ -147,6 +156,14 @@ module T::Private::Methods
 
   private_class_method def self.final_method?(method_key)
     @final_methods.include?(method_key)
+  end
+
+  private_class_method def self.add_was_ever_final(method_name)
+    @was_ever_final_names.add(method_name)
+  end
+
+  private_class_method def self.was_ever_final?(method_name)
+    @was_ever_final_names.include?(method_name)
   end
 
   def self.add_module_with_final(mod)
@@ -230,6 +247,7 @@ module T::Private::Methods
     @sig_wrappers[key] = sig_block
     if current_declaration.final
       add_final_method(key)
+      add_was_ever_final(method_name)
       # use hook_mod, not mod, because for example, we want class C to be marked as having final if we def C.foo as
       # final. change this to mod to see some final_method tests fail.
       add_module_with_final(hook_mod)
@@ -412,6 +430,8 @@ module T::Private::Methods
     if !module_with_final?(target) && !module_with_final?(source)
       return
     end
+    # we do not need to call add_was_ever_final here, because we have already marked
+    # any such methods when source was originally defined.
     add_module_with_final(target)
     install_hooks(target)
     _check_final_ancestors(target, target_ancestors - source.ancestors, source.instance_methods)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR attempts to make the inner loop of final method checking less costly by filtering out names that we've never seen declared as `final`.  Ideally, this should make `_on_method_added` checking much faster by never having to enter the doubly-nested loop in `_check_final_ancestors`, and the module-level checking we need to do much faster by reducing the number of method names we need to check for every ancestor.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
