### PR TITLE
Allow abstract modules to require ONE unrelated ancestor class

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -544,7 +544,7 @@ void validateUnsatisfiableRequiredAncestors(core::Context ctx, const core::Class
         }
     }
 
-    if (data->isClassOrModuleAbstract()) {
+    if (data->isClassOrModuleClass() && data->isClassOrModuleAbstract()) {
         for (auto ancst : requiredClasses) {
             if (!sym.data(ctx)->derivesFrom(ctx, ancst.symbol) && !ancst.symbol.data(ctx)->derivesFrom(ctx, sym)) {
                 if (auto e = ctx.state.beginError(data->loc(), core::errors::Resolver::UnsatisfiableRequiredAncestor)) {

--- a/test/testdata/resolver/requires_ancestor_unrelated_classes.rb
+++ b/test/testdata/resolver/requires_ancestor_unrelated_classes.rb
@@ -102,3 +102,27 @@ module Test5
     include M2
   end
 end
+
+### Abstract module requires unrelated classes
+
+module Test6
+  module M1
+    extend T::Helpers
+    abstract!
+    requires_ancestor R2
+  end
+
+  module M2
+# ^^^^^^^^^ error: `Test6::M2` requires unrelated classes `R2` and `R3` making it impossible to include
+    extend T::Helpers
+    abstract!
+    requires_ancestor R2, R3
+  end
+
+  module M3
+# ^^^^^^^^^ error: `Test6::M3` requires unrelated classes `R2` and `R3` making it impossible to include
+    include M2
+    extend T::Helpers
+    abstract!
+  end
+end

--- a/test/testdata/resolver/requires_ancestor_unrelated_classes.rb
+++ b/test/testdata/resolver/requires_ancestor_unrelated_classes.rb
@@ -126,3 +126,27 @@ module Test6
     abstract!
   end
 end
+
+### Interface module requires unrelated classes
+
+module Test7
+  module M1
+    extend T::Helpers
+    interface!
+    requires_ancestor R2
+  end
+
+  module M2
+# ^^^^^^^^^ error: `Test7::M2` requires unrelated classes `R2` and `R3` making it impossible to include
+    extend T::Helpers
+    interface!
+    requires_ancestor R2, R3
+  end
+
+  module M3
+# ^^^^^^^^^ error: `Test7::M3` requires unrelated classes `R2` and `R3` making it impossible to include
+    include M2
+    extend T::Helpers
+    interface!
+  end
+end


### PR DESCRIPTION
### Motivation

The validator for `requires_ancestor` was considering abstract modules like abstract class thus this was rejected while valid:

```rb
class R; end

module M # error: M` requires unrelated class `R` making it impossible to include
  extend T::Helpers
  abstract!
  requires_ancestor R
end
```

This PR makes this example pass correctly.

### Test plan

See included automated tests.
