### PR TITLE
Pass flags when building bison to silence warnings

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,7 +37,9 @@ m4_register_toolchains()
 
 load("@rules_bison//bison:bison.bzl", "bison_register_toolchains")
 
-bison_register_toolchains()
+bison_register_toolchains(
+    extra_copts = ["-Wno-implicit-const-int-float-conversion"]
+)
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,7 +38,9 @@ m4_register_toolchains()
 load("@rules_bison//bison:bison.bzl", "bison_register_toolchains")
 
 bison_register_toolchains(
-    extra_copts = ["-Wno-implicit-const-int-float-conversion"]
+    # Clang 12+ introduced this flag. All versions of Bison at time of writing
+    # (up to 3.7.6) include code flagged by this warning.
+    extra_copts = ["-Wno-implicit-const-int-float-conversion"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -252,9 +252,9 @@ package(default_visibility = ["//visibility:public"])
 
     http_archive(
         name = "rules_bison",
-        urls = _github_public_urls("jez/rules_bison/archive/fece3b14754228c7623537a972a778f7d5443b4f.zip"),
-        sha256 = "03039da0cd8a3b512fa57a8b4c1b0b8ca7732867975e292db61de01a32a4c0bc",
-        strip_prefix = "rules_bison-fece3b14754228c7623537a972a778f7d5443b4f",
+        urls = _github_public_urls("jez/rules_bison/archive/478079b28605a38000eaf83719568d756b3383a0.zip"),
+        sha256 = "d662d200f4e2a868f6873d666402fa4d413f07ba1a433591c5f60ac601157fb9",
+        strip_prefix = "rules_bison-478079b28605a38000eaf83719568d756b3383a0",
     )
 
     http_archive(

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -252,8 +252,9 @@ package(default_visibility = ["//visibility:public"])
 
     http_archive(
         name = "rules_bison",
-        urls = _github_public_urls("jmillikin/rules_bison/releases/download/v0.2/rules_bison-v0.2.tar.xz"),
-        sha256 = "6ee9b396f450ca9753c3283944f9a6015b61227f8386893fb59d593455141481",
+        urls = _github_public_urls("jez/rules_bison/archive/fece3b14754228c7623537a972a778f7d5443b4f.zip"),
+        sha256 = "03039da0cd8a3b512fa57a8b4c1b0b8ca7732867975e292db61de01a32a4c0bc",
+        strip_prefix = "rules_bison-fece3b14754228c7623537a972a778f7d5443b4f",
     )
 
     http_archive(

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -252,7 +252,7 @@ package(default_visibility = ["//visibility:public"])
 
     http_archive(
         name = "rules_bison",
-        urls = _github_public_urls("jez/rules_bison/archive/478079b28605a38000eaf83719568d756b3383a0.zip"),
+        urls = _github_public_urls("jmillikin/rules_bison/archive/478079b28605a38000eaf83719568d756b3383a0.zip"),
         sha256 = "d662d200f4e2a868f6873d666402fa4d413f07ba1a433591c5f60ac601157fb9",
         strip_prefix = "rules_bison-478079b28605a38000eaf83719568d756b3383a0",
     )


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The recent Clang 12 upgrade (#4189) introduces some warnings when building
bison.

This silences them.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Built locally. We can also check that the warnings are gone in CI.