### PR TITLE
Add T.bind for changing bindings inside procs and lambdas

### DIFF
--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -78,7 +78,7 @@ void Cast::_sanityCheck() {
     ENFORCE(arg);
     ENFORCE(type);
     ENFORCE(cast == core::Names::cast() || cast == core::Names::assertType() || cast == core::Names::let() ||
-            cast == core::Names::uncheckedLet());
+            cast == core::Names::uncheckedLet() || cast == core::Names::bind());
 }
 
 void ClassDef::_sanityCheck() {

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -767,7 +767,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                         current->exprs.emplace_back(cctx.target, c.loc, make_unique<Ident>(self));
                     } else {
                         if (auto e = cctx.ctx.beginError(what.loc(), core::errors::CFG::MalformedTBind)) {
-                            e.setHeader("T.bind can only be used with `self`");
+                            e.setHeader("`{}` can only be used with `{}`", "T.bind", "self");
                         }
                     }
                 } else {

--- a/core/errors/cfg.h
+++ b/core/errors/cfg.h
@@ -7,5 +7,6 @@ constexpr ErrorClass NoNextScope{6001, StrictLevel::False};
 constexpr ErrorClass UndeclaredVariable{6002, StrictLevel::Strict};
 // constexpr ErrorClass ReturnExprVoid{6003, StrictLevel::True};
 constexpr ErrorClass MalformedTAbsurd{6004, StrictLevel::True};
+constexpr ErrorClass MalformedTBind{6005, StrictLevel::False};
 } // namespace sorbet::core::errors::CFG
 #endif

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -147,7 +147,7 @@ module T
     Private::Casts.cast(value, type, cast_method: "T.let")
   end
 
-  # Tells the typechecker to bind the current proc to the type `type`.
+  # Tells the type checker to treat `self` in the current block as `type`.
   # Useful for blocks that are captured and executed later with instance_exec.
   # Use like:
   #
@@ -156,10 +156,10 @@ module T
   #    ...
   #  end
   #
-  # Compared to `T.cast`, `T.let` is _checked_ by static system.
+  # `T.bind` behaves like `T.cast` in that it is assumed to be true statically.
   #
   # If `checked` is true, raises an exception at runtime if the value
-  # doesn't match the type.
+  # doesn't match the type (this is the default).
   def self.bind(value, type, checked: true)
     return value unless checked
 

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -147,6 +147,25 @@ module T
     Private::Casts.cast(value, type, cast_method: "T.let")
   end
 
+  # Tells the typechecker to bind the current proc to the type `type`.
+  # Useful for blocks that are captured and executed later with instance_exec.
+  # Use like:
+  #
+  #  seconds = lambda do
+  #    T.bind(self, NewBinding)
+  #    ...
+  #  end
+  #
+  # Compared to `T.cast`, `T.let` is _checked_ by static system.
+  #
+  # If `checked` is true, raises an exception at runtime if the value
+  # doesn't match the type.
+  def self.bind(value, type, checked: true)
+    return value unless checked
+
+    Private::Casts.cast(value, type, cast_method: "T.bind")
+  end
+
   # Tells the typechecker to ensure that `value` is of type `type` (if not, the typechecker will
   # fail). Use this for debugging typechecking errors, or to ensure that type information is
   # statically known and being checked appropriately. If `checked` is true, raises an exception at

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -15,6 +15,23 @@ module Opus::Types::Test
       def self.receive(*); end
     end
 
+    module Readable; end
+    module Writable
+      def write
+        T.bind(self, T.all(Readable, Writable))
+        true
+      end
+    end
+
+    class BadArticle
+      include Writable
+    end
+
+    class GoodArticle
+      include Writable
+      include Readable
+    end
+
     describe 'inline_type_error_handler' do
       describe 'when in default state' do
         it 'T.must raises an error' do
@@ -27,6 +44,33 @@ module Opus::Types::Test
           assert_raises(TypeError) do
             T.let(1, String)
           end
+        end
+
+        it 'T.bind raises an error if block is executing on the wrong type' do
+          block = -> {T.bind(self, String); upcase}
+
+          assert_raises(TypeError) do
+            123.instance_exec(&block)
+          end
+        end
+
+        it 'T.bind raises an error if block is executing on the wrong type' do
+          block = -> {T.bind(self, String); upcase}
+
+          assert_raises(TypeError) do
+            123.instance_exec(&block)
+          end
+        end
+
+        it 'T.bind raises error if type constraints are not all satisfied' do
+          bad_article = BadArticle.new
+
+          assert_raises(TypeError) do
+            bad_article.write
+          end
+
+          good_article = GoodArticle.new
+          assert good_article.write
         end
       end
 

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -54,14 +54,6 @@ module Opus::Types::Test
           end
         end
 
-        it 'T.bind raises an error if block is executing on the wrong type' do
-          block = -> {T.bind(self, String); upcase}
-
-          assert_raises(TypeError) do
-            123.instance_exec(&block)
-          end
-        end
-
         it 'T.bind raises error if type constraints are not all satisfied' do
           bad_article = BadArticle.new
 

--- a/gems/sorbet/lib/t.rb
+++ b/gems/sorbet/lib/t.rb
@@ -30,6 +30,7 @@ module T
 
   def self.cast(value, type, checked: true); value; end
   def self.let(value, type, checked: true); value; end
+  def self.bind(value, type, checked: true); value; end
   def self.assert_type!(value, type, checked: true); value; end
   def self.unsafe(value); value; end
   def self.must(arg, msg=nil); arg; end

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -928,7 +928,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
         core::TypeAndOrigins tp;
         bool noLoopChecking = cfg::isa_instruction<cfg::Alias>(bind.value.get()) ||
                               cfg::isa_instruction<cfg::LoadArg>(bind.value.get()) ||
-                              cfg::isa_instruction<cfg::LoadSelf>(bind.value.get());
+                              bind.bind.variable == cfg::LocalRef::selfVariable();
 
         bool checkFullyDefined = true;
         const core::lsp::Query &lspQuery = ctx.state.lspQuery;
@@ -1280,7 +1280,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 }
 
                 const core::TypeAndOrigins &ty = getAndFillTypeAndOrigin(ctx, c->value);
-                ENFORCE(c->cast != core::Names::uncheckedLet());
+                ENFORCE(c->cast != core::Names::uncheckedLet() && c->cast != core::Names::bind());
+
                 if (c->cast != core::Names::cast()) {
                     if (c->cast == core::Names::assertType() && ty.type.isUntyped()) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -30,6 +30,9 @@ module T
   def self.let(value, type, checked: true); end
 
   sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean).returns(BasicObject)}
+  def self.bind(value, type, checked: true); end
+
+  sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean).returns(BasicObject)}
   def self.assert_type!(value, type, checked: true); end
 
   sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean).returns(BasicObject)}

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2049,6 +2049,7 @@ public:
 
             switch (send.fun.rawId()) {
                 case core::Names::let().rawId():
+                case core::Names::bind().rawId():
                 case core::Names::uncheckedLet().rawId():
                 case core::Names::assertType().rawId():
                 case core::Names::cast().rawId(): {

--- a/test/testdata/infer/bound_proc.rb
+++ b/test/testdata/infer/bound_proc.rb
@@ -55,7 +55,7 @@ class Post < Base
 
   def score
     T.bind("100", Integer)
-  # ^^^^^^^^^^^^^^^^^^^^^^ error: T.bind can only be used with `self`
+  # ^^^^^^^^^^^^^^^^^^^^^^ error: `T.bind` can only be used with `self`
   end
 end
 

--- a/test/testdata/infer/bound_proc.rb
+++ b/test/testdata/infer/bound_proc.rb
@@ -1,0 +1,135 @@
+# typed: true
+
+class Base
+  def self.before_save(method_name, **options)
+  end
+
+  def self.before_create(method_name, **options)
+  end
+end
+
+module Concern
+  def included(&block)
+    @block = block
+  end
+end
+
+module Readable
+  extend Concern
+
+  included do
+    before_create :do_this
+  # ^^^^^^^^^^^^^^^^^^^^^^ error: Method `before_create` does not exist on `T.class_of(Readable)`
+  end
+end
+
+module Writable
+  extend Concern
+
+  included do
+    T.bind(self, T.any(T.class_of(Article), T.class_of(Post)))
+    some_class_method :name
+  # ^^^^^^^^^^^^^^^^^^^^^^^ error: Method `some_class_method` does not exist on `T.class_of(Article)` component of `T.any(T.class_of(Article), T.class_of(Post))`
+  end
+end
+
+module Shareable
+  extend Concern
+
+  included do
+    T.bind(self, T.class_of(Article))
+    before_save :do_this
+  end
+end
+
+class Post < Base
+  include Readable
+  include Writable
+
+  before_create :run_callback, if: -> { should_run_callback? }
+                                      # ^^^^^^^^^^^^^^^^^^^^ error: Method `should_run_callback?` does not exist on `T.class_of(Post)`
+
+  def self.some_class_method(name); end
+  def author; end
+  def should_run_callback?; true; end
+
+  def score
+    T.bind("100", Integer)
+  # ^^^^^^^^^^^^^^^^^^^^^^ error: T.bind can only be used with `self`
+  end
+end
+
+class Article < Base
+  include Writable
+  include Shareable
+
+  before_create :run_callback, if: -> { T.bind(self, Article).should_run_callback? }
+
+  def author; end
+  def should_run_callback?; true; end
+end
+
+class A
+  def instance_helper; end
+
+  f = -> do
+    T.bind(self, A)
+
+    T.reveal_type(self) # error: type: `A`
+
+    self.instance_helper
+  end
+
+  T.reveal_type(self) # error: type: `T.class_of(A)`
+
+  puts f
+end
+
+class B
+  extend T::Sig
+
+  sig {params(blk: T.proc.void).void}
+  def self.class_helper(&blk); end
+
+  def instance_helper; end
+end
+
+B.class_helper {
+  T.bind(self, B)
+
+  T.reveal_type(self) # error: type: `B`
+
+  self.instance_helper
+}
+
+T.reveal_type(self) # error: type: `T.class_of(<root>)`
+
+module N
+  def helper_from_N; end
+end
+
+module M
+  extend T::Sig
+
+  def helper_from_M; end
+
+  def main
+    T.bind(self, T.all(M, N))
+    T.reveal_type(self) # error: type: `T.all(M, N)`
+
+    helper_from_M
+    helper_from_N
+  end
+end
+
+module ThisSelf
+  extend T::Sig
+
+  def main
+    this = T.bind(self, Kernel)
+
+    T.reveal_type(this) # error: type: `Kernel`
+
+    this.puts
+  end
+end

--- a/test/testdata/infer/bound_proc.rb.cfg.exp
+++ b/test/testdata/infer/bound_proc.rb.cfg.exp
@@ -1,0 +1,743 @@
+digraph "bound_proc.rb" {
+subgraph "cluster_::<Class:<root>>#<static-init>" {
+    label = "::<Class:<root>>#<static-init>";
+    color = blue;
+    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:<root>>#<static-init>_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(Base) = alias <C Base>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(Base))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(Base) = alias <C Base>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(Base))\l<cfgAlias>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$19: T.class_of(Concern) = alias <C Concern>\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$19: T.class_of(Concern))\l<cfgAlias>$22: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$24: T.class_of(Concern) = alias <C Concern>\l<statTemp>$20: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$24: T.class_of(Concern))\l<cfgAlias>$28: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$30: T.class_of(Readable) = alias <C Readable>\l<statTemp>$26: Sorbet::Private::Static::Void = <cfgAlias>$28: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$30: T.class_of(Readable))\l<cfgAlias>$33: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$35: T.class_of(Readable) = alias <C Readable>\l<statTemp>$31: Sorbet::Private::Static::Void = <cfgAlias>$33: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$35: T.class_of(Readable))\l<cfgAlias>$39: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$41: T.class_of(Writable) = alias <C Writable>\l<statTemp>$37: Sorbet::Private::Static::Void = <cfgAlias>$39: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$41: T.class_of(Writable))\l<cfgAlias>$44: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$46: T.class_of(Writable) = alias <C Writable>\l<statTemp>$42: Sorbet::Private::Static::Void = <cfgAlias>$44: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$46: T.class_of(Writable))\l<cfgAlias>$50: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$52: T.class_of(Shareable) = alias <C Shareable>\l<statTemp>$48: Sorbet::Private::Static::Void = <cfgAlias>$50: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$52: T.class_of(Shareable))\l<cfgAlias>$55: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$57: T.class_of(Shareable) = alias <C Shareable>\l<statTemp>$53: Sorbet::Private::Static::Void = <cfgAlias>$55: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$57: T.class_of(Shareable))\l<cfgAlias>$61: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$63: T.class_of(Post) = alias <C Post>\l<statTemp>$59: Sorbet::Private::Static::Void = <cfgAlias>$61: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$63: T.class_of(Post))\l<cfgAlias>$66: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$68: T.class_of(Post) = alias <C Post>\l<statTemp>$64: Sorbet::Private::Static::Void = <cfgAlias>$66: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$68: T.class_of(Post))\l<cfgAlias>$71: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$73: T.class_of(Base) = alias <C Base>\l<statTemp>$69: Sorbet::Private::Static::Void = <cfgAlias>$71: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$73: T.class_of(Base))\l<cfgAlias>$77: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$79: T.class_of(Article) = alias <C Article>\l<statTemp>$75: Sorbet::Private::Static::Void = <cfgAlias>$77: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$79: T.class_of(Article))\l<cfgAlias>$82: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$84: T.class_of(Article) = alias <C Article>\l<statTemp>$80: Sorbet::Private::Static::Void = <cfgAlias>$82: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$84: T.class_of(Article))\l<cfgAlias>$87: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$89: T.class_of(Base) = alias <C Base>\l<statTemp>$85: Sorbet::Private::Static::Void = <cfgAlias>$87: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$89: T.class_of(Base))\l<cfgAlias>$93: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$95: T.class_of(A) = alias <C A>\l<statTemp>$91: Sorbet::Private::Static::Void = <cfgAlias>$93: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$95: T.class_of(A))\l<cfgAlias>$98: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$100: T.class_of(A) = alias <C A>\l<statTemp>$96: Sorbet::Private::Static::Void = <cfgAlias>$98: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$100: T.class_of(A))\l<cfgAlias>$104: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$106: T.class_of(B) = alias <C B>\l<statTemp>$102: Sorbet::Private::Static::Void = <cfgAlias>$104: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$106: T.class_of(B))\l<cfgAlias>$109: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$111: T.class_of(B) = alias <C B>\l<statTemp>$107: Sorbet::Private::Static::Void = <cfgAlias>$109: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$111: T.class_of(B))\l<cfgAlias>$114: T.class_of(B) = alias <C B>\l<block-pre-call-temp>$115: Sorbet::Private::Static::Void = <cfgAlias>$114: T.class_of(B).class_helper()\l<selfRestore>$116: T.class_of(<root>) = <self>\l<unconditional>\l"
+    ];
+
+    "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_2" [style="bold"];
+    "bb::<Class:<root>>#<static-init>_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:<root>>#<static-init>_1" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
+    "bb::<Class:<root>>#<static-init>_2" [
+        color = black;
+        label = "block[id=2, rubyBlockId=1](<self>: T.class_of(<root>), <block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(<root>))\louterLoops: 1\l<block-call>: NilClass\l"
+    ];
+
+    "bb::<Class:<root>>#<static-init>_2" -> "bb::<Class:<root>>#<static-init>_5" [style="bold"];
+    "bb::<Class:<root>>#<static-init>_2" -> "bb::<Class:<root>>#<static-init>_3" [style="tapered"];
+
+    "bb::<Class:<root>>#<static-init>_3" [
+        color = black;
+        label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(<root>))\l<statTemp>$112: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$115, class_helper>\l<self>: T.class_of(<root>) = <selfRestore>$116\l<cfgAlias>$135: T.class_of(T) = alias <C T>\l<statTemp>$133: T.class_of(<root>) = <cfgAlias>$135: T.class_of(T).reveal_type(<self>: T.class_of(<root>))\l<cfgAlias>$140: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$142: T.class_of(N) = alias <C N>\l<statTemp>$138: Sorbet::Private::Static::Void = <cfgAlias>$140: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$142: T.class_of(N))\l<cfgAlias>$145: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$147: T.class_of(N) = alias <C N>\l<statTemp>$143: Sorbet::Private::Static::Void = <cfgAlias>$145: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$147: T.class_of(N))\l<cfgAlias>$151: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$153: T.class_of(M) = alias <C M>\l<statTemp>$149: Sorbet::Private::Static::Void = <cfgAlias>$151: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$153: T.class_of(M))\l<cfgAlias>$156: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$158: T.class_of(M) = alias <C M>\l<statTemp>$154: Sorbet::Private::Static::Void = <cfgAlias>$156: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$158: T.class_of(M))\l<cfgAlias>$162: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$164: T.class_of(ThisSelf) = alias <C ThisSelf>\l<statTemp>$160: Sorbet::Private::Static::Void = <cfgAlias>$162: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$164: T.class_of(ThisSelf))\l<cfgAlias>$167: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$169: T.class_of(ThisSelf) = alias <C ThisSelf>\l<statTemp>$165: Sorbet::Private::Static::Void = <cfgAlias>$167: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$169: T.class_of(ThisSelf))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:<root>>#<static-init>_3" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
+    "bb::<Class:<root>>#<static-init>_5" [
+        color = black;
+        label = "block[id=5, rubyBlockId=1](<self>: T.class_of(<root>), <block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(<root>))\louterLoops: 1\l<self>: T.class_of(<root>) = loadSelf\l<cfgAlias>$123: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$125: T.class_of(B) = alias <C B>\l<statTemp>$121: Sorbet::Private::Static::Void = <cfgAlias>$123: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$125: T.class_of(B))\l<castTemp>$126: T.class_of(<root>) = <self>\l<self>: B = cast(<castTemp>$126: T.class_of(<root>), B);\l<cfgAlias>$129: T.class_of(T) = alias <C T>\l<statTemp>$127: B = <cfgAlias>$129: T.class_of(T).reveal_type(<self>: B)\l<blockReturnTemp>$119: T.untyped = <self>: B.instance_helper()\l<blockReturnTemp>$132: T.noreturn = blockreturn<class_helper> <blockReturnTemp>$119: T.untyped\l<unconditional>\l"
+    ];
+
+    "bb::<Class:<root>>#<static-init>_5" -> "bb::<Class:<root>>#<static-init>_2" [style="bold"];
+}
+
+subgraph "cluster_::<Class:Base>#before_save" {
+    label = "::<Class:Base>#before_save";
+    color = blue;
+    "bb::<Class:Base>#before_save_0" [shape = invhouse];
+    "bb::<Class:Base>#before_save_1" [shape = parallelogram];
+
+    "bb::<Class:Base>#before_save_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Base) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Base>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Base>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Base>#before_save_0" -> "bb::<Class:Base>#before_save_1" [style="bold"];
+    "bb::<Class:Base>#before_save_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Base>#before_save_1" -> "bb::<Class:Base>#before_save_1" [style="bold"];
+}
+
+subgraph "cluster_::<Class:Base>#before_create" {
+    label = "::<Class:Base>#before_create";
+    color = blue;
+    "bb::<Class:Base>#before_create_0" [shape = invhouse];
+    "bb::<Class:Base>#before_create_1" [shape = parallelogram];
+
+    "bb::<Class:Base>#before_create_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Base) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Base>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Base>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Base>#before_create_0" -> "bb::<Class:Base>#before_create_1" [style="bold"];
+    "bb::<Class:Base>#before_create_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Base>#before_create_1" -> "bb::<Class:Base>#before_create_1" [style="bold"];
+}
+
+subgraph "cluster_::<Class:Base>#<static-init>" {
+    label = "::<Class:Base>#<static-init>";
+    color = blue;
+    "bb::<Class:Base>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:Base>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:Base>#<static-init>_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Base) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Base>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Base>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:before_save) = :before_save\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:before_save) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(Base), <statTemp>$7: Symbol(:before_save), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:before_create) = :before_create\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:before_create) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(Base), <statTemp>$13: Symbol(:before_create), <statTemp>$14: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Base>#<static-init>_0" -> "bb::<Class:Base>#<static-init>_1" [style="bold"];
+    "bb::<Class:Base>#<static-init>_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Base>#<static-init>_1" -> "bb::<Class:Base>#<static-init>_1" [style="bold"];
+}
+
+subgraph "cluster_::Concern#included" {
+    label = "::Concern#included";
+    color = blue;
+    "bb::Concern#included_0" [shape = invhouse];
+    "bb::Concern#included_1" [shape = parallelogram];
+
+    "bb::Concern#included_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l@block$3: T.untyped = alias <C <undeclared-field-stub>> (@block)\l<self>: Concern = cast(<self>: NilClass, Concern);\lblock: T.untyped = load_arg(block)\l@block$3: T.untyped = block\l<returnMethodTemp>$2: T.untyped = @block$3\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
+    ];
+
+    "bb::Concern#included_0" -> "bb::Concern#included_1" [style="bold"];
+    "bb::Concern#included_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::Concern#included_1" -> "bb::Concern#included_1" [style="bold"];
+}
+
+subgraph "cluster_::<Class:Concern>#<static-init>" {
+    label = "::<Class:Concern>#<static-init>";
+    color = blue;
+    "bb::<Class:Concern>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:Concern>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:Concern>#<static-init>_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Concern) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Concern>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Concern>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:included) = :included\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:included) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Concern), <statTemp>$6: Symbol(:included), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:included)\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Concern>#<static-init>_0" -> "bb::<Class:Concern>#<static-init>_1" [style="bold"];
+    "bb::<Class:Concern>#<static-init>_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Concern>#<static-init>_1" -> "bb::<Class:Concern>#<static-init>_1" [style="bold"];
+}
+
+subgraph "cluster_::<Class:Readable>#<static-init>" {
+    label = "::<Class:Readable>#<static-init>";
+    color = blue;
+    "bb::<Class:Readable>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:Readable>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:Readable>#<static-init>_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Readable) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Readable>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Readable>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(Concern) = alias <C Concern>\l<statTemp>$3: T.class_of(Readable) = <self>: T.class_of(Readable).extend(<cfgAlias>$6: T.class_of(Concern))\l<block-pre-call-temp>$9: Sorbet::Private::Static::Void = <self>: T.class_of(Readable).included()\l<selfRestore>$10: T.class_of(Readable) = <self>\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Readable>#<static-init>_0" -> "bb::<Class:Readable>#<static-init>_2" [style="bold"];
+    "bb::<Class:Readable>#<static-init>_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Readable>#<static-init>_1" -> "bb::<Class:Readable>#<static-init>_1" [style="bold"];
+    "bb::<Class:Readable>#<static-init>_2" [
+        color = black;
+        label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Readable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable))\louterLoops: 1\l<block-call>: NilClass\l"
+    ];
+
+    "bb::<Class:Readable>#<static-init>_2" -> "bb::<Class:Readable>#<static-init>_5" [style="bold"];
+    "bb::<Class:Readable>#<static-init>_2" -> "bb::<Class:Readable>#<static-init>_3" [style="tapered"];
+
+    "bb::<Class:Readable>#<static-init>_3" [
+        color = black;
+        label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable))\l<statTemp>$7: T.untyped = Solve<<block-pre-call-temp>$9, included>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Readable>#<static-init>_3" -> "bb::<Class:Readable>#<static-init>_1" [style="bold"];
+    "bb::<Class:Readable>#<static-init>_5" [
+        color = black;
+        label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Readable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable))\louterLoops: 1\l<self>: T.class_of(Readable) = loadSelf\l<statTemp>$15: Symbol(:do_this) = :do_this\l<blockReturnTemp>$13: T.untyped = <self>: T.class_of(Readable).before_create(<statTemp>$15: Symbol(:do_this))\l<blockReturnTemp>$16: T.noreturn = blockreturn<included> <blockReturnTemp>$13: T.untyped\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Readable>#<static-init>_5" -> "bb::<Class:Readable>#<static-init>_2" [style="bold"];
+}
+
+subgraph "cluster_::<Class:Writable>#<static-init>" {
+    label = "::<Class:Writable>#<static-init>";
+    color = blue;
+    "bb::<Class:Writable>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:Writable>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:Writable>#<static-init>_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Writable) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Writable>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Writable>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(Concern) = alias <C Concern>\l<statTemp>$3: T.class_of(Writable) = <self>: T.class_of(Writable).extend(<cfgAlias>$6: T.class_of(Concern))\l<block-pre-call-temp>$9: Sorbet::Private::Static::Void = <self>: T.class_of(Writable).included()\l<selfRestore>$10: T.class_of(Writable) = <self>\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Writable>#<static-init>_0" -> "bb::<Class:Writable>#<static-init>_2" [style="bold"];
+    "bb::<Class:Writable>#<static-init>_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Writable>#<static-init>_1" -> "bb::<Class:Writable>#<static-init>_1" [style="bold"];
+    "bb::<Class:Writable>#<static-init>_2" [
+        color = black;
+        label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Writable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable))\louterLoops: 1\l<block-call>: NilClass\l"
+    ];
+
+    "bb::<Class:Writable>#<static-init>_2" -> "bb::<Class:Writable>#<static-init>_5" [style="bold"];
+    "bb::<Class:Writable>#<static-init>_2" -> "bb::<Class:Writable>#<static-init>_3" [style="tapered"];
+
+    "bb::<Class:Writable>#<static-init>_3" [
+        color = black;
+        label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable))\l<statTemp>$7: T.untyped = Solve<<block-pre-call-temp>$9, included>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Writable>#<static-init>_3" -> "bb::<Class:Writable>#<static-init>_1" [style="bold"];
+    "bb::<Class:Writable>#<static-init>_5" [
+        color = black;
+        label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Writable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable))\louterLoops: 1\l<self>: T.class_of(Writable) = loadSelf\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$20: T.class_of(T) = alias <C T>\l<cfgAlias>$23: T.class_of(T) = alias <C T>\l<cfgAlias>$25: T.class_of(Article) = alias <C Article>\l<statTemp>$21: T.untyped = <cfgAlias>$23: T.class_of(T).class_of(<cfgAlias>$25: T.class_of(Article))\l<cfgAlias>$28: T.class_of(T) = alias <C T>\l<cfgAlias>$30: T.class_of(Post) = alias <C Post>\l<statTemp>$26: T.untyped = <cfgAlias>$28: T.class_of(T).class_of(<cfgAlias>$30: T.class_of(Post))\l<statTemp>$18: <Type: T.untyped> = <cfgAlias>$20: T.class_of(T).any(<statTemp>$21: T.untyped, <statTemp>$26: T.untyped)\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$18: <Type: T.untyped>)\l<castTemp>$31: T.class_of(Writable) = <self>\l<self>: T.any(T.class_of(Article), T.class_of(Post)) = cast(<castTemp>$31: T.class_of(Writable), AppliedType {\l      klass = <S <C <U Article>> $1>\l      targs = [\l        <C <U <AttachedClass>>> = Article\l      ]\l    } | AppliedType {\l      klass = <S <C <U Post>> $1>\l      targs = [\l        <C <U <AttachedClass>>> = Post\l      ]\l    });\l<statTemp>$33: Symbol(:name) = :name\l<blockReturnTemp>$13: T.untyped = <self>: T.any(T.class_of(Article), T.class_of(Post)).some_class_method(<statTemp>$33: Symbol(:name))\l<blockReturnTemp>$34: T.noreturn = blockreturn<included> <blockReturnTemp>$13: T.untyped\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Writable>#<static-init>_5" -> "bb::<Class:Writable>#<static-init>_2" [style="bold"];
+}
+
+subgraph "cluster_::<Class:Shareable>#<static-init>" {
+    label = "::<Class:Shareable>#<static-init>";
+    color = blue;
+    "bb::<Class:Shareable>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:Shareable>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:Shareable>#<static-init>_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Shareable) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Shareable>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Shareable>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(Concern) = alias <C Concern>\l<statTemp>$3: T.class_of(Shareable) = <self>: T.class_of(Shareable).extend(<cfgAlias>$6: T.class_of(Concern))\l<block-pre-call-temp>$9: Sorbet::Private::Static::Void = <self>: T.class_of(Shareable).included()\l<selfRestore>$10: T.class_of(Shareable) = <self>\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Shareable>#<static-init>_0" -> "bb::<Class:Shareable>#<static-init>_2" [style="bold"];
+    "bb::<Class:Shareable>#<static-init>_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Shareable>#<static-init>_1" -> "bb::<Class:Shareable>#<static-init>_1" [style="bold"];
+    "bb::<Class:Shareable>#<static-init>_2" [
+        color = black;
+        label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Shareable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable))\louterLoops: 1\l<block-call>: NilClass\l"
+    ];
+
+    "bb::<Class:Shareable>#<static-init>_2" -> "bb::<Class:Shareable>#<static-init>_5" [style="bold"];
+    "bb::<Class:Shareable>#<static-init>_2" -> "bb::<Class:Shareable>#<static-init>_3" [style="tapered"];
+
+    "bb::<Class:Shareable>#<static-init>_3" [
+        color = black;
+        label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable))\l<statTemp>$7: T.untyped = Solve<<block-pre-call-temp>$9, included>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Shareable>#<static-init>_3" -> "bb::<Class:Shareable>#<static-init>_1" [style="bold"];
+    "bb::<Class:Shareable>#<static-init>_5" [
+        color = black;
+        label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Shareable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable))\louterLoops: 1\l<self>: T.class_of(Shareable) = loadSelf\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$20: T.class_of(T) = alias <C T>\l<cfgAlias>$22: T.class_of(Article) = alias <C Article>\l<statTemp>$18: T.untyped = <cfgAlias>$20: T.class_of(T).class_of(<cfgAlias>$22: T.class_of(Article))\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$18: T.untyped)\l<castTemp>$23: T.class_of(Shareable) = <self>\l<self>: T.class_of(Article) = cast(<castTemp>$23: T.class_of(Shareable), AppliedType {\l  klass = <S <C <U Article>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = Article\l  ]\l});\l<statTemp>$25: Symbol(:do_this) = :do_this\l<blockReturnTemp>$13: T.untyped = <self>: T.class_of(Article).before_save(<statTemp>$25: Symbol(:do_this))\l<blockReturnTemp>$26: T.noreturn = blockreturn<included> <blockReturnTemp>$13: T.untyped\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Shareable>#<static-init>_5" -> "bb::<Class:Shareable>#<static-init>_2" [style="bold"];
+}
+
+subgraph "cluster_::<Class:Post>#some_class_method" {
+    label = "::<Class:Post>#some_class_method";
+    color = blue;
+    "bb::<Class:Post>#some_class_method_0" [shape = invhouse];
+    "bb::<Class:Post>#some_class_method_1" [shape = parallelogram];
+
+    "bb::<Class:Post>#some_class_method_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Post) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Post>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Post>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Post>#some_class_method_0" -> "bb::<Class:Post>#some_class_method_1" [style="bold"];
+    "bb::<Class:Post>#some_class_method_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Post>#some_class_method_1" -> "bb::<Class:Post>#some_class_method_1" [style="bold"];
+}
+
+subgraph "cluster_::Post#author" {
+    label = "::Post#author";
+    color = blue;
+    "bb::Post#author_0" [shape = invhouse];
+    "bb::Post#author_1" [shape = parallelogram];
+
+    "bb::Post#author_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: Post = cast(<self>: NilClass, Post);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::Post#author_0" -> "bb::Post#author_1" [style="bold"];
+    "bb::Post#author_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::Post#author_1" -> "bb::Post#author_1" [style="bold"];
+}
+
+subgraph "cluster_::Post#should_run_callback?" {
+    label = "::Post#should_run_callback?";
+    color = blue;
+    "bb::Post#should_run_callback?_0" [shape = invhouse];
+    "bb::Post#should_run_callback?_1" [shape = parallelogram];
+
+    "bb::Post#should_run_callback?_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: Post = cast(<self>: NilClass, Post);\l<returnMethodTemp>$2: TrueClass = true\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: TrueClass\l<unconditional>\l"
+    ];
+
+    "bb::Post#should_run_callback?_0" -> "bb::Post#should_run_callback?_1" [style="bold"];
+    "bb::Post#should_run_callback?_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::Post#should_run_callback?_1" -> "bb::Post#should_run_callback?_1" [style="bold"];
+}
+
+subgraph "cluster_::Post#score" {
+    label = "::Post#score";
+    color = blue;
+    "bb::Post#score_0" [shape = invhouse];
+    "bb::Post#score_1" [shape = parallelogram];
+
+    "bb::Post#score_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: Post = cast(<self>: NilClass, Post);\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$7: T.class_of(Integer) = alias <C Integer>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$7: T.class_of(Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::Post#score_0" -> "bb::Post#score_1" [style="bold"];
+    "bb::Post#score_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::Post#score_1" -> "bb::Post#score_1" [style="bold"];
+}
+
+subgraph "cluster_::<Class:Post>#<static-init>" {
+    label = "::<Class:Post>#<static-init>";
+    color = blue;
+    "bb::<Class:Post>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:Post>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:Post>#<static-init>_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Post) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Post>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Post>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(Readable) = alias <C Readable>\l<statTemp>$3: T.class_of(Post) = <self>: T.class_of(Post).include(<cfgAlias>$6: T.class_of(Readable))\l<cfgAlias>$10: T.class_of(Writable) = alias <C Writable>\l<statTemp>$7: T.class_of(Post) = <self>: T.class_of(Post).include(<cfgAlias>$10: T.class_of(Writable))\l<statTemp>$12: T.class_of(Post) = <self>\l<statTemp>$13: Symbol(:run_callback) = :run_callback\l<hashTemp>$14: Symbol(:if) = :if\l<cfgAlias>$17: T.class_of(Kernel) = alias <C Kernel>\l<block-pre-call-temp>$18: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(Kernel).lambda()\l<selfRestore>$19: T.class_of(Post) = <self>\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Post>#<static-init>_0" -> "bb::<Class:Post>#<static-init>_2" [style="bold"];
+    "bb::<Class:Post>#<static-init>_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Post>#<static-init>_1" -> "bb::<Class:Post>#<static-init>_1" [style="bold"];
+    "bb::<Class:Post>#<static-init>_2" [
+        color = black;
+        label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post))\louterLoops: 1\l<block-call>: NilClass\l"
+    ];
+
+    "bb::<Class:Post>#<static-init>_2" -> "bb::<Class:Post>#<static-init>_5" [style="bold"];
+    "bb::<Class:Post>#<static-init>_2" -> "bb::<Class:Post>#<static-init>_3" [style="tapered"];
+
+    "bb::<Class:Post>#<static-init>_3" [
+        color = black;
+        label = "block[id=3, rubyBlockId=0](<statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post))\l<hashTemp>$15: T.proc.returns(T.untyped) = Solve<<block-pre-call-temp>$18, lambda>\l<self>: T.class_of(Post) = <selfRestore>$19\l<statTemp>$11: T.untyped = <statTemp>$12: T.class_of(Post).before_create(<statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <hashTemp>$15: T.proc.returns(T.untyped))\l<cfgAlias>$27: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$29: Symbol(:some_class_method) = :some_class_method\l<statTemp>$30: Symbol(:normal) = :normal\l<statTemp>$25: Symbol(:some_class_method) = <cfgAlias>$27: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(Post), <statTemp>$29: Symbol(:some_class_method), <statTemp>$30: Symbol(:normal))\l<cfgAlias>$33: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$35: Symbol(:author) = :author\l<statTemp>$36: Symbol(:normal) = :normal\l<statTemp>$31: Symbol(:author) = <cfgAlias>$33: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Post), <statTemp>$35: Symbol(:author), <statTemp>$36: Symbol(:normal))\l<cfgAlias>$39: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$41: Symbol(:should_run_callback?) = :should_run_callback?\l<statTemp>$42: Symbol(:normal) = :normal\l<statTemp>$37: Symbol(:should_run_callback?) = <cfgAlias>$39: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Post), <statTemp>$41: Symbol(:should_run_callback?), <statTemp>$42: Symbol(:normal))\l<cfgAlias>$45: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$47: Symbol(:score) = :score\l<statTemp>$48: Symbol(:normal) = :normal\l<statTemp>$43: Symbol(:score) = <cfgAlias>$45: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Post), <statTemp>$47: Symbol(:score), <statTemp>$48: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Post>#<static-init>_3" -> "bb::<Class:Post>#<static-init>_1" [style="bold"];
+    "bb::<Class:Post>#<static-init>_5" [
+        color = black;
+        label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post))\louterLoops: 1\l<self>: T.class_of(Post) = loadSelf\l<blockReturnTemp>$22: T.untyped = <self>: T.class_of(Post).should_run_callback?()\l<blockReturnTemp>$24: T.noreturn = blockreturn<lambda> <blockReturnTemp>$22: T.untyped\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Post>#<static-init>_5" -> "bb::<Class:Post>#<static-init>_2" [style="bold"];
+}
+
+subgraph "cluster_::Article#author" {
+    label = "::Article#author";
+    color = blue;
+    "bb::Article#author_0" [shape = invhouse];
+    "bb::Article#author_1" [shape = parallelogram];
+
+    "bb::Article#author_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: Article = cast(<self>: NilClass, Article);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::Article#author_0" -> "bb::Article#author_1" [style="bold"];
+    "bb::Article#author_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::Article#author_1" -> "bb::Article#author_1" [style="bold"];
+}
+
+subgraph "cluster_::Article#should_run_callback?" {
+    label = "::Article#should_run_callback?";
+    color = blue;
+    "bb::Article#should_run_callback?_0" [shape = invhouse];
+    "bb::Article#should_run_callback?_1" [shape = parallelogram];
+
+    "bb::Article#should_run_callback?_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: Article = cast(<self>: NilClass, Article);\l<returnMethodTemp>$2: TrueClass = true\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: TrueClass\l<unconditional>\l"
+    ];
+
+    "bb::Article#should_run_callback?_0" -> "bb::Article#should_run_callback?_1" [style="bold"];
+    "bb::Article#should_run_callback?_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::Article#should_run_callback?_1" -> "bb::Article#should_run_callback?_1" [style="bold"];
+}
+
+subgraph "cluster_::<Class:Article>#<static-init>" {
+    label = "::<Class:Article>#<static-init>";
+    color = blue;
+    "bb::<Class:Article>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:Article>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:Article>#<static-init>_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Article) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Article>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Article>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(Writable) = alias <C Writable>\l<statTemp>$3: T.class_of(Article) = <self>: T.class_of(Article).include(<cfgAlias>$6: T.class_of(Writable))\l<cfgAlias>$10: T.class_of(Shareable) = alias <C Shareable>\l<statTemp>$7: T.class_of(Article) = <self>: T.class_of(Article).include(<cfgAlias>$10: T.class_of(Shareable))\l<statTemp>$12: T.class_of(Article) = <self>\l<statTemp>$13: Symbol(:run_callback) = :run_callback\l<hashTemp>$14: Symbol(:if) = :if\l<cfgAlias>$17: T.class_of(Kernel) = alias <C Kernel>\l<block-pre-call-temp>$18: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(Kernel).lambda()\l<selfRestore>$19: T.class_of(Article) = <self>\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Article>#<static-init>_0" -> "bb::<Class:Article>#<static-init>_2" [style="bold"];
+    "bb::<Class:Article>#<static-init>_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Article>#<static-init>_1" -> "bb::<Class:Article>#<static-init>_1" [style="bold"];
+    "bb::<Class:Article>#<static-init>_2" [
+        color = black;
+        label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article))\louterLoops: 1\l<block-call>: NilClass\l"
+    ];
+
+    "bb::<Class:Article>#<static-init>_2" -> "bb::<Class:Article>#<static-init>_5" [style="bold"];
+    "bb::<Class:Article>#<static-init>_2" -> "bb::<Class:Article>#<static-init>_3" [style="tapered"];
+
+    "bb::<Class:Article>#<static-init>_3" [
+        color = black;
+        label = "block[id=3, rubyBlockId=0](<statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article))\l<hashTemp>$15: T.proc.returns(T.untyped) = Solve<<block-pre-call-temp>$18, lambda>\l<self>: T.class_of(Article) = <selfRestore>$19\l<statTemp>$11: T.untyped = <statTemp>$12: T.class_of(Article).before_create(<statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <hashTemp>$15: T.proc.returns(T.untyped))\l<cfgAlias>$33: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$35: Symbol(:author) = :author\l<statTemp>$36: Symbol(:normal) = :normal\l<statTemp>$31: Symbol(:author) = <cfgAlias>$33: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Article), <statTemp>$35: Symbol(:author), <statTemp>$36: Symbol(:normal))\l<cfgAlias>$39: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$41: Symbol(:should_run_callback?) = :should_run_callback?\l<statTemp>$42: Symbol(:normal) = :normal\l<statTemp>$37: Symbol(:should_run_callback?) = <cfgAlias>$39: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Article), <statTemp>$41: Symbol(:should_run_callback?), <statTemp>$42: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Article>#<static-init>_3" -> "bb::<Class:Article>#<static-init>_1" [style="bold"];
+    "bb::<Class:Article>#<static-init>_5" [
+        color = black;
+        label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article))\louterLoops: 1\l<self>: T.class_of(Article) = loadSelf\l<cfgAlias>$26: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$28: T.class_of(Article) = alias <C Article>\l<statTemp>$24: Sorbet::Private::Static::Void = <cfgAlias>$26: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$28: T.class_of(Article))\l<castTemp>$29: T.class_of(Article) = <self>\l<self>: Article = cast(<castTemp>$29: T.class_of(Article), Article);\l<blockReturnTemp>$22: T.untyped = <self>: Article.should_run_callback?()\l<blockReturnTemp>$30: T.noreturn = blockreturn<lambda> <blockReturnTemp>$22: T.untyped\l<unconditional>\l"
+    ];
+
+    "bb::<Class:Article>#<static-init>_5" -> "bb::<Class:Article>#<static-init>_2" [style="bold"];
+}
+
+subgraph "cluster_::A#instance_helper" {
+    label = "::A#instance_helper";
+    color = blue;
+    "bb::A#instance_helper_0" [shape = invhouse];
+    "bb::A#instance_helper_1" [shape = parallelogram];
+
+    "bb::A#instance_helper_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: A = cast(<self>: NilClass, A);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::A#instance_helper_0" -> "bb::A#instance_helper_1" [style="bold"];
+    "bb::A#instance_helper_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::A#instance_helper_1" -> "bb::A#instance_helper_1" [style="bold"];
+}
+
+subgraph "cluster_::<Class:A>#<static-init>" {
+    label = "::<Class:A>#<static-init>";
+    color = blue;
+    "bb::<Class:A>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:A>#<static-init>_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:instance_helper) = :instance_helper\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:instance_helper) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(A), <statTemp>$7: Symbol(:instance_helper), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Kernel) = alias <C Kernel>\l<block-pre-call-temp>$12: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Kernel).lambda()\l<selfRestore>$13: T.class_of(A) = <self>\l<unconditional>\l"
+    ];
+
+    "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_2" [style="bold"];
+    "bb::<Class:A>#<static-init>_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:A>#<static-init>_1" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
+    "bb::<Class:A>#<static-init>_2" [
+        color = black;
+        label = "block[id=2, rubyBlockId=1](<self>: T.class_of(A), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(A))\louterLoops: 1\l<block-call>: NilClass\l"
+    ];
+
+    "bb::<Class:A>#<static-init>_2" -> "bb::<Class:A>#<static-init>_5" [style="bold"];
+    "bb::<Class:A>#<static-init>_2" -> "bb::<Class:A>#<static-init>_3" [style="tapered"];
+
+    "bb::<Class:A>#<static-init>_3" [
+        color = black;
+        label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(A))\lf: T.proc.returns(T.untyped) = Solve<<block-pre-call-temp>$12, lambda>\l<self>: T.class_of(A) = <selfRestore>$13\l<cfgAlias>$32: T.class_of(T) = alias <C T>\l<statTemp>$30: T.class_of(A) = <cfgAlias>$32: T.class_of(T).reveal_type(<self>: T.class_of(A))\l<statTemp>$34: NilClass = <self>: T.class_of(A).puts(f: T.proc.returns(T.untyped))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:A>#<static-init>_3" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
+    "bb::<Class:A>#<static-init>_5" [
+        color = black;
+        label = "block[id=5, rubyBlockId=1](<self>: T.class_of(A), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(A))\louterLoops: 1\l<self>: T.class_of(A) = loadSelf\l<cfgAlias>$20: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$22: T.class_of(A) = alias <C A>\l<statTemp>$18: Sorbet::Private::Static::Void = <cfgAlias>$20: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$22: T.class_of(A))\l<castTemp>$23: T.class_of(A) = <self>\l<self>: A = cast(<castTemp>$23: T.class_of(A), A);\l<cfgAlias>$26: T.class_of(T) = alias <C T>\l<statTemp>$24: A = <cfgAlias>$26: T.class_of(T).reveal_type(<self>: A)\l<blockReturnTemp>$16: T.untyped = <self>: A.instance_helper()\l<blockReturnTemp>$29: T.noreturn = blockreturn<lambda> <blockReturnTemp>$16: T.untyped\l<unconditional>\l"
+    ];
+
+    "bb::<Class:A>#<static-init>_5" -> "bb::<Class:A>#<static-init>_2" [style="bold"];
+}
+
+subgraph "cluster_::<Class:B>#class_helper" {
+    label = "::<Class:B>#class_helper";
+    color = blue;
+    "bb::<Class:B>#class_helper_0" [shape = invhouse];
+    "bb::<Class:B>#class_helper_1" [shape = parallelogram];
+
+    "bb::<Class:B>#class_helper_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(B) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U B>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U B>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:B>#class_helper_0" -> "bb::<Class:B>#class_helper_1" [style="bold"];
+    "bb::<Class:B>#class_helper_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:B>#class_helper_1" -> "bb::<Class:B>#class_helper_1" [style="bold"];
+}
+
+subgraph "cluster_::B#instance_helper" {
+    label = "::B#instance_helper";
+    color = blue;
+    "bb::B#instance_helper_0" [shape = invhouse];
+    "bb::B#instance_helper_1" [shape = parallelogram];
+
+    "bb::B#instance_helper_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: B = cast(<self>: NilClass, B);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::B#instance_helper_0" -> "bb::B#instance_helper_1" [style="bold"];
+    "bb::B#instance_helper_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::B#instance_helper_1" -> "bb::B#instance_helper_1" [style="bold"];
+}
+
+subgraph "cluster_::<Class:B>#<static-init>" {
+    label = "::<Class:B>#<static-init>";
+    color = blue;
+    "bb::<Class:B>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:B>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:B>#<static-init>_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(B) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U B>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U B>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(B))\l<selfRestore>$8: T.class_of(B) = <self>\l<unconditional>\l"
+    ];
+
+    "bb::<Class:B>#<static-init>_0" -> "bb::<Class:B>#<static-init>_2" [style="bold"];
+    "bb::<Class:B>#<static-init>_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:B>#<static-init>_1" -> "bb::<Class:B>#<static-init>_1" [style="bold"];
+    "bb::<Class:B>#<static-init>_2" [
+        color = black;
+        label = "block[id=2, rubyBlockId=1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B))\louterLoops: 1\l<block-call>: NilClass\l"
+    ];
+
+    "bb::<Class:B>#<static-init>_2" -> "bb::<Class:B>#<static-init>_5" [style="bold"];
+    "bb::<Class:B>#<static-init>_2" -> "bb::<Class:B>#<static-init>_3" [style="tapered"];
+
+    "bb::<Class:B>#<static-init>_3" [
+        color = black;
+        label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(B) = <selfRestore>$8\l<cfgAlias>$23: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$25: T.class_of(T) = alias <C T>\l<statTemp>$20: T.class_of(B) = <self>: T.class_of(B).extend(<cfgAlias>$23: T.class_of(T::Sig))\l<cfgAlias>$28: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$30: Symbol(:class_helper) = :class_helper\l<statTemp>$31: Symbol(:normal) = :normal\l<statTemp>$26: Symbol(:class_helper) = <cfgAlias>$28: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(B), <statTemp>$30: Symbol(:class_helper), <statTemp>$31: Symbol(:normal))\l<cfgAlias>$34: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$36: Symbol(:instance_helper) = :instance_helper\l<statTemp>$37: Symbol(:normal) = :normal\l<statTemp>$32: Symbol(:instance_helper) = <cfgAlias>$34: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(B), <statTemp>$36: Symbol(:instance_helper), <statTemp>$37: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:B>#<static-init>_3" -> "bb::<Class:B>#<static-init>_1" [style="bold"];
+    "bb::<Class:B>#<static-init>_5" [
+        color = black;
+        label = "block[id=5, rubyBlockId=1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$14: Symbol(:blk) = :blk\l<cfgAlias>$18: T.class_of(T) = alias <C T>\l<statTemp>$16: T.class_of(T.proc) = <cfgAlias>$18: T.class_of(T).proc()\l<hashTemp>$15: T.class_of(T.proc) = <statTemp>$16: T.class_of(T.proc).void()\l<statTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$14: Symbol(:blk), <hashTemp>$15: T.class_of(T.proc))\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <statTemp>$12: T::Private::Methods::DeclBuilder.void()\l<blockReturnTemp>$19: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
+    ];
+
+    "bb::<Class:B>#<static-init>_5" -> "bb::<Class:B>#<static-init>_2" [style="bold"];
+}
+
+subgraph "cluster_::N#helper_from_N" {
+    label = "::N#helper_from_N";
+    color = blue;
+    "bb::N#helper_from_N_0" [shape = invhouse];
+    "bb::N#helper_from_N_1" [shape = parallelogram];
+
+    "bb::N#helper_from_N_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: N = cast(<self>: NilClass, N);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::N#helper_from_N_0" -> "bb::N#helper_from_N_1" [style="bold"];
+    "bb::N#helper_from_N_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::N#helper_from_N_1" -> "bb::N#helper_from_N_1" [style="bold"];
+}
+
+subgraph "cluster_::<Class:N>#<static-init>" {
+    label = "::<Class:N>#<static-init>";
+    color = blue;
+    "bb::<Class:N>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:N>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:N>#<static-init>_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(N) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U N>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U N>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:helper_from_N) = :helper_from_N\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:helper_from_N) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(N), <statTemp>$6: Symbol(:helper_from_N), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:helper_from_N)\l<unconditional>\l"
+    ];
+
+    "bb::<Class:N>#<static-init>_0" -> "bb::<Class:N>#<static-init>_1" [style="bold"];
+    "bb::<Class:N>#<static-init>_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:N>#<static-init>_1" -> "bb::<Class:N>#<static-init>_1" [style="bold"];
+}
+
+subgraph "cluster_::M#helper_from_M" {
+    label = "::M#helper_from_M";
+    color = blue;
+    "bb::M#helper_from_M_0" [shape = invhouse];
+    "bb::M#helper_from_M_1" [shape = parallelogram];
+
+    "bb::M#helper_from_M_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: M = cast(<self>: NilClass, M);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::M#helper_from_M_0" -> "bb::M#helper_from_M_1" [style="bold"];
+    "bb::M#helper_from_M_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::M#helper_from_M_1" -> "bb::M#helper_from_M_1" [style="bold"];
+}
+
+subgraph "cluster_::M#main" {
+    label = "::M#main";
+    color = blue;
+    "bb::M#main_0" [shape = invhouse];
+    "bb::M#main_1" [shape = parallelogram];
+
+    "bb::M#main_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: M = cast(<self>: NilClass, M);\l<cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$9: T.class_of(T) = alias <C T>\l<cfgAlias>$11: T.class_of(M) = alias <C M>\l<cfgAlias>$13: T.class_of(N) = alias <C N>\l<statTemp>$7: <Type: T.all(M, N)> = <cfgAlias>$9: T.class_of(T).all(<cfgAlias>$11: T.class_of(M), <cfgAlias>$13: T.class_of(N))\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$7: <Type: T.all(M, N)>)\l<castTemp>$14: M = <self>\l<self>: T.all(M, N) = cast(<castTemp>$14: M, M & N);\l<cfgAlias>$17: T.class_of(T) = alias <C T>\l<statTemp>$15: T.all(M, N) = <cfgAlias>$17: T.class_of(T).reveal_type(<self>: T.all(M, N))\l<statTemp>$19: T.untyped = <self>: T.all(M, N).helper_from_M()\l<returnMethodTemp>$2: T.untyped = <self>: T.all(M, N).helper_from_N()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
+    ];
+
+    "bb::M#main_0" -> "bb::M#main_1" [style="bold"];
+    "bb::M#main_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::M#main_1" -> "bb::M#main_1" [style="bold"];
+}
+
+subgraph "cluster_::<Class:M>#<static-init>" {
+    label = "::<Class:M>#<static-init>";
+    color = blue;
+    "bb::<Class:M>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:M>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:M>#<static-init>_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(M) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U M>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U M>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$8: T.class_of(T) = alias <C T>\l<statTemp>$3: T.class_of(M) = <self>: T.class_of(M).extend(<cfgAlias>$6: T.class_of(T::Sig))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:helper_from_M) = :helper_from_M\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:helper_from_M) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(M), <statTemp>$13: Symbol(:helper_from_M), <statTemp>$14: Symbol(:normal))\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$19: Symbol(:main) = :main\l<statTemp>$20: Symbol(:normal) = :normal\l<statTemp>$15: Symbol(:main) = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(M), <statTemp>$19: Symbol(:main), <statTemp>$20: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:M>#<static-init>_0" -> "bb::<Class:M>#<static-init>_1" [style="bold"];
+    "bb::<Class:M>#<static-init>_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:M>#<static-init>_1" -> "bb::<Class:M>#<static-init>_1" [style="bold"];
+}
+
+subgraph "cluster_::ThisSelf#main" {
+    label = "::ThisSelf#main";
+    color = blue;
+    "bb::ThisSelf#main_0" [shape = invhouse];
+    "bb::ThisSelf#main_1" [shape = parallelogram];
+
+    "bb::ThisSelf#main_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: ThisSelf = cast(<self>: NilClass, ThisSelf);\l<cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$8: T.class_of(Kernel) = alias <C Kernel>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$8: T.class_of(Kernel))\l<castTemp>$9: ThisSelf = <self>\l<self>: Kernel = cast(<castTemp>$9: ThisSelf, Kernel);\lthis: Kernel = <self>\l<cfgAlias>$12: T.class_of(T) = alias <C T>\l<statTemp>$10: Kernel = <cfgAlias>$12: T.class_of(T).reveal_type(this: Kernel)\l<returnMethodTemp>$2: NilClass = this: Kernel.puts()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::ThisSelf#main_0" -> "bb::ThisSelf#main_1" [style="bold"];
+    "bb::ThisSelf#main_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::ThisSelf#main_1" -> "bb::ThisSelf#main_1" [style="bold"];
+}
+
+subgraph "cluster_::<Class:ThisSelf>#<static-init>" {
+    label = "::<Class:ThisSelf>#<static-init>";
+    color = blue;
+    "bb::<Class:ThisSelf>#<static-init>_0" [shape = invhouse];
+    "bb::<Class:ThisSelf>#<static-init>_1" [shape = parallelogram];
+
+    "bb::<Class:ThisSelf>#<static-init>_0" [
+        color = black;
+        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(ThisSelf) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U ThisSelf>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U ThisSelf>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$8: T.class_of(T) = alias <C T>\l<statTemp>$3: T.class_of(ThisSelf) = <self>: T.class_of(ThisSelf).extend(<cfgAlias>$6: T.class_of(T::Sig))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:main) = :main\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:main) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(ThisSelf), <statTemp>$13: Symbol(:main), <statTemp>$14: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
+    ];
+
+    "bb::<Class:ThisSelf>#<static-init>_0" -> "bb::<Class:ThisSelf>#<static-init>_1" [style="bold"];
+    "bb::<Class:ThisSelf>#<static-init>_1" [
+        color = black;
+        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+    ];
+
+    "bb::<Class:ThisSelf>#<static-init>_1" -> "bb::<Class:ThisSelf>#<static-init>_1" [style="bold"];
+}
+
+}
+

--- a/website/docs/procs.md
+++ b/website/docs/procs.md
@@ -104,7 +104,7 @@ Note that the `yield` itself in the method body doesn't need to change at all.
 Since every Ruby method can only accept one block, both Ruby and Sorbet are able
 to connect the `yield` call to the `blk` parameter automatically.
 
-## Modifying the self type
+## Annotating the self type with `T.proc.bind`
 
 Many Ruby constructs accept a block argument in one context, but then execute it
 in a different context entirely. This means that the methods that exist inside
@@ -164,9 +164,69 @@ end
 puts(upcased) # => "HELLO"
 ```
 
-The `T.bind` assertion allows the `self` type to be changed on a case by case
-basis, for cases when changing the method signature binding doesn't satisfy all
-conditions. See [Type Assertions](type-assertions.md#tbind).
+## Casting the self type with `T.bind`
+
+As mentioned above, by default, Sorbet assumes that a block executes in a
+context where `self` has the same type as the lexically surrounding scope.
+
+The `T.proc.bind` annotation (from the previous section) can change this
+assumption, but is only valid for use on the distinguished `&blk` parameter of a
+method:
+
+- It cannot be used with non-`&blk` parameters at a call site.
+- It cannot be used with procs or lambdas that are assigned into a variable,
+  disconnected from any single call site.
+
+(This is due to some simplifying architectural choices in the implementation of
+Sorbet's type checking algorithm.)
+
+We still might want to ascribe a type to `self` for non-`&blk` usages. For
+example, look at the block passed to `before_create` below:
+
+```ruby
+class Post
+  before_create :set_pending, if: -> {
+    draft? # error: Method `draft?` does not exist on `T.class_of(Post)`
+  }
+
+  def draft?
+    true
+  end
+end
+```
+
+By default, Sorbet assumes that when `draft?` runs, `self` will have type
+`T.class_of(Post)`. In reality, `before_create` will execute the lambda provided
+to the `if` argument in a context where the block's `self` has type `Post`.
+
+To type this code accurately, Sorbet requires a
+[`T.bind` annotation](type-assertions.md#tbind) in the lambda:
+
+```ruby
+class Post
+  before_create :set_pending, if: -> {
+    T.bind(self, Post)
+    draft? # OK!
+  }
+
+  # ...
+end
+```
+
+<a href="https://sorbet.run/#%23%20typed%3A%20true%0A%0Aclass%20Base%0A%20%20def%20self.before_create(name%2C%20**options)%0A%20%20end%0Aend%0A%0Aclass%20Post%20%3C%20Base%0A%20%20before_create%20%3Aset_pending%2C%20if%3A%20-%3E%20%7B%20T.bind(self%2C%20Post).draft%3F%20%7D%0A%0A%20%20def%20draft%3F%0A%20%20%20%20true%0A%20%20end%0Aend%0A%0Aclass%20Article%20%3C%20Base%0A%20%20before_create%20%3Aset_pending%2C%20if%3A%20-%3E%20%7B%20draft%3F%20%7D%0A%0A%20%20def%20draft%3F%0A%20%20%20%20true%0A%20%20end%0Aend">
+  → View on sorbet.run
+</a>
+
+Like with `T.cast`, the full range of Sorbet types can be used in the `T.bind`
+annotation. For example, here is a more complicated example that uses `T.any`
+with `T.bind`:
+
+<a href="https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20Concern%0A%20%20def%20included(%26block)%0A%20%20end%0Aend%0A%0Amodule%20Taggeable%0A%20%20extend%20Concern%0A%0A%20%20included%20do%0A%20%20%20%20T.bind(self%2C%20T.any(Post%2C%20Article))%0A%0A%20%20%20%20create_tag!%0A%20%20end%0Aend%0A%0Aclass%20Post%0A%20%20include%20Taggeable%0A%0A%20%20def%20self.create_tag!%0A%20%20end%0Aend%0A%0Aclass%20Article%0A%20%20include%20Taggeable%0Aend">
+  → View on sorbet.run
+</a>
+
+For more information on `T.bind`, see
+[Type Assertions](type-assertions.md#tbind).
 
 ## Proc.new vs proc
 

--- a/website/docs/procs.md
+++ b/website/docs/procs.md
@@ -164,6 +164,10 @@ end
 puts(upcased) # => "HELLO"
 ```
 
+The `T.bind` assertion allows the `self` type to be changed on a case by case
+basis, for cases when changing the method signature binding doesn't satisfy all
+conditions. See [Type Assertions](type-assertions.md#tbind).
+
 ## Proc.new vs proc
 
 In Ruby there's several ways to create a Proc: `proc` and `Proc.new`. Sorbet


### PR DESCRIPTION

This PR introduces `T.bind` outside of the context of method signatures to allow users to bind procs and lambdas to different types. This is especially useful in the Rails world, where a lot of procs are executed with `instance_exec`.

For example,
```rb
class Post < ApplicationRecord
  # In callbacks from ActiveRecord, ActiveModel and Actionpack, `if` and `unless` options
  # can be passed as lambdas to determine whether it should run or not. These keys are part
  # of keyword arguments and the block is captured and then executed in the context of the instance.
  #
  # Sorbet doesn't know that it will be executed in an instance context and errors with
  # "method `should_do_it?` is not defined for T.class_of(Post)
  before_create :do_something, if: -> { should_do_it? }

  private

  def should_do_it?
    true
  end
end
```

With the changes in this PR, users can indicate the correct binding inside each proc, guaranteeing that type checking is verifying against the right types. Below is an example usage and more examples can be found in the tests included.
```rb
class Post < ApplicationRecord
  # Proc is now bound to `Post` and not `T.class_of(Post)`. No errors!
  before_create :do_something, if: -> { T.bind(self, Post); should_do_it? }

  private

  def should_do_it?
    true
  end
end
```

### Motivation

Sorbet currently does not allow indicating the context in which a captured block will run, which limits typing in common Rails use cases, such as the previously mentioned callbacks, but also active support concerns.

### Test plan

The included tests display examples for concerns and callbacks.