### PR TITLE
fix JSON loading error when encountering empty strings

### DIFF
--- a/gems/sorbet/lib/require_everything.rb
+++ b/gems/sorbet/lib/require_everything.rb
@@ -131,7 +131,7 @@ class Sorbet::Private::RequireEverything
     #     ...
     #   ]
     # }
-    parsed = JSON.parse(output)
+    parsed = output.empty? ? {} : JSON.parse(output)
     parsed
       .fetch('files', [])
       .reject{|file| ["Ignore", "Stdlib"].include?(file["strict"])}


### PR DESCRIPTION
happens when requiring everything

I had an error when trying to load JSON with an empty string, probably because loading of dependent gems failed, not sure.

### Motivation

This is more to make you aware of the problem.

### Test plan

It should probably have tests, this isn't meant to be merged just to show you there is a place where an error can happen.
