### PR TITLE
UnboundMethod#bind_call supports a block

### DIFF
--- a/rbi/core/unbound_method.rbi
+++ b/rbi/core/unbound_method.rbi
@@ -137,7 +137,7 @@ class UnboundMethod
   # Bind *umeth* to *recv* and then invokes the method with the specified
   # arguments. This is semantically equivalent to `umeth.bind(recv).call(args,
   # ...)`.
-  sig {params(recv: BasicObject, args: T.untyped, &blk: T.untyped).returns(T.untyped)}
+  sig {params(recv: BasicObject, args: T.untyped, blk: T.untyped).returns(T.untyped)}
   def bind_call(recv, *args, &blk); end
 
   # Returns a clone of this method.

--- a/rbi/core/unbound_method.rbi
+++ b/rbi/core/unbound_method.rbi
@@ -137,8 +137,8 @@ class UnboundMethod
   # Bind *umeth* to *recv* and then invokes the method with the specified
   # arguments. This is semantically equivalent to `umeth.bind(recv).call(args,
   # ...)`.
-  sig {params(recv: BasicObject, args: T.untyped).returns(T.untyped)}
-  def bind_call(recv, *args); end
+  sig {params(recv: BasicObject, args: T.untyped, &blk: T.untyped).returns(T.untyped)}
+  def bind_call(recv, *args, &blk); end
 
   # Returns a clone of this method.
   #


### PR DESCRIPTION
### Motivation
Improve accuracy of stdlib types

### Test plan
Didn't see any existing tests for unbound_method.rbi so didn't add one, but verified Ruby's behavior locally:

```
irb(main):002:0> class C; def foo(&blk); blk.call; end; end
=> :foo
irb(main):003:0> m = C.instance_method(:foo)
=> #<UnboundMethod: C#foo(&blk) (irb):2>
irb(main):004:0> m.bind_call(C.new) {puts "hi"}
hi
=> nil
```