### PR TITLE
move deserialization errors to a separate method

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
@@ -167,7 +167,7 @@ module T::Props
 
         assert_equal(:send, deserialization_error.type)
         receiver, method, *args = deserialization_error.children
-        assert_equal(s(:send, s(:send, s(:self), :class), :decorator), receiver)
+        assert_equal(nil, receiver)
         assert_equal(:raise_deserialization_error, method)
         args.each {|a| validate_lack_of_side_effects(a, whitelisted_methods_for_deserialize)}
 
@@ -270,7 +270,6 @@ module T::Props
     private_class_method def self.whitelisted_methods_for_deserialize
       @whitelisted_methods_for_deserialize ||= {
         lvar: %i{dup map transform_values transform_keys each_with_object nil? []= to_f},
-        self: %i{class},
         const: %i[deserialize from_hash deep_clone_object],
       }
     end

--- a/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
@@ -162,7 +162,16 @@ module T::Props
         exceptions.children.each {|c| assert_equal(:const, c.type)}
         assert_equal(:lvasgn, assignment.type)
         assert_equal([:e], assignment.children)
-        validate_lack_of_side_effects(handler, whitelisted_methods_for_deserialize)
+
+        deserialization_error, val_return = handler.children
+
+        assert_equal(:send, deserialization_error.type)
+        receiver, method, *args = deserialization_error.children
+        assert_equal(s(:send, s(:send, s(:self), :class), :decorator), receiver)
+        assert_equal(:raise_deserialization_error, method)
+        args.each {|a| validate_lack_of_side_effects(a, whitelisted_methods_for_deserialize)}
+
+        validate_lack_of_side_effects(val_return, whitelisted_methods_for_deserialize)
       else
         validate_lack_of_side_effects(else_body, whitelisted_methods_for_deserialize)
       end
@@ -261,7 +270,8 @@ module T::Props
     private_class_method def self.whitelisted_methods_for_deserialize
       @whitelisted_methods_for_deserialize ||= {
         lvar: %i{dup map transform_values transform_keys each_with_object nil? []= to_f},
-        const: %i[deserialize from_hash deep_clone_object soft_assert_handler],
+        self: %i{class},
+        const: %i[deserialize from_hash deep_clone_object],
       }
     end
   end

--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -57,15 +57,11 @@ module T::Props
               begin
                 #{transformation}
               rescue NoMethodError => e
-                T::Configuration.soft_assert_handler(
-                  'Deserialization error (probably unexpected stored type)',
-                  storytime: {
-                    klass: self.class,
-                    prop: #{prop.inspect},
-                    value: val,
-                    error: e.message,
-                    notify: 'djudd'
-                  }
+                self.class.decorator.raise_deserialization_error(
+                  self.class,
+                  #{prop.inspect},
+                  val,
+                  e,
                 )
                 val
               end

--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -57,8 +57,7 @@ module T::Props
               begin
                 #{transformation}
               rescue NoMethodError => e
-                self.class.decorator.raise_deserialization_error(
-                  self.class,
+                raise_deserialization_error(
                   #{prop.inspect},
                   val,
                   e,

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -235,6 +235,19 @@ module T::Props::Serializable::DecoratorMethods
     MSG
   end
 
+  def raise_deserialization_error(klass, prop_name, value, orig_error)
+    T::Configuration.soft_assert_handler(
+      'Deserialization error (probably unexpected stored type)',
+      storytime: {
+        klass: klass,
+        prop: prop_name,
+        value: value,
+        error: orig_error.message,
+        notify: 'djudd'
+      }
+    )
+  end
+
   def raise_nil_deserialize_error(hkey)
     msg = "Tried to deserialize a required prop from a nil value. It's "\
       "possible that a nil value exists in the database, so you should "\

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -156,6 +156,19 @@ module T::Props::Serializable
     @_required_props_missing_from_deserialize << prop
     nil
   end
+
+  private def raise_deserialization_error(prop_name, value, orig_error)
+    T::Configuration.soft_assert_handler(
+      'Deserialization error (probably unexpected stored type)',
+      storytime: {
+        klass: self.class,
+        prop: prop_name,
+        value: value,
+        error: orig_error.message,
+        notify: 'djudd'
+      }
+    )
+  end
 end
 
 
@@ -233,19 +246,6 @@ module T::Props::Serializable::DecoratorMethods
       at line #{line_num-previous_blank-1} in:
       #{context}
     MSG
-  end
-
-  def raise_deserialization_error(klass, prop_name, value, orig_error)
-    T::Configuration.soft_assert_handler(
-      'Deserialization error (probably unexpected stored type)',
-      storytime: {
-        klass: klass,
-        prop: prop_name,
-        value: value,
-        error: orig_error.message,
-        notify: 'djudd'
-      }
-    )
   end
 
   def raise_nil_deserialize_error(hkey)


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This PR essentially reimplements #4148, but puts the error handler not on `T::Configuration`.  I will quote the motivation from that PR below:

> It seems better to have a separate path for deserialization errors, rather than forcing everything to go through `soft_assert_handler`. I also have some changes to how deserialization works where it would be nice if the error reporting were wrapped up in a single method to call, rather than having to manually reproduce the `T::Configuration.soft_assert_handler` call.

> I don't know whether/how much it actually matters, but one nice side-effect of this change is that the generated deserialization code becomes relatively smaller in cases where we would be throwing errors.

It would be nice if it were not quite so complicated to get to `raise_deserialization_error`, but that is life.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
