### PR TITLE
add T::Configuration.*vm_prop_serde* methods to t.rbi

### DIFF
--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -145,6 +145,9 @@ module T::Configuration
   def self.exclude_value_in_type_errors; end
   sig {void}
   def self.include_value_in_type_errors; end
+  def self.use_vm_prop_serde?; end
+  def self.enable_vm_prop_serde; end
+  def self.disable_vm_prop_serde; end
   def self.hard_assert_handler(str, extra); end
   def self.hard_assert_handler=(value); end
   def self.inline_type_error_handler(error); end


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Discovered that I forgot to add these; without them, using them fails Sorbet typechecking.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
