### PR TITLE
FIx bundler with_*_env missing block in signatures

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_5_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_5_hidden.rbi.exp
@@ -1894,8 +1894,6 @@ module Bundler
   def self.unbundled_exec(*args); end
 
   def self.unbundled_system(*args); end
-
-  def self.with_unbundled_env(); end
 end
 
 class Class

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
@@ -1898,8 +1898,6 @@ module Bundler
   def self.unbundled_exec(*args); end
 
   def self.unbundled_system(*args); end
-
-  def self.with_unbundled_env(); end
 end
 
 class Class

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_5_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_5_hidden.rbi.exp
@@ -1894,8 +1894,6 @@ module Bundler
   def self.unbundled_exec(*args); end
 
   def self.unbundled_system(*args); end
-
-  def self.with_unbundled_env(); end
 end
 
 class C1

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
@@ -1898,8 +1898,6 @@ module Bundler
   def self.unbundled_exec(*args); end
 
   def self.unbundled_system(*args); end
-
-  def self.with_unbundled_env(); end
 end
 
 class C1

--- a/rbi/stdlib/bundler.rbi
+++ b/rbi/stdlib/bundler.rbi
@@ -376,13 +376,16 @@ module Bundler
   def self.which(executable); end
 
   # @deprecated Use `with\_unbundled\_env` instead
-  sig {returns(T.untyped)}
-  def self.with_clean_env(); end
+  sig {params(block: T.proc.returns(T.untyped)).returns(T.untyped)}
+  def self.with_clean_env(&block); end
+
+  sig {params(block: T.proc.returns(T.untyped)).returns(T.untyped)}
+  def self.with_unbundled_env(&block); end
 
   # Run block with environment present before
   # [`Bundler`](https://docs.ruby-lang.org/en/2.7.0/Bundler.html) was activated
-  sig {returns(T.untyped)}
-  def self.with_original_env(); end
+  sig {params(block: T.proc.returns(T.untyped)).returns(T.untyped)}
+  def self.with_original_env(&block); end
 end
 
 class Bundler::APIResponseMismatchError < Bundler::BundlerError

--- a/test/testdata/rbi/bundler.rb
+++ b/test/testdata/rbi/bundler.rb
@@ -1,0 +1,16 @@
+# typed: true
+
+require "bundler"
+
+Bundler.with_clean_env { true }
+Bundler.with_original_env { true }
+Bundler.with_unbundled_env { true }
+
+  Bundler.with_clean_env
+# ^^^^^^^^^^^^^^^^^^^^^^ error: `with_clean_env` requires a block parameter, but no block was passed
+
+  Bundler.with_original_env
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ error: `with_original_env` requires a block parameter, but no block was passed
+
+  Bundler.with_unbundled_env
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `with_unbundled_env` requires a block parameter, but no block was passed


### PR DESCRIPTION
The bundler methods `with_*_env` all take a block that is missing from the signature. I added the block in and also added a signature for `with_unbundled_env`, since it's the new recommended method instead of `with_clean_env`.

### Motivation

Type checking is incorrectly failing saying that the method does not accept a block.

### Test plan

See included automated tests.