### PR TITLE
wip: type T::InterfaceWrapper#dynamic_cast

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -356,6 +356,10 @@ public:
         return Send2(loc, T(loc), core::Names::let(), std::move(value), std::move(type));
     }
 
+    static ExpressionPtr Cast(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
+        return Send2(loc, T(loc), core::Names::cast(), std::move(value), std::move(type));
+    }
+
     static ExpressionPtr AssertType(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
         return Send2(loc, T(loc), core::Names::assertType(), std::move(value), std::move(type));
     }

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -464,6 +464,16 @@ void GlobalState::initEmpty() {
     ENFORCE(typeArgument == Symbols::todoTypeArgument());
     typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
 
+    id = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::InterfaceWrapper());
+    ENFORCE(id == Symbols::T_InterfaceWrapper());
+    method = enterMethodSymbol(Loc::none(), Symbols::T_InterfaceWrapper(), Names::dynamicCast());
+    {
+        auto &arg0 = enterMethodArgumentSymbol(Loc::none(), method, Names::arg0());
+        arg0.type = Types::untyped(*this, method);
+        auto &arg1 = enterMethodArgumentSymbol(Loc::none(), method, Names::arg1());
+        arg1.type = Types::untyped(*this, method);
+    }
+
     // Root members
     Symbols::root().data(*this)->members()[core::Names::Constants::NoSymbol()] = Symbols::noSymbol();
     Symbols::root().data(*this)->members()[core::Names::Constants::Top()] = Symbols::top();

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -861,6 +861,10 @@ public:
         return MethodRef::fromRaw(10);
     }
 
+    static ClassOrModuleRef T_InterfaceWrapper() {
+        return ClassOrModuleRef::fromRaw(86);
+    }
+
     static constexpr int MAX_PROC_ARITY = 10;
     static ClassOrModuleRef Proc0() {
         return ClassOrModuleRef::fromRaw(MAX_SYNTHETIC_CLASS_SYMBOLS - MAX_PROC_ARITY * 2 - 2);
@@ -884,10 +888,10 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 200;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 36;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 37;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 3;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
-    static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 97;
+    static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 98;
 };
 
 template <typename H> H AbslHashValue(H h, const SymbolRef &m) {

--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -13,5 +13,6 @@ constexpr ErrorClass TEnumConstNotEnumValue{3506, StrictLevel::False};
 constexpr ErrorClass BadTestEach{3507, StrictLevel::True};
 constexpr ErrorClass PropForeignStrict{3508, StrictLevel::False};
 constexpr ErrorClass ComputedBySymbol{3509, StrictLevel::False};
+constexpr ErrorClass BadDynamicCast{3510, StrictLevel::False};
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -240,6 +240,8 @@ NameDef names[] = {
     {"skipSetter", "skip_setter"},
 
     {"wrapInstance", "wrap_instance"},
+    {"dynamicCast", "dynamic_cast"},
+    {"InterfaceWrapper", "InterfaceWrapper", true},
 
     {"registered"},
     {"instanceRegistered", "<instance_registered>"},

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -242,6 +242,7 @@ NameDef names[] = {
     {"wrapInstance", "wrap_instance"},
     {"dynamicCast", "dynamic_cast"},
     {"InterfaceWrapper", "InterfaceWrapper", true},
+    {"nonNilDynamicCast", "non_nil_dynamic_cast"},
 
     {"registered"},
     {"instanceRegistered", "<instance_registered>"},

--- a/rewriter/InterfaceWrapper.cc
+++ b/rewriter/InterfaceWrapper.cc
@@ -55,7 +55,9 @@ ast::ExpressionPtr rewriteDynamicCast(core::MutableContext ctx, ast::Send *send,
         return nullptr;
     }
 
-    auto type = ast::MK::Nilable(send->loc, move(send->args[1]));
+    auto type = name == core::Names::dynamicCast()
+        ? ast::MK::Nilable(send->loc, move(send->args[1]))
+        : move(send->args[1]);
     return ast::MK::Cast(send->loc, move(send->args[0]), move(type));
 }
 }
@@ -69,7 +71,7 @@ ast::ExpressionPtr InterfaceWrapper::run(core::MutableContext ctx, ast::Send *se
         return rewriteWrapInstance(ctx, send);
     }
 
-    if (send->fun == core::Names::dynamicCast()) {
+    if (send->fun == core::Names::dynamicCast() || send->fun == core::Names::nonNilDynamicCast()) {
         return rewriteDynamicCast(ctx, send, send->fun);
     }
 

--- a/rewriter/InterfaceWrapper.cc
+++ b/rewriter/InterfaceWrapper.cc
@@ -55,12 +55,11 @@ ast::ExpressionPtr rewriteDynamicCast(core::MutableContext ctx, ast::Send *send,
         return nullptr;
     }
 
-    auto type = name == core::Names::dynamicCast()
-        ? ast::MK::Nilable(send->loc, move(send->args[1]))
-        : move(send->args[1]);
+    auto type =
+        name == core::Names::dynamicCast() ? ast::MK::Nilable(send->loc, move(send->args[1])) : move(send->args[1]);
     return ast::MK::Cast(send->loc, move(send->args[0]), move(type));
 }
-}
+} // namespace
 
 ast::ExpressionPtr InterfaceWrapper::run(core::MutableContext ctx, ast::Send *send) {
     if (ctx.state.runningUnderAutogen) {

--- a/test/testdata/rewriter/interface_wrapper.rb
+++ b/test/testdata/rewriter/interface_wrapper.rb
@@ -29,4 +29,8 @@ def testit
   Other.wrap_instance("hi", "there") # error: Wrong number of arguments
   o = Other
   o.wrap_instance("hi") # error: Unsupported wrap_instance() on a non-constant-literal
+
+  T::InterfaceWrapper.dynamic_cast(s) # error: Not enough arguments
+  T::InterfaceWrapper.dynamic_cast(s, s, s) # error: Too many arguments
+  x = T::InterfaceWrapper.dynamic_cast(s, Other)
 end

--- a/test/testdata/rewriter/interface_wrapper.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/interface_wrapper.rb.rewrite-tree.exp
@@ -9,6 +9,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C Other>.wrap_instance("hi", "there")
       o = <emptyTree>::<C Other>
       o.wrap_instance("hi")
+      <emptyTree>::<C T>::<C InterfaceWrapper>.dynamic_cast(s)
+      <emptyTree>::<C T>::<C InterfaceWrapper>.dynamic_cast(s, s, s)
+      x = ::T.cast(s, ::T.nilable(<emptyTree>::<C Other>))
     end
   end
 


### PR DESCRIPTION
`T::InterfaceWrapper#dynamic_cast` appears to be `T.untyped`, which isn't helpful; we can do somewhat better by rewriting it into a type assertion (dynamically checked, unfortunately).  This at least lets us detect places where `dynamic_cast` could return `nil` but people are obviously not expecting it to.  The followup is to make such places use `non_nil_dynamic_cast`, which raises if `nil` would be returned.

### Motivation

We want to get rid of `wrap_instance` and `dynamic_cast`.  A good first step to doing that is making sure the latter is typed correctly for all existing uses, so they're easier to convert away.

A further ratchet down would be turning the cast into `T.let`, which ideally would be safe, but would probably turn up its own set of bugs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
