### PR TITLE
Remove super_method call from hidden-definition-finder.rb - Fixes #4199

### DIFF
--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -372,9 +372,6 @@ class Sorbet::Private::HiddenMethodFinder
         next
       end
 
-      super_method = method.super_method
-      # next if super_method && T::AbstractUtils.abstract_method?(method) == T::AbstractUtils.abstract_method?(super_method)
-
       errors = capture_stderr do
         ret << maker.serialize_method(method, is_singleton, with_sig: false)
       end

--- a/gems/sorbet/test/hidden-method-finder/hidden-method-tests.rb
+++ b/gems/sorbet/test/hidden-method-finder/hidden-method-tests.rb
@@ -20,8 +20,8 @@ TEST_CASES = [
 
 class Sorbet::Private::HiddenMethodFinder::Test::Simple < MiniTest::Spec
   TEST_CASES.each do |path|
-
     it "works on the #{path} example" do
+
       Dir.mktmpdir do |dir|
         FileUtils.cp_r(File.join(__dir__, path), dir)
         olddir = __dir__

--- a/gems/sorbet/test/hidden-method-finder/hidden-method-tests.rb
+++ b/gems/sorbet/test/hidden-method-finder/hidden-method-tests.rb
@@ -20,8 +20,8 @@ TEST_CASES = [
 
 class Sorbet::Private::HiddenMethodFinder::Test::Simple < MiniTest::Spec
   TEST_CASES.each do |path|
-    it "works on the #{path} example" do
 
+    it "works on the #{path} example" do
       Dir.mktmpdir do |dir|
         FileUtils.cp_r(File.join(__dir__, path), dir)
         olddir = __dir__
@@ -56,7 +56,7 @@ class Sorbet::Private::HiddenMethodFinder::Test::Simple < MiniTest::Spec
             # we also might expect some substring to definitely /not/ appear in hidden.rbi
             elsif exp["assertion"] == "omits"
               refute_match(exp["substring"], hidden)
-            # we should also fail loudly if someone mistypeed one of the assertions
+            # we should also fail loudly if someone mistyped one of the assertions
             else
               assert(false, "Unknown assertion: #{exp['assertion']}")
             end

--- a/gems/sorbet/test/hidden-method-finder/thorough/expectations.json
+++ b/gems/sorbet/test/hidden-method-finder/thorough/expectations.json
@@ -6,5 +6,11 @@
   },
   {"assertion": "contains",
    "substring": "class C3\n  X = ::T.let(nil, ::T.untyped)"
+  },
+  {"assertion": "contains",
+   "substring": "class C4\n  def m_six()"
+  },
+  {"assertion": "contains",
+   "substring": "class C5\n  def self.m_eight()"
   }
 ]

--- a/gems/sorbet/test/hidden-method-finder/thorough/expectations.json
+++ b/gems/sorbet/test/hidden-method-finder/thorough/expectations.json
@@ -8,9 +8,9 @@
    "substring": "class C3\n  X = ::T.let(nil, ::T.untyped)"
   },
   {"assertion": "contains",
-   "substring": "class C4\n  def m_six()"
+   "substring": "class C4\n  def m_five(); end\n\n  def m_six()"
   },
   {"assertion": "contains",
-   "substring": "class C5\n  def self.m_eight()"
+   "substring": "class C5\n  def self.m_eight(); end\n\n  def self.m_seven()"
   }
 ]

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
@@ -1912,6 +1912,18 @@ class C3
   X = ::T.let(nil, ::T.untyped)
 end
 
+class C4
+  def m_five(); end
+
+  def m_six(); end
+end
+
+class C5
+  def self.m_eight(); end
+
+  def self.m_seven(); end
+end
+
 class Class
   def json_creatable?(); end
 end

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_7_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_7_hidden.rbi.exp
@@ -1910,6 +1910,18 @@ class C3
   X = ::T.let(nil, ::T.untyped)
 end
 
+class C4
+  def m_five(); end
+
+  def m_six(); end
+end
+
+class C5
+  def self.m_eight(); end
+
+  def self.m_seven(); end
+end
+
 class Class
   def json_creatable?(); end
 end

--- a/gems/sorbet/test/hidden-method-finder/thorough/src/thorough.rb
+++ b/gems/sorbet/test/hidden-method-finder/thorough/src/thorough.rb
@@ -13,3 +13,8 @@ end
 
 class C3; end
 C3.const_set('X', 5)
+
+C4 = Class.new do
+  define_method(:m_five) do; end
+  alias_method(:m_six, :m_five)
+end

--- a/gems/sorbet/test/hidden-method-finder/thorough/src/thorough.rb
+++ b/gems/sorbet/test/hidden-method-finder/thorough/src/thorough.rb
@@ -18,3 +18,8 @@ C4 = Class.new do
   define_method(:m_five) do; end
   alias_method(:m_six, :m_five)
 end
+
+C5 = Class.new do
+  define_singleton_method(:m_seven) do; end
+  alias_method(:m_eight, :m_seven)
+end

--- a/gems/sorbet/test/hidden-method-finder/thorough/src/thorough.rb
+++ b/gems/sorbet/test/hidden-method-finder/thorough/src/thorough.rb
@@ -16,10 +16,10 @@ C3.const_set('X', 5)
 
 C4 = Class.new do
   define_method(:m_five) do; end
-  alias_method(:m_six, :m_five)
 end
+C4.alias_method(:m_six, :m_five)
 
 C5 = Class.new do
   define_singleton_method(:m_seven) do; end
-  alias_method(:m_eight, :m_seven)
 end
+C5.singleton_class.alias_method(:m_eight, :m_seven)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Deleting the following lines in https://github.com/sorbet/sorbet/blob/master/gems/sorbet/lib/hidden-definition-finder.rb#L375:

```ruby
super_method = method.super_method
# next if super_method && T::AbstractUtils.abstract_method?(method) == T::AbstractUtils.abstract_method?(super_method)
```

Because they're not being used. Also wrote some tests to ensure aliased methods work correctly in `hidden-definition-finder`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
See https://github.com/sorbet/sorbet/issues/4199 - existing bug in Ruby causes a crash if calling `.super_method` on an aliased method.

Since `.super_method` is defined but not being used, I figured its safe to just get rid of it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
