### PR TITLE
add a T::Configuration option for VM prop serde and appropriate modifications

### DIFF
--- a/gems/sorbet-runtime/Rakefile
+++ b/gems/sorbet-runtime/Rakefile
@@ -8,13 +8,17 @@ T::Configuration.default_checked_level = :always
 
 task default: %i[test rubocop]
 
-task :test do
+def require_tests
   Dir.glob('./test/**/*.rb').reject {|path| path.match(%r{^./test/types/fixtures/})}.each(&method(:require))
+end
+
+task :test do
+  require_tests
 end
 
 task :test_vm_serde do
   T::Configuration.enable_vm_prop_serde
-  Rake::Task[:test].invoke
+  require_tests
 end
 
 require 'rubocop/rake_task'

--- a/gems/sorbet-runtime/Rakefile
+++ b/gems/sorbet-runtime/Rakefile
@@ -12,6 +12,11 @@ task :test do
   Dir.glob('./test/**/*.rb').reject {|path| path.match(%r{^./test/types/fixtures/})}.each(&method(:require))
 end
 
+task :test_vm_serde do
+  T::Configuration.enable_vm_prop_serde
+  Rake::Task[:test].invoke
+end
+
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:rubocop) do |t|
   t.requires << 'rubocop-performance'

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -73,6 +73,27 @@ module T::Configuration
     @include_value_in_type_errors = true
   end
 
+  # Whether to use VM-defined prop serialization/deserialization routines.
+  #
+  # The default is to use runtime codegen inside sorbet-runtime itself.
+  #
+  # @return [T::Boolean]
+  def self.use_vm_prop_serde?
+    @use_vm_prop_serde || false
+  end
+
+  # Enable using VM-defined prop serialization/deserialization routines.
+  #
+  # This method is likely to break things outside of Stripe's systems.
+  def self.enable_vm_prop_serde
+    @use_vm_prop_serde = true
+  end
+
+  # Disable using VM-defined prop serialization/deserialization routines.
+  def self.disable_vm_prop_serde
+    @use_vm_prop_serde = false
+  end
+
   # Configure the default checked level for a sig with no explicit `.checked`
   # builder. When unset, the default checked level is `:always`.
   #


### PR DESCRIPTION
### Motivation

We have some changes to prop serialization/deserialization that are faster than the `sorbet-runtime` codegen and avoid the use of `class_eval`.  To be able to reasonably test those changes, we'd like to add a `T::Configuration` option that selects between the status quo and the accelerated routines.

### Test plan

There's not much to test here.  I did verify that the `test` and `test_vm_serde` Rakefile targets pass (well, subject to error handling problems with the VM-defined routines) on an appropriately configured Ruby.