### PR TITLE
Fix a segfault in the Magic_mergeHashValues intrinsic

### DIFF
--- a/test/testdata/infer/kwargs_splat.rb
+++ b/test/testdata/infer/kwargs_splat.rb
@@ -36,3 +36,7 @@ untyped_values_hash = T.let(shaped_hash, T::Hash[Symbol, T.untyped])
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Passing a hash where the specific keys are unknown to a method taking keyword arguments
   g(3, **untyped_values_hash, w: 2.0)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Passing a hash where the specific keys are unknown to a method taking keyword arguments
+
+# Ensure that constructing a kwargs hash with untyped keys works
+untyped = T.unsafe(:y)
+f(3, **untyped_hash, untyped => 20)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
When hash construction was reworked in #4185, the `Magic_mergeHashValues` call intrinsic would unconditionally make a `ShapeType` from its args, ignoring the possibility that they might not all be `LiteralType` instances. The solution is to check that each key is a literal type and construct a `T::Hash[T.untyped, T.untyped]` if they are not (we already do something similar when processing keyword args in `dispatchCallSymbol`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #4217 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
