### PR TITLE
Pathname#mkdir accepts an Integer, not a String

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -925,7 +925,7 @@ class Pathname < Object
   # [`Dir.mkdir`](https://docs.ruby-lang.org/en/2.7.0/Dir.html#method-c-mkdir).
   sig do
     params(
-        p1: String,
+        p1: Integer,
     )
     .returns(Integer)
   end


### PR DESCRIPTION
It's for the mode of the file getting created.