### PR TITLE
Explain how to enable `requires_ancestor`

### DIFF
--- a/website/docs/requires-ancestor.md
+++ b/website/docs/requires-ancestor.md
@@ -4,6 +4,10 @@ title: Requiring Ancestors
 sidebar_label: Requiring Ancestors
 ---
 
+> This feature is experimental and might be changed or removed without notice.
+> To enable it pass the `--enable-experimental-requires-ancestor` option to
+> Sorbet or add it to your `sorbet/config`.
+
 It's not uncommon in Ruby to define helper modules that depends on other
 modules. For example, let's take the following helper which provides `say_error`
 method:


### PR DESCRIPTION
### Motivation

Add documentation on how to enable the `requires_anmcestor` feature.

Closes #4175.

### Test plan

Output:
![image](https://user-images.githubusercontent.com/583144/116098513-252ea680-a679-11eb-9e6b-1bb26613e808.png)
