### PR TITLE
Fix syntax in requires-ancestor docs

### DIFF
--- a/website/docs/requires-ancestor.md
+++ b/website/docs/requires-ancestor.md
@@ -12,7 +12,7 @@ method:
 # typed: true
 
 module MyHelper
-  def say_error(message):
+  def say_error(message)
     raise "InternalError: #{message}" # error: Method `raise` does not exist on `MyHelper`
   end
 end
@@ -62,7 +62,7 @@ module MyHelper
 
   requires_ancestor Kernel
 
-  def say_error(message):
+  def say_error(message)
     raise "InternalError: #{message}"
   end
 end


### PR DESCRIPTION
Remove trailing colon from method definition in the docs for `requires_ancestor`

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fix the code examples so they can be copy-pasted
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
N/A
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

