### PR TITLE
Fix Resolv::DNS#timeouts= signature

### DIFF
--- a/rbi/stdlib/resolv.rbi
+++ b/rbi/stdlib/resolv.rbi
@@ -339,7 +339,7 @@ class Resolv::DNS
   # ```ruby
   # dns.timeouts = 3
   # ```
-  sig { params(values: T.any(NilClass, Integer, T::Array[Integer])).void }
+  sig { params(values: T.any(NilClass, Numeric, T::Array[Numeric])).void }
   def timeouts=(values); end
 
   # Creates a new [`DNS`](https://docs.ruby-lang.org/en/2.7.0/Resolv/DNS.html)


### PR DESCRIPTION
### Motivation

`Resolv::DNS#timeouts=` also accepts floats:

```
$ irb
irb(main):001:0> require "resolv"
=> true
irb(main):002:0> dns = Resolv::DNS.new
=> #<Resolv::DNS:0x00007fa3d704bb68 @mutex=#<Thread::Mutex:0x00007fa3d704bb40>, @config=#<Resolv::DNS::Config:0x00007fa3d704bb18 @mutex=#<Thread::Mutex:0x00007fa3d704baf0>, @config_info=nil, @initialized=nil, @timeouts=nil>, @initialized=nil>
irb(main):003:0> dns.timeouts = 0.1
=> 0.1
irb(main):004:0> dns.timeouts = 1
=> 1
```

### Test plan

See included automated tests.
