### PR TITLE
Add blocks to some sigs that are missing them

### DIFF
--- a/rbi/stdlib/resolv.rbi
+++ b/rbi/stdlib/resolv.rbi
@@ -357,10 +357,11 @@ class Resolv::DNS
         String,
         { nameserver: T.any(String, T::Array[String]), search: T::Array[String], ndots: Integer },
         { nameserver_port: T::Array[[String, Integer]], search: T::Array[String], ndots: Integer }
-      )
+      ),
+      blk: T.nilable(T.proc.params(arg0: Resolv::DNS).void),
     ).returns(Resolv::DNS)
   end
-  def self.open(config_info = nil); end
+  def self.open(config_info = nil, &blk); end
 end
 
 class Resolv::DNS::Config

--- a/rbi/stdlib/set.rbi
+++ b/rbi/stdlib/set.rbi
@@ -992,8 +992,8 @@ end
 #
 # for pack.c
 class Array
-  sig {returns(T::Set[T.untyped])}
-  def to_set; end
+  sig { params(blk: T.nilable(T.proc.params(arg0: T.untyped).void)).returns(T::Set[T.untyped]) }
+  def to_set(&blk); end
 end
 
 # The [`Enumerable`](https://docs.ruby-lang.org/en/2.7.0/Enumerable.html) mixin

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -56,3 +56,6 @@ T.reveal_type(['a','b','c'].bsearch {|x| x == 'a'}) # error: Revealed type: `T.n
 
 # bsearch_index
 T.reveal_type(['a','b','c'].bsearch_index {|x| x == 'a'}) # error: Revealed type: `T.nilable(Integer)`
+
+T.assert_type!([1, 2].to_set { |x| x + 1 }, T::Set[T.untyped])
+T.assert_type!([1, 2].to_set, T::Set[T.untyped])

--- a/test/testdata/rbi/resolv.rb
+++ b/test/testdata/rbi/resolv.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+Resolv::DNS.open do |resolv|
+  T.assert_type!(resolv, Resolv::DNS)
+end
+
+T.assert_type!(Resolv::DNS.open, Resolv::DNS)


### PR DESCRIPTION
Following up on https://github.com/sorbet/sorbet/pull/4084, these are a few other methods that take blocks, but the block is missing from the RBI definition.

This has started causing problems since #4082 landed.

### Test plan

See included automated tests. They'll fail if the blocks are removed from the signatures.
