### PR TITLE
Add the missing Enumerable#chain method and signature

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_6_hidden.rbi.exp
@@ -2027,8 +2027,6 @@ class Encoding
 end
 
 module Enumerable
-  def chain(*_); end
-
   def sum(*_); end
 end
 

--- a/gems/sorbet/test/hidden-method-finder/simple/ruby_2_7_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/ruby_2_7_hidden.rbi.exp
@@ -2067,8 +2067,6 @@ class Encoding
 end
 
 module Enumerable
-  def chain(*_); end
-
   def sum(*_); end
 end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_6_hidden.rbi.exp
@@ -2051,8 +2051,6 @@ class Encoding
 end
 
 module Enumerable
-  def chain(*_); end
-
   def sum(*_); end
 end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_7_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/ruby_2_7_hidden.rbi.exp
@@ -2091,8 +2091,6 @@ class Encoding
 end
 
 module Enumerable
-  def chain(*_); end
-
   def sum(*_); end
 end
 

--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -82,6 +82,12 @@ module Enumerable
   sig { params(pattern: T.untyped).returns(T::Boolean) }
   def any?(pattern = nil, &blk); end
 
+  sig do
+    type_parameters(:U).params(enums: T::Enumerable[T.type_parameter(:U)])
+    .returns(T::Enumerator[T.any(Elem, T.type_parameter(:U))])
+  end
+  def chain(*enums); end
+
   # Enumerates over the items, chunking them together based on the return value
   # of the block.
   #


### PR DESCRIPTION
[Enumerable#chain](https://ruby-doc.org/core-2.6/Enumerable.html#method-i-chain) introduced in ruby 2.6 wasn't defined.