### PR TITLE
delay work in final method checks until we absolutely need it

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -427,7 +427,8 @@ module T::Private::Methods
   # the module target is adding the methods from the module source to itself. we need to check that for all instance
   # methods M on source, M is not defined on any of target's ancestors.
   def self._hook_impl(target, singleton_class, source)
-    if !module_with_final?(target) && !module_with_final?(source)
+    target_was_final = module_with_final?(target)
+    if !target_was_final && !module_with_final?(source)
       return
     end
     # we do not need to call add_was_ever_final here, because we have already marked
@@ -435,7 +436,7 @@ module T::Private::Methods
     add_module_with_final(target)
     install_hooks(target)
 
-    if !module_with_final?(target)
+    if !target_was_final
       return
     end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -185,7 +185,7 @@ module T::Private::Methods
       raise "#{mod} was declared as final but its method `#{method_name}` was not declared as final"
     end
     # Don't compute mod.ancestors if we don't need to bother checking final-ness.
-    if module_with_final?(mod)
+    if was_ever_final?(method_name) && module_with_final?(mod)
       _check_final_ancestors(mod, mod.ancestors, [method_name])
     end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -434,10 +434,13 @@ module T::Private::Methods
     # any such methods when source was originally defined.
     add_module_with_final(target)
     install_hooks(target)
-    if module_with_final?(target)
-      target_ancestors = singleton_class ? target.singleton_class.ancestors : target.ancestors
-      _check_final_ancestors(target, target_ancestors - source.ancestors, source.instance_methods)
+
+    if !module_with_final?(target)
+      return
     end
+
+    target_ancestors = singleton_class ? target.singleton_class.ancestors : target.ancestors
+    _check_final_ancestors(target, target_ancestors - source.ancestors, source.instance_methods)
   end
 
   def self.set_final_checks_on_hooks(enable)


### PR DESCRIPTION
We do a lot of computations during final method checks eagerly, potentially throwing away the results if we determine we don't need to do the full amount of checking.  We shouldn't do that, because in many cases the work can be delayed until we need it.

In `_check_final_ancestors`, we can probably avoid doing either the ancestors computation or determining instance methods, should one or the other say we don't need it.  I want to try and get numbers tomorrow; my hunch is that it's faster to compute instance methods, reject everything that's never been final, and then early exit if we don't have any methods to check.

### Motivation

Speed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
