### PR TITLE
revert "add a separate T::Configuration.deserialization_error_handler hook (#4148)"

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -290,51 +290,6 @@ module T::Configuration
     end
   end
 
-  # Set a handler for deserialization errors
-  #
-  # These generally shouldn't stop execution of the program, but rather inform
-  # some party of the error to action on later.
-  #
-  # @param [Lambda, Proc, Object, nil] value Proc that handles the error
-  #   report (pass nil to reset to default behavior)
-  #
-  # Parameters passed to value.call:
-  #
-  # @param [Class] klass The class of the top-level object being deserialized
-  # @param [String] prop_name The name of the prop being deserialized
-  # @param [Object] value The prop value being deserialized
-  # @param [Error] orig_error The original error raised during deserialization
-  #
-  # @example
-  #   T::Configuration.deserialization_error_handler = lambda do |klass, prop_name, value, orig_error}
-  #     puts "Error deserializing #{prop_name} on #{klass}: #{orig_error.message}
-  #   end
-  def self.deserialization_error_handler=(value)
-    validate_lambda_given!(value)
-    @deserialization_error_handler = value
-  end
-
-  private_class_method def self.deserialization_error_handler_default(klass, prop_name, value, orig_error)
-    soft_assert_handler(
-      'Deserialization error (probably unexpected stored type)',
-      storytime: {
-        klass: klass,
-        prop: prop_name,
-        value: value,
-        error: orig_error.message,
-        notify: 'djudd'
-      }
-    )
-  end
-
-  def self.deserialization_error_handler(klass, prop_name, value, orig_error)
-    if @deserialization_error_handler
-      @deserialization_error_handler.call(klass, prop_name, value, orig_error)
-    else
-      deserialization_error_handler_default(klass, prop_name, value, orig_error)
-    end
-  end
-
   # Set a handler for soft assertions
   #
   # These generally shouldn't stop execution of the program, but rather inform

--- a/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
@@ -261,8 +261,7 @@ module T::Props
     private_class_method def self.whitelisted_methods_for_deserialize
       @whitelisted_methods_for_deserialize ||= {
         lvar: %i{dup map transform_values transform_keys each_with_object nil? []= to_f},
-        self: %i{class},
-        const: %i[deserialize from_hash deep_clone_object deserialization_error_handler],
+        const: %i[deserialize from_hash deep_clone_object soft_assert_handler],
       }
     end
   end

--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -57,11 +57,15 @@ module T::Props
               begin
                 #{transformation}
               rescue NoMethodError => e
-                T::Configuration.deserialization_error_handler(
-                  self.class,
-                  #{prop.inspect},
-                  val,
-                  e,
+                T::Configuration.soft_assert_handler(
+                  'Deserialization error (probably unexpected stored type)',
+                  storytime: {
+                    klass: self.class,
+                    prop: #{prop.inspect},
+                    value: val,
+                    error: e.message,
+                    notify: 'djudd'
+                  }
                 )
                 val
               end

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -245,8 +245,6 @@ module Opus::Types::Test
       end
     end
 
-    # Tests for deserialization_error_handler are in serializable.rb.
-
     describe 'scalar_types' do
       describe 'when overridden' do
         it 'requires string values' do

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -152,8 +152,6 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(MySerializable, storytime[:klass])
       assert_equal(:foo, storytime[:prop])
       assert_equal("Won't respond like hash", storytime[:value])
-
-      T::Configuration.soft_assert_handler = nil
     end
 
     it 'includes relevant generated code on deserialize when we raise' do
@@ -168,28 +166,6 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_includes(e.message, "undefined method `transform_values'")
       assert_includes(e.message, "foo")
       assert_includes(e.message, "val.transform_values {|v| T::Props::Utils.deep_clone_object(v)}")
-
-      T::Configuration.soft_assert_handler = nil
-    end
-
-    it 'uses T::Configuration.deserialization_error_handler when we raise' do
-      T::Configuration.soft_assert_handler = proc do |msg, extra|
-        raise "shouldn't be here"
-      end
-      T::Configuration.deserialization_error_handler = proc do |klass, prop_name, value, orig_err|
-        raise "#{orig_err.message} #{prop_name}"
-      end
-
-      e = assert_raises(RuntimeError) do
-        MySerializable.from_hash({'foo' => "Won't respond like hash"})
-      end
-
-      assert_includes(e.message, "undefined method `transform_values'")
-      assert_includes(e.message, "foo")
-      assert_includes(e.message, "val.transform_values {|v| T::Props::Utils.deep_clone_object(v)}")
-
-      T::Configuration.soft_assert_handler = nil
-      T::Configuration.deserialization_error_handler = nil
     end
 
     it 'includes relevant generated code on serialize' do


### PR DESCRIPTION
r? @jez 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
