### PR TITLE
minor tweaks to final method checks and final method tests

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/final.rb
+++ b/gems/sorbet-runtime/lib/types/private/final.rb
@@ -37,7 +37,6 @@ module T::Private::Final
     mod.extend(mod.is_a?(Class) ? NoInherit : NoIncludeExtend)
     mark_as_final_module(mod)
     mark_as_final_module(mod.singleton_class)
-    T::Private::Methods.add_module_with_final(mod)
     T::Private::Methods.install_hooks(mod)
   end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -184,11 +184,11 @@ module T::Private::Methods
     # Don't compute mod.ancestors if we don't need to bother checking final-ness.
     if was_ever_final?(method_name) && module_with_final?(mod)
       _check_final_ancestors(mod, mod.ancestors, [method_name])
+      # We need to fetch the active declaration again, as _check_final_ancestors
+      # may have reset it (see the comment in that method for details).
+      current_declaration = T::Private::DeclState.current.active_declaration
     end
 
-    # We need to fetch the active declaration again, as _check_final_ancestors
-    # may have reset it (see the comment in that method for details).
-    current_declaration = T::Private::DeclState.current.active_declaration
     if current_declaration.nil?
       return
     end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -210,9 +210,9 @@ module T::Private::Methods
     # which is called only on the *first* invocation.
     # This wrapper is very slow, so it will subsequently re-wrap with a much faster wrapper
     # (or unwrap back to the original method).
-    new_method = nil
+    key = method_owner_and_name_to_key(mod, method_name)
     T::Private::ClassUtils.replace_method(mod, method_name) do |*args, &blk|
-      method_sig = T::Private::Methods.maybe_run_sig_block_for_method(new_method)
+      method_sig = T::Private::Methods.maybe_run_sig_block_for_key(key)
       method_sig ||= T::Private::Methods._handle_missing_method_signature(
         self,
         original_method,
@@ -239,8 +239,6 @@ module T::Private::Methods
       end
     end
 
-    new_method = mod.instance_method(method_name)
-    key = method_to_key(new_method)
     @sig_wrappers[key] = sig_block
     if current_declaration.final
       add_final_method(key)
@@ -379,7 +377,8 @@ module T::Private::Methods
     maybe_run_sig_block_for_key(method_to_key(method))
   end
 
-  private_class_method def self.maybe_run_sig_block_for_key(key)
+  # Only public so that it can be accessed in the closure for _on_method_added
+  def self.maybe_run_sig_block_for_key(key)
     run_sig_block_for_key(key) if has_sig_block_for_key(key)
   end
 

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -220,6 +220,24 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
     assert_equal(:class, c.foo)
   end
 
+  it "allows declaring a final instance method and a non-final class method with the same name" do
+    c = Class.new do
+      extend T::Sig
+      sig(:final) {returns(Symbol)}
+      def foo
+        :instance
+      end
+
+      sig {returns(Symbol)}
+      def self.foo
+        :class
+      end
+    end
+
+    assert_equal(:instance, c.new.foo)
+    assert_equal(:class, c.foo)
+  end
+
   it "forbids toggling a final method's visibility in a child class" do
     c = Class.new do
       extend T::Sig

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -184,6 +184,42 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
     end
   end
 
+  it "allows declaring a final instance method and a final class method with the same name" do
+    c = Class.new do
+      extend T::Sig
+      sig(:final) {returns(Symbol)}
+      def foo
+        :instance
+      end
+
+      sig(:final) {returns(Symbol)}
+      def self.foo
+        :class
+      end
+    end
+
+    assert_equal(:instance, c.new.foo)
+    assert_equal(:class, c.foo)
+  end
+
+  it "allows declaring a final class method and a non-final instance method with the same name" do
+    c = Class.new do
+      extend T::Sig
+      sig(:final) {returns(Symbol)}
+      def self.foo
+        :class
+      end
+
+      sig {returns(Symbol)}
+      def foo
+        :instance
+      end
+    end
+
+    assert_equal(:instance, c.new.foo)
+    assert_equal(:class, c.foo)
+  end
+
   it "forbids toggling a final method's visibility in a child class" do
     c = Class.new do
       extend T::Sig


### PR DESCRIPTION
Some small changes:

* eb038f7: removes some confusion: `T::Private::Final` has its own bits for determining whether a particular module was itself declared as `sealed!`, and indeed the hooks already consult that. So we should be safe in removing the bit that inserts the module into the table `@modules_with_final` maintained by `T::Private::Methods`. Said table is now easier to describe: "the set of modules that have at least one method as final".
* b3393d7: small observation that we don't need to reset this unless we actually did final method checks.
* d892f15: some tests motivated by some failures that other changes of mine induced on Stripe's codebase, but not on our current tests.
* c739177: we're creating the lookup key for `@final_methods` twice: once in the hook, and once when we're running the method for the first time, plus we're uselessly grabbing the instance method just for the purposes of constructing that key. Let's not do that; instead, create the key once for everything to use.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
