### PR TITLE
treat sig(:final) .checked(:never) sigs as not unchecked

### DIFF
--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -149,6 +149,15 @@ bool sigIsUnchecked(core::MutableContext ctx, ast::Send *sig) {
         return true;
     }
 
+    // We want sig(:final) to overrule .checked(:never)
+    if (sig->args.size() > 0) {
+        int final_arg = sig->args.size() == 1 ? 0 : 1;
+        auto lit = ast::cast_tree<ast::Literal>(sig->args[final_arg]);
+        if (lit != nullptr && lit->isSymbol(ctx) && lit->asSymbol(ctx) == core::Names::final_()) {
+            return false;
+        }
+    }
+
     auto checked = findSendChecked(sig);
     if (checked == nullptr || checked->args.size() != 1) {
         // Unknown: default to false

--- a/test/testdata/rewriter/attr_reader_method_kind.rb
+++ b/test/testdata/rewriter/attr_reader_method_kind.rb
@@ -13,6 +13,15 @@ class A
 
   sig {returns(Integer).checked(:never)}
   attr_reader :using_attr_reader_sig_checked_never
+
+  sig(:final) {returns(Integer)}
+  attr_reader :using_attr_reader_sig_final
+
+  sig(:final) {returns(Integer).checked(:tests)}
+  attr_reader :using_attr_reader_sig_final_checked_tests
+
+  sig(:final) {returns(Integer).checked(:never)}
+  attr_reader :using_attr_reader_sig_final_checked_never
 end
 
 class B < T::Struct

--- a/test/testdata/rewriter/attr_reader_method_kind.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/attr_reader_method_kind.rb.rewrite-tree.exp
@@ -28,6 +28,30 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @using_attr_reader_sig_checked_never
     end
 
+    ::Sorbet::Private::Static.sig(<self>, :final) do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def using_attr_reader_sig_final<<todo method>>(&<blk>)
+      @using_attr_reader_sig_final
+    end
+
+    ::Sorbet::Private::Static.sig(<self>, :final) do ||
+      <self>.returns(<emptyTree>::<C Integer>).checked(:tests)
+    end
+
+    def using_attr_reader_sig_final_checked_tests<<todo method>>(&<blk>)
+      @using_attr_reader_sig_final_checked_tests
+    end
+
+    ::Sorbet::Private::Static.sig(<self>, :final) do ||
+      <self>.returns(<emptyTree>::<C Integer>).checked(:never)
+    end
+
+    def using_attr_reader_sig_final_checked_never<<todo method>>(&<blk>)
+      @using_attr_reader_sig_final_checked_never
+    end
+
     <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :using_attr_reader, :attr_reader)
@@ -37,6 +61,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::Sorbet::Private::Static.keep_def(<self>, :using_attr_reader_sig_checked_tests, :normal)
 
     ::Sorbet::Private::Static.keep_def(<self>, :using_attr_reader_sig_checked_never, :attr_reader)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :using_attr_reader_sig_final, :normal)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :using_attr_reader_sig_final_checked_tests, :normal)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :using_attr_reader_sig_final_checked_never, :normal)
   end
 
   class <emptyTree>::<C B><<C <todo sym>>> < (<emptyTree>::<C T>::<C Struct>)


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The state of affairs decided on by the patch is not ideal, but it is the most expedient thing to do.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
