### PR TITLE
nano-optimize final method checks

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -6,11 +6,6 @@ module T::Private::Methods
   @signatures_by_method = {}
   @sig_wrappers = {}
   @sigs_that_raised = {}
-  # the info about whether a method is final is not stored in a DeclBuilder nor a Signature, but instead right here.
-  # this is because final checks are special:
-  # - they are done possibly before any sig block has run.
-  # - they are done even if the method being defined doesn't have a sig.
-  @final_methods = Set.new
   # stores method names that were declared final without regard for where.
   # enables early rejection of names that we know can't induce final method violations.
   @was_ever_final_names = Set.new
@@ -136,14 +131,6 @@ module T::Private::Methods
     end
   end
 
-  private_class_method def self.add_final_method(method_key)
-    @final_methods.add(method_key)
-  end
-
-  private_class_method def self.final_method?(method_key)
-    @final_methods.include?(method_key)
-  end
-
   private_class_method def self.add_was_ever_final(method_name)
     @was_ever_final_names.add(method_name)
   end
@@ -240,7 +227,6 @@ module T::Private::Methods
 
     @sig_wrappers[key] = sig_block
     if current_declaration.final
-      add_final_method(key)
       add_was_ever_final(method_name)
       # use hook_mod, not mod, because for example, we want class C to be marked as having final if we def C.foo as
       # final. change this to mod to see some final_method tests fail.

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -165,7 +165,7 @@ module T::Private::Methods
   end
 
   private_class_method def self.module_with_final?(mod)
-    @modules_with_final.has_key?(mod)
+    @modules_with_final.include?(mod)
   end
 
   # Only public because it needs to get called below inside the replace_method blocks below.

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -106,6 +106,10 @@ module T::Private::Methods
     # the version of ruby that adds the optional argument to method_defined? that allows you to exclude ancestors.
     target_ancestors.reverse_each do |ancestor|
       final_methods = @modules_with_final.fetch(ancestor, nil)
+      # In this case, either ancestor didn't have any final methods anywhere in its
+      # ancestor chain, or ancestor did have final methods somewhere in its ancestor
+      # chain, but no final methods defined in ancestor itself.  Either way, there
+      # are no final methods to check here, so we can move on to the next ancestor.
       next if !final_methods
       source_method_names.each do |method_name|
         if final_methods.include?(method_name)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -9,8 +9,18 @@ module T::Private::Methods
   # stores method names that were declared final without regard for where.
   # enables early rejection of names that we know can't induce final method violations.
   @was_ever_final_names = Set.new
-  # maps from modules to the set of final methods they declare
-  @modules_with_final = Hash.new { |hash, key| hash[key] = Set.new }
+  # maps from modules to the set of final methods declared in that module.
+  # we also overload entries slightly: if the value is nil, that means that the
+  # module has final methods somewhere along its ancestor chain, but does not itself
+  # have any final methods.
+  #
+  # we need the latter information to know whether we need to check along the ancestor
+  # chain for final method violations.  we need the former information because we
+  # care about exactly where a final method is defined (e.g. including the same module
+  # twice is permitted).  we could do this with two tables, but it seems slightly
+  # cleaner with a single table.
+  # Effectively T::Hash[Module, T.nilable(Set))]
+  @modules_with_final = Hash.new { |hash, key| hash[key] = nil }
   # this stores the old [included, extended] hooks for Module and inherited hook for Class that we override when
   # enabling final checks for when those hooks are called. the 'hooks' here don't have anything to do with the 'hooks'
   # in installed_hooks.
@@ -96,8 +106,7 @@ module T::Private::Methods
     # the version of ruby that adds the optional argument to method_defined? that allows you to exclude ancestors.
     target_ancestors.reverse_each do |ancestor|
       final_methods = @modules_with_final.fetch(ancestor, nil)
-      next unless final_methods
-      next if final_methods.empty?
+      next if !final_methods
       source_method_names.each do |method_name|
         if final_methods.include?(method_name)
           definition_file, definition_line = T::Private::Methods.signature_for_method(ancestor.instance_method(method_name)).method.source_location
@@ -139,16 +148,20 @@ module T::Private::Methods
     @was_ever_final_names.include?(method_name)
   end
 
-  def self.add_module_with_final_method(mod, method_name)
-    @modules_with_final[mod].add(method_name)
-    @modules_with_final[mod.singleton_class].add(method_name)
+  def self.add_module_with_final_method(mod, method_name, is_singleton_method)
+    m = is_singleton_method ? mod.singleton_class : mod
+    methods = @modules_with_final[m]
+    if methods.nil?
+      methods = Set.new
+      @modules_with_final[m] = methods
+    end
+    methods.add(method_name)
   end
 
-  def self.add_module_with_final_with_methods(mod, set)
-    methods = @modules_with_final[mod]
-    methods |= set
-    methods = @modules_with_final[mod.singleton_class]
-    methods |= set
+  def self.note_module_deals_with_final(mod)
+    # Side-effectfully initialize the value if it's not already there
+    @modules_with_final[mod]
+    @modules_with_final[mod.singleton_class]
   end
 
   private_class_method def self.module_with_final?(mod)
@@ -230,7 +243,8 @@ module T::Private::Methods
       add_was_ever_final(method_name)
       # use hook_mod, not mod, because for example, we want class C to be marked as having final if we def C.foo as
       # final. change this to mod to see some final_method tests fail.
-      add_module_with_final_method(hook_mod, method_name)
+      note_module_deals_with_final(hook_mod)
+      add_module_with_final_method(hook_mod, method_name, is_singleton_method)
     end
   end
 
@@ -414,9 +428,7 @@ module T::Private::Methods
     end
     # we do not need to call add_was_ever_final here, because we have already marked
     # any such methods when source was originally defined.
-    if (methods = @modules_with_final.fetch(source, nil))
-      add_module_with_final_with_methods(target, methods)
-    end
+    note_module_deals_with_final(target)
     install_hooks(target)
 
     if !target_was_final

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -422,16 +422,14 @@ module T::Private::Methods
   # the module target is adding the methods from the module source to itself. we need to check that for all instance
   # methods M on source, M is not defined on any of target's ancestors.
   def self._hook_impl(target, singleton_class, source)
-    target_was_final = module_with_final?(target)
-    if !target_was_final && !module_with_final?(source)
-      return
-    end
     # we do not need to call add_was_ever_final here, because we have already marked
     # any such methods when source was originally defined.
-    note_module_deals_with_final(target)
-    install_hooks(target)
-
-    if !target_was_final
+    if !module_with_final?(target)
+      if !module_with_final?(source)
+        return
+      end
+      note_module_deals_with_final(target)
+      install_hooks(target)
       return
     end
 


### PR DESCRIPTION
Final method checks are (probably) still too slow.  We've taken care of -- I think -- all the "don't do unnecessary work" bits, so the only path left is to make the actual checking faster.

* b7dfd83 was the first stab at this: we're creating the lookup key for `@final_methods` twice: once in the hook, and once when we're running the method for the first time, plus we're uselessly grabbing the instance method just for the purposes of constructing that key.  Let's not do that by creating the key once for everything to use.
* 821197e removes some confusion: `T::Private::Final` has its own bits for determining whether a particular module was itself declared as `final`, and indeed the hooks already consult that.  So we should be safe in removing the bit that inserts the module into the table `@modules_with_final` maintained by `T::Private::Methods`.  Said table is now easier to describe: "the set of modules that have at least one method as `final`".
* 90eb529 is motivated by `@final_methods` not really being in the form we want for fast checks: we have to construct a string key out of a module and method_name, requiring string formatting and consing during final method checks.  (And we're repeatedly formatting the `owner_id` of the relevant ancestor for each possibly-final name, which is just wasted work.)  Let's not do that: instead, now that `@modules_with_final` has been clarified, we can turn it into a mapping from `Module` to the set of final method names defined on that module.  That turns our "is this method final on this module?" check into set membership, with no consing.  We are maintaining more information, which is not great for memory, but...
* 96dbe63 notices that, given the above change, we're not using `@final_methods` anymore, so we can delete all the code associated with that, which should make the overall memory changes...roughly neutral?
* cda482e recognizes that we can do slightly less work if we didn't have to do final method checks; since not doing final method checks is the common case, this is a very small speedup.

All of this ~should make things faster, but the only way to be sure is testing.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
