### PR TITLE
Make isPackagerName work on singleton packager class names.

### DIFF
--- a/core/Names.cc
+++ b/core/Names.cc
@@ -208,16 +208,21 @@ bool NameRef::isTEnumName(const GlobalState &gs) const {
 }
 
 bool NameRef::isPackagerName(const GlobalState &gs) const {
-    if (kind() == NameKind::UNIQUE) {
-        // May be the name of a package's singleton class.
-        auto data = dataUnique(gs);
-        return data->uniqueNameKind == UniqueNameKind::Singleton && data->original.isPackagerName(gs);
+    switch (kind()) {
+        case NameKind::UNIQUE: {
+            // May be the name of a package's singleton class.
+            auto data = dataUnique(gs);
+            return data->uniqueNameKind == UniqueNameKind::Singleton && data->original.isPackagerName(gs);
+        }
+        case NameKind::CONSTANT: {
+            auto original = dataCnst(gs)->original;
+            return original.kind() == NameKind::UNIQUE &&
+                   original.dataUnique(gs)->uniqueNameKind == UniqueNameKind::Packager;
+        }
+        case NameKind::UTF8: {
+            return false;
+        }
     }
-    if (kind() != NameKind::CONSTANT) {
-        return false;
-    }
-    auto original = dataCnst(gs)->original;
-    return original.kind() == NameKind::UNIQUE && original.dataUnique(gs)->uniqueNameKind == UniqueNameKind::Packager;
 }
 
 bool NameRef::isValidConstantName(const GlobalState &gs) const {

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -208,6 +208,11 @@ bool NameRef::isTEnumName(const GlobalState &gs) const {
 }
 
 bool NameRef::isPackagerName(const GlobalState &gs) const {
+    if (kind() == NameKind::UNIQUE) {
+        // May be the name of a package's singleton class.
+        auto data = dataUnique(gs);
+        return data->uniqueNameKind == UniqueNameKind::Singleton && data->original.isPackagerName(gs);
+    }
     if (kind() != NameKind::CONSTANT) {
         return false;
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Make isPackagerName work on singleton packager class names.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

@elliottt and @aprocter-stripe discovered this bug while showing me a different bug.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We don't have tests for this. I can add an explicit test into core/test/core_test.cc if it seems useful.
