### PR TITLE
Use `select!` instead of `filter!` for backcompat

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -103,7 +103,7 @@ module T::Private::Methods
     if !module_with_final?(target)
       return
     end
-    source_method_names.filter! do |method_name|
+    source_method_names.select! do |method_name|
       was_ever_final?(method_name)
     end
     if source_method_names.empty?


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Only Ruby 2.6 and above have the `filter!` alias defined for `select!` on `Array`. Thus, using `filter!` breaks the ability to run Sorbet runtime on Ruby 2.4 and 2.5.

Using `select!`, instead of `filter!`, which exists on Ruby 2.4 and 2.5, seems to be equivalent and compatible.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No automated tests.
