### PR TITLE
`FixedHash` serialization should not assume symbol keys

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
@@ -13,7 +13,15 @@ module T::Types
 
     # @override Base
     def name
-      "{#{@types.map {|(k, v)| "#{k}: #{v}"}.join(', ')}}"
+      entries = @types.map do |(k, v)|
+        if Symbol === k && ":#{k}" == k.inspect
+          "#{k}: #{v}"
+        else
+          "#{k.inspect} => #{v}"
+        end
+      end
+
+      "{#{entries.join(', ')}}"
     end
 
     # @override Base

--- a/gems/sorbet-runtime/test/types/types_to_ruby.rb
+++ b/gems/sorbet-runtime/test/types/types_to_ruby.rb
@@ -29,6 +29,9 @@ class Opus::Types::Test::TypesToRubyTest < Critic::Unit::UnitTest
 
     # FixedHash:
     [{a: T.nilable(String)}, "{a: T.nilable(String)}"],
+    [{"a" => T.nilable(String)}, "{\"a\" => T.nilable(String)}"],
+    [{"a" => String, b: T.any(Integer, Float)}, "{\"a\" => String, b: T.any(Float, Integer)}"],
+    [{"foo bar" => String, :"foo bar" => T.any(Integer, Float)}, "{\"foo bar\" => String, :\"foo bar\" => T.any(Float, Integer)}"],
 
     # TypedHash:
     [T::Hash[T.any(String, Symbol), String], "T::Hash[T.any(String, Symbol), String]"],


### PR DESCRIPTION
Runtime output should make the distinction that static checker does: https://sorbet.run/#%23%20typed%3A%20true%0AT.reveal_type(%7Ba%3A%20String%2C%20b%3A%20Integer%7D)%0AT.reveal_type(%7B%22a%22%20%3D%3E%20String%2C%20%22b%22%20%3D%3E%20Integer%7D)
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
`FixedHash` current serializes itself assuming that the keys are symbols but it can also be the case that keys are strings. Thus, it is more correct to use the `{ a => b }` syntax when serializing fixed hashes entries with non-symbol keys, along with calling `inspect` on those keys instead of an implicit `to_s`.

Entries with symbol keys are serialized using the `{a: b}` syntax stil.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
