### PR TITLE
Add Object.itself signature (#4152)

### DIFF
--- a/rbi/core/object.rbi
+++ b/rbi/core/object.rbi
@@ -52,6 +52,14 @@ class Object < BasicObject
   sig {returns(Integer)}
   def object_id(); end
 
+  # Returns the receiver `obj`.
+  #
+  # ```ruby
+  # obj = Object.new; obj.itself.object_id == o.object_id # => true
+  # ```
+  sig {returns(T.self_type)}
+  def itself(); end
+
   # Yields self to the block and returns the result of the block.
   #
   # ```ruby


### PR DESCRIPTION
### Motivation

The RBI are missing type signature for Object#itself. This PR adds that signature based on the standard lib documentation. This PR fixes #4152

### Test plan

See included automated tests.
