### PR TITLE
lazily compute source ancestors during final method checks

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -103,8 +103,7 @@ module T::Private::Methods
   # names that were declared final at one point.
   def self._check_final_ancestors(target, target_ancestors, source_method_names, source)
     source_ancestors = nil
-    # use reverse_each to check farther-up ancestors first, for better error messages. we could avoid this if we were on
-    # the version of ruby that adds the optional argument to method_defined? that allows you to exclude ancestors.
+    # use reverse_each to check farther-up ancestors first, for better error messages.
     target_ancestors.reverse_each do |ancestor|
       final_methods = @modules_with_final.fetch(ancestor, nil)
       # In this case, either ancestor didn't have any final methods anywhere in its

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -110,7 +110,7 @@ module T::Private::Methods
       # ancestor chain, or ancestor did have final methods somewhere in its ancestor
       # chain, but no final methods defined in ancestor itself.  Either way, there
       # are no final methods to check here, so we can move on to the next ancestor.
-      next if !final_methods
+      next unless final_methods
       source_method_names.each do |method_name|
         next unless final_methods.include?(method_name)
 


### PR DESCRIPTION
This is the latest entry in the continuing effort to do as little work as possible during final method checks.  When we were extending/including/inheriting from a module, we have this code:

https://github.com/sorbet/sorbet/blob/b26edd89cb930ee7e58790c72c15a64fb74b3f8f/gems/sorbet-runtime/lib/types/private/methods/_methods.rb#L436-L437

It looks like we're just trying to filter out some classes.  But this is relatively expensive: we're computing `ancestors` and we're doing a set-difference operation on arrays, which is not super-quick (though Ruby is smart enough to do set-based differencing if the arrays are long enough...but that's also memory pressure that we don't really want).  Wouldn't it be nice if we could avoid doing those things?

It turns out that we can!...most of the time.  Since we permit the same module to be included or extended from multiple times (we have tests for this), the above check was ensuring that we never actually saw such a module during final method checks: if `target` already had it in its ancestor chain, the set difference operation would remove it.  But it turns out we can wait to see if we would have a final method violation, and only then compute whether the violation that we care about results in the same module being included multiple times.  Since violations are uncommon, this should be a decent savings from moving work off the critical path.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
