### PR TITLE
Add option for not printing error sections to CLI

### DIFF
--- a/core/Error.cc
+++ b/core/Error.cc
@@ -112,9 +112,12 @@ string Error::toString(const GlobalState &gs) const {
         buf << '\n' << loc.toStringWithTabs(gs, 2);
     }
 
-    for (auto &section : this->sections) {
-        buf << '\n' << section.toString(gs);
+    if (gs.includeErrorSections) {
+        for (auto &section : this->sections) {
+            buf << '\n' << section.toString(gs);
+        }
     }
+
     return buf.str();
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1842,6 +1842,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->kvstoreUuid = this->kvstoreUuid;
     result->lspTypecheckCount = this->lspTypecheckCount;
     result->errorUrlBase = this->errorUrlBase;
+    result->includeErrorSections = this->includeErrorSections;
     result->ignoredForSuggestTypedErrorClasses = this->ignoredForSuggestTypedErrorClasses;
     result->suppressedErrorClasses = this->suppressedErrorClasses;
     result->onlyErrorClasses = this->onlyErrorClasses;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -251,6 +251,9 @@ public:
     // The error code is appended to this string.
     std::string errorUrlBase;
 
+    // If 'true', print error sections
+    bool includeErrorSections = true;
+
     // If 'true', enforce use of Ruby 3.0-style keyword args.
     bool ruby3KeywordArgs = false;
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -409,6 +409,7 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("dev")("error-black-list",
                                "(DEPRECATED) Alias for --suppress-error-code. Will be removed in a later release.",
                                cxxopts::value<vector<int>>(), "errorCode");
+    options.add_options("dev")("no-error-sections", "Do not print error sections.");
     options.add_options("dev")("typed", "Force all code to specified strictness level",
                                cxxopts::value<string>()->default_value("auto"), "{false,true,strict,strong,[auto]}");
     options.add_options("dev")("typed-override", "Yaml config that overrides strictness levels on files",
@@ -825,6 +826,7 @@ void readOptions(Options &opts,
         opts.stripePackages = raw["stripe-packages"].as<bool>();
         extractAutoloaderConfig(raw, opts, logger);
         opts.errorUrlBase = raw["error-url-base"].as<string>();
+        opts.noErrorSections = raw["no-error-sections"].as<bool>();
         opts.ruby3KeywordArgs = raw["ruby3-keyword-args"].as<bool>();
         if (raw.count("error-white-list") > 0) {
             logger->error("`{}` is deprecated; please use `{}` instead", "--error-white-list", "--isolate-error-code");

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -159,6 +159,7 @@ struct Options {
     bool ruby3KeywordArgs = false;
     std::set<int> isolateErrorCode;
     std::set<int> suppressErrorCode;
+    bool noErrorSections = false;
     /** Prefix to remove from all printed paths. */
     std::string pathPrefix;
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -472,6 +472,9 @@ int realmain(int argc, char *argv[]) {
     for (auto code : opts.suppressErrorCode) {
         gs->suppressErrorClass(code);
     }
+    if (opts.noErrorSections) {
+        gs->includeErrorSections = false;
+    }
     gs->ruby3KeywordArgs = opts.ruby3KeywordArgs;
     if (!opts.stripeMode) {
         // Definitions in multiple locations interact poorly with autoloader this error is enforced in Stripe code.

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -227,6 +227,7 @@ Usage:
       --error-black-list errorCode
                                 (DEPRECATED) Alias for --suppress-error-code.
                                 Will be removed in a later release.
+      --no-error-sections       Do not print error sections.
       --typed {false,true,strict,strong,[auto]}
                                 Force all code to specified strictness level
                                 (default: auto)

--- a/test/cli/no-error-sections/no-error-sections-2.rb
+++ b/test/cli/no-error-sections/no-error-sections-2.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+pouts
+

--- a/test/cli/no-error-sections/no-error-sections-3.rb
+++ b/test/cli/no-error-sections/no-error-sections-3.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+pouts
+

--- a/test/cli/no-error-sections/no-error-sections.out
+++ b/test/cli/no-error-sections/no-error-sections.out
@@ -1,0 +1,12 @@
+test/cli/no-error-sections/no-error-sections-2.rb:3: Method `pouts` does not exist on `T.class_of(<root>)` https://srb.help/7003
+     3 |pouts
+        ^^^^^
+
+test/cli/no-error-sections/no-error-sections-3.rb:3: Method `pouts` does not exist on `T.class_of(<root>)` https://srb.help/7003
+     3 |pouts
+        ^^^^^
+
+test/cli/no-error-sections/no-error-sections.rb:3: Method `pouts` does not exist on `T.class_of(<root>)` https://srb.help/7003
+     3 |pouts
+        ^^^^^
+Errors: 3

--- a/test/cli/no-error-sections/no-error-sections.rb
+++ b/test/cli/no-error-sections/no-error-sections.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+pouts
+

--- a/test/cli/no-error-sections/no-error-sections.sh
+++ b/test/cli/no-error-sections/no-error-sections.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+main/sorbet --silence-dev-message test/cli/no-error-sections/*.rb --no-error-sections 2>&1


### PR DESCRIPTION
This PR adds the option `--no-error-sections` to the CLI to not print error sections.

It includes the new CLI option in the global state and then reads it in the `toString` method to decide whether to add the sections to the buffer or not.

Considering the following example:
```rb
# typed: true

class Foo
  def foo
  end
end

Foo.new.foos # typo
```
Without the new CLI option, the output is:
```bash
./example.rb:8: Method foos does not exist on Foo https://srb.help/7003
     8 |Foo.new.foos
        ^^^^^^^^^^^^
  Got Foo originating from:
    ./example.rb:8:
     8 |Foo.new.foos
        ^^^^^^^
  Autocorrect: Use `-a` to autocorrect
    ./example.rb:8: Replace with foo
     8 |Foo.new.foos
                ^^^^
Errors: 1
```
With the new option, the output is:
```bash
./example.rb:8: Method foos does not exist on Foo https://srb.help/7003
     8 |Foo.new.foos
        ^^^^^^^^^^^^
Errors: 1
```

### Motivation

We'd like to have an option with a smaller amount of output for usage in conjunction with [Spoom](https://github.com/Shopify/spoom)

### Test plan

See included automated tests.

I have also verified that running with both `--no-error-sections` and auto correct works as expected (auto corrects, but doesn't print sections).