### PR TITLE
Fix sig for WEBrick::HTTPAuth::Htpasswd#initialize

### DIFF
--- a/rbi/stdlib/webrick.rbi
+++ b/rbi/stdlib/webrick.rbi
@@ -1358,10 +1358,11 @@ class WEBrick::HTTPAuth::Htpasswd
   sig do
     params(
       path: T.untyped,
+      password_hash: T.untyped,
     )
     .returns(T.untyped)
   end
-  def initialize(path); end
+  def initialize(path, password_hash: T.unsafe(nil)); end
 
   # Reload passwords from the database
   sig {returns(T.untyped)}


### PR DESCRIPTION
### Motivation

This method takes an optional keyword argument called `password_hash` so adding that in. [See source](https://github.com/ruby/webrick/blob/master/lib/webrick/httpauth/htpasswd.rb#L38).

```
irb(main):001:0> require 'webrick'
=> true

irb(main):002:0> WEBrick::HTTPAuth::Htpasswd.new(File.join(Dir.pwd, 'temp'), password_hash: :bcrypt)
=> #<WEBrick::HTTPAuth::Htpasswd:0x00007fb240873c88 @path="/Users/ryanbrushett/src/github.com/ryanbrushett/sorbet/temp", @mtime=2021-05-14 10:34:28.022710933 -0400, @passwd={}, @auth_type=WEBrick::HTTPAuth::BasicAuth, @password_hash=:bcrypt>

irb(main):003:0> WEBrick::HTTPAuth::Htpasswd.new(File.join(Dir.pwd, 'temp'), password_hash: nil)
=> #<WEBrick::HTTPAuth::Htpasswd:0x00007fb2409894d8 @path="/Users/ryanbrushett/src/github.com/ryanbrushett/sorbet/temp", @mtime=2021-05-14 10:34:28.022710933 -0400, @passwd={}, @auth_type=WEBrick::HTTPAuth::BasicAuth, @password_hash=:crypt>

irb(main):004:0> WEBrick::HTTPAuth::Htpasswd.new(File.join(Dir.pwd, 'temp'))
=> #<WEBrick::HTTPAuth::Htpasswd:0x00007fb24092a280 @path="/Users/ryanbrushett/src/github.com/ryanbrushett/sorbet/temp", @mtime=2021-05-14 10:34:28.022710933 -0400, @passwd={}, @auth_type=WEBrick::HTTPAuth::BasicAuth, @password_hash=:crypt>
```