### PR TITLE
Fix bundle install bin warnings

### DIFF
--- a/gems/sorbet/sorbet.gemspec
+++ b/gems/sorbet/sorbet.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.authors     = ['Stripe']
   s.email       = 'sorbet@stripe.com'
   s.files       = Dir.glob('lib/**/*')
-  s.executables = Dir.glob('bin/**/*').map {|path| path.gsub('bin/', '')}
+  s.executables = ['srb', 'srb-rbi']
   s.homepage    = 'https://sorbet.run'
   s.license     = 'Apache-2.0'
   s.metadata = {


### PR DESCRIPTION
Inline bin names to avoid searching to missing binaries

https://github.com/sorbet/sorbet/issues/4102

### Motivation

I was getting warning when installing the `sorbet` gem from GitHub.

### Test plan

No test, because I don't know how to test it, except that I got the warnings, and then didn't after the change.
