### PR TITLE
add some sorbet-runtime serialization tests

### DIFF
--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -688,12 +688,10 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       struct.set = set
 
       h = struct.serialize
-      assert_equal(1, h['set'].length)
-      assert(h['set'].include?('foo'))
+      assert_equal(set, h['set'])
 
       roundtripped = SetPropStruct.from_hash(h)
-      assert_equal(1, roundtripped.set.length)
-      assert(roundtripped.set.include?('foo'))
+      assert_equal(roundtripped.set, set)
     end
 
     it 'does not share structure on serialize' do

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -568,6 +568,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(CustomTypeStruct, storytime[:klass])
       assert_equal(:array, storytime[:prop])
       assert_equal(obj, storytime[:value])
+      assert_includes(storytime[:error], "undefined method `map'")
     end
 
     it 'round trips as hash key' do
@@ -603,6 +604,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(CustomTypeStruct, storytime[:klass])
       assert_equal(:hash_key, storytime[:prop])
       assert_equal(obj, storytime[:value])
+      assert_includes(storytime[:error], "undefined method `transform_keys'")
     end
 
     it 'round trips as hash value' do
@@ -638,6 +640,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(CustomTypeStruct, storytime[:klass])
       assert_equal(:hash_value, storytime[:prop])
       assert_equal(obj, storytime[:value])
+      assert_includes(storytime[:error], "undefined method `transform_values'")
     end
 
     it 'round trips as hash key and value' do
@@ -673,6 +676,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(CustomTypeStruct, storytime[:klass])
       assert_equal(:hash_both, storytime[:prop])
       assert_equal(obj, storytime[:value])
+      assert_includes(storytime[:error], "undefined method `each_with_object'")
     end
   end
 

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -504,7 +504,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal('foo', CustomTypeStruct.from_hash({'single' => 'foo'}).serialize['single'])
     end
 
-    it 'raises serialize errors for members with a custom subtype' do
+    it 'raises serialize errors when props with a custom subtype store the wrong datatype' do
       struct = CustomTypeStruct.new
       struct.instance_variable_set(:@single, 'not a serializable thing')
       e = assert_raises(TypeError) do
@@ -516,7 +516,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
 
     # It's hard to write tests for a CustomType with a custom deserialize method, so skip that.
 
-    it 'raises serialize errors for members with a serializable subtype' do
+    it 'raises serialize errors when props with a serializable subtype store the wrong datatype' do
       struct = CustomTypeWrapper.new
       struct.instance_variable_set(:@struct, 'not a serializable thing')
       e = assert_raises(NoMethodError) do
@@ -526,7 +526,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_includes(e.message, "undefined method `serialize'")
     end
 
-    it 'raises deserialize errors for members with a serializable subtype' do
+    it 'raises deserialize errors when props with a serializable subtype store the wrong datatype' do
       obj = 'not a serializable thing'
       e = assert_raises(TypeError) do
         CustomTypeWrapper.from_hash({'struct' => obj})
@@ -539,7 +539,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(['foo'], CustomTypeStruct.from_hash({'array' => ['foo']}).serialize['array'])
     end
 
-    it 'raises serialize errors for members needing map' do
+    it 'raises serialize errors when props with an array of a custom subtype store the wrong datatype' do
       obj = CustomType.new
       struct = CustomTypeStruct.new
       struct.instance_variable_set(:@array, obj)
@@ -550,7 +550,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_includes(e.message, "undefined method `map'")
     end
 
-    it 'raises deserialize errors for members needing map' do
+    it 'raises deserialize errors when props with an array of a custom subtype store the wrong datatype' do
       msg_string = nil
       extra_hash = nil
       T::Configuration.soft_assert_handler = proc do |msg, extra|
@@ -574,7 +574,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal({'foo' => 'bar'}, CustomTypeStruct.from_hash({'hash_key' => {'foo' => 'bar'}}).serialize['hash_key'])
     end
 
-    it 'raises serialize errors for members needing transform_keys' do
+    it 'raises serialize errors when props with a hash with keys of a custom subtype store the wrong datatype' do
       obj = CustomType.new
       struct = CustomTypeStruct.new
       struct.instance_variable_set(:@hash_key, obj)
@@ -585,7 +585,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_includes(e.message, "undefined method `transform_keys'")
     end
 
-    it 'raises deserialize errors for bad members needing transform_keys' do
+    it 'raises deserialize errors when props with a hash with keys of a custom subtype store the wrong datatype' do
       msg_string = nil
       extra_hash = nil
       T::Configuration.soft_assert_handler = proc do |msg, extra|
@@ -609,7 +609,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal({'foo' => 'bar'}, CustomTypeStruct.from_hash({'hash_value' => {'foo' => 'bar'}}).serialize['hash_value'])
     end
 
-    it 'raises serialize errors for members needing transform_values' do
+    it 'raises serialize errors when props with a hash with values of a custom subtype store the wrong datatype' do
       obj = CustomType.new
       struct = CustomTypeStruct.new
       struct.instance_variable_set(:@hash_value, obj)
@@ -620,7 +620,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_includes(e.message, "undefined method `transform_values'")
     end
 
-    it 'raises deserialize errors for members needing transform_values' do
+    it 'raises deserialize errors when props with a hash with values of a custom subtype store the wrong datatype' do
       msg_string = nil
       extra_hash = nil
       T::Configuration.soft_assert_handler = proc do |msg, extra|
@@ -644,7 +644,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal({'foo' => 'bar'}, CustomTypeStruct.from_hash({'hash_both' => {'foo' => 'bar'}}).serialize['hash_both'])
     end
 
-    it 'raises serialize errors for members needing each_with_object' do
+    it 'raises serialize errors when props with a hash with keys/values of a custom subtype store the wrong datatype' do
       obj = CustomType.new
       struct = CustomTypeStruct.new
       struct.instance_variable_set(:@hash_both, obj)
@@ -655,7 +655,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_includes(e.message, "undefined method `each_with_object'")
     end
 
-    it 'raises deserialize errors for members needing each_with_object' do
+    it 'raises deserialize errors when props with a hash with keys/values of a custom subtype store the wrong datatype' do
       msg_string = nil
       extra_hash = nil
       T::Configuration.soft_assert_handler = proc do |msg, extra|

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -499,6 +499,18 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal('foo', CustomTypeStruct.from_hash({'single' => 'foo'}).serialize['single'])
     end
 
+    it 'raises serialize errors for members with a custom subtype' do
+      struct = CustomTypeStruct.new
+      struct.instance_variable_set(:@single, 'not a serializable thing')
+      e = assert_raises(TypeError) do
+        struct.serialize
+      end
+
+      assert_includes(e.message, "Expected type T::Props::CustomType")
+    end
+
+    # It's hard to write tests for a CustomType with a custom deserialize method, so skip that.
+
     it 'round trips as array value' do
       assert_equal(['foo'], CustomTypeStruct.from_hash({'array' => ['foo']}).serialize['array'])
     end

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -503,16 +503,140 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(['foo'], CustomTypeStruct.from_hash({'array' => ['foo']}).serialize['array'])
     end
 
+    it 'raises serialize errors for members needing map' do
+      obj = CustomType.new
+      struct = CustomTypeStruct.new
+      struct.instance_variable_set(:@array, obj)
+      e = assert_raises(NoMethodError) do
+        struct.serialize
+      end
+
+      assert_includes(e.message, "undefined method `map'")
+    end
+
+    it 'raises deserialize errors for members needing map' do
+      msg_string = nil
+      extra_hash = nil
+      T::Configuration.soft_assert_handler = proc do |msg, extra|
+        msg_string = msg
+        extra_hash = extra
+      end
+
+      obj = CustomType.new
+      result = CustomTypeStruct.from_hash({'array' => obj})
+      assert_equal(obj, result.array)
+
+      refute_nil(msg_string)
+      refute_nil(extra_hash)
+      storytime = extra_hash[:storytime]
+      assert_equal(CustomTypeStruct, storytime[:klass])
+      assert_equal(:array, storytime[:prop])
+      assert_equal(obj, storytime[:value])
+    end
+
     it 'round trips as hash key' do
       assert_equal({'foo' => 'bar'}, CustomTypeStruct.from_hash({'hash_key' => {'foo' => 'bar'}}).serialize['hash_key'])
+    end
+
+    it 'raises serialize errors for members needing transform_keys' do
+      obj = CustomType.new
+      struct = CustomTypeStruct.new
+      struct.instance_variable_set(:@hash_key, obj)
+      e = assert_raises(NoMethodError) do
+        struct.serialize
+      end
+
+      assert_includes(e.message, "undefined method `transform_keys'")
+    end
+
+    it 'raises deserialize errors for bad members needing transform_keys' do
+      msg_string = nil
+      extra_hash = nil
+      T::Configuration.soft_assert_handler = proc do |msg, extra|
+        msg_string = msg
+        extra_hash = extra
+      end
+
+      obj = 'not a hash'
+      result = CustomTypeStruct.from_hash({'hash_key' => obj})
+      assert_equal('not a hash', result.hash_key)
+
+      refute_nil(msg_string)
+      refute_nil(extra_hash)
+      storytime = extra_hash[:storytime]
+      assert_equal(CustomTypeStruct, storytime[:klass])
+      assert_equal(:hash_key, storytime[:prop])
+      assert_equal(obj, storytime[:value])
     end
 
     it 'round trips as hash value' do
       assert_equal({'foo' => 'bar'}, CustomTypeStruct.from_hash({'hash_value' => {'foo' => 'bar'}}).serialize['hash_value'])
     end
 
+    it 'raises serialize errors for members needing transform_values' do
+      obj = CustomType.new
+      struct = CustomTypeStruct.new
+      struct.instance_variable_set(:@hash_value, obj)
+      e = assert_raises(NoMethodError) do
+        struct.serialize
+      end
+
+      assert_includes(e.message, "undefined method `transform_values'")
+    end
+
+    it 'raises deserialize errors for members needing transform_values' do
+      msg_string = nil
+      extra_hash = nil
+      T::Configuration.soft_assert_handler = proc do |msg, extra|
+        msg_string = msg
+        extra_hash = extra
+      end
+
+      obj = 'not a hash'
+      result = CustomTypeStruct.from_hash({'hash_value' => obj})
+      assert_equal('not a hash', result.hash_value)
+
+      refute_nil(msg_string)
+      refute_nil(extra_hash)
+      storytime = extra_hash[:storytime]
+      assert_equal(CustomTypeStruct, storytime[:klass])
+      assert_equal(:hash_value, storytime[:prop])
+      assert_equal(obj, storytime[:value])
+    end
+
     it 'round trips as hash key and value' do
       assert_equal({'foo' => 'bar'}, CustomTypeStruct.from_hash({'hash_both' => {'foo' => 'bar'}}).serialize['hash_both'])
+    end
+
+    it 'raises serialize errors for members needing each_with_object' do
+      obj = CustomType.new
+      struct = CustomTypeStruct.new
+      struct.instance_variable_set(:@hash_both, obj)
+      e = assert_raises(NoMethodError) do
+        struct.serialize
+      end
+
+      assert_includes(e.message, "undefined method `each_with_object'")
+    end
+
+    it 'raises deserialize errors for members needing each_with_object' do
+      msg_string = nil
+      extra_hash = nil
+      T::Configuration.soft_assert_handler = proc do |msg, extra|
+        msg_string = msg
+        extra_hash = extra
+      end
+
+      obj = 'not a hash'
+      result = CustomTypeStruct.from_hash({'hash_both' => obj})
+      assert_equal('not a hash', result.hash_both)
+
+      refute_nil(msg_string)
+      refute_nil(extra_hash)
+      storytime = extra_hash[:storytime]
+      assert_equal(CustomTypeStruct, storytime[:klass])
+      assert_equal(:hash_both, storytime[:prop])
+      assert_equal(obj, storytime[:value])
     end
   end
 


### PR DESCRIPTION

### Motivation

We weren't testing error cases very well, and we weren't testing set props at all.

(Some of the error cases for the sorbet-runtime generated serialization/deserialization code can theoretically be lumped together, but those cases have distinct handling in some changes we have.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
