### PR TITLE
add a separate T::Configuration.deserialization_error_handler hook

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -294,29 +294,44 @@ module T::Configuration
   #
   # These generally shouldn't stop execution of the program, but rather inform
   # some party of the error to action on later.
+  #
+  # @param [Lambda, Proc, Object, nil] value Proc that handles the error
+  #   report (pass nil to reset to default behavior)
+  #
+  # Parameters passed to value.call:
+  #
+  # @param [Class] klass The class of the top-level object being deserialized
+  # @param [String] prop_name The name of the prop being deserialized
+  # @param [Object] value The prop value being deserialized
+  # @param [Error] orig_error The original error raised during deserialization
+  #
+  # @example
+  #   T::Configuration.deserialization_error_handler = lambda do |klass, prop_name, value, orig_error}
+  #     puts "Error deserializing #{prop_name} on #{klass}: #{orig_error.message}
+  #   end
   def self.deserialization_error_handler=(value)
     validate_lambda_given!(value)
     @deserialization_error_handler = value
   end
 
-  private_class_method def self.deserialization_error_handler_default(klass, prop_name, value, orig_err)
+  private_class_method def self.deserialization_error_handler_default(klass, prop_name, value, orig_error)
     soft_assert_handler(
       'Deserialization error (probably unexpected stored type)',
       storytime: {
         klass: klass,
         prop: prop_name,
         value: value,
-        error: orig_err.message,
+        error: orig_error.message,
         notify: 'djudd'
       }
     )
   end
 
-  def self.deserialization_error_handler(klass, prop_name, value, orig_err)
+  def self.deserialization_error_handler(klass, prop_name, value, orig_error)
     if @deserialization_error_handler
-      @deserialization_error_handler.call(klass, prop_name, value, orig_err)
+      @deserialization_error_handler.call(klass, prop_name, value, orig_error)
     else
-      deserialization_error_handler_default(klass, prop_name, value, orig_err)
+      deserialization_error_handler_default(klass, prop_name, value, orig_error)
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -290,6 +290,36 @@ module T::Configuration
     end
   end
 
+  # Set a handler for deserialization errors
+  #
+  # These generally shouldn't stop execution of the program, but rather inform
+  # some party of the error to action on later.
+  def self.deserialization_error_handler=(value)
+    validate_lambda_given!(value)
+    @deserialization_error_handler = value
+  end
+
+  private_class_method def self.deserialization_error_handler_default(klass, prop_name, value, orig_err)
+    soft_assert_handler(
+      'Deserialization error (probably unexpected stored type)',
+      storytime: {
+        klass: klass,
+        prop: prop_name,
+        value: value,
+        error: orig_err.message,
+        notify: 'djudd'
+      }
+    )
+  end
+
+  def self.deserialization_error_handler(klass, prop_name, value, orig_err)
+    if @deserialization_error_handler
+      @deserialization_error_handler.call(klass, prop_name, value, orig_err)
+    else
+      deserialization_error_handler_default(klass, prop_name, value, orig_err)
+    end
+  end
+
   # Set a handler for soft assertions
   #
   # These generally shouldn't stop execution of the program, but rather inform

--- a/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
@@ -261,7 +261,8 @@ module T::Props
     private_class_method def self.whitelisted_methods_for_deserialize
       @whitelisted_methods_for_deserialize ||= {
         lvar: %i{dup map transform_values transform_keys each_with_object nil? []= to_f},
-        const: %i[deserialize from_hash deep_clone_object soft_assert_handler],
+        self: %i{class},
+        const: %i[deserialize from_hash deep_clone_object deserialization_error_handler],
       }
     end
   end

--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -57,15 +57,11 @@ module T::Props
               begin
                 #{transformation}
               rescue NoMethodError => e
-                T::Configuration.soft_assert_handler(
-                  'Deserialization error (probably unexpected stored type)',
-                  storytime: {
-                    klass: self.class,
-                    prop: #{prop.inspect},
-                    value: val,
-                    error: e.message,
-                    notify: 'djudd'
-                  }
+                T::Configuration.deserialization_error_handler(
+                  self.class,
+                  #{prop.inspect},
+                  val,
+                  e,
                 )
                 val
               end

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -245,6 +245,8 @@ module Opus::Types::Test
       end
     end
 
+    # Tests for deserialization_error_handler are in serializable.rb.
+
     describe 'scalar_types' do
       describe 'when overridden' do
         it 'requires string values' do

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -152,6 +152,8 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(MySerializable, storytime[:klass])
       assert_equal(:foo, storytime[:prop])
       assert_equal("Won't respond like hash", storytime[:value])
+
+      T::Configuration.soft_assert_handler = nil
     end
 
     it 'includes relevant generated code on deserialize when we raise' do
@@ -166,6 +168,8 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_includes(e.message, "undefined method `transform_values'")
       assert_includes(e.message, "foo")
       assert_includes(e.message, "val.transform_values {|v| T::Props::Utils.deep_clone_object(v)}")
+
+      T::Configuration.soft_assert_handler = nil
     end
 
     it 'uses T::Configuration.deserialization_error_handler when we raise' do
@@ -183,6 +187,9 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_includes(e.message, "undefined method `transform_values'")
       assert_includes(e.message, "foo")
       assert_includes(e.message, "val.transform_values {|v| T::Props::Utils.deep_clone_object(v)}")
+
+      T::Configuration.soft_assert_handler = nil
+      T::Configuration.deserialization_error_handler = nil
     end
 
     it 'includes relevant generated code on serialize' do


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It seems better to have a separate path for deserialization errors, rather than forcing everything to go through `soft_assert_handler`.  I also have some changes to how deserialization works where it would be nice if the error reporting were wrapped up in a single method to call, rather than having to manually reproduce the `T::Configuration.soft_assert_handler` call.

I don't know whether/how much it actually matters, but one nice side-effect of this change is that the generated deserialization code becomes relatively smaller in cases where we would be throwing errors.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I added the resets for the `T::Configuration` hooks in the `serializable.rb` tests because otherwise I would see intermittent errors because test state was leaking across `describe` blocks (I assume?).  Example error from when `deserialization_error_handle` got left in its `raise` state:

```
froydnj@pyro:~/src/sorbet/gems/sorbet-runtime$ env PATH=/home/froydnj/ruby/bin:$PATH ~/ruby/bin/bundle exec ~/ruby/bin/rake test
warning: parser/current is loading parser/ruby27, which recognizes
warning: 2.7.2-compliant syntax, but you are running 2.7.3.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
/home/froydnj/src/sorbet/gems/sorbet-runtime/test/types/method_validation.rb:514: warning: key :_ is duplicated and overwritten on line 514
Run options: --seed 7632

# Running:

.......................................................................................................................E..............................................................................................................................................................S................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 0.407350s, 1784.7056 runs/s, 3999.0171 assertions/s.

  1) Error:
error message#test_0001_is only soft-assert by default for prop deserialize error:
RuntimeError: Error in Opus::Types::Test::Props::SerializableTest::MySerializable#__t_props_generated_deserialize: undefined method `transform_values' for "Won't respond like hash":String foo
at line 6 in:
  val = hash["foo"]
  @foo = if val.nil?
    found -= 1 unless hash.key?("foo")
    nil
  else
    begin
    val.transform_values {|v| T::Props::Utils.deep_clone_object(v)}
  rescue NoMethodError => e
    T::Configuration.deserialization_error_handler(
      self.class,
      :foo,
      val,
      e,
    )
    val
  end

    /home/froydnj/src/sorbet/gems/sorbet-runtime/lib/types/props/serializable.rb:70:in `rescue in deserialize'
    /home/froydnj/src/sorbet/gems/sorbet-runtime/lib/types/props/serializable.rb:60:in `deserialize'
    /home/froydnj/src/sorbet/gems/sorbet-runtime/lib/types/props/serializable.rb:187:in `from_hash'
    /home/froydnj/src/sorbet/gems/sorbet-runtime/lib/types/props/serializable.rb:322:in `from_hash'
    /home/froydnj/src/sorbet/gems/sorbet-runtime/test/types/props/serializable.rb:146:in `block (2 levels) in <class:SerializableTest>'

727 runs, 1629 assertions, 0 failures, 1 errors, 1 skips

You have skipped tests. Run with --verbose for details.
```

The other tests that were modified just seemed like good practice; happy to revert those changes.