### PR TITLE
T::Utils.coerce: Push special-case module->T::Types::Base logic behind cache

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -41,11 +41,26 @@ module T::Types
     module Private
       module Pool
         def self.type_for_module(mod)
-          cached = mod.instance_variable_get(:@__as_sorbet_simple_type)
+          cached = mod.instance_variable_get(:@__as_sorbet_type)
           return cached if cached
 
-          type = Simple.new(mod)
-          mod.instance_variable_set(:@__as_sorbet_simple_type, type) unless mod.frozen?
+          type = if mod == ::Array
+            T::Array[T.untyped]
+          elsif mod == ::Set
+            T::Set[T.untyped]
+          elsif mod == ::Hash
+            T::Hash[T.untyped, T.untyped]
+          elsif mod == ::Enumerable
+            T::Enumerable[T.untyped]
+          elsif mod == ::Enumerator
+            T::Enumerator[T.untyped]
+          elsif mod == ::Range
+            T::Range[T.untyped]
+          else
+            Simple.new(mod)
+          end
+
+          mod.instance_variable_set(:@__as_sorbet_type, type) unless mod.frozen?
           type
         end
       end

--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -8,12 +8,12 @@ module T::Types
 
     def initialize(types)
       @types = types.flat_map do |type|
-        type = T::Utils.resolve_alias(type)
+        type = T::Utils.coerce(type)
         if type.is_a?(Union)
           # Simplify nested unions (mostly so `name` returns a nicer value)
           type.types
         else
-          T::Utils.coerce(type)
+          type
         end
       end.uniq
     end

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -8,18 +8,6 @@ module T::Utils
       val.aliased_type
     elsif val.is_a?(T::Types::Base)
       val
-    elsif val == ::Array
-      T::Array[T.untyped]
-    elsif val == ::Set
-      T::Set[T.untyped]
-    elsif val == ::Hash
-      T::Hash[T.untyped, T.untyped]
-    elsif val == ::Enumerable
-      T::Enumerable[T.untyped]
-    elsif val == ::Enumerator
-      T::Enumerator[T.untyped]
-    elsif val == ::Range
-      T::Range[T.untyped]
     elsif val.is_a?(Module)
       T::Types::Simple::Private::Pool.type_for_module(val)
     elsif val.is_a?(::Array)


### PR DESCRIPTION
First commit: When coercing a module to a type, we do a bunch of checks for specific special classes like Array before falling back to the generic `T::Types::Simple.new`. But these are edge cases that don't occur often, plus the same caching mechanism we use for Simple can work here, so we can speed up `T.let` and friends in the common case by pushing these checks into `type_for_module` and caching the result.

Second commit: Lower impact and only loosely related, but since `T::Utils.coerce` already resolves aliases there's no need to invoke `resolve_alias` separately when initializing a `T::Types::Union`.

### Motivation
Before (relevant excerpt):
```
 sorbet-runtime git:(master) ✗ bundle exec rake bench:typecheck
...
T.let(..., Integer): 431.782 ns
T.let(..., T.nilable(Integer)): 1.129 μs
T.let(..., Example): 425.731 ns
T.let(..., T.nilable(Example)): 1.119 μs
```

After:
```
sorbet-runtime git:(djudd/coerce-opts) ✗ bundle exec rake bench:typecheck
...
T.let(..., Integer): 304.652 ns
T.let(..., T.nilable(Integer)): 1.001 μs
T.let(..., Example): 310.781 ns
T.let(..., T.nilable(Example)): 1.028 μs
```

### Test plan
Existing tests