### PR TITLE
Upgrade abseil in advance of clang-12

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -146,9 +146,9 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "com_google_absl",
-        urls = _github_public_urls("abseil/abseil-cpp/archive/62f05b1f57ad660e9c09e02ce7d591dcc4d0ca08.zip"),
-        sha256 = "afcab9f226ac4ca6b6b7c9ec704a995fe32a6b555d6935b0de247ae6ac6940e0",
-        strip_prefix = "abseil-cpp-62f05b1f57ad660e9c09e02ce7d591dcc4d0ca08",
+        urls = _github_public_urls("abseil/abseil-cpp/archive/f14d5f4af12eb521a5142151d6ea3addbbed42bb.zip"),
+        #sha256 = "afcab9f226ac4ca6b6b7c9ec704a995fe32a6b555d6935b0de247ae6ac6940e0",
+        strip_prefix = "abseil-cpp-f14d5f4af12eb521a5142151d6ea3addbbed42bb",
     )
 
     http_archive(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Upgrade abseil to enable building with clang-12.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Clang-12 unblocks builds on big sur.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
