### PR TITLE
Really unchecked version of `T.let`

### DIFF
--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -85,9 +85,24 @@ module SorbetBenchmarks
         type.valid?(false)
       end
 
+      time_block("T.unsafe(...)") do
+        T.unsafe(0)
+        T.unsafe(1)
+      end
+
       time_block("T.let(..., Integer)") do
         T.let(0, Integer)
         T.let(1, Integer)
+      end
+
+      time_block("T.let(..., Integer, checked: false)") do
+        T.let(0, Integer, checked: false)
+        T.let(1, Integer, checked: false)
+      end
+
+      time_block("T.let(..., checked: false) {Integer}") do
+        T.let(0, checked: false) {Integer}
+        T.let(1, checked: false) {Integer}
       end
 
       time_block("sig {params(x: Integer).void}") do
@@ -100,6 +115,16 @@ module SorbetBenchmarks
         T.let(1, T.nilable(Integer))
       end
 
+      time_block("T.let(..., T.nilable(Integer), checked: false)") do
+        T.let(nil, T.nilable(Integer), checked: false)
+        T.let(1, T.nilable(Integer), checked: false)
+      end
+
+      time_block("T.let(..., checked: false) {T.nilable(Integer)}") do
+        T.let(nil, checked: false) {T.nilable(Integer)}
+        T.let(1, checked: false) {T.nilable(Integer)}
+      end
+
       time_block("sig {params(x: T.nilable(Integer)).void}") do
         nilable_integer_param(nil)
         nilable_integer_param(1)
@@ -110,6 +135,16 @@ module SorbetBenchmarks
         T.let(example, Example)
       end
 
+      time_block("T.let(..., Example, checked: false)") do
+        T.let(example, Example, checked: false)
+        T.let(example, Example, checked: false)
+      end
+
+      time_block("T.let(..., checked: false) {Example}") do
+        T.let(example, checked: false) {Example}
+        T.let(example, checked: false) {Example}
+      end
+
       time_block("sig {params(x: Example).void}") do
         application_class_param(example)
         application_class_param(example)
@@ -118,6 +153,16 @@ module SorbetBenchmarks
       time_block("T.let(..., T.nilable(Example))") do
         T.let(nil, T.nilable(Example))
         T.let(example, T.nilable(Example))
+      end
+
+      time_block("T.let(..., T.nilable(Example), checked: false)") do
+        T.let(nil, T.nilable(Example), checked: false)
+        T.let(example, T.nilable(Example), checked: false)
+      end
+
+      time_block("T.let(..., checked: false) {T.nilable(Example)}") do
+        T.let(nil, checked: false) {T.nilable(Example)}
+        T.let(example, checked: false) {T.nilable(Example)}
       end
 
       time_block("sig {params(x: T.nilable(Example)).void}") do

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -126,7 +126,9 @@ module T
   # exception at runtime if the value doesn't match the type.
   #
   # Compared to `T.let`, `T.cast` is _trusted_ by static system.
-  def self.cast(value, type, checked: true)
+  def self.cast(value, type=nil, checked: true, &blk)
+    # To save time, we don't additionally validation that `checked` is `false` (enforced statically at `typed: false`)
+    return value if block_given?
     return value unless checked
 
     Private::Casts.cast(value, type, cast_method: "T.cast")
@@ -141,7 +143,9 @@ module T
   #
   # If `checked` is true, raises an exception at runtime if the value
   # doesn't match the type.
-  def self.let(value, type, checked: true)
+  def self.let(value, type=nil, checked: true, &blk)
+    # To save time, we don't additionally validation that `checked` is `false` (enforced statically at `typed: false`)
+    return value if block_given?
     return value unless checked
 
     Private::Casts.cast(value, type, cast_method: "T.let")
@@ -170,7 +174,9 @@ module T
   # fail). Use this for debugging typechecking errors, or to ensure that type information is
   # statically known and being checked appropriately. If `checked` is true, raises an exception at
   # runtime if the value doesn't match the type.
-  def self.assert_type!(value, type, checked: true)
+  def self.assert_type!(value, type=nil, checked: true, &blk)
+    # To save time, we don't additionally validation that `checked` is `false` (enforced statically at `typed: false`)
+    return value if block_given?
     return value unless checked
 
     Private::Casts.cast(value, type, cast_method: "T.assert_type!")

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -127,11 +127,9 @@ module T
   #
   # Compared to `T.let`, `T.cast` is _trusted_ by static system.
   def self.cast(value, type=nil, checked: true, &blk)
-    # To save time, we don't additionally validation that `checked` is `false` (enforced statically at `typed: false`)
-    return value if block_given?
     return value unless checked
 
-    Private::Casts.cast(value, type, cast_method: "T.cast")
+    Private::Casts.cast(value, type, cast_method: "T.cast", block_given: block_given?)
   end
 
   # Tells the typechecker to declare a variable of type `type`. Use
@@ -144,11 +142,9 @@ module T
   # If `checked` is true, raises an exception at runtime if the value
   # doesn't match the type.
   def self.let(value, type=nil, checked: true, &blk)
-    # To save time, we don't additionally validation that `checked` is `false` (enforced statically at `typed: false`)
-    return value if block_given?
     return value unless checked
 
-    Private::Casts.cast(value, type, cast_method: "T.let")
+    Private::Casts.cast(value, type, cast_method: "T.let", block_given: block_given?)
   end
 
   # Tells the type checker to treat `self` in the current block as `type`.
@@ -175,11 +171,9 @@ module T
   # statically known and being checked appropriately. If `checked` is true, raises an exception at
   # runtime if the value doesn't match the type.
   def self.assert_type!(value, type=nil, checked: true, &blk)
-    # To save time, we don't additionally validation that `checked` is `false` (enforced statically at `typed: false`)
-    return value if block_given?
     return value unless checked
 
-    Private::Casts.cast(value, type, cast_method: "T.assert_type!")
+    Private::Casts.cast(value, type, cast_method: "T.assert_type!", block_given: block_given?)
   end
 
   # For the static type checker, strips all type information from a value

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -160,10 +160,10 @@ module T
   #
   # If `checked` is true, raises an exception at runtime if the value
   # doesn't match the type (this is the default).
-  def self.bind(value, type, checked: true)
+  def self.bind(value, type=nil, checked: true, &blk)
     return value unless checked
 
-    Private::Casts.cast(value, type, cast_method: "T.bind")
+    Private::Casts.cast(value, type, cast_method: "T.bind", block_given: block_given?)
   end
 
   # Tells the typechecker to ensure that `value` is of type `type` (if not, the typechecker will

--- a/gems/sorbet-runtime/lib/types/private/casts.rb
+++ b/gems/sorbet-runtime/lib/types/private/casts.rb
@@ -11,7 +11,10 @@ module T::Private
   end
 
   module Casts
-    def self.cast(value, type, cast_method:)
+    def self.cast(value, type, cast_method:, block_given:)
+      raise "T.#{cast_method} with a block must use `checked: false`" if block_given
+      raise "T.#{cast_method} be given a type" unless type
+
       begin
         error = T::Utils.coerce(type).error_message_for_obj(value)
         return value unless error

--- a/gems/sorbet-runtime/test/types/casts.rb
+++ b/gems/sorbet-runtime/test/types/casts.rb
@@ -33,6 +33,19 @@ module Opus::Types::Test
           assert_equal(:foo, method.call(:foo, T.noreturn, checked: false))
         end
 
+        it 'allows invalid casts with block form' do
+          assert_equal(:foo, method.call(:foo, checked: false) {Integer})
+          assert_equal(:foo, method.call(:foo, checked: false) {T.any(String, Integer)})
+          assert_equal(:foo, method.call(:foo, checked: false) {T.noreturn})
+        end
+
+        it 'allows invalid casts with block form, even without checked: false' do
+          # We don't necessarily want to allow this, but we do anyways for speed.
+          assert_equal(:foo, method.call(:foo) {Integer})
+          assert_equal(:foo, method.call(:foo) {T.any(String, Integer)})
+          assert_equal(:foo, method.call(:foo) {T.noreturn})
+        end
+
         it 'has a good error message' do
           lno = nil
           ex = assert_raises(TypeError) do
@@ -42,6 +55,7 @@ module Opus::Types::Test
           assert_match(/type T.any\(Integer, String\)/, ex.message)
           assert_match(/\nCaller: #{__FILE__}:#{lno}/, ex.message)
         end
+
       end
     end
 

--- a/gems/sorbet-runtime/test/types/casts.rb
+++ b/gems/sorbet-runtime/test/types/casts.rb
@@ -39,11 +39,21 @@ module Opus::Types::Test
           assert_equal(:foo, method.call(:foo, checked: false) {T.noreturn})
         end
 
-        it 'allows invalid casts with block form, even without checked: false' do
-          # We don't necessarily want to allow this, but we do anyways for speed.
-          assert_equal(:foo, method.call(:foo) {Integer})
-          assert_equal(:foo, method.call(:foo) {T.any(String, Integer)})
-          assert_equal(:foo, method.call(:foo) {T.noreturn})
+        it 'rejects block form casts without checked: false' do
+          exn = assert_raises(RuntimeError) do
+            assert_equal(:foo, method.call(:foo) {Integer})
+          end
+          assert_match(/with a block must use `checked: false`/, exn.message)
+
+          exn = assert_raises(RuntimeError) do
+            assert_equal(:foo, method.call(:foo) {T.any(String, Integer)})
+          end
+          assert_match(/with a block must use `checked: false`/, exn.message)
+
+          exn = assert_raises(RuntimeError) do
+            assert_equal(:foo, method.call(:foo) {T.noreturn})
+          end
+          assert_match(/with a block must use `checked: false`/, exn.message)
         end
 
         it 'has a good error message' do

--- a/gems/sorbet/lib/t.rb
+++ b/gems/sorbet/lib/t.rb
@@ -28,10 +28,10 @@ module T
   def self.type_alias(type=nil, &blk); end
   def self.type_parameter(name); end
 
-  def self.cast(value, type, checked: true); value; end
-  def self.let(value, type, checked: true); value; end
-  def self.bind(value, type, checked: true); value; end
-  def self.assert_type!(value, type, checked: true); value; end
+  def self.cast(value, type=nil, checked: true, &blk); value; end
+  def self.let(value, type=nil, checked: true, &blk); value; end
+  def self.bind(value, type=nil, checked: true, &blk); value; end
+  def self.assert_type!(value, type=nil, checked: true, &blk); value; end
   def self.unsafe(value); value; end
   def self.must(arg, msg=nil); arg; end
   def self.reveal_type(value); value; end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -29,10 +29,10 @@ module T
   sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean, blk: T.untyped).returns(BasicObject)}
   def self.let(value, type=nil, checked: true, &blk); end
 
-  sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean).returns(BasicObject)}
+  sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean, blk: T.untyped).returns(BasicObject)}
   def self.bind(value, type=nil, checked: true, &blk); end
 
-  sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean).returns(BasicObject)}
+  sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean, blk: T.untyped).returns(BasicObject)}
   def self.assert_type!(value, type=nil, checked: true, &blk); end
 
   sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean, blk: T.untyped).returns(BasicObject)}

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -26,17 +26,17 @@ module T
   # here still applies, but additional checking and/or analysis is
   # performed in C++ for that method.
 
-  sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean).returns(BasicObject)}
-  def self.let(value, type, checked: true); end
+  sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean, blk: T.untyped).returns(BasicObject)}
+  def self.let(value, type=nil, checked: true, &blk); end
 
   sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean).returns(BasicObject)}
-  def self.bind(value, type, checked: true); end
+  def self.bind(value, type=nil, checked: true, &blk); end
 
   sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean).returns(BasicObject)}
-  def self.assert_type!(value, type, checked: true); end
+  def self.assert_type!(value, type=nil, checked: true, &blk); end
 
-  sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean).returns(BasicObject)}
-  def self.cast(value, type, checked: true); end
+  sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean, blk: T.untyped).returns(BasicObject)}
+  def self.cast(value, type=nil, checked: true, &blk); end
 
   sig {params(type: T.untyped).returns(BasicObject)}
   def self.nilable(type); end

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2109,11 +2109,7 @@ public:
                             return tree;
                         }
                         auto keywordVal = ast::cast_tree<ast::Literal>(send.args[2]);
-                        if (keywordVal == nullptr || (!keywordVal->isTrue(ctx) && !keywordVal->isFalse(ctx))) {
-                            return tree;
-                        }
-
-                        if (!keywordVal->isFalse(ctx)) {
+                        if (keywordVal == nullptr || !keywordVal->isFalse(ctx)) {
                             if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                                 e.setHeader("Using `{}` in block form requires `{}`",
                                             fmt::format("T.{}", send.fun.show(ctx)), "checked: false");

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2080,7 +2080,7 @@ public:
                         return tree;
                     }
 
-                    auto castBlock = ast::cast_tree<ast::Block>(send.block);
+                    auto *castBlock = ast::cast_tree<ast::Block>(send.block);
                     if (send.numPosArgs == 1) {
                         if (castBlock == nullptr) {
                             if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2097,11 +2097,6 @@ public:
                             if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                                 e.setHeader("Using `{}` in block form requires `{}`",
                                             fmt::format("T.{}", send.fun.show(ctx)), "checked: false");
-                                auto endPos = send.loc.endPos();
-                                if (send.loc.exists() && endPos > 0) {
-                                    auto insertLoc = core::Loc(ctx.file, endPos - 1, endPos - 1);
-                                    e.replaceWith("Insert `checked: false`", insertLoc, ", checked: false");
-                                }
                             }
 
                             return sendToCast(ctx, send.loc, send.fun, std::move(send.args[0]),
@@ -2122,10 +2117,6 @@ public:
                             if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                                 e.setHeader("Using `{}` in block form requires `{}`",
                                             fmt::format("T.{}", send.fun.show(ctx)), "checked: false");
-                                auto replaceLoc = core::Loc(ctx.file, keywordVal->loc);
-                                if (replaceLoc.source(ctx) == "true") {
-                                    e.replaceWith("Change to `false`", replaceLoc, "false");
-                                }
                             }
                         }
 
@@ -2136,10 +2127,6 @@ public:
                             if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                                 e.setHeader("Passed type to `{}` twice, via argument and block",
                                             fmt::format("T.{}", send.fun.show(ctx)));
-                                auto deleteLoc = core::Loc(ctx.file, castBlock->loc).adjust(ctx, -2, 0);
-                                if (deleteLoc.exists()) {
-                                    e.replaceWith("Remove block", deleteLoc, "");
-                                }
                             }
                         }
 

--- a/test/testdata/rbi/t.rb
+++ b/test/testdata/rbi/t.rb
@@ -17,9 +17,9 @@ T.any(String, Integer, Symbol)
 T.all(String, Integer, Symbol)
 
 
-T.let # error: Not enough arguments provided for method `T.let`. Expected: `2`, got: `0`
-T.assert_type! # error: Not enough arguments provided for method `T.assert_type!`. Expected: `2`, got: `0`
-T.cast # error: Not enough arguments provided for method `T.cast`. Expected: `2`, got: `0`
+T.let # error: Not enough arguments provided for method `T.let`. Expected: `1..2`, got: `0`
+T.assert_type! # error: Not enough arguments provided for method `T.assert_type!`. Expected: `1..2`, got: `0`
+T.cast # error: Not enough arguments provided for method `T.cast`. Expected: `1..2`, got: `0`
 T.unsafe # error: Not enough arguments provided for method `T.unsafe`. Expected: `1`, got: `0`
 T.nilable # error: Not enough arguments provided for method `T.nilable`. Expected: `1`, got: `0`
   T.proc(String)

--- a/test/testdata/resolver/missing_type_combinator_args.rb
+++ b/test/testdata/resolver/missing_type_combinator_args.rb
@@ -5,8 +5,8 @@ T.cast(nil, T.nilable(Integer, Integer))
 T.cast(nil, T.any) # error: Not enough arguments provided for method
 T.cast(nil, T.all) # error: Not enough arguments provided for method
 T.must # error: Not enough arguments provided for method
-T.let(1) # error: Not enough arguments provided for method
-T.let(1, 2, 3) # error: Unsupported literal in type syntax
+T.let(1) # error: No type provided to `T.let`
+T.let(1, 2, 3) # error: Too many positional arguments provided for method
 T.reveal_type() # error: Not enough arguments provided for method
   T.reveal_type(1, 2)
 # ^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method

--- a/test/testdata/resolver/missing_type_combinator_args.rb.flatten-tree.exp
+++ b/test/testdata/resolver/missing_type_combinator_args.rb.flatten-tree.exp
@@ -21,10 +21,7 @@ begin
         end
         ::T.must()
         ::T.let(1)
-        begin
-          ::Sorbet::Private::Static.keep_for_typechecking(2)
-          T.let(1, Integer)
-        end
+        ::T.let(1, 2, 3)
         ::T.reveal_type()
         ::T.reveal_type(1, 2)
         <emptyTree>

--- a/test/testdata/resolver/t_let_block.rb
+++ b/test/testdata/resolver/t_let_block.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+w = T.let(1) {T.nilable(Integer)}
+T.reveal_type(w) # error: Revealed type: `T.nilable(Integer)`
+
+x = T.cast('') {T.nilable(String)}
+T.reveal_type(x) # error: Revealed type: `T.nilable(String)`
+
+y = T.assert_type!('') {T.nilable(Float)} # error: Argument does not have asserted type `T.nilable(Float)`
+T.reveal_type(y) # error: Revealed type: `T.nilable(Float)`
+
+# TODO(jez) Update this test after rebasing on the `T.bind` branch.

--- a/test/testdata/resolver/t_let_block.rb
+++ b/test/testdata/resolver/t_let_block.rb
@@ -5,10 +5,10 @@ MyType = T.type_alias {Integer}
 
 # For these using **expr, I don't really care what happens as long as it doesn't crash.
 
-T.let(**expr) # error: Not enough arguments
-T.let(**expr) {MyType} # error: Not enough arguments
-T.let(expr, **expr) # error: Not enough arguments
-T.let(expr, **expr) {MyType} # error: Not enough arguments
+T.let(**expr)
+T.let(**expr) {MyType}
+T.let(expr, **expr)
+T.let(expr, **expr) {MyType}
 
 T.let(checked: false, **expr)
 T.let(checked: false, **expr) {MyType}
@@ -32,7 +32,7 @@ T.let(expr, checked: 1) {MyType} # error: Expected `T::Boolean` but found `Integ
 T.let(expr, checked: true) {MyType} # error: Using `T.let` in block form requires `checked: false`
 
 x1 = T.let(1, checked: false) {T.nilable(Integer)}
-T.reveal_type(x1) # error: type `T.nilable(Integer)`
+T.reveal_type(x1) # error: type: `T.nilable(Integer)`
 
 T.let('not an int', checked: false) {T.nilable(Integer)} # error: Argument does not have asserted type `T.nilable(Integer)`
 

--- a/test/testdata/resolver/t_let_block.rb
+++ b/test/testdata/resolver/t_let_block.rb
@@ -1,12 +1,58 @@
 # typed: true
 
-w = T.let(1) {T.nilable(Integer)}
+expr = T.unsafe(nil)
+MyType = T.type_alias {Integer}
+
+# For these using **expr, I don't really care what happens as long as it doesn't crash.
+
+T.let(**expr) # error: Not enough arguments
+T.let(**expr) {MyType} # error: Not enough arguments
+T.let(expr, **expr) # error: Not enough arguments
+T.let(expr, **expr) {MyType} # error: Not enough arguments
+
+T.let(checked: false, **expr)
+T.let(checked: false, **expr) {MyType}
+T.let(expr, checked: false, **expr) {MyType} # error: specific keys are unknown
+
+# --- Neither block form nor positional form ---
+
+T.let(expr) # error: No type provided to `T.let`
+T.let(expr, checked: false) # error: No type provided to `T.let`
+
+# --- Block form ---
+
+T.let(expr, checked: false, garbage: true) {MyType} # error: Unrecognized keyword argument `garbage`
+
+T.let(expr) {MyType} # error: Using `T.let` in block form requires `checked: false`
+
+T.let(expr, garbage: true) {MyType} # error: Unrecognized keyword argument `garbage`
+T.let(expr, checked: nil) {MyType} # error: Expected `T::Boolean` but found `NilClass`
+T.let(expr, checked: 1) {MyType} # error: Expected `T::Boolean` but found `Integer(1)`
+
+T.let(expr, checked: true) {MyType} # error: Using `T.let` in block form requires `checked: false`
+
+x1 = T.let(1, checked: false) {T.nilable(Integer)}
+T.reveal_type(x1) # error: type `T.nilable(Integer)`
+
+T.let('not an int', checked: false) {T.nilable(Integer)} # error: Argument does not have asserted type `T.nilable(Integer)`
+
+# --- Positional form ---
+
+T.let(expr, MyType) {MyType} # error: Passed type to `T.let` twice, via argument and block
+
+# --- All cast names ---
+
+_a = T.let(1) {T.nilable(Integer)} # error: requires `checked: false`
+_b = T.cast(1) {T.nilable(Integer)} # error: requires `checked: false`
+_c = T.assert_type!(1) {T.nilable(Integer)} # error: requires `checked: false`
+
+w = T.let(1, checked: false) {T.nilable(Integer)}
 T.reveal_type(w) # error: Revealed type: `T.nilable(Integer)`
 
-x = T.cast('') {T.nilable(String)}
+x = T.cast('', checked: false) {T.nilable(String)}
 T.reveal_type(x) # error: Revealed type: `T.nilable(String)`
 
-y = T.assert_type!('') {T.nilable(Float)} # error: Argument does not have asserted type `T.nilable(Float)`
+y = T.assert_type!('', checked: false) {T.nilable(Float)} # error: does not have asserted type
 T.reveal_type(y) # error: Revealed type: `T.nilable(Float)`
 
 # TODO(jez) Update this test after rebasing on the `T.bind` branch.

--- a/test/testdata/resolver/t_let_block.rb
+++ b/test/testdata/resolver/t_let_block.rb
@@ -57,3 +57,12 @@ y = T.assert_type!('', checked: false) {T.nilable(Float)} # error: does not have
 T.reveal_type(y) # error: Revealed type: `T.nilable(Float)`
 
 # TODO(jez) Update this test after rebasing on the `T.bind` branch.
+
+def bad_bind_block
+  T.bind(self) {Integer} # error: requires `checked: false`
+end
+
+def good_bind_block
+  T.bind(self, checked: false) {T.nilable(Integer)}
+  T.reveal_type(self) # error: type: `T.nilable(Integer)`
+end

--- a/test/testdata/resolver/t_let_block.rb
+++ b/test/testdata/resolver/t_let_block.rb
@@ -26,9 +26,10 @@ T.let(expr, checked: false, garbage: true) {MyType} # error: Unrecognized keywor
 T.let(expr) {MyType} # error: Using `T.let` in block form requires `checked: false`
 
 T.let(expr, garbage: true) {MyType} # error: Unrecognized keyword argument `garbage`
-T.let(expr, checked: nil) {MyType} # error: Expected `T::Boolean` but found `NilClass`
-T.let(expr, checked: 1) {MyType} # error: Expected `T::Boolean` but found `Integer(1)`
 
+T.let(expr, checked: nil) {MyType} # error: Using `T.let` in block form requires `checked: false`
+T.let(expr, checked: 1) {MyType} # error: Using `T.let` in block form requires `checked: false`
+T.let(expr, checked: expr) {MyType} # error: Using `T.let` in block form requires `checked: false`
 T.let(expr, checked: true) {MyType} # error: Using `T.let` in block form requires `checked: false`
 
 x1 = T.let(1, checked: false) {T.nilable(Integer)}

--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -284,6 +284,20 @@ For example, this should probably be placed as the first line of any `rake test`
 target, as well as any other entry point to a project's tests. If this line is
 absent, `.checked(:tests)` sigs behave as if they had been `.checked(:never)`.
 
+## `checked: false` with `T.let` and other assertions
+
+Similar to the section above for method signatures, it is also possible to turn
+off type checking for individual `T.let` assertions:
+
+```ruby
+x = T.let(nil, checked: false) {T.nilable(Integer)}
+```
+
+In this form, the block will never be executed, so the runtime object
+representing the type will never execute, and the value `nil` will be returned
+unchanged. This works with all other [Type Assertions](type-assertions.md) that
+require types.
+
 ## `T::Sig::WithoutRuntime.sig`
 
 Even with `.checked(:never)`, there is some slight runtime overhead. The block


### PR DESCRIPTION
## Motivation

The `checked: false` annotation on a `T.let` is somewhat of a lie, because
the program still pays the cost of constructing the runtime type, even
though it's going to be discarded.

Inside hot code paths, constructing these runtime types is costly, both in
terms of allocations and time.

## Summary

T.let and friends now can take the type as a block:

```ruby
T.let(expr, checked: false) {Type}
```

In this form, the block will never run, so the program will not spend time
building the runtime type.

## Performance

Collected using

```
cd gems/sorbet-runtime
bundle exec rake bench:typecheck
```

| benchmark                                         | time        |
| ---------                                         | ---:        |
| `T.unsafe(...)`                                   | 23.941 ns   |
| `T.let(..., Integer)`                             | 463.187 ns  |
| `T.let(..., Integer, checked: false)`             | 91.872 ns   |
| `T.let(..., checked: false) {Integer}`            | 92.954 ns   |
| &nbsp;                                            | &nbsp;      |
| `T.let(..., T.nilable(Integer))`                  | 1126.000 ns |
| `T.let(..., T.nilable(Integer), checked: false)`  | 773.141 ns  |
| `T.let(..., checked: false) {T.nilable(Integer)}` | 92.947 ns   |
| &nbsp;                                            | &nbsp;      |
| `T.let(..., Example)`                             | 459.601 ns  |
| `T.let(..., Example, checked: false)`             | 90.671 ns   |
| `T.let(..., checked: false) {Example}`            | 93.025 ns   |
| &nbsp;                                            | &nbsp;      |
| `T.let(..., T.nilable(Example))`                  | 1125.000 ns |
| `T.let(..., T.nilable(Example), checked: false)`  | 768.239 ns  |
| `T.let(..., checked: false) {T.nilable(Example)}` | 94.174 ns   |

All the block forms:

- are about ~90 ns (regardless of type complexity)
- are never more than ~1 ns slower than non-block form (likely noise)
- take about 4x the time spent to run T.unsafe

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.