### PR TITLE
Improve OpenStruct type definitions

### DIFF
--- a/rbi/stdlib/open_struct.rbi
+++ b/rbi/stdlib/open_struct.rbi
@@ -196,7 +196,6 @@ class OpenStruct
   # data = OpenStruct.new("country" => "Australia", :capital => "Canberra")
   # data.each_pair.to_a   # => [[:country, "Australia"], [:capital, "Canberra"]]
   # ```
-  # sig {returns(::T.untyped)}
   sig do
     params(
         blk: T.proc.params(arg0: Symbol, arg1: ::T.untyped).returns(BasicObject),

--- a/rbi/stdlib/open_struct.rbi
+++ b/rbi/stdlib/open_struct.rbi
@@ -100,7 +100,7 @@ class OpenStruct
     params(
       other: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .returns(::T::Boolean)
   end
   def ==(other); end
 
@@ -196,8 +196,15 @@ class OpenStruct
   # data = OpenStruct.new("country" => "Australia", :capital => "Canberra")
   # data.each_pair.to_a   # => [[:country, "Australia"], [:capital, "Canberra"]]
   # ```
-  sig {returns(::T.untyped)}
-  def each_pair(); end
+  # sig {returns(::T.untyped)}
+  sig do
+    params(
+        blk: T.proc.params(arg0: Symbol, arg1: ::T.untyped).returns(BasicObject),
+    )
+    .returns(T::Array[[Symbol, ::T.untyped]])
+  end
+  sig {returns(T::Enumerator[[Symbol,::T.untyped]])}
+  def each_pair(&blk); end
 
   # Compares this object and `other` for equality. An
   # [`OpenStruct`](https://docs.ruby-lang.org/en/2.7.0/OpenStruct.html) is eql?
@@ -209,7 +216,7 @@ class OpenStruct
     params(
       other: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .returns(::T::Boolean)
   end
   def eql?(other); end
 
@@ -224,7 +231,7 @@ class OpenStruct
   #
   # See also
   # [`Object#hash`](https://docs.ruby-lang.org/en/2.7.0/Object.html#method-i-hash).
-  sig {returns(::T.untyped)}
+  sig {returns(Integer)}
   def hash(); end
 
   sig do
@@ -239,7 +246,7 @@ class OpenStruct
   #
   # Also aliased as:
   # [`to_s`](https://docs.ruby-lang.org/en/2.7.0/OpenStruct.html#method-i-to_s)
-  sig {returns(::T.untyped)}
+  sig {returns(String)}
   def inspect(); end
 
   # Provides marshalling support for use by the
@@ -298,11 +305,11 @@ class OpenStruct
   # data.to_h {|name, value| [name.to_s, value.upcase] }
   #             # => {"country" => "AUSTRALIA", "capital" => "CANBERRA" }
   # ```
-  sig {returns(::T.untyped)}
+  sig {returns(::T::Hash[Symbol, ::T.untyped])}
   def to_h(); end
 
   # Alias for:
   # [`inspect`](https://docs.ruby-lang.org/en/2.7.0/OpenStruct.html#method-i-inspect)
-  sig {returns(::T.untyped)}
+  sig {returns(String)}
   def to_s(); end
 end

--- a/test/testdata/rbi/open_struct.rb
+++ b/test/testdata/rbi/open_struct.rb
@@ -1,0 +1,26 @@
+# typed: strict
+
+require 'ostruct'
+
+OpenStruct.new
+person = OpenStruct.new(name: 'John Smith', age: 70)
+person.send(:age)
+person[:name]
+person[:not_defined]
+person[:name] = 'Jane Smith'
+
+T.reveal_type(person.send(:age)) # error: Revealed type: `T.untyped`
+T.reveal_type(person[:name]) # error: Revealed type: `T.untyped`
+T.reveal_type(person[:not_defined]) # error: Revealed type: `T.untyped`
+
+T.assert_type!(person.hash, Integer)
+T.assert_type!(person == person, T::Boolean)
+
+T.assert_type!(person.each_pair, T::Enumerator[[Symbol,T.untyped]])
+
+person.each_pair do |k, v|
+  T.reveal_type(k) # error: Revealed type: `Symbol`
+  T.reveal_type(v) # error: Revealed type: `T.untyped`
+end
+
+T.assert_type!(person.to_h, T::Hash[Symbol, T.untyped])


### PR DESCRIPTION
Tighten up OpenStruct return types and allow passing blocks to `each_pair`


### Motivation

OpenStruct#each_pair previously did not include support for blocks. I tightened up a few existing type signatures as well.


### Test plan

Includes automated tests.
