### PR TITLE
Add Boolean -> T::Boolean autocorrect

### DIFF
--- a/core/TypeDrivenAutocorrect.cc
+++ b/core/TypeDrivenAutocorrect.cc
@@ -18,6 +18,15 @@ void TypeDrivenAutocorrect::maybeAutocorrect(const GlobalState &gs, ErrorBuilder
         if (!withoutNil.isBottom() &&
             Types::isSubTypeUnderConstraint(gs, constr, withoutNil, expectedType, UntypedMode::AlwaysCompatible)) {
             e.replaceWith("Wrap in `T.must`", loc, "T.must({})", loc.source(gs).value());
+        } else if (Types::isSubTypeUnderConstraint(gs, constr, expectedType, Types::Boolean(),
+                                                   UntypedMode::AlwaysCompatible)) {
+            if (core::isa_type<ClassType>(actualType)) {
+                auto classSymbol = core::cast_type_nonnull<ClassType>(actualType).symbol;
+                if (classSymbol.exists() && classSymbol.data(gs)->owner == core::Symbols::root() &&
+                    classSymbol.data(gs)->name == core::Names::Constants::Boolean()) {
+                    e.replaceWith("Prepend `!!`", loc, "!!({})", loc.source(gs).value());
+                }
+            }
         }
     }
 }

--- a/test/testdata/infer/boolean_t_boolean.rb
+++ b/test/testdata/infer/boolean_t_boolean.rb
@@ -1,0 +1,34 @@
+# typed: true
+
+extend T::Sig
+
+module ::Boolean
+end
+
+class TrueClass
+  include Boolean
+end
+
+class FalseClass
+  include Boolean
+end
+
+sig {params(arg0: T.untyped).returns(Boolean)}
+def returns_boolean(arg0)
+  false
+end
+
+sig {params(x: Boolean).returns(T::Boolean)}
+def boolean_to_t_boolean(x)
+  x # error: Expected `T::Boolean` but found `Boolean`
+end
+
+sig {params(x: Boolean).returns(T::Boolean)}
+def explicit_return(x)
+  return x # error: Expected `T::Boolean` but found `Boolean`
+end
+
+sig {returns(T::Boolean)}
+def can_have_spaces
+  returns_boolean T.unsafe(nil) # error: Expected `T::Boolean` but found `Boolean`
+end

--- a/test/testdata/infer/boolean_t_boolean.rb
+++ b/test/testdata/infer/boolean_t_boolean.rb
@@ -44,5 +44,5 @@ end
 
 sig {params(x: BadBang).returns(T::Boolean)}
 def should_not_suggest_bang_bang(x)
-  x # error: Expected `T::Boolean` but found `Boolean`
+  x # error: Expected `T::Boolean` but found `BadBang`
 end

--- a/test/testdata/infer/boolean_t_boolean.rb
+++ b/test/testdata/infer/boolean_t_boolean.rb
@@ -13,6 +13,15 @@ class FalseClass
   include Boolean
 end
 
+class BadBang
+  extend T::Sig
+
+  sig {returns(String)}
+  def !()
+    'bad bang override'
+  end
+end
+
 sig {params(arg0: T.untyped).returns(Boolean)}
 def returns_boolean(arg0)
   false
@@ -31,4 +40,9 @@ end
 sig {returns(T::Boolean)}
 def can_have_spaces
   returns_boolean T.unsafe(nil) # error: Expected `T::Boolean` but found `Boolean`
+end
+
+sig {params(x: BadBang).returns(T::Boolean)}
+def should_not_suggest_bang_bang(x)
+  x # error: Expected `T::Boolean` but found `Boolean`
 end

--- a/test/testdata/infer/boolean_t_boolean.rb.autocorrects.exp
+++ b/test/testdata/infer/boolean_t_boolean.rb.autocorrects.exp
@@ -1,0 +1,36 @@
+# -- test/testdata/infer/boolean_t_boolean.rb --
+# typed: true
+
+extend T::Sig
+
+module ::Boolean
+end
+
+class TrueClass
+  include Boolean
+end
+
+class FalseClass
+  include Boolean
+end
+
+sig {params(arg0: T.untyped).returns(Boolean)}
+def returns_boolean(arg0)
+  false
+end
+
+sig {params(x: Boolean).returns(T::Boolean)}
+def boolean_to_t_boolean(x)
+  !!(x) # error: Expected `T::Boolean` but found `Boolean`
+end
+
+sig {params(x: Boolean).returns(T::Boolean)}
+def explicit_return(x)
+  return !!(x) # error: Expected `T::Boolean` but found `Boolean`
+end
+
+sig {returns(T::Boolean)}
+def can_have_spaces
+  !!(returns_boolean T.unsafe(nil)) # error: Expected `T::Boolean` but found `Boolean`
+end
+# ------------------------------

--- a/test/testdata/infer/boolean_t_boolean.rb.autocorrects.exp
+++ b/test/testdata/infer/boolean_t_boolean.rb.autocorrects.exp
@@ -45,6 +45,6 @@ end
 
 sig {params(x: BadBang).returns(T::Boolean)}
 def should_not_suggest_bang_bang(x)
-  x # error: Expected `T::Boolean` but found `Boolean`
+  x # error: Expected `T::Boolean` but found `BadBang`
 end
 # ------------------------------

--- a/test/testdata/infer/boolean_t_boolean.rb.autocorrects.exp
+++ b/test/testdata/infer/boolean_t_boolean.rb.autocorrects.exp
@@ -14,6 +14,15 @@ class FalseClass
   include Boolean
 end
 
+class BadBang
+  extend T::Sig
+
+  sig {returns(String)}
+  def !()
+    'bad bang override'
+  end
+end
+
 sig {params(arg0: T.untyped).returns(Boolean)}
 def returns_boolean(arg0)
   false
@@ -32,5 +41,10 @@ end
 sig {returns(T::Boolean)}
 def can_have_spaces
   !!(returns_boolean T.unsafe(nil)) # error: Expected `T::Boolean` but found `Boolean`
+end
+
+sig {params(x: BadBang).returns(T::Boolean)}
+def should_not_suggest_bang_bang(x)
+  x # error: Expected `T::Boolean` but found `Boolean`
 end
 # ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Stripe's codebase has something that looks like this.

```ruby
# typed: true

extend T::Sig

module ::Boolean
end

class TrueClass
  include Boolean
end

class FalseClass
  include Boolean
end

sig {params(x: Boolean).returns(T::Boolean)}
def boolean_to_t_boolean(x)
  x
end
```

It's a dumb legacy thing that we'd love to get rid of, but it causes no end of
questions when people see it for the first time. It also shows up from time to
time when fixing previously-silent errors (like those in #4134).

The fix is just to prepend `!!`, which converts `Boolean` to `T::Boolean`, which
we can write a quick autocorrect for.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Need to write tests.