### PR TITLE
Fix parser shift/reduce conflicts

### DIFF
--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -179,6 +179,8 @@ using namespace std::string_literals;
   tANDDOT             1142    "&."
   tRATIONAL_IMAGINARY 1143
   tFLOAT_IMAGINARY    1144
+  tBDOT2              1145    // Used to avoid shift/reduce conflicts with productions using `tDOT2`
+  tBDOT3              1146    // Used to avoid shift/reduce conflicts with productions using `tDOT3`
 ;
 
 %type <node>
@@ -388,7 +390,7 @@ using namespace std::string_literals;
 %right    tEQL tOP_ASGN
 %left     kRESCUE_MOD
 %right    tEH tCOLON
-%nonassoc tDOT2 tDOT3
+%nonassoc tDOT2 tDOT3 tBDOT2 tBDOT3
 %left     tOROP
 %left     tANDOP
 %nonassoc tCMP tEQ tEQQ tNEQ tMATCH tNMATCH
@@ -714,8 +716,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                       driver.lex.in_kwarg = $<boolean>3;
                       $$ = driver.build.in_match(self, $1, $2, $4);
                     }
-                | arg tLBRACE_ARG
-                | arg
+                | arg %prec tLBRACE_ARG
 
       expr_value: expr
 
@@ -1127,11 +1128,11 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                     {
                       $$ = driver.build.range_exclusive(self, $1, $2, nullptr);
                     }
-                | tDOT2 arg
+                | tBDOT2 arg
                     {
                       $$ = driver.build.range_inclusive(self, nullptr, $1, $2);
                     }
-                | tDOT3 arg
+                | tBDOT3 arg
                     {
                       $$ = driver.build.range_exclusive(self, nullptr, $1, $2);
                     }
@@ -2619,11 +2620,11 @@ opt_block_args_tail:
                 | p_variable
                 | p_var_ref
                 | p_const
-                | tDOT2 p_primitive
+                | tBDOT2 p_primitive
                     {
                       $$ = driver.build.range_inclusive(self, nullptr, $1, $2);
                     }
-                | tDOT3 p_primitive
+                | tBDOT3 p_primitive
                     {
                       $$ = driver.build.range_exclusive(self, nullptr, $1, $2);
                     }
@@ -3225,7 +3226,7 @@ keyword_variable: kNIL
                     {
                       $$ = driver.alloc.node_list();
                     }
-    args_forward: tDOT3
+    args_forward: tBDOT3
                     {
                       $$ = $1;
                     }

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -434,14 +434,22 @@ namespace typedruby27 {
 } while(false);
 
 void parser::error(const std::string &msg) {
-  std::string error_message = msg;
+	std::string error_message = msg;
 
-  int token_type = static_cast<int>(driver.last_token->type());
-  const char* token_str_name = yytname_[yytranslate_(token_type)];
+	int token_type = static_cast<int>(driver.last_token->type());
+	const char* token_str_name = yytname_[yytranslate_(token_type)];
 
-  if (token_str_name != nullptr) {
-    error_message = token_str_name;
-  }
+	if (token_type == token_type::tBDOT2) {
+		// Because we have two tokens matching `..`, we can't set the token name as `..` directly.
+		// This hack allows to display the real token string instead of `tBDOT2` in parsing errors.
+		error_message = "\"..\"";
+	} else if (token_type == token_type::tBDOT3) {
+		// Because we have two tokens matching `...`, we can't set the token name as `...` directly.
+		// This hack allows to display the real token string instead of `tBDOT3` in parsing errors.
+		error_message = "\"...\"";
+	} else if (token_str_name != nullptr) {
+		error_message = token_str_name;
+	}
 
 	driver.diagnostics.emplace_back(
 		dlevel::ERROR, dclass::UnexpectedToken,

--- a/third_party/parser/cc/lexer.rl
+++ b/third_party/parser/cc/lexer.rl
@@ -2312,6 +2312,33 @@ void lexer::set_state_expr_value() {
       };
 
       #
+      # RUBY 2.7 BEGINLESS RANGE
+
+      '..'
+      => {
+        auto ident = tok(ts, te - 2);
+        if (version >= ruby_version::RUBY_27) {
+          emit(token_type::tBDOT2, ident, ts, te);
+        } else {
+          emit(token_type::tDOT2, ident, ts, te);
+        }
+
+        fnext expr_beg; fbreak;
+      };
+
+      '...'
+      => {
+        auto ident = tok(ts, te - 2);
+        if (version >= ruby_version::RUBY_27) {
+          emit(token_type::tBDOT3, ident, ts, te);
+        } else {
+          emit(token_type::tDOT3, ident, ts, te);
+        }
+
+        fnext expr_beg; fbreak;
+      };
+
+      #
       # CONTEXT-DEPENDENT VARIABLE LOOKUP OR COMMAND INVOCATION
       #
 

--- a/third_party/parser/include/ruby_parser/token.hh
+++ b/third_party/parser/include/ruby_parser/token.hh
@@ -153,7 +153,9 @@
     XX(tLABEL_END, 1141)            \
     XX(tANDDOT, 1142)               \
     XX(tRATIONAL_IMAGINARY, 1143)   \
-    XX(tFLOAT_IMAGINARY, 1144)
+    XX(tFLOAT_IMAGINARY, 1144)      \
+    XX(tBDOT2, 1145)                \
+    XX(tBDOT3, 1146)
 
 namespace ruby_parser {
 enum class token_type : int {


### PR DESCRIPTION
### Motivation

I introduced shift/reduce conflicts in the grammar while adding support for begin-less ranges with `..` and `...` (https://github.com/sorbet/sorbet/pull/3313). This PR fixes them.

Example when compiling the parser before this PR:

![image](https://user-images.githubusercontent.com/583144/116124914-e3aaf500-a692-11eb-995c-7a7652962c54.png)

The approach is the same as the one used by Whitequark (https://github.com/whitequark/parser/blob/de619a2ff36a39b4d43efa9b86cdec98621ed435/lib/parser/lexer.rl#L2026-L2035): duplicating the tokens `tDOT2` and `tDOT3` and lexing them differently depending on the Ruby version used.

One quirk with this approach is the way we display the parsing errors. Without any additional change, the error message would be:

```
^^^ error: unexpected token tBDOT3
```

In order to get a friendlier output, I tweaker the error generation method (see second commit) so we get back to the expected following error:

```
^^^ error: unexpected token "..."
```

Compiling the parser after this PR:

![image](https://user-images.githubusercontent.com/583144/116125639-bf9be380-a693-11eb-93ce-87f8ca9b8ef0.png)

No more shift/reduce conflict warning. 🎉 

### Test plan

See included automated tests.
