### PR TITLE
Add missing block for `Pathname.glob` method

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -249,7 +249,15 @@ class Pathname < Object
     )
     .returns(T::Array[Pathname])
   end
-  def self.glob(p1, p2=T.unsafe(nil)); end
+  sig do
+    params(
+        p1: T.any(String, Pathname),
+        p2: String,
+        blk: T.proc.params(arg0: Pathname).void,
+    )
+    .returns(NilClass)
+  end
+  def self.glob(p1, p2=T.unsafe(nil), &blk); end
 
   def initialize(p); end
 


### PR DESCRIPTION
### Motivation
`Pathname.glob` takes a block, just like `Dir.glob`, but that was missing from the RBI definition. This has started causing problems since https://github.com/sorbet/sorbet/pull/4082 landed.

### Test plan
No extra tests.
