### PR TITLE
Fix crash with --suggest-unsafe for bad Loc's

### DIFF
--- a/core/AutocorrectSuggestion.cc
+++ b/core/AutocorrectSuggestion.cc
@@ -53,6 +53,12 @@ UnorderedMap<FileRef, string> AutocorrectSuggestion::apply(vector<AutocorrectSug
     UnorderedMap<FileRef, string> ret;
     for (auto &edit : edits) {
         core::Loc loc = edit.loc;
+        ENFORCE(loc.exists(), "Can't apply autocorrect when Loc doesn't exist");
+        if (!loc.exists()) {
+            // Recover gracefully even if ENFORCE fails.
+            continue;
+        }
+
         if (!ret.count(loc.file())) {
             ret[loc.file()] = sources[loc.file()];
         }

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -272,10 +272,13 @@ string Loc::filePosToString(const GlobalState &gs, bool showFull) const {
     return buf.str();
 }
 
-string Loc::source(const GlobalState &gs) const {
-    ENFORCE(exists(), "Can't take source of Loc that doesn't exist");
-    auto source = this->file().data(gs).source();
-    return string(source.substr(beginPos(), endPos() - beginPos()));
+optional<string> Loc::source(const GlobalState &gs) const {
+    if (!exists()) {
+        return nullopt;
+    } else {
+        auto source = this->file().data(gs).source();
+        return string(source.substr(beginPos(), endPos() - beginPos()));
+    }
 }
 
 bool Loc::contains(const Loc &other) const {

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -115,7 +115,7 @@ public:
     }
     std::string showRaw(const GlobalState &gs) const;
     std::string filePosToString(const GlobalState &gs, bool showFull = false) const;
-    std::string source(const GlobalState &gs) const;
+    std::optional<std::string> source(const GlobalState &gs) const;
 
     bool operator==(const Loc &rhs) const;
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1062,8 +1062,8 @@ string ArgInfo::argumentName(const GlobalState &gs) const {
         return (string)name.shortName(gs);
     } else {
         // positional arg
-        if (loc.exists()) {
-            return loc.source(gs);
+        if (auto source = loc.source(gs)) {
+            return source.value();
         } else {
             return (string)name.shortName(gs);
         }

--- a/core/lsp/QueryResponse.cc
+++ b/core/lsp/QueryResponse.cc
@@ -20,20 +20,25 @@ const SendResponse *QueryResponse::isSend() const {
 const optional<core::Loc> SendResponse::getMethodNameLoc(const core::GlobalState &gs) const {
     auto methodName = this->callerSideName.show(gs);
     auto expr = termLoc.source(gs);
+    if (!expr.has_value()) {
+        return nullopt;
+    }
     // We parse two forms of send expressions:
     //   <receiver expr><whitespace?>.<whitespace?><method>
     //   <method>
     // All other forms (operator overloads etc) cause nullopt to be returned.
     string::size_type methodNameOffset = receiverLoc.endPos() - termLoc.beginPos();
     if (methodNameOffset != 0) {
-        methodNameOffset = expr.find_first_of(".", methodNameOffset) + 1;
-        methodNameOffset = expr.find_first_not_of(" \t", methodNameOffset);
+        methodNameOffset = expr.value().find_first_of(".", methodNameOffset) + 1;
+        methodNameOffset = expr.value().find_first_not_of(" \t", methodNameOffset);
     }
+    // TODO(jez) Use Loc::adjust here
     auto offsets = termLoc.offsets();
     offsets.beginLoc += methodNameOffset;
     offsets.endLoc = offsets.beginLoc + methodName.length();
     auto methodNameLoc = core::Loc(termLoc.file(), offsets);
-    if (offsets.endPos() > termLoc.endPos() || methodName != methodNameLoc.source(gs)) {
+    if (offsets.endPos() > termLoc.endPos() || !methodNameLoc.exists() ||
+        methodName != methodNameLoc.source(gs).value()) {
         return nullopt;
     }
     return optional<core::Loc>(methodNameLoc);

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -207,7 +207,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
 
                             if (ctx.state.suggestUnsafe.has_value() && bexitLoc.exists()) {
                                 e.replaceWith(fmt::format("Wrap in `{}`", *ctx.state.suggestUnsafe), bexitLoc, "{}({})",
-                                              *ctx.state.suggestUnsafe, bexitLoc.source(ctx));
+                                              *ctx.state.suggestUnsafe, bexitLoc.source(ctx).value());
                             }
 
                             auto ty = prevEnv.getTypeAndOrigin(ctx, cond.variable);

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -317,22 +317,25 @@ void populateFieldAccessorType(const core::GlobalState &gs, AccessorInfo &info) 
     // Check definition site of method for `prop`, `const`, etc. The loc for the method should begin with
     // `def|prop|const|...`.
     auto methodSource = method.data(gs)->loc().source(gs);
+    if (!methodSource.has_value()) {
+        return;
+    }
     // Common case: ordinary `def`. Fast reject.
-    if (absl::StartsWith(methodSource, "def")) {
+    if (absl::StartsWith(methodSource.value(), "def")) {
         info.accessorType = FieldAccessorType::None;
         return;
     }
 
     if (absl::c_any_of(accessorNames, [&methodSource, &gs](auto name) -> bool {
-            return absl::StartsWith(methodSource, name.toString(gs));
+            return absl::StartsWith(methodSource.value(), name.toString(gs));
         })) {
         info.accessorType = FieldAccessorType::Accessor;
     } else if (absl::c_any_of(writerNames, [&methodSource, &gs](auto name) -> bool {
-                   return absl::StartsWith(methodSource, name.toString(gs));
+                   return absl::StartsWith(methodSource.value(), name.toString(gs));
                })) {
         info.accessorType = FieldAccessorType::Writer;
     } else if (absl::c_any_of(readerNames, [&methodSource, &gs](auto name) -> bool {
-                   return absl::StartsWith(methodSource, name.toString(gs));
+                   return absl::StartsWith(methodSource.value(), name.toString(gs));
                })) {
         info.accessorType = FieldAccessorType::Reader;
     } else {

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -244,11 +244,14 @@ public:
         }
 
         auto source = loc.source(gs);
+        if (!source.has_value()) {
+            return;
+        }
         string newsrc;
         if (auto sendResp = response->isSend()) {
-            newsrc = replaceMethodNameInSend(source, sendResp);
+            newsrc = replaceMethodNameInSend(source.value(), sendResp);
         } else if (auto defResp = response->isDefinition()) {
-            newsrc = replaceMethodNameInDef(source);
+            newsrc = replaceMethodNameInDef(source.value());
         } else {
             ENFORCE(0, "Unexpected query response type while renaming method");
             return;
@@ -330,7 +333,10 @@ public:
     void rename(unique_ptr<core::lsp::QueryResponse> &response) override {
         auto loc = response->getLoc();
         auto source = loc.source(gs);
-        vector<string> strs = absl::StrSplit(source, "::");
+        if (!source.has_value()) {
+            return;
+        }
+        vector<string> strs = absl::StrSplit(source.value(), "::");
         strs[strs.size() - 1] = string(newName);
         auto newsrc = absl::StrJoin(strs, "::");
         edits[loc] = newsrc;

--- a/resolver/CorrectTypeAlias.cc
+++ b/resolver/CorrectTypeAlias.cc
@@ -35,20 +35,24 @@ void CorrectTypeAlias::eagerToLazy(core::Context ctx, core::ErrorBuilder &e, ast
     auto &back = send->args.back();
     core::Loc argsLoc{ctx.file, front.loc().join(back.loc())};
 
+    if (!argsLoc.exists()) {
+        return;
+    }
+
     auto [start, end] = core::Loc(ctx.file, send->loc).position(ctx);
 
     if (start.line == end.line) {
         if (wrapHash) {
             e.replaceWith("Convert to lazy type alias", core::Loc(ctx.file, send->loc), "T.type_alias {{{{{}}}}}",
-                          argsLoc.source(ctx));
+                          argsLoc.source(ctx).value());
         } else {
             e.replaceWith("Convert to lazy type alias", core::Loc(ctx.file, send->loc), "T.type_alias {{{}}}",
-                          argsLoc.source(ctx));
+                          argsLoc.source(ctx).value());
         }
     } else {
         core::Loc endLoc(argsLoc.file(), argsLoc.endPos(), argsLoc.endPos());
         string argIndent = getIndent(ctx, endLoc);
-        string argSrc = fmt::format("{}{}", argIndent, argsLoc.source(ctx));
+        string argSrc = fmt::format("{}{}", argIndent, argsLoc.source(ctx).value());
         if (wrapHash) {
             argSrc = fmt::format("{}{{\n{}\n{}}}", argIndent, indented(argSrc), argIndent);
         }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -430,8 +430,10 @@ private:
             if (auto e = ctx.beginError(it.rhs->loc, core::errors::Resolver::ReassignsTypeAlias)) {
                 e.setHeader("Reassigning a type alias is not allowed");
                 e.addErrorLine(rhsData->loc(), "Originally defined here");
-                e.replaceWith("Declare as type alias", core::Loc(ctx.file, it.rhs->loc), "T.type_alias {{{}}}",
-                              core::Loc(ctx.file, it.rhs->loc).source(ctx));
+                auto rhsLoc = core::Loc{ctx.file, it.rhs->loc};
+                if (rhsLoc.exists()) {
+                    e.replaceWith("Declare as type alias", rhsLoc, "T.type_alias {{{}}}", rhsLoc.source(ctx).value());
+                }
             }
             it.lhs.data(ctx)->resultType = core::Types::untypedUntracked();
             return true;

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -22,7 +22,9 @@ pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Exp
         if (lit->isSymbol(ctx)) {
             res = lit->asSymbol(ctx);
             loc = lit->loc;
-            ENFORCE(core::Loc(ctx.file, loc).source(ctx).size() > 1 && core::Loc(ctx.file, loc).source(ctx)[0] == ':');
+            ENFORCE(core::Loc(ctx.file, loc).exists());
+            ENFORCE(core::Loc(ctx.file, loc).source(ctx).value().size() > 1 &&
+                    core::Loc(ctx.file, loc).source(ctx).value()[0] == ':');
             loc = core::LocOffsets{loc.beginPos() + 1, loc.endPos()};
         } else if (lit->isString(ctx)) {
             core::NameRef nameRef = lit->asString(ctx);

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -48,7 +48,9 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
     }
     name = sym->asSymbol(ctx);
 
-    ENFORCE(!core::Loc(ctx.file, sym->loc).source(ctx).empty() && core::Loc(ctx.file, sym->loc).source(ctx)[0] == ':');
+    ENFORCE(core::Loc(ctx.file, sym->loc).exists());
+    ENFORCE(!core::Loc(ctx.file, sym->loc).source(ctx).value().empty() &&
+            core::Loc(ctx.file, sym->loc).source(ctx).value()[0] == ':');
     auto nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};
 
     type = ASTUtil::dupType(send->args[1]);

--- a/rewriter/MixinEncryptedProp.cc
+++ b/rewriter/MixinEncryptedProp.cc
@@ -51,8 +51,9 @@ vector<ast::ExpressionPtr> MixinEncryptedProp::run(core::MutableContext ctx, ast
         return empty;
     }
     name = sym->asSymbol(ctx);
-    ENFORCE(core::Loc(ctx.file, sym->loc).source(ctx).size() > 1 &&
-            core::Loc(ctx.file, sym->loc).source(ctx)[0] == ':');
+    ENFORCE(core::Loc(ctx.file, sym->loc).exists());
+    ENFORCE(core::Loc(ctx.file, sym->loc).source(ctx).value().size() > 1 &&
+            core::Loc(ctx.file, sym->loc).source(ctx).value()[0] == ':');
     auto nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};
     enc_name = name.prepend(ctx, "encrypted_");
 

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -94,7 +94,8 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
         }
         core::NameRef name = sym->asSymbol(ctx);
         auto symLoc = sym->loc;
-        if (symLoc.exists() && absl::StartsWith(core::Loc(ctx.file, symLoc).source(ctx), ":")) {
+        // TODO(jez) Use Loc::adjust here
+        if (symLoc.exists() && absl::StartsWith(core::Loc(ctx.file, symLoc).source(ctx).value(), ":")) {
             symLoc = core::LocOffsets{symLoc.beginPos() + 1, symLoc.endPos()};
         }
 

--- a/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
+++ b/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
@@ -1,75 +1,89 @@
-suggest_t_unsafe.rb:6: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
-     6 |foo[0]
+suggest_t_unsafe.rb:25: Expected `String` but found `T.nilable(String)` for argument `str` https://srb.help/7002
+    25 |  takes_string_kw(str: nilable_string)
+                          ^^^^^^^^^^^^^^^^^^^
+  Expected `String` for argument `str` of method `Object#takes_string_kw`:
+    suggest_t_unsafe.rb:19:
+    19 |sig {params(str: String).void}
+                    ^^^
+  Got `T.nilable(String)` originating from:
+    suggest_t_unsafe.rb:25:
+    25 |  takes_string_kw(str: nilable_string)
+                          ^^^^^^^^^^^^^^^^^^^
+
+suggest_t_unsafe.rb:8: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
+     8 |foo[0]
         ^^^^^^
   Got T.nilable(String) originating from:
-    suggest_t_unsafe.rb:5:
-     5 |foo = T.let(nil, T.nilable(String))
+    suggest_t_unsafe.rb:7:
+     7 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest_t_unsafe.rb:6: Replaced with `T.unsafe(foo)`
-     6 |foo[0]
+    suggest_t_unsafe.rb:8: Replaced with `T.unsafe(foo)`
+     8 |foo[0]
         ^^^
 
-suggest_t_unsafe.rb:8: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
-     8 |"hi" + foo
+suggest_t_unsafe.rb:10: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
+    10 |"hi" + foo
         ^^^^^^^^^^
   Expected `String` for argument `arg0` of method `String#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L68:
     68 |        arg0: String,
                 ^^^^
   Got `T.nilable(String)` originating from:
-    suggest_t_unsafe.rb:5:
-     5 |foo = T.let(nil, T.nilable(String))
+    suggest_t_unsafe.rb:7:
+     7 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest_t_unsafe.rb:8: Replaced with `T.unsafe(foo)`
-     8 |"hi" + foo
+    suggest_t_unsafe.rb:10: Replaced with `T.unsafe(foo)`
+    10 |"hi" + foo
                ^^^
 
-suggest_t_unsafe.rb:11: Method `even?` does not exist on `String` component of `T.any(Integer, String)` https://srb.help/7003
-    11 |bar.even?
+suggest_t_unsafe.rb:13: Method `even?` does not exist on `String` component of `T.any(Integer, String)` https://srb.help/7003
+    13 |bar.even?
         ^^^^^^^^^
   Got T.any(Integer, String) originating from:
-    suggest_t_unsafe.rb:10:
-    10 |bar = T.let(1, T.any(Integer, String))
+    suggest_t_unsafe.rb:12:
+    12 |bar = T.let(1, T.any(Integer, String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest_t_unsafe.rb:11: Replaced with `T.unsafe(bar)`
-    11 |bar.even?
+    suggest_t_unsafe.rb:13: Replaced with `T.unsafe(bar)`
+    13 |bar.even?
         ^^^
 
-suggest_t_unsafe.rb:13: Expected `String` but found `Integer(1)` for argument `arg0` https://srb.help/7002
-    13 |"hi" + 1
+suggest_t_unsafe.rb:15: Expected `String` but found `Integer(1)` for argument `arg0` https://srb.help/7002
+    15 |"hi" + 1
                ^
   Expected `String` for argument `arg0` of method `String#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L68:
     68 |        arg0: String,
                 ^^^^
   Got `Integer(1)` originating from:
-    suggest_t_unsafe.rb:13:
-    13 |"hi" + 1
+    suggest_t_unsafe.rb:15:
+    15 |"hi" + 1
                ^
   Autocorrect: Done
-    suggest_t_unsafe.rb:13: Replaced with `T.unsafe(1)`
-    13 |"hi" + 1
+    suggest_t_unsafe.rb:15: Replaced with `T.unsafe(1)`
+    15 |"hi" + 1
                ^
 
-suggest_t_unsafe.rb:15: Method `even?` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
-    15 |T::Array[T.nilable(Integer)].new.map(&:even?)
+suggest_t_unsafe.rb:17: Method `even?` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
+    17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^^^^^^
   Got T.nilable(Integer) originating from:
-    suggest_t_unsafe.rb:15:
-    15 |T::Array[T.nilable(Integer)].new.map(&:even?)
+    suggest_t_unsafe.rb:17:
+    17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^
   Autocorrect: Done
-    suggest_t_unsafe.rb:15: Replaced with ` {|x| T.unsafe(x).even?}`
-    15 |T::Array[T.nilable(Integer)].new.map(&:even?)
+    suggest_t_unsafe.rb:17: Replaced with ` {|x| T.unsafe(x).even?}`
+    17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                             ^^^^^^^^^
-Errors: 5
+Errors: 6
 
 --------------------------------------------------------------------------
 
 # typed: true
+
+extend T::Sig
 
 def custom_wrapper(arg0); end
 
@@ -85,80 +99,103 @@ T.unsafe(bar).even?
 
 T::Array[T.nilable(Integer)].new.map {|x| T.unsafe(x).even?}
 
+sig {params(str: String).void}
+def takes_string_kw(str:); end
+
+sig {params(nilable_string: T.nilable(String)).void}
+def takes_nilable_string(nilable_string)
+  # This used to crash Sorbet, because there was no Loc for the `str` argument
+  takes_string_kw(str: nilable_string)
+end
+
 --------------------------------------------------------------------------
 
-suggest_t_unsafe.rb:6: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
-     6 |foo[0]
+suggest_t_unsafe.rb:25: Expected `String` but found `T.nilable(String)` for argument `str` https://srb.help/7002
+    25 |  takes_string_kw(str: nilable_string)
+                          ^^^^^^^^^^^^^^^^^^^
+  Expected `String` for argument `str` of method `Object#takes_string_kw`:
+    suggest_t_unsafe.rb:19:
+    19 |sig {params(str: String).void}
+                    ^^^
+  Got `T.nilable(String)` originating from:
+    suggest_t_unsafe.rb:25:
+    25 |  takes_string_kw(str: nilable_string)
+                          ^^^^^^^^^^^^^^^^^^^
+
+suggest_t_unsafe.rb:8: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
+     8 |foo[0]
         ^^^^^^
   Got T.nilable(String) originating from:
-    suggest_t_unsafe.rb:5:
-     5 |foo = T.let(nil, T.nilable(String))
+    suggest_t_unsafe.rb:7:
+     7 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest_t_unsafe.rb:6: Replaced with `custom_wrapper(foo)`
-     6 |foo[0]
+    suggest_t_unsafe.rb:8: Replaced with `custom_wrapper(foo)`
+     8 |foo[0]
         ^^^
 
-suggest_t_unsafe.rb:8: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
-     8 |"hi" + foo
+suggest_t_unsafe.rb:10: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
+    10 |"hi" + foo
         ^^^^^^^^^^
   Expected `String` for argument `arg0` of method `String#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L68:
     68 |        arg0: String,
                 ^^^^
   Got `T.nilable(String)` originating from:
-    suggest_t_unsafe.rb:5:
-     5 |foo = T.let(nil, T.nilable(String))
+    suggest_t_unsafe.rb:7:
+     7 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest_t_unsafe.rb:8: Replaced with `custom_wrapper(foo)`
-     8 |"hi" + foo
+    suggest_t_unsafe.rb:10: Replaced with `custom_wrapper(foo)`
+    10 |"hi" + foo
                ^^^
 
-suggest_t_unsafe.rb:11: Method `even?` does not exist on `String` component of `T.any(Integer, String)` https://srb.help/7003
-    11 |bar.even?
+suggest_t_unsafe.rb:13: Method `even?` does not exist on `String` component of `T.any(Integer, String)` https://srb.help/7003
+    13 |bar.even?
         ^^^^^^^^^
   Got T.any(Integer, String) originating from:
-    suggest_t_unsafe.rb:10:
-    10 |bar = T.let(1, T.any(Integer, String))
+    suggest_t_unsafe.rb:12:
+    12 |bar = T.let(1, T.any(Integer, String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest_t_unsafe.rb:11: Replaced with `custom_wrapper(bar)`
-    11 |bar.even?
+    suggest_t_unsafe.rb:13: Replaced with `custom_wrapper(bar)`
+    13 |bar.even?
         ^^^
 
-suggest_t_unsafe.rb:13: Expected `String` but found `Integer(1)` for argument `arg0` https://srb.help/7002
-    13 |"hi" + 1
+suggest_t_unsafe.rb:15: Expected `String` but found `Integer(1)` for argument `arg0` https://srb.help/7002
+    15 |"hi" + 1
                ^
   Expected `String` for argument `arg0` of method `String#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L68:
     68 |        arg0: String,
                 ^^^^
   Got `Integer(1)` originating from:
-    suggest_t_unsafe.rb:13:
-    13 |"hi" + 1
+    suggest_t_unsafe.rb:15:
+    15 |"hi" + 1
                ^
   Autocorrect: Done
-    suggest_t_unsafe.rb:13: Replaced with `custom_wrapper(1)`
-    13 |"hi" + 1
+    suggest_t_unsafe.rb:15: Replaced with `custom_wrapper(1)`
+    15 |"hi" + 1
                ^
 
-suggest_t_unsafe.rb:15: Method `even?` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
-    15 |T::Array[T.nilable(Integer)].new.map(&:even?)
+suggest_t_unsafe.rb:17: Method `even?` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
+    17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^^^^^^
   Got T.nilable(Integer) originating from:
-    suggest_t_unsafe.rb:15:
-    15 |T::Array[T.nilable(Integer)].new.map(&:even?)
+    suggest_t_unsafe.rb:17:
+    17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^
   Autocorrect: Done
-    suggest_t_unsafe.rb:15: Replaced with ` {|x| custom_wrapper(x).even?}`
-    15 |T::Array[T.nilable(Integer)].new.map(&:even?)
+    suggest_t_unsafe.rb:17: Replaced with ` {|x| custom_wrapper(x).even?}`
+    17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                             ^^^^^^^^^
-Errors: 5
+Errors: 6
 
 --------------------------------------------------------------------------
 
 # typed: true
+
+extend T::Sig
 
 def custom_wrapper(arg0); end
 
@@ -173,3 +210,12 @@ custom_wrapper(bar).even?
 "hi" + custom_wrapper(1)
 
 T::Array[T.nilable(Integer)].new.map {|x| custom_wrapper(x).even?}
+
+sig {params(str: String).void}
+def takes_string_kw(str:); end
+
+sig {params(nilable_string: T.nilable(String)).void}
+def takes_nilable_string(nilable_string)
+  # This used to crash Sorbet, because there was no Loc for the `str` argument
+  takes_string_kw(str: nilable_string)
+end

--- a/test/cli/suggest_t_unsafe/suggest_t_unsafe.rb
+++ b/test/cli/suggest_t_unsafe/suggest_t_unsafe.rb
@@ -1,5 +1,7 @@
 # typed: true
 
+extend T::Sig
+
 def custom_wrapper(arg0); end
 
 foo = T.let(nil, T.nilable(String))
@@ -13,3 +15,12 @@ bar.even?
 "hi" + 1
 
 T::Array[T.nilable(Integer)].new.map(&:even?)
+
+sig {params(str: String).void}
+def takes_string_kw(str:); end
+
+sig {params(nilable_string: T.nilable(String)).void}
+def takes_nilable_string(nilable_string)
+  # This used to crash Sorbet, because there was no Loc for the `str` argument
+  takes_string_kw(str: nilable_string)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`Loc::source` used to fail an `ENFORCE` if the `Loc` did not exist.

This started surfacing a lot as I started to use `--suggest-unsafe` (which
usually uses `Loc::source` to figure out what to autocorrect to) for more
codemods.

One thing to do here would be to make it more likely that a `Loc` exists.

But I think it's more prudent to be defensive in these places because:

- It usually happens in error reporting code, which is not exercised nearly as
  frequently as other codepaths

- In particular, there are a lot `Loc::source` calls that only get reached when
  using `--suggest-unsafe`, which we have some tests for but the vast, vast
  majority of our test suite and Stripe's codebase isn't run in this mode.

- Some `Loc`'s just don't exist (whether because it's the fuzzer mode or some
  synthetic code, or something else), so I think that in fact it is expected to
  see `Loc`'s that don't exist here from time to time.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I added a test case for the one problem I was seeing on Stripe's codebase from a
recent codemod. I did not exhaustively test all codepaths that I changed.