### PR TITLE
Use git clone --single-branch for sorbet.run

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -31,7 +31,7 @@ buildkite-agent artifact download "_out_/**/*" .
 echo "--- releasing sorbet.run"
 
 rm -rf sorbet.run
-git clone --single-branch git@github.com:sorbet/sorbet.run.git
+git clone git@github.com:sorbet/sorbet.run.git --single-branch --branch master
 tar -xvf ./_out_/webasm/sorbet-wasm.tar ./sorbet-wasm.wasm ./sorbet-wasm.js
 mv sorbet-wasm.wasm sorbet.run/docs
 mv sorbet-wasm.js sorbet.run/docs

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -31,7 +31,7 @@ buildkite-agent artifact download "_out_/**/*" .
 echo "--- releasing sorbet.run"
 
 rm -rf sorbet.run
-git clone git@github.com:sorbet/sorbet.run.git
+git clone --single-branch git@github.com:sorbet/sorbet.run.git
 tar -xvf ./_out_/webasm/sorbet-wasm.tar ./sorbet-wasm.wasm ./sorbet-wasm.js
 mv sorbet-wasm.wasm sorbet.run/docs
 mv sorbet-wasm.js sorbet.run/docs


### PR DESCRIPTION
### Motivation
Work around git dying by `SIGKILL` (perhaps OOM?) during the `git clone sorbet.run` step in CI by passing `--single-branch`, so that we only clone `master` (whose history has recently been cleaned up).

### Test plan
Existing CI, and the `SIGKILL` did not seem to pop up during branch builds.