### PR TITLE
use abseil's contains method rather than std's find()/end() idiom

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -566,9 +566,9 @@ public:
             return;
         }
 
-        if (isSymbol && hashKeySymbols.find(nameRef) == hashKeySymbols.end()) {
+        if (isSymbol && !hashKeySymbols.contains(nameRef)) {
             hashKeySymbols[nameRef] = key.loc();
-        } else if (!isSymbol && hashKeyStrings.find(nameRef) == hashKeyStrings.end()) {
+        } else if (!isSymbol && !hashKeyStrings.contains(nameRef)) {
             hashKeyStrings[nameRef] = key.loc();
         } else {
             if (auto e = dctx.ctx.beginError(key.loc(), core::errors::Desugar::DuplicatedHashKeys)) {

--- a/common/common.cc
+++ b/common/common.cc
@@ -279,7 +279,7 @@ void appendFilesInDir(string_view basePath, string_view path, const sorbet::Unor
             // Note: Can't call substr with an index > string length, so explicitly check if a dot isn't found.
             if (dotLocation != string::npos) {
                 auto ext = fullPath.substr(dotLocation);
-                if (extensions.find(ext) != extensions.end()) {
+                if (extensions.contains(ext)) {
                     result.emplace_back(fullPath);
                 }
             }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -972,7 +972,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                         }
 
                         NameRef arg = key.asName(gs);
-                        if (consumed.find(arg) != consumed.end()) {
+                        if (consumed.contains(arg)) {
                             continue;
                         }
                         consumed.insert(arg);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -726,7 +726,7 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef 
     auto &noTests = knowledgeToChoose->noTypeTests;
 
     for (auto &typeTested : yesTests) {
-        if (filter.find(typeTested.first) == filter.end()) {
+        if (!filter.contains(typeTested.first)) {
             continue;
         }
         core::TypeAndOrigins tp = getTypeAndOrigin(ctx, typeTested.first);
@@ -743,7 +743,7 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef 
     }
 
     for (auto &typeTested : noTests) {
-        if (filter.find(typeTested.first) == filter.end()) {
+        if (!filter.contains(typeTested.first)) {
             continue;
         }
         core::TypeAndOrigins tp = getTypeAndOrigin(ctx, typeTested.first);

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -20,7 +20,7 @@ namespace sorbet::autogen {
 
 bool AutoloaderConfig::include(const NamedDefinition &nd) const {
     return !nd.qname.nameParts.empty() &&
-           topLevelNamespaceRefs.find(nd.qname.nameParts[0]) != topLevelNamespaceRefs.end();
+           topLevelNamespaceRefs.contains(nd.qname.nameParts[0]);
 }
 
 bool AutoloaderConfig::includePath(string_view path) const {

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -19,8 +19,7 @@ namespace sorbet::autogen {
 // converts it to a `DefTree`, and then emits the autoloader files based on passed-in string fragments
 
 bool AutoloaderConfig::include(const NamedDefinition &nd) const {
-    return !nd.qname.nameParts.empty() &&
-           topLevelNamespaceRefs.contains(nd.qname.nameParts[0]);
+    return !nd.qname.nameParts.empty() && topLevelNamespaceRefs.contains(nd.qname.nameParts[0]);
 }
 
 bool AutoloaderConfig::includePath(string_view path) const {

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -30,11 +30,11 @@ bool AutoloaderConfig::includePath(string_view path) const {
 }
 
 bool AutoloaderConfig::includeRequire(core::NameRef req) const {
-    return excludedRequireRefs.find(req) == excludedRequireRefs.end();
+    return !excludedRequireRefs.contains(req);
 }
 
 bool AutoloaderConfig::sameFileCollapsable(const vector<core::NameRef> &module) const {
-    return nonCollapsableModuleNames.find(module) == nonCollapsableModuleNames.end();
+    return !nonCollapsableModuleNames.contains(module);
 }
 
 string_view AutoloaderConfig::normalizePath(const core::GlobalState &gs, core::FileRef file) const {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -156,7 +156,7 @@ SimilarMethodsByName mergeSimilarMethods(SimilarMethodsByName left, SimilarMetho
     auto result = SimilarMethodsByName{};
 
     for (auto [methodName, leftSimilarMethods] : left) {
-        if (right.find(methodName) != right.end()) {
+        if (right.contains(methodName)) {
             for (auto similarMethod : leftSimilarMethods) {
                 result[methodName].emplace_back(similarMethod);
             }

--- a/main/lsp/tools/generate_lsp_messages.h
+++ b/main/lsp/tools/generate_lsp_messages.h
@@ -823,7 +823,7 @@ public:
         std::vector<std::string> emitOrder;
         for (auto &variant : variants) {
             auto cppType = variant->getCPPType();
-            if (uniqueTypes.find(cppType) == uniqueTypes.end()) {
+            if (!uniqueTypes.contains(cppType)) {
                 uniqueTypes.insert(cppType);
                 emitOrder.push_back(cppType);
             }

--- a/main/lsp/tools/generate_lsp_messages.h
+++ b/main/lsp/tools/generate_lsp_messages.h
@@ -930,12 +930,12 @@ public:
                 variant->getJSONBaseKind() == BaseKind::ComplexKind) {
                 throw std::invalid_argument("Invalid variant type: Complex are not supported.");
             }
-            if (cppKindSeen.find(variant->getCPPBaseKind()) != cppKindSeen.end()) {
+            if (cppKindSeen.contains(variant->getCPPBaseKind())) {
                 throw std::invalid_argument(
                     "Invalid variant type: Cannot discriminate between multiple types with same base C++ kind.");
             }
             cppKindSeen.insert(variant->getCPPBaseKind());
-            if (jsonKindSeen.find(variant->getJSONBaseKind()) != jsonKindSeen.end()) {
+            if (jsonKindSeen.contains(variant->getJSONBaseKind())) {
                 throw std::invalid_argument(
                     "Invalid variant type: Cannot discriminate between multiple types with same base JSON kind.");
             }

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -360,7 +360,7 @@ vector<shared_ptr<RangeAssertion>> parseAssertionsForFile(const shared_ptr<core:
             if (findConstructor != assertionConstructors.end()) {
                 assertions.push_back(
                     findConstructor->second(filename, range, lineNum, assertionContents, assertionType));
-            } else if (ignoredAssertionLabels.find(assertionType) == ignoredAssertionLabels.end()) {
+            } else if (!ignoredAssertionLabels.contains(assertionType)) {
                 ADD_FAIL_CHECK_AT(
                     filename.c_str(), lineNum + 1,
                     fmt::format("Found unrecognized assertion of type `{}`. Expected one of {{{}}}.\nIf this is a "

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -329,7 +329,7 @@ TEST_CASE("LSPTest") {
         lspWrapper->enableAllExperimentalFeatures();
     }
 
-    if (test.expectations.find("autogen") != test.expectations.end()) {
+    if (test.expectations.contains("autogen")) {
         // When autogen is enabled, skip Rewriter passes...
         lspWrapper->opts->skipRewriterPasses = true;
         // Some autogen tests assume that some errors will occur from the resolver step, others assume the resolver


### PR DESCRIPTION
abseil's sets and maps helpfully provide a `contains()` method, so you don't have to `find()` and then compare to `end()`, as you would with `std::` associative containers.

### Motivation

More readable code.  I don't claim that this is complete, this is just what grep told me was easily doable.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
