### PR TITLE
Add `range` argument support to `Comparable#clamp`

### DIFF
--- a/rbi/core/comparable.rbi
+++ b/rbi/core/comparable.rbi
@@ -113,6 +113,7 @@ module Comparable
   # ```ruby
   # 100.clamp(0...100)       # ArgumentError
   # ```
-  sig { params(min: T.untyped, max: T.untyped).returns(T.untyped) }
-  def clamp(min, max); end
+  sig { params(s: T::Range[T.untyped]).returns(T.untyped) }
+  sig { params(s: T.untyped, e: T.untyped).returns(T.untyped) }
+  def clamp(s, e); end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
As of Ruby 2.7, `Comparable#clamp` can accept a `range` [ruby-lang:issue#14784](https://bugs.ruby-lang.org/issues/14784). This adds support for `Comparable#clamp` which accepts a `range` as input.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
A part of https://github.com/sorbet/sorbet/issues/2390

Prior to this change:

```ruby
100.clamp(0..1)
# editor.rb:4: Not enough arguments provided for method Comparable#clamp on Integer component of Integer(123). Expected: 2, got: 1 https://srb.help/7004
#  4 |100.clamp(0..1)
#     ^^^^^^^^^^^^^^^
#    https://github.com/sorbet/sorbet/tree/master/rbi/core/comparable.rbi#L117: Comparable#clamp defined here
#     117 |  def clamp(min, max); end
#            ^^^^^^^^^^^^^^^^^^^
# Errors: 1
```

After this change:

```ruby
100.clamp(0..1)
# No errors! Great job.
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
