### PR TITLE
Fix Pathname#find signature

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -809,17 +809,11 @@ class Pathname < Object
   sig do
     params(
         ignore_error: T::Boolean,
-        blk: T.proc.params(arg0: Pathname).returns(BasicObject),
+        blk: T.nilable(T.proc.params(arg0: Pathname).void),
     )
-    .returns(T.untyped)
+    .returns(T.nilable(T::Enumerator[Pathname]))
   end
-  sig do
-    params(
-        ignore_error: T::Boolean,
-    )
-    .returns(T::Enumerator[Pathname])
-  end
-  def find(ignore_error, &blk); end
+  def find(ignore_error: true, &blk); end
 
   # Return `true` if the receiver matches the given pattern.
   #


### PR DESCRIPTION
### Motivation
`ignore_error` is an optional keyword argument, as documented at https://ruby-doc.org/stdlib-2.6.3/libdoc/pathname/rdoc/Pathname.html#method-i-find.
