### PR TITLE
RBI: Add signature for OpenSSL::SSL::SSLContext#add_certificate

### DIFF
--- a/rbi/stdlib/openssl.rbi
+++ b/rbi/stdlib/openssl.rbi
@@ -7404,6 +7404,16 @@ class OpenSSL::SSL::SSLContext
   # Server sessions are added to the session cache
   SESSION_CACHE_SERVER = ::T.let(nil, ::T.untyped)
 
+  sig do
+    params(
+      certificate: ::OpenSSL::X509::Certificate,
+      pkey: ::OpenSSL::PKey::PKey,
+      extra_certs: ::T.nilable(T::Array[::OpenSSL::X509::Certificate])
+    )
+    .returns(::OpenSSL::SSL::SSLContext)
+  end
+  def add_certificate(certificate, pkey, extra_certs = nil);
+
   # The path to a file containing a PEM-format CA certificate
   sig {returns(::T.untyped)}
   def ca_file(); end

--- a/rbi/stdlib/openssl.rbi
+++ b/rbi/stdlib/openssl.rbi
@@ -7412,7 +7412,7 @@ class OpenSSL::SSL::SSLContext
     )
     .returns(::OpenSSL::SSL::SSLContext)
   end
-  def add_certificate(certificate, pkey, extra_certs = nil);
+  def add_certificate(certificate, pkey, extra_certs = nil); end
 
   # The path to a file containing a PEM-format CA certificate
   sig {returns(::T.untyped)}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The RBI are missing type signature for `OpenSSL::SSL::SSLContext#add_certificate`. This PR adds that signature based on the standard lib documentation. This PR fixes #4096 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
