### PR TITLE
Move enclosingClass to SymbolRef and make Symbol.rebind a ClassOrModuleRef

### DIFF
--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -29,7 +29,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
 
         auto selfClaz = md.symbol.data(ctx)->rebind();
         if (!selfClaz.exists()) {
-            selfClaz = md.symbol.data(ctx)->enclosingClass(ctx);
+            selfClaz = md.symbol.enclosingClass(ctx);
         }
         synthesizeExpr(
             entry, LocalRef::selfVariable(), core::LocOffsets::none(),

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -29,12 +29,11 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
 
         auto selfClaz = md.symbol.data(ctx)->rebind();
         if (!selfClaz.exists()) {
-            selfClaz = md.symbol;
+            selfClaz = md.symbol.data(ctx)->enclosingClass(ctx);
         }
-        synthesizeExpr(entry, LocalRef::selfVariable(), core::LocOffsets::none(),
-                       make_unique<Cast>(LocalRef::selfVariable(),
-                                         selfClaz.data(ctx)->enclosingClass(ctx).data(ctx)->selfType(ctx),
-                                         core::Names::cast()));
+        synthesizeExpr(
+            entry, LocalRef::selfVariable(), core::LocOffsets::none(),
+            make_unique<Cast>(LocalRef::selfVariable(), selfClaz.data(ctx)->selfType(ctx), core::Names::cast()));
 
         BasicBlock *presentCont = entry;
         BasicBlock *defaultCont = nullptr;

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -58,7 +58,7 @@ LocalRef unresolvedIdent2Local(CFGContext cctx, const ast::UnresolvedIdent &id) 
 
     switch (id.kind) {
         case ast::UnresolvedIdent::Kind::Class:
-            klass = cctx.ctx.owner.data(cctx.ctx)->enclosingClass(cctx.ctx);
+            klass = cctx.ctx.owner.enclosingClass(cctx.ctx);
             while (klass.data(cctx.ctx)->attachedClass(cctx.ctx).exists()) {
                 klass = klass.data(cctx.ctx)->attachedClass(cctx.ctx);
             }

--- a/core/Context.cc
+++ b/core/Context.cc
@@ -18,11 +18,10 @@ using namespace std;
 namespace sorbet::core {
 
 ClassOrModuleRef MutableContext::selfClass() {
-    SymbolData data = this->owner.data(this->state);
     if (this->owner.isClassOrModule()) {
-        return data->singletonClass(this->state);
+        return this->owner.asClassOrModuleRef().data(this->state)->singletonClass(this->state);
     }
-    return data->enclosingClass(this->state);
+    return this->owner.enclosingClass(this->state);
 }
 
 bool Context::permitOverloadDefinitions(const core::GlobalState &gs, FileRef sigLoc, core::SymbolRef owner) {

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -97,6 +97,7 @@ public:
 
     SymbolData data(GlobalState &gs) const;
     ConstSymbolData data(const GlobalState &gs) const;
+    ClassOrModuleRef enclosingClass(const GlobalState &gs) const;
 
     bool operator==(const MethodRef &rhs) const;
 
@@ -340,6 +341,7 @@ public:
 
     bool operator!=(const SymbolRef &rhs) const;
 
+    ClassOrModuleRef enclosingClass(const GlobalState &gs) const;
     std::string showRaw(const GlobalState &gs) const;
     std::string toString(const GlobalState &gs) const;
     std::string show(const GlobalState &gs) const;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1550,7 +1550,7 @@ u4 Symbol::hash(const GlobalState &gs) const {
     result = mix(result, !this->resultType ? 0 : this->resultType.hash(gs));
     result = mix(result, this->flags);
     result = mix(result, this->owner._id);
-    result = mix(result, this->superClassOrRebind._id);
+    result = mix(result, this->superClassOrRebind.id());
     // argumentsOrMixins, typeParams, typeAliases
     if (!members().empty()) {
         // Rather than use membersStableOrderSlow, which is... slow..., use an order dictated by symbol ref ID.
@@ -1596,7 +1596,7 @@ u4 Symbol::methodShapeHash(const GlobalState &gs) const {
     u4 result = _hash(name.shortName(gs));
     result = mix(result, this->flags);
     result = mix(result, this->owner._id);
-    result = mix(result, this->superClassOrRebind._id);
+    result = mix(result, this->superClassOrRebind.id());
     result = mix(result, this->hasSig());
     for (auto &arg : this->methodArgumentHash(gs)) {
         result = mix(result, arg);

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -389,7 +389,7 @@ string SymbolRef::show(const GlobalState &gs) const {
 
 TypePtr ArgInfo::argumentTypeAsSeenByImplementation(Context ctx, core::TypeConstraint &constr) const {
     auto owner = ctx.owner;
-    auto klass = owner.data(ctx)->enclosingClass(ctx);
+    auto klass = owner.enclosingClass(ctx);
     auto instantiated = Types::resultTypeAsSeenFrom(ctx, type, klass, klass, klass.data(ctx)->selfTypeArgs(ctx));
     if (instantiated == nullptr) {
         instantiated = core::Types::untyped(ctx, owner);
@@ -1536,13 +1536,28 @@ void Symbol::sanityCheck(const GlobalState &gs) const {
     }
 }
 
-ClassOrModuleRef Symbol::enclosingClass(const GlobalState &gs) const {
-    SymbolRef owner = ref(gs);
-    while (!owner.isClassOrModule()) {
-        ENFORCE(owner.exists(), "non-existing owner in enclosingClass");
-        owner = owner.data(gs)->owner;
+ClassOrModuleRef MethodRef::enclosingClass(const GlobalState &gs) const {
+    // Methods can only be owned by classes or modules.
+    return data(gs)->owner.asClassOrModuleRef();
+}
+
+ClassOrModuleRef SymbolRef::enclosingClass(const GlobalState &gs) const {
+    switch (kind()) {
+        case SymbolRef::Kind::ClassOrModule:
+            return asClassOrModuleRef();
+        case SymbolRef::Kind::Method:
+            // Methods can only be owned by classes or modules.
+            return asMethodRef().data(gs)->owner.asClassOrModuleRef();
+        case SymbolRef::Kind::FieldOrStaticField:
+            // Fields can only be owned by classes or modules.
+            return asFieldRef().data(gs)->owner.asClassOrModuleRef();
+        case SymbolRef::Kind::TypeArgument:
+            // Typeargs are owned by methods, which are owned by classes or modules.
+            return asTypeArgumentRef().data(gs)->owner.asMethodRef().data(gs)->owner.asClassOrModuleRef();
+        case SymbolRef::Kind::TypeMember:
+            // TypeMembers are only owned by classes or modules.
+            return asTypeMemberRef().data(gs)->owner.asClassOrModuleRef();
     }
-    return owner.asClassOrModuleRef();
 }
 
 u4 Symbol::hash(const GlobalState &gs) const {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1546,14 +1546,13 @@ ClassOrModuleRef SymbolRef::enclosingClass(const GlobalState &gs) const {
         case SymbolRef::Kind::ClassOrModule:
             return asClassOrModuleRef();
         case SymbolRef::Kind::Method:
-            // Methods can only be owned by classes or modules.
-            return asMethodRef().data(gs)->owner.asClassOrModuleRef();
+            return asMethodRef().enclosingClass(gs);
         case SymbolRef::Kind::FieldOrStaticField:
             // Fields can only be owned by classes or modules.
             return asFieldRef().data(gs)->owner.asClassOrModuleRef();
         case SymbolRef::Kind::TypeArgument:
-            // Typeargs are owned by methods, which are owned by classes or modules.
-            return asTypeArgumentRef().data(gs)->owner.asMethodRef().data(gs)->owner.asClassOrModuleRef();
+            // Typeargs are owned by methods.
+            return asTypeArgumentRef().data(gs)->owner.asMethodRef().enclosingClass(gs);
         case SymbolRef::Kind::TypeMember:
             // TypeMembers are only owned by classes or modules.
             return asTypeMemberRef().data(gs)->owner.asClassOrModuleRef();

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -624,11 +624,11 @@ public:
     bool ignoreInHashing(const GlobalState &gs) const;
 
     SymbolRef owner;
-    SymbolRef superClassOrRebind; // method arguments store rebind here
+    ClassOrModuleRef superClassOrRebind; // method arguments store rebind here
 
     inline ClassOrModuleRef superClass() const {
         ENFORCE_NO_TIMER(isClassOrModule());
-        return superClassOrRebind.asClassOrModuleRef();
+        return superClassOrRebind;
     }
 
     inline void setSuperClass(ClassOrModuleRef claz) {
@@ -636,12 +636,12 @@ public:
         superClassOrRebind = claz;
     }
 
-    inline void setReBind(SymbolRef rebind) {
+    inline void setReBind(ClassOrModuleRef rebind) {
         ENFORCE(isMethod());
         superClassOrRebind = rebind;
     }
 
-    SymbolRef rebind() const {
+    ClassOrModuleRef rebind() const {
         ENFORCE_NO_TIMER(isMethod());
         return superClassOrRebind;
     }

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -682,8 +682,6 @@ public:
     Symbol deepCopy(const GlobalState &to, bool keepGsId = false) const;
     void sanityCheck(const GlobalState &gs) const;
 
-    ClassOrModuleRef enclosingClass(const GlobalState &gs) const;
-
     // All `IntrinsicMethod`s in sorbet should be statically-allocated, which is
     // why raw pointers are safe.
     const IntrinsicMethod *intrinsic = nullptr;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -535,7 +535,7 @@ ArgInfo SerializerImpl::unpickleArgInfo(UnPickler &p, const GlobalState *gs) {
 void SerializerImpl::pickle(Pickler &p, const Symbol &what) {
     p.putU4(what.owner.rawId());
     p.putU4(what.name.rawId());
-    p.putU4(what.superClassOrRebind.rawId());
+    p.putU4(what.superClassOrRebind.id());
     p.putU4(what.flags);
     if (!what.isMethod()) {
         p.putU4(what.mixins_.size());
@@ -577,7 +577,7 @@ Symbol SerializerImpl::unpickleSymbol(UnPickler &p, const GlobalState *gs) {
     Symbol result;
     result.owner = SymbolRef::fromRaw(p.getU4());
     result.name = NameRef::fromRaw(*gs, p.getU4());
-    result.superClassOrRebind = SymbolRef::fromRaw(p.getU4());
+    result.superClassOrRebind = ClassOrModuleRef::fromRaw(p.getU4());
     result.flags = p.getU4();
     if (!result.isMethod()) {
         int mixinsSize = p.getU4();

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -21,7 +21,7 @@ bool extendsTSig(core::Context ctx, core::ClassOrModuleRef enclosingClass) {
 optional<core::AutocorrectSuggestion::Edit> maybeSuggestExtendTSig(core::Context ctx, core::MethodRef methodSymbol) {
     auto method = methodSymbol.data(ctx);
 
-    auto enclosingClass = method->enclosingClass(ctx).data(ctx)->topAttachedClass(ctx);
+    auto enclosingClass = methodSymbol.enclosingClass(ctx).data(ctx)->topAttachedClass(ctx);
     if (extendsTSig(ctx, enclosingClass)) {
         // No need to suggest here, because it already has 'extend T::Sig'
         return nullopt;
@@ -340,7 +340,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
 
     auto guessedArgumentTypes = guessArgumentTypes(ctx, methodSymbol, cfg);
 
-    auto enclosingClass = methodSymbol.data(ctx)->enclosingClass(ctx);
+    auto enclosingClass = methodSymbol.enclosingClass(ctx);
     auto closestMethod = closestOverridenMethod(ctx, enclosingClass, methodSymbol.data(ctx)->name);
 
     fmt::memory_buffer ss;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1061,8 +1061,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         } else if (data->isField()) {
                             tp.type = core::Types::resultTypeAsSeenFrom(
                                 ctx, symbol.data(ctx)->resultType, symbol.data(ctx)->owner.asClassOrModuleRef(),
-                                ctx.owner.data(ctx)->enclosingClass(ctx),
-                                ctx.owner.data(ctx)->enclosingClass(ctx).data(ctx)->selfTypeArgs(ctx));
+                                ctx.owner.enclosingClass(ctx),
+                                ctx.owner.enclosingClass(ctx).data(ctx)->selfTypeArgs(ctx));
                         } else {
                             tp.type = data->resultType;
                         }
@@ -1252,7 +1252,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 }
             },
             [&](cfg::Cast *c) {
-                auto klass = ctx.owner.data(ctx)->enclosingClass(ctx);
+                auto klass = ctx.owner.enclosingClass(ctx);
                 auto castType = core::Types::instantiate(ctx, c->type, klass.data(ctx)->typeMembers(),
                                                          klass.data(ctx)->selfTypeArgs(ctx));
 

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -60,7 +60,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
             methodReturnType = core::Types::untyped(ctx, cfg->symbol);
         }
     } else {
-        auto enclosingClass = cfg->symbol.data(ctx)->enclosingClass(ctx);
+        auto enclosingClass = cfg->symbol.enclosingClass(ctx);
         methodReturnType = core::Types::instantiate(
             ctx,
             core::Types::resultTypeAsSeenFrom(ctx, cfg->symbol.data(ctx)->resultType,

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -193,7 +193,7 @@ class LocalNameInserter {
     }
 
     core::ClassOrModuleRef methodOwner(core::MutableContext ctx) {
-        core::ClassOrModuleRef owner = ctx.owner.data(ctx)->enclosingClass(ctx);
+        core::ClassOrModuleRef owner = ctx.owner.enclosingClass(ctx);
         if (owner == core::Symbols::root()) {
             // Root methods end up going on object
             owner = core::Symbols::Object();

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -59,7 +59,7 @@ ast::ExpressionPtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, 
             klass = ctx.owner.data(ctx)->owner.asClassOrModuleRef();
         } else {
             // Class var.
-            klass = ctx.owner.data(ctx)->enclosingClass(ctx);
+            klass = ctx.owner.enclosingClass(ctx);
             while (klass.data(ctx)->attachedClass(ctx).exists()) {
                 klass = klass.data(ctx)->attachedClass(ctx);
             }

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -252,8 +252,8 @@ core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &ty
     }
     if (auto *applied = core::cast_type<core::AppliedType>(receiver)) {
         /* instantiate generic classes */
-        resultType = core::Types::resultTypeAsSeenFrom(gs, resultType, inWhat.data(gs)->enclosingClass(gs),
-                                                       applied->klass, applied->targs);
+        resultType = core::Types::resultTypeAsSeenFrom(gs, resultType, inWhat.enclosingClass(gs), applied->klass,
+                                                       applied->targs);
     }
     if (!resultType) {
         resultType = core::Types::untypedUntracked();

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -124,7 +124,7 @@ void addSubclassRelatedMethods(const core::GlobalState &gs, core::MethodRef symb
     // We have to check for methods as part of a class hierarchy: Follow superClass() links till we find the root;
     // then find the full tree; then look for methods with the same name as ours; then find all references to all
     // those methods and rename them.
-    auto symbolClass = symbolData->enclosingClass(gs);
+    auto symbolClass = symbol.enclosingClass(gs);
 
     // We have to be careful to follow superclass links only as long as we find a method that `symbol` overrides.
     // Otherwise we will find unrelated methods and rename them even though they don't need to be (see the

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -19,9 +19,9 @@ core::SymbolRef dealiasAt(const core::GlobalState &gs, core::TypeMemberRef tpara
     if (tparam.data(gs)->owner == klass) {
         return tparam;
     } else {
-        core::SymbolRef cursor;
+        core::ClassOrModuleRef cursor;
         if (tparam.data(gs)->owner.data(gs)->derivesFrom(gs, klass)) {
-            cursor = tparam.data(gs)->owner;
+            cursor = tparam.data(gs)->owner.asClassOrModuleRef();
         } else if (klass.data(gs)->derivesFrom(gs, tparam.data(gs)->owner.asClassOrModuleRef())) {
             cursor = klass;
         }
@@ -29,7 +29,7 @@ core::SymbolRef dealiasAt(const core::GlobalState &gs, core::TypeMemberRef tpara
             if (!cursor.exists()) {
                 return cursor;
             }
-            for (auto aliasPair : typeAliases[cursor.classOrModuleIndex()]) {
+            for (auto aliasPair : typeAliases[cursor.id()]) {
                 if (aliasPair.first == tparam) {
                     return dealiasAt(gs, aliasPair.second, klass, typeAliases);
                 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -392,14 +392,14 @@ private:
 
     static bool resolveTypeAliasJob(core::MutableContext ctx, TypeAliasResolutionItem &job) {
         core::TypeMemberRef enclosingTypeMember;
-        core::ClassOrModuleRef enclosingClass = job.lhs.data(ctx)->enclosingClass(ctx);
+        core::ClassOrModuleRef enclosingClass = job.lhs.enclosingClass(ctx);
         while (enclosingClass != core::Symbols::root()) {
             auto typeMembers = enclosingClass.data(ctx)->typeMembers();
             if (!typeMembers.empty()) {
                 enclosingTypeMember = typeMembers[0].asTypeMemberRef();
                 break;
             }
-            enclosingClass = enclosingClass.data(ctx)->owner.data(ctx)->enclosingClass(ctx);
+            enclosingClass = enclosingClass.data(ctx)->owner.enclosingClass(ctx);
         }
         auto &rhs = *job.rhs;
         if (enclosingTypeMember.exists()) {
@@ -734,7 +734,7 @@ private:
             job.ancestor = cnst;
         } else if (ancestor.isSelfReference()) {
             auto loc = ancestor.loc();
-            auto enclosingClass = ctx.owner.data(ctx)->enclosingClass(ctx);
+            auto enclosingClass = ctx.owner.enclosingClass(ctx);
             auto nw = ast::MK::UnresolvedConstant(loc, std::move(ancestor), enclosingClass.data(ctx)->name);
             auto out = ast::make_expression<ast::ConstantLit>(loc, enclosingClass, std::move(nw));
             job.ancestor = ast::cast_tree<ast::ConstantLit>(out);
@@ -1338,7 +1338,7 @@ class ResolveTypeMembersAndFieldsWalk {
                 }
             }
 
-            scope = ctx.owner.data(ctx)->enclosingClass(ctx);
+            scope = ctx.owner.enclosingClass(ctx);
         } else {
             // we need to check nested block counts because we want all fields to be declared on top level of either
             // class or body, rather then nested in some block
@@ -1912,7 +1912,7 @@ class ResolveTypeMembersAndFieldsWalk {
     }
 
     core::ClassOrModuleRef methodOwner(core::Context ctx) {
-        core::ClassOrModuleRef owner = ctx.owner.data(ctx)->enclosingClass(ctx);
+        core::ClassOrModuleRef owner = ctx.owner.enclosingClass(ctx);
         if (owner == core::Symbols::root()) {
             // Root methods end up going on object
             owner = core::Symbols::Object();
@@ -2064,7 +2064,7 @@ public:
                     // Compute the containing class when translating the type,
                     // as there's a very good chance this has been called from a
                     // method context.
-                    item.owner = ctx.owner.data(ctx)->enclosingClass(ctx);
+                    item.owner = ctx.owner.enclosingClass(ctx);
 
                     auto typeExpr = ast::MK::KeepForTypechecking(std::move(send.args[1]));
                     auto expr = std::move(send.args[0]);
@@ -2446,7 +2446,7 @@ private:
 
                 mdef.rhs = ast::MK::EmptyTree();
             }
-            if (!mdef.symbol.data(ctx)->enclosingClass(ctx).data(ctx)->isClassOrModuleAbstract()) {
+            if (!mdef.symbol.enclosingClass(ctx).data(ctx)->isClassOrModuleAbstract()) {
                 if (auto e = ctx.beginError(mdef.loc, core::errors::Resolver::AbstractMethodOutsideAbstract)) {
                     e.setHeader("Before declaring an abstract method, you must mark your class/module "
                                 "as abstract using `abstract!` or `interface!`");
@@ -2485,7 +2485,7 @@ private:
 
             auto self = ast::MK::Self(mdef.loc);
             mdef.rhs = ast::MK::Send(mdef.loc, std::move(self), core::Names::super(), numPosArgs, std::move(args));
-        } else if (mdef.symbol.data(ctx)->enclosingClass(ctx).data(ctx)->isClassOrModuleInterface()) {
+        } else if (mdef.symbol.enclosingClass(ctx).data(ctx)->isClassOrModuleInterface()) {
             if (auto e = ctx.beginError(mdef.loc, core::errors::Resolver::ConcreteMethodInInterface)) {
                 e.setHeader("All methods in an interface must be declared abstract");
             }
@@ -2692,7 +2692,7 @@ private:
         InlinedVector<ast::Send *, 1> lastSigs;
 
         // Explicitly check in the contxt of the class, not <static-init>
-        auto classCtx = ctx.withOwner(ctx.owner.data(ctx)->enclosingClass(ctx));
+        auto classCtx = ctx.withOwner(ctx.owner.enclosingClass(ctx));
 
         for (auto &stat : seq.stats) {
             processStatement(classCtx, stat, lastSigs);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Here are a few small improvements that involve the *Ref classes. This PR contains the following changes:

* Moves `enclosingClass` to `SymbolRef` and reimplements it without a loop.
  * Prepares us for having different underlying Symbol objects per-symbol-type.
* Changes `superClassOrRebind` to `ClassOrModuleRef`, since both uses of that field are class or modules.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Slowly moving us toward a world where we can have separate symbol classes, which reduces memory usage and allocation overhead.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests
