### PR TITLE
Add support for def_delegators (plural)

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -180,6 +180,7 @@ NameDef names[] = {
     {"encryptedProp", "encrypted_prop"},
     {"array"},
     {"defDelegator", "def_delegator"},
+    {"defDelegators", "def_delegators"},
     {"delegate"},
     {"type"},
     {"optional"},

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -8,13 +8,29 @@ using namespace std;
 
 namespace sorbet::rewriter {
 
-vector<ast::ExpressionPtr> DefDelegator::run(core::MutableContext ctx, const ast::Send *send) {
+/// Generate method stub and sig for the delegator method
+void generateStub(vector<ast::ExpressionPtr> &methodStubs, const core::LocOffsets &loc,
+                  const core::NameRef &methodName) {
+    // sig {params(arg0: T.untyped, blk: Proc).returns(T.untyped)}
+    auto sigArgs = ast::MK::SendArgs(ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
+                                     ast::MK::Symbol(loc, core::Names::blkArg()),
+                                     ast::MK::Nilable(loc, ast::MK::Constant(loc, core::Symbols::Proc())));
+
+    methodStubs.push_back(ast::MK::Sig(loc, std::move(sigArgs), ast::MK::Untyped(loc)));
+
+    // def $methodName(*arg0, &blk); end
+    ast::MethodDef::ARGS_store args;
+    args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
+    args.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
+
+    methodStubs.push_back(
+        ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::RaiseUnimplemented(loc)));
+}
+
+/// Handle #def_delegator for a single delegate method
+vector<ast::ExpressionPtr> runDefDelegator(core::MutableContext ctx, const ast::Send *send) {
     vector<ast::ExpressionPtr> methodStubs;
     auto loc = send->loc;
-
-    if (send->fun != core::Names::defDelegator()) {
-        return methodStubs;
-    }
 
     // This method takes 2..3 positional arguments and no keyword args:
     // `def_delegator(accessor, method, ali = method)`
@@ -47,26 +63,61 @@ vector<ast::ExpressionPtr> DefDelegator::run(core::MutableContext ctx, const ast
         methodName = alias->asSymbol(ctx);
     }
 
-    // sig {params(arg0: T.untyped, blk: Proc).returns(T.untyped)}
-    auto sigArgs = ast::MK::SendArgs(ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
-                                     ast::MK::Symbol(loc, core::Names::blkArg()),
-                                     ast::MK::Nilable(loc, ast::MK::Constant(loc, core::Symbols::Proc())));
-
-    methodStubs.push_back(ast::MK::Sig(loc, std::move(sigArgs), ast::MK::Untyped(loc)));
-
-    // def $methodName(*arg0, &blk); end
-    ast::MethodDef::ARGS_store args;
-    args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
-    args.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
-
-    methodStubs.push_back(
-        ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::RaiseUnimplemented(loc)));
+    generateStub(methodStubs, loc, methodName);
 
     // Include the original call to def_delegator so sorbet will still type-check it
     // and throw errors if the class (or its parent) didn't `extend Forwardable`
     methodStubs.push_back(send->deepCopy());
 
     return methodStubs;
+}
+
+/// Handle #def_delegators for zero or more delegate methods
+vector<ast::ExpressionPtr> runDefDelegators(core::MutableContext ctx, const ast::Send *send) {
+    vector<ast::ExpressionPtr> methodStubs;
+    auto loc = send->loc;
+
+    // This method takes 1.. positional arguments and no keyword args:
+    // `def_delegators(accessor, methods*)`
+    if (send->numPosArgs == 0) {
+        return methodStubs;
+    }
+
+    if (send->hasKwArgs()) {
+        return methodStubs;
+    }
+
+    auto *accessor = ast::cast_tree<ast::Literal>(send->args[0]);
+    if (!accessor || !(accessor->isSymbol(ctx) || accessor->isString(ctx))) {
+        return methodStubs;
+    }
+
+    for (auto arg = send->args.begin() + 1, end = send->args.end(); arg != end; ++arg) {
+        auto *method = ast::cast_tree<ast::Literal>(*arg);
+        // Skip method names that we don't understand, but continue to emit
+        // desugared calls for the ones we do.
+        if (!method || !method->isSymbol(ctx)) {
+            continue;
+        }
+
+        generateStub(methodStubs, loc, method->asSymbol(ctx));
+    }
+
+    // Include the original call to def_delegators so sorbet will still type-check it
+    // and throw errors if the class (or its parent) didn't `extend Forwardable`
+    methodStubs.push_back(send->deepCopy());
+
+    return methodStubs;
+}
+
+vector<ast::ExpressionPtr> DefDelegator::run(core::MutableContext ctx, const ast::Send *send) {
+    if (send->fun == core::Names::defDelegator()) {
+        return runDefDelegator(ctx, send);
+    } else if (send->fun == core::Names::defDelegators()) {
+        return runDefDelegators(ctx, send);
+    } else {
+        return vector<ast::ExpressionPtr>();
+    }
 }
 
 } // namespace sorbet::rewriter

--- a/rewriter/DefDelegator.h
+++ b/rewriter/DefDelegator.h
@@ -5,12 +5,13 @@
 namespace sorbet::rewriter {
 
 /**
- * This class implements Forwardable#def_delegator
+ * This class implements Forwardable#def_delegator and Forwardable#def_delegators
  * by desugaring things of the form
  *
  *    class MyClass
  *      def_delegator :thing, :foo
  *      def_delegator :thing, :bar, :aliased_bar
+ *      def_delegators :thing, :baz, :qux
  *    end
  *
  * into
@@ -21,6 +22,12 @@ namespace sorbet::rewriter {
  *
  *      sig {params(arg0: T.untyped, blk: T.nilable(Proc)).returns(T.untyped)}
  *      def aliased_bar(*arg0, &blk); end
+ *
+ *      sig {params(arg0: T.untyped, blk: T.nilable(Proc)).returns(T.untyped)}
+ *      def baz(*arg0, &blk); end
+ *
+ *      sig {params(arg0: T.untyped, blk: T.nilable(Proc)).returns(T.untyped)}
+ *      def qux(*arg0, &blk); end
  *    end
  */
 class DefDelegator final {

--- a/test/testdata/rewriter/def_delegator.rb
+++ b/test/testdata/rewriter/def_delegator.rb
@@ -6,6 +6,8 @@ class GoodUsages
 
   def_delegator :thing, :foo
   def_delegator :thing, :bar, :aliased_bar
+  def_delegators :thing, :baz, :qux
+  def_delegators :thing # Legal, but does nothing
 
   sig {void}
   def usages
@@ -25,6 +27,22 @@ class GoodUsages
     aliased_bar(hey: true)
     aliased_bar(hey: true) {}
 
+    baz {}
+    baz(1, 2)
+    baz(1, 2) {}
+    baz(1, 2, hey: true)
+    baz(1, 2, hey: true) {}
+    baz(hey: true)
+    baz(hey: true) {}
+
+    qux {}
+    qux(1, 2)
+    qux(1, 2) {}
+    qux(1, 2, hey: true)
+    qux(1, 2, hey: true) {}
+    qux(hey: true)
+    qux(hey: true) {}
+
     bar # error: Method `bar` does not exist
   end
 end
@@ -34,11 +52,15 @@ class WorksWithoutExtendingTSig
 
   def_delegator :thing, :foo
   def_delegator :thing, :bar, :aliased_bar
+  def_delegators :thing, :baz, :qux
+  def_delegators :thing
 end
 
 class ErrorsWhenMissingForwardable
   def_delegator :thing, :foo # error: Method `def_delegator` does not exist
   def_delegator :thing, :bar, :aliased_bar # error: Method `def_delegator` does not exist
+  def_delegators :thing, :baz, :qux # error: Method `def_delegators` does not exist
+  def_delegators :thing # error: Method `def_delegators` does not exist
 end
 
 class IgnoredUsages
@@ -62,6 +84,14 @@ class IgnoredUsages
   #             ^^^ error: Expected `T.any(Symbol, String)` but found `Integer(234)` for argument `accessor`
   def_delegator :thing => :foo # error: Not enough arguments provided for method `Forwardable#def_delegator
               # ^^^^^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `{thing: Symbol(:foo)}` for argument `accessor`
+
+
+  def_delegators # error: Not enough arguments provided for method `Forwardable#def_delegators`
+  def_delegators :thing, :foo, :bar, kwarg: :thing # error: Expected `Symbol` but found `{kwarg: Symbol(:thing)}` for argument `methods`
+  def_delegators :foo, kwarg1: :thing, kwarg2: local # error: Expected `Symbol` but found `{kwarg1: Symbol(:thing), kwarg2: Integer(0)}` for argument `methods`
+  def_delegators :foo, local => :thing # error: Expected `Symbol` but found `{Integer(0) => Symbol(:thing)}` for argument `methods`
+  def_delegators 234, :foo # error: Expected `T.any(Symbol, String)` but found `Integer(234)` for argument `accessor`
+  def_delegators :thing => :foo # error: Expected `T.any(Symbol, String)` but found `{thing: Symbol(:foo)}` for argument `accessor`
 end
 
 class EnumerableUsage

--- a/test/testdata/rewriter/def_delegator.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/def_delegator.rb.rewrite-tree.exp
@@ -16,6 +16,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def baz<<todo method>>(*arg0, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def qux<<todo method>>(*arg0, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.void()
     end
@@ -52,6 +68,36 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.aliased_bar(:hey, true) do ||
           <emptyTree>
         end
+        <self>.baz() do ||
+          <emptyTree>
+        end
+        <self>.baz(1, 2)
+        <self>.baz(1, 2) do ||
+          <emptyTree>
+        end
+        <self>.baz(1, 2, :hey, true)
+        <self>.baz(1, 2, :hey, true) do ||
+          <emptyTree>
+        end
+        <self>.baz(:hey, true)
+        <self>.baz(:hey, true) do ||
+          <emptyTree>
+        end
+        <self>.qux() do ||
+          <emptyTree>
+        end
+        <self>.qux(1, 2)
+        <self>.qux(1, 2) do ||
+          <emptyTree>
+        end
+        <self>.qux(1, 2, :hey, true)
+        <self>.qux(1, 2, :hey, true) do ||
+          <emptyTree>
+        end
+        <self>.qux(:hey, true)
+        <self>.qux(:hey, true) do ||
+          <emptyTree>
+        end
         <self>.bar()
       end
     end
@@ -67,6 +113,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::Sorbet::Private::Static.keep_def(<self>, :aliased_bar, :normal)
 
     <self>.def_delegator(:thing, :bar, :aliased_bar)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :baz, :normal)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :qux, :normal)
+
+    <self>.def_delegators(:thing, :baz, :qux)
+
+    <self>.def_delegators(:thing)
 
     ::Sorbet::Private::Static.keep_def(<self>, :usages, :normal)
   end
@@ -88,6 +142,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def baz<<todo method>>(*arg0, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def qux<<todo method>>(*arg0, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
     <self>.extend(<emptyTree>::<C Forwardable>)
 
     ::Sorbet::Private::Static.keep_def(<self>, :foo, :normal)
@@ -97,6 +167,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::Sorbet::Private::Static.keep_def(<self>, :aliased_bar, :normal)
 
     <self>.def_delegator(:thing, :bar, :aliased_bar)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :baz, :normal)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :qux, :normal)
+
+    <self>.def_delegators(:thing, :baz, :qux)
+
+    <self>.def_delegators(:thing)
   end
 
   class <emptyTree>::<C ErrorsWhenMissingForwardable><<C <todo sym>>> < (::<todo sym>)
@@ -116,6 +194,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def baz<<todo method>>(*arg0, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def qux<<todo method>>(*arg0, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
     ::Sorbet::Private::Static.keep_def(<self>, :foo, :normal)
 
     <self>.def_delegator(:thing, :foo)
@@ -123,6 +217,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::Sorbet::Private::Static.keep_def(<self>, :aliased_bar, :normal)
 
     <self>.def_delegator(:thing, :bar, :aliased_bar)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :baz, :normal)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :qux, :normal)
+
+    <self>.def_delegators(:thing, :baz, :qux)
+
+    <self>.def_delegators(:thing)
   end
 
   class <emptyTree>::<C IgnoredUsages><<C <todo sym>>> < (::<todo sym>)
@@ -149,6 +251,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.def_delegator(234, :foo)
 
     <self>.def_delegator(:thing, :foo)
+
+    <self>.def_delegators()
+
+    <self>.def_delegators(:thing, :foo, :bar, :kwarg, :thing)
+
+    <self>.def_delegators(:foo, :kwarg1, :thing, :kwarg2, local)
+
+    <self>.def_delegators(:foo, {local => :thing})
+
+    <self>.def_delegators(234, :foo)
+
+    <self>.def_delegators(:thing, :foo)
   end
 
   class <emptyTree>::<C EnumerableUsage><<C <todo sym>>> < (::<todo sym>)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR builds on top of the constructs added in https://github.com/sorbet/sorbet/pull/3636 for handling `#def_delegator` by modifying the rewriter to also support [`#def_delegators`](https://ruby-doc.org/stdlib-2.5.1/libdoc/forwardable/rdoc/Forwardable.html#method-i-def_delegators), which is a variadic version of `#def_delegator`. My solution was to emit a synthetic delegator method for each of the methods passed to `#def_delegators`.

I split up the `DefDelegator::run()` into a few separate functions so that I could reuse the pieces that should be the same between `#def_delegator` and `#def_delegators`, but without trying to be overly DRY, since there are a few differences between the two. The biggest difference is that `#def_delegators` does not support the optional third argument of `#def_delegator`, which specifies an alias name for the delegator method. Another difference it is legal to call `#def_delegators` without specifying _any_ method names (e.g. `def_delegators :@foo`), and it just results in a no-op.

Because of these differences, I just had separate functions for the "argument parsing" of the two different methods, and I only shared the code for generating method stubs.

I'm not that experienced with C++, so apologies in advance if my code is not idiomatic, but I definitely welcome feedback on how to write this better. I especially don't really have a good feel for how ownership, references, and copies should should be done here.

Also, I apologize for not exactly following the instructions in CONTRIBUTING.md. If you want me to file a GitHub issue to discuss this more first, I can do that retroactively.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Sorbet already had an existing AST rewriter for `#def_delegator`, but not [`#def_delegators`](https://ruby-doc.org/stdlib-2.5.1/libdoc/forwardable/rdoc/Forwardable.html#method-i-def_delegators) (plural), which is a similar method in Ruby's `Forwardable` module.  `#def_delegators` is the same as `#def_delegator` except it takes a variable number of positional parameters, each specifying a different method symbol to delegate to another object. Since Sorbet already has basic support for `#def_delegator`, it would be convenient for it to support `#def_delegators` in a similar way.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I updated the tests that were first added in https://github.com/sorbet/sorbet/pull/3636 to include new test cases for `def_delegators`. I more or less applied the same test scenarios to `#def_delegators`.