### PR TITLE
Fix Kernel#catch signature

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -206,9 +206,9 @@ module Kernel
   sig do
     params(
         tag: Object,
-        blk: T.proc.params(arg0: Object).returns(BasicObject),
+        blk: T.proc.params(arg0: Object).returns(T.untyped),
     )
-    .returns(BasicObject)
+    .returns(T.untyped)
   end
   def catch(tag=Object.new, &blk); end
 

--- a/test/testdata/rbi/kernel.rb
+++ b/test/testdata/rbi/kernel.rb
@@ -1,10 +1,5 @@
 # typed: true
 
-T.assert_type!(catch(1) { throw 1 }, BasicObject)
-T.assert_type!(catch(1) { throw 1, 'test' }, BasicObject)
-T.assert_type!(catch {|obj_A| throw(obj_A, 'test')}, BasicObject)
-T.assert_type!(catch {1}, BasicObject)
-
 T.assert_type!(caller, T::Array[String])
 T.assert_type!(caller(10), T.nilable(T::Array[String]))
 


### PR DESCRIPTION
Was: catch returns `BaseObject`
Now: catch returns `T.untyped`

See https://apidock.com/ruby/Kernel/catch
