### PR TITLE
add T::Configuration.can_enable_vm_prop_serde?

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -73,6 +73,13 @@ module T::Configuration
     @include_value_in_type_errors = true
   end
 
+  # Whether VM-defined prop serialization/deserialization routines can be enabled.
+  #
+  # @return [T::Boolean]
+  def self.can_enable_vm_prop_serde?
+    T::Props::Private::DeserializerGenerator.respond_to?(:generate2)
+  end
+
   # Whether to use VM-defined prop serialization/deserialization routines.
   #
   # The default is to use runtime codegen inside sorbet-runtime itself.
@@ -86,6 +93,9 @@ module T::Configuration
   #
   # This method is likely to break things outside of Stripe's systems.
   def self.enable_vm_prop_serde
+    if !can_enable_vm_prop_serde?
+      hard_assert_handler('Ruby VM is not setup to use VM-defined prop serde')
+    end
     @use_vm_prop_serde = true
   end
 

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -327,6 +327,28 @@ module Opus::Types::Test
           assert_equal('T.let: Expected type Integer, got type String', e.message.split("\n").first)
         end
       end
+
+      describe 'enable_vm_prop_serde' do
+        it "fails if the VM doesn't support it" do
+          return if T::Configuration.can_enable_vm_prop_serde?
+
+          assert_raises(RuntimeError) do
+            T::Configuration.enable_vm_prop_serde
+          end
+        end
+
+        it "succeeds if the VM does support it" do
+          return unless T::Configuration.can_enable_vm_prop_serde?
+
+          was_enabled = T::Configuration.use_vm_prop_serde?
+
+          begin
+            T::Configuration.enable_vm_prop_serde
+          ensure
+            T::Configuration.disable_vm_prop_serde unless was_enabled
+          end
+        end
+      end
     end
   end
 end

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -328,31 +328,5 @@ module Opus::Types::Test
         end
       end
     end
-
-    describe 'vm_prop_serde' do
-      it 'raises errors if no runtime support exists' do
-        # This test is checking that we get errors from serialization/deserialization
-        # when the VM we're running on doesn't support VM-backed serialization/deserialization
-        # routines, so bail if the VM does support such routines.
-        return unless T::Configuration.can_enable_vm_prop_serde?
-
-        was_enabled = T::Configuration.use_vm_prop_serde?
-
-        begin
-          T::Configuration.enable_vm_prop_serde
-          c = Class.new(T::Struct) do
-            prop :p, Integer
-          end
-
-          i = c.new(p: 5)
-          e = assert_raises(NoMethodError) do
-            s = i.serialize
-          end
-          assert_equal(:generate2, e.name)
-        ensure
-          T::Configuration.disable_vm_prop_serde unless was_enabled
-        end
-      end
-    end
   end
 end

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -334,7 +334,7 @@ module Opus::Types::Test
         # This test is checking that we get errors from serialization/deserialization
         # when the VM we're running on doesn't support VM-backed serialization/deserialization
         # routines, so bail if the VM does support such routines.
-        return if T::Props::Private::DeserializerGenerator.singleton_class.method_defined?(:generate2)
+        return unless T::Configuration.can_enable_vm_prop_serde?
 
         was_enabled = T::Configuration.use_vm_prop_serde?
 

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -145,6 +145,7 @@ module T::Configuration
   def self.exclude_value_in_type_errors; end
   sig {void}
   def self.include_value_in_type_errors; end
+  def self.can_enable_vm_prop_serde?; end
   def self.use_vm_prop_serde?; end
   def self.enable_vm_prop_serde; end
   def self.disable_vm_prop_serde; end


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It turns out there was one wrinkle in #4171: to know whether you could safely call `T::Configuration.enable_vm_prop_serde`, you had to dive into internal implementation details of `sorbet-runtime`, which is not a good thing.  Instead of that, we should provide a method on `T::Configuration` that hides the implementation details.

The test for ensuring that VM-based serialization/deserialization has been removed, given the hard assertion in `enable_vm_prop_serde`; happy to have a discussion about whether we should remove the assert and/or find some way to work around the assert.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
