### PR TITLE
Validate overrides for attr accessors and T::Struct props

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -312,8 +312,15 @@ private:
     }
 
 public:
-    static ExpressionPtr Sig(core::LocOffsets loc, Send::ARGS_store args, ExpressionPtr ret) {
-        auto params = Params(loc, Self(loc), std::move(args));
+    static ExpressionPtr Sig(core::LocOffsets loc, Send::ARGS_store args, ExpressionPtr ret, bool isOverride = false) {
+        sorbet::ast::ExpressionPtr receiver;
+        if (isOverride) {
+            receiver = Send0(loc, Self(loc), core::Names::override_());
+        } else {
+            receiver = Self(loc);
+        }
+
+        auto params = Params(loc, std::move(receiver), std::move(args));
         auto returns = Send1(loc, std::move(params), core::Names::returns(), std::move(ret));
         auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(),
                          Constant(loc, core::Symbols::T_Sig_WithoutRuntime()));
@@ -334,8 +341,15 @@ public:
         return sig;
     }
 
-    static ExpressionPtr Sig0(core::LocOffsets loc, ExpressionPtr ret) {
-        auto returns = Send1(loc, Self(loc), core::Names::returns(), std::move(ret));
+    static ExpressionPtr Sig0(core::LocOffsets loc, ExpressionPtr ret, bool isOverride = false) {
+        sorbet::ast::ExpressionPtr receiver;
+        if (isOverride) {
+            receiver = Send0(loc, Self(loc), core::Names::override_());
+        } else {
+            receiver = Self(loc);
+        }
+
+        auto returns = Send1(loc, std::move(receiver), core::Names::returns(), std::move(ret));
         auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(),
                          Constant(loc, core::Symbols::T_Sig_WithoutRuntime()));
         auto sigSend = ast::cast_tree<ast::Send>(sig);
@@ -344,8 +358,9 @@ public:
         return sig;
     }
 
-    static ExpressionPtr Sig1(core::LocOffsets loc, ExpressionPtr key, ExpressionPtr value, ExpressionPtr ret) {
-        return Sig(loc, SendArgs(std::move(key), std::move(value)), std::move(ret));
+    static ExpressionPtr Sig1(core::LocOffsets loc, ExpressionPtr key, ExpressionPtr value, ExpressionPtr ret,
+                              bool isOverride = false) {
+        return Sig(loc, SendArgs(std::move(key), std::move(value)), std::move(ret), isOverride);
     }
 
     static ExpressionPtr T(core::LocOffsets loc) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -312,10 +312,15 @@ private:
     }
 
 public:
-    static ExpressionPtr Sig(core::LocOffsets loc, Send::ARGS_store args, ExpressionPtr ret, bool isOverride = false) {
+    static ExpressionPtr Sig(core::LocOffsets loc, Send::ARGS_store args, ExpressionPtr ret, bool isOverride = false,
+                             bool allowIncompatible = false) {
         sorbet::ast::ExpressionPtr receiver;
+
         if (isOverride) {
-            receiver = Send0(loc, Self(loc), core::Names::override_());
+            auto incompatible = allowIncompatible ? True(loc) : False(loc);
+            auto args = SendArgs(Symbol(loc, core::Names::allowIncompatible()), std::move(incompatible));
+
+            receiver = Send(loc, Self(loc), core::Names::override_(), 0, std::move(args));
         } else {
             receiver = Self(loc);
         }
@@ -341,10 +346,14 @@ public:
         return sig;
     }
 
-    static ExpressionPtr Sig0(core::LocOffsets loc, ExpressionPtr ret, bool isOverride = false) {
+    static ExpressionPtr Sig0(core::LocOffsets loc, ExpressionPtr ret, bool isOverride = false,
+                              bool allowIncompatible = false) {
         sorbet::ast::ExpressionPtr receiver;
         if (isOverride) {
-            receiver = Send0(loc, Self(loc), core::Names::override_());
+            auto incompatible = allowIncompatible ? True(loc) : False(loc);
+            auto args = SendArgs(Symbol(loc, core::Names::allowIncompatible()), std::move(incompatible));
+
+            receiver = Send(loc, Self(loc), core::Names::override_(), 0, std::move(args));
         } else {
             receiver = Self(loc);
         }
@@ -359,8 +368,8 @@ public:
     }
 
     static ExpressionPtr Sig1(core::LocOffsets loc, ExpressionPtr key, ExpressionPtr value, ExpressionPtr ret,
-                              bool isOverride = false) {
-        return Sig(loc, SendArgs(std::move(key), std::move(value)), std::move(ret), isOverride);
+                              bool isOverride = false, bool allowIncompatible = false) {
+        return Sig(loc, SendArgs(std::move(key), std::move(value)), std::move(ret), isOverride, allowIncompatible);
     }
 
     static ExpressionPtr T(core::LocOffsets loc) {

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -364,9 +364,12 @@ public:
         bool isRewriterSynthesized : 1;
         bool isAttrReader : 1;
         bool discardDef : 1;
+        bool performOverrideChecks : 1;
 
         // In C++20 we can replace this with bit field initialzers
-        Flags() : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), discardDef(false) {}
+        Flags()
+            : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), discardDef(false),
+              performOverrideChecks(true) {}
     };
     CheckSize(Flags, 1, 1);
 

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -327,8 +327,7 @@ void validateOverriding(const core::Context ctx, core::MethodRef method) {
         auto isRBI = absl::c_any_of(method.data(ctx)->locs(), [&](auto &loc) { return loc.file().data(ctx).isRBI(); });
         if (!method.data(ctx)->isOverride() && method.data(ctx)->hasSig() &&
             (overridenMethod.data(ctx)->isOverridable() || overridenMethod.data(ctx)->isOverride()) &&
-            !anyIsInterface && overridenMethod.data(ctx)->hasSig() && !method.data(ctx)->isRewriterSynthesized() &&
-            !isRBI) {
+            !anyIsInterface && overridenMethod.data(ctx)->hasSig() && !isRBI) {
             if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::UndeclaredOverride)) {
                 e.setHeader("Method `{}` overrides an overridable method `{}` but is not declared with `{}`",
                             method.show(ctx), overridenMethod.show(ctx), "override.");
@@ -336,7 +335,7 @@ void validateOverriding(const core::Context ctx, core::MethodRef method) {
             }
         }
         if (!method.data(ctx)->isOverride() && method.data(ctx)->hasSig() && overridenMethod.data(ctx)->isAbstract() &&
-            overridenMethod.data(ctx)->hasSig() && !method.data(ctx)->isRewriterSynthesized() && !isRBI) {
+            overridenMethod.data(ctx)->hasSig() && !isRBI) {
             if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::UndeclaredOverride)) {
                 e.setHeader("Method `{}` implements an abstract method `{}` but is not declared with `{}`",
                             method.show(ctx), overridenMethod.show(ctx), "override.");
@@ -345,7 +344,8 @@ void validateOverriding(const core::Context ctx, core::MethodRef method) {
         }
         if ((overridenMethod.data(ctx)->isAbstract() || overridenMethod.data(ctx)->isOverridable() ||
              (overridenMethod.data(ctx)->hasSig() && method.data(ctx)->isOverride())) &&
-            !method.data(ctx)->isIncompatibleOverride() && !isRBI && !method.data(ctx)->isRewriterSynthesized()) {
+            !method.data(ctx)->isIncompatibleOverride() && !isRBI &&
+            (!method.data(ctx)->isRewriterSynthesized() || method.data(ctx)->isOverride())) {
             validateCompatibleOverride(ctx, overridenMethod, method);
         }
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -713,7 +713,10 @@ public:
             variance::validateMethodVariance(ctx, methodDef.symbol);
         }
 
-        validateOverriding(ctx, methodDef.symbol);
+        if (methodDef.flags.performOverrideChecks) {
+            validateOverriding(ctx, methodDef.symbol);
+        }
+
         return tree;
     }
 };

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -66,7 +66,7 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
 
   class OverrideSubProps
     include BaseProps
-    prop :prop2, T::Array[Object], override: true
+    prop :prop2, T::Array[Object], override: true, allow_incompatible: true
   end
 
   class InheritedOverrideSubProps < OverrideSubProps

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -23,8 +23,11 @@ void generateStub(vector<ast::ExpressionPtr> &methodStubs, const core::LocOffset
     args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
     args.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
+    auto flags = ast::MethodDef::Flags();
+    flags.performOverrideChecks = false;
+
     methodStubs.push_back(
-        ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::RaiseUnimplemented(loc)));
+        ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::RaiseUnimplemented(loc), flags));
 }
 
 /// Handle #def_delegator for a single delegate method

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -121,7 +121,11 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
         args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
         args.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
-        methodStubs.push_back(ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree()));
+        auto flags = ast::MethodDef::Flags();
+        flags.performOverrideChecks = false;
+
+        methodStubs.push_back(
+            ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree(), flags));
     }
 
     return methodStubs;

--- a/test/testdata/resolver/abstract_validation.rb
+++ b/test/testdata/resolver/abstract_validation.rb
@@ -166,3 +166,26 @@ module BadTypedImpl
   sig {override.returns(Integer)}
   def foo; 1; end # error: Return type `Integer` does not match return type of abstract method `GoodInterface#foo`
 end
+
+class BadAttrImpl
+  extend T::Sig
+  extend T::Helpers
+  include GoodInterface
+
+  sig {override.returns(Integer)}
+  attr_reader :foo # error: Return type `Integer` does not match return type of abstract method `GoodInterface#foo`
+end
+
+class BadStructImpl < T::Struct
+  include GoodInterface
+
+  const :foo, Integer, override: true
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Return type `Integer` does not match return type of abstract method `GoodInterface#foo`
+end
+
+class BadStructMissingOverride < T::Struct
+  include GoodInterface
+
+  const :foo, Integer
+# ^^^^^^^^^^^^^^^^^^^ error: Method `BadStructMissingOverride#foo` implements an abstract method `GoodInterface#foo` but is not declared with `override.`
+end

--- a/test/testdata/resolver/abstract_validation.rb
+++ b/test/testdata/resolver/abstract_validation.rb
@@ -189,3 +189,9 @@ class BadStructMissingOverride < T::Struct
   const :foo, Integer
 # ^^^^^^^^^^^^^^^^^^^ error: Method `BadStructMissingOverride#foo` implements an abstract method `GoodInterface#foo` but is not declared with `override.`
 end
+
+class IncompatibleOverride < T::Struct
+  include GoodInterface
+
+  const :foo, Integer, override: true, allow_incompatible: true
+end


### PR DESCRIPTION
Closes #4094
Closes #4100
Closes #1694

This PR proposes a few changes to type check `attr_accessors` and `props` that implement abstract methods. The implementation consists of doing the following:
1. Sorbet was not trying to check overrides for methods with `isRewriterSynthesized` true. I've removed those checks to let it type check overrides for any method. Please, let me know if this is okay or if there are other consequences I'm unaware about
2. The type signature for props are generated internally by Sorbet, using the arguments passed to `prop`. Therefore, I don't see a way of indicating that a `prop` is an override other than adding another option. This one a bit odd, since the option does nothing in runtime, but allows us to mark the prop as an override and correctly type check

Please, let me know if this is the right direction to fix this issue and if I am missing something. The example below displays the new `override` option (which again does nothing in the runtime).

```ruby
module Interface
  extend T::Sig
  extend T::Helpers

  sig { abstract.void }
  def foo; end
end

class A
  include Interface
  
  sig { returns(Integer) }
  attr_reader :foo # error Integer doesn't match void
end

class B < T::Struct
  include Interface
 
  prop :foo, String, override: true # error String doesn't match void
end
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet should be able to type check overrides implemented in attributes or props.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.