### PR TITLE
LSP - Assume large changes cannot take the incremental (fast) path.

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -43,10 +43,8 @@ MarkupKind getPreferredMarkupKind(vector<MarkupKind> formats) {
 } // namespace
 
 LSPConfiguration::LSPConfiguration(const options::Options &opts, const shared_ptr<LSPOutput> &output,
-                                   const shared_ptr<spdlog::logger> &logger, bool disableFastPath,
-                                   u4 maxFilesOnFastPath)
-    : initialized(atomic<bool>(false)), opts(opts), output(output), logger(logger),
-      maxFilesOnFastPath(maxFilesOnFastPath), disableFastPath(disableFastPath),
+                                   const shared_ptr<spdlog::logger> &logger, bool disableFastPath)
+    : initialized(atomic<bool>(false)), opts(opts), output(output), logger(logger), disableFastPath(disableFastPath),
       rootPath(getRootPath(output, opts, logger)) {}
 
 void LSPConfiguration::assertHasClientConfig() const {

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -43,8 +43,10 @@ MarkupKind getPreferredMarkupKind(vector<MarkupKind> formats) {
 } // namespace
 
 LSPConfiguration::LSPConfiguration(const options::Options &opts, const shared_ptr<LSPOutput> &output,
-                                   const shared_ptr<spdlog::logger> &logger, bool disableFastPath)
-    : initialized(atomic<bool>(false)), opts(opts), output(output), logger(logger), disableFastPath(disableFastPath),
+                                   const shared_ptr<spdlog::logger> &logger, bool disableFastPath,
+                                   u4 maxFilesOnFastPath)
+    : initialized(atomic<bool>(false)), opts(opts), output(output), logger(logger),
+      maxFilesOnFastPath(maxFilesOnFastPath), disableFastPath(disableFastPath),
       rootPath(getRootPath(output, opts, logger)) {}
 
 void LSPConfiguration::assertHasClientConfig() const {

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -59,8 +59,6 @@ public:
  * initialized boolean. All other threads have read-only access.
  */
 class LSPConfiguration {
-    static constexpr u4 DEFAULT_MAX_FILES_ON_FAST_PATH = 50;
-
     // Raw access to clientConfig is restricted to avoid race conditions. `getClientConfig` safely mediates read-only
     // access to this object. Object is `const` to avoid mutations post-initialization.
     // clientConfig is set by the LSPPreprocessor.
@@ -79,8 +77,6 @@ public:
     const options::Options &opts;
     const std::shared_ptr<LSPOutput> output;
     const std::shared_ptr<spdlog::logger> logger;
-    /* The maximum number of files that are permitted to typecheck on the fast path concurrently. */
-    const u4 maxFilesOnFastPath;
     /** If true, all queries will hit the slow path. */
     const bool disableFastPath;
     /** File system root of LSP client workspace. May be empty if it is the current working directory. */
@@ -89,8 +85,7 @@ public:
     // The following properties are configured during initialization.
 
     LSPConfiguration(const options::Options &opts, const std::shared_ptr<LSPOutput> &output,
-                     const std::shared_ptr<spdlog::logger> &logger, bool disableFastPath = false,
-                     u4 maxFilesOnFastPath = DEFAULT_MAX_FILES_ON_FAST_PATH);
+                     const std::shared_ptr<spdlog::logger> &logger, bool disableFastPath = false);
 
     // Note: These two methods should only be called from the LSPPreprocessor thread, which is the only place that
     // should have mutable access to LSPConfiguration.

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -59,6 +59,8 @@ public:
  * initialized boolean. All other threads have read-only access.
  */
 class LSPConfiguration {
+    static constexpr u4 DEFAULT_MAX_FILES_ON_FAST_PATH = 50;
+
     // Raw access to clientConfig is restricted to avoid race conditions. `getClientConfig` safely mediates read-only
     // access to this object. Object is `const` to avoid mutations post-initialization.
     // clientConfig is set by the LSPPreprocessor.
@@ -77,6 +79,8 @@ public:
     const options::Options &opts;
     const std::shared_ptr<LSPOutput> output;
     const std::shared_ptr<spdlog::logger> logger;
+    /* The maximum number of files that are permitted to typecheck on the fast path concurrently. */
+    const u4 maxFilesOnFastPath;
     /** If true, all queries will hit the slow path. */
     const bool disableFastPath;
     /** File system root of LSP client workspace. May be empty if it is the current working directory. */
@@ -85,7 +89,8 @@ public:
     // The following properties are configured during initialization.
 
     LSPConfiguration(const options::Options &opts, const std::shared_ptr<LSPOutput> &output,
-                     const std::shared_ptr<spdlog::logger> &logger, bool disableFastPath = false);
+                     const std::shared_ptr<spdlog::logger> &logger, bool disableFastPath = false,
+                     u4 maxFilesOnFastPath = DEFAULT_MAX_FILES_ON_FAST_PATH);
 
     // Note: These two methods should only be called from the LSPPreprocessor thread, which is the only place that
     // should have mutable access to LSPConfiguration.

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -95,7 +95,7 @@ bool LSPIndexer::canTakeFastPathInternal(
     }
 
     if (changedFiles.size() > config->opts.lspMaxFilesOnFastPath) {
-        logger.debug("Taking slow path because too many files chnaged ({} files > {} files)", changedFiles.size(),
+        logger.debug("Taking slow path because too many files changed ({} files > {} files)", changedFiles.size(),
                      config->opts.lspMaxFilesOnFastPath);
         prodCategoryCounterInc("lsp.slow_path_reason", "too_many_files");
         return false;
@@ -159,7 +159,7 @@ bool LSPIndexer::canTakeFastPath(const vector<shared_ptr<core::File>> &changedFi
 
     // Avoid expensively computing file hashes if there are too many files.
     if (changedFiles.size() > config->opts.lspMaxFilesOnFastPath) {
-        config->logger->debug("Taking slow path because too many files chnaged ({} files > {} files)",
+        config->logger->debug("Taking slow path because too many files changed ({} files > {} files)",
                               changedFiles.size(), config->opts.lspMaxFilesOnFastPath);
         prodCategoryCounterInc("lsp.slow_path_reason", "too_many_files");
         return false;

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -82,14 +82,22 @@ void LSPIndexer::computeFileHashes(const vector<shared_ptr<core::File>> &files) 
     computeFileHashes(files, *emptyWorkers);
 }
 
-bool LSPIndexer::canTakeFastPath(const vector<shared_ptr<core::File>> &changedFiles,
-                                 const UnorderedMap<core::FileRef, shared_ptr<core::File>> &evictedFiles) const {
+bool LSPIndexer::canTakeFastPathInternal(
+    const vector<shared_ptr<core::File>> &changedFiles,
+    const UnorderedMap<core::FileRef, shared_ptr<core::File>> &evictedFiles) const {
     Timer timeit(config->logger, "fast_path_decision");
     auto &logger = *config->logger;
     logger.debug("Trying to see if fast path is available after {} file changes", changedFiles.size());
     if (config->disableFastPath) {
         logger.debug("Taking slow path because fast path is disabled.");
         prodCategoryCounterInc("lsp.slow_path_reason", "fast_path_disabled");
+        return false;
+    }
+
+    if (changedFiles.size() > config->maxFilesOnFastPath) {
+        logger.debug("Taking slow path because too many files chnaged ({} files > {} files)", changedFiles.size(),
+                     config->maxFilesOnFastPath);
+        prodCategoryCounterInc("lsp.slow_path_reason", "too_many_files");
         return false;
     }
 
@@ -143,12 +151,23 @@ bool LSPIndexer::canTakeFastPath(const LSPFileUpdates &edit,
         prodCategoryCounterInc("lsp.slow_path_reason", "new_file");
         return false;
     }
-    return canTakeFastPath(edit.updatedFiles, evictedFiles);
+    return canTakeFastPathInternal(edit.updatedFiles, evictedFiles);
 }
 
 bool LSPIndexer::canTakeFastPath(const vector<shared_ptr<core::File>> &changedFiles) const {
     static UnorderedMap<core::FileRef, shared_ptr<core::File>> emptyMap;
-    return canTakeFastPath(changedFiles, emptyMap);
+
+    // Avoid expensively computing file hashes if there are too many files.
+    if (changedFiles.size() > config->maxFilesOnFastPath) {
+        config->logger->debug("Taking slow path because too many files chnaged ({} files > {} files)",
+                              changedFiles.size(), config->maxFilesOnFastPath);
+        prodCategoryCounterInc("lsp.slow_path_reason", "too_many_files");
+        return false;
+    }
+
+    // Ensure all files have computed hashes.
+    computeFileHashes(changedFiles);
+    return canTakeFastPathInternal(changedFiles, emptyMap);
 }
 
 void LSPIndexer::initialize(LSPFileUpdates &updates, WorkerPool &workers) {
@@ -197,7 +216,7 @@ void LSPIndexer::initialize(LSPFileUpdates &updates, WorkerPool &workers) {
     initialGS->errorQueue = move(savedErrorQueue);
 }
 
-LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
+LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit, WorkerPool &workers) {
     Timer timeit(config->logger, "LSPIndexer::commitEdit");
     LSPFileUpdates update;
     update.epoch = edit.epoch;
@@ -250,7 +269,7 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
         initialGS->errorQueue = make_shared<core::ErrorQueue>(
             initialGS->errorQueue->logger, initialGS->errorQueue->tracer, make_shared<core::NullFlusher>());
         auto trees = hashing::Hashing::indexAndComputeFileHashes(initialGS, config->opts, *config->logger, frefs,
-                                                                 *emptyWorkers, kvstore);
+                                                                 workers, kvstore);
         update.updatedFileIndexes.resize(trees.size());
         for (auto &ast : trees) {
             const int i = fileToPos[ast.file];
@@ -318,6 +337,11 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
     pendingTypecheckUpdates.preemptionsExpected = 0;
 
     return update;
+}
+
+LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
+    ENFORCE(edit.updates.size() <= config->maxFilesOnFastPath, "Too many files to index serially");
+    return commitEdit(edit, *emptyWorkers);
 }
 
 core::FileRef LSPIndexer::uri2FileRef(string_view uri) const {

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -94,9 +94,9 @@ bool LSPIndexer::canTakeFastPathInternal(
         return false;
     }
 
-    if (changedFiles.size() > config->maxFilesOnFastPath) {
+    if (changedFiles.size() > config->opts.lspMaxFilesOnFastPath) {
         logger.debug("Taking slow path because too many files chnaged ({} files > {} files)", changedFiles.size(),
-                     config->maxFilesOnFastPath);
+                     config->opts.lspMaxFilesOnFastPath);
         prodCategoryCounterInc("lsp.slow_path_reason", "too_many_files");
         return false;
     }
@@ -158,9 +158,9 @@ bool LSPIndexer::canTakeFastPath(const vector<shared_ptr<core::File>> &changedFi
     static UnorderedMap<core::FileRef, shared_ptr<core::File>> emptyMap;
 
     // Avoid expensively computing file hashes if there are too many files.
-    if (changedFiles.size() > config->maxFilesOnFastPath) {
+    if (changedFiles.size() > config->opts.lspMaxFilesOnFastPath) {
         config->logger->debug("Taking slow path because too many files chnaged ({} files > {} files)",
-                              changedFiles.size(), config->maxFilesOnFastPath);
+                              changedFiles.size(), config->opts.lspMaxFilesOnFastPath);
         prodCategoryCounterInc("lsp.slow_path_reason", "too_many_files");
         return false;
     }
@@ -340,7 +340,7 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit, WorkerPoo
 }
 
 LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
-    ENFORCE(edit.updates.size() <= config->maxFilesOnFastPath, "Too many files to index serially");
+    ENFORCE(edit.updates.size() <= config->opts.lspMaxFilesOnFastPath, "Too many files to index serially");
     return commitEdit(edit, *emptyWorkers);
 }
 

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -48,8 +48,11 @@ class LSPIndexer final {
      */
     bool canTakeFastPath(const LSPFileUpdates &edit,
                          const UnorderedMap<core::FileRef, std::shared_ptr<core::File>> &evictedFiles) const;
-    bool canTakeFastPath(const std::vector<std::shared_ptr<core::File>> &changedFiles,
-                         const UnorderedMap<core::FileRef, std::shared_ptr<core::File>> &evictedFiles) const;
+    /**
+     * INVARIANT: `changedFiles` must have hashes computed.
+     */
+    bool canTakeFastPathInternal(const std::vector<std::shared_ptr<core::File>> &changedFiles,
+                                 const UnorderedMap<core::FileRef, std::shared_ptr<core::File>> &evictedFiles) const;
 
 public:
     LSPIndexer(std::shared_ptr<const LSPConfiguration> config, std::unique_ptr<core::GlobalState> initialGS,
@@ -74,6 +77,7 @@ public:
      * Commits the given edit to `initialGS`, and returns a canonical LSPFileUpdates object containing indexed trees
      * and file hashes. Also handles canceling the running slow path.
      */
+    LSPFileUpdates commitEdit(SorbetWorkspaceEditParams &edit, WorkerPool &workers);
     LSPFileUpdates commitEdit(SorbetWorkspaceEditParams &edit);
 
     /**

--- a/main/lsp/notifications/initialized.cc
+++ b/main/lsp/notifications/initialized.cc
@@ -13,8 +13,8 @@ void InitializedTask::preprocess(LSPPreprocessor &preprocessor) {
 }
 
 void InitializedTask::index(LSPIndexer &indexer) {
-    // Hacky: We need to use the indexer, but with the WorkerPool from runSpecial. This is the only task to have this
-    // special requirement.
+    // Hacky: We need to use the indexer, but with the WorkerPool from runSpecial. This + SorbetWorkspaceEdit are the
+    // only tasks to have this special requirement.
     this->indexer = &indexer;
 }
 

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -56,7 +56,7 @@ void SorbetWorkspaceEditTask::preprocess(LSPPreprocessor &preprocessor) {
 }
 
 void SorbetWorkspaceEditTask::index(LSPIndexer &indexer) {
-    if (params->updates.size() <= config.maxFilesOnFastPath) {
+    if (params->updates.size() <= config.opts.lspMaxFilesOnFastPath) {
         updates = make_unique<LSPFileUpdates>(indexer.commitEdit(*params));
     } else {
         // HACK: Too many files to `commitEdit` serially. Index in `runSpecial`.

--- a/main/lsp/notifications/sorbet_workspace_edit.h
+++ b/main/lsp/notifications/sorbet_workspace_edit.h
@@ -15,6 +15,8 @@ class SorbetWorkspaceEditTask final : public LSPDangerousTypecheckerTask {
     // Caches the fast path decision for the provided update. Becomes invalidated when the update changes.
     mutable bool cachedFastPathDecisionValid = false;
     mutable bool cachedFastPathDecision = false;
+    // HACK: In the event that this edit is too large to index serially, stash the indexer here for use in `runSpecial`.
+    LSPIndexer *indexer = nullptr;
 
 public:
     SorbetWorkspaceEditTask(const LSPConfiguration &config, std::unique_ptr<SorbetWorkspaceEditParams> params);

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -173,6 +173,10 @@ struct Options {
     u4 reserveConstantNameTableCapacity = 0;
     u4 reserveUniqueNameTableCapacity = 0;
 
+    /* The maximum number of files that are permitted to typecheck on the fast path concurrently. Not exposed on CLI.
+     * Placed on Options for convenience so tests can override. */
+    u4 lspMaxFilesOnFastPath = 50;
+
     std::string statsdHost;
     std::string statsdPrefix = "ruby_typer.unknown";
     int statsdPort = 8200;

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -323,7 +323,7 @@ TEST_CASE("LSPTest") {
             BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
         opts->stripePackages = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
         // Set to a number that is reasonable large for tests, but small enough that we can have a test to handle this
-        // edge case. If you change this number, update the `lsp/fast_path/too_many_files` test.
+        // edge case. If you change this number, update the `lsp/fast_path/too_many_files` and `not_enough_files` tests.
         opts->lspMaxFilesOnFastPath = 10;
         lspWrapper = SingleThreadedLSPWrapper::create("", move(opts));
         lspWrapper->enableAllExperimentalFeatures();

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -322,6 +322,9 @@ TEST_CASE("LSPTest") {
         opts->requiresAncestorEnabled =
             BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
         opts->stripePackages = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
+        // Set to a number that is reasonable large for tests, but small enough that we can have a test to handle this
+        // edge case. If you change this number, update the `lsp/fast_path/too_many_files` test.
+        opts->lspMaxFilesOnFastPath = 10;
         lspWrapper = SingleThreadedLSPWrapper::create("", move(opts));
         lspWrapper->enableAllExperimentalFeatures();
     }

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__1.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__1.rb
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__1.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__2.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__2.rb
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__2.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__3.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__3.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__3.rb
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__3.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__4.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__4.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__4.rb
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__4.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__5.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__5.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__5.rb
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__5.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__6.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__6.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__6.rb
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__6.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__7.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__7.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__7.rb
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__7.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__8.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__8.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__8.rb
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__8.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__9.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__9.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__9.rb
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__9.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__main.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__main.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+# assert-fast-path: not_enough_files__main.rb,not_enough_files__1.rb,not_enough_files__2.rb,not_enough_files__3.rb,not_enough_files__4.rb,not_enough_files__5.rb,not_enough_files__6.rb,not_enough_files__7.rb,not_enough_files__8.rb,not_enough_files__9.rb
+
+class MyClass
+  def my_method
+    a = T.let(10, Float) # error: Argument does not have asserted type `Float`
+  end
+end

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__main.rb
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__main.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+# Sorbet does not take the fast path when a "large" number of files change (10 in the test suite).
+# This test ensures that 1 fewer than this limit (9) still takes the fast path.
+
+class MyClass
+  def my_method
+    a = T.let(10, String) # error: Argument does not have asserted type `String`
+  end
+end

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__1.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__1.rb
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__1.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__10.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__10.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__10.rb
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__10.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__2.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__2.rb
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__2.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__3.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__3.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__3.rb
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__3.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__4.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__4.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__4.rb
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__4.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__5.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__5.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__5.rb
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__5.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__6.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__6.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__6.rb
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__6.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__7.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__7.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__7.rb
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__7.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__8.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__8.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__8.rb
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__8.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__9.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__9.1.rbupdate
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__9.rb
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__9.rb
@@ -1,0 +1,1 @@
+# typed: strict

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__main.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__main.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+# assert-slow-path: true
+
+class MyClass
+  def my_method
+    a = T.let(10, Float) # error: Argument does not have asserted type `Float`
+  end
+end

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__main.rb
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__main.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+# This test ensures that we _always_ take the slow path when a "large" number of files change -- even when the changes
+# could technically take the fast path. This is a performance optimization, as parallelism is only available on the
+# slow path.
+# The other files in this test are empty. This file has code to ensure that errors are properly updated.
+
+class MyClass
+  def my_method
+    a = T.let(10, String) # error: Argument does not have asserted type `String`
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

LSP - Assume large changes cannot take the incremental (fast) path.

To determine if a change (`SorbetWorkspaceEdit`) can be typechecked incrementally, the LSP server does the following:

* Parses the files.
* Calculates each file's file hash.
* Compares each file's hash against the previous version of the file's file hash.

This operation is serial and expensive if many files change. It is also unlikely that a large change can take the fast path. The user impact is that **Sorbet pauses for many seconds and does not respond to user input**.

To fix this problem, this PR does the following: If many files change, it assumes that the edit cannot take the fast path and _defers_ calculating file hashes (which are required for making the fast path determination for subsequent file edits) until just before the change typechecks, when a `WorkerPool` is available to parallelize the work.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

After fixing a crash that is correlated with large file edits, I noticed an uptick in tail latency and memory consumption and user complaints about Sorbet being unresponsive.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
