### PR TITLE
RBI: Fix invalid return type for Resolv::DNS#getaddresses

### DIFF
--- a/rbi/stdlib/resolv.rbi
+++ b/rbi/stdlib/resolv.rbi
@@ -237,7 +237,7 @@ class Resolv::DNS
   # [`Resolv::IPv6`](https://docs.ruby-lang.org/en/2.7.0/Resolv/IPv6.html)
   sig do
     params(name: T.any(String, Resolv::DNS::Name))
-    .returns(T.any(Resolv::IPv4, Resolv::IPv6))
+    .returns(T::Array[T.any(Resolv::IPv4, Resolv::IPv6)])
   end
   def getaddresses(name); end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
`getaddresses` actually returns an array and not single address. This PR fixes #4128 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
