### PR TITLE
Draw CFG basic blocks with rectangles

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -208,24 +208,24 @@ string CFG::toString(const core::GlobalState &gs) const {
     fmt::format_to(buf,
                    "subgraph \"cluster_{}\" {{\n"
                    "    label = \"{}\";\n"
-                   "    color = blue;\n"
-                   "    \"bb{}_0\" [shape = invhouse];\n"
-                   "    \"bb{}_1\" [shape = parallelogram];\n\n",
+                   "    color = blue;\n\n",
                    symbolName, symbolName, symbolName, symbolName);
     for (auto &basicBlock : this->basicBlocks) {
         auto text = basicBlock->toString(gs, *this);
         auto lines = absl::StrSplit(text, "\n");
 
+        auto shape = basicBlock->id == 0 ? "invhouse" : basicBlock->id == 1 ? "parallelogram" : "rectangle";
         // whole block red if whole block is dead
         auto color = basicBlock->firstDeadInstructionIdx == 0 ? "red" : "black";
         fmt::format_to(
             buf,
             "    \"bb{}_{}\" [\n"
+            "        shape = {};\n"
             "        color = {};\n"
             "        label = \"{}\\l\"\n"
             "    ];\n\n"
             "    \"bb{}_{}\" -> \"bb{}_{}\" [style=\"bold\"];\n",
-            symbolName, basicBlock->id, color,
+            symbolName, basicBlock->id, shape, color,
             fmt::map_join(lines.begin(), lines.end(), "\\l", [](auto line) -> string { return absl::CEscape(line); }),
             symbolName, basicBlock->id, symbolName, basicBlock->bexit.thenb->id);
 
@@ -269,24 +269,24 @@ string CFG::showRaw(core::Context ctx) const {
     fmt::format_to(buf,
                    "subgraph \"cluster_{}\" {{\n"
                    "    label = \"{}\";\n"
-                   "    color = blue;\n"
-                   "    \"bb{}_0\" [shape = box];\n"
-                   "    \"bb{}_1\" [shape = parallelogram];\n\n",
+                   "    color = blue;\n\n",
                    symbolName, symbolName, symbolName, symbolName);
     for (auto &basicBlock : this->basicBlocks) {
         auto text = basicBlock->showRaw(ctx, *this);
         auto lines = absl::StrSplit(text, "\n");
 
+        auto shape = basicBlock->id == 0 ? "invhouse" : basicBlock->id == 1 ? "parallelogram" : "rectangle";
         // whole block red if whole block is dead
         auto color = basicBlock->firstDeadInstructionIdx == 0 ? "red" : "black";
         fmt::format_to(
             buf,
             "    \"bb{}_{}\" [\n"
+            "        shape = {};\n"
             "        color = {};\n"
             "        label = \"{}\\l\"\n"
             "    ];\n\n"
             "    \"bb{}_{}\" -> \"bb{}_{}\" [style=\"bold\"];\n",
-            symbolName, basicBlock->id, color,
+            symbolName, basicBlock->id, shape, color,
             fmt::map_join(lines.begin(), lines.end(), "\\l", [](auto line) -> string { return absl::CEscape(line); }),
             symbolName, basicBlock->id, symbolName, basicBlock->bexit.thenb->id);
 

--- a/test/cli/phases/phases.out
+++ b/test/cli/phases/phases.out
@@ -194,16 +194,16 @@ digraph "-e" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Integer(1) = 1\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -222,16 +222,16 @@ digraph "-e" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = box];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0]()\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <self>>,\l&nbsp;&nbsp;type = T.class_of(<root>),\l&nbsp;},\l&nbsp;value = Cast {\l&nbsp;&nbsp;cast = T.cast,\l&nbsp;&nbsp;value = VariableUseSite {\l&nbsp;&nbsp;&nbsp;variable = <U <self>>,\l&nbsp;&nbsp;&nbsp;type = NilClass,\l&nbsp;&nbsp;},\l&nbsp;&nbsp;type = T.class_of(<root>),\l&nbsp;},\l}\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <returnMethodTemp>>$2,\l&nbsp;&nbsp;type = Integer(1),\l&nbsp;},\l&nbsp;value = Literal { value = Integer(1) },\l}\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <finalReturn>>,\l&nbsp;&nbsp;type = T.noreturn,\l&nbsp;},\l&nbsp;value = Return {\l&nbsp;&nbsp;what = VariableUseSite {\l&nbsp;&nbsp;&nbsp;variable = <U <returnMethodTemp>>$2,\l&nbsp;&nbsp;&nbsp;type = Integer(1),\l&nbsp;&nbsp;},\l&nbsp;},\l}\lVariableUseSite { variable = <U <unconditional>> }\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1]()\lVariableUseSite { variable = <U <unconditional>> }\l"
     ];

--- a/test/testdata/cfg/array.rb.cfg.exp
+++ b/test/testdata/cfg/array.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "array.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(TestArray) = alias <C TestArray>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(TestArray))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(TestArray) = alias <C TestArray>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(TestArray))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::TestArray#an_int" {
     label = "::TestArray#an_int";
     color = blue;
-    "bb::TestArray#an_int_0" [shape = invhouse];
-    "bb::TestArray#an_int_1" [shape = parallelogram];
 
     "bb::TestArray#an_int_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestArray = cast(<self>: NilClass, TestArray);\l<returnMethodTemp>$2: Integer(0) = 0\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(0)\l<unconditional>\l"
     ];
 
     "bb::TestArray#an_int_0" -> "bb::TestArray#an_int_1" [style="bold"];
     "bb::TestArray#an_int_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::TestArray#an_int" {
 subgraph "cluster_::TestArray#a_string" {
     label = "::TestArray#a_string";
     color = blue;
-    "bb::TestArray#a_string_0" [shape = invhouse];
-    "bb::TestArray#a_string_1" [shape = parallelogram];
 
     "bb::TestArray#a_string_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestArray = cast(<self>: NilClass, TestArray);\l<returnMethodTemp>$2: String(\"str\") = \"str\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: String(\"str\")\l<unconditional>\l"
     ];
 
     "bb::TestArray#a_string_0" -> "bb::TestArray#a_string_1" [style="bold"];
     "bb::TestArray#a_string_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::TestArray#a_string" {
 subgraph "cluster_::TestArray#test_arrays" {
     label = "::TestArray#test_arrays";
     color = blue;
-    "bb::TestArray#test_arrays_0" [shape = invhouse];
-    "bb::TestArray#test_arrays_1" [shape = parallelogram];
 
     "bb::TestArray#test_arrays_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestArray = cast(<self>: NilClass, TestArray);\l<magic>$4: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$3: [] = <magic>$4: T.class_of(<Magic>).<build-array>()\l<arrayTemp>$6: Integer(1) = 1\l<arrayTemp>$7: Integer(2) = 2\l<magic>$8: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$5: [Integer(1), Integer(2)] = <magic>$8: T.class_of(<Magic>).<build-array>(<arrayTemp>$6: Integer(1), <arrayTemp>$7: Integer(2))\l<arrayTemp>$9: Integer = <self>: TestArray.an_int()\l<arrayTemp>$11: String = <self>: TestArray.a_string()\l<magic>$14: T.class_of(<Magic>) = alias <C <Magic>>\l<arrayTemp>$13: [] = <magic>$14: T.class_of(<Magic>).<build-array>()\l<magic>$15: T.class_of(<Magic>) = alias <C <Magic>>\l<returnMethodTemp>$2: [Integer, String, []] = <magic>$15: T.class_of(<Magic>).<build-array>(<arrayTemp>$9: Integer, <arrayTemp>$11: String, <arrayTemp>$13: [])\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: [Integer, String, []]\l<unconditional>\l"
     ];
 
     "bb::TestArray#test_arrays_0" -> "bb::TestArray#test_arrays_1" [style="bold"];
     "bb::TestArray#test_arrays_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,22 +82,23 @@ subgraph "cluster_::TestArray#test_arrays" {
 subgraph "cluster_::<Class:TestArray>#<static-init>" {
     label = "::<Class:TestArray>#<static-init>";
     color = blue;
-    "bb::<Class:TestArray>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:TestArray>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:TestArray>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(TestArray) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U TestArray>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U TestArray>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(TestArray))\l<selfRestore>$8: T.class_of(TestArray) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:TestArray>#<static-init>_0" -> "bb::<Class:TestArray>#<static-init>_2" [style="bold"];
     "bb::<Class:TestArray>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:TestArray>#<static-init>_1" -> "bb::<Class:TestArray>#<static-init>_1" [style="bold"];
     "bb::<Class:TestArray>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(TestArray), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestArray))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -106,18 +107,21 @@ subgraph "cluster_::<Class:TestArray>#<static-init>" {
     "bb::<Class:TestArray>#<static-init>_2" -> "bb::<Class:TestArray>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:TestArray>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestArray))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(TestArray) = <selfRestore>$8\l<cfgAlias>$18: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$20: Sorbet::Private::Static::Void = <cfgAlias>$18: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(TestArray))\l<selfRestore>$21: T.class_of(TestArray) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:TestArray>#<static-init>_3" -> "bb::<Class:TestArray>#<static-init>_6" [style="bold"];
     "bb::<Class:TestArray>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(TestArray), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestArray))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<cfgAlias>$14: T.class_of(Integer) = alias <C Integer>\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$14: T.class_of(Integer))\l<blockReturnTemp>$15: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:TestArray>#<static-init>_5" -> "bb::<Class:TestArray>#<static-init>_2" [style="bold"];
     "bb::<Class:TestArray>#<static-init>_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=2](<self>: T.class_of(TestArray), <block-pre-call-temp>$20: Sorbet::Private::Static::Void, <selfRestore>$21: T.class_of(TestArray))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -126,12 +130,14 @@ subgraph "cluster_::<Class:TestArray>#<static-init>" {
     "bb::<Class:TestArray>#<static-init>_6" -> "bb::<Class:TestArray>#<static-init>_7" [style="tapered"];
 
     "bb::<Class:TestArray>#<static-init>_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](<block-pre-call-temp>$20: Sorbet::Private::Static::Void, <selfRestore>$21: T.class_of(TestArray))\l<statTemp>$16: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$20, sig>\l<self>: T.class_of(TestArray) = <selfRestore>$21\l<cfgAlias>$32: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$34: T.class_of(T) = alias <C T>\l<statTemp>$29: T.class_of(TestArray) = <self>: T.class_of(TestArray).extend(<cfgAlias>$32: T.class_of(T::Sig))\l<cfgAlias>$37: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$39: Symbol(:an_int) = :an_int\l<statTemp>$40: Symbol(:normal) = :normal\l<statTemp>$35: Symbol(:an_int) = <cfgAlias>$37: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestArray), <statTemp>$39: Symbol(:an_int), <statTemp>$40: Symbol(:normal))\l<cfgAlias>$43: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$45: Symbol(:a_string) = :a_string\l<statTemp>$46: Symbol(:normal) = :normal\l<statTemp>$41: Symbol(:a_string) = <cfgAlias>$43: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestArray), <statTemp>$45: Symbol(:a_string), <statTemp>$46: Symbol(:normal))\l<cfgAlias>$49: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$51: Symbol(:test_arrays) = :test_arrays\l<statTemp>$52: Symbol(:normal) = :normal\l<statTemp>$47: Symbol(:test_arrays) = <cfgAlias>$49: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestArray), <statTemp>$51: Symbol(:test_arrays), <statTemp>$52: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:TestArray>#<static-init>_7" -> "bb::<Class:TestArray>#<static-init>_1" [style="bold"];
     "bb::<Class:TestArray>#<static-init>_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=2](<self>: T.class_of(TestArray), <block-pre-call-temp>$20: Sorbet::Private::Static::Void, <selfRestore>$21: T.class_of(TestArray))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<cfgAlias>$27: T.class_of(String) = alias <C String>\l<blockReturnTemp>$24: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$27: T.class_of(String))\l<blockReturnTemp>$28: T.noreturn = blockreturn<sig> <blockReturnTemp>$24: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/block_in_deadcode.rb.cfg.exp
+++ b/test/testdata/cfg/block_in_deadcode.rb.cfg.exp
@@ -2,22 +2,23 @@ digraph "block_in_deadcode.rb" {
 subgraph "cluster_::Object#foo" {
     label = "::Object#foo";
     color = blue;
-    "bb::Object#foo_0" [shape = invhouse];
-    "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Object.outer()\l<unconditional>\l"
     ];
 
     "bb::Object#foo_0" -> "bb::Object#foo_2" [style="bold"];
     "bb::Object#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<self>)\l<statTemp>$11 = <self>\l<block-pre-call-temp>$12 = <statTemp>$11.inner()\l<unconditional>\l"
     ];
 
     "bb::Object#foo_1" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: Object, <block-pre-call-temp>$4: Sorbet::Private::Static::Void)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -26,12 +27,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_2" -> "bb::Object#foo_3" [style="tapered"];
 
     "bb::Object#foo_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<self>: Object, <block-pre-call-temp>$4: Sorbet::Private::Static::Void)\l<returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, outer>\l<self>: Object = <self>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Object#foo_3" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: Object)\louterLoops: 1\l<self>: Object = loadSelf\l<statTemp>$9: T.noreturn = return <returnTemp>$10: NilClass\l<unconditional>\l"
     ];
@@ -42,16 +45,16 @@ subgraph "cluster_::Object#foo" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:foo) = :foo\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:foo) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$6: Symbol(:foo), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/blocks.rb.cfg.exp
+++ b/test/testdata/cfg/blocks.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "blocks.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(BlockTest) = alias <C BlockTest>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(BlockTest))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(BlockTest) = alias <C BlockTest>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(BlockTest))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,22 +22,23 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::BlockTest#blockPass" {
     label = "::BlockTest#blockPass";
     color = blue;
-    "bb::BlockTest#blockPass_0" [shape = invhouse];
-    "bb::BlockTest#blockPass_1" [shape = parallelogram];
 
     "bb::BlockTest#blockPass_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: BlockTest = cast(<self>: NilClass, BlockTest);\l<statTemp>$4: Integer(1) = 1\l<statTemp>$5: Integer(2) = 2\l<statTemp>$6: Integer(3) = 3\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <self>: BlockTest.foo(<statTemp>$4: Integer(1), <statTemp>$5: Integer(2), <statTemp>$6: Integer(3))\l<selfRestore>$8: BlockTest = <self>\l<unconditional>\l"
     ];
 
     "bb::BlockTest#blockPass_0" -> "bb::BlockTest#blockPass_2" [style="bold"];
     "bb::BlockTest#blockPass_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::BlockTest#blockPass_1" -> "bb::BlockTest#blockPass_1" [style="bold"];
     "bb::BlockTest#blockPass_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: BlockTest, <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -46,12 +47,14 @@ subgraph "cluster_::BlockTest#blockPass" {
     "bb::BlockTest#blockPass_2" -> "bb::BlockTest#blockPass_3" [style="tapered"];
 
     "bb::BlockTest#blockPass_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest)\l<returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$7, foo>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::BlockTest#blockPass_3" -> "bb::BlockTest#blockPass_1" [style="bold"];
     "bb::BlockTest#blockPass_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: BlockTest, <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest)\louterLoops: 1\l<self>: BlockTest = loadSelf\l<blk>$9: T.untyped = load_yield_params(foo)\l<blk>$10: Integer(0) = 0\lx$1: T.untyped = <blk>$9: T.untyped.[](<blk>$10: Integer(0))\l<blk>$10: Integer(1) = 1\ly$1: T.untyped = <blk>$9: T.untyped.[](<blk>$10: Integer(1))\l<blockReturnTemp>$11: T.untyped = x$1\l<blockReturnTemp>$12: T.noreturn = blockreturn<foo> <blockReturnTemp>$11: T.untyped\l<unconditional>\l"
     ];
@@ -62,16 +65,16 @@ subgraph "cluster_::BlockTest#blockPass" {
 subgraph "cluster_::<Class:BlockTest>#<static-init>" {
     label = "::<Class:BlockTest>#<static-init>";
     color = blue;
-    "bb::<Class:BlockTest>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:BlockTest>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:BlockTest>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(BlockTest) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U BlockTest>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U BlockTest>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:blockPass) = :blockPass\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:blockPass) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(BlockTest), <statTemp>$6: Symbol(:blockPass), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:blockPass)\l<unconditional>\l"
     ];
 
     "bb::<Class:BlockTest>#<static-init>_0" -> "bb::<Class:BlockTest>#<static-init>_1" [style="bold"];
     "bb::<Class:BlockTest>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/break.rb.cfg.exp
+++ b/test/testdata/cfg/break.rb.cfg.exp
@@ -2,22 +2,23 @@ digraph "break.rb" {
 subgraph "cluster_::Object#foo" {
     label = "::Object#foo";
     color = blue;
-    "bb::Object#foo_0" [shape = invhouse];
-    "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<arrayTemp>$5: Integer(1) = 1\l<arrayTemp>$6: Integer(2) = 2\l<magic>$7: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$4: [Integer(1), Integer(2)] = <magic>$7: T.class_of(<Magic>).<build-array>(<arrayTemp>$5: Integer(1), <arrayTemp>$6: Integer(2))\l<block-pre-call-temp>$8: Sorbet::Private::Static::Void = <statTemp>$4: [Integer(1), Integer(2)].map()\l<selfRestore>$9: Object = <self>\l<unconditional>\l"
     ];
 
     "bb::Object#foo_0" -> "bb::Object#foo_2" [style="bold"];
     "bb::Object#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#foo_1" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: Object, <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: Object)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -26,18 +27,21 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_2" -> "bb::Object#foo_3" [style="tapered"];
 
     "bb::Object#foo_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: Object)\ltarget: T::Array[T.noreturn] = Solve<<block-pre-call-temp>$8, map>\l<unconditional>\l"
     ];
 
     "bb::Object#foo_3" -> "bb::Object#foo_4" [style="bold"];
     "bb::Object#foo_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](target: T.any(T::Array[T.noreturn], Integer), <selfRestore>$9: Object)\l<cfgAlias>$20: T.class_of(T) = alias <C T>\l<returnMethodTemp>$2: T.any(T::Array[T.noreturn], Integer) = <cfgAlias>$20: T.class_of(T).reveal_type(target: T.any(T::Array[T.noreturn], Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.any(T::Array[T.noreturn], Integer)\l<unconditional>\l"
     ];
 
     "bb::Object#foo_4" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: Object, <selfRestore>$9: Object)\louterLoops: 1\l<self>: Object = loadSelf\l<blk>$10: [Integer] = load_yield_params(map)\l<blk>$11: Integer(0) = 0\lx$1: Integer = <blk>$10: [Integer].[](<blk>$11: Integer(0))\l<returnTemp>$15: Integer = x$1\l<block-break-assign>$16: Integer = x$1\ltarget: Integer = <block-break-assign>$16\l<magic>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$18: T.untyped = <magic>$17: T.class_of(<Magic>).<block-break>(<returnTemp>$15: Integer)\l<unconditional>\l"
     ];
@@ -48,16 +52,16 @@ subgraph "cluster_::Object#foo" {
 subgraph "cluster_::Object#bar" {
     label = "::Object#bar";
     color = blue;
-    "bb::Object#bar_0" [shape = invhouse];
-    "bb::Object#bar_1" [shape = parallelogram];
 
     "bb::Object#bar_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<returnMethodTemp>$2: String(\"foo bar\") = \"foo bar\"\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: String(\"foo bar\")\l<unconditional>\l"
     ];
 
     "bb::Object#bar_0" -> "bb::Object#bar_1" [style="bold"];
     "bb::Object#bar_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -68,22 +72,23 @@ subgraph "cluster_::Object#bar" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(<root>))\l<selfRestore>$8: T.class_of(<root>) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_2" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_1" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -92,18 +97,21 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_2" -> "bb::<Class:<root>>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(<root>) = <selfRestore>$8\l<cfgAlias>$31: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$33: T.class_of(T) = alias <C T>\l<statTemp>$28: T.class_of(<root>) = <self>: T.class_of(<root>).extend(<cfgAlias>$31: T.class_of(T::Sig))\l<cfgAlias>$36: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$38: Symbol(:foo) = :foo\l<statTemp>$39: Symbol(:normal) = :normal\l<statTemp>$34: Symbol(:foo) = <cfgAlias>$36: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$38: Symbol(:foo), <statTemp>$39: Symbol(:normal))\l<statTemp>$42: T.untyped = <self>: T.class_of(<root>).foo()\l<statTemp>$40: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$42: T.untyped)\l<cfgAlias>$46: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$48: Symbol(:bar) = :bar\l<statTemp>$49: Symbol(:normal) = :normal\l<statTemp>$44: Symbol(:bar) = <cfgAlias>$46: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$48: Symbol(:bar), <statTemp>$49: Symbol(:normal))\l<block-pre-call-temp>$52: Sorbet::Private::Static::Void = <self>: T.class_of(<root>).bar()\l<selfRestore>$53: T.class_of(<root>) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_3" -> "bb::<Class:<root>>#<static-init>_6" [style="bold"];
     "bb::<Class:<root>>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$14: Symbol(:blk) = :blk\l<cfgAlias>$19: T.class_of(T) = alias <C T>\l<statTemp>$17: T.class_of(T.proc) = <cfgAlias>$19: T.class_of(T).proc()\l<hashTemp>$20: Symbol(:x) = :x\l<cfgAlias>$22: T.class_of(Integer) = alias <C Integer>\l<statTemp>$16: T.class_of(T.proc) = <statTemp>$17: T.class_of(T.proc).params(<hashTemp>$20: Symbol(:x), <cfgAlias>$22: T.class_of(Integer))\l<cfgAlias>$24: T.class_of(String) = alias <C String>\l<hashTemp>$15: T.class_of(T.proc) = <statTemp>$16: T.class_of(T.proc).returns(<cfgAlias>$24: T.class_of(String))\l<statTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$14: Symbol(:blk), <hashTemp>$15: T.class_of(T.proc))\l<cfgAlias>$26: T.class_of(String) = alias <C String>\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <statTemp>$12: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$26: T.class_of(String))\l<blockReturnTemp>$27: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_5" -> "bb::<Class:<root>>#<static-init>_2" [style="bold"];
     "bb::<Class:<root>>#<static-init>_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=2](<self>: T.class_of(<root>), <block-pre-call-temp>$52: Sorbet::Private::Static::Void, <selfRestore>$53: T.class_of(<root>))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -112,18 +120,21 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_6" -> "bb::<Class:<root>>#<static-init>_7" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](<block-pre-call-temp>$52: Sorbet::Private::Static::Void, <selfRestore>$53: T.class_of(<root>))\la: String = Solve<<block-pre-call-temp>$52, bar>\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_7" -> "bb::<Class:<root>>#<static-init>_8" [style="bold"];
     "bb::<Class:<root>>#<static-init>_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=0](a: T.any(String, Integer), <selfRestore>$53: T.class_of(<root>))\l<self>: T.class_of(<root>) = <selfRestore>$53\l<cfgAlias>$68: T.class_of(T) = alias <C T>\l<statTemp>$66: T.any(String, Integer) = <cfgAlias>$68: T.class_of(T).reveal_type(a: T.any(String, Integer))\l<block-pre-call-temp>$72: Sorbet::Private::Static::Void = <self>: T.class_of(<root>).bar()\l<selfRestore>$73: T.class_of(<root>) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_8" -> "bb::<Class:<root>>#<static-init>_12" [style="bold"];
     "bb::<Class:<root>>#<static-init>_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=2](<self>: T.class_of(<root>), <block-pre-call-temp>$52: Sorbet::Private::Static::Void, <selfRestore>$53: T.class_of(<root>))\louterLoops: 1\l<self>: T.class_of(<root>) = loadSelf\l<blk>$54: [Integer] = load_yield_params(bar)\l<blk>$55: Integer(0) = 0\lx$2: Integer = <blk>$54: [Integer].[](<blk>$55: Integer(0))\l<statTemp>$60: Integer(5) = 5\l<ifTemp>$58: T::Boolean = x$2: Integer.>(<statTemp>$60: Integer(5))\l<ifTemp>$58: T::Boolean\l"
     ];
@@ -132,18 +143,21 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_9" -> "bb::<Class:<root>>#<static-init>_11" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=2](<selfRestore>$53: T.class_of(<root>))\louterLoops: 1\l<returnTemp>$61: Integer(10) = 10\l<block-break-assign>$62: Integer(10) = <returnTemp>$61\la: Integer(10) = <block-break-assign>$62\l<magic>$63: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$64: T.untyped = <magic>$63: T.class_of(<Magic>).<block-break>(<returnTemp>$61: Integer(10))\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_10" -> "bb::<Class:<root>>#<static-init>_8" [style="bold"];
     "bb::<Class:<root>>#<static-init>_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=2](<self>: T.class_of(<root>), <block-pre-call-temp>$52: Sorbet::Private::Static::Void, <selfRestore>$53: T.class_of(<root>))\louterLoops: 1\l<blockReturnTemp>$56: String(\"test\") = \"test\"\l<blockReturnTemp>$65: T.noreturn = blockreturn<bar> <blockReturnTemp>$56: String(\"test\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_11" -> "bb::<Class:<root>>#<static-init>_6" [style="bold"];
     "bb::<Class:<root>>#<static-init>_12" [
+        shape = rectangle;
         color = black;
         label = "block[id=12, rubyBlockId=3](<self>: T.class_of(<root>), <block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(<root>))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -152,18 +166,21 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_12" -> "bb::<Class:<root>>#<static-init>_13" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_13" [
+        shape = rectangle;
         color = black;
         label = "block[id=13, rubyBlockId=0](<block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(<root>))\lb: String = Solve<<block-pre-call-temp>$72, bar>\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_13" -> "bb::<Class:<root>>#<static-init>_14" [style="bold"];
     "bb::<Class:<root>>#<static-init>_14" [
+        shape = rectangle;
         color = black;
         label = "block[id=14, rubyBlockId=0](b: T.nilable(String), <selfRestore>$73: T.class_of(<root>))\l<cfgAlias>$88: T.class_of(T) = alias <C T>\l<statTemp>$86: T.nilable(String) = <cfgAlias>$88: T.class_of(T).reveal_type(b: T.nilable(String))\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_14" -> "bb::<Class:<root>>#<static-init>_18" [style="bold"];
     "bb::<Class:<root>>#<static-init>_15" [
+        shape = rectangle;
         color = black;
         label = "block[id=15, rubyBlockId=3](<self>: T.class_of(<root>), <block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(<root>))\louterLoops: 1\l<self>: T.class_of(<root>) = loadSelf\l<blk>$74: [Integer] = load_yield_params(bar)\l<blk>$75: Integer(0) = 0\lx$3: Integer = <blk>$74: [Integer].[](<blk>$75: Integer(0))\l<statTemp>$80: Integer(5) = 5\l<ifTemp>$78: T::Boolean = x$3: Integer.>(<statTemp>$80: Integer(5))\l<ifTemp>$78: T::Boolean\l"
     ];
@@ -172,18 +189,21 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_15" -> "bb::<Class:<root>>#<static-init>_17" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_16" [
+        shape = rectangle;
         color = black;
         label = "block[id=16, rubyBlockId=3](<selfRestore>$73: T.class_of(<root>))\louterLoops: 1\l<block-break-assign>$82: NilClass = <returnTemp>$81\lb: NilClass = <block-break-assign>$82\l<magic>$83: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$84: T.untyped = <magic>$83: T.class_of(<Magic>).<block-break>(<returnTemp>$81: NilClass)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_16" -> "bb::<Class:<root>>#<static-init>_14" [style="bold"];
     "bb::<Class:<root>>#<static-init>_17" [
+        shape = rectangle;
         color = black;
         label = "block[id=17, rubyBlockId=3](<self>: T.class_of(<root>), <block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(<root>))\louterLoops: 1\l<blockReturnTemp>$76: String(\"test\") = \"test\"\l<blockReturnTemp>$85: T.noreturn = blockreturn<bar> <blockReturnTemp>$76: String(\"test\")\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_17" -> "bb::<Class:<root>>#<static-init>_12" [style="bold"];
     "bb::<Class:<root>>#<static-init>_18" [
+        shape = rectangle;
         color = black;
         label = "block[id=18, rubyBlockId=0]()\louterLoops: 1\l<statTemp>$93: Integer(1) = 1\l<statTemp>$92: String = <statTemp>$93: Integer(1).to_s()\l<statTemp>$94: String(\"\") = \"\"\l<whileTemp>$91: T::Boolean = <statTemp>$92: String.==(<statTemp>$94: String(\"\"))\l<whileTemp>$91: T::Boolean\l"
     ];
@@ -192,18 +212,21 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_18" -> "bb::<Class:<root>>#<static-init>_19" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_19" [
+        shape = rectangle;
         color = black;
         label = "block[id=19, rubyBlockId=0]()\lc: NilClass = nil\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_19" -> "bb::<Class:<root>>#<static-init>_20" [style="bold"];
     "bb::<Class:<root>>#<static-init>_20" [
+        shape = rectangle;
         color = black;
         label = "block[id=20, rubyBlockId=0](c: T.nilable(Symbol))\l<cfgAlias>$106: T.class_of(T) = alias <C T>\l<statTemp>$104: T.nilable(Symbol) = <cfgAlias>$106: T.class_of(T).reveal_type(c: T.nilable(Symbol))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_20" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_21" [
+        shape = rectangle;
         color = black;
         label = "block[id=21, rubyBlockId=0]()\louterLoops: 1\l<statTemp>$98: Integer(1) = 1\l<statTemp>$97: String = <statTemp>$98: Integer(1).to_s()\l<statTemp>$99: String(\"\") = \"\"\l<ifTemp>$96: T::Boolean = <statTemp>$97: String.==(<statTemp>$99: String(\"\"))\l<ifTemp>$96: T::Boolean\l"
     ];
@@ -212,6 +235,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_21" -> "bb::<Class:<root>>#<static-init>_18" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_22" [
+        shape = rectangle;
         color = black;
         label = "block[id=22, rubyBlockId=0]()\louterLoops: 1\l<returnTemp>$100: Symbol(:abc) = :abc\l<block-break-assign>$101: Symbol(:abc) = <returnTemp>$100\lc: Symbol(:abc) = <block-break-assign>$101\l<magic>$102: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$103: T.untyped = <magic>$102: T.class_of(<Magic>).<block-break>(<returnTemp>$100: Symbol(:abc))\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/break_in_junk.rb.cfg.exp
+++ b/test/testdata/cfg/break_in_junk.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "break_in_junk.rb" {
 subgraph "cluster_::Object#foo" {
     label = "::Object#foo";
     color = blue;
-    "bb::Object#foo_0" [shape = invhouse];
-    "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<returnTemp>$3: Integer(5) = 5\l<block-break-assign>$4: Integer(5) = <returnTemp>$3\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$6: T.untyped = <magic>$5: T.class_of(<Magic>).<block-break>(<returnTemp>$3: Integer(5))\l<unconditional>\l"
     ];
 
     "bb::Object#foo_0" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::Object#foo" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:foo) = :foo\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:foo) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$6: Symbol(:foo), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/break_in_while.rb.cfg.exp
+++ b/test/testdata/cfg/break_in_while.rb.cfg.exp
@@ -2,22 +2,23 @@ digraph "break_in_while.rb" {
 subgraph "cluster_::Object#foo" {
     label = "::Object#foo";
     color = blue;
-    "bb::Object#foo_0" [shape = invhouse];
-    "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<unconditional>\l"
     ];
 
     "bb::Object#foo_0" -> "bb::Object#foo_2" [style="bold"];
     "bb::Object#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<self>)\l<statTemp>$11 = <self>\l<statTemp>$4 = <statTemp>$11.dead()\l<unconditional>\l"
     ];
 
     "bb::Object#foo_1" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\louterLoops: 1\l<whileTemp>$3: TrueClass = true\l<whileTemp>$3: TrueClass\l"
     ];
@@ -26,18 +27,21 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_2" -> "bb::Object#foo_3" [style="tapered"];
 
     "bb::Object#foo_3" [
+        shape = rectangle;
         color = red;
         label = "block[id=3, rubyBlockId=0]()\l<returnMethodTemp>$2 = nil\l<unconditional>\l"
     ];
 
     "bb::Object#foo_3" -> "bb::Object#foo_4" [style="bold"];
     "bb::Object#foo_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](<returnMethodTemp>$2: Integer(2))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(2)\l<unconditional>\l"
     ];
 
     "bb::Object#foo_4" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0]()\louterLoops: 1\l<returnTemp>$7: Integer(2) = 2\l<block-break-assign>$8: Integer(2) = <returnTemp>$7\l<returnMethodTemp>$2: Integer(2) = <block-break-assign>$8\l<magic>$9: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$10: T.untyped = <magic>$9: T.class_of(<Magic>).<block-break>(<returnTemp>$7: Integer(2))\l<unconditional>\l"
     ];
@@ -48,16 +52,16 @@ subgraph "cluster_::Object#foo" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:foo) = :foo\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:foo) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$7: Symbol(:foo), <statTemp>$8: Symbol(:normal))\l<statTemp>$11: T.untyped = <self>: T.class_of(<root>).foo()\l<statTemp>$9: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$11: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/dealias_with_return.rb.cfg.exp
+++ b/test/testdata/cfg/dealias_with_return.rb.cfg.exp
@@ -2,10 +2,9 @@ digraph "dealias_with_return.rb" {
 subgraph "cluster_::Object#a" {
     label = "::Object#a";
     color = blue;
-    "bb::Object#a_0" [shape = invhouse];
-    "bb::Object#a_1" [shape = parallelogram];
 
     "bb::Object#a_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<magic>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$4: T.untyped = <get-current-exception>\l<exceptionValue>$4: T.untyped\l"
     ];
@@ -14,12 +13,14 @@ subgraph "cluster_::Object#a" {
     "bb::Object#a_0" -> "bb::Object#a_4" [style="tapered"];
 
     "bb::Object#a_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<exceptionValue>$4 = <get-current-exception>\l<unconditional>\l"
     ];
 
     "bb::Object#a_1" -> "bb::Object#a_1" [style="bold"];
     "bb::Object#a_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<exceptionValue>$4: T.untyped, <magic>$6: T.class_of(<Magic>))\l<cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$10: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$9: T.class_of(StandardError))\l<isaCheckTemp>$10: T.untyped\l"
     ];
@@ -28,12 +29,14 @@ subgraph "cluster_::Object#a" {
     "bb::Object#a_3" -> "bb::Object#a_8" [style="tapered"];
 
     "bb::Object#a_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1]()\l<returnTemp>$5: Integer(1) = 1\l<statTemp>$3: T.noreturn = return <returnTemp>$5: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::Object#a_4" -> "bb::Object#a_1" [style="bold"];
     "bb::Object#a_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](a: T.nilable(Integer), <gotoDeadTemp>$11: T.nilable(TrueClass))\l<gotoDeadTemp>$11: T.nilable(TrueClass)\l"
     ];
@@ -42,18 +45,21 @@ subgraph "cluster_::Object#a" {
     "bb::Object#a_6" -> "bb::Object#a_9" [style="tapered"];
 
     "bb::Object#a_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<magic>$6: T.class_of(<Magic>))\l<exceptionValue>$4: NilClass = nil\l<keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)\la: Integer(2) = 2\l<unconditional>\l"
     ];
 
     "bb::Object#a_7" -> "bb::Object#a_6" [style="bold"];
     "bb::Object#a_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$11: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#a_8" -> "bb::Object#a_6" [style="bold"];
     "bb::Object#a_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](a: Integer(2))\l<statTemp>$14: Integer(3) = 3\l<returnMethodTemp>$2: Integer = a: Integer(2).+(<statTemp>$14: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
     ];
@@ -64,16 +70,16 @@ subgraph "cluster_::Object#a" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:a) = :a\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:a) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$6: Symbol(:a), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:a)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/default_args_cases.rb.cfg.exp
+++ b/test/testdata/cfg/default_args_cases.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "default_args_cases.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(Test) = alias <C Test>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(Test))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(Test) = alias <C Test>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(Test))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,10 +22,9 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::Test#test1" {
     label = "::Test#test1";
     color = blue;
-    "bb::Test#test1_0" [shape = invhouse];
-    "bb::Test#test1_1" [shape = parallelogram];
 
     "bb::Test#test1_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Test = cast(<self>: NilClass, Test);\la: Integer = load_arg(a)\lb: Integer = load_arg(b)\l<argPresent>$3: T::Boolean = arg_present(c)\l<argPresent>$3: T::Boolean\l"
     ];
@@ -34,12 +33,14 @@ subgraph "cluster_::Test#test1" {
     "bb::Test#test1_0" -> "bb::Test#test1_3" [style="tapered"];
 
     "bb::Test#test1_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Test#test1_1" -> "bb::Test#test1_1" [style="bold"];
     "bb::Test#test1_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](a: Integer, b: Integer)\lc: Integer = load_arg(c)\l<argPresent>$6: T::Boolean = arg_present(d)\l<argPresent>$6: T::Boolean\l"
     ];
@@ -48,24 +49,28 @@ subgraph "cluster_::Test#test1" {
     "bb::Test#test1_2" -> "bb::Test#test1_5" [style="tapered"];
 
     "bb::Test#test1_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](a: Integer, b: Integer)\l<statTemp>$4: Integer(10) = 10\l<castTemp>$5: Integer = cast(<statTemp>$4: Integer(10), Integer);\lc: Integer(10) = <statTemp>$4\l<unconditional>\l"
     ];
 
     "bb::Test#test1_3" -> "bb::Test#test1_5" [style="bold"];
     "bb::Test#test1_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](a: Integer, b: Integer, c: Integer)\ld: Integer = load_arg(d)\l<unconditional>\l"
     ];
 
     "bb::Test#test1_4" -> "bb::Test#test1_6" [style="bold"];
     "bb::Test#test1_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0](a: Integer, b: Integer, c: Integer)\lx: Integer(20) = 20\l<statTemp>$7: Integer(20) = x\l<castTemp>$8: Integer = cast(<statTemp>$7: Integer(20), Integer);\ld: Integer(20) = x\l<unconditional>\l"
     ];
 
     "bb::Test#test1_5" -> "bb::Test#test1_6" [style="bold"];
     "bb::Test#test1_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=0](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer))\le: Integer = load_arg(e)\l<argPresent>$9: T::Boolean = arg_present(f)\l<argPresent>$9: T::Boolean\l"
     ];
@@ -74,18 +79,21 @@ subgraph "cluster_::Test#test1" {
     "bb::Test#test1_6" -> "bb::Test#test1_8" [style="tapered"];
 
     "bb::Test#test1_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer)\lf: String = load_arg(f)\l<unconditional>\l"
     ];
 
     "bb::Test#test1_7" -> "bb::Test#test1_9" [style="bold"];
     "bb::Test#test1_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=0](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer)\l<statTemp>$10: String(\"foo\") = \"foo\"\l<castTemp>$11: String = cast(<statTemp>$10: String(\"foo\"), String);\lf: String(\"foo\") = <statTemp>$10\l<unconditional>\l"
     ];
 
     "bb::Test#test1_8" -> "bb::Test#test1_9" [style="bold"];
     "bb::Test#test1_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer, f: String)\lblk: T.proc.void = load_arg(blk)\l<cfgAlias>$14: T.class_of(T) = alias <C T>\l<statTemp>$12: Integer = <cfgAlias>$14: T.class_of(T).reveal_type(a: Integer)\l<cfgAlias>$18: T.class_of(T) = alias <C T>\l<statTemp>$16: Integer = <cfgAlias>$18: T.class_of(T).reveal_type(b: Integer)\l<cfgAlias>$22: T.class_of(T) = alias <C T>\l<statTemp>$20: Integer = <cfgAlias>$22: T.class_of(T).reveal_type(c: Integer)\l<cfgAlias>$26: T.class_of(T) = alias <C T>\l<statTemp>$24: Integer = <cfgAlias>$26: T.class_of(T).reveal_type(d: Integer)\l<cfgAlias>$30: T.class_of(T) = alias <C T>\l<statTemp>$28: Integer = <cfgAlias>$30: T.class_of(T).reveal_type(e: Integer)\l<cfgAlias>$34: T.class_of(T) = alias <C T>\l<statTemp>$32: String = <cfgAlias>$34: T.class_of(T).reveal_type(f: String)\l<cfgAlias>$38: T.class_of(T) = alias <C T>\l<statTemp>$36: T.proc.void = <cfgAlias>$38: T.class_of(T).reveal_type(blk: T.proc.void)\l<statTemp>$40: Sorbet::Private::Static::Void = blk: T.proc.void.call()\l<cfgAlias>$43: T.class_of(T) = alias <C T>\l<returnMethodTemp>$2: T.nilable(Integer) = <cfgAlias>$43: T.class_of(T).reveal_type(x: T.nilable(Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
     ];
@@ -96,10 +104,9 @@ subgraph "cluster_::Test#test1" {
 subgraph "cluster_::Test#test2" {
     label = "::Test#test2";
     color = blue;
-    "bb::Test#test2_0" [shape = invhouse];
-    "bb::Test#test2_1" [shape = parallelogram];
 
     "bb::Test#test2_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Test = cast(<self>: NilClass, Test);\l<argPresent>$3: T::Boolean = arg_present(x)\l<argPresent>$3: T::Boolean\l"
     ];
@@ -108,24 +115,28 @@ subgraph "cluster_::Test#test2" {
     "bb::Test#test2_0" -> "bb::Test#test2_3" [style="tapered"];
 
     "bb::Test#test2_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Test#test2_1" -> "bb::Test#test2_1" [style="bold"];
     "bb::Test#test2_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\lx: Integer = load_arg(x)\l<unconditional>\l"
     ];
 
     "bb::Test#test2_2" -> "bb::Test#test2_4" [style="bold"];
     "bb::Test#test2_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0]()\l<statTemp>$4: Integer(10) = 10\l<castTemp>$5: Integer = cast(<statTemp>$4: Integer(10), Integer);\lx: Integer(10) = <statTemp>$4\l<unconditional>\l"
     ];
 
     "bb::Test#test2_3" -> "bb::Test#test2_4" [style="bold"];
     "bb::Test#test2_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](x: Integer)\lrest: T::Array[Integer] = load_arg(rest)\lblk: T.proc.void = load_arg(blk)\l<cfgAlias>$8: T.class_of(T) = alias <C T>\l<statTemp>$6: Integer = <cfgAlias>$8: T.class_of(T).reveal_type(x: Integer)\l<cfgAlias>$12: T.class_of(T) = alias <C T>\l<statTemp>$10: T::Array[Integer] = <cfgAlias>$12: T.class_of(T).reveal_type(rest: T::Array[Integer])\l<cfgAlias>$15: T.class_of(T) = alias <C T>\l<returnMethodTemp>$2: T.proc.void = <cfgAlias>$15: T.class_of(T).reveal_type(blk: T.proc.void)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.proc.void\l<unconditional>\l"
     ];
@@ -136,10 +147,9 @@ subgraph "cluster_::Test#test2" {
 subgraph "cluster_::Test#test3" {
     label = "::Test#test3";
     color = blue;
-    "bb::Test#test3_0" [shape = invhouse];
-    "bb::Test#test3_1" [shape = parallelogram];
 
     "bb::Test#test3_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Test = cast(<self>: NilClass, Test);\l<argPresent>$3: T::Boolean = arg_present(x)\l<argPresent>$3: T::Boolean\l"
     ];
@@ -148,24 +158,28 @@ subgraph "cluster_::Test#test3" {
     "bb::Test#test3_0" -> "bb::Test#test3_3" [style="tapered"];
 
     "bb::Test#test3_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Test#test3_1" -> "bb::Test#test3_1" [style="bold"];
     "bb::Test#test3_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\lx: Integer = load_arg(x)\l<unconditional>\l"
     ];
 
     "bb::Test#test3_2" -> "bb::Test#test3_4" [style="bold"];
     "bb::Test#test3_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0]()\l<statTemp>$4: Integer(10) = 10\l<castTemp>$5: Integer = cast(<statTemp>$4: Integer(10), Integer);\lx: Integer(10) = <statTemp>$4\l<unconditional>\l"
     ];
 
     "bb::Test#test3_3" -> "bb::Test#test3_4" [style="bold"];
     "bb::Test#test3_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](x: Integer)\lrest: T::Hash[Symbol, Integer] = load_arg(rest)\lblk: T.proc.void = load_arg(blk)\l<cfgAlias>$8: T.class_of(T) = alias <C T>\l<statTemp>$6: Integer = <cfgAlias>$8: T.class_of(T).reveal_type(x: Integer)\l<cfgAlias>$12: T.class_of(T) = alias <C T>\l<statTemp>$10: T::Hash[Symbol, Integer] = <cfgAlias>$12: T.class_of(T).reveal_type(rest: T::Hash[Symbol, Integer])\l<cfgAlias>$15: T.class_of(T) = alias <C T>\l<returnMethodTemp>$2: T.proc.void = <cfgAlias>$15: T.class_of(T).reveal_type(blk: T.proc.void)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.proc.void\l<unconditional>\l"
     ];
@@ -176,22 +190,23 @@ subgraph "cluster_::Test#test3" {
 subgraph "cluster_::<Class:Test>#<static-init>" {
     label = "::<Class:Test>#<static-init>";
     color = blue;
-    "bb::<Class:Test>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Test>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Test>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Test) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Test>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Test>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Test))\l<selfRestore>$8: T.class_of(Test) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Test>#<static-init>_0" -> "bb::<Class:Test>#<static-init>_2" [style="bold"];
     "bb::<Class:Test>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:Test>#<static-init>_1" -> "bb::<Class:Test>#<static-init>_1" [style="bold"];
     "bb::<Class:Test>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Test), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Test))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -200,18 +215,21 @@ subgraph "cluster_::<Class:Test>#<static-init>" {
     "bb::<Class:Test>#<static-init>_2" -> "bb::<Class:Test>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:Test>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Test))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(Test) = <selfRestore>$8\l<cfgAlias>$40: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$42: Sorbet::Private::Static::Void = <cfgAlias>$40: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Test))\l<selfRestore>$43: T.class_of(Test) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Test>#<static-init>_3" -> "bb::<Class:Test>#<static-init>_6" [style="bold"];
     "bb::<Class:Test>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Test), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Test))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$14: Symbol(:a) = :a\l<cfgAlias>$16: T.class_of(Integer) = alias <C Integer>\l<hashTemp>$17: Symbol(:b) = :b\l<cfgAlias>$19: T.class_of(Integer) = alias <C Integer>\l<hashTemp>$20: Symbol(:c) = :c\l<cfgAlias>$22: T.class_of(Integer) = alias <C Integer>\l<hashTemp>$23: Symbol(:d) = :d\l<cfgAlias>$25: T.class_of(Integer) = alias <C Integer>\l<hashTemp>$26: Symbol(:e) = :e\l<cfgAlias>$28: T.class_of(Integer) = alias <C Integer>\l<hashTemp>$29: Symbol(:f) = :f\l<cfgAlias>$31: T.class_of(String) = alias <C String>\l<hashTemp>$32: Symbol(:blk) = :blk\l<cfgAlias>$36: T.class_of(T) = alias <C T>\l<statTemp>$34: T.class_of(T.proc) = <cfgAlias>$36: T.class_of(T).proc()\l<hashTemp>$33: T.class_of(T.proc) = <statTemp>$34: T.class_of(T.proc).void()\l<statTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$14: Symbol(:a), <cfgAlias>$16: T.class_of(Integer), <hashTemp>$17: Symbol(:b), <cfgAlias>$19: T.class_of(Integer), <hashTemp>$20: Symbol(:c), <cfgAlias>$22: T.class_of(Integer), <hashTemp>$23: Symbol(:d), <cfgAlias>$25: T.class_of(Integer), <hashTemp>$26: Symbol(:e), <cfgAlias>$28: T.class_of(Integer), <hashTemp>$29: Symbol(:f), <cfgAlias>$31: T.class_of(String), <hashTemp>$32: Symbol(:blk), <hashTemp>$33: T.class_of(T.proc))\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <statTemp>$12: T::Private::Methods::DeclBuilder.void()\l<blockReturnTemp>$37: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:Test>#<static-init>_5" -> "bb::<Class:Test>#<static-init>_2" [style="bold"];
     "bb::<Class:Test>#<static-init>_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=2](<self>: T.class_of(Test), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Test))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -220,18 +238,21 @@ subgraph "cluster_::<Class:Test>#<static-init>" {
     "bb::<Class:Test>#<static-init>_6" -> "bb::<Class:Test>#<static-init>_7" [style="tapered"];
 
     "bb::<Class:Test>#<static-init>_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](<block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Test))\l<statTemp>$38: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$42, sig>\l<self>: T.class_of(Test) = <selfRestore>$43\l<cfgAlias>$63: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$65: Sorbet::Private::Static::Void = <cfgAlias>$63: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Test))\l<selfRestore>$66: T.class_of(Test) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Test>#<static-init>_7" -> "bb::<Class:Test>#<static-init>_10" [style="bold"];
     "bb::<Class:Test>#<static-init>_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=2](<self>: T.class_of(Test), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Test))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$49: Symbol(:x) = :x\l<cfgAlias>$51: T.class_of(Integer) = alias <C Integer>\l<hashTemp>$52: Symbol(:rest) = :rest\l<cfgAlias>$54: T.class_of(Integer) = alias <C Integer>\l<hashTemp>$55: Symbol(:blk) = :blk\l<cfgAlias>$59: T.class_of(T) = alias <C T>\l<statTemp>$57: T.class_of(T.proc) = <cfgAlias>$59: T.class_of(T).proc()\l<hashTemp>$56: T.class_of(T.proc) = <statTemp>$57: T.class_of(T.proc).void()\l<statTemp>$47: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$49: Symbol(:x), <cfgAlias>$51: T.class_of(Integer), <hashTemp>$52: Symbol(:rest), <cfgAlias>$54: T.class_of(Integer), <hashTemp>$55: Symbol(:blk), <hashTemp>$56: T.class_of(T.proc))\l<blockReturnTemp>$46: T::Private::Methods::DeclBuilder = <statTemp>$47: T::Private::Methods::DeclBuilder.void()\l<blockReturnTemp>$60: T.noreturn = blockreturn<sig> <blockReturnTemp>$46: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:Test>#<static-init>_9" -> "bb::<Class:Test>#<static-init>_6" [style="bold"];
     "bb::<Class:Test>#<static-init>_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=3](<self>: T.class_of(Test), <block-pre-call-temp>$65: Sorbet::Private::Static::Void, <selfRestore>$66: T.class_of(Test))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -240,12 +261,14 @@ subgraph "cluster_::<Class:Test>#<static-init>" {
     "bb::<Class:Test>#<static-init>_10" -> "bb::<Class:Test>#<static-init>_11" [style="tapered"];
 
     "bb::<Class:Test>#<static-init>_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=0](<block-pre-call-temp>$65: Sorbet::Private::Static::Void, <selfRestore>$66: T.class_of(Test))\l<statTemp>$61: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$65, sig>\l<self>: T.class_of(Test) = <selfRestore>$66\l<cfgAlias>$87: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$89: T.class_of(T) = alias <C T>\l<statTemp>$84: T.class_of(Test) = <self>: T.class_of(Test).extend(<cfgAlias>$87: T.class_of(T::Sig))\l<cfgAlias>$92: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$94: Symbol(:test1) = :test1\l<statTemp>$95: Symbol(:normal) = :normal\l<statTemp>$90: Symbol(:test1) = <cfgAlias>$92: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Test), <statTemp>$94: Symbol(:test1), <statTemp>$95: Symbol(:normal))\l<cfgAlias>$98: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$100: Symbol(:test2) = :test2\l<statTemp>$101: Symbol(:normal) = :normal\l<statTemp>$96: Symbol(:test2) = <cfgAlias>$98: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Test), <statTemp>$100: Symbol(:test2), <statTemp>$101: Symbol(:normal))\l<cfgAlias>$104: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$106: Symbol(:test3) = :test3\l<statTemp>$107: Symbol(:normal) = :normal\l<statTemp>$102: Symbol(:test3) = <cfgAlias>$104: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Test), <statTemp>$106: Symbol(:test3), <statTemp>$107: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Test>#<static-init>_11" -> "bb::<Class:Test>#<static-init>_1" [style="bold"];
     "bb::<Class:Test>#<static-init>_13" [
+        shape = rectangle;
         color = black;
         label = "block[id=13, rubyBlockId=3](<self>: T.class_of(Test), <block-pre-call-temp>$65: Sorbet::Private::Static::Void, <selfRestore>$66: T.class_of(Test))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$72: Symbol(:x) = :x\l<cfgAlias>$74: T.class_of(Integer) = alias <C Integer>\l<hashTemp>$75: Symbol(:rest) = :rest\l<cfgAlias>$77: T.class_of(Integer) = alias <C Integer>\l<hashTemp>$78: Symbol(:blk) = :blk\l<cfgAlias>$82: T.class_of(T) = alias <C T>\l<statTemp>$80: T.class_of(T.proc) = <cfgAlias>$82: T.class_of(T).proc()\l<hashTemp>$79: T.class_of(T.proc) = <statTemp>$80: T.class_of(T.proc).void()\l<statTemp>$70: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$72: Symbol(:x), <cfgAlias>$74: T.class_of(Integer), <hashTemp>$75: Symbol(:rest), <cfgAlias>$77: T.class_of(Integer), <hashTemp>$78: Symbol(:blk), <hashTemp>$79: T.class_of(T.proc))\l<blockReturnTemp>$69: T::Private::Methods::DeclBuilder = <statTemp>$70: T::Private::Methods::DeclBuilder.void()\l<blockReturnTemp>$83: T.noreturn = blockreturn<sig> <blockReturnTemp>$69: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/do_while.rb.cfg.exp
+++ b/test/testdata/cfg/do_while.rb.cfg.exp
@@ -2,22 +2,23 @@ digraph "do_while.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_2" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_1" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](<self>: T.class_of(<root>))\louterLoops: 1\l<whileTemp>$4: TrueClass = true\l<whileTemp>$4: TrueClass\l"
     ];
@@ -26,6 +27,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_2" -> "bb::<Class:<root>>#<static-init>_8" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0](<self>: T.class_of(<root>))\louterLoops: 1\l<statTemp>$8: Integer(2) = 2\l<statTemp>$6: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$8: Integer(2))\l<statTemp>$10: FalseClass = false\l<ifTemp>$9: TrueClass = <statTemp>$10: FalseClass.!()\l<ifTemp>$9: TrueClass\l"
     ];
@@ -34,12 +36,14 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_5" -> "bb::<Class:<root>>#<static-init>_2" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=0](<self>: T.class_of(<root>))\louterLoops: 1\l<block-break-assign>$12: NilClass = <returnTemp>$11\l<magic>$13: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$14: T.untyped = <magic>$13: T.class_of(<Magic>).<block-break>(<returnTemp>$11: NilClass)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_6" -> "bb::<Class:<root>>#<static-init>_8" [style="bold"];
     "bb::<Class:<root>>#<static-init>_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=0](<self>: T.class_of(<root>))\louterLoops: 1\l<whileTemp>$16: TrueClass = true\l<whileTemp>$16: TrueClass\l"
     ];
@@ -48,12 +52,14 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_8" -> "bb::<Class:<root>>#<static-init>_10" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=0](<self>: T.class_of(<root>))\lx: Integer(0) = 0\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_10" -> "bb::<Class:<root>>#<static-init>_14" [style="bold"];
     "bb::<Class:<root>>#<static-init>_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=0](<self>: T.class_of(<root>))\louterLoops: 1\l<statTemp>$20: Integer(2) = 2\l<statTemp>$18: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$20: Integer(2))\l<ifTemp>$21: TrueClass = true\l<ifTemp>$21: TrueClass\l"
     ];
@@ -62,12 +68,14 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_11" -> "bb::<Class:<root>>#<static-init>_8" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_12" [
+        shape = rectangle;
         color = black;
         label = "block[id=12, rubyBlockId=0](<self>: T.class_of(<root>))\louterLoops: 1\l<block-break-assign>$23: NilClass = <returnTemp>$22\l<magic>$24: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$25: T.untyped = <magic>$24: T.class_of(<Magic>).<block-break>(<returnTemp>$22: NilClass)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_12" -> "bb::<Class:<root>>#<static-init>_10" [style="bold"];
     "bb::<Class:<root>>#<static-init>_14" [
+        shape = rectangle;
         color = black;
         label = "block[id=14, rubyBlockId=0](<self>: T.class_of(<root>), x: Integer(0))\louterLoops: 1\l<whileTemp>$28: FalseClass = false\l<whileTemp>$28: FalseClass\l"
     ];
@@ -76,18 +84,21 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_14" -> "bb::<Class:<root>>#<static-init>_16" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_16" [
+        shape = rectangle;
         color = black;
         label = "block[id=16, rubyBlockId=0](<self>: T.class_of(<root>), x: Integer(0))\ly: Integer(0) = 0\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_16" -> "bb::<Class:<root>>#<static-init>_18" [style="bold"];
     "bb::<Class:<root>>#<static-init>_17" [
+        shape = rectangle;
         color = red;
         label = "block[id=17, rubyBlockId=0](<self>: T.class_of(<root>), x: Integer(0))\louterLoops: 1\l<statTemp>$32 = 2\l<statTemp>$30 = <self>.puts(<statTemp>$32)\lx = 1\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_17" -> "bb::<Class:<root>>#<static-init>_14" [style="bold"];
     "bb::<Class:<root>>#<static-init>_18" [
+        shape = rectangle;
         color = black;
         label = "block[id=18, rubyBlockId=0](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0))\louterLoops: 1\l<statTemp>$36: TrueClass = true\l<whileTemp>$35: FalseClass = <statTemp>$36: TrueClass.!()\l<whileTemp>$35: FalseClass\l"
     ];
@@ -96,12 +107,14 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_18" -> "bb::<Class:<root>>#<static-init>_20" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_20" [
+        shape = rectangle;
         color = black;
         label = "block[id=20, rubyBlockId=0](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0))\l<statTemp>$41: NilClass = <self>: T.class_of(<root>).puts(x: Integer(0), y: Integer(0))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_20" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_21" [
+        shape = rectangle;
         color = red;
         label = "block[id=21, rubyBlockId=0](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0))\louterLoops: 1\l<statTemp>$40 = 2\l<statTemp>$38 = <self>.puts(<statTemp>$40)\ly = 1\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/examples.rb.cfg.exp
+++ b/test/testdata/cfg/examples.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "examples.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(Examples) = alias <C Examples>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(Examples))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(Examples) = alias <C Examples>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(Examples))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,10 +22,9 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::Examples#i_like_ifs" {
     label = "::Examples#i_like_ifs";
     color = blue;
-    "bb::Examples#i_like_ifs_0" [shape = invhouse];
-    "bb::Examples#i_like_ifs_1" [shape = parallelogram];
 
     "bb::Examples#i_like_ifs_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Examples = cast(<self>: NilClass, Examples);\l<ifTemp>$3: TrueClass = true\l<ifTemp>$3: TrueClass\l"
     ];
@@ -34,18 +33,21 @@ subgraph "cluster_::Examples#i_like_ifs" {
     "bb::Examples#i_like_ifs_0" -> "bb::Examples#i_like_ifs_3" [style="tapered"];
 
     "bb::Examples#i_like_ifs_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<returnMethodTemp>$2)\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::Examples#i_like_ifs_1" -> "bb::Examples#i_like_ifs_1" [style="bold"];
     "bb::Examples#i_like_ifs_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\l<returnTemp>$4: Integer(1) = 1\l<returnMethodTemp>$2: T.noreturn = return <returnTemp>$4: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::Examples#i_like_ifs_2" -> "bb::Examples#i_like_ifs_1" [style="bold"];
     "bb::Examples#i_like_ifs_3" [
+        shape = rectangle;
         color = red;
         label = "block[id=3, rubyBlockId=0]()\l<returnTemp>$5 = 2\l<returnMethodTemp>$2 = return <returnTemp>$5\l<unconditional>\l"
     ];
@@ -56,10 +58,9 @@ subgraph "cluster_::Examples#i_like_ifs" {
 subgraph "cluster_::Examples#i_like_exps" {
     label = "::Examples#i_like_exps";
     color = blue;
-    "bb::Examples#i_like_exps_0" [shape = invhouse];
-    "bb::Examples#i_like_exps_1" [shape = parallelogram];
 
     "bb::Examples#i_like_exps_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Examples = cast(<self>: NilClass, Examples);\l<ifTemp>$3: TrueClass = true\l<ifTemp>$3: TrueClass\l"
     ];
@@ -68,24 +69,28 @@ subgraph "cluster_::Examples#i_like_exps" {
     "bb::Examples#i_like_exps_0" -> "bb::Examples#i_like_exps_3" [style="tapered"];
 
     "bb::Examples#i_like_exps_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Examples#i_like_exps_1" -> "bb::Examples#i_like_exps_1" [style="bold"];
     "bb::Examples#i_like_exps_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\l<returnMethodTemp>$2: Integer(1) = 1\l<unconditional>\l"
     ];
 
     "bb::Examples#i_like_exps_2" -> "bb::Examples#i_like_exps_4" [style="bold"];
     "bb::Examples#i_like_exps_3" [
+        shape = rectangle;
         color = red;
         label = "block[id=3, rubyBlockId=0]()\l<returnMethodTemp>$2 = 2\l<unconditional>\l"
     ];
 
     "bb::Examples#i_like_exps_3" -> "bb::Examples#i_like_exps_4" [style="bold"];
     "bb::Examples#i_like_exps_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](<returnMethodTemp>$2: Integer(1))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)\l<unconditional>\l"
     ];
@@ -96,10 +101,9 @@ subgraph "cluster_::Examples#i_like_exps" {
 subgraph "cluster_::Examples#return_in_one_branch1" {
     label = "::Examples#return_in_one_branch1";
     color = blue;
-    "bb::Examples#return_in_one_branch1_0" [shape = invhouse];
-    "bb::Examples#return_in_one_branch1_1" [shape = parallelogram];
 
     "bb::Examples#return_in_one_branch1_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Examples = cast(<self>: NilClass, Examples);\l<ifTemp>$3: TrueClass = true\l<ifTemp>$3: TrueClass\l"
     ];
@@ -108,18 +112,21 @@ subgraph "cluster_::Examples#return_in_one_branch1" {
     "bb::Examples#return_in_one_branch1_0" -> "bb::Examples#return_in_one_branch1_3" [style="tapered"];
 
     "bb::Examples#return_in_one_branch1_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Examples#return_in_one_branch1_1" -> "bb::Examples#return_in_one_branch1_1" [style="bold"];
     "bb::Examples#return_in_one_branch1_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\l<returnTemp>$4: Integer(1) = 1\l<returnMethodTemp>$2: T.noreturn = return <returnTemp>$4: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::Examples#return_in_one_branch1_2" -> "bb::Examples#return_in_one_branch1_1" [style="bold"];
     "bb::Examples#return_in_one_branch1_3" [
+        shape = rectangle;
         color = red;
         label = "block[id=3, rubyBlockId=0]()\l<returnMethodTemp>$2 = 2\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
@@ -130,10 +137,9 @@ subgraph "cluster_::Examples#return_in_one_branch1" {
 subgraph "cluster_::Examples#return_in_one_branch2" {
     label = "::Examples#return_in_one_branch2";
     color = blue;
-    "bb::Examples#return_in_one_branch2_0" [shape = invhouse];
-    "bb::Examples#return_in_one_branch2_1" [shape = parallelogram];
 
     "bb::Examples#return_in_one_branch2_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Examples = cast(<self>: NilClass, Examples);\l<ifTemp>$3: TrueClass = true\l<ifTemp>$3: TrueClass\l"
     ];
@@ -142,18 +148,21 @@ subgraph "cluster_::Examples#return_in_one_branch2" {
     "bb::Examples#return_in_one_branch2_0" -> "bb::Examples#return_in_one_branch2_3" [style="tapered"];
 
     "bb::Examples#return_in_one_branch2_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Examples#return_in_one_branch2_1" -> "bb::Examples#return_in_one_branch2_1" [style="bold"];
     "bb::Examples#return_in_one_branch2_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\l<returnMethodTemp>$2: Integer(1) = 1\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::Examples#return_in_one_branch2_2" -> "bb::Examples#return_in_one_branch2_1" [style="bold"];
     "bb::Examples#return_in_one_branch2_3" [
+        shape = rectangle;
         color = red;
         label = "block[id=3, rubyBlockId=0]()\l<returnTemp>$4 = 2\l<returnMethodTemp>$2 = return <returnTemp>$4\l<unconditional>\l"
     ];
@@ -164,10 +173,9 @@ subgraph "cluster_::Examples#return_in_one_branch2" {
 subgraph "cluster_::Examples#variables" {
     label = "::Examples#variables";
     color = blue;
-    "bb::Examples#variables_0" [shape = invhouse];
-    "bb::Examples#variables_1" [shape = parallelogram];
 
     "bb::Examples#variables_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Examples = cast(<self>: NilClass, Examples);\l<ifTemp>$4: TrueClass = true\l<ifTemp>$4: TrueClass\l"
     ];
@@ -176,24 +184,28 @@ subgraph "cluster_::Examples#variables" {
     "bb::Examples#variables_0" -> "bb::Examples#variables_3" [style="tapered"];
 
     "bb::Examples#variables_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_1" -> "bb::Examples#variables_1" [style="bold"];
     "bb::Examples#variables_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\la: Integer(1) = 1\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_2" -> "bb::Examples#variables_4" [style="bold"];
     "bb::Examples#variables_3" [
+        shape = rectangle;
         color = red;
         label = "block[id=3, rubyBlockId=0]()\la = 2\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_3" -> "bb::Examples#variables_4" [style="bold"];
     "bb::Examples#variables_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](a: Integer(1))\l<ifTemp>$6: FalseClass = false\l<ifTemp>$6: FalseClass\l"
     ];
@@ -202,18 +214,21 @@ subgraph "cluster_::Examples#variables" {
     "bb::Examples#variables_4" -> "bb::Examples#variables_6" [style="tapered"];
 
     "bb::Examples#variables_5" [
+        shape = rectangle;
         color = red;
         label = "block[id=5, rubyBlockId=0](a: Integer(1))\lb = 1\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_5" -> "bb::Examples#variables_7" [style="bold"];
     "bb::Examples#variables_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=0](a: Integer(1))\lb: Integer(2) = 2\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_6" -> "bb::Examples#variables_7" [style="bold"];
     "bb::Examples#variables_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](a: Integer(1), b: Integer(2))\l<returnMethodTemp>$2: Integer = a: Integer(1).+(b: Integer(2))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
     ];
@@ -224,10 +239,9 @@ subgraph "cluster_::Examples#variables" {
 subgraph "cluster_::Examples#variables_and_loop" {
     label = "::Examples#variables_and_loop";
     color = blue;
-    "bb::Examples#variables_and_loop_0" [shape = invhouse];
-    "bb::Examples#variables_and_loop_1" [shape = parallelogram];
 
     "bb::Examples#variables_and_loop_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Examples = cast(<self>: NilClass, Examples);\lcond: T.untyped = load_arg(cond)\l<ifTemp>$4: TrueClass = true\l<ifTemp>$4: TrueClass\l"
     ];
@@ -236,24 +250,28 @@ subgraph "cluster_::Examples#variables_and_loop" {
     "bb::Examples#variables_and_loop_0" -> "bb::Examples#variables_and_loop_3" [style="tapered"];
 
     "bb::Examples#variables_and_loop_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_and_loop_1" -> "bb::Examples#variables_and_loop_1" [style="bold"];
     "bb::Examples#variables_and_loop_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](cond: T.untyped)\la: Integer(1) = 1\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_and_loop_2" -> "bb::Examples#variables_and_loop_5" [style="bold"];
     "bb::Examples#variables_and_loop_3" [
+        shape = rectangle;
         color = red;
         label = "block[id=3, rubyBlockId=0](cond: T.untyped)\la = 2\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_and_loop_3" -> "bb::Examples#variables_and_loop_5" [style="bold"];
     "bb::Examples#variables_and_loop_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0](cond: T.untyped, b: NilClass)\louterLoops: 1\l<whileTemp>$6: TrueClass = true\l<whileTemp>$6: TrueClass\l"
     ];
@@ -262,12 +280,14 @@ subgraph "cluster_::Examples#variables_and_loop" {
     "bb::Examples#variables_and_loop_5" -> "bb::Examples#variables_and_loop_7" [style="tapered"];
 
     "bb::Examples#variables_and_loop_7" [
+        shape = rectangle;
         color = red;
         label = "block[id=7, rubyBlockId=0](b: NilClass)\l<returnMethodTemp>$2 = b\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_and_loop_7" -> "bb::Examples#variables_and_loop_1" [style="bold"];
     "bb::Examples#variables_and_loop_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=0](cond: T.untyped, b: NilClass)\louterLoops: 1\lcond: T.untyped\l"
     ];
@@ -276,12 +296,14 @@ subgraph "cluster_::Examples#variables_and_loop" {
     "bb::Examples#variables_and_loop_8" -> "bb::Examples#variables_and_loop_10" [style="tapered"];
 
     "bb::Examples#variables_and_loop_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](cond: T.untyped, b: NilClass)\louterLoops: 1\lb: T.untyped = 1\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_and_loop_9" -> "bb::Examples#variables_and_loop_5" [style="bold"];
     "bb::Examples#variables_and_loop_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=0](cond: T.nilable(FalseClass), b: NilClass)\louterLoops: 1\lb: T.untyped = 2\l<unconditional>\l"
     ];
@@ -292,22 +314,23 @@ subgraph "cluster_::Examples#variables_and_loop" {
 subgraph "cluster_::Examples#variables_loop_if" {
     label = "::Examples#variables_loop_if";
     color = blue;
-    "bb::Examples#variables_loop_if_0" [shape = invhouse];
-    "bb::Examples#variables_loop_if_1" [shape = parallelogram];
 
     "bb::Examples#variables_loop_if_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Examples = cast(<self>: NilClass, Examples);\lcond: T.untyped = load_arg(cond)\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_loop_if_0" -> "bb::Examples#variables_loop_if_2" [style="bold"];
     "bb::Examples#variables_loop_if_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_loop_if_1" -> "bb::Examples#variables_loop_if_1" [style="bold"];
     "bb::Examples#variables_loop_if_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](cond: T.untyped, b: NilClass)\louterLoops: 1\l<whileTemp>$4: TrueClass = true\l<whileTemp>$4: TrueClass\l"
     ];
@@ -316,12 +339,14 @@ subgraph "cluster_::Examples#variables_loop_if" {
     "bb::Examples#variables_loop_if_2" -> "bb::Examples#variables_loop_if_4" [style="tapered"];
 
     "bb::Examples#variables_loop_if_4" [
+        shape = rectangle;
         color = red;
         label = "block[id=4, rubyBlockId=0](b: NilClass)\l<returnMethodTemp>$2 = b\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_loop_if_4" -> "bb::Examples#variables_loop_if_1" [style="bold"];
     "bb::Examples#variables_loop_if_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0](cond: T.untyped, b: NilClass)\louterLoops: 1\lcond: T.untyped\l"
     ];
@@ -330,12 +355,14 @@ subgraph "cluster_::Examples#variables_loop_if" {
     "bb::Examples#variables_loop_if_5" -> "bb::Examples#variables_loop_if_7" [style="tapered"];
 
     "bb::Examples#variables_loop_if_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=0](cond: T.untyped, b: NilClass)\louterLoops: 1\lb: T.untyped = 1\l<unconditional>\l"
     ];
 
     "bb::Examples#variables_loop_if_6" -> "bb::Examples#variables_loop_if_2" [style="bold"];
     "bb::Examples#variables_loop_if_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](cond: T.nilable(FalseClass), b: NilClass)\louterLoops: 1\lb: T.untyped = 2\l<unconditional>\l"
     ];
@@ -346,10 +373,9 @@ subgraph "cluster_::Examples#variables_loop_if" {
 subgraph "cluster_::Examples#take_arguments" {
     label = "::Examples#take_arguments";
     color = blue;
-    "bb::Examples#take_arguments_0" [shape = invhouse];
-    "bb::Examples#take_arguments_1" [shape = parallelogram];
 
     "bb::Examples#take_arguments_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Examples = cast(<self>: NilClass, Examples);\li: T.untyped = load_arg(i)\l<ifTemp>$3: FalseClass = false\l<ifTemp>$3: FalseClass\l"
     ];
@@ -358,24 +384,28 @@ subgraph "cluster_::Examples#take_arguments" {
     "bb::Examples#take_arguments_0" -> "bb::Examples#take_arguments_3" [style="tapered"];
 
     "bb::Examples#take_arguments_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Examples#take_arguments_1" -> "bb::Examples#take_arguments_1" [style="bold"];
     "bb::Examples#take_arguments_2" [
+        shape = rectangle;
         color = red;
         label = "block[id=2, rubyBlockId=0]()\l<returnMethodTemp>$2 = 2\l<unconditional>\l"
     ];
 
     "bb::Examples#take_arguments_2" -> "bb::Examples#take_arguments_4" [style="bold"];
     "bb::Examples#take_arguments_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](i: T.untyped)\l<returnMethodTemp>$2: T.untyped = i\l<unconditional>\l"
     ];
 
     "bb::Examples#take_arguments_3" -> "bb::Examples#take_arguments_4" [style="bold"];
     "bb::Examples#take_arguments_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -386,16 +416,16 @@ subgraph "cluster_::Examples#take_arguments" {
 subgraph "cluster_::<Class:Examples>#<static-init>" {
     label = "::<Class:Examples>#<static-init>";
     color = blue;
-    "bb::<Class:Examples>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Examples>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Examples>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Examples) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Examples>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Examples>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:i_like_ifs) = :i_like_ifs\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:i_like_ifs) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Examples), <statTemp>$7: Symbol(:i_like_ifs), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:i_like_exps) = :i_like_exps\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:i_like_exps) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Examples), <statTemp>$13: Symbol(:i_like_exps), <statTemp>$14: Symbol(:normal))\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$19: Symbol(:return_in_one_branch1) = :return_in_one_branch1\l<statTemp>$20: Symbol(:normal) = :normal\l<statTemp>$15: Symbol(:return_in_one_branch1) = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Examples), <statTemp>$19: Symbol(:return_in_one_branch1), <statTemp>$20: Symbol(:normal))\l<cfgAlias>$23: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$25: Symbol(:return_in_one_branch2) = :return_in_one_branch2\l<statTemp>$26: Symbol(:normal) = :normal\l<statTemp>$21: Symbol(:return_in_one_branch2) = <cfgAlias>$23: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Examples), <statTemp>$25: Symbol(:return_in_one_branch2), <statTemp>$26: Symbol(:normal))\l<cfgAlias>$29: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$31: Symbol(:variables) = :variables\l<statTemp>$32: Symbol(:normal) = :normal\l<statTemp>$27: Symbol(:variables) = <cfgAlias>$29: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Examples), <statTemp>$31: Symbol(:variables), <statTemp>$32: Symbol(:normal))\l<cfgAlias>$35: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$37: Symbol(:variables_and_loop) = :variables_and_loop\l<statTemp>$38: Symbol(:normal) = :normal\l<statTemp>$33: Symbol(:variables_and_loop) = <cfgAlias>$35: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Examples), <statTemp>$37: Symbol(:variables_and_loop), <statTemp>$38: Symbol(:normal))\l<cfgAlias>$41: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$43: Symbol(:variables_loop_if) = :variables_loop_if\l<statTemp>$44: Symbol(:normal) = :normal\l<statTemp>$39: Symbol(:variables_loop_if) = <cfgAlias>$41: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Examples), <statTemp>$43: Symbol(:variables_loop_if), <statTemp>$44: Symbol(:normal))\l<cfgAlias>$47: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$49: Symbol(:take_arguments) = :take_arguments\l<statTemp>$50: Symbol(:normal) = :normal\l<statTemp>$45: Symbol(:take_arguments) = <cfgAlias>$47: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Examples), <statTemp>$49: Symbol(:take_arguments), <statTemp>$50: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Examples>#<static-init>_0" -> "bb::<Class:Examples>#<static-init>_1" [style="bold"];
     "bb::<Class:Examples>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/extra_bb_args.rb.cfg.exp
+++ b/test/testdata/cfg/extra_bb_args.rb.cfg.exp
@@ -2,10 +2,9 @@ digraph "extra_bb_args.rb" {
 subgraph "cluster_::Object#main" {
     label = "::Object#main";
     color = blue;
-    "bb::Object#main_0" [shape = invhouse];
-    "bb::Object#main_1" [shape = parallelogram];
 
     "bb::Object#main_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$9: T.class_of(T) = alias <C T>\l<cfgAlias>$11: T.class_of(String) = alias <C String>\l<statTemp>$7: <Type: T.nilable(String)> = <cfgAlias>$9: T.class_of(T).nilable(<cfgAlias>$11: T.class_of(String))\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$7: <Type: T.nilable(String)>)\l<castTemp>$12: NilClass = nil\lname: T.nilable(String) = cast(<castTemp>$12: NilClass, String | NilClass);\l<ifTemp>$14: T::Boolean = name: T.nilable(String).nil?()\l<ifTemp>$14: T::Boolean\l"
     ];
@@ -14,18 +13,21 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_0" -> "bb::Object#main_3" [style="tapered"];
 
     "bb::Object#main_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#main_1" -> "bb::Object#main_1" [style="bold"];
     "bb::Object#main_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\l<returnTemp>$16: String(\"missing name\") = \"missing name\"\l<statTemp>$13: T.noreturn = return <returnTemp>$16: String(\"missing name\")\l<unconditional>\l"
     ];
 
     "bb::Object#main_2" -> "bb::Object#main_1" [style="bold"];
     "bb::Object#main_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](name: String)\l<statTemp>$18: String(\"foo\") = \"foo\"\l<returnMethodTemp>$2: T::Boolean = name: String.include?(<statTemp>$18: String(\"foo\"))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Boolean\l<unconditional>\l"
     ];
@@ -36,16 +38,16 @@ subgraph "cluster_::Object#main" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:main) = :main\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:main) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$6: Symbol(:main), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:main)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/floats.rb.cfg.exp
+++ b/test/testdata/cfg/floats.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "floats.rb" {
 subgraph "cluster_::Object#test_large_float" {
     label = "::Object#test_large_float";
     color = blue;
-    "bb::Object#test_large_float_0" [shape = invhouse];
-    "bb::Object#test_large_float_1" [shape = parallelogram];
 
     "bb::Object#test_large_float_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\la: Float(3.141593) = 3.141593\la: Float(0.000001) = 0.000001\la: Float(-0.000001) = -0.000001\la: Float(10.000000) = 10.000000\la: Float(0.000000) = 0.000000\la: Float(17976931348623157580412819756850388593900235011794141176754562789180111453639664485361928830517704263393537268510363518759043843737070229269956251768752166883397940628862983287625967246810352023792017211936260189893797509826303293149283469713429932049693599732425511693654044437030940398714664210204414967808.000000) = 17976931348623157580412819756850388593900235011794141176754562789180111453639664485361928830517704263393537268510363518759043843737070229269956251768752166883397940628862983287625967246810352023792017211936260189893797509826303293149283469713429932049693599732425511693654044437030940398714664210204414967808.000000\la: Float(-0.000000) = -0.000000\la: Float(-17976931348623157580412819756850388593900235011794141176754562789180111453639664485361928830517704263393537268510363518759043843737070229269956251768752166883397940628862983287625967246810352023792017211936260189893797509826303293149283469713429932049693599732425511693654044437030940398714664210204414967808.000000) = -17976931348623157580412819756850388593900235011794141176754562789180111453639664485361928830517704263393537268510363518759043843737070229269956251768752166883397940628862983287625967246810352023792017211936260189893797509826303293149283469713429932049693599732425511693654044437030940398714664210204414967808.000000\la: Float(0.000000) = 0.000000\la: Float(inf) = inf\la: Float(-0.000000) = -0.000000\la: Float(-inf) = -inf\l<returnMethodTemp>$2: Float(-inf) = a\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Float(-inf)\l<unconditional>\l"
     ];
 
     "bb::Object#test_large_float_0" -> "bb::Object#test_large_float_1" [style="bold"];
     "bb::Object#test_large_float_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::Object#test_large_float" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:test_large_float) = :test_large_float\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:test_large_float) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$6: Symbol(:test_large_float), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:test_large_float)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/hash.rb.cfg.exp
+++ b/test/testdata/cfg/hash.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "hash.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(TestHash) = alias <C TestHash>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(TestHash))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(TestHash) = alias <C TestHash>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(TestHash))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::TestHash#something" {
     label = "::TestHash#something";
     color = blue;
-    "bb::TestHash#something_0" [shape = invhouse];
-    "bb::TestHash#something_1" [shape = parallelogram];
 
     "bb::TestHash#something_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestHash = cast(<self>: NilClass, TestHash);\l<returnMethodTemp>$2: Integer(17) = 17\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(17)\l<unconditional>\l"
     ];
 
     "bb::TestHash#something_0" -> "bb::TestHash#something_1" [style="bold"];
     "bb::TestHash#something_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::TestHash#something" {
 subgraph "cluster_::TestHash#test" {
     label = "::TestHash#test";
     color = blue;
-    "bb::TestHash#test_0" [shape = invhouse];
-    "bb::TestHash#test_1" [shape = parallelogram];
 
     "bb::TestHash#test_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestHash = cast(<self>: NilClass, TestHash);\l<hashTemp>$3: T.untyped = <self>: TestHash.something()\l<hashTemp>$4: Symbol(:bar) = :bar\l<statTemp>$8: Integer(1) = 1\l<statTemp>$9: Integer(2) = 2\l<hashTemp>$6: Integer = <statTemp>$8: Integer(1).+(<statTemp>$9: Integer(2))\l<hashTemp>$7: Integer(2) = 2\l<magic>$10: T.class_of(<Magic>) = alias <C <Magic>>\l<returnMethodTemp>$2: T::Hash[T.untyped, T.untyped] = <magic>$10: T.class_of(<Magic>).<build-hash>(<hashTemp>$3: T.untyped, <hashTemp>$4: Symbol(:bar), <hashTemp>$6: Integer, <hashTemp>$7: Integer(2))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Hash[T.untyped, T.untyped]\l<unconditional>\l"
     ];
 
     "bb::TestHash#test_0" -> "bb::TestHash#test_1" [style="bold"];
     "bb::TestHash#test_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::TestHash#test" {
 subgraph "cluster_::TestHash#test_shaped" {
     label = "::TestHash#test_shaped";
     color = blue;
-    "bb::TestHash#test_shaped_0" [shape = invhouse];
-    "bb::TestHash#test_shaped_1" [shape = parallelogram];
 
     "bb::TestHash#test_shaped_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestHash = cast(<self>: NilClass, TestHash);\l<hashTemp>$3: Integer(1) = 1\l<hashTemp>$4: Integer(2) = 2\l<hashTemp>$5: Integer(2) = 2\l<hashTemp>$6: Integer(3) = 3\l<hashTemp>$7: Symbol(:foo) = :foo\l<hashTemp>$8: Symbol(:bar) = :bar\l<hashTemp>$9: Symbol(:baz) = :baz\l<hashTemp>$10: T.untyped = <self>: TestHash.something()\l<magic>$12: T.class_of(<Magic>) = alias <C <Magic>>\l<returnMethodTemp>$2: {Integer(1) => Integer(2), Integer(2) => Integer(3), foo: Symbol(:bar), baz: T.untyped} = <magic>$12: T.class_of(<Magic>).<build-hash>(<hashTemp>$3: Integer(1), <hashTemp>$4: Integer(2), <hashTemp>$5: Integer(2), <hashTemp>$6: Integer(3), <hashTemp>$7: Symbol(:foo), <hashTemp>$8: Symbol(:bar), <hashTemp>$9: Symbol(:baz), <hashTemp>$10: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: {Integer(1) => Integer(2), Integer(2) => Integer(3), foo: Symbol(:bar), baz: T.untyped}\l<unconditional>\l"
     ];
 
     "bb::TestHash#test_shaped_0" -> "bb::TestHash#test_shaped_1" [style="bold"];
     "bb::TestHash#test_shaped_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,16 +82,16 @@ subgraph "cluster_::TestHash#test_shaped" {
 subgraph "cluster_::<Class:TestHash>#<static-init>" {
     label = "::<Class:TestHash>#<static-init>";
     color = blue;
-    "bb::<Class:TestHash>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:TestHash>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:TestHash>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(TestHash) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U TestHash>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U TestHash>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:something) = :something\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:something) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestHash), <statTemp>$7: Symbol(:something), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:test) = :test\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:test) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestHash), <statTemp>$13: Symbol(:test), <statTemp>$14: Symbol(:normal))\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$19: Symbol(:test_shaped) = :test_shaped\l<statTemp>$20: Symbol(:normal) = :normal\l<statTemp>$15: Symbol(:test_shaped) = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestHash), <statTemp>$19: Symbol(:test_shaped), <statTemp>$20: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:TestHash>#<static-init>_0" -> "bb::<Class:TestHash>#<static-init>_1" [style="bold"];
     "bb::<Class:TestHash>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/ivar_assign.rb.cfg.exp
+++ b/test/testdata/cfg/ivar_assign.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "ivar_assign.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(TestIVar) = alias <C TestIVar>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(TestIVar))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(TestIVar) = alias <C TestIVar>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(TestIVar))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::TestIVar#initialize" {
     label = "::TestIVar#initialize";
     color = blue;
-    "bb::TestIVar#initialize_0" [shape = invhouse];
-    "bb::TestIVar#initialize_1" [shape = parallelogram];
 
     "bb::TestIVar#initialize_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l@foo$3: Integer = alias @foo\l<self>: TestIVar = cast(<self>: NilClass, TestIVar);\l<cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$8: T.class_of(Integer) = alias <C Integer>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$8: T.class_of(Integer))\l<castTemp>$9: Integer(0) = 0\l@foo$3: Integer = cast(<castTemp>$9: Integer(0), Integer);\l<returnMethodTemp>$2: Integer = @foo$3\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
     ];
 
     "bb::TestIVar#initialize_0" -> "bb::TestIVar#initialize_1" [style="bold"];
     "bb::TestIVar#initialize_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::TestIVar#initialize" {
 subgraph "cluster_::TestIVar#test" {
     label = "::TestIVar#test";
     color = blue;
-    "bb::TestIVar#test_0" [shape = invhouse];
-    "bb::TestIVar#test_1" [shape = parallelogram];
 
     "bb::TestIVar#test_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l@foo$3: Integer = alias @foo\l<self>: TestIVar = cast(<self>: NilClass, TestIVar);\l@foo$3: Integer = nil\l<returnMethodTemp>$2: Integer = @foo$3\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
     ];
 
     "bb::TestIVar#test_0" -> "bb::TestIVar#test_1" [style="bold"];
     "bb::TestIVar#test_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::TestIVar#test" {
 subgraph "cluster_::<Class:TestIVar>#<static-init>" {
     label = "::<Class:TestIVar>#<static-init>";
     color = blue;
-    "bb::<Class:TestIVar>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:TestIVar>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:TestIVar>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(TestIVar) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U TestIVar>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U TestIVar>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:initialize) = :initialize\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:initialize) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestIVar), <statTemp>$7: Symbol(:initialize), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:test) = :test\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:test) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestIVar), <statTemp>$13: Symbol(:test), <statTemp>$14: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:TestIVar>#<static-init>_0" -> "bb::<Class:TestIVar>#<static-init>_1" [style="bold"];
     "bb::<Class:TestIVar>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/next.rb.cfg.exp
+++ b/test/testdata/cfg/next.rb.cfg.exp
@@ -2,22 +2,23 @@ digraph "next.rb" {
 subgraph "cluster_::Object#foo" {
     label = "::Object#foo";
     color = blue;
-    "bb::Object#foo_0" [shape = invhouse];
-    "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<arrayTemp>$4: Integer(1) = 1\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$3: [Integer(1)] = <magic>$5: T.class_of(<Magic>).<build-array>(<arrayTemp>$4: Integer(1))\l<block-pre-call-temp>$6: Sorbet::Private::Static::Void = <statTemp>$3: [Integer(1)].map()\l<selfRestore>$7: Object = <self>\l<unconditional>\l"
     ];
 
     "bb::Object#foo_0" -> "bb::Object#foo_2" [style="bold"];
     "bb::Object#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<self>)\l<statTemp>$16 = <self>\l<blockReturnTemp>$10 = <statTemp>$16.bad()\l<unconditional>\l"
     ];
 
     "bb::Object#foo_1" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -26,12 +27,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_2" -> "bb::Object#foo_3" [style="tapered"];
 
     "bb::Object#foo_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object)\l<returnMethodTemp>$2: T::Array[Integer] = Solve<<block-pre-call-temp>$6, map>\l<self>: Object = <selfRestore>$7\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Array[Integer]\l<unconditional>\l"
     ];
 
     "bb::Object#foo_3" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object)\louterLoops: 1\l<self>: Object = loadSelf\l<blk>$8: [Integer] = load_yield_params(map)\l<blk>$9: Integer(0) = 0\lx$1: Integer = <blk>$8: [Integer].[](<blk>$9: Integer(0))\l<statTemp>$11: T.untyped = <self>: Object.good()\l<nextTemp>$14: Integer = x$1\l<nextTemp>$15: T.noreturn = blockreturn<map> <nextTemp>$14: Integer\l<unconditional>\l"
     ];
@@ -42,16 +45,16 @@ subgraph "cluster_::Object#foo" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:foo) = :foo\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:foo) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$6: Symbol(:foo), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/next_in_junk.rb.cfg.exp
+++ b/test/testdata/cfg/next_in_junk.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "next_in_junk.rb" {
 subgraph "cluster_::Object#foo" {
     label = "::Object#foo";
     color = blue;
-    "bb::Object#foo_0" [shape = invhouse];
-    "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<unconditional>\l"
     ];
 
     "bb::Object#foo_0" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::Object#foo" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:foo) = :foo\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:foo) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$6: Symbol(:foo), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/next_in_while.rb.cfg.exp
+++ b/test/testdata/cfg/next_in_while.rb.cfg.exp
@@ -2,22 +2,23 @@ digraph "next_in_while.rb" {
 subgraph "cluster_::Object#foo" {
     label = "::Object#foo";
     color = blue;
-    "bb::Object#foo_0" [shape = invhouse];
-    "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<unconditional>\l"
     ];
 
     "bb::Object#foo_0" -> "bb::Object#foo_2" [style="bold"];
     "bb::Object#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<self>)\l<statTemp>$10 = <self>\l<statTemp>$4 = <statTemp>$10.bad()\l<unconditional>\l"
     ];
 
     "bb::Object#foo_1" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](<self>: Object)\louterLoops: 1\l<whileTemp>$3: TrueClass = true\l<whileTemp>$3: TrueClass\l"
     ];
@@ -26,12 +27,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_2" -> "bb::Object#foo_3" [style="tapered"];
 
     "bb::Object#foo_3" [
+        shape = rectangle;
         color = red;
         label = "block[id=3, rubyBlockId=0]()\l<returnMethodTemp>$2 = nil\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::Object#foo_3" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0](<self>: Object)\louterLoops: 1\l<statTemp>$5: T.untyped = <self>: Object.good()\l<nextTemp>$8: T.untyped = <self>: Object.value()\l<unconditional>\l"
     ];
@@ -42,16 +45,16 @@ subgraph "cluster_::Object#foo" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:foo) = :foo\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:foo) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$6: Symbol(:foo), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/raw_test.rb.cfg-raw.exp
+++ b/test/testdata/cfg/raw_test.rb.cfg-raw.exp
@@ -5,16 +5,16 @@ digraph "raw_test.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = box];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0]()\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <self>>,\l&nbsp;&nbsp;type = T.class_of(<root>),\l&nbsp;},\l&nbsp;value = Cast {\l&nbsp;&nbsp;cast = T.cast,\l&nbsp;&nbsp;value = VariableUseSite {\l&nbsp;&nbsp;&nbsp;variable = <U <self>>,\l&nbsp;&nbsp;&nbsp;type = NilClass,\l&nbsp;&nbsp;},\l&nbsp;&nbsp;type = T.class_of(<root>),\l&nbsp;},\l}\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <statTemp>>$4,\l&nbsp;&nbsp;type = Integer(0),\l&nbsp;},\l&nbsp;value = Literal { value = Integer(0) },\l}\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <returnMethodTemp>>$2,\l&nbsp;&nbsp;type = NilClass,\l&nbsp;},\l&nbsp;value = Send {\l&nbsp;&nbsp;recv = <self>: T.class_of(<root>),\l&nbsp;&nbsp;fun = <U puts>,\l&nbsp;&nbsp;args = (VariableUseSite {\l&nbsp;&nbsp;&nbsp;variable = <U <statTemp>>$4,\l&nbsp;&nbsp;&nbsp;type = Integer(0),\l&nbsp;&nbsp;}),\l&nbsp;},\l}\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <finalReturn>>,\l&nbsp;&nbsp;type = T.noreturn,\l&nbsp;},\l&nbsp;value = Return {\l&nbsp;&nbsp;what = VariableUseSite {\l&nbsp;&nbsp;&nbsp;variable = <U <returnMethodTemp>>$2,\l&nbsp;&nbsp;&nbsp;type = NilClass,\l&nbsp;&nbsp;},\l&nbsp;},\l}\lVariableUseSite { variable = <U <unconditional>> }\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1]()\lVariableUseSite { variable = <U <unconditional>> }\l"
     ];

--- a/test/testdata/cfg/reassign_dead_block_bug.rb.cfg.exp
+++ b/test/testdata/cfg/reassign_dead_block_bug.rb.cfg.exp
@@ -2,22 +2,23 @@ digraph "reassign_dead_block_bug.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<statTemp>$3: Integer(2) = 2\l<block-pre-call-temp>$4: Sorbet::Private::Static::Void = <statTemp>$3: Integer(2).times()\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_2" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\lx$1 = 10\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_1" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Private::Static::Void)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -26,12 +27,14 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_2" -> "bb::<Class:<root>>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Private::Static::Void)\l<returnMethodTemp>$2: Integer = Solve<<block-pre-call-temp>$4, times>\l<self>: T.class_of(<root>) = <self>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_3" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(<root>))\louterLoops: 1\l<self>: T.class_of(<root>) = loadSelf\lx$1: Integer(1) = 1\l<returnTemp>$11: Integer(1) = 1\l<statTemp>$10: T.noreturn = return <returnTemp>$11: Integer(1)\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/rescue.rb.cfg.exp
+++ b/test/testdata/cfg/rescue.rb.cfg.exp
@@ -2,10 +2,9 @@ digraph "rescue.rb" {
 subgraph "cluster_::Object#main" {
     label = "::Object#main";
     color = blue;
-    "bb::Object#main_0" [shape = invhouse];
-    "bb::Object#main_1" [shape = parallelogram];
 
     "bb::Object#main_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<magic>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -14,12 +13,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_0" -> "bb::Object#main_4" [style="tapered"];
 
     "bb::Object#main_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#main_1" -> "bb::Object#main_1" [style="bold"];
     "bb::Object#main_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$6: T.class_of(<Magic>))\l<cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$10: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$9: T.class_of(StandardError))\l<isaCheckTemp>$10: T.untyped\l"
     ];
@@ -28,6 +29,7 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_3" -> "bb::Object#main_8" [style="tapered"];
 
     "bb::Object#main_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: Object, <magic>$6: T.class_of(<Magic>))\l<returnMethodTemp>$2: T.untyped = <self>: Object.a()\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -36,12 +38,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_4" -> "bb::Object#main_5" [style="tapered"];
 
     "bb::Object#main_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<self>: Object)\l<returnMethodTemp>$2: T.untyped = <self>: Object.c()\l<unconditional>\l"
     ];
 
     "bb::Object#main_5" -> "bb::Object#main_6" [style="bold"];
     "bb::Object#main_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass))\l<throwAwayTemp>$13: T.untyped = <self>: Object.d()\l<gotoDeadTemp>$12: T.nilable(TrueClass)\l"
     ];
@@ -50,18 +54,21 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_6" -> "bb::Object#main_9" [style="tapered"];
 
     "bb::Object#main_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<self>: Object, <magic>$6: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: Object.b()\l<unconditional>\l"
     ];
 
     "bb::Object#main_7" -> "bb::Object#main_6" [style="bold"];
     "bb::Object#main_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$12: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#main_8" -> "bb::Object#main_6" [style="bold"];
     "bb::Object#main_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -72,16 +79,16 @@ subgraph "cluster_::Object#main" {
 subgraph "cluster_::Object#a" {
     label = "::Object#a";
     color = blue;
-    "bb::Object#a_0" [shape = invhouse];
-    "bb::Object#a_1" [shape = parallelogram];
 
     "bb::Object#a_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Object#a_0" -> "bb::Object#a_1" [style="bold"];
     "bb::Object#a_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -92,16 +99,16 @@ subgraph "cluster_::Object#a" {
 subgraph "cluster_::Object#b" {
     label = "::Object#b";
     color = blue;
-    "bb::Object#b_0" [shape = invhouse];
-    "bb::Object#b_1" [shape = parallelogram];
 
     "bb::Object#b_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Object#b_0" -> "bb::Object#b_1" [style="bold"];
     "bb::Object#b_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -112,16 +119,16 @@ subgraph "cluster_::Object#b" {
 subgraph "cluster_::Object#c" {
     label = "::Object#c";
     color = blue;
-    "bb::Object#c_0" [shape = invhouse];
-    "bb::Object#c_1" [shape = parallelogram];
 
     "bb::Object#c_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Object#c_0" -> "bb::Object#c_1" [style="bold"];
     "bb::Object#c_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -132,16 +139,16 @@ subgraph "cluster_::Object#c" {
 subgraph "cluster_::Object#d" {
     label = "::Object#d";
     color = blue;
-    "bb::Object#d_0" [shape = invhouse];
-    "bb::Object#d_1" [shape = parallelogram];
 
     "bb::Object#d_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Object#d_0" -> "bb::Object#d_1" [style="bold"];
     "bb::Object#d_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -152,16 +159,16 @@ subgraph "cluster_::Object#d" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:main) = :main\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:main) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$7: Symbol(:main), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:a) = :a\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:a) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$13: Symbol(:a), <statTemp>$14: Symbol(:normal))\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$19: Symbol(:b) = :b\l<statTemp>$20: Symbol(:normal) = :normal\l<statTemp>$15: Symbol(:b) = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$19: Symbol(:b), <statTemp>$20: Symbol(:normal))\l<cfgAlias>$23: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$25: Symbol(:c) = :c\l<statTemp>$26: Symbol(:normal) = :normal\l<statTemp>$21: Symbol(:c) = <cfgAlias>$23: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$25: Symbol(:c), <statTemp>$26: Symbol(:normal))\l<cfgAlias>$29: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$31: Symbol(:d) = :d\l<statTemp>$32: Symbol(:normal) = :normal\l<statTemp>$27: Symbol(:d) = <cfgAlias>$29: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$31: Symbol(:d), <statTemp>$32: Symbol(:normal))\l<statTemp>$35: T.untyped = <self>: T.class_of(<root>).foo()\l<statTemp>$33: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$35: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/rescue_complex.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "rescue_complex.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(TestRescue) = alias <C TestRescue>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(TestRescue))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(TestRescue) = alias <C TestRescue>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(TestRescue))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::TestRescue#meth" {
     label = "::TestRescue#meth";
     color = blue;
-    "bb::TestRescue#meth_0" [shape = invhouse];
-    "bb::TestRescue#meth_1" [shape = parallelogram];
 
     "bb::TestRescue#meth_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<returnMethodTemp>$2: Integer(0) = 0\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(0)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#meth_0" -> "bb::TestRescue#meth_1" [style="bold"];
     "bb::TestRescue#meth_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::TestRescue#meth" {
 subgraph "cluster_::TestRescue#foo" {
     label = "::TestRescue#foo";
     color = blue;
-    "bb::TestRescue#foo_0" [shape = invhouse];
-    "bb::TestRescue#foo_1" [shape = parallelogram];
 
     "bb::TestRescue#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<returnMethodTemp>$2: Integer(1) = 1\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#foo_0" -> "bb::TestRescue#foo_1" [style="bold"];
     "bb::TestRescue#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::TestRescue#foo" {
 subgraph "cluster_::TestRescue#bar" {
     label = "::TestRescue#bar";
     color = blue;
-    "bb::TestRescue#bar_0" [shape = invhouse];
-    "bb::TestRescue#bar_1" [shape = parallelogram];
 
     "bb::TestRescue#bar_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<returnMethodTemp>$2: Integer(2) = 2\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(2)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#bar_0" -> "bb::TestRescue#bar_1" [style="bold"];
     "bb::TestRescue#bar_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,16 +82,16 @@ subgraph "cluster_::TestRescue#bar" {
 subgraph "cluster_::TestRescue#baz" {
     label = "::TestRescue#baz";
     color = blue;
-    "bb::TestRescue#baz_0" [shape = invhouse];
-    "bb::TestRescue#baz_1" [shape = parallelogram];
 
     "bb::TestRescue#baz_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<returnMethodTemp>$2: Integer(3) = 3\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#baz_0" -> "bb::TestRescue#baz_1" [style="bold"];
     "bb::TestRescue#baz_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -102,16 +102,16 @@ subgraph "cluster_::TestRescue#baz" {
 subgraph "cluster_::TestRescue#take_arg" {
     label = "::TestRescue#take_arg";
     color = blue;
-    "bb::TestRescue#take_arg_0" [shape = invhouse];
-    "bb::TestRescue#take_arg_1" [shape = parallelogram];
 
     "bb::TestRescue#take_arg_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\lx: T.untyped = load_arg(x)\l<returnMethodTemp>$2: T.untyped = x\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::TestRescue#take_arg_0" -> "bb::TestRescue#take_arg_1" [style="bold"];
     "bb::TestRescue#take_arg_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -122,16 +122,16 @@ subgraph "cluster_::TestRescue#take_arg" {
 subgraph "cluster_::TestRescue#initialize" {
     label = "::TestRescue#initialize";
     color = blue;
-    "bb::TestRescue#initialize_0" [shape = invhouse];
-    "bb::TestRescue#initialize_1" [shape = parallelogram];
 
     "bb::TestRescue#initialize_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l@ex$3: T.nilable(StandardError) = alias @ex\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$9: T.class_of(T) = alias <C T>\l<cfgAlias>$11: T.class_of(StandardError) = alias <C StandardError>\l<statTemp>$7: <Type: T.nilable(StandardError)> = <cfgAlias>$9: T.class_of(T).nilable(<cfgAlias>$11: T.class_of(StandardError))\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$7: <Type: T.nilable(StandardError)>)\l<castTemp>$12: NilClass = nil\l@ex$3: T.nilable(StandardError) = cast(<castTemp>$12: NilClass, StandardError | NilClass);\l<returnMethodTemp>$2: T.nilable(StandardError) = @ex$3\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(StandardError)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#initialize_0" -> "bb::TestRescue#initialize_1" [style="bold"];
     "bb::TestRescue#initialize_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -142,10 +142,9 @@ subgraph "cluster_::TestRescue#initialize" {
 subgraph "cluster_::TestRescue#multiple_rescue" {
     label = "::TestRescue#multiple_rescue";
     color = blue;
-    "bb::TestRescue#multiple_rescue_0" [shape = invhouse];
-    "bb::TestRescue#multiple_rescue_1" [shape = parallelogram];
 
     "bb::TestRescue#multiple_rescue_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -154,12 +153,14 @@ subgraph "cluster_::TestRescue#multiple_rescue" {
     "bb::TestRescue#multiple_rescue_0" -> "bb::TestRescue#multiple_rescue_4" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#multiple_rescue_1" -> "bb::TestRescue#multiple_rescue_1" [style="bold"];
     "bb::TestRescue#multiple_rescue_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>))\l<cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))\l<isaCheckTemp>$9: T.untyped\l"
     ];
@@ -168,6 +169,7 @@ subgraph "cluster_::TestRescue#multiple_rescue" {
     "bb::TestRescue#multiple_rescue_3" -> "bb::TestRescue#multiple_rescue_8" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -176,12 +178,14 @@ subgraph "cluster_::TestRescue#multiple_rescue" {
     "bb::TestRescue#multiple_rescue_4" -> "bb::TestRescue#multiple_rescue_5" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#multiple_rescue_5" -> "bb::TestRescue#multiple_rescue_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass))\l<gotoDeadTemp>$16: T.nilable(TrueClass)\l"
     ];
@@ -190,12 +194,14 @@ subgraph "cluster_::TestRescue#multiple_rescue" {
     "bb::TestRescue#multiple_rescue_6" -> "bb::TestRescue#multiple_rescue_11" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#multiple_rescue_7" -> "bb::TestRescue#multiple_rescue_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>))\l<cfgAlias>$13: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$14: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$13: T.class_of(StandardError))\l<isaCheckTemp>$14: T.untyped\l"
     ];
@@ -204,18 +210,21 @@ subgraph "cluster_::TestRescue#multiple_rescue" {
     "bb::TestRescue#multiple_rescue_8" -> "bb::TestRescue#multiple_rescue_10" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$11: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#multiple_rescue_9" -> "bb::TestRescue#multiple_rescue_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$16: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#multiple_rescue_10" -> "bb::TestRescue#multiple_rescue_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -226,10 +235,9 @@ subgraph "cluster_::TestRescue#multiple_rescue" {
 subgraph "cluster_::TestRescue#multiple_rescue_classes" {
     label = "::TestRescue#multiple_rescue_classes";
     color = blue;
-    "bb::TestRescue#multiple_rescue_classes_0" [shape = invhouse];
-    "bb::TestRescue#multiple_rescue_classes_1" [shape = parallelogram];
 
     "bb::TestRescue#multiple_rescue_classes_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -238,12 +246,14 @@ subgraph "cluster_::TestRescue#multiple_rescue_classes" {
     "bb::TestRescue#multiple_rescue_classes_0" -> "bb::TestRescue#multiple_rescue_classes_4" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_classes_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#multiple_rescue_classes_1" -> "bb::TestRescue#multiple_rescue_classes_1" [style="bold"];
     "bb::TestRescue#multiple_rescue_classes_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>))\lbaz: T.untyped = <exceptionValue>$3\l<cfgAlias>$8: T.untyped = alias <C T.untyped>\l<isaCheckTemp>$9: T.untyped = baz: T.untyped.is_a?(<cfgAlias>$8: T.untyped)\l<isaCheckTemp>$9: T.untyped\l"
     ];
@@ -252,6 +262,7 @@ subgraph "cluster_::TestRescue#multiple_rescue_classes" {
     "bb::TestRescue#multiple_rescue_classes_3" -> "bb::TestRescue#multiple_rescue_classes_8" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_classes_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -260,12 +271,14 @@ subgraph "cluster_::TestRescue#multiple_rescue_classes" {
     "bb::TestRescue#multiple_rescue_classes_4" -> "bb::TestRescue#multiple_rescue_classes_5" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_classes_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#multiple_rescue_classes_5" -> "bb::TestRescue#multiple_rescue_classes_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_classes_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass))\l<gotoDeadTemp>$13: T.nilable(TrueClass)\l"
     ];
@@ -274,12 +287,14 @@ subgraph "cluster_::TestRescue#multiple_rescue_classes" {
     "bb::TestRescue#multiple_rescue_classes_6" -> "bb::TestRescue#multiple_rescue_classes_10" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_classes_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<magic>$5: T.class_of(<Magic>), baz: T.untyped)\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = baz\l<unconditional>\l"
     ];
 
     "bb::TestRescue#multiple_rescue_classes_7" -> "bb::TestRescue#multiple_rescue_classes_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_classes_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped, <magic>$5: T.class_of(<Magic>), baz: T.untyped)\l<cfgAlias>$11: T.untyped = alias <C T.untyped>\l<isaCheckTemp>$12: T.untyped = baz: T.untyped.is_a?(<cfgAlias>$11: T.untyped)\l<isaCheckTemp>$12: T.untyped\l"
     ];
@@ -288,12 +303,14 @@ subgraph "cluster_::TestRescue#multiple_rescue_classes" {
     "bb::TestRescue#multiple_rescue_classes_8" -> "bb::TestRescue#multiple_rescue_classes_9" [style="tapered"];
 
     "bb::TestRescue#multiple_rescue_classes_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$13: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#multiple_rescue_classes_9" -> "bb::TestRescue#multiple_rescue_classes_6" [style="bold"];
     "bb::TestRescue#multiple_rescue_classes_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -304,10 +321,9 @@ subgraph "cluster_::TestRescue#multiple_rescue_classes" {
 subgraph "cluster_::TestRescue#parse_rescue_ensure" {
     label = "::TestRescue#parse_rescue_ensure";
     color = blue;
-    "bb::TestRescue#parse_rescue_ensure_0" [shape = invhouse];
-    "bb::TestRescue#parse_rescue_ensure_1" [shape = parallelogram];
 
     "bb::TestRescue#parse_rescue_ensure_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -316,12 +332,14 @@ subgraph "cluster_::TestRescue#parse_rescue_ensure" {
     "bb::TestRescue#parse_rescue_ensure_0" -> "bb::TestRescue#parse_rescue_ensure_4" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_ensure_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_ensure_1" -> "bb::TestRescue#parse_rescue_ensure_1" [style="bold"];
     "bb::TestRescue#parse_rescue_ensure_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>))\l<cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))\l<isaCheckTemp>$9: T.untyped\l"
     ];
@@ -330,6 +348,7 @@ subgraph "cluster_::TestRescue#parse_rescue_ensure" {
     "bb::TestRescue#parse_rescue_ensure_3" -> "bb::TestRescue#parse_rescue_ensure_8" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_ensure_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -338,12 +357,14 @@ subgraph "cluster_::TestRescue#parse_rescue_ensure" {
     "bb::TestRescue#parse_rescue_ensure_4" -> "bb::TestRescue#parse_rescue_ensure_5" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_ensure_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<self>: TestRescue, <returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_ensure_5" -> "bb::TestRescue#parse_rescue_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_ensure_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass))\l<throwAwayTemp>$12: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$11: T.nilable(TrueClass)\l"
     ];
@@ -352,18 +373,21 @@ subgraph "cluster_::TestRescue#parse_rescue_ensure" {
     "bb::TestRescue#parse_rescue_ensure_6" -> "bb::TestRescue#parse_rescue_ensure_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_ensure_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_ensure_7" -> "bb::TestRescue#parse_rescue_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_ensure_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_ensure_8" -> "bb::TestRescue#parse_rescue_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_ensure_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -374,10 +398,9 @@ subgraph "cluster_::TestRescue#parse_rescue_ensure" {
 subgraph "cluster_::TestRescue#parse_bug_rescue_empty_else" {
     label = "::TestRescue#parse_bug_rescue_empty_else";
     color = blue;
-    "bb::TestRescue#parse_bug_rescue_empty_else_0" [shape = invhouse];
-    "bb::TestRescue#parse_bug_rescue_empty_else_1" [shape = parallelogram];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<magic>$4: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -386,12 +409,14 @@ subgraph "cluster_::TestRescue#parse_bug_rescue_empty_else" {
     "bb::TestRescue#parse_bug_rescue_empty_else_0" -> "bb::TestRescue#parse_bug_rescue_empty_else_4" [style="tapered"];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_1" -> "bb::TestRescue#parse_bug_rescue_empty_else_1" [style="bold"];
     "bb::TestRescue#parse_bug_rescue_empty_else_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<exceptionValue>$3: T.untyped, <magic>$4: T.class_of(<Magic>))\l<cfgAlias>$7: T.class_of(LoadError) = alias <C LoadError>\l<isaCheckTemp>$8: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$7: T.class_of(LoadError))\l<isaCheckTemp>$8: T.untyped\l"
     ];
@@ -400,6 +425,7 @@ subgraph "cluster_::TestRescue#parse_bug_rescue_empty_else" {
     "bb::TestRescue#parse_bug_rescue_empty_else_3" -> "bb::TestRescue#parse_bug_rescue_empty_else_8" [style="tapered"];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<magic>$4: T.class_of(<Magic>))\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -408,12 +434,14 @@ subgraph "cluster_::TestRescue#parse_bug_rescue_empty_else" {
     "bb::TestRescue#parse_bug_rescue_empty_else_4" -> "bb::TestRescue#parse_bug_rescue_empty_else_5" [style="tapered"];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_5" -> "bb::TestRescue#parse_bug_rescue_empty_else_6" [style="bold"];
     "bb::TestRescue#parse_bug_rescue_empty_else_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<gotoDeadTemp>$9: T.nilable(TrueClass))\l<gotoDeadTemp>$9: T.nilable(TrueClass)\l"
     ];
@@ -422,18 +450,21 @@ subgraph "cluster_::TestRescue#parse_bug_rescue_empty_else" {
     "bb::TestRescue#parse_bug_rescue_empty_else_6" -> "bb::TestRescue#parse_bug_rescue_empty_else_9" [style="tapered"];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<magic>$4: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$5: Sorbet::Private::Static::Void = <magic>$4: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_7" -> "bb::TestRescue#parse_bug_rescue_empty_else_6" [style="bold"];
     "bb::TestRescue#parse_bug_rescue_empty_else_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$9: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_bug_rescue_empty_else_8" -> "bb::TestRescue#parse_bug_rescue_empty_else_6" [style="bold"];
     "bb::TestRescue#parse_bug_rescue_empty_else_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0]()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
@@ -444,10 +475,9 @@ subgraph "cluster_::TestRescue#parse_bug_rescue_empty_else" {
 subgraph "cluster_::TestRescue#parse_ruby_bug_12686" {
     label = "::TestRescue#parse_ruby_bug_12686";
     color = blue;
-    "bb::TestRescue#parse_ruby_bug_12686_0" [shape = invhouse];
-    "bb::TestRescue#parse_ruby_bug_12686_1" [shape = parallelogram];
 
     "bb::TestRescue#parse_ruby_bug_12686_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<magic>$7: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$5: T.untyped = <get-current-exception>\l<exceptionValue>$5: T.untyped\l"
     ];
@@ -456,12 +486,14 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12686" {
     "bb::TestRescue#parse_ruby_bug_12686_0" -> "bb::TestRescue#parse_ruby_bug_12686_4" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12686_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12686_1" -> "bb::TestRescue#parse_ruby_bug_12686_1" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12686_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: TestRescue, <statTemp>$4: T.untyped, <exceptionValue>$5: T.untyped, <magic>$7: T.class_of(<Magic>))\l<cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$11: T.untyped = <exceptionValue>$5: T.untyped.is_a?(<cfgAlias>$10: T.class_of(StandardError))\l<isaCheckTemp>$11: T.untyped\l"
     ];
@@ -470,6 +502,7 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12686" {
     "bb::TestRescue#parse_ruby_bug_12686_3" -> "bb::TestRescue#parse_ruby_bug_12686_8" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12686_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, <magic>$7: T.class_of(<Magic>))\l<statTemp>$4: T.untyped = <self>: TestRescue.bar()\l<exceptionValue>$5: T.untyped = <get-current-exception>\l<exceptionValue>$5: T.untyped\l"
     ];
@@ -478,12 +511,14 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12686" {
     "bb::TestRescue#parse_ruby_bug_12686_4" -> "bb::TestRescue#parse_ruby_bug_12686_5" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12686_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<self>: TestRescue, <statTemp>$4: T.untyped)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12686_5" -> "bb::TestRescue#parse_ruby_bug_12686_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12686_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<self>: TestRescue, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass))\l<gotoDeadTemp>$12: T.nilable(TrueClass)\l"
     ];
@@ -492,18 +527,21 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12686" {
     "bb::TestRescue#parse_ruby_bug_12686_6" -> "bb::TestRescue#parse_ruby_bug_12686_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12686_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$7: T.class_of(<Magic>))\l<exceptionValue>$5: NilClass = nil\l<keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)\l<statTemp>$4: NilClass = nil\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12686_7" -> "bb::TestRescue#parse_ruby_bug_12686_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12686_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<self>: TestRescue, <statTemp>$4: T.untyped)\l<gotoDeadTemp>$12: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12686_8" -> "bb::TestRescue#parse_ruby_bug_12686_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12686_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<self>: TestRescue, <statTemp>$4: T.untyped)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.take_arg(<statTemp>$4: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -514,10 +552,9 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12686" {
 subgraph "cluster_::TestRescue#parse_rescue_mod" {
     label = "::TestRescue#parse_rescue_mod";
     color = blue;
-    "bb::TestRescue#parse_rescue_mod_0" [shape = invhouse];
-    "bb::TestRescue#parse_rescue_mod_1" [shape = parallelogram];
 
     "bb::TestRescue#parse_rescue_mod_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -526,12 +563,14 @@ subgraph "cluster_::TestRescue#parse_rescue_mod" {
     "bb::TestRescue#parse_rescue_mod_0" -> "bb::TestRescue#parse_rescue_mod_4" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_1" -> "bb::TestRescue#parse_rescue_mod_1" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>))\l<cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))\l<isaCheckTemp>$9: T.untyped\l"
     ];
@@ -540,6 +579,7 @@ subgraph "cluster_::TestRescue#parse_rescue_mod" {
     "bb::TestRescue#parse_rescue_mod_3" -> "bb::TestRescue#parse_rescue_mod_8" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -548,12 +588,14 @@ subgraph "cluster_::TestRescue#parse_rescue_mod" {
     "bb::TestRescue#parse_rescue_mod_4" -> "bb::TestRescue#parse_rescue_mod_5" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_5" -> "bb::TestRescue#parse_rescue_mod_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass))\l<gotoDeadTemp>$11: T.nilable(TrueClass)\l"
     ];
@@ -562,18 +604,21 @@ subgraph "cluster_::TestRescue#parse_rescue_mod" {
     "bb::TestRescue#parse_rescue_mod_6" -> "bb::TestRescue#parse_rescue_mod_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_7" -> "bb::TestRescue#parse_rescue_mod_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_8" -> "bb::TestRescue#parse_rescue_mod_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -584,10 +629,9 @@ subgraph "cluster_::TestRescue#parse_rescue_mod" {
 subgraph "cluster_::TestRescue#parse_resbody_list_var" {
     label = "::TestRescue#parse_resbody_list_var";
     color = blue;
-    "bb::TestRescue#parse_resbody_list_var_0" [shape = invhouse];
-    "bb::TestRescue#parse_resbody_list_var_1" [shape = parallelogram];
 
     "bb::TestRescue#parse_resbody_list_var_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -596,12 +640,14 @@ subgraph "cluster_::TestRescue#parse_resbody_list_var" {
     "bb::TestRescue#parse_resbody_list_var_0" -> "bb::TestRescue#parse_resbody_list_var_4" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_list_var_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_list_var_1" -> "bb::TestRescue#parse_resbody_list_var_1" [style="bold"];
     "bb::TestRescue#parse_resbody_list_var_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>))\lex: T.untyped = <exceptionValue>$3\l<exceptionClassTemp>$7: T.untyped = <self>: TestRescue.foo()\l<isaCheckTemp>$9: T.untyped = ex: T.untyped.is_a?(<exceptionClassTemp>$7: T.untyped)\l<isaCheckTemp>$9: T.untyped\l"
     ];
@@ -610,6 +656,7 @@ subgraph "cluster_::TestRescue#parse_resbody_list_var" {
     "bb::TestRescue#parse_resbody_list_var_3" -> "bb::TestRescue#parse_resbody_list_var_8" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_list_var_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -618,12 +665,14 @@ subgraph "cluster_::TestRescue#parse_resbody_list_var" {
     "bb::TestRescue#parse_resbody_list_var_4" -> "bb::TestRescue#parse_resbody_list_var_5" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_list_var_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_list_var_5" -> "bb::TestRescue#parse_resbody_list_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_list_var_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass))\l<gotoDeadTemp>$11: T.nilable(TrueClass)\l"
     ];
@@ -632,18 +681,21 @@ subgraph "cluster_::TestRescue#parse_resbody_list_var" {
     "bb::TestRescue#parse_resbody_list_var_6" -> "bb::TestRescue#parse_resbody_list_var_9" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_list_var_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_list_var_7" -> "bb::TestRescue#parse_resbody_list_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_list_var_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_list_var_8" -> "bb::TestRescue#parse_resbody_list_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_list_var_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -654,10 +706,9 @@ subgraph "cluster_::TestRescue#parse_resbody_list_var" {
 subgraph "cluster_::TestRescue#parse_rescue_else_ensure" {
     label = "::TestRescue#parse_rescue_else_ensure";
     color = blue;
-    "bb::TestRescue#parse_rescue_else_ensure_0" [shape = invhouse];
-    "bb::TestRescue#parse_rescue_else_ensure_1" [shape = parallelogram];
 
     "bb::TestRescue#parse_rescue_else_ensure_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<magic>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -666,12 +717,14 @@ subgraph "cluster_::TestRescue#parse_rescue_else_ensure" {
     "bb::TestRescue#parse_rescue_else_ensure_0" -> "bb::TestRescue#parse_rescue_else_ensure_4" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_else_ensure_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_else_ensure_1" -> "bb::TestRescue#parse_rescue_else_ensure_1" [style="bold"];
     "bb::TestRescue#parse_rescue_else_ensure_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$6: T.class_of(<Magic>))\l<cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$10: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$9: T.class_of(StandardError))\l<isaCheckTemp>$10: T.untyped\l"
     ];
@@ -680,6 +733,7 @@ subgraph "cluster_::TestRescue#parse_rescue_else_ensure" {
     "bb::TestRescue#parse_rescue_else_ensure_3" -> "bb::TestRescue#parse_rescue_else_ensure_8" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_else_ensure_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>))\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -688,12 +742,14 @@ subgraph "cluster_::TestRescue#parse_rescue_else_ensure" {
     "bb::TestRescue#parse_rescue_else_ensure_4" -> "bb::TestRescue#parse_rescue_else_ensure_5" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_else_ensure_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<self>: TestRescue)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_else_ensure_5" -> "bb::TestRescue#parse_rescue_else_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_else_ensure_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass))\l<throwAwayTemp>$13: T.untyped = <self>: TestRescue.bar()\l<gotoDeadTemp>$12: T.nilable(TrueClass)\l"
     ];
@@ -702,18 +758,21 @@ subgraph "cluster_::TestRescue#parse_rescue_else_ensure" {
     "bb::TestRescue#parse_rescue_else_ensure_6" -> "bb::TestRescue#parse_rescue_else_ensure_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_else_ensure_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$6: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_else_ensure_7" -> "bb::TestRescue#parse_rescue_else_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_else_ensure_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$12: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_else_ensure_8" -> "bb::TestRescue#parse_rescue_else_ensure_6" [style="bold"];
     "bb::TestRescue#parse_rescue_else_ensure_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -724,10 +783,9 @@ subgraph "cluster_::TestRescue#parse_rescue_else_ensure" {
 subgraph "cluster_::TestRescue#parse_rescue" {
     label = "::TestRescue#parse_rescue";
     color = blue;
-    "bb::TestRescue#parse_rescue_0" [shape = invhouse];
-    "bb::TestRescue#parse_rescue_1" [shape = parallelogram];
 
     "bb::TestRescue#parse_rescue_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -736,12 +794,14 @@ subgraph "cluster_::TestRescue#parse_rescue" {
     "bb::TestRescue#parse_rescue_0" -> "bb::TestRescue#parse_rescue_4" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_1" -> "bb::TestRescue#parse_rescue_1" [style="bold"];
     "bb::TestRescue#parse_rescue_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>))\l<cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))\l<isaCheckTemp>$9: T.untyped\l"
     ];
@@ -750,6 +810,7 @@ subgraph "cluster_::TestRescue#parse_rescue" {
     "bb::TestRescue#parse_rescue_3" -> "bb::TestRescue#parse_rescue_8" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -758,12 +819,14 @@ subgraph "cluster_::TestRescue#parse_rescue" {
     "bb::TestRescue#parse_rescue_4" -> "bb::TestRescue#parse_rescue_5" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_5" -> "bb::TestRescue#parse_rescue_6" [style="bold"];
     "bb::TestRescue#parse_rescue_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass))\l<gotoDeadTemp>$11: T.nilable(TrueClass)\l"
     ];
@@ -772,18 +835,21 @@ subgraph "cluster_::TestRescue#parse_rescue" {
     "bb::TestRescue#parse_rescue_6" -> "bb::TestRescue#parse_rescue_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_7" -> "bb::TestRescue#parse_rescue_6" [style="bold"];
     "bb::TestRescue#parse_rescue_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_8" -> "bb::TestRescue#parse_rescue_6" [style="bold"];
     "bb::TestRescue#parse_rescue_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -794,10 +860,9 @@ subgraph "cluster_::TestRescue#parse_rescue" {
 subgraph "cluster_::TestRescue#parse_resbody_var" {
     label = "::TestRescue#parse_resbody_var";
     color = blue;
-    "bb::TestRescue#parse_resbody_var_0" [shape = invhouse];
-    "bb::TestRescue#parse_resbody_var_1" [shape = parallelogram];
 
     "bb::TestRescue#parse_resbody_var_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -806,12 +871,14 @@ subgraph "cluster_::TestRescue#parse_resbody_var" {
     "bb::TestRescue#parse_resbody_var_0" -> "bb::TestRescue#parse_resbody_var_4" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_1" -> "bb::TestRescue#parse_resbody_var_1" [style="bold"];
     "bb::TestRescue#parse_resbody_var_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>))\lex: T.untyped = <exceptionValue>$3\l<cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$9: T.untyped = ex: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))\l<isaCheckTemp>$9: T.untyped\l"
     ];
@@ -820,6 +887,7 @@ subgraph "cluster_::TestRescue#parse_resbody_var" {
     "bb::TestRescue#parse_resbody_var_3" -> "bb::TestRescue#parse_resbody_var_8" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -828,12 +896,14 @@ subgraph "cluster_::TestRescue#parse_resbody_var" {
     "bb::TestRescue#parse_resbody_var_4" -> "bb::TestRescue#parse_resbody_var_5" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_5" -> "bb::TestRescue#parse_resbody_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass))\l<gotoDeadTemp>$11: T.nilable(TrueClass)\l"
     ];
@@ -842,18 +912,21 @@ subgraph "cluster_::TestRescue#parse_resbody_var" {
     "bb::TestRescue#parse_resbody_var_6" -> "bb::TestRescue#parse_resbody_var_9" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_7" -> "bb::TestRescue#parse_resbody_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$11: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_8" -> "bb::TestRescue#parse_resbody_var_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -864,10 +937,9 @@ subgraph "cluster_::TestRescue#parse_resbody_var" {
 subgraph "cluster_::TestRescue#parse_resbody_var_1" {
     label = "::TestRescue#parse_resbody_var_1";
     color = blue;
-    "bb::TestRescue#parse_resbody_var_1_0" [shape = invhouse];
-    "bb::TestRescue#parse_resbody_var_1_1" [shape = parallelogram];
 
     "bb::TestRescue#parse_resbody_var_1_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l@ex$11: T.nilable(StandardError) = alias @ex\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -876,12 +948,14 @@ subgraph "cluster_::TestRescue#parse_resbody_var_1" {
     "bb::TestRescue#parse_resbody_var_1_0" -> "bb::TestRescue#parse_resbody_var_1_4" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_1_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_1_1" -> "bb::TestRescue#parse_resbody_var_1_1" [style="bold"];
     "bb::TestRescue#parse_resbody_var_1_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError))\l<rescueTemp>$2: T.untyped = <exceptionValue>$3\l<cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))\l<isaCheckTemp>$9: T.untyped\l"
     ];
@@ -890,6 +964,7 @@ subgraph "cluster_::TestRescue#parse_resbody_var_1" {
     "bb::TestRescue#parse_resbody_var_1_3" -> "bb::TestRescue#parse_resbody_var_1_8" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_1_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError))\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -898,12 +973,14 @@ subgraph "cluster_::TestRescue#parse_resbody_var_1" {
     "bb::TestRescue#parse_resbody_var_1_4" -> "bb::TestRescue#parse_resbody_var_1_5" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_1_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_1_5" -> "bb::TestRescue#parse_resbody_var_1_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_1_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass))\l<gotoDeadTemp>$13: T.nilable(TrueClass)\l"
     ];
@@ -912,18 +989,21 @@ subgraph "cluster_::TestRescue#parse_resbody_var_1" {
     "bb::TestRescue#parse_resbody_var_1_6" -> "bb::TestRescue#parse_resbody_var_1_9" [style="tapered"];
 
     "bb::TestRescue#parse_resbody_var_1_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), <rescueTemp>$2: T.untyped, @ex$11: T.nilable(StandardError))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l@ex$11: T.untyped = <rescueTemp>$2\l<returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_1_7" -> "bb::TestRescue#parse_resbody_var_1_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_1_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$13: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_resbody_var_1_8" -> "bb::TestRescue#parse_resbody_var_1_6" [style="bold"];
     "bb::TestRescue#parse_resbody_var_1_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -934,10 +1014,9 @@ subgraph "cluster_::TestRescue#parse_resbody_var_1" {
 subgraph "cluster_::TestRescue#parse_rescue_mod_op_assign" {
     label = "::TestRescue#parse_rescue_mod_op_assign";
     color = blue;
-    "bb::TestRescue#parse_rescue_mod_op_assign_0" [shape = invhouse];
-    "bb::TestRescue#parse_rescue_mod_op_assign_1" [shape = parallelogram];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<statTemp>$3: NilClass = foo\l<magic>$7: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$5: T.untyped = <get-current-exception>\l<exceptionValue>$5: T.untyped\l"
     ];
@@ -946,12 +1025,14 @@ subgraph "cluster_::TestRescue#parse_rescue_mod_op_assign" {
     "bb::TestRescue#parse_rescue_mod_op_assign_0" -> "bb::TestRescue#parse_rescue_mod_op_assign_4" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_1" -> "bb::TestRescue#parse_rescue_mod_op_assign_1" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_op_assign_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: TestRescue, <statTemp>$3: NilClass, <statTemp>$4: T.untyped, <exceptionValue>$5: T.untyped, <magic>$7: T.class_of(<Magic>))\l<cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$11: T.untyped = <exceptionValue>$5: T.untyped.is_a?(<cfgAlias>$10: T.class_of(StandardError))\l<isaCheckTemp>$11: T.untyped\l"
     ];
@@ -960,6 +1041,7 @@ subgraph "cluster_::TestRescue#parse_rescue_mod_op_assign" {
     "bb::TestRescue#parse_rescue_mod_op_assign_3" -> "bb::TestRescue#parse_rescue_mod_op_assign_8" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$7: T.class_of(<Magic>))\l<statTemp>$4: T.untyped = <self>: TestRescue.meth()\l<exceptionValue>$5: T.untyped = <get-current-exception>\l<exceptionValue>$5: T.untyped\l"
     ];
@@ -968,12 +1050,14 @@ subgraph "cluster_::TestRescue#parse_rescue_mod_op_assign" {
     "bb::TestRescue#parse_rescue_mod_op_assign_4" -> "bb::TestRescue#parse_rescue_mod_op_assign_5" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_5" -> "bb::TestRescue#parse_rescue_mod_op_assign_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_op_assign_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass))\l<gotoDeadTemp>$13: T.nilable(TrueClass)\l"
     ];
@@ -982,18 +1066,21 @@ subgraph "cluster_::TestRescue#parse_rescue_mod_op_assign" {
     "bb::TestRescue#parse_rescue_mod_op_assign_6" -> "bb::TestRescue#parse_rescue_mod_op_assign_9" [style="tapered"];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$7: T.class_of(<Magic>))\l<exceptionValue>$5: NilClass = nil\l<keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)\l<statTemp>$4: T.untyped = <self>: TestRescue.bar()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_7" -> "bb::TestRescue#parse_rescue_mod_op_assign_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_op_assign_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)\l<gotoDeadTemp>$13: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_rescue_mod_op_assign_8" -> "bb::TestRescue#parse_rescue_mod_op_assign_6" [style="bold"];
     "bb::TestRescue#parse_rescue_mod_op_assign_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)\lfoo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: T.untyped)\l<returnMethodTemp>$2: T.untyped = foo\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -1004,10 +1091,9 @@ subgraph "cluster_::TestRescue#parse_rescue_mod_op_assign" {
 subgraph "cluster_::TestRescue#parse_ruby_bug_12402" {
     label = "::TestRescue#parse_ruby_bug_12402";
     color = blue;
-    "bb::TestRescue#parse_ruby_bug_12402_0" [shape = invhouse];
-    "bb::TestRescue#parse_ruby_bug_12402_1" [shape = parallelogram];
 
     "bb::TestRescue#parse_ruby_bug_12402_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<magic>$7: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -1016,12 +1102,14 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402" {
     "bb::TestRescue#parse_ruby_bug_12402_0" -> "bb::TestRescue#parse_ruby_bug_12402_4" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_1" -> "bb::TestRescue#parse_ruby_bug_12402_1" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](foo: NilClass, <exceptionValue>$3: T.untyped, <magic>$7: T.class_of(<Magic>))\l<cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$11: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$10: T.class_of(StandardError))\l<isaCheckTemp>$11: T.untyped\l"
     ];
@@ -1030,6 +1118,7 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402" {
     "bb::TestRescue#parse_ruby_bug_12402_3" -> "bb::TestRescue#parse_ruby_bug_12402_8" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, <magic>$7: T.class_of(<Magic>))\l<statTemp>$5: T.untyped = <self>: TestRescue.bar()\lfoo: T.noreturn = <self>: TestRescue.raise(<statTemp>$5: T.untyped)\l<exceptionValue>$3 = <get-current-exception>\l<exceptionValue>$3\l"
     ];
@@ -1038,12 +1127,14 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402" {
     "bb::TestRescue#parse_ruby_bug_12402_4" -> "bb::TestRescue#parse_ruby_bug_12402_5" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_5" [
+        shape = rectangle;
         color = red;
         label = "block[id=5, rubyBlockId=4](foo: NilClass)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_5" -> "bb::TestRescue#parse_ruby_bug_12402_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](foo: NilClass, <gotoDeadTemp>$12: T.nilable(TrueClass))\l<gotoDeadTemp>$12: T.nilable(TrueClass)\l"
     ];
@@ -1052,18 +1143,21 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402" {
     "bb::TestRescue#parse_ruby_bug_12402_6" -> "bb::TestRescue#parse_ruby_bug_12402_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<magic>$7: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\lfoo: NilClass = nil\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_7" -> "bb::TestRescue#parse_ruby_bug_12402_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](foo: NilClass)\l<gotoDeadTemp>$12: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_8" -> "bb::TestRescue#parse_ruby_bug_12402_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](foo: NilClass)\l<returnMethodTemp>$2: NilClass = foo\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
@@ -1074,10 +1168,9 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402" {
 subgraph "cluster_::TestRescue#parse_ruby_bug_12402_1" {
     label = "::TestRescue#parse_ruby_bug_12402_1";
     color = blue;
-    "bb::TestRescue#parse_ruby_bug_12402_1_0" [shape = invhouse];
-    "bb::TestRescue#parse_ruby_bug_12402_1_1" [shape = parallelogram];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l<statTemp>$3: NilClass = foo\l<magic>$9: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$5: T.untyped = <get-current-exception>\l<exceptionValue>$5: T.untyped\l"
     ];
@@ -1086,12 +1179,14 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_1" {
     "bb::TestRescue#parse_ruby_bug_12402_1_0" -> "bb::TestRescue#parse_ruby_bug_12402_1_4" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_1" -> "bb::TestRescue#parse_ruby_bug_12402_1_1" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_1_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <exceptionValue>$5: T.untyped, <magic>$9: T.class_of(<Magic>))\l<cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$13: T.untyped = <exceptionValue>$5: T.untyped.is_a?(<cfgAlias>$12: T.class_of(StandardError))\l<isaCheckTemp>$13: T.untyped\l"
     ];
@@ -1100,6 +1195,7 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_1" {
     "bb::TestRescue#parse_ruby_bug_12402_1_3" -> "bb::TestRescue#parse_ruby_bug_12402_1_8" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$9: T.class_of(<Magic>))\l<statTemp>$7: T.untyped = <self>: TestRescue.bar()\l<statTemp>$4: T.noreturn = <self>: TestRescue.raise(<statTemp>$7: T.untyped)\l<exceptionValue>$5 = <get-current-exception>\l<exceptionValue>$5\l"
     ];
@@ -1108,12 +1204,14 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_1" {
     "bb::TestRescue#parse_ruby_bug_12402_1_4" -> "bb::TestRescue#parse_ruby_bug_12402_1_5" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_5" [
+        shape = rectangle;
         color = red;
         label = "block[id=5, rubyBlockId=4](<statTemp>$3: NilClass, <statTemp>$4: NilClass)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_5" -> "bb::TestRescue#parse_ruby_bug_12402_1_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_1_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$14: T.nilable(TrueClass))\l<gotoDeadTemp>$14: T.nilable(TrueClass)\l"
     ];
@@ -1122,18 +1220,21 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_1" {
     "bb::TestRescue#parse_ruby_bug_12402_1_6" -> "bb::TestRescue#parse_ruby_bug_12402_1_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<statTemp>$3: NilClass, <magic>$9: T.class_of(<Magic>))\l<exceptionValue>$5: NilClass = nil\l<keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$9: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)\l<statTemp>$4: NilClass = nil\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_7" -> "bb::TestRescue#parse_ruby_bug_12402_1_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_1_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<statTemp>$3: NilClass, <statTemp>$4: NilClass)\l<gotoDeadTemp>$14: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_1_8" -> "bb::TestRescue#parse_ruby_bug_12402_1_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_1_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass)\lfoo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: NilClass)\l<returnMethodTemp>$2: T.untyped = foo\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -1144,10 +1245,9 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_1" {
 subgraph "cluster_::TestRescue#parse_ruby_bug_12402_2" {
     label = "::TestRescue#parse_ruby_bug_12402_2";
     color = blue;
-    "bb::TestRescue#parse_ruby_bug_12402_2_0" [shape = invhouse];
-    "bb::TestRescue#parse_ruby_bug_12402_2_1" [shape = parallelogram];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestRescue = cast(<self>: NilClass, TestRescue);\l[]$3: T.untyped = <self>: TestRescue.foo()\l[]$4: Integer(0) = 0\l<statTemp>$9: T.untyped = []$3: T.untyped.[]([]$4: Integer(0))\l<magic>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$13: T.untyped = <get-current-exception>\l<exceptionValue>$13: T.untyped\l"
     ];
@@ -1156,12 +1256,14 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_2" {
     "bb::TestRescue#parse_ruby_bug_12402_2_0" -> "bb::TestRescue#parse_ruby_bug_12402_2_4" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_1" -> "bb::TestRescue#parse_ruby_bug_12402_2_1" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_2_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <exceptionValue>$13: T.untyped, <magic>$17: T.class_of(<Magic>))\l<cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$21: T.untyped = <exceptionValue>$13: T.untyped.is_a?(<cfgAlias>$20: T.class_of(StandardError))\l<isaCheckTemp>$21: T.untyped\l"
     ];
@@ -1170,6 +1272,7 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_2" {
     "bb::TestRescue#parse_ruby_bug_12402_2_3" -> "bb::TestRescue#parse_ruby_bug_12402_2_8" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: TestRescue, []$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <magic>$17: T.class_of(<Magic>))\l<statTemp>$15: T.untyped = <self>: TestRescue.bar()\l<statTemp>$12: T.noreturn = <self>: TestRescue.raise(<statTemp>$15: T.untyped)\l<exceptionValue>$13 = <get-current-exception>\l<exceptionValue>$13\l"
     ];
@@ -1178,12 +1281,14 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_2" {
     "bb::TestRescue#parse_ruby_bug_12402_2_4" -> "bb::TestRescue#parse_ruby_bug_12402_2_5" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_5" [
+        shape = rectangle;
         color = red;
         label = "block[id=5, rubyBlockId=4]([]$3: NilClass, []$4: NilClass, <statTemp>$9: NilClass, <statTemp>$12: NilClass)\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_5" -> "bb::TestRescue#parse_ruby_bug_12402_2_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_2_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <gotoDeadTemp>$22: T.nilable(TrueClass))\l<gotoDeadTemp>$22: T.nilable(TrueClass)\l"
     ];
@@ -1192,18 +1297,21 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_2" {
     "bb::TestRescue#parse_ruby_bug_12402_2_6" -> "bb::TestRescue#parse_ruby_bug_12402_2_9" [style="tapered"];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <magic>$17: T.class_of(<Magic>))\l<exceptionValue>$13: NilClass = nil\l<keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$13: NilClass)\l<statTemp>$12: NilClass = nil\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_7" -> "bb::TestRescue#parse_ruby_bug_12402_2_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_2_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass)\l<gotoDeadTemp>$22: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::TestRescue#parse_ruby_bug_12402_2_8" -> "bb::TestRescue#parse_ruby_bug_12402_2_6" [style="bold"];
     "bb::TestRescue#parse_ruby_bug_12402_2_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass)\l<statTemp>$8: T.untyped = <statTemp>$9: T.untyped.+(<statTemp>$12: NilClass)\l<returnMethodTemp>$2: T.untyped = []$3: T.untyped.[]=([]$4: Integer(0), <statTemp>$8: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -1214,16 +1322,16 @@ subgraph "cluster_::TestRescue#parse_ruby_bug_12402_2" {
 subgraph "cluster_::<Class:TestRescue>#<static-init>" {
     label = "::<Class:TestRescue>#<static-init>";
     color = blue;
-    "bb::<Class:TestRescue>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:TestRescue>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:TestRescue>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(TestRescue) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U TestRescue>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U TestRescue>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:meth) = :meth\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:meth) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$7: Symbol(:meth), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:foo) = :foo\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:foo) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$13: Symbol(:foo), <statTemp>$14: Symbol(:normal))\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$19: Symbol(:bar) = :bar\l<statTemp>$20: Symbol(:normal) = :normal\l<statTemp>$15: Symbol(:bar) = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$19: Symbol(:bar), <statTemp>$20: Symbol(:normal))\l<cfgAlias>$23: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$25: Symbol(:baz) = :baz\l<statTemp>$26: Symbol(:normal) = :normal\l<statTemp>$21: Symbol(:baz) = <cfgAlias>$23: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$25: Symbol(:baz), <statTemp>$26: Symbol(:normal))\l<cfgAlias>$29: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$31: Symbol(:take_arg) = :take_arg\l<statTemp>$32: Symbol(:normal) = :normal\l<statTemp>$27: Symbol(:take_arg) = <cfgAlias>$29: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$31: Symbol(:take_arg), <statTemp>$32: Symbol(:normal))\l<cfgAlias>$35: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$37: Symbol(:initialize) = :initialize\l<statTemp>$38: Symbol(:normal) = :normal\l<statTemp>$33: Symbol(:initialize) = <cfgAlias>$35: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$37: Symbol(:initialize), <statTemp>$38: Symbol(:normal))\l<cfgAlias>$41: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$43: Symbol(:multiple_rescue) = :multiple_rescue\l<statTemp>$44: Symbol(:normal) = :normal\l<statTemp>$39: Symbol(:multiple_rescue) = <cfgAlias>$41: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$43: Symbol(:multiple_rescue), <statTemp>$44: Symbol(:normal))\l<cfgAlias>$47: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$49: Symbol(:multiple_rescue_classes) = :multiple_rescue_classes\l<statTemp>$50: Symbol(:normal) = :normal\l<statTemp>$45: Symbol(:multiple_rescue_classes) = <cfgAlias>$47: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$49: Symbol(:multiple_rescue_classes), <statTemp>$50: Symbol(:normal))\l<cfgAlias>$53: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$55: Symbol(:parse_rescue_ensure) = :parse_rescue_ensure\l<statTemp>$56: Symbol(:normal) = :normal\l<statTemp>$51: Symbol(:parse_rescue_ensure) = <cfgAlias>$53: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$55: Symbol(:parse_rescue_ensure), <statTemp>$56: Symbol(:normal))\l<cfgAlias>$59: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$61: Symbol(:parse_bug_rescue_empty_else) = :parse_bug_rescue_empty_else\l<statTemp>$62: Symbol(:normal) = :normal\l<statTemp>$57: Symbol(:parse_bug_rescue_empty_else) = <cfgAlias>$59: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$61: Symbol(:parse_bug_rescue_empty_else), <statTemp>$62: Symbol(:normal))\l<cfgAlias>$65: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$67: Symbol(:parse_ruby_bug_12686) = :parse_ruby_bug_12686\l<statTemp>$68: Symbol(:normal) = :normal\l<statTemp>$63: Symbol(:parse_ruby_bug_12686) = <cfgAlias>$65: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$67: Symbol(:parse_ruby_bug_12686), <statTemp>$68: Symbol(:normal))\l<cfgAlias>$71: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$73: Symbol(:parse_rescue_mod) = :parse_rescue_mod\l<statTemp>$74: Symbol(:normal) = :normal\l<statTemp>$69: Symbol(:parse_rescue_mod) = <cfgAlias>$71: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$73: Symbol(:parse_rescue_mod), <statTemp>$74: Symbol(:normal))\l<cfgAlias>$77: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$79: Symbol(:parse_resbody_list_var) = :parse_resbody_list_var\l<statTemp>$80: Symbol(:normal) = :normal\l<statTemp>$75: Symbol(:parse_resbody_list_var) = <cfgAlias>$77: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$79: Symbol(:parse_resbody_list_var), <statTemp>$80: Symbol(:normal))\l<cfgAlias>$83: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$85: Symbol(:parse_rescue_else_ensure) = :parse_rescue_else_ensure\l<statTemp>$86: Symbol(:normal) = :normal\l<statTemp>$81: Symbol(:parse_rescue_else_ensure) = <cfgAlias>$83: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$85: Symbol(:parse_rescue_else_ensure), <statTemp>$86: Symbol(:normal))\l<cfgAlias>$89: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$91: Symbol(:parse_rescue) = :parse_rescue\l<statTemp>$92: Symbol(:normal) = :normal\l<statTemp>$87: Symbol(:parse_rescue) = <cfgAlias>$89: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$91: Symbol(:parse_rescue), <statTemp>$92: Symbol(:normal))\l<cfgAlias>$95: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$97: Symbol(:parse_resbody_var) = :parse_resbody_var\l<statTemp>$98: Symbol(:normal) = :normal\l<statTemp>$93: Symbol(:parse_resbody_var) = <cfgAlias>$95: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$97: Symbol(:parse_resbody_var), <statTemp>$98: Symbol(:normal))\l<cfgAlias>$101: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$103: Symbol(:parse_resbody_var_1) = :parse_resbody_var_1\l<statTemp>$104: Symbol(:normal) = :normal\l<statTemp>$99: Symbol(:parse_resbody_var_1) = <cfgAlias>$101: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$103: Symbol(:parse_resbody_var_1), <statTemp>$104: Symbol(:normal))\l<cfgAlias>$107: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$109: Symbol(:parse_rescue_mod_op_assign) = :parse_rescue_mod_op_assign\l<statTemp>$110: Symbol(:normal) = :normal\l<statTemp>$105: Symbol(:parse_rescue_mod_op_assign) = <cfgAlias>$107: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$109: Symbol(:parse_rescue_mod_op_assign), <statTemp>$110: Symbol(:normal))\l<cfgAlias>$113: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$115: Symbol(:parse_ruby_bug_12402) = :parse_ruby_bug_12402\l<statTemp>$116: Symbol(:normal) = :normal\l<statTemp>$111: Symbol(:parse_ruby_bug_12402) = <cfgAlias>$113: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$115: Symbol(:parse_ruby_bug_12402), <statTemp>$116: Symbol(:normal))\l<cfgAlias>$119: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$121: Symbol(:parse_ruby_bug_12402_1) = :parse_ruby_bug_12402_1\l<statTemp>$122: Symbol(:normal) = :normal\l<statTemp>$117: Symbol(:parse_ruby_bug_12402_1) = <cfgAlias>$119: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$121: Symbol(:parse_ruby_bug_12402_1), <statTemp>$122: Symbol(:normal))\l<cfgAlias>$125: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$127: Symbol(:parse_ruby_bug_12402_2) = :parse_ruby_bug_12402_2\l<statTemp>$128: Symbol(:normal) = :normal\l<statTemp>$123: Symbol(:parse_ruby_bug_12402_2) = <cfgAlias>$125: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestRescue), <statTemp>$127: Symbol(:parse_ruby_bug_12402_2), <statTemp>$128: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:TestRescue>#<static-init>_0" -> "bb::<Class:TestRescue>#<static-init>_1" [style="bold"];
     "bb::<Class:TestRescue>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/rescue_else_block.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg.exp
@@ -2,10 +2,9 @@ digraph "rescue_else_block.rb" {
 subgraph "cluster_::Object#foo" {
     label = "::Object#foo";
     color = blue;
-    "bb::Object#foo_0" [shape = invhouse];
-    "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -14,12 +13,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_0" -> "bb::Object#foo_4" [style="tapered"];
 
     "bb::Object#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#foo_1" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>))\l<cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))\l<isaCheckTemp>$9: T.untyped\l"
     ];
@@ -28,6 +29,7 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_3" -> "bb::Object#foo_11" [style="tapered"];
 
     "bb::Object#foo_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<magic>$5: T.class_of(<Magic>))\l<returnMethodTemp>$2: Integer(1) = 1\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -36,6 +38,7 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_4" -> "bb::Object#foo_5" [style="tapered"];
 
     "bb::Object#foo_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: Integer(1))\l<ifTemp>$4: Integer(2) = 2\l<ifTemp>$4: Integer(2)\l"
     ];
@@ -44,12 +47,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_5" -> "bb::Object#foo_9" [style="tapered"];
 
     "bb::Object#foo_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=4]()\l<returnMethodTemp>$2: Integer(3) = 3\l<unconditional>\l"
     ];
 
     "bb::Object#foo_6" -> "bb::Object#foo_9" [style="bold"];
     "bb::Object#foo_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=3](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$10: T.nilable(TrueClass))\l<gotoDeadTemp>$10: T.nilable(TrueClass)\l"
     ];
@@ -58,18 +63,21 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_9" -> "bb::Object#foo_12" [style="tapered"];
 
     "bb::Object#foo_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=2](<returnMethodTemp>$2: T.nilable(Integer), <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<unconditional>\l"
     ];
 
     "bb::Object#foo_10" -> "bb::Object#foo_9" [style="bold"];
     "bb::Object#foo_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: T.nilable(Integer))\l<gotoDeadTemp>$10: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#foo_11" -> "bb::Object#foo_9" [style="bold"];
     "bb::Object#foo_12" [
+        shape = rectangle;
         color = black;
         label = "block[id=12, rubyBlockId=0](<returnMethodTemp>$2: T.nilable(Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
     ];
@@ -80,16 +88,16 @@ subgraph "cluster_::Object#foo" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:foo) = :foo\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:foo) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$6: Symbol(:foo), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/rescue_expression.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_expression.rb.cfg.exp
@@ -2,10 +2,9 @@ digraph "rescue_expression.rb" {
 subgraph "cluster_::Object#foo" {
     label = "::Object#foo";
     color = blue;
-    "bb::Object#foo_0" [shape = invhouse];
-    "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<magic>$8: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -14,12 +13,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_0" -> "bb::Object#foo_4" [style="tapered"];
 
     "bb::Object#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#foo_1" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: T.untyped, <magic>$8: T.class_of(<Magic>))\le: T.untyped = <exceptionValue>$3\l<cfgAlias>$13: T.class_of(MyException) = alias <C MyException>\l<statTemp>$11: MyException = <cfgAlias>$13: T.class_of(MyException).new()\l<exceptionClassTemp>$10: T.class_of(MyException) = <statTemp>$11: MyException.class()\l<isaCheckTemp>$14: T.untyped = e: T.untyped.is_a?(<exceptionClassTemp>$10: T.class_of(MyException))\l<isaCheckTemp>$14: T.untyped\l"
     ];
@@ -28,6 +29,7 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_3" -> "bb::Object#foo_8" [style="tapered"];
 
     "bb::Object#foo_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: Object, <magic>$8: T.class_of(<Magic>))\l<cfgAlias>$7: T.class_of(MyException) = alias <C MyException>\l<statTemp>$5: MyException = <cfgAlias>$7: T.class_of(MyException).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: MyException)\l<exceptionValue>$3 = <get-current-exception>\l<exceptionValue>$3\l"
     ];
@@ -36,12 +38,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_4" -> "bb::Object#foo_5" [style="tapered"];
 
     "bb::Object#foo_5" [
+        shape = rectangle;
         color = red;
         label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: NilClass)\l<unconditional>\l"
     ];
 
     "bb::Object#foo_5" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$15: T.nilable(TrueClass))\l<gotoDeadTemp>$15: T.nilable(TrueClass)\l"
     ];
@@ -50,18 +54,21 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_6" -> "bb::Object#foo_9" [style="tapered"];
 
     "bb::Object#foo_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<magic>$8: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$9: Sorbet::Private::Static::Void = <magic>$8: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<returnMethodTemp>$2: Integer(3) = 3\l<unconditional>\l"
     ];
 
     "bb::Object#foo_7" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$15: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#foo_8" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)\l<unconditional>\l"
     ];
@@ -72,16 +79,16 @@ subgraph "cluster_::Object#foo" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(MyException) = alias <C MyException>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(MyException))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(MyException) = alias <C MyException>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(MyException))\l<cfgAlias>$16: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$18: T.class_of(Exception) = alias <C Exception>\l<statTemp>$14: Sorbet::Private::Static::Void = <cfgAlias>$16: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$18: T.class_of(Exception))\l<cfgAlias>$21: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$23: Symbol(:foo) = :foo\l<statTemp>$24: Symbol(:normal) = :normal\l<statTemp>$19: Symbol(:foo) = <cfgAlias>$21: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$23: Symbol(:foo), <statTemp>$24: Symbol(:normal))\l<statTemp>$27: T.untyped = <self>: T.class_of(<root>).foo()\l<statTemp>$25: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$27: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -92,16 +99,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::<Class:MyException>#<static-init>" {
     label = "::<Class:MyException>#<static-init>";
     color = blue;
-    "bb::<Class:MyException>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:MyException>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:MyException>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(MyException) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U MyException>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U MyException>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:MyException>#<static-init>_0" -> "bb::<Class:MyException>#<static-init>_1" [style="bold"];
     "bb::<Class:MyException>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/rescue_two_return.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_two_return.rb.cfg.exp
@@ -2,10 +2,9 @@ digraph "rescue_two_return.rb" {
 subgraph "cluster_::Object#foo" {
     label = "::Object#foo";
     color = blue;
-    "bb::Object#foo_0" [shape = invhouse];
-    "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<magic>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$4: T.untyped = <get-current-exception>\l<exceptionValue>$4: T.untyped\l"
     ];
@@ -14,12 +13,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_0" -> "bb::Object#foo_4" [style="tapered"];
 
     "bb::Object#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<exceptionValue>$4 = <get-current-exception>\l<unconditional>\l"
     ];
 
     "bb::Object#foo_1" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: Object, <exceptionValue>$4: T.untyped, <magic>$6: T.class_of(<Magic>))\l<cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$10: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$9: T.class_of(StandardError))\l<isaCheckTemp>$10: T.untyped\l"
     ];
@@ -28,12 +29,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_3" -> "bb::Object#foo_8" [style="tapered"];
 
     "bb::Object#foo_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1]()\l<returnTemp>$5: Integer(1) = 1\l<statTemp>$3: T.noreturn = return <returnTemp>$5: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::Object#foo_4" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<self>: Object, <gotoDeadTemp>$12: TrueClass)\l<gotoDeadTemp>$12: TrueClass\l"
     ];
@@ -42,18 +45,21 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_6" -> "bb::Object#foo_9" [style="tapered"];
 
     "bb::Object#foo_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<magic>$6: T.class_of(<Magic>))\l<exceptionValue>$4: NilClass = nil\l<keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)\l<returnTemp>$11: Integer(2) = 2\l<statTemp>$3: T.noreturn = return <returnTemp>$11: Integer(2)\l<unconditional>\l"
     ];
 
     "bb::Object#foo_7" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<self>: Object)\l<gotoDeadTemp>$12: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#foo_8" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_9" [
+        shape = rectangle;
         color = red;
         label = "block[id=9, rubyBlockId=0](<self>: Object)\l<returnMethodTemp>$2 = <self>.deadcode()\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
@@ -64,16 +70,16 @@ subgraph "cluster_::Object#foo" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:foo) = :foo\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:foo) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$6: Symbol(:foo), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg.exp
@@ -2,10 +2,9 @@ digraph "rescue_var_expression.rb" {
 subgraph "cluster_::Object#foo" {
     label = "::Object#foo";
     color = blue;
-    "bb::Object#foo_0" [shape = invhouse];
-    "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<magic>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -14,12 +13,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_0" -> "bb::Object#foo_4" [style="tapered"];
 
     "bb::Object#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#foo_1" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: T.untyped, <magic>$6: T.class_of(<Magic>))\l<rescueTemp>$2: T.untyped = <exceptionValue>$3\l<cfgAlias>$9: T.class_of(Exception) = alias <C Exception>\l<isaCheckTemp>$10: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$9: T.class_of(Exception))\l<isaCheckTemp>$10: T.untyped\l"
     ];
@@ -28,6 +29,7 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_3" -> "bb::Object#foo_8" [style="tapered"];
 
     "bb::Object#foo_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: Object, <magic>$6: T.class_of(<Magic>))\l<statTemp>$5: String(\"boop\") = \"boop\"\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: String(\"boop\"))\l<exceptionValue>$3 = <get-current-exception>\l<exceptionValue>$3\l"
     ];
@@ -36,12 +38,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_4" -> "bb::Object#foo_5" [style="tapered"];
 
     "bb::Object#foo_5" [
+        shape = rectangle;
         color = red;
         label = "block[id=5, rubyBlockId=4](<returnMethodTemp>$2: NilClass)\l<unconditional>\l"
     ];
 
     "bb::Object#foo_5" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$16: T.nilable(TrueClass))\l<gotoDeadTemp>$16: T.nilable(TrueClass)\l"
     ];
@@ -50,18 +54,21 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_6" -> "bb::Object#foo_9" [style="tapered"];
 
     "bb::Object#foo_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<magic>$6: T.class_of(<Magic>), <rescueTemp>$2: T.untyped)\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<cfgAlias>$14: T.class_of(MyClass) = alias <C MyClass>\l<statTemp>$12: MyClass = <cfgAlias>$14: T.class_of(MyClass).new()\l<statTemp>$11: T.untyped = <statTemp>$12: MyClass.foo=(<rescueTemp>$2: T.untyped)\l<returnMethodTemp>$2: Integer(3) = 3\l<unconditional>\l"
     ];
 
     "bb::Object#foo_7" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$16: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#foo_8" -> "bb::Object#foo_6" [style="bold"];
     "bb::Object#foo_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<returnMethodTemp>$2: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)\l<unconditional>\l"
     ];
@@ -72,16 +79,16 @@ subgraph "cluster_::Object#foo" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(MyClass) = alias <C MyClass>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(MyClass))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(MyClass) = alias <C MyClass>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(MyClass))\l<cfgAlias>$16: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$18: Symbol(:foo) = :foo\l<statTemp>$19: Symbol(:normal) = :normal\l<statTemp>$14: Symbol(:foo) = <cfgAlias>$16: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$18: Symbol(:foo), <statTemp>$19: Symbol(:normal))\l<statTemp>$22: T.untyped = <self>: T.class_of(<root>).foo()\l<statTemp>$20: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$22: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -92,16 +99,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::MyClass#foo=" {
     label = "::MyClass#foo=";
     color = blue;
-    "bb::MyClass#foo=_0" [shape = invhouse];
-    "bb::MyClass#foo=_1" [shape = parallelogram];
 
     "bb::MyClass#foo=_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: MyClass = cast(<self>: NilClass, MyClass);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::MyClass#foo=_0" -> "bb::MyClass#foo=_1" [style="bold"];
     "bb::MyClass#foo=_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -112,16 +119,16 @@ subgraph "cluster_::MyClass#foo=" {
 subgraph "cluster_::<Class:MyClass>#<static-init>" {
     label = "::<Class:MyClass>#<static-init>";
     color = blue;
-    "bb::<Class:MyClass>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:MyClass>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:MyClass>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(MyClass) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U MyClass>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U MyClass>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:foo=) = :foo=\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:foo=) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(MyClass), <statTemp>$6: Symbol(:foo=), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo=)\l<unconditional>\l"
     ];
 
     "bb::<Class:MyClass>#<static-init>_0" -> "bb::<Class:MyClass>#<static-init>_1" [style="bold"];
     "bb::<Class:MyClass>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/rescue_with_return.rb.cfg.exp
+++ b/test/testdata/cfg/rescue_with_return.rb.cfg.exp
@@ -2,10 +2,9 @@ digraph "rescue_with_return.rb" {
 subgraph "cluster_::Object#a" {
     label = "::Object#a";
     color = blue;
-    "bb::Object#a_0" [shape = invhouse];
-    "bb::Object#a_1" [shape = parallelogram];
 
     "bb::Object#a_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -14,12 +13,14 @@ subgraph "cluster_::Object#a" {
     "bb::Object#a_0" -> "bb::Object#a_4" [style="tapered"];
 
     "bb::Object#a_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<exceptionValue>$3 = <get-current-exception>\l<unconditional>\l"
     ];
 
     "bb::Object#a_1" -> "bb::Object#a_1" [style="bold"];
     "bb::Object#a_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>))\l<cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))\l<isaCheckTemp>$9: T.untyped\l"
     ];
@@ -28,12 +29,14 @@ subgraph "cluster_::Object#a" {
     "bb::Object#a_3" -> "bb::Object#a_8" [style="tapered"];
 
     "bb::Object#a_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1]()\l<returnTemp>$4: Integer(1) = 1\l<returnMethodTemp>$2: T.noreturn = return <returnTemp>$4: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::Object#a_4" -> "bb::Object#a_1" [style="bold"];
     "bb::Object#a_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<gotoDeadTemp>$10: T.nilable(TrueClass))\l<gotoDeadTemp>$10: T.nilable(TrueClass)\l"
     ];
@@ -42,18 +45,21 @@ subgraph "cluster_::Object#a" {
     "bb::Object#a_6" -> "bb::Object#a_9" [style="tapered"];
 
     "bb::Object#a_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](<magic>$5: T.class_of(<Magic>))\l<exceptionValue>$3: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)\l<unconditional>\l"
     ];
 
     "bb::Object#a_7" -> "bb::Object#a_6" [style="bold"];
     "bb::Object#a_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2]()\l<gotoDeadTemp>$10: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#a_8" -> "bb::Object#a_6" [style="bold"];
     "bb::Object#a_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0]()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
@@ -64,16 +70,16 @@ subgraph "cluster_::Object#a" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:a) = :a\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:a) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$6: Symbol(:a), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:a)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/retry.rb.cfg.exp
+++ b/test/testdata/cfg/retry.rb.cfg.exp
@@ -2,22 +2,23 @@ digraph "retry.rb" {
 subgraph "cluster_::Object#main" {
     label = "::Object#main";
     color = blue;
-    "bb::Object#main_0" [shape = invhouse];
-    "bb::Object#main_1" [shape = parallelogram];
 
     "bb::Object#main_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\ltry: Integer(0) = 0\l<magic>$13: T.class_of(<Magic>) = alias <C <Magic>>\l<unconditional>\l"
     ];
 
     "bb::Object#main_0" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#main_1" -> "bb::Object#main_1" [style="bold"];
     "bb::Object#main_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>))\l<exceptionValue>$4: T.untyped = <get-current-exception>\l<exceptionValue>$4: T.untyped\l"
     ];
@@ -26,6 +27,7 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_2" -> "bb::Object#main_4" [style="tapered"];
 
     "bb::Object#main_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <magic>$13: T.class_of(<Magic>))\l<cfgAlias>$16: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$17: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$16: T.class_of(StandardError))\l<isaCheckTemp>$17: T.untyped\l"
     ];
@@ -34,6 +36,7 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_3" -> "bb::Object#main_11" [style="tapered"];
 
     "bb::Object#main_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>))\l<statTemp>$7: Integer(3) = 3\l<ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))\l<ifTemp>$5: T::Boolean\l"
     ];
@@ -42,12 +45,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_4" -> "bb::Object#main_7" [style="tapered"];
 
     "bb::Object#main_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: Object, try: Integer(0), <magic>$13: T.class_of(<Magic>))\l<statTemp>$9: Integer(0) = try\l<statTemp>$10: Integer(1) = 1\ltry: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))\l<statTemp>$12: String(\"e\") = \"e\"\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$12: String(\"e\"))\l<unconditional>\l"
     ];
 
     "bb::Object#main_5" -> "bb::Object#main_7" [style="bold"];
     "bb::Object#main_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>))\l<exceptionValue>$4: T.untyped = <get-current-exception>\l<exceptionValue>$4: T.untyped\l"
     ];
@@ -56,12 +61,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_7" -> "bb::Object#main_8" [style="tapered"];
 
     "bb::Object#main_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=4](<returnMethodTemp>$2: NilClass)\l<unconditional>\l"
     ];
 
     "bb::Object#main_8" -> "bb::Object#main_9" [style="bold"];
     "bb::Object#main_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$24: T.nilable(TrueClass))\l<gotoDeadTemp>$24: T.nilable(TrueClass)\l"
     ];
@@ -70,18 +77,21 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_9" -> "bb::Object#main_12" [style="tapered"];
 
     "bb::Object#main_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>))\l<exceptionValue>$4: NilClass = nil\l<keepForCfgTemp>$14: Sorbet::Private::Static::Void = <magic>$13: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)\l<statTemp>$20: String(\"rescue\") = \"rescue\"\l<statTemp>$18: NilClass = <self>: Object.puts(<statTemp>$20: String(\"rescue\"))\l<magic>$22: T.class_of(<Magic>) = alias <C <Magic>>\l<retryTemp>$23: Sorbet::Private::Static::Void = <magic>$22: T.class_of(<Magic>).<retry>()\l<unconditional>\l"
     ];
 
     "bb::Object#main_10" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$24: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#main_11" -> "bb::Object#main_9" [style="bold"];
     "bb::Object#main_12" [
+        shape = rectangle;
         color = black;
         label = "block[id=12, rubyBlockId=0](<returnMethodTemp>$2: NilClass)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
@@ -92,16 +102,16 @@ subgraph "cluster_::Object#main" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:main) = :main\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:main) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$7: Symbol(:main), <statTemp>$8: Symbol(:normal))\l<statTemp>$9: T.untyped = <self>: T.class_of(<root>).main()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/retry_multiple.rb.cfg.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg.exp
@@ -2,22 +2,23 @@ digraph "retry_multiple.rb" {
 subgraph "cluster_::Object#main" {
     label = "::Object#main";
     color = blue;
-    "bb::Object#main_0" [shape = invhouse];
-    "bb::Object#main_1" [shape = parallelogram];
 
     "bb::Object#main_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\ltry: Integer(0) = 0\l<magic>$25: T.class_of(<Magic>) = alias <C <Magic>>\l<unconditional>\l"
     ];
 
     "bb::Object#main_0" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#main_1" -> "bb::Object#main_1" [style="bold"];
     "bb::Object#main_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>))\l<exceptionValue>$4: T.untyped = <get-current-exception>\l<exceptionValue>$4: T.untyped\l"
     ];
@@ -26,6 +27,7 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_2" -> "bb::Object#main_4" [style="tapered"];
 
     "bb::Object#main_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <magic>$25: T.class_of(<Magic>))\l<cfgAlias>$28: T.class_of(A) = alias <C A>\l<isaCheckTemp>$29: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$28: T.class_of(A))\l<isaCheckTemp>$29: T.untyped\l"
     ];
@@ -34,6 +36,7 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_3" -> "bb::Object#main_14" [style="tapered"];
 
     "bb::Object#main_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>))\l<statTemp>$7: Integer(3) = 3\l<ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))\l<ifTemp>$5: T::Boolean\l"
     ];
@@ -42,12 +45,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_4" -> "bb::Object#main_6" [style="tapered"];
 
     "bb::Object#main_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>))\l<statTemp>$9: Integer(0) = try\l<statTemp>$10: Integer(1) = 1\ltry: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))\l<cfgAlias>$14: T.class_of(A) = alias <C A>\l<statTemp>$12: A = <cfgAlias>$14: T.class_of(A).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$12: A)\l<unconditional>\l"
     ];
 
     "bb::Object#main_5" -> "bb::Object#main_10" [style="bold"];
     "bb::Object#main_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>))\l<statTemp>$17: Integer(6) = 6\l<ifTemp>$15: T::Boolean = try: Integer(0).<(<statTemp>$17: Integer(6))\l<ifTemp>$15: T::Boolean\l"
     ];
@@ -56,12 +61,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_6" -> "bb::Object#main_10" [style="tapered"];
 
     "bb::Object#main_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=1](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>))\l<statTemp>$19: Integer(0) = try\l<statTemp>$20: Integer(1) = 1\ltry: Integer = <statTemp>$19: Integer(0).+(<statTemp>$20: Integer(1))\l<cfgAlias>$24: T.class_of(B) = alias <C B>\l<statTemp>$22: B = <cfgAlias>$24: T.class_of(B).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$22: B)\l<unconditional>\l"
     ];
 
     "bb::Object#main_7" -> "bb::Object#main_10" [style="bold"];
     "bb::Object#main_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>))\l<exceptionValue>$4: T.untyped = <get-current-exception>\l<exceptionValue>$4: T.untyped\l"
     ];
@@ -70,12 +77,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_10" -> "bb::Object#main_11" [style="tapered"];
 
     "bb::Object#main_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=4](<returnMethodTemp>$2: NilClass)\l<unconditional>\l"
     ];
 
     "bb::Object#main_11" -> "bb::Object#main_12" [style="bold"];
     "bb::Object#main_12" [
+        shape = rectangle;
         color = black;
         label = "block[id=12, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$46: T.nilable(TrueClass))\l<gotoDeadTemp>$46: T.nilable(TrueClass)\l"
     ];
@@ -84,12 +93,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_12" -> "bb::Object#main_17" [style="tapered"];
 
     "bb::Object#main_13" [
+        shape = rectangle;
         color = black;
         label = "block[id=13, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>))\l<exceptionValue>$4: NilClass = nil\l<keepForCfgTemp>$26: Sorbet::Private::Static::Void = <magic>$25: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)\l<statTemp>$32: String(\"rescue A \") = \"rescue A \"\l<statTemp>$30: NilClass = <self>: Object.puts(<statTemp>$32: String(\"rescue A \"))\l<magic>$34: T.class_of(<Magic>) = alias <C <Magic>>\l<retryTemp>$35: Sorbet::Private::Static::Void = <magic>$34: T.class_of(<Magic>).<retry>()\l<unconditional>\l"
     ];
 
     "bb::Object#main_13" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_14" [
+        shape = rectangle;
         color = black;
         label = "block[id=14, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <magic>$25: T.class_of(<Magic>))\l<cfgAlias>$38: T.class_of(B) = alias <C B>\l<isaCheckTemp>$39: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$38: T.class_of(B))\l<isaCheckTemp>$39: T.untyped\l"
     ];
@@ -98,18 +109,21 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_14" -> "bb::Object#main_16" [style="tapered"];
 
     "bb::Object#main_15" [
+        shape = rectangle;
         color = black;
         label = "block[id=15, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>))\l<exceptionValue>$4: NilClass = nil\l<keepForCfgTemp>$36: Sorbet::Private::Static::Void = <magic>$25: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)\l<statTemp>$42: String(\"rescue B \") = \"rescue B \"\l<statTemp>$40: NilClass = <self>: Object.puts(<statTemp>$42: String(\"rescue B \"))\l<magic>$44: T.class_of(<Magic>) = alias <C <Magic>>\l<retryTemp>$45: Sorbet::Private::Static::Void = <magic>$44: T.class_of(<Magic>).<retry>()\l<unconditional>\l"
     ];
 
     "bb::Object#main_15" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_16" [
+        shape = rectangle;
         color = black;
         label = "block[id=16, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$46: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#main_16" -> "bb::Object#main_12" [style="bold"];
     "bb::Object#main_17" [
+        shape = rectangle;
         color = black;
         label = "block[id=17, rubyBlockId=0](<returnMethodTemp>$2: NilClass)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
@@ -120,16 +134,16 @@ subgraph "cluster_::Object#main" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(A) = alias <C A>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(A))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(A) = alias <C A>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(A))\l<cfgAlias>$16: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$18: T.class_of(Exception) = alias <C Exception>\l<statTemp>$14: Sorbet::Private::Static::Void = <cfgAlias>$16: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$18: T.class_of(Exception))\l<cfgAlias>$22: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$24: T.class_of(B) = alias <C B>\l<statTemp>$20: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$24: T.class_of(B))\l<cfgAlias>$27: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$29: T.class_of(B) = alias <C B>\l<statTemp>$25: Sorbet::Private::Static::Void = <cfgAlias>$27: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$29: T.class_of(B))\l<cfgAlias>$32: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$34: T.class_of(Exception) = alias <C Exception>\l<statTemp>$30: Sorbet::Private::Static::Void = <cfgAlias>$32: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$34: T.class_of(Exception))\l<cfgAlias>$37: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$39: Symbol(:main) = :main\l<statTemp>$40: Symbol(:normal) = :normal\l<statTemp>$35: Symbol(:main) = <cfgAlias>$37: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$39: Symbol(:main), <statTemp>$40: Symbol(:normal))\l<statTemp>$41: T.untyped = <self>: T.class_of(<root>).main()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -140,16 +154,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::<Class:A>#<static-init>" {
     label = "::<Class:A>#<static-init>";
     color = blue;
-    "bb::<Class:A>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
     "bb::<Class:A>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -160,16 +174,16 @@ subgraph "cluster_::<Class:A>#<static-init>" {
 subgraph "cluster_::<Class:B>#<static-init>" {
     label = "::<Class:B>#<static-init>";
     color = blue;
-    "bb::<Class:B>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:B>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:B>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(B) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U B>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U B>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_0" -> "bb::<Class:B>#<static-init>_1" [style="bold"];
     "bb::<Class:B>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/retry_nested.rb.cfg.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg.exp
@@ -2,22 +2,23 @@ digraph "retry_nested.rb" {
 subgraph "cluster_::Object#main" {
     label = "::Object#main";
     color = blue;
-    "bb::Object#main_0" [shape = invhouse];
-    "bb::Object#main_1" [shape = parallelogram];
 
     "bb::Object#main_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\ltry: Integer(0) = 0\l<magic>$42: T.class_of(<Magic>) = alias <C <Magic>>\l<unconditional>\l"
     ];
 
     "bb::Object#main_0" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#main_1" -> "bb::Object#main_1" [style="bold"];
     "bb::Object#main_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<exceptionValue>$4: T.untyped = <get-current-exception>\l<exceptionValue>$4: T.untyped\l"
     ];
@@ -26,6 +27,7 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_2" -> "bb::Object#main_4" [style="tapered"];
 
     "bb::Object#main_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<cfgAlias>$45: T.class_of(B) = alias <C B>\l<isaCheckTemp>$46: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$45: T.class_of(B))\l<isaCheckTemp>$46: T.untyped\l"
     ];
@@ -34,12 +36,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_3" -> "bb::Object#main_22" [style="tapered"];
 
     "bb::Object#main_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<statTemp>$7: String(\"top\") = \"top\"\l<statTemp>$5: NilClass = <self>: Object.puts(<statTemp>$7: String(\"top\"))\l<magic>$29: T.class_of(<Magic>) = alias <C <Magic>>\l<unconditional>\l"
     ];
 
     "bb::Object#main_4" -> "bb::Object#main_5" [style="bold"];
     "bb::Object#main_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<exceptionValue>$8: T.untyped = <get-current-exception>\l<exceptionValue>$8: T.untyped\l"
     ];
@@ -48,6 +52,7 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_5" -> "bb::Object#main_7" [style="tapered"];
 
     "bb::Object#main_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=6](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: T.untyped, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<cfgAlias>$32: T.class_of(A) = alias <C A>\l<isaCheckTemp>$33: T.untyped = <exceptionValue>$8: T.untyped.is_a?(<cfgAlias>$32: T.class_of(A))\l<isaCheckTemp>$33: T.untyped\l"
     ];
@@ -56,6 +61,7 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_6" -> "bb::Object#main_17" [style="tapered"];
 
     "bb::Object#main_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=5](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<statTemp>$11: Integer(3) = 3\l<ifTemp>$9: T::Boolean = try: Integer(0).<(<statTemp>$11: Integer(3))\l<ifTemp>$9: T::Boolean\l"
     ];
@@ -64,12 +70,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_7" -> "bb::Object#main_9" [style="tapered"];
 
     "bb::Object#main_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=5](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<statTemp>$13: Integer(0) = try\l<statTemp>$14: Integer(1) = 1\ltry: Integer = <statTemp>$13: Integer(0).+(<statTemp>$14: Integer(1))\l<cfgAlias>$18: T.class_of(A) = alias <C A>\l<statTemp>$16: A = <cfgAlias>$18: T.class_of(A).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$16: A)\l<unconditional>\l"
     ];
 
     "bb::Object#main_8" -> "bb::Object#main_13" [style="bold"];
     "bb::Object#main_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=5](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<statTemp>$21: Integer(6) = 6\l<ifTemp>$19: T::Boolean = try: Integer(0).<(<statTemp>$21: Integer(6))\l<ifTemp>$19: T::Boolean\l"
     ];
@@ -78,12 +86,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_9" -> "bb::Object#main_13" [style="tapered"];
 
     "bb::Object#main_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=5](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<statTemp>$23: Integer(0) = try\l<statTemp>$24: Integer(1) = 1\ltry: Integer = <statTemp>$23: Integer(0).+(<statTemp>$24: Integer(1))\l<cfgAlias>$28: T.class_of(B) = alias <C B>\l<statTemp>$26: B = <cfgAlias>$28: T.class_of(B).new()\l<returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$26: B)\l<unconditional>\l"
     ];
 
     "bb::Object#main_10" -> "bb::Object#main_13" [style="bold"];
     "bb::Object#main_13" [
+        shape = rectangle;
         color = black;
         label = "block[id=13, rubyBlockId=5](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<exceptionValue>$8: T.untyped = <get-current-exception>\l<exceptionValue>$8: T.untyped\l"
     ];
@@ -92,12 +102,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_13" -> "bb::Object#main_14" [style="tapered"];
 
     "bb::Object#main_14" [
+        shape = rectangle;
         color = black;
         label = "block[id=14, rubyBlockId=8](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<unconditional>\l"
     ];
 
     "bb::Object#main_14" -> "bb::Object#main_15" [style="bold"];
     "bb::Object#main_15" [
+        shape = rectangle;
         color = black;
         label = "block[id=15, rubyBlockId=7](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: T.nilable(TrueClass), <magic>$42: T.class_of(<Magic>))\l<gotoDeadTemp>$40: T.nilable(TrueClass)\l"
     ];
@@ -106,18 +118,21 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_15" -> "bb::Object#main_18" [style="tapered"];
 
     "bb::Object#main_16" [
+        shape = rectangle;
         color = black;
         label = "block[id=16, rubyBlockId=6](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<exceptionValue>$8: NilClass = nil\l<keepForCfgTemp>$30: Sorbet::Private::Static::Void = <magic>$29: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$8: NilClass)\l<statTemp>$36: String(\"rescue A\") = \"rescue A\"\l<statTemp>$34: NilClass = <self>: Object.puts(<statTemp>$36: String(\"rescue A\"))\l<magic>$38: T.class_of(<Magic>) = alias <C <Magic>>\l<retryTemp>$39: Sorbet::Private::Static::Void = <magic>$38: T.class_of(<Magic>).<retry>()\l<unconditional>\l"
     ];
 
     "bb::Object#main_16" -> "bb::Object#main_5" [style="bold"];
     "bb::Object#main_17" [
+        shape = rectangle;
         color = black;
         label = "block[id=17, rubyBlockId=6](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$42: T.class_of(<Magic>))\l<gotoDeadTemp>$40: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#main_17" -> "bb::Object#main_15" [style="bold"];
     "bb::Object#main_18" [
+        shape = rectangle;
         color = black;
         label = "block[id=18, rubyBlockId=1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<exceptionValue>$4: T.untyped = <get-current-exception>\l<exceptionValue>$4: T.untyped\l"
     ];
@@ -126,12 +141,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_18" -> "bb::Object#main_19" [style="tapered"];
 
     "bb::Object#main_19" [
+        shape = rectangle;
         color = black;
         label = "block[id=19, rubyBlockId=4](<returnMethodTemp>$2: NilClass)\l<unconditional>\l"
     ];
 
     "bb::Object#main_19" -> "bb::Object#main_20" [style="bold"];
     "bb::Object#main_20" [
+        shape = rectangle;
         color = black;
         label = "block[id=20, rubyBlockId=3](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$53: T.nilable(TrueClass))\l<gotoDeadTemp>$53: T.nilable(TrueClass)\l"
     ];
@@ -140,18 +157,21 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_20" -> "bb::Object#main_23" [style="tapered"];
 
     "bb::Object#main_21" [
+        shape = rectangle;
         color = black;
         label = "block[id=21, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>))\l<exceptionValue>$4: NilClass = nil\l<keepForCfgTemp>$43: Sorbet::Private::Static::Void = <magic>$42: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)\l<statTemp>$49: String(\"rescue B \") = \"rescue B \"\l<statTemp>$47: NilClass = <self>: Object.puts(<statTemp>$49: String(\"rescue B \"))\l<magic>$51: T.class_of(<Magic>) = alias <C <Magic>>\l<retryTemp>$52: Sorbet::Private::Static::Void = <magic>$51: T.class_of(<Magic>).<retry>()\l<unconditional>\l"
     ];
 
     "bb::Object#main_21" -> "bb::Object#main_2" [style="bold"];
     "bb::Object#main_22" [
+        shape = rectangle;
         color = black;
         label = "block[id=22, rubyBlockId=2](<returnMethodTemp>$2: NilClass)\l<gotoDeadTemp>$53: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#main_22" -> "bb::Object#main_20" [style="bold"];
     "bb::Object#main_23" [
+        shape = rectangle;
         color = black;
         label = "block[id=23, rubyBlockId=0](<returnMethodTemp>$2: NilClass)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
@@ -162,16 +182,16 @@ subgraph "cluster_::Object#main" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(A) = alias <C A>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(A))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(A) = alias <C A>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(A))\l<cfgAlias>$16: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$18: T.class_of(Exception) = alias <C Exception>\l<statTemp>$14: Sorbet::Private::Static::Void = <cfgAlias>$16: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$18: T.class_of(Exception))\l<cfgAlias>$22: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$24: T.class_of(B) = alias <C B>\l<statTemp>$20: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$24: T.class_of(B))\l<cfgAlias>$27: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$29: T.class_of(B) = alias <C B>\l<statTemp>$25: Sorbet::Private::Static::Void = <cfgAlias>$27: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$29: T.class_of(B))\l<cfgAlias>$32: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$34: T.class_of(Exception) = alias <C Exception>\l<statTemp>$30: Sorbet::Private::Static::Void = <cfgAlias>$32: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$34: T.class_of(Exception))\l<cfgAlias>$37: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$39: Symbol(:main) = :main\l<statTemp>$40: Symbol(:normal) = :normal\l<statTemp>$35: Symbol(:main) = <cfgAlias>$37: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$39: Symbol(:main), <statTemp>$40: Symbol(:normal))\l<statTemp>$41: T.untyped = <self>: T.class_of(<root>).main()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -182,16 +202,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::<Class:A>#<static-init>" {
     label = "::<Class:A>#<static-init>";
     color = blue;
-    "bb::<Class:A>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
     "bb::<Class:A>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -202,16 +222,16 @@ subgraph "cluster_::<Class:A>#<static-init>" {
 subgraph "cluster_::<Class:B>#<static-init>" {
     label = "::<Class:B>#<static-init>";
     color = blue;
-    "bb::<Class:B>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:B>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:B>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(B) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U B>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U B>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_0" -> "bb::<Class:B>#<static-init>_1" [style="bold"];
     "bb::<Class:B>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/side_effects.rb.cfg.exp
+++ b/test/testdata/cfg/side_effects.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "side_effects.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(Side) = alias <C Side>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(Side))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(Side) = alias <C Side>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(Side))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,10 +22,9 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::Side#foo" {
     label = "::Side#foo";
     color = blue;
-    "bb::Side#foo_0" [shape = invhouse];
-    "bb::Side#foo_1" [shape = parallelogram];
 
     "bb::Side#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Side = cast(<self>: NilClass, Side);\lcond: T.untyped = load_arg(cond)\la: Integer(1) = 1\l<statTemp>$4: Integer(1) = a\l<statTemp>$5: Integer(1) = a\lcond: T.untyped\l"
     ];
@@ -34,24 +33,28 @@ subgraph "cluster_::Side#foo" {
     "bb::Side#foo_0" -> "bb::Side#foo_3" [style="tapered"];
 
     "bb::Side#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Side#foo_1" -> "bb::Side#foo_1" [style="bold"];
     "bb::Side#foo_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](<statTemp>$4: Integer(1), <statTemp>$5: Integer(1))\la: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Side#foo_2" -> "bb::Side#foo_4" [style="bold"];
     "bb::Side#foo_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<statTemp>$4: Integer(1), <statTemp>$5: Integer(1))\la: Integer(2) = 2\l<unconditional>\l"
     ];
 
     "bb::Side#foo_3" -> "bb::Side#foo_4" [style="bold"];
     "bb::Side#foo_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](a: T.any(TrueClass, Integer), <statTemp>$4: Integer(1), <statTemp>$5: Integer(1))\l<returnMethodTemp>$2: T.untyped = <statTemp>$4: Integer(1).foo(<statTemp>$5: Integer(1), a: T.any(TrueClass, Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -62,16 +65,16 @@ subgraph "cluster_::Side#foo" {
 subgraph "cluster_::<Class:Side>#<static-init>" {
     label = "::<Class:Side>#<static-init>";
     color = blue;
-    "bb::<Class:Side>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Side>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Side>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Side) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Side>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Side>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:foo) = :foo\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:foo) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Side), <statTemp>$6: Symbol(:foo), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)\l<unconditional>\l"
     ];
 
     "bb::<Class:Side>#<static-init>_0" -> "bb::<Class:Side>#<static-init>_1" [style="bold"];
     "bb::<Class:Side>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/side_effects2.rb.cfg.exp
+++ b/test/testdata/cfg/side_effects2.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "side_effects2.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(Side) = alias <C Side>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(Side))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(Side) = alias <C Side>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(Side))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,10 +22,9 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::Side#foo" {
     label = "::Side#foo";
     color = blue;
-    "bb::Side#foo_0" [shape = invhouse];
-    "bb::Side#foo_1" [shape = parallelogram];
 
     "bb::Side#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Side = cast(<self>: NilClass, Side);\lcond: T.untyped = load_arg(cond)\la: Side = <self>\l<statTemp>$4: Side = a\l<statTemp>$5: Side = a\lcond: T.untyped\l"
     ];
@@ -34,24 +33,28 @@ subgraph "cluster_::Side#foo" {
     "bb::Side#foo_0" -> "bb::Side#foo_3" [style="tapered"];
 
     "bb::Side#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Side#foo_1" -> "bb::Side#foo_1" [style="bold"];
     "bb::Side#foo_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](<statTemp>$4: Side, <statTemp>$5: Side)\la: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Side#foo_2" -> "bb::Side#foo_4" [style="bold"];
     "bb::Side#foo_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<statTemp>$4: Side, <statTemp>$5: Side)\la: Integer(2) = 2\l<unconditional>\l"
     ];
 
     "bb::Side#foo_3" -> "bb::Side#foo_4" [style="bold"];
     "bb::Side#foo_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](a: T.any(TrueClass, Integer), <statTemp>$4: Side, <statTemp>$5: Side)\l<returnMethodTemp>$2: T.untyped = <statTemp>$4: Side.bar(<statTemp>$5: Side, a: T.any(TrueClass, Integer), a: T.any(TrueClass, Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -62,16 +65,16 @@ subgraph "cluster_::Side#foo" {
 subgraph "cluster_::Side#bar" {
     label = "::Side#bar";
     color = blue;
-    "bb::Side#bar_0" [shape = invhouse];
-    "bb::Side#bar_1" [shape = parallelogram];
 
     "bb::Side#bar_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Side = cast(<self>: NilClass, Side);\la: T.untyped = load_arg(a)\lb: T.untyped = load_arg(b)\lc: T.untyped = load_arg(c)\l<returnMethodTemp>$2: NilClass = <self>: Side.puts(a: T.untyped, b: T.untyped, c: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Side#bar_0" -> "bb::Side#bar_1" [style="bold"];
     "bb::Side#bar_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,16 +85,16 @@ subgraph "cluster_::Side#bar" {
 subgraph "cluster_::<Class:Side>#<static-init>" {
     label = "::<Class:Side>#<static-init>";
     color = blue;
-    "bb::<Class:Side>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Side>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Side>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Side) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Side>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Side>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:foo) = :foo\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:foo) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Side), <statTemp>$7: Symbol(:foo), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:bar) = :bar\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:bar) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Side), <statTemp>$13: Symbol(:bar), <statTemp>$14: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Side>#<static-init>_0" -> "bb::<Class:Side>#<static-init>_1" [style="bold"];
     "bb::<Class:Side>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/cfg/uaf1.rb.cfg.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "uaf1.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(A) = alias <C A>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(A))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(A) = alias <C A>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(A))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,22 +22,23 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::A#initialize" {
     label = "::A#initialize";
     color = blue;
-    "bb::A#initialize_0" [shape = invhouse];
-    "bb::A#initialize_1" [shape = parallelogram];
 
     "bb::A#initialize_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: A = cast(<self>: NilClass, A);\l<statTemp>$3: T.untyped = <self>: A.spec_list()\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$3: T.untyped.map()\l<selfRestore>$6: A = <self>\l<unconditional>\l"
     ];
 
     "bb::A#initialize_0" -> "bb::A#initialize_2" [style="bold"];
     "bb::A#initialize_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::A#initialize_1" -> "bb::A#initialize_1" [style="bold"];
     "bb::A#initialize_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$9: NilClass, <gotoDeadTemp>$16: NilClass)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -46,12 +47,14 @@ subgraph "cluster_::A#initialize" {
     "bb::A#initialize_2" -> "bb::A#initialize_3" [style="tapered"];
 
     "bb::A#initialize_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A)\l<returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$5, map>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::A#initialize_3" -> "bb::A#initialize_1" [style="bold"];
     "bb::A#initialize_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$9: NilClass, <gotoDeadTemp>$16: NilClass)\louterLoops: 1\l<self>: A = loadSelf\l<magic>$11: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$10: T.untyped = <get-current-exception>\l<exceptionValue>$10: T.untyped\l"
     ];
@@ -60,6 +63,7 @@ subgraph "cluster_::A#initialize" {
     "bb::A#initialize_5" -> "bb::A#initialize_8" [style="tapered"];
 
     "bb::A#initialize_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=3](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$9: T.nilable(Integer), <exceptionValue>$10: T.untyped, <magic>$11: T.class_of(<Magic>), <gotoDeadTemp>$16: NilClass)\louterLoops: 1\lse$1: T.untyped = <exceptionValue>$10\l<cfgAlias>$14: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$15: T.untyped = se$1: T.untyped.is_a?(<cfgAlias>$14: T.class_of(StandardError))\l<isaCheckTemp>$15: T.untyped\l"
     ];
@@ -68,6 +72,7 @@ subgraph "cluster_::A#initialize" {
     "bb::A#initialize_7" -> "bb::A#initialize_12" [style="tapered"];
 
     "bb::A#initialize_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$11: T.class_of(<Magic>), <gotoDeadTemp>$16: NilClass)\louterLoops: 1\l<blockReturnTemp>$9: Integer(1) = 1\l<exceptionValue>$10: T.untyped = <get-current-exception>\l<exceptionValue>$10: T.untyped\l"
     ];
@@ -76,12 +81,14 @@ subgraph "cluster_::A#initialize" {
     "bb::A#initialize_8" -> "bb::A#initialize_9" [style="tapered"];
 
     "bb::A#initialize_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=5](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$9: Integer(1), <gotoDeadTemp>$16: NilClass)\louterLoops: 1\l<unconditional>\l"
     ];
 
     "bb::A#initialize_9" -> "bb::A#initialize_10" [style="bold"];
     "bb::A#initialize_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=4](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$9: T.nilable(Integer), <gotoDeadTemp>$16: T.nilable(TrueClass))\louterLoops: 1\l<gotoDeadTemp>$16: T.nilable(TrueClass)\l"
     ];
@@ -90,18 +97,21 @@ subgraph "cluster_::A#initialize" {
     "bb::A#initialize_10" -> "bb::A#initialize_13" [style="tapered"];
 
     "bb::A#initialize_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=3](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$11: T.class_of(<Magic>), <gotoDeadTemp>$16: NilClass)\louterLoops: 1\l<exceptionValue>$10: NilClass = nil\l<keepForCfgTemp>$12: Sorbet::Private::Static::Void = <magic>$11: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$10: NilClass)\l<blockReturnTemp>$9: Integer(2) = 2\l<unconditional>\l"
     ];
 
     "bb::A#initialize_11" -> "bb::A#initialize_10" [style="bold"];
     "bb::A#initialize_12" [
+        shape = rectangle;
         color = black;
         label = "block[id=12, rubyBlockId=3](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$9: T.nilable(Integer))\louterLoops: 1\l<gotoDeadTemp>$16: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::A#initialize_12" -> "bb::A#initialize_10" [style="bold"];
     "bb::A#initialize_13" [
+        shape = rectangle;
         color = black;
         label = "block[id=13, rubyBlockId=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$9: Integer, <gotoDeadTemp>$16: NilClass)\louterLoops: 1\l<blockReturnTemp>$18: T.noreturn = blockreturn<map> <blockReturnTemp>$9: Integer\l<unconditional>\l"
     ];
@@ -112,16 +122,16 @@ subgraph "cluster_::A#initialize" {
 subgraph "cluster_::<Class:A>#<static-init>" {
     label = "::<Class:A>#<static-init>";
     color = blue;
-    "bb::<Class:A>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:initialize) = :initialize\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:initialize) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(A), <statTemp>$6: Symbol(:initialize), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:initialize)\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
     "bb::<Class:A>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/desugar/ensure_without_rescue.rb.cfg.exp
+++ b/test/testdata/desugar/ensure_without_rescue.rb.cfg.exp
@@ -2,10 +2,9 @@ digraph "ensure_without_rescue.rb" {
 subgraph "cluster_::Object#main" {
     label = "::Object#main";
     color = blue;
-    "bb::Object#main_0" [shape = invhouse];
-    "bb::Object#main_1" [shape = parallelogram];
 
     "bb::Object#main_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -14,18 +13,21 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_0" -> "bb::Object#main_4" [style="tapered"];
 
     "bb::Object#main_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#main_1" -> "bb::Object#main_1" [style="bold"];
     "bb::Object#main_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](<self>: Object, <returnMethodTemp>$2: T.untyped)\l<gotoDeadTemp>$6: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::Object#main_3" -> "bb::Object#main_6" [style="bold"];
     "bb::Object#main_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](<self>: Object)\l<returnMethodTemp>$2: T.untyped = <self>: Object.a()\l<exceptionValue>$3: T.untyped = <get-current-exception>\l<exceptionValue>$3: T.untyped\l"
     ];
@@ -34,12 +36,14 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_4" -> "bb::Object#main_5" [style="tapered"];
 
     "bb::Object#main_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](<self>: Object, <returnMethodTemp>$2: T.untyped)\l<unconditional>\l"
     ];
 
     "bb::Object#main_5" -> "bb::Object#main_6" [style="bold"];
     "bb::Object#main_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$6: T.nilable(TrueClass))\l<throwAwayTemp>$7: T.untyped = <self>: Object.b()\l<gotoDeadTemp>$6: T.nilable(TrueClass)\l"
     ];
@@ -48,6 +52,7 @@ subgraph "cluster_::Object#main" {
     "bb::Object#main_6" -> "bb::Object#main_7" [style="tapered"];
 
     "bb::Object#main_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -58,16 +63,16 @@ subgraph "cluster_::Object#main" {
 subgraph "cluster_::Object#a" {
     label = "::Object#a";
     color = blue;
-    "bb::Object#a_0" [shape = invhouse];
-    "bb::Object#a_1" [shape = parallelogram];
 
     "bb::Object#a_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Object#a_0" -> "bb::Object#a_1" [style="bold"];
     "bb::Object#a_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -78,16 +83,16 @@ subgraph "cluster_::Object#a" {
 subgraph "cluster_::Object#b" {
     label = "::Object#b";
     color = blue;
-    "bb::Object#b_0" [shape = invhouse];
-    "bb::Object#b_1" [shape = parallelogram];
 
     "bb::Object#b_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Object#b_0" -> "bb::Object#b_1" [style="bold"];
     "bb::Object#b_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -98,16 +103,16 @@ subgraph "cluster_::Object#b" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:main) = :main\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:main) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$7: Symbol(:main), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:a) = :a\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:a) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$13: Symbol(:a), <statTemp>$14: Symbol(:normal))\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$19: Symbol(:b) = :b\l<statTemp>$20: Symbol(:normal) = :normal\l<statTemp>$15: Symbol(:b) = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$19: Symbol(:b), <statTemp>$20: Symbol(:normal))\l<statTemp>$21: T.untyped = <self>: T.class_of(<root>).main()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/desugar/for.rb.cfg.exp
+++ b/test/testdata/desugar/for.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "for.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(A) = alias <C A>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(A))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(A) = alias <C A>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(A))\l<cfgAlias>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$19: T.class_of(E) = alias <C E>\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$19: T.class_of(E))\l<cfgAlias>$22: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$24: T.class_of(E) = alias <C E>\l<statTemp>$20: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$24: T.class_of(E))\l<cfgAlias>$28: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$30: T.class_of(Main) = alias <C Main>\l<statTemp>$26: Sorbet::Private::Static::Void = <cfgAlias>$28: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$30: T.class_of(Main))\l<cfgAlias>$33: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$35: T.class_of(Main) = alias <C Main>\l<statTemp>$31: Sorbet::Private::Static::Void = <cfgAlias>$33: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$35: T.class_of(Main))\l<cfgAlias>$38: T.class_of(Main) = alias <C Main>\l<statTemp>$36: T.untyped = <cfgAlias>$38: T.class_of(Main).main()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::<Class:A>#each" {
     label = "::<Class:A>#each";
     color = blue;
-    "bb::<Class:A>#each_0" [shape = invhouse];
-    "bb::<Class:A>#each_1" [shape = parallelogram];
 
     "bb::<Class:A>#each_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\lblk: T.untyped = load_arg(blk)\l<statTemp>$5: Integer(1) = 1\l<statTemp>$6: Integer(2) = 2\l<statTemp>$7: Integer(3) = 3\l<statTemp>$8: Integer(4) = 4\l<statTemp>$9: Integer(5) = 5\l<statTemp>$3: T.untyped = blk: T.untyped.call(<statTemp>$5: Integer(1), <statTemp>$6: Integer(2), <statTemp>$7: Integer(3), <statTemp>$8: Integer(4), <statTemp>$9: Integer(5))\l<statTemp>$11: Integer(6) = 6\l<statTemp>$12: Integer(7) = 7\l<statTemp>$13: Integer(8) = 8\l<statTemp>$14: Integer(9) = 9\l<statTemp>$15: Integer(0) = 0\l<returnMethodTemp>$2: T.untyped = blk: T.untyped.call(<statTemp>$11: Integer(6), <statTemp>$12: Integer(7), <statTemp>$13: Integer(8), <statTemp>$14: Integer(9), <statTemp>$15: Integer(0))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#each_0" -> "bb::<Class:A>#each_1" [style="bold"];
     "bb::<Class:A>#each_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::<Class:A>#each" {
 subgraph "cluster_::<Class:A>#<static-init>" {
     label = "::<Class:A>#<static-init>";
     color = blue;
-    "bb::<Class:A>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:each) = :each\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:each) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(A), <statTemp>$6: Symbol(:each), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:each)\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
     "bb::<Class:A>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::<Class:A>#<static-init>" {
 subgraph "cluster_::<Class:E>#e=" {
     label = "::<Class:E>#e=";
     color = blue;
-    "bb::<Class:E>#e=_0" [shape = invhouse];
-    "bb::<Class:E>#e=_1" [shape = parallelogram];
 
     "bb::<Class:E>#e=_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l@e$3: T.untyped = alias <C <undeclared-field-stub>> (@e)\l<self>: T.class_of(E) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U E>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U E>> $1><C <U <AttachedClass>>>)\l  ]\l});\le: T.untyped = load_arg(e)\l@e$3: T.untyped = e\l<returnMethodTemp>$2: T.untyped = @e$3\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::<Class:E>#e=_0" -> "bb::<Class:E>#e=_1" [style="bold"];
     "bb::<Class:E>#e=_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,16 +82,16 @@ subgraph "cluster_::<Class:E>#e=" {
 subgraph "cluster_::<Class:E>#e" {
     label = "::<Class:E>#e";
     color = blue;
-    "bb::<Class:E>#e_0" [shape = invhouse];
-    "bb::<Class:E>#e_1" [shape = parallelogram];
 
     "bb::<Class:E>#e_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l@e$3: T.untyped = alias <C <undeclared-field-stub>> (@e)\l<self>: T.class_of(E) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U E>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U E>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: T.untyped = @e$3\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::<Class:E>#e_0" -> "bb::<Class:E>#e_1" [style="bold"];
     "bb::<Class:E>#e_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -102,16 +102,16 @@ subgraph "cluster_::<Class:E>#e" {
 subgraph "cluster_::<Class:E>#<static-init>" {
     label = "::<Class:E>#<static-init>";
     color = blue;
-    "bb::<Class:E>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:E>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:E>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(E) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U E>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U E>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:e=) = :e=\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:e=) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(E), <statTemp>$7: Symbol(:e=), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:e) = :e\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:e) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(E), <statTemp>$13: Symbol(:e), <statTemp>$14: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:E>#<static-init>_0" -> "bb::<Class:E>#<static-init>_1" [style="bold"];
     "bb::<Class:E>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -122,22 +122,23 @@ subgraph "cluster_::<Class:E>#<static-init>" {
 subgraph "cluster_::<Class:Main>#main" {
     label = "::<Class:Main>#main";
     color = blue;
-    "bb::<Class:Main>#main_0" [shape = invhouse];
-    "bb::<Class:Main>#main_1" [shape = parallelogram];
 
     "bb::<Class:Main>#main_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l@a$110: T.untyped = alias <C <undeclared-field-stub>> (@a)\l@@b$114: T.untyped = alias <C <undeclared-field-stub>> (@@b)\l$c$118: T.untyped = alias <C <undeclared-field-stub>> ($c)\l<self>: T.class_of(Main) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Main>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Main>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$6: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(A).each()\l<selfRestore>$7: T.class_of(Main) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_0" -> "bb::<Class:Main>#main_2" [style="bold"];
     "bb::<Class:Main>#main_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_1" -> "bb::<Class:Main>#main_1" [style="bold"];
     "bb::<Class:Main>#main_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -146,18 +147,21 @@ subgraph "cluster_::<Class:Main>#main" {
     "bb::<Class:Main>#main_2" -> "bb::<Class:Main>#main_3" [style="tapered"];
 
     "bb::<Class:Main>#main_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\l<statTemp>$3: T.untyped = Solve<<block-pre-call-temp>$6, each>\l<self>: T.class_of(Main) = <selfRestore>$7\l<cfgAlias>$17: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$18: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(A).each()\l<selfRestore>$19: T.class_of(Main) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_3" -> "bb::<Class:Main>#main_6" [style="bold"];
     "bb::<Class:Main>#main_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\louterLoops: 1\l<self>: T.class_of(Main) = loadSelf\l<blk>$8: T.untyped = load_yield_params(each)\l<blk>$9: Integer(0) = 0\la$1: T.untyped = <blk>$8: T.untyped.[](<blk>$9: Integer(0))\l<statTemp>$12: T.untyped = a$1: T.untyped.inspect()\l<blockReturnTemp>$10: NilClass = <self>: T.class_of(Main).puts(<statTemp>$12: T.untyped)\l<blockReturnTemp>$14: T.noreturn = blockreturn<each> <blockReturnTemp>$10: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_5" -> "bb::<Class:Main>#main_2" [style="bold"];
     "bb::<Class:Main>#main_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=2](<self>: T.class_of(Main), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -166,18 +170,21 @@ subgraph "cluster_::<Class:Main>#main" {
     "bb::<Class:Main>#main_6" -> "bb::<Class:Main>#main_7" [style="tapered"];
 
     "bb::<Class:Main>#main_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](<block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\l<statTemp>$15: T.untyped = Solve<<block-pre-call-temp>$18, each>\l<self>: T.class_of(Main) = <selfRestore>$19\l<cfgAlias>$43: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$44: Sorbet::Private::Static::Void = <cfgAlias>$43: T.class_of(A).each()\l<selfRestore>$45: T.class_of(Main) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_7" -> "bb::<Class:Main>#main_10" [style="bold"];
     "bb::<Class:Main>#main_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=2](<self>: T.class_of(Main), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\louterLoops: 1\l<self>: T.class_of(Main) = loadSelf\l<blk>$20: T.untyped = load_yield_params(each)\lforTemp$2: T.untyped = <blk>$20\l<cfgAlias>$26: T.class_of(<Magic>) = alias <C <Magic>>\l<assignTemp>$2$2: T.untyped = <cfgAlias>$26: T.class_of(<Magic>).<splat>(forTemp$2: T.untyped)\l<cfgAlias>$30: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$32: Integer(1) = 1\l<statTemp>$33: Integer(0) = 0\l<assignTemp>$3$2: T.untyped = <cfgAlias>$30: T.class_of(<Magic>).<expand-splat>(<assignTemp>$2$2: T.untyped, <statTemp>$32: Integer(1), <statTemp>$33: Integer(0))\l<statTemp>$36: Integer(0) = 0\la$2: T.untyped = <assignTemp>$3$2: T.untyped.[](<statTemp>$36: Integer(0))\l<statTemp>$38: T.untyped = a$2: T.untyped.inspect()\l<blockReturnTemp>$22: NilClass = <self>: T.class_of(Main).puts(<statTemp>$38: T.untyped)\l<blockReturnTemp>$40: T.noreturn = blockreturn<each> <blockReturnTemp>$22: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_9" -> "bb::<Class:Main>#main_6" [style="bold"];
     "bb::<Class:Main>#main_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=3](<self>: T.class_of(Main), <block-pre-call-temp>$44: Sorbet::Private::Static::Void, <selfRestore>$45: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -186,18 +193,21 @@ subgraph "cluster_::<Class:Main>#main" {
     "bb::<Class:Main>#main_10" -> "bb::<Class:Main>#main_11" [style="tapered"];
 
     "bb::<Class:Main>#main_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=0](<block-pre-call-temp>$44: Sorbet::Private::Static::Void, <selfRestore>$45: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\l<statTemp>$41: T.untyped = Solve<<block-pre-call-temp>$44, each>\l<self>: T.class_of(Main) = <selfRestore>$45\l<cfgAlias>$59: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$60: Sorbet::Private::Static::Void = <cfgAlias>$59: T.class_of(A).each()\l<selfRestore>$61: T.class_of(Main) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_11" -> "bb::<Class:Main>#main_14" [style="bold"];
     "bb::<Class:Main>#main_13" [
+        shape = rectangle;
         color = black;
         label = "block[id=13, rubyBlockId=3](<self>: T.class_of(Main), <block-pre-call-temp>$44: Sorbet::Private::Static::Void, <selfRestore>$45: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\louterLoops: 1\l<self>: T.class_of(Main) = loadSelf\l<blk>$46: T.untyped = load_yield_params(each)\l<blk>$47: Integer(0) = 0\la$3: T.untyped = <blk>$46: T.untyped.[](<blk>$47: Integer(0))\l<blk>$47: Integer(1) = 1\lb$3: T.untyped = <blk>$46: T.untyped.[](<blk>$47: Integer(1))\l<statTemp>$51: T.untyped = a$3: T.untyped.inspect()\l<statTemp>$49: NilClass = <self>: T.class_of(Main).puts(<statTemp>$51: T.untyped)\l<statTemp>$54: T.untyped = b$3: T.untyped.inspect()\l<blockReturnTemp>$48: NilClass = <self>: T.class_of(Main).puts(<statTemp>$54: T.untyped)\l<blockReturnTemp>$56: T.noreturn = blockreturn<each> <blockReturnTemp>$48: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_13" -> "bb::<Class:Main>#main_10" [style="bold"];
     "bb::<Class:Main>#main_14" [
+        shape = rectangle;
         color = black;
         label = "block[id=14, rubyBlockId=4](<self>: T.class_of(Main), <block-pre-call-temp>$60: Sorbet::Private::Static::Void, <selfRestore>$61: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -206,18 +216,21 @@ subgraph "cluster_::<Class:Main>#main" {
     "bb::<Class:Main>#main_14" -> "bb::<Class:Main>#main_15" [style="tapered"];
 
     "bb::<Class:Main>#main_15" [
+        shape = rectangle;
         color = black;
         label = "block[id=15, rubyBlockId=0](<block-pre-call-temp>$60: Sorbet::Private::Static::Void, <selfRestore>$61: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\l<statTemp>$57: T.untyped = Solve<<block-pre-call-temp>$60, each>\l<self>: T.class_of(Main) = <selfRestore>$61\l<statTemp>$92: String(\"main\") = \"main\"\l<statTemp>$90: NilClass = <self>: T.class_of(Main).puts(<statTemp>$92: String(\"main\"))\l<cfgAlias>$95: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$96: Sorbet::Private::Static::Void = <cfgAlias>$95: T.class_of(A).each()\l<selfRestore>$97: T.class_of(Main) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_15" -> "bb::<Class:Main>#main_18" [style="bold"];
     "bb::<Class:Main>#main_17" [
+        shape = rectangle;
         color = black;
         label = "block[id=17, rubyBlockId=4](<self>: T.class_of(Main), <block-pre-call-temp>$60: Sorbet::Private::Static::Void, <selfRestore>$61: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\louterLoops: 1\l<self>: T.class_of(Main) = loadSelf\l<blk>$62: T.untyped = load_yield_params(each)\lforTemp$4: T.untyped = <blk>$62\l<cfgAlias>$68: T.class_of(<Magic>) = alias <C <Magic>>\l<assignTemp>$4$4: T.untyped = <cfgAlias>$68: T.class_of(<Magic>).<splat>(forTemp$4: T.untyped)\l<cfgAlias>$72: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$74: Integer(2) = 2\l<statTemp>$75: Integer(0) = 0\l<assignTemp>$5$4: T.untyped = <cfgAlias>$72: T.class_of(<Magic>).<expand-splat>(<assignTemp>$4$4: T.untyped, <statTemp>$74: Integer(2), <statTemp>$75: Integer(0))\l<statTemp>$78: Integer(0) = 0\la$4: T.untyped = <assignTemp>$5$4: T.untyped.[](<statTemp>$78: Integer(0))\l<statTemp>$81: Integer(1) = 1\lb$4: T.untyped = <assignTemp>$5$4: T.untyped.[](<statTemp>$81: Integer(1))\l<statTemp>$84: T.untyped = a$4: T.untyped.inspect()\l<statTemp>$82: NilClass = <self>: T.class_of(Main).puts(<statTemp>$84: T.untyped)\l<statTemp>$87: T.untyped = b$4: T.untyped.inspect()\l<blockReturnTemp>$64: NilClass = <self>: T.class_of(Main).puts(<statTemp>$87: T.untyped)\l<blockReturnTemp>$89: T.noreturn = blockreturn<each> <blockReturnTemp>$64: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_17" -> "bb::<Class:Main>#main_14" [style="bold"];
     "bb::<Class:Main>#main_18" [
+        shape = rectangle;
         color = black;
         label = "block[id=18, rubyBlockId=5](<self>: T.class_of(Main), <block-pre-call-temp>$96: Sorbet::Private::Static::Void, <selfRestore>$97: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -226,18 +239,21 @@ subgraph "cluster_::<Class:Main>#main" {
     "bb::<Class:Main>#main_18" -> "bb::<Class:Main>#main_19" [style="tapered"];
 
     "bb::<Class:Main>#main_19" [
+        shape = rectangle;
         color = black;
         label = "block[id=19, rubyBlockId=0](<block-pre-call-temp>$96: Sorbet::Private::Static::Void, <selfRestore>$97: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\l<statTemp>$93: T.untyped = Solve<<block-pre-call-temp>$96, each>\l<self>: T.class_of(Main) = <selfRestore>$97\l<cfgAlias>$153: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$154: Sorbet::Private::Static::Void = <cfgAlias>$153: T.class_of(A).each()\l<selfRestore>$155: T.class_of(Main) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_19" -> "bb::<Class:Main>#main_22" [style="bold"];
     "bb::<Class:Main>#main_21" [
+        shape = rectangle;
         color = black;
         label = "block[id=21, rubyBlockId=5](<self>: T.class_of(Main), <block-pre-call-temp>$96: Sorbet::Private::Static::Void, <selfRestore>$97: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped)\louterLoops: 1\l<self>: T.class_of(Main) = loadSelf\l<cfgAlias>$105: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$107: Integer(5) = 5\l<statTemp>$108: Integer(0) = 0\l<assignTemp>$8$5: [NilClass, NilClass, NilClass, NilClass, NilClass] = <cfgAlias>$105: T.class_of(<Magic>).<expand-splat>(forTemp$6$5: NilClass, <statTemp>$107: Integer(5), <statTemp>$108: Integer(0))\l<statTemp>$112: Integer(0) = 0\l@a$110: NilClass = <assignTemp>$8$5: [NilClass, NilClass, NilClass, NilClass, NilClass].[](<statTemp>$112: Integer(0))\l<statTemp>$116: Integer(1) = 1\l@@b$114: NilClass = <assignTemp>$8$5: [NilClass, NilClass, NilClass, NilClass, NilClass].[](<statTemp>$116: Integer(1))\l<statTemp>$120: Integer(2) = 2\l$c$118: NilClass = <assignTemp>$8$5: [NilClass, NilClass, NilClass, NilClass, NilClass].[](<statTemp>$120: Integer(2))\l<statTemp>$123: Integer(3) = 3\ld$5: NilClass = <assignTemp>$8$5: [NilClass, NilClass, NilClass, NilClass, NilClass].[](<statTemp>$123: Integer(3))\l<cfgAlias>$126: T.class_of(E) = alias <C E>\l<statTemp>$129: Integer(4) = 4\l<statTemp>$127: NilClass = <assignTemp>$8$5: [NilClass, NilClass, NilClass, NilClass, NilClass].[](<statTemp>$129: Integer(4))\l<statTemp>$124: NilClass = <cfgAlias>$126: T.class_of(E).e=(<statTemp>$127: NilClass)\l<statTemp>$132: T.untyped = @a$110: NilClass.inspect()\l<statTemp>$130: NilClass = <self>: T.class_of(Main).puts(<statTemp>$132: T.untyped)\l<statTemp>$136: T.untyped = @@b$114: NilClass.inspect()\l<statTemp>$134: NilClass = <self>: T.class_of(Main).puts(<statTemp>$136: T.untyped)\l<statTemp>$140: T.untyped = $c$118: NilClass.inspect()\l<statTemp>$138: NilClass = <self>: T.class_of(Main).puts(<statTemp>$140: T.untyped)\l<statTemp>$144: T.untyped = d$5: NilClass.inspect()\l<statTemp>$142: NilClass = <self>: T.class_of(Main).puts(<statTemp>$144: T.untyped)\l<cfgAlias>$150: T.class_of(E) = alias <C E>\l<statTemp>$148: T.untyped = <cfgAlias>$150: T.class_of(E).e()\l<statTemp>$147: T.untyped = <statTemp>$148: T.untyped.inspect()\l<blockReturnTemp>$100: NilClass = <self>: T.class_of(Main).puts(<statTemp>$147: T.untyped)\l<blockReturnTemp>$151: T.noreturn = blockreturn<each> <blockReturnTemp>$100: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_21" -> "bb::<Class:Main>#main_18" [style="bold"];
     "bb::<Class:Main>#main_22" [
+        shape = rectangle;
         color = black;
         label = "block[id=22, rubyBlockId=6](<self>: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped, <block-pre-call-temp>$154: Sorbet::Private::Static::Void, <selfRestore>$155: T.class_of(Main))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -246,12 +262,14 @@ subgraph "cluster_::<Class:Main>#main" {
     "bb::<Class:Main>#main_22" -> "bb::<Class:Main>#main_23" [style="tapered"];
 
     "bb::<Class:Main>#main_23" [
+        shape = rectangle;
         color = black;
         label = "block[id=23, rubyBlockId=0](<block-pre-call-temp>$154: Sorbet::Private::Static::Void, <selfRestore>$155: T.class_of(Main))\l<returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$154, each>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#main_23" -> "bb::<Class:Main>#main_1" [style="bold"];
     "bb::<Class:Main>#main_25" [
+        shape = rectangle;
         color = black;
         label = "block[id=25, rubyBlockId=6](<self>: T.class_of(Main), @a$110: T.untyped, @@b$114: T.untyped, $c$118: T.untyped, <block-pre-call-temp>$154: Sorbet::Private::Static::Void, <selfRestore>$155: T.class_of(Main))\louterLoops: 1\l<self>: T.class_of(Main) = loadSelf\l<blk>$156: T.untyped = load_yield_params(each)\lforTemp$6: T.untyped = <blk>$156\l<cfgAlias>$162: T.class_of(<Magic>) = alias <C <Magic>>\l<assignTemp>$9$6: T.untyped = <cfgAlias>$162: T.class_of(<Magic>).<splat>(forTemp$6: T.untyped)\l<cfgAlias>$166: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$168: Integer(5) = 5\l<statTemp>$169: Integer(0) = 0\l<assignTemp>$10$6: T.untyped = <cfgAlias>$166: T.class_of(<Magic>).<expand-splat>(<assignTemp>$9$6: T.untyped, <statTemp>$168: Integer(5), <statTemp>$169: Integer(0))\l<statTemp>$172: Integer(0) = 0\l@a$110: T.untyped = <assignTemp>$10$6: T.untyped.[](<statTemp>$172: Integer(0))\l<statTemp>$175: Integer(1) = 1\l@@b$114: T.untyped = <assignTemp>$10$6: T.untyped.[](<statTemp>$175: Integer(1))\l<statTemp>$178: Integer(2) = 2\l$c$118: T.untyped = <assignTemp>$10$6: T.untyped.[](<statTemp>$178: Integer(2))\l<statTemp>$181: Integer(3) = 3\ld$6: T.untyped = <assignTemp>$10$6: T.untyped.[](<statTemp>$181: Integer(3))\l<cfgAlias>$184: T.class_of(E) = alias <C E>\l<statTemp>$187: Integer(4) = 4\l<statTemp>$185: T.untyped = <assignTemp>$10$6: T.untyped.[](<statTemp>$187: Integer(4))\l<statTemp>$182: T.untyped = <cfgAlias>$184: T.class_of(E).e=(<statTemp>$185: T.untyped)\l<statTemp>$190: T.untyped = @a$110: T.untyped.inspect()\l<statTemp>$188: NilClass = <self>: T.class_of(Main).puts(<statTemp>$190: T.untyped)\l<statTemp>$194: T.untyped = @@b$114: T.untyped.inspect()\l<statTemp>$192: NilClass = <self>: T.class_of(Main).puts(<statTemp>$194: T.untyped)\l<statTemp>$198: T.untyped = $c$118: T.untyped.inspect()\l<statTemp>$196: NilClass = <self>: T.class_of(Main).puts(<statTemp>$198: T.untyped)\l<statTemp>$202: T.untyped = d$6: T.untyped.inspect()\l<statTemp>$200: NilClass = <self>: T.class_of(Main).puts(<statTemp>$202: T.untyped)\l<cfgAlias>$208: T.class_of(E) = alias <C E>\l<statTemp>$206: T.untyped = <cfgAlias>$208: T.class_of(E).e()\l<statTemp>$205: T.untyped = <statTemp>$206: T.untyped.inspect()\l<blockReturnTemp>$158: NilClass = <self>: T.class_of(Main).puts(<statTemp>$205: T.untyped)\l<blockReturnTemp>$209: T.noreturn = blockreturn<each> <blockReturnTemp>$158: NilClass\l<unconditional>\l"
     ];
@@ -262,16 +280,16 @@ subgraph "cluster_::<Class:Main>#main" {
 subgraph "cluster_::<Class:Main>#<static-init>" {
     label = "::<Class:Main>#<static-init>";
     color = blue;
-    "bb::<Class:Main>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Main>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Main>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Main) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Main>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Main>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:main) = :main\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:main) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(Main), <statTemp>$6: Symbol(:main), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:main)\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#<static-init>_0" -> "bb::<Class:Main>#<static-init>_1" [style="bold"];
     "bb::<Class:Main>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/blocks2.rb.cfg.exp
+++ b/test/testdata/infer/blocks2.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "blocks2.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(Foo) = alias <C Foo>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(Foo))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(Foo) = alias <C Foo>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(Foo))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::Foo#bar" {
     label = "::Foo#bar";
     color = blue;
-    "bb::Foo#bar_0" [shape = invhouse];
-    "bb::Foo#bar_1" [shape = parallelogram];
 
     "bb::Foo#bar_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Foo = cast(<self>: NilClass, Foo);\l<blk>: T.untyped = load_arg(<blk>)\l<statTemp>$4: Integer(1) = 1\l<returnMethodTemp>$2: T.untyped = <blk>: T.untyped.call(<statTemp>$4: Integer(1))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Foo#bar_0" -> "bb::Foo#bar_1" [style="bold"];
     "bb::Foo#bar_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,22 +42,23 @@ subgraph "cluster_::Foo#bar" {
 subgraph "cluster_::Foo#baz" {
     label = "::Foo#baz";
     color = blue;
-    "bb::Foo#baz_0" [shape = invhouse];
-    "bb::Foo#baz_1" [shape = parallelogram];
 
     "bb::Foo#baz_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Foo = cast(<self>: NilClass, Foo);\l<block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Foo.bar()\l<selfRestore>$5: Foo = <self>\l<unconditional>\l"
     ];
 
     "bb::Foo#baz_0" -> "bb::Foo#baz_2" [style="bold"];
     "bb::Foo#baz_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Foo#baz_1" -> "bb::Foo#baz_1" [style="bold"];
     "bb::Foo#baz_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: Foo, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -66,12 +67,14 @@ subgraph "cluster_::Foo#baz" {
     "bb::Foo#baz_2" -> "bb::Foo#baz_3" [style="tapered"];
 
     "bb::Foo#baz_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo)\l<returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, bar>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Foo#baz_3" -> "bb::Foo#baz_1" [style="bold"];
     "bb::Foo#baz_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: Foo, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo)\louterLoops: 1\l<self>: Foo = loadSelf\l<blk>$6: T.untyped = load_yield_params(bar)\l<blk>$7: Integer(0) = 0\lr$1: T.untyped = <blk>$6: T.untyped.[](<blk>$7: Integer(0))\l<blockReturnTemp>$8: NilClass = <self>: Foo.puts(r$1: T.untyped)\l<blockReturnTemp>$11: T.noreturn = blockreturn<bar> <blockReturnTemp>$8: NilClass\l<unconditional>\l"
     ];
@@ -82,16 +85,16 @@ subgraph "cluster_::Foo#baz" {
 subgraph "cluster_::<Class:Foo>#<static-init>" {
     label = "::<Class:Foo>#<static-init>";
     color = blue;
-    "bb::<Class:Foo>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Foo>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Foo>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Foo) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Foo>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:bar) = :bar\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:bar) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Foo), <statTemp>$7: Symbol(:bar), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:baz) = :baz\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:baz) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Foo), <statTemp>$13: Symbol(:baz), <statTemp>$14: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Foo>#<static-init>_0" -> "bb::<Class:Foo>#<static-init>_1" [style="bold"];
     "bb::<Class:Foo>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/bound_proc.rb.cfg.exp
+++ b/test/testdata/infer/bound_proc.rb.cfg.exp
@@ -2,22 +2,23 @@ digraph "bound_proc.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(Base) = alias <C Base>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(Base))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(Base) = alias <C Base>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(Base))\l<cfgAlias>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$19: T.class_of(Concern) = alias <C Concern>\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$19: T.class_of(Concern))\l<cfgAlias>$22: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$24: T.class_of(Concern) = alias <C Concern>\l<statTemp>$20: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$24: T.class_of(Concern))\l<cfgAlias>$28: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$30: T.class_of(Readable) = alias <C Readable>\l<statTemp>$26: Sorbet::Private::Static::Void = <cfgAlias>$28: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$30: T.class_of(Readable))\l<cfgAlias>$33: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$35: T.class_of(Readable) = alias <C Readable>\l<statTemp>$31: Sorbet::Private::Static::Void = <cfgAlias>$33: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$35: T.class_of(Readable))\l<cfgAlias>$39: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$41: T.class_of(Writable) = alias <C Writable>\l<statTemp>$37: Sorbet::Private::Static::Void = <cfgAlias>$39: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$41: T.class_of(Writable))\l<cfgAlias>$44: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$46: T.class_of(Writable) = alias <C Writable>\l<statTemp>$42: Sorbet::Private::Static::Void = <cfgAlias>$44: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$46: T.class_of(Writable))\l<cfgAlias>$50: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$52: T.class_of(Shareable) = alias <C Shareable>\l<statTemp>$48: Sorbet::Private::Static::Void = <cfgAlias>$50: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$52: T.class_of(Shareable))\l<cfgAlias>$55: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$57: T.class_of(Shareable) = alias <C Shareable>\l<statTemp>$53: Sorbet::Private::Static::Void = <cfgAlias>$55: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$57: T.class_of(Shareable))\l<cfgAlias>$61: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$63: T.class_of(Post) = alias <C Post>\l<statTemp>$59: Sorbet::Private::Static::Void = <cfgAlias>$61: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$63: T.class_of(Post))\l<cfgAlias>$66: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$68: T.class_of(Post) = alias <C Post>\l<statTemp>$64: Sorbet::Private::Static::Void = <cfgAlias>$66: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$68: T.class_of(Post))\l<cfgAlias>$71: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$73: T.class_of(Base) = alias <C Base>\l<statTemp>$69: Sorbet::Private::Static::Void = <cfgAlias>$71: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$73: T.class_of(Base))\l<cfgAlias>$77: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$79: T.class_of(Article) = alias <C Article>\l<statTemp>$75: Sorbet::Private::Static::Void = <cfgAlias>$77: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$79: T.class_of(Article))\l<cfgAlias>$82: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$84: T.class_of(Article) = alias <C Article>\l<statTemp>$80: Sorbet::Private::Static::Void = <cfgAlias>$82: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$84: T.class_of(Article))\l<cfgAlias>$87: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$89: T.class_of(Base) = alias <C Base>\l<statTemp>$85: Sorbet::Private::Static::Void = <cfgAlias>$87: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$89: T.class_of(Base))\l<cfgAlias>$93: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$95: T.class_of(A) = alias <C A>\l<statTemp>$91: Sorbet::Private::Static::Void = <cfgAlias>$93: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$95: T.class_of(A))\l<cfgAlias>$98: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$100: T.class_of(A) = alias <C A>\l<statTemp>$96: Sorbet::Private::Static::Void = <cfgAlias>$98: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$100: T.class_of(A))\l<cfgAlias>$104: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$106: T.class_of(B) = alias <C B>\l<statTemp>$102: Sorbet::Private::Static::Void = <cfgAlias>$104: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$106: T.class_of(B))\l<cfgAlias>$109: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$111: T.class_of(B) = alias <C B>\l<statTemp>$107: Sorbet::Private::Static::Void = <cfgAlias>$109: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$111: T.class_of(B))\l<cfgAlias>$114: T.class_of(B) = alias <C B>\l<block-pre-call-temp>$115: Sorbet::Private::Static::Void = <cfgAlias>$114: T.class_of(B).class_helper()\l<selfRestore>$116: T.class_of(<root>) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_2" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_1" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(<root>), <block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(<root>))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -26,12 +27,14 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_2" -> "bb::<Class:<root>>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(<root>))\l<statTemp>$112: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$115, class_helper>\l<self>: T.class_of(<root>) = <selfRestore>$116\l<cfgAlias>$135: T.class_of(T) = alias <C T>\l<statTemp>$133: T.class_of(<root>) = <cfgAlias>$135: T.class_of(T).reveal_type(<self>: T.class_of(<root>))\l<cfgAlias>$140: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$142: T.class_of(N) = alias <C N>\l<statTemp>$138: Sorbet::Private::Static::Void = <cfgAlias>$140: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$142: T.class_of(N))\l<cfgAlias>$145: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$147: T.class_of(N) = alias <C N>\l<statTemp>$143: Sorbet::Private::Static::Void = <cfgAlias>$145: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$147: T.class_of(N))\l<cfgAlias>$151: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$153: T.class_of(M) = alias <C M>\l<statTemp>$149: Sorbet::Private::Static::Void = <cfgAlias>$151: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$153: T.class_of(M))\l<cfgAlias>$156: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$158: T.class_of(M) = alias <C M>\l<statTemp>$154: Sorbet::Private::Static::Void = <cfgAlias>$156: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$158: T.class_of(M))\l<cfgAlias>$162: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$164: T.class_of(ThisSelf) = alias <C ThisSelf>\l<statTemp>$160: Sorbet::Private::Static::Void = <cfgAlias>$162: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$164: T.class_of(ThisSelf))\l<cfgAlias>$167: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$169: T.class_of(ThisSelf) = alias <C ThisSelf>\l<statTemp>$165: Sorbet::Private::Static::Void = <cfgAlias>$167: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$169: T.class_of(ThisSelf))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_3" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(<root>), <block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(<root>))\louterLoops: 1\l<self>: T.class_of(<root>) = loadSelf\l<cfgAlias>$123: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$125: T.class_of(B) = alias <C B>\l<statTemp>$121: Sorbet::Private::Static::Void = <cfgAlias>$123: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$125: T.class_of(B))\l<castTemp>$126: T.class_of(<root>) = <self>\l<self>: B = cast(<castTemp>$126: T.class_of(<root>), B);\l<cfgAlias>$129: T.class_of(T) = alias <C T>\l<statTemp>$127: B = <cfgAlias>$129: T.class_of(T).reveal_type(<self>: B)\l<blockReturnTemp>$119: T.untyped = <self>: B.instance_helper()\l<blockReturnTemp>$132: T.noreturn = blockreturn<class_helper> <blockReturnTemp>$119: T.untyped\l<unconditional>\l"
     ];
@@ -42,16 +45,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::<Class:Base>#before_save" {
     label = "::<Class:Base>#before_save";
     color = blue;
-    "bb::<Class:Base>#before_save_0" [shape = invhouse];
-    "bb::<Class:Base>#before_save_1" [shape = parallelogram];
 
     "bb::<Class:Base>#before_save_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Base) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Base>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Base>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Base>#before_save_0" -> "bb::<Class:Base>#before_save_1" [style="bold"];
     "bb::<Class:Base>#before_save_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +65,16 @@ subgraph "cluster_::<Class:Base>#before_save" {
 subgraph "cluster_::<Class:Base>#before_create" {
     label = "::<Class:Base>#before_create";
     color = blue;
-    "bb::<Class:Base>#before_create_0" [shape = invhouse];
-    "bb::<Class:Base>#before_create_1" [shape = parallelogram];
 
     "bb::<Class:Base>#before_create_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Base) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Base>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Base>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Base>#before_create_0" -> "bb::<Class:Base>#before_create_1" [style="bold"];
     "bb::<Class:Base>#before_create_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,16 +85,16 @@ subgraph "cluster_::<Class:Base>#before_create" {
 subgraph "cluster_::<Class:Base>#<static-init>" {
     label = "::<Class:Base>#<static-init>";
     color = blue;
-    "bb::<Class:Base>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Base>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Base>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Base) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Base>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Base>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:before_save) = :before_save\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:before_save) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(Base), <statTemp>$7: Symbol(:before_save), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:before_create) = :before_create\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:before_create) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(Base), <statTemp>$13: Symbol(:before_create), <statTemp>$14: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Base>#<static-init>_0" -> "bb::<Class:Base>#<static-init>_1" [style="bold"];
     "bb::<Class:Base>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -102,16 +105,16 @@ subgraph "cluster_::<Class:Base>#<static-init>" {
 subgraph "cluster_::Concern#included" {
     label = "::Concern#included";
     color = blue;
-    "bb::Concern#included_0" [shape = invhouse];
-    "bb::Concern#included_1" [shape = parallelogram];
 
     "bb::Concern#included_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l@block$3: T.untyped = alias <C <undeclared-field-stub>> (@block)\l<self>: Concern = cast(<self>: NilClass, Concern);\lblock: T.untyped = load_arg(block)\l@block$3: T.untyped = block\l<returnMethodTemp>$2: T.untyped = @block$3\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Concern#included_0" -> "bb::Concern#included_1" [style="bold"];
     "bb::Concern#included_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -122,16 +125,16 @@ subgraph "cluster_::Concern#included" {
 subgraph "cluster_::<Class:Concern>#<static-init>" {
     label = "::<Class:Concern>#<static-init>";
     color = blue;
-    "bb::<Class:Concern>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Concern>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Concern>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Concern) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Concern>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Concern>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:included) = :included\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:included) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Concern), <statTemp>$6: Symbol(:included), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:included)\l<unconditional>\l"
     ];
 
     "bb::<Class:Concern>#<static-init>_0" -> "bb::<Class:Concern>#<static-init>_1" [style="bold"];
     "bb::<Class:Concern>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -142,22 +145,23 @@ subgraph "cluster_::<Class:Concern>#<static-init>" {
 subgraph "cluster_::<Class:Readable>#<static-init>" {
     label = "::<Class:Readable>#<static-init>";
     color = blue;
-    "bb::<Class:Readable>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Readable>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Readable>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Readable) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Readable>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Readable>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(Concern) = alias <C Concern>\l<statTemp>$3: T.class_of(Readable) = <self>: T.class_of(Readable).extend(<cfgAlias>$6: T.class_of(Concern))\l<block-pre-call-temp>$9: Sorbet::Private::Static::Void = <self>: T.class_of(Readable).included()\l<selfRestore>$10: T.class_of(Readable) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Readable>#<static-init>_0" -> "bb::<Class:Readable>#<static-init>_2" [style="bold"];
     "bb::<Class:Readable>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:Readable>#<static-init>_1" -> "bb::<Class:Readable>#<static-init>_1" [style="bold"];
     "bb::<Class:Readable>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Readable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -166,12 +170,14 @@ subgraph "cluster_::<Class:Readable>#<static-init>" {
     "bb::<Class:Readable>#<static-init>_2" -> "bb::<Class:Readable>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:Readable>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable))\l<statTemp>$7: T.untyped = Solve<<block-pre-call-temp>$9, included>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Readable>#<static-init>_3" -> "bb::<Class:Readable>#<static-init>_1" [style="bold"];
     "bb::<Class:Readable>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Readable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable))\louterLoops: 1\l<self>: T.class_of(Readable) = loadSelf\l<statTemp>$15: Symbol(:do_this) = :do_this\l<blockReturnTemp>$13: T.untyped = <self>: T.class_of(Readable).before_create(<statTemp>$15: Symbol(:do_this))\l<blockReturnTemp>$16: T.noreturn = blockreturn<included> <blockReturnTemp>$13: T.untyped\l<unconditional>\l"
     ];
@@ -182,22 +188,23 @@ subgraph "cluster_::<Class:Readable>#<static-init>" {
 subgraph "cluster_::<Class:Writable>#<static-init>" {
     label = "::<Class:Writable>#<static-init>";
     color = blue;
-    "bb::<Class:Writable>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Writable>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Writable>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Writable) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Writable>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Writable>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(Concern) = alias <C Concern>\l<statTemp>$3: T.class_of(Writable) = <self>: T.class_of(Writable).extend(<cfgAlias>$6: T.class_of(Concern))\l<block-pre-call-temp>$9: Sorbet::Private::Static::Void = <self>: T.class_of(Writable).included()\l<selfRestore>$10: T.class_of(Writable) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Writable>#<static-init>_0" -> "bb::<Class:Writable>#<static-init>_2" [style="bold"];
     "bb::<Class:Writable>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:Writable>#<static-init>_1" -> "bb::<Class:Writable>#<static-init>_1" [style="bold"];
     "bb::<Class:Writable>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Writable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -206,12 +213,14 @@ subgraph "cluster_::<Class:Writable>#<static-init>" {
     "bb::<Class:Writable>#<static-init>_2" -> "bb::<Class:Writable>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:Writable>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable))\l<statTemp>$7: T.untyped = Solve<<block-pre-call-temp>$9, included>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Writable>#<static-init>_3" -> "bb::<Class:Writable>#<static-init>_1" [style="bold"];
     "bb::<Class:Writable>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Writable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable))\louterLoops: 1\l<self>: T.class_of(Writable) = loadSelf\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$20: T.class_of(T) = alias <C T>\l<cfgAlias>$23: T.class_of(T) = alias <C T>\l<cfgAlias>$25: T.class_of(Article) = alias <C Article>\l<statTemp>$21: T.untyped = <cfgAlias>$23: T.class_of(T).class_of(<cfgAlias>$25: T.class_of(Article))\l<cfgAlias>$28: T.class_of(T) = alias <C T>\l<cfgAlias>$30: T.class_of(Post) = alias <C Post>\l<statTemp>$26: T.untyped = <cfgAlias>$28: T.class_of(T).class_of(<cfgAlias>$30: T.class_of(Post))\l<statTemp>$18: <Type: T.untyped> = <cfgAlias>$20: T.class_of(T).any(<statTemp>$21: T.untyped, <statTemp>$26: T.untyped)\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$18: <Type: T.untyped>)\l<castTemp>$31: T.class_of(Writable) = <self>\l<self>: T.any(T.class_of(Article), T.class_of(Post)) = cast(<castTemp>$31: T.class_of(Writable), AppliedType {\l      klass = <S <C <U Article>> $1>\l      targs = [\l        <C <U <AttachedClass>>> = Article\l      ]\l    } | AppliedType {\l      klass = <S <C <U Post>> $1>\l      targs = [\l        <C <U <AttachedClass>>> = Post\l      ]\l    });\l<statTemp>$33: Symbol(:name) = :name\l<blockReturnTemp>$13: T.untyped = <self>: T.any(T.class_of(Article), T.class_of(Post)).some_class_method(<statTemp>$33: Symbol(:name))\l<blockReturnTemp>$34: T.noreturn = blockreturn<included> <blockReturnTemp>$13: T.untyped\l<unconditional>\l"
     ];
@@ -222,22 +231,23 @@ subgraph "cluster_::<Class:Writable>#<static-init>" {
 subgraph "cluster_::<Class:Shareable>#<static-init>" {
     label = "::<Class:Shareable>#<static-init>";
     color = blue;
-    "bb::<Class:Shareable>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Shareable>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Shareable>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Shareable) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Shareable>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Shareable>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(Concern) = alias <C Concern>\l<statTemp>$3: T.class_of(Shareable) = <self>: T.class_of(Shareable).extend(<cfgAlias>$6: T.class_of(Concern))\l<block-pre-call-temp>$9: Sorbet::Private::Static::Void = <self>: T.class_of(Shareable).included()\l<selfRestore>$10: T.class_of(Shareable) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Shareable>#<static-init>_0" -> "bb::<Class:Shareable>#<static-init>_2" [style="bold"];
     "bb::<Class:Shareable>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:Shareable>#<static-init>_1" -> "bb::<Class:Shareable>#<static-init>_1" [style="bold"];
     "bb::<Class:Shareable>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Shareable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -246,12 +256,14 @@ subgraph "cluster_::<Class:Shareable>#<static-init>" {
     "bb::<Class:Shareable>#<static-init>_2" -> "bb::<Class:Shareable>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:Shareable>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable))\l<statTemp>$7: T.untyped = Solve<<block-pre-call-temp>$9, included>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Shareable>#<static-init>_3" -> "bb::<Class:Shareable>#<static-init>_1" [style="bold"];
     "bb::<Class:Shareable>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Shareable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable))\louterLoops: 1\l<self>: T.class_of(Shareable) = loadSelf\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$20: T.class_of(T) = alias <C T>\l<cfgAlias>$22: T.class_of(Article) = alias <C Article>\l<statTemp>$18: T.untyped = <cfgAlias>$20: T.class_of(T).class_of(<cfgAlias>$22: T.class_of(Article))\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$18: T.untyped)\l<castTemp>$23: T.class_of(Shareable) = <self>\l<self>: T.class_of(Article) = cast(<castTemp>$23: T.class_of(Shareable), AppliedType {\l  klass = <S <C <U Article>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = Article\l  ]\l});\l<statTemp>$25: Symbol(:do_this) = :do_this\l<blockReturnTemp>$13: T.untyped = <self>: T.class_of(Article).before_save(<statTemp>$25: Symbol(:do_this))\l<blockReturnTemp>$26: T.noreturn = blockreturn<included> <blockReturnTemp>$13: T.untyped\l<unconditional>\l"
     ];
@@ -262,16 +274,16 @@ subgraph "cluster_::<Class:Shareable>#<static-init>" {
 subgraph "cluster_::<Class:Post>#some_class_method" {
     label = "::<Class:Post>#some_class_method";
     color = blue;
-    "bb::<Class:Post>#some_class_method_0" [shape = invhouse];
-    "bb::<Class:Post>#some_class_method_1" [shape = parallelogram];
 
     "bb::<Class:Post>#some_class_method_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Post) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Post>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Post>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Post>#some_class_method_0" -> "bb::<Class:Post>#some_class_method_1" [style="bold"];
     "bb::<Class:Post>#some_class_method_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -282,16 +294,16 @@ subgraph "cluster_::<Class:Post>#some_class_method" {
 subgraph "cluster_::Post#author" {
     label = "::Post#author";
     color = blue;
-    "bb::Post#author_0" [shape = invhouse];
-    "bb::Post#author_1" [shape = parallelogram];
 
     "bb::Post#author_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Post = cast(<self>: NilClass, Post);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Post#author_0" -> "bb::Post#author_1" [style="bold"];
     "bb::Post#author_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -302,16 +314,16 @@ subgraph "cluster_::Post#author" {
 subgraph "cluster_::Post#should_run_callback?" {
     label = "::Post#should_run_callback?";
     color = blue;
-    "bb::Post#should_run_callback?_0" [shape = invhouse];
-    "bb::Post#should_run_callback?_1" [shape = parallelogram];
 
     "bb::Post#should_run_callback?_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Post = cast(<self>: NilClass, Post);\l<returnMethodTemp>$2: TrueClass = true\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: TrueClass\l<unconditional>\l"
     ];
 
     "bb::Post#should_run_callback?_0" -> "bb::Post#should_run_callback?_1" [style="bold"];
     "bb::Post#should_run_callback?_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -322,16 +334,16 @@ subgraph "cluster_::Post#should_run_callback?" {
 subgraph "cluster_::Post#score" {
     label = "::Post#score";
     color = blue;
-    "bb::Post#score_0" [shape = invhouse];
-    "bb::Post#score_1" [shape = parallelogram];
 
     "bb::Post#score_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Post = cast(<self>: NilClass, Post);\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$7: T.class_of(Integer) = alias <C Integer>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$7: T.class_of(Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Post#score_0" -> "bb::Post#score_1" [style="bold"];
     "bb::Post#score_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -342,22 +354,23 @@ subgraph "cluster_::Post#score" {
 subgraph "cluster_::<Class:Post>#<static-init>" {
     label = "::<Class:Post>#<static-init>";
     color = blue;
-    "bb::<Class:Post>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Post>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Post>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Post) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Post>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Post>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(Readable) = alias <C Readable>\l<statTemp>$3: T.class_of(Post) = <self>: T.class_of(Post).include(<cfgAlias>$6: T.class_of(Readable))\l<cfgAlias>$10: T.class_of(Writable) = alias <C Writable>\l<statTemp>$7: T.class_of(Post) = <self>: T.class_of(Post).include(<cfgAlias>$10: T.class_of(Writable))\l<statTemp>$12: T.class_of(Post) = <self>\l<statTemp>$13: Symbol(:run_callback) = :run_callback\l<hashTemp>$14: Symbol(:if) = :if\l<cfgAlias>$17: T.class_of(Kernel) = alias <C Kernel>\l<block-pre-call-temp>$18: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(Kernel).lambda()\l<selfRestore>$19: T.class_of(Post) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Post>#<static-init>_0" -> "bb::<Class:Post>#<static-init>_2" [style="bold"];
     "bb::<Class:Post>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:Post>#<static-init>_1" -> "bb::<Class:Post>#<static-init>_1" [style="bold"];
     "bb::<Class:Post>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -366,12 +379,14 @@ subgraph "cluster_::<Class:Post>#<static-init>" {
     "bb::<Class:Post>#<static-init>_2" -> "bb::<Class:Post>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:Post>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post))\l<hashTemp>$15: T.proc.returns(T.untyped) = Solve<<block-pre-call-temp>$18, lambda>\l<self>: T.class_of(Post) = <selfRestore>$19\l<statTemp>$11: T.untyped = <statTemp>$12: T.class_of(Post).before_create(<statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <hashTemp>$15: T.proc.returns(T.untyped))\l<cfgAlias>$27: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$29: Symbol(:some_class_method) = :some_class_method\l<statTemp>$30: Symbol(:normal) = :normal\l<statTemp>$25: Symbol(:some_class_method) = <cfgAlias>$27: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(Post), <statTemp>$29: Symbol(:some_class_method), <statTemp>$30: Symbol(:normal))\l<cfgAlias>$33: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$35: Symbol(:author) = :author\l<statTemp>$36: Symbol(:normal) = :normal\l<statTemp>$31: Symbol(:author) = <cfgAlias>$33: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Post), <statTemp>$35: Symbol(:author), <statTemp>$36: Symbol(:normal))\l<cfgAlias>$39: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$41: Symbol(:should_run_callback?) = :should_run_callback?\l<statTemp>$42: Symbol(:normal) = :normal\l<statTemp>$37: Symbol(:should_run_callback?) = <cfgAlias>$39: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Post), <statTemp>$41: Symbol(:should_run_callback?), <statTemp>$42: Symbol(:normal))\l<cfgAlias>$45: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$47: Symbol(:score) = :score\l<statTemp>$48: Symbol(:normal) = :normal\l<statTemp>$43: Symbol(:score) = <cfgAlias>$45: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Post), <statTemp>$47: Symbol(:score), <statTemp>$48: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Post>#<static-init>_3" -> "bb::<Class:Post>#<static-init>_1" [style="bold"];
     "bb::<Class:Post>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post))\louterLoops: 1\l<self>: T.class_of(Post) = loadSelf\l<blockReturnTemp>$22: T.untyped = <self>: T.class_of(Post).should_run_callback?()\l<blockReturnTemp>$24: T.noreturn = blockreturn<lambda> <blockReturnTemp>$22: T.untyped\l<unconditional>\l"
     ];
@@ -382,16 +397,16 @@ subgraph "cluster_::<Class:Post>#<static-init>" {
 subgraph "cluster_::Article#author" {
     label = "::Article#author";
     color = blue;
-    "bb::Article#author_0" [shape = invhouse];
-    "bb::Article#author_1" [shape = parallelogram];
 
     "bb::Article#author_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Article = cast(<self>: NilClass, Article);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Article#author_0" -> "bb::Article#author_1" [style="bold"];
     "bb::Article#author_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -402,16 +417,16 @@ subgraph "cluster_::Article#author" {
 subgraph "cluster_::Article#should_run_callback?" {
     label = "::Article#should_run_callback?";
     color = blue;
-    "bb::Article#should_run_callback?_0" [shape = invhouse];
-    "bb::Article#should_run_callback?_1" [shape = parallelogram];
 
     "bb::Article#should_run_callback?_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Article = cast(<self>: NilClass, Article);\l<returnMethodTemp>$2: TrueClass = true\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: TrueClass\l<unconditional>\l"
     ];
 
     "bb::Article#should_run_callback?_0" -> "bb::Article#should_run_callback?_1" [style="bold"];
     "bb::Article#should_run_callback?_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -422,22 +437,23 @@ subgraph "cluster_::Article#should_run_callback?" {
 subgraph "cluster_::<Class:Article>#<static-init>" {
     label = "::<Class:Article>#<static-init>";
     color = blue;
-    "bb::<Class:Article>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Article>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Article>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Article) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Article>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Article>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(Writable) = alias <C Writable>\l<statTemp>$3: T.class_of(Article) = <self>: T.class_of(Article).include(<cfgAlias>$6: T.class_of(Writable))\l<cfgAlias>$10: T.class_of(Shareable) = alias <C Shareable>\l<statTemp>$7: T.class_of(Article) = <self>: T.class_of(Article).include(<cfgAlias>$10: T.class_of(Shareable))\l<statTemp>$12: T.class_of(Article) = <self>\l<statTemp>$13: Symbol(:run_callback) = :run_callback\l<hashTemp>$14: Symbol(:if) = :if\l<cfgAlias>$17: T.class_of(Kernel) = alias <C Kernel>\l<block-pre-call-temp>$18: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(Kernel).lambda()\l<selfRestore>$19: T.class_of(Article) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Article>#<static-init>_0" -> "bb::<Class:Article>#<static-init>_2" [style="bold"];
     "bb::<Class:Article>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:Article>#<static-init>_1" -> "bb::<Class:Article>#<static-init>_1" [style="bold"];
     "bb::<Class:Article>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -446,12 +462,14 @@ subgraph "cluster_::<Class:Article>#<static-init>" {
     "bb::<Class:Article>#<static-init>_2" -> "bb::<Class:Article>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:Article>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article))\l<hashTemp>$15: T.proc.returns(T.untyped) = Solve<<block-pre-call-temp>$18, lambda>\l<self>: T.class_of(Article) = <selfRestore>$19\l<statTemp>$11: T.untyped = <statTemp>$12: T.class_of(Article).before_create(<statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <hashTemp>$15: T.proc.returns(T.untyped))\l<cfgAlias>$33: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$35: Symbol(:author) = :author\l<statTemp>$36: Symbol(:normal) = :normal\l<statTemp>$31: Symbol(:author) = <cfgAlias>$33: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Article), <statTemp>$35: Symbol(:author), <statTemp>$36: Symbol(:normal))\l<cfgAlias>$39: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$41: Symbol(:should_run_callback?) = :should_run_callback?\l<statTemp>$42: Symbol(:normal) = :normal\l<statTemp>$37: Symbol(:should_run_callback?) = <cfgAlias>$39: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Article), <statTemp>$41: Symbol(:should_run_callback?), <statTemp>$42: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Article>#<static-init>_3" -> "bb::<Class:Article>#<static-init>_1" [style="bold"];
     "bb::<Class:Article>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article))\louterLoops: 1\l<self>: T.class_of(Article) = loadSelf\l<cfgAlias>$26: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$28: T.class_of(Article) = alias <C Article>\l<statTemp>$24: Sorbet::Private::Static::Void = <cfgAlias>$26: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$28: T.class_of(Article))\l<castTemp>$29: T.class_of(Article) = <self>\l<self>: Article = cast(<castTemp>$29: T.class_of(Article), Article);\l<blockReturnTemp>$22: T.untyped = <self>: Article.should_run_callback?()\l<blockReturnTemp>$30: T.noreturn = blockreturn<lambda> <blockReturnTemp>$22: T.untyped\l<unconditional>\l"
     ];
@@ -462,16 +480,16 @@ subgraph "cluster_::<Class:Article>#<static-init>" {
 subgraph "cluster_::A#instance_helper" {
     label = "::A#instance_helper";
     color = blue;
-    "bb::A#instance_helper_0" [shape = invhouse];
-    "bb::A#instance_helper_1" [shape = parallelogram];
 
     "bb::A#instance_helper_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: A = cast(<self>: NilClass, A);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::A#instance_helper_0" -> "bb::A#instance_helper_1" [style="bold"];
     "bb::A#instance_helper_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -482,22 +500,23 @@ subgraph "cluster_::A#instance_helper" {
 subgraph "cluster_::<Class:A>#<static-init>" {
     label = "::<Class:A>#<static-init>";
     color = blue;
-    "bb::<Class:A>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:instance_helper) = :instance_helper\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:instance_helper) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(A), <statTemp>$7: Symbol(:instance_helper), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Kernel) = alias <C Kernel>\l<block-pre-call-temp>$12: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Kernel).lambda()\l<selfRestore>$13: T.class_of(A) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_2" [style="bold"];
     "bb::<Class:A>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_1" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
     "bb::<Class:A>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(A), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(A))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -506,12 +525,14 @@ subgraph "cluster_::<Class:A>#<static-init>" {
     "bb::<Class:A>#<static-init>_2" -> "bb::<Class:A>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:A>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(A))\lf: T.proc.returns(T.untyped) = Solve<<block-pre-call-temp>$12, lambda>\l<self>: T.class_of(A) = <selfRestore>$13\l<cfgAlias>$32: T.class_of(T) = alias <C T>\l<statTemp>$30: T.class_of(A) = <cfgAlias>$32: T.class_of(T).reveal_type(<self>: T.class_of(A))\l<statTemp>$34: NilClass = <self>: T.class_of(A).puts(f: T.proc.returns(T.untyped))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_3" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
     "bb::<Class:A>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(A), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(A))\louterLoops: 1\l<self>: T.class_of(A) = loadSelf\l<cfgAlias>$20: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$22: T.class_of(A) = alias <C A>\l<statTemp>$18: Sorbet::Private::Static::Void = <cfgAlias>$20: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$22: T.class_of(A))\l<castTemp>$23: T.class_of(A) = <self>\l<self>: A = cast(<castTemp>$23: T.class_of(A), A);\l<cfgAlias>$26: T.class_of(T) = alias <C T>\l<statTemp>$24: A = <cfgAlias>$26: T.class_of(T).reveal_type(<self>: A)\l<blockReturnTemp>$16: T.untyped = <self>: A.instance_helper()\l<blockReturnTemp>$29: T.noreturn = blockreturn<lambda> <blockReturnTemp>$16: T.untyped\l<unconditional>\l"
     ];
@@ -522,16 +543,16 @@ subgraph "cluster_::<Class:A>#<static-init>" {
 subgraph "cluster_::<Class:B>#class_helper" {
     label = "::<Class:B>#class_helper";
     color = blue;
-    "bb::<Class:B>#class_helper_0" [shape = invhouse];
-    "bb::<Class:B>#class_helper_1" [shape = parallelogram];
 
     "bb::<Class:B>#class_helper_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(B) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U B>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U B>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#class_helper_0" -> "bb::<Class:B>#class_helper_1" [style="bold"];
     "bb::<Class:B>#class_helper_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -542,16 +563,16 @@ subgraph "cluster_::<Class:B>#class_helper" {
 subgraph "cluster_::B#instance_helper" {
     label = "::B#instance_helper";
     color = blue;
-    "bb::B#instance_helper_0" [shape = invhouse];
-    "bb::B#instance_helper_1" [shape = parallelogram];
 
     "bb::B#instance_helper_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: B = cast(<self>: NilClass, B);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::B#instance_helper_0" -> "bb::B#instance_helper_1" [style="bold"];
     "bb::B#instance_helper_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -562,22 +583,23 @@ subgraph "cluster_::B#instance_helper" {
 subgraph "cluster_::<Class:B>#<static-init>" {
     label = "::<Class:B>#<static-init>";
     color = blue;
-    "bb::<Class:B>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:B>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:B>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(B) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U B>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U B>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(B))\l<selfRestore>$8: T.class_of(B) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_0" -> "bb::<Class:B>#<static-init>_2" [style="bold"];
     "bb::<Class:B>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_1" -> "bb::<Class:B>#<static-init>_1" [style="bold"];
     "bb::<Class:B>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -586,12 +608,14 @@ subgraph "cluster_::<Class:B>#<static-init>" {
     "bb::<Class:B>#<static-init>_2" -> "bb::<Class:B>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:B>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(B) = <selfRestore>$8\l<cfgAlias>$23: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$25: T.class_of(T) = alias <C T>\l<statTemp>$20: T.class_of(B) = <self>: T.class_of(B).extend(<cfgAlias>$23: T.class_of(T::Sig))\l<cfgAlias>$28: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$30: Symbol(:class_helper) = :class_helper\l<statTemp>$31: Symbol(:normal) = :normal\l<statTemp>$26: Symbol(:class_helper) = <cfgAlias>$28: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(B), <statTemp>$30: Symbol(:class_helper), <statTemp>$31: Symbol(:normal))\l<cfgAlias>$34: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$36: Symbol(:instance_helper) = :instance_helper\l<statTemp>$37: Symbol(:normal) = :normal\l<statTemp>$32: Symbol(:instance_helper) = <cfgAlias>$34: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(B), <statTemp>$36: Symbol(:instance_helper), <statTemp>$37: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_3" -> "bb::<Class:B>#<static-init>_1" [style="bold"];
     "bb::<Class:B>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$14: Symbol(:blk) = :blk\l<cfgAlias>$18: T.class_of(T) = alias <C T>\l<statTemp>$16: T.class_of(T.proc) = <cfgAlias>$18: T.class_of(T).proc()\l<hashTemp>$15: T.class_of(T.proc) = <statTemp>$16: T.class_of(T.proc).void()\l<statTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$14: Symbol(:blk), <hashTemp>$15: T.class_of(T.proc))\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <statTemp>$12: T::Private::Methods::DeclBuilder.void()\l<blockReturnTemp>$19: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
@@ -602,16 +626,16 @@ subgraph "cluster_::<Class:B>#<static-init>" {
 subgraph "cluster_::N#helper_from_N" {
     label = "::N#helper_from_N";
     color = blue;
-    "bb::N#helper_from_N_0" [shape = invhouse];
-    "bb::N#helper_from_N_1" [shape = parallelogram];
 
     "bb::N#helper_from_N_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: N = cast(<self>: NilClass, N);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::N#helper_from_N_0" -> "bb::N#helper_from_N_1" [style="bold"];
     "bb::N#helper_from_N_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -622,16 +646,16 @@ subgraph "cluster_::N#helper_from_N" {
 subgraph "cluster_::<Class:N>#<static-init>" {
     label = "::<Class:N>#<static-init>";
     color = blue;
-    "bb::<Class:N>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:N>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:N>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(N) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U N>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U N>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:helper_from_N) = :helper_from_N\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:helper_from_N) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(N), <statTemp>$6: Symbol(:helper_from_N), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:helper_from_N)\l<unconditional>\l"
     ];
 
     "bb::<Class:N>#<static-init>_0" -> "bb::<Class:N>#<static-init>_1" [style="bold"];
     "bb::<Class:N>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -642,16 +666,16 @@ subgraph "cluster_::<Class:N>#<static-init>" {
 subgraph "cluster_::M#helper_from_M" {
     label = "::M#helper_from_M";
     color = blue;
-    "bb::M#helper_from_M_0" [shape = invhouse];
-    "bb::M#helper_from_M_1" [shape = parallelogram];
 
     "bb::M#helper_from_M_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: M = cast(<self>: NilClass, M);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::M#helper_from_M_0" -> "bb::M#helper_from_M_1" [style="bold"];
     "bb::M#helper_from_M_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -662,16 +686,16 @@ subgraph "cluster_::M#helper_from_M" {
 subgraph "cluster_::M#main" {
     label = "::M#main";
     color = blue;
-    "bb::M#main_0" [shape = invhouse];
-    "bb::M#main_1" [shape = parallelogram];
 
     "bb::M#main_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: M = cast(<self>: NilClass, M);\l<cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$9: T.class_of(T) = alias <C T>\l<cfgAlias>$11: T.class_of(M) = alias <C M>\l<cfgAlias>$13: T.class_of(N) = alias <C N>\l<statTemp>$7: <Type: T.all(M, N)> = <cfgAlias>$9: T.class_of(T).all(<cfgAlias>$11: T.class_of(M), <cfgAlias>$13: T.class_of(N))\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$7: <Type: T.all(M, N)>)\l<castTemp>$14: M = <self>\l<self>: T.all(M, N) = cast(<castTemp>$14: M, M & N);\l<cfgAlias>$17: T.class_of(T) = alias <C T>\l<statTemp>$15: T.all(M, N) = <cfgAlias>$17: T.class_of(T).reveal_type(<self>: T.all(M, N))\l<statTemp>$19: T.untyped = <self>: T.all(M, N).helper_from_M()\l<returnMethodTemp>$2: T.untyped = <self>: T.all(M, N).helper_from_N()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::M#main_0" -> "bb::M#main_1" [style="bold"];
     "bb::M#main_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -682,16 +706,16 @@ subgraph "cluster_::M#main" {
 subgraph "cluster_::<Class:M>#<static-init>" {
     label = "::<Class:M>#<static-init>";
     color = blue;
-    "bb::<Class:M>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:M>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:M>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(M) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U M>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U M>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$8: T.class_of(T) = alias <C T>\l<statTemp>$3: T.class_of(M) = <self>: T.class_of(M).extend(<cfgAlias>$6: T.class_of(T::Sig))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:helper_from_M) = :helper_from_M\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:helper_from_M) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(M), <statTemp>$13: Symbol(:helper_from_M), <statTemp>$14: Symbol(:normal))\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$19: Symbol(:main) = :main\l<statTemp>$20: Symbol(:normal) = :normal\l<statTemp>$15: Symbol(:main) = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(M), <statTemp>$19: Symbol(:main), <statTemp>$20: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:M>#<static-init>_0" -> "bb::<Class:M>#<static-init>_1" [style="bold"];
     "bb::<Class:M>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -702,16 +726,16 @@ subgraph "cluster_::<Class:M>#<static-init>" {
 subgraph "cluster_::ThisSelf#main" {
     label = "::ThisSelf#main";
     color = blue;
-    "bb::ThisSelf#main_0" [shape = invhouse];
-    "bb::ThisSelf#main_1" [shape = parallelogram];
 
     "bb::ThisSelf#main_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: ThisSelf = cast(<self>: NilClass, ThisSelf);\l<cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$8: T.class_of(Kernel) = alias <C Kernel>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$8: T.class_of(Kernel))\l<castTemp>$9: ThisSelf = <self>\l<self>: Kernel = cast(<castTemp>$9: ThisSelf, Kernel);\lthis: Kernel = <self>\l<cfgAlias>$12: T.class_of(T) = alias <C T>\l<statTemp>$10: Kernel = <cfgAlias>$12: T.class_of(T).reveal_type(this: Kernel)\l<returnMethodTemp>$2: NilClass = this: Kernel.puts()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::ThisSelf#main_0" -> "bb::ThisSelf#main_1" [style="bold"];
     "bb::ThisSelf#main_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -722,16 +746,16 @@ subgraph "cluster_::ThisSelf#main" {
 subgraph "cluster_::<Class:ThisSelf>#<static-init>" {
     label = "::<Class:ThisSelf>#<static-init>";
     color = blue;
-    "bb::<Class:ThisSelf>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:ThisSelf>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:ThisSelf>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(ThisSelf) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U ThisSelf>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U ThisSelf>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$8: T.class_of(T) = alias <C T>\l<statTemp>$3: T.class_of(ThisSelf) = <self>: T.class_of(ThisSelf).extend(<cfgAlias>$6: T.class_of(T::Sig))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:main) = :main\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:main) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(ThisSelf), <statTemp>$13: Symbol(:main), <statTemp>$14: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:ThisSelf>#<static-init>_0" -> "bb::<Class:ThisSelf>#<static-init>_1" [style="bold"];
     "bb::<Class:ThisSelf>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/casts.rb.cfg.exp
+++ b/test/testdata/infer/casts.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "casts.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(TestCasts) = alias <C TestCasts>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(TestCasts))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(TestCasts) = alias <C TestCasts>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(TestCasts))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::TestCasts#untyped" {
     label = "::TestCasts#untyped";
     color = blue;
-    "bb::TestCasts#untyped_0" [shape = invhouse];
-    "bb::TestCasts#untyped_1" [shape = parallelogram];
 
     "bb::TestCasts#untyped_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestCasts = cast(<self>: NilClass, TestCasts);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::TestCasts#untyped_0" -> "bb::TestCasts#untyped_1" [style="bold"];
     "bb::TestCasts#untyped_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::TestCasts#untyped" {
 subgraph "cluster_::TestCasts#test_casts" {
     label = "::TestCasts#test_casts";
     color = blue;
-    "bb::TestCasts#test_casts_0" [shape = invhouse];
-    "bb::TestCasts#test_casts_1" [shape = parallelogram];
 
     "bb::TestCasts#test_casts_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestCasts = cast(<self>: NilClass, TestCasts);\l<cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$8: T.class_of(Integer) = alias <C Integer>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$8: T.class_of(Integer))\l<castTemp>$9: T.untyped = <self>: TestCasts.untyped()\lt: Integer = cast(<castTemp>$9: T.untyped, Integer);\l<statTemp>$13: Integer(4) = 4\l<statTemp>$11: Integer = t: Integer.+(<statTemp>$13: Integer(4))\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$19: T.class_of(Integer) = alias <C Integer>\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$19: T.class_of(Integer))\l<castTemp>$20: String(\"hi\") = \"hi\"\lt1: Integer = cast(<castTemp>$20: String(\"hi\"), Integer);\l<statTemp>$23: Integer(1) = 1\l<statTemp>$21: Integer = t1: Integer.+(<statTemp>$23: Integer(1))\l<cfgAlias>$27: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$29: T.class_of(String) = alias <C String>\l<statTemp>$25: Sorbet::Private::Static::Void = <cfgAlias>$27: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$29: T.class_of(String))\l<castTemp>$30: T.untyped = <self>: TestCasts.untyped()\ls: String = cast(<castTemp>$30: T.untyped, String);\l<statTemp>$34: String(\"hi\") = \"hi\"\l<statTemp>$32: String = s: String.+(<statTemp>$34: String(\"hi\"))\l<cfgAlias>$38: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$40: T.class_of(String) = alias <C String>\l<statTemp>$36: Sorbet::Private::Static::Void = <cfgAlias>$38: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$40: T.class_of(String))\l<castTemp>$41: Integer(6) = 6\ls: String = cast(<castTemp>$41: Integer(6), String);\l<statTemp>$44: String(\"hi\") = \"hi\"\l<statTemp>$42: String = s: String.+(<statTemp>$44: String(\"hi\"))\l<statTemp>$47: Integer(3) = 3\l<statTemp>$45: String = s: String.+(<statTemp>$47: Integer(3))\l<cfgAlias>$51: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$53: T.class_of(Integer) = alias <C Integer>\l<statTemp>$49: Sorbet::Private::Static::Void = <cfgAlias>$51: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$53: T.class_of(Integer))\l<castTemp>$54: Integer(6) = 6\ls: Integer = cast(<castTemp>$54: Integer(6), Integer);\l<cfgAlias>$58: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$61: T.class_of(T) = alias <C T>\l<statTemp>$59: <Type: T.untyped> = <cfgAlias>$61: T.class_of(T).untyped()\l<statTemp>$56: Sorbet::Private::Static::Void = <cfgAlias>$58: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$59: <Type: T.untyped>)\l<castTemp>$62: Integer(6) = 6\ls: T.untyped = cast(<castTemp>$62: Integer(6), T.untyped);\l<cfgAlias>$66: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$67: Integer(7) = 7\l<statTemp>$64: Sorbet::Private::Static::Void = <cfgAlias>$66: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$67: Integer(7))\l<castTemp>$68: Integer(6) = 6\ls: Integer = cast(<castTemp>$68: Integer(6), Integer);\l<statTemp>$71: String(\"hi\") = \"hi\"\l<statTemp>$69: Integer = s: Integer.+(<statTemp>$71: String(\"hi\"))\l<statTemp>$73: Integer(3) = 3\l<returnMethodTemp>$2: Integer = s: Integer.+(<statTemp>$73: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
     ];
 
     "bb::TestCasts#test_casts_0" -> "bb::TestCasts#test_casts_1" [style="bold"];
     "bb::TestCasts#test_casts_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::TestCasts#test_casts" {
 subgraph "cluster_::<Class:TestCasts>#<static-init>" {
     label = "::<Class:TestCasts>#<static-init>";
     color = blue;
-    "bb::<Class:TestCasts>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:TestCasts>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:TestCasts>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(TestCasts) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U TestCasts>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U TestCasts>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:untyped) = :untyped\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:untyped) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestCasts), <statTemp>$7: Symbol(:untyped), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:test_casts) = :test_casts\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:test_casts) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestCasts), <statTemp>$13: Symbol(:test_casts), <statTemp>$14: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:TestCasts>#<static-init>_0" -> "bb::<Class:TestCasts>#<static-init>_1" [style="bold"];
     "bb::<Class:TestCasts>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "complex_implication_1.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(ModuleMethods) = alias <C ModuleMethods>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(ModuleMethods))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(ModuleMethods) = alias <C ModuleMethods>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(ModuleMethods))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,10 +22,9 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::ModuleMethods#instrumented_request" {
     label = "::ModuleMethods#instrumented_request";
     color = blue;
-    "bb::ModuleMethods#instrumented_request_0" [shape = invhouse];
-    "bb::ModuleMethods#instrumented_request_1" [shape = parallelogram];
 
     "bb::ModuleMethods#instrumented_request_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: ModuleMethods = cast(<self>: NilClass, ModuleMethods);\lfinal_attempt: T.untyped = load_arg(final_attempt)\lfoo: T.untyped = load_arg(foo)\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<exceptionValue>$4: T.untyped = <get-current-exception>\l<exceptionValue>$4: T.untyped\l"
     ];
@@ -34,12 +33,14 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     "bb::ModuleMethods#instrumented_request_0" -> "bb::ModuleMethods#instrumented_request_4" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::ModuleMethods#instrumented_request_1" -> "bb::ModuleMethods#instrumented_request_1" [style="bold"];
     "bb::ModuleMethods#instrumented_request_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=2](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: T.untyped, <magic>$5: T.class_of(<Magic>))\le: T.untyped = <exceptionValue>$4\l<cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>\l<isaCheckTemp>$9: T.untyped = e: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))\l<isaCheckTemp>$9: T.untyped\l"
     ];
@@ -48,6 +49,7 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     "bb::ModuleMethods#instrumented_request_3" -> "bb::ModuleMethods#instrumented_request_8" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=1](final_attempt: T.untyped, foo: T.untyped, <magic>$5: T.class_of(<Magic>))\l<exceptionValue>$4: T.untyped = <get-current-exception>\l<exceptionValue>$4: T.untyped\l"
     ];
@@ -56,12 +58,14 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     "bb::ModuleMethods#instrumented_request_4" -> "bb::ModuleMethods#instrumented_request_5" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=4](final_attempt: T.untyped, foo: T.untyped)\l<unconditional>\l"
     ];
 
     "bb::ModuleMethods#instrumented_request_5" -> "bb::ModuleMethods#instrumented_request_6" [style="bold"];
     "bb::ModuleMethods#instrumented_request_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=3](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError), <gotoDeadTemp>$10: T.nilable(TrueClass))\l<gotoDeadTemp>$10: T.nilable(TrueClass)\l"
     ];
@@ -70,18 +74,21 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     "bb::ModuleMethods#instrumented_request_6" -> "bb::ModuleMethods#instrumented_request_9" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=2](final_attempt: T.untyped, foo: T.untyped, <magic>$5: T.class_of(<Magic>), e: StandardError)\l<exceptionValue>$4: NilClass = nil\l<keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)\lerr: StandardError = e\l<unconditional>\l"
     ];
 
     "bb::ModuleMethods#instrumented_request_7" -> "bb::ModuleMethods#instrumented_request_6" [style="bold"];
     "bb::ModuleMethods#instrumented_request_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=2](final_attempt: T.untyped, foo: T.untyped)\l<gotoDeadTemp>$10: TrueClass = true\l<unconditional>\l"
     ];
 
     "bb::ModuleMethods#instrumented_request_8" -> "bb::ModuleMethods#instrumented_request_6" [style="bold"];
     "bb::ModuleMethods#instrumented_request_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError))\lis_successful: T::Boolean = err: T.nilable(StandardError).nil?()\lis_successful: T::Boolean\l"
     ];
@@ -90,6 +97,7 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     "bb::ModuleMethods#instrumented_request_9" -> "bb::ModuleMethods#instrumented_request_11" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=0](foo: T.untyped, err: NilClass, is_successful: TrueClass)\l||$2: TrueClass = is_successful\l||$2: TrueClass\l"
     ];
@@ -98,6 +106,7 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     "bb::ModuleMethods#instrumented_request_10" -> "bb::ModuleMethods#instrumented_request_14" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=0](final_attempt: T.untyped, foo: T.untyped, err: StandardError, is_successful: FalseClass)\l||$2: T.untyped = final_attempt\l||$2: T.untyped\l"
     ];
@@ -106,6 +115,7 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     "bb::ModuleMethods#instrumented_request_11" -> "bb::ModuleMethods#instrumented_request_14" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_13" [
+        shape = rectangle;
         color = black;
         label = "block[id=13, rubyBlockId=0](is_successful: T::Boolean, ||$2: T.untyped)\l<ifTemp>$14: T.untyped = ||$2\l<ifTemp>$14: T.untyped\l"
     ];
@@ -114,6 +124,7 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     "bb::ModuleMethods#instrumented_request_13" -> "bb::ModuleMethods#instrumented_request_24" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_14" [
+        shape = rectangle;
         color = black;
         label = "block[id=14, rubyBlockId=0](foo: T.untyped, err: StandardError, is_successful: FalseClass)\lerr: StandardError\l"
     ];
@@ -122,6 +133,7 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     "bb::ModuleMethods#instrumented_request_14" -> "bb::ModuleMethods#instrumented_request_16" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_15" [
+        shape = rectangle;
         color = black;
         label = "block[id=15, rubyBlockId=0](foo: T.untyped, is_successful: FalseClass)\l<ifTemp>$14: T.untyped = foo\l<ifTemp>$14: T.untyped\l"
     ];
@@ -130,6 +142,7 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     "bb::ModuleMethods#instrumented_request_15" -> "bb::ModuleMethods#instrumented_request_24" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_16" [
+        shape = rectangle;
         color = red;
         label = "block[id=16, rubyBlockId=0](err: StandardError, is_successful: FalseClass)\l<ifTemp>$14 = err\l<ifTemp>$14\l"
     ];
@@ -138,6 +151,7 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     "bb::ModuleMethods#instrumented_request_16" -> "bb::ModuleMethods#instrumented_request_24" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_19" [
+        shape = rectangle;
         color = black;
         label = "block[id=19, rubyBlockId=0](is_successful: T::Boolean)\l<ifTemp>$19: T::Boolean = is_successful: T::Boolean.!()\l<ifTemp>$19: T::Boolean\l"
     ];
@@ -146,12 +160,14 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
     "bb::ModuleMethods#instrumented_request_19" -> "bb::ModuleMethods#instrumented_request_24" [style="tapered"];
 
     "bb::ModuleMethods#instrumented_request_21" [
+        shape = rectangle;
         color = black;
         label = "block[id=21, rubyBlockId=0]()\l<returnMethodTemp>$2: Integer(1) = 1\l<unconditional>\l"
     ];
 
     "bb::ModuleMethods#instrumented_request_21" -> "bb::ModuleMethods#instrumented_request_24" [style="bold"];
     "bb::ModuleMethods#instrumented_request_24" [
+        shape = rectangle;
         color = black;
         label = "block[id=24, rubyBlockId=0](<returnMethodTemp>$2: T.nilable(Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
     ];
@@ -162,16 +178,16 @@ subgraph "cluster_::ModuleMethods#instrumented_request" {
 subgraph "cluster_::<Class:ModuleMethods>#<static-init>" {
     label = "::<Class:ModuleMethods>#<static-init>";
     color = blue;
-    "bb::<Class:ModuleMethods>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:ModuleMethods>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:ModuleMethods>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(ModuleMethods) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U ModuleMethods>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U ModuleMethods>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:instrumented_request) = :instrumented_request\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:instrumented_request) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(ModuleMethods), <statTemp>$6: Symbol(:instrumented_request), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:instrumented_request)\l<unconditional>\l"
     ];
 
     "bb::<Class:ModuleMethods>#<static-init>_0" -> "bb::<Class:ModuleMethods>#<static-init>_1" [style="bold"];
     "bb::<Class:ModuleMethods>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/control_flow/complex_implications_2.rb.cfg.exp
+++ b/test/testdata/infer/control_flow/complex_implications_2.rb.cfg.exp
@@ -2,10 +2,9 @@ digraph "complex_implications_2.rb" {
 subgraph "cluster_::Object#foo" {
     label = "::Object#foo";
     color = blue;
-    "bb::Object#foo_0" [shape = invhouse];
-    "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\lfoo: T.untyped = load_arg(foo)\lfoo: T.untyped\l"
     ];
@@ -14,12 +13,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_0" -> "bb::Object#foo_7" [style="tapered"];
 
     "bb::Object#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#foo_1" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](foo: T.untyped)\l<cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>\lbar: T.untyped = foo: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))\lbar: T.untyped\l"
     ];
@@ -28,12 +29,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_2" -> "bb::Object#foo_7" [style="tapered"];
 
     "bb::Object#foo_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](foo: StandardError)\le: StandardError = foo\lerr: StandardError = e\l<unconditional>\l"
     ];
 
     "bb::Object#foo_4" -> "bb::Object#foo_7" [style="bold"];
     "bb::Object#foo_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](err: T.nilable(StandardError))\ljunk: T.nilable(StandardError) = err\lerr: T.nilable(StandardError)\l"
     ];
@@ -42,12 +45,14 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_7" -> "bb::Object#foo_10" [style="tapered"];
 
     "bb::Object#foo_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=0]()\l<returnMethodTemp>$2: Integer(1) = 1\l<unconditional>\l"
     ];
 
     "bb::Object#foo_8" -> "bb::Object#foo_10" [style="bold"];
     "bb::Object#foo_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=0](<returnMethodTemp>$2: T.nilable(Integer))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
     ];
@@ -58,16 +63,16 @@ subgraph "cluster_::Object#foo" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:foo) = :foo\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:foo) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$6: Symbol(:foo), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/control_flow/normalize_params.rb.cfg.exp
+++ b/test/testdata/infer/control_flow/normalize_params.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "normalize_params.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(Test) = alias <C Test>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(Test))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(Test) = alias <C Test>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(Test))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,10 +22,9 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::Test#normalize_params" {
     label = "::Test#normalize_params";
     color = blue;
-    "bb::Test#normalize_params_0" [shape = invhouse];
-    "bb::Test#normalize_params_1" [shape = parallelogram];
 
     "bb::Test#normalize_params_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Test = cast(<self>: NilClass, Test);\lv: T.untyped = load_arg(v)\l<cfgAlias>$6: T.class_of(Hash) = alias <C Hash>\l<ifTemp>$3: T.untyped = v: T.untyped.is_a?(<cfgAlias>$6: T.class_of(Hash))\l<ifTemp>$3: T.untyped\l"
     ];
@@ -34,18 +33,21 @@ subgraph "cluster_::Test#normalize_params" {
     "bb::Test#normalize_params_0" -> "bb::Test#normalize_params_3" [style="tapered"];
 
     "bb::Test#normalize_params_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Test#normalize_params_1" -> "bb::Test#normalize_params_1" [style="bold"];
     "bb::Test#normalize_params_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](<self>: Test, v: T::Hash[T.untyped, T.untyped])\l<statTemp>$9: T::Array[[T.untyped, T.untyped]] = v: T::Hash[T.untyped, T.untyped].to_a()\l<statTemp>$7: T.untyped = <self>: Test.normalize_params(<statTemp>$9: T::Array[[T.untyped, T.untyped]])\l<returnMethodTemp>$2: T.untyped = <statTemp>$7: T.untyped.sort()\l<unconditional>\l"
     ];
 
     "bb::Test#normalize_params_2" -> "bb::Test#normalize_params_11" [style="bold"];
     "bb::Test#normalize_params_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<self>: Test, v: T.untyped)\l<cfgAlias>$14: T.class_of(Array) = alias <C Array>\l<ifTemp>$11: T.untyped = v: T.untyped.is_a?(<cfgAlias>$14: T.class_of(Array))\l<ifTemp>$11: T.untyped\l"
     ];
@@ -54,18 +56,21 @@ subgraph "cluster_::Test#normalize_params" {
     "bb::Test#normalize_params_3" -> "bb::Test#normalize_params_5" [style="tapered"];
 
     "bb::Test#normalize_params_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](<self>: Test, v: T::Array[T.untyped])\l<block-pre-call-temp>$16: Sorbet::Private::Static::Void = v: T::Array[T.untyped].map()\l<selfRestore>$17: Test = <self>\l<unconditional>\l"
     ];
 
     "bb::Test#normalize_params_4" -> "bb::Test#normalize_params_6" [style="bold"];
     "bb::Test#normalize_params_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0](v: T.untyped)\l<returnMethodTemp>$2: T.untyped = v\l<unconditional>\l"
     ];
 
     "bb::Test#normalize_params_5" -> "bb::Test#normalize_params_11" [style="bold"];
     "bb::Test#normalize_params_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=1](<self>: Test, <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -74,18 +79,21 @@ subgraph "cluster_::Test#normalize_params" {
     "bb::Test#normalize_params_6" -> "bb::Test#normalize_params_7" [style="tapered"];
 
     "bb::Test#normalize_params_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](<block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test)\l<returnMethodTemp>$2: T::Array[T.untyped] = Solve<<block-pre-call-temp>$16, map>\l<unconditional>\l"
     ];
 
     "bb::Test#normalize_params_7" -> "bb::Test#normalize_params_11" [style="bold"];
     "bb::Test#normalize_params_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=1](<self>: Test, <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test)\louterLoops: 1\l<self>: Test = loadSelf\l<blk>$18: [T.untyped] = load_yield_params(map)\l<blk>$19: Integer(0) = 0\le$1: T.untyped = <blk>$18: [T.untyped].[](<blk>$19: Integer(0))\l<blockReturnTemp>$20: T.untyped = <self>: Test.normalize_params(e$1: T.untyped)\l<blockReturnTemp>$23: T.noreturn = blockreturn<map> <blockReturnTemp>$20: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Test#normalize_params_9" -> "bb::Test#normalize_params_6" [style="bold"];
     "bb::Test#normalize_params_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=0](<returnMethodTemp>$2: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -96,16 +104,16 @@ subgraph "cluster_::Test#normalize_params" {
 subgraph "cluster_::<Class:Test>#<static-init>" {
     label = "::<Class:Test>#<static-init>";
     color = blue;
-    "bb::<Class:Test>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Test>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Test>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Test) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Test>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Test>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:normalize_params) = :normalize_params\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:normalize_params) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Test), <statTemp>$6: Symbol(:normalize_params), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:normalize_params)\l<unconditional>\l"
     ];
 
     "bb::<Class:Test>#<static-init>_0" -> "bb::<Class:Test>#<static-init>_1" [style="bold"];
     "bb::<Class:Test>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/control_flow/simple.rb.cfg.exp
+++ b/test/testdata/infer/control_flow/simple.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "simple.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(ControlFlow) = alias <C ControlFlow>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(ControlFlow))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(ControlFlow) = alias <C ControlFlow>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(ControlFlow))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,10 +22,9 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::ControlFlow#orZero0" {
     label = "::ControlFlow#orZero0";
     color = blue;
-    "bb::ControlFlow#orZero0_0" [shape = invhouse];
-    "bb::ControlFlow#orZero0_1" [shape = parallelogram];
 
     "bb::ControlFlow#orZero0_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: ControlFlow = cast(<self>: NilClass, ControlFlow);\la: T.nilable(Integer) = load_arg(a)\la: T.nilable(Integer)\l"
     ];
@@ -34,18 +33,21 @@ subgraph "cluster_::ControlFlow#orZero0" {
     "bb::ControlFlow#orZero0_0" -> "bb::ControlFlow#orZero0_3" [style="tapered"];
 
     "bb::ControlFlow#orZero0_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<returnMethodTemp>$2)\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero0_1" -> "bb::ControlFlow#orZero0_1" [style="bold"];
     "bb::ControlFlow#orZero0_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](a: Integer)\l<returnMethodTemp>$2: T.noreturn = return a: Integer\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero0_2" -> "bb::ControlFlow#orZero0_1" [style="bold"];
     "bb::ControlFlow#orZero0_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0]()\l<returnTemp>$5: Integer(0) = 0\l<returnMethodTemp>$2: T.noreturn = return <returnTemp>$5: Integer(0)\l<unconditional>\l"
     ];
@@ -56,10 +58,9 @@ subgraph "cluster_::ControlFlow#orZero0" {
 subgraph "cluster_::ControlFlow#orZero0a" {
     label = "::ControlFlow#orZero0a";
     color = blue;
-    "bb::ControlFlow#orZero0a_0" [shape = invhouse];
-    "bb::ControlFlow#orZero0a_1" [shape = parallelogram];
 
     "bb::ControlFlow#orZero0a_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: ControlFlow = cast(<self>: NilClass, ControlFlow);\la: Integer = load_arg(a)\la: Integer\l"
     ];
@@ -68,18 +69,21 @@ subgraph "cluster_::ControlFlow#orZero0a" {
     "bb::ControlFlow#orZero0a_0" -> "bb::ControlFlow#orZero0a_3" [style="tapered"];
 
     "bb::ControlFlow#orZero0a_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<returnMethodTemp>$2)\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero0a_1" -> "bb::ControlFlow#orZero0a_1" [style="bold"];
     "bb::ControlFlow#orZero0a_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](a: Integer)\l<returnMethodTemp>$2: T.noreturn = return a: Integer\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero0a_2" -> "bb::ControlFlow#orZero0a_1" [style="bold"];
     "bb::ControlFlow#orZero0a_3" [
+        shape = rectangle;
         color = red;
         label = "block[id=3, rubyBlockId=0]()\l<returnTemp>$5 = 0\l<returnMethodTemp>$2 = return <returnTemp>$5\l<unconditional>\l"
     ];
@@ -90,10 +94,9 @@ subgraph "cluster_::ControlFlow#orZero0a" {
 subgraph "cluster_::ControlFlow#orZero0n" {
     label = "::ControlFlow#orZero0n";
     color = blue;
-    "bb::ControlFlow#orZero0n_0" [shape = invhouse];
-    "bb::ControlFlow#orZero0n_1" [shape = parallelogram];
 
     "bb::ControlFlow#orZero0n_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: ControlFlow = cast(<self>: NilClass, ControlFlow);\la: T.nilable(Integer) = load_arg(a)\lb: T::Boolean = a: T.nilable(Integer).!()\lb: T::Boolean\l"
     ];
@@ -102,18 +105,21 @@ subgraph "cluster_::ControlFlow#orZero0n" {
     "bb::ControlFlow#orZero0n_0" -> "bb::ControlFlow#orZero0n_3" [style="tapered"];
 
     "bb::ControlFlow#orZero0n_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<returnMethodTemp>$2)\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero0n_1" -> "bb::ControlFlow#orZero0n_1" [style="bold"];
     "bb::ControlFlow#orZero0n_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\l<returnTemp>$6: Integer(0) = 0\l<returnMethodTemp>$2: T.noreturn = return <returnTemp>$6: Integer(0)\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero0n_2" -> "bb::ControlFlow#orZero0n_1" [style="bold"];
     "bb::ControlFlow#orZero0n_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](a: Integer)\l<returnMethodTemp>$2: T.noreturn = return a: Integer\l<unconditional>\l"
     ];
@@ -124,10 +130,9 @@ subgraph "cluster_::ControlFlow#orZero0n" {
 subgraph "cluster_::ControlFlow#orZero1n" {
     label = "::ControlFlow#orZero1n";
     color = blue;
-    "bb::ControlFlow#orZero1n_0" [shape = invhouse];
-    "bb::ControlFlow#orZero1n_1" [shape = parallelogram];
 
     "bb::ControlFlow#orZero1n_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: ControlFlow = cast(<self>: NilClass, ControlFlow);\la: T.nilable(Integer) = load_arg(a)\l<cfgAlias>$7: T.class_of(Integer) = alias <C Integer>\l<statTemp>$4: T::Boolean = a: T.nilable(Integer).is_a?(<cfgAlias>$7: T.class_of(Integer))\lb: T::Boolean = <statTemp>$4: T::Boolean.!()\lb: T::Boolean\l"
     ];
@@ -136,18 +141,21 @@ subgraph "cluster_::ControlFlow#orZero1n" {
     "bb::ControlFlow#orZero1n_0" -> "bb::ControlFlow#orZero1n_3" [style="tapered"];
 
     "bb::ControlFlow#orZero1n_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<returnMethodTemp>$2)\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero1n_1" -> "bb::ControlFlow#orZero1n_1" [style="bold"];
     "bb::ControlFlow#orZero1n_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\l<returnTemp>$9: Integer(0) = 0\l<returnMethodTemp>$2: T.noreturn = return <returnTemp>$9: Integer(0)\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero1n_2" -> "bb::ControlFlow#orZero1n_1" [style="bold"];
     "bb::ControlFlow#orZero1n_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](a: Integer)\l<returnMethodTemp>$2: T.noreturn = return a: Integer\l<unconditional>\l"
     ];
@@ -158,10 +166,9 @@ subgraph "cluster_::ControlFlow#orZero1n" {
 subgraph "cluster_::ControlFlow#orZero2" {
     label = "::ControlFlow#orZero2";
     color = blue;
-    "bb::ControlFlow#orZero2_0" [shape = invhouse];
-    "bb::ControlFlow#orZero2_1" [shape = parallelogram];
 
     "bb::ControlFlow#orZero2_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: ControlFlow = cast(<self>: NilClass, ControlFlow);\la: T.nilable(Integer) = load_arg(a)\la: T.nilable(Integer)\l"
     ];
@@ -170,18 +177,21 @@ subgraph "cluster_::ControlFlow#orZero2" {
     "bb::ControlFlow#orZero2_0" -> "bb::ControlFlow#orZero2_3" [style="tapered"];
 
     "bb::ControlFlow#orZero2_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero2_1" -> "bb::ControlFlow#orZero2_1" [style="bold"];
     "bb::ControlFlow#orZero2_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0]()\la: Integer(0) = 0\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero2_3" -> "bb::ControlFlow#orZero2_4" [style="bold"];
     "bb::ControlFlow#orZero2_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](a: Integer)\l<returnMethodTemp>$2: Integer = a\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
     ];
@@ -192,10 +202,9 @@ subgraph "cluster_::ControlFlow#orZero2" {
 subgraph "cluster_::ControlFlow#orZero3" {
     label = "::ControlFlow#orZero3";
     color = blue;
-    "bb::ControlFlow#orZero3_0" [shape = invhouse];
-    "bb::ControlFlow#orZero3_1" [shape = parallelogram];
 
     "bb::ControlFlow#orZero3_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: ControlFlow = cast(<self>: NilClass, ControlFlow);\la: T.nilable(Integer) = load_arg(a)\la: T.nilable(Integer)\l"
     ];
@@ -204,12 +213,14 @@ subgraph "cluster_::ControlFlow#orZero3" {
     "bb::ControlFlow#orZero3_0" -> "bb::ControlFlow#orZero3_3" [style="tapered"];
 
     "bb::ControlFlow#orZero3_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<returnMethodTemp>$2)\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero3_1" -> "bb::ControlFlow#orZero3_1" [style="bold"];
     "bb::ControlFlow#orZero3_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\l<statTemp>$5: Integer(1) = 1\l<statTemp>$6: Integer(2) = 2\l<ifTemp>$3: T::Boolean = <statTemp>$5: Integer(1).==(<statTemp>$6: Integer(2))\l<ifTemp>$3: T::Boolean\l"
     ];
@@ -218,6 +229,7 @@ subgraph "cluster_::ControlFlow#orZero3" {
     "bb::ControlFlow#orZero3_2" -> "bb::ControlFlow#orZero3_6" [style="tapered"];
 
     "bb::ControlFlow#orZero3_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](a: NilClass)\l<ifTemp>$3: NilClass = a\l<ifTemp>$3: NilClass\l"
     ];
@@ -226,12 +238,14 @@ subgraph "cluster_::ControlFlow#orZero3" {
     "bb::ControlFlow#orZero3_3" -> "bb::ControlFlow#orZero3_6" [style="tapered"];
 
     "bb::ControlFlow#orZero3_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0]()\l<returnTemp>$7: Integer(1) = 1\l<returnMethodTemp>$2: T.noreturn = return <returnTemp>$7: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero3_5" -> "bb::ControlFlow#orZero3_1" [style="bold"];
     "bb::ControlFlow#orZero3_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=0]()\l<returnTemp>$8: Integer(0) = 0\l<returnMethodTemp>$2: T.noreturn = return <returnTemp>$8: Integer(0)\l<unconditional>\l"
     ];
@@ -242,10 +256,9 @@ subgraph "cluster_::ControlFlow#orZero3" {
 subgraph "cluster_::ControlFlow#orZero3n" {
     label = "::ControlFlow#orZero3n";
     color = blue;
-    "bb::ControlFlow#orZero3n_0" [shape = invhouse];
-    "bb::ControlFlow#orZero3n_1" [shape = parallelogram];
 
     "bb::ControlFlow#orZero3n_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: ControlFlow = cast(<self>: NilClass, ControlFlow);\la: T.nilable(Integer) = load_arg(a)\la: T.nilable(Integer)\l"
     ];
@@ -254,24 +267,28 @@ subgraph "cluster_::ControlFlow#orZero3n" {
     "bb::ControlFlow#orZero3n_0" -> "bb::ControlFlow#orZero3n_3" [style="tapered"];
 
     "bb::ControlFlow#orZero3n_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<returnMethodTemp>$2)\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero3n_1" -> "bb::ControlFlow#orZero3n_1" [style="bold"];
     "bb::ControlFlow#orZero3n_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\l<statTemp>$6: Integer(1) = 1\l<statTemp>$7: Integer(2) = 2\l<statTemp>$4: T::Boolean = <statTemp>$6: Integer(1).==(<statTemp>$7: Integer(2))\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero3n_2" -> "bb::ControlFlow#orZero3n_4" [style="bold"];
     "bb::ControlFlow#orZero3n_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](a: NilClass)\l<statTemp>$4: NilClass = a\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero3n_3" -> "bb::ControlFlow#orZero3n_4" [style="bold"];
     "bb::ControlFlow#orZero3n_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](<statTemp>$4: T.nilable(T::Boolean))\lb: T::Boolean = <statTemp>$4: T.nilable(T::Boolean).!()\lb: T::Boolean\l"
     ];
@@ -280,12 +297,14 @@ subgraph "cluster_::ControlFlow#orZero3n" {
     "bb::ControlFlow#orZero3n_4" -> "bb::ControlFlow#orZero3n_6" [style="tapered"];
 
     "bb::ControlFlow#orZero3n_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0]()\l<returnTemp>$9: Integer(0) = 0\l<returnMethodTemp>$2: T.noreturn = return <returnTemp>$9: Integer(0)\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero3n_5" -> "bb::ControlFlow#orZero3n_1" [style="bold"];
     "bb::ControlFlow#orZero3n_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=0]()\l<returnTemp>$10: Integer(1) = 1\l<returnMethodTemp>$2: T.noreturn = return <returnTemp>$10: Integer(1)\l<unconditional>\l"
     ];
@@ -296,10 +315,9 @@ subgraph "cluster_::ControlFlow#orZero3n" {
 subgraph "cluster_::ControlFlow#orZero4" {
     label = "::ControlFlow#orZero4";
     color = blue;
-    "bb::ControlFlow#orZero4_0" [shape = invhouse];
-    "bb::ControlFlow#orZero4_1" [shape = parallelogram];
 
     "bb::ControlFlow#orZero4_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: ControlFlow = cast(<self>: NilClass, ControlFlow);\la: T.nilable(Integer) = load_arg(a)\la: T.nilable(Integer)\l"
     ];
@@ -308,12 +326,14 @@ subgraph "cluster_::ControlFlow#orZero4" {
     "bb::ControlFlow#orZero4_0" -> "bb::ControlFlow#orZero4_3" [style="tapered"];
 
     "bb::ControlFlow#orZero4_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<returnMethodTemp>$2)\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero4_1" -> "bb::ControlFlow#orZero4_1" [style="bold"];
     "bb::ControlFlow#orZero4_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](a: Integer)\l<ifTemp>$3: Integer = a\l<ifTemp>$3: Integer\l"
     ];
@@ -322,6 +342,7 @@ subgraph "cluster_::ControlFlow#orZero4" {
     "bb::ControlFlow#orZero4_2" -> "bb::ControlFlow#orZero4_6" [style="tapered"];
 
     "bb::ControlFlow#orZero4_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](a: NilClass)\l<ifTemp>$3: TrueClass = true\l<ifTemp>$3: TrueClass\l"
     ];
@@ -330,12 +351,14 @@ subgraph "cluster_::ControlFlow#orZero4" {
     "bb::ControlFlow#orZero4_3" -> "bb::ControlFlow#orZero4_6" [style="tapered"];
 
     "bb::ControlFlow#orZero4_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0](a: T.nilable(Integer))\l<returnMethodTemp>$2: T.noreturn = return a: T.nilable(Integer)\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero4_5" -> "bb::ControlFlow#orZero4_1" [style="bold"];
     "bb::ControlFlow#orZero4_6" [
+        shape = rectangle;
         color = red;
         label = "block[id=6, rubyBlockId=0]()\l<returnTemp>$6 = 0\l<returnMethodTemp>$2 = return <returnTemp>$6\l<unconditional>\l"
     ];
@@ -346,10 +369,9 @@ subgraph "cluster_::ControlFlow#orZero4" {
 subgraph "cluster_::ControlFlow#orZero5" {
     label = "::ControlFlow#orZero5";
     color = blue;
-    "bb::ControlFlow#orZero5_0" [shape = invhouse];
-    "bb::ControlFlow#orZero5_1" [shape = parallelogram];
 
     "bb::ControlFlow#orZero5_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: ControlFlow = cast(<self>: NilClass, ControlFlow);\la: T.nilable(Integer) = load_arg(a)\la: T.nilable(Integer)\l"
     ];
@@ -358,12 +380,14 @@ subgraph "cluster_::ControlFlow#orZero5" {
     "bb::ControlFlow#orZero5_0" -> "bb::ControlFlow#orZero5_3" [style="tapered"];
 
     "bb::ControlFlow#orZero5_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<returnMethodTemp>$2)\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero5_1" -> "bb::ControlFlow#orZero5_1" [style="bold"];
     "bb::ControlFlow#orZero5_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](a: Integer)\l<ifTemp>$3: TrueClass = true\l<ifTemp>$3: TrueClass\l"
     ];
@@ -372,6 +396,7 @@ subgraph "cluster_::ControlFlow#orZero5" {
     "bb::ControlFlow#orZero5_2" -> "bb::ControlFlow#orZero5_6" [style="tapered"];
 
     "bb::ControlFlow#orZero5_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](a: NilClass)\l<ifTemp>$3: NilClass = a\l<ifTemp>$3: NilClass\l"
     ];
@@ -380,12 +405,14 @@ subgraph "cluster_::ControlFlow#orZero5" {
     "bb::ControlFlow#orZero5_3" -> "bb::ControlFlow#orZero5_6" [style="tapered"];
 
     "bb::ControlFlow#orZero5_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0](a: Integer)\l<returnMethodTemp>$2: T.noreturn = return a: Integer\l<unconditional>\l"
     ];
 
     "bb::ControlFlow#orZero5_5" -> "bb::ControlFlow#orZero5_1" [style="bold"];
     "bb::ControlFlow#orZero5_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=0]()\l<returnTemp>$6: Integer(0) = 0\l<returnMethodTemp>$2: T.noreturn = return <returnTemp>$6: Integer(0)\l<unconditional>\l"
     ];
@@ -396,22 +423,23 @@ subgraph "cluster_::ControlFlow#orZero5" {
 subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     label = "::<Class:ControlFlow>#<static-init>";
     color = blue;
-    "bb::<Class:ControlFlow>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:ControlFlow>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:ControlFlow>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(ControlFlow) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U ControlFlow>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U ControlFlow>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))\l<selfRestore>$8: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_0" -> "bb::<Class:ControlFlow>#<static-init>_2" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_1" -> "bb::<Class:ControlFlow>#<static-init>_1" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(ControlFlow))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -420,18 +448,21 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_2" -> "bb::<Class:ControlFlow>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(ControlFlow))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$8\l<cfgAlias>$27: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$29: Sorbet::Private::Static::Void = <cfgAlias>$27: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))\l<selfRestore>$30: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_3" -> "bb::<Class:ControlFlow>#<static-init>_6" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(ControlFlow))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$14: Symbol(:a) = :a\l<cfgAlias>$17: T.class_of(T) = alias <C T>\l<cfgAlias>$19: T.class_of(Integer) = alias <C Integer>\l<cfgAlias>$21: T.class_of(NilClass) = alias <C NilClass>\l<hashTemp>$15: <Type: T.nilable(Integer)> = <cfgAlias>$17: T.class_of(T).any(<cfgAlias>$19: T.class_of(Integer), <cfgAlias>$21: T.class_of(NilClass))\l<statTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$14: Symbol(:a), <hashTemp>$15: <Type: T.nilable(Integer)>)\l<cfgAlias>$23: T.class_of(Integer) = alias <C Integer>\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <statTemp>$12: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$23: T.class_of(Integer))\l<blockReturnTemp>$24: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_5" -> "bb::<Class:ControlFlow>#<static-init>_2" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=2](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$29: Sorbet::Private::Static::Void, <selfRestore>$30: T.class_of(ControlFlow))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -440,18 +471,21 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_6" -> "bb::<Class:ControlFlow>#<static-init>_7" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](<block-pre-call-temp>$29: Sorbet::Private::Static::Void, <selfRestore>$30: T.class_of(ControlFlow))\l<statTemp>$25: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$29, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$30\l<cfgAlias>$44: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$46: Sorbet::Private::Static::Void = <cfgAlias>$44: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))\l<selfRestore>$47: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_7" -> "bb::<Class:ControlFlow>#<static-init>_10" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=2](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$29: Sorbet::Private::Static::Void, <selfRestore>$30: T.class_of(ControlFlow))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$36: Symbol(:a) = :a\l<cfgAlias>$38: T.class_of(Integer) = alias <C Integer>\l<statTemp>$34: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$36: Symbol(:a), <cfgAlias>$38: T.class_of(Integer))\l<cfgAlias>$40: T.class_of(Integer) = alias <C Integer>\l<blockReturnTemp>$33: T::Private::Methods::DeclBuilder = <statTemp>$34: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$40: T.class_of(Integer))\l<blockReturnTemp>$41: T.noreturn = blockreturn<sig> <blockReturnTemp>$33: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_9" -> "bb::<Class:ControlFlow>#<static-init>_6" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=3](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$46: Sorbet::Private::Static::Void, <selfRestore>$47: T.class_of(ControlFlow))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -460,18 +494,21 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_10" -> "bb::<Class:ControlFlow>#<static-init>_11" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=0](<block-pre-call-temp>$46: Sorbet::Private::Static::Void, <selfRestore>$47: T.class_of(ControlFlow))\l<statTemp>$42: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$46, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$47\l<cfgAlias>$66: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$68: Sorbet::Private::Static::Void = <cfgAlias>$66: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))\l<selfRestore>$69: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_11" -> "bb::<Class:ControlFlow>#<static-init>_14" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_13" [
+        shape = rectangle;
         color = black;
         label = "block[id=13, rubyBlockId=3](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$46: Sorbet::Private::Static::Void, <selfRestore>$47: T.class_of(ControlFlow))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$53: Symbol(:a) = :a\l<cfgAlias>$56: T.class_of(T) = alias <C T>\l<cfgAlias>$58: T.class_of(Integer) = alias <C Integer>\l<cfgAlias>$60: T.class_of(NilClass) = alias <C NilClass>\l<hashTemp>$54: <Type: T.nilable(Integer)> = <cfgAlias>$56: T.class_of(T).any(<cfgAlias>$58: T.class_of(Integer), <cfgAlias>$60: T.class_of(NilClass))\l<statTemp>$51: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$53: Symbol(:a), <hashTemp>$54: <Type: T.nilable(Integer)>)\l<cfgAlias>$62: T.class_of(Integer) = alias <C Integer>\l<blockReturnTemp>$50: T::Private::Methods::DeclBuilder = <statTemp>$51: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$62: T.class_of(Integer))\l<blockReturnTemp>$63: T.noreturn = blockreturn<sig> <blockReturnTemp>$50: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_13" -> "bb::<Class:ControlFlow>#<static-init>_10" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_14" [
+        shape = rectangle;
         color = black;
         label = "block[id=14, rubyBlockId=4](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$68: Sorbet::Private::Static::Void, <selfRestore>$69: T.class_of(ControlFlow))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -480,18 +517,21 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_14" -> "bb::<Class:ControlFlow>#<static-init>_15" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_15" [
+        shape = rectangle;
         color = black;
         label = "block[id=15, rubyBlockId=0](<block-pre-call-temp>$68: Sorbet::Private::Static::Void, <selfRestore>$69: T.class_of(ControlFlow))\l<statTemp>$64: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$68, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$69\l<cfgAlias>$88: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$90: Sorbet::Private::Static::Void = <cfgAlias>$88: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))\l<selfRestore>$91: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_15" -> "bb::<Class:ControlFlow>#<static-init>_18" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_17" [
+        shape = rectangle;
         color = black;
         label = "block[id=17, rubyBlockId=4](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$68: Sorbet::Private::Static::Void, <selfRestore>$69: T.class_of(ControlFlow))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$75: Symbol(:a) = :a\l<cfgAlias>$78: T.class_of(T) = alias <C T>\l<cfgAlias>$80: T.class_of(Integer) = alias <C Integer>\l<cfgAlias>$82: T.class_of(NilClass) = alias <C NilClass>\l<hashTemp>$76: <Type: T.nilable(Integer)> = <cfgAlias>$78: T.class_of(T).any(<cfgAlias>$80: T.class_of(Integer), <cfgAlias>$82: T.class_of(NilClass))\l<statTemp>$73: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$75: Symbol(:a), <hashTemp>$76: <Type: T.nilable(Integer)>)\l<cfgAlias>$84: T.class_of(Integer) = alias <C Integer>\l<blockReturnTemp>$72: T::Private::Methods::DeclBuilder = <statTemp>$73: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$84: T.class_of(Integer))\l<blockReturnTemp>$85: T.noreturn = blockreturn<sig> <blockReturnTemp>$72: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_17" -> "bb::<Class:ControlFlow>#<static-init>_14" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_18" [
+        shape = rectangle;
         color = black;
         label = "block[id=18, rubyBlockId=5](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$90: Sorbet::Private::Static::Void, <selfRestore>$91: T.class_of(ControlFlow))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -500,18 +540,21 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_18" -> "bb::<Class:ControlFlow>#<static-init>_19" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_19" [
+        shape = rectangle;
         color = black;
         label = "block[id=19, rubyBlockId=0](<block-pre-call-temp>$90: Sorbet::Private::Static::Void, <selfRestore>$91: T.class_of(ControlFlow))\l<statTemp>$86: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$90, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$91\l<cfgAlias>$110: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$112: Sorbet::Private::Static::Void = <cfgAlias>$110: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))\l<selfRestore>$113: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_19" -> "bb::<Class:ControlFlow>#<static-init>_22" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_21" [
+        shape = rectangle;
         color = black;
         label = "block[id=21, rubyBlockId=5](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$90: Sorbet::Private::Static::Void, <selfRestore>$91: T.class_of(ControlFlow))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$97: Symbol(:a) = :a\l<cfgAlias>$100: T.class_of(T) = alias <C T>\l<cfgAlias>$102: T.class_of(Integer) = alias <C Integer>\l<cfgAlias>$104: T.class_of(NilClass) = alias <C NilClass>\l<hashTemp>$98: <Type: T.nilable(Integer)> = <cfgAlias>$100: T.class_of(T).any(<cfgAlias>$102: T.class_of(Integer), <cfgAlias>$104: T.class_of(NilClass))\l<statTemp>$95: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$97: Symbol(:a), <hashTemp>$98: <Type: T.nilable(Integer)>)\l<cfgAlias>$106: T.class_of(Integer) = alias <C Integer>\l<blockReturnTemp>$94: T::Private::Methods::DeclBuilder = <statTemp>$95: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$106: T.class_of(Integer))\l<blockReturnTemp>$107: T.noreturn = blockreturn<sig> <blockReturnTemp>$94: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_21" -> "bb::<Class:ControlFlow>#<static-init>_18" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_22" [
+        shape = rectangle;
         color = black;
         label = "block[id=22, rubyBlockId=6](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$112: Sorbet::Private::Static::Void, <selfRestore>$113: T.class_of(ControlFlow))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -520,18 +563,21 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_22" -> "bb::<Class:ControlFlow>#<static-init>_23" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_23" [
+        shape = rectangle;
         color = black;
         label = "block[id=23, rubyBlockId=0](<block-pre-call-temp>$112: Sorbet::Private::Static::Void, <selfRestore>$113: T.class_of(ControlFlow))\l<statTemp>$108: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$112, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$113\l<cfgAlias>$132: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$134: Sorbet::Private::Static::Void = <cfgAlias>$132: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))\l<selfRestore>$135: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_23" -> "bb::<Class:ControlFlow>#<static-init>_26" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_25" [
+        shape = rectangle;
         color = black;
         label = "block[id=25, rubyBlockId=6](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$112: Sorbet::Private::Static::Void, <selfRestore>$113: T.class_of(ControlFlow))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$119: Symbol(:a) = :a\l<cfgAlias>$122: T.class_of(T) = alias <C T>\l<cfgAlias>$124: T.class_of(Integer) = alias <C Integer>\l<cfgAlias>$126: T.class_of(NilClass) = alias <C NilClass>\l<hashTemp>$120: <Type: T.nilable(Integer)> = <cfgAlias>$122: T.class_of(T).any(<cfgAlias>$124: T.class_of(Integer), <cfgAlias>$126: T.class_of(NilClass))\l<statTemp>$117: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$119: Symbol(:a), <hashTemp>$120: <Type: T.nilable(Integer)>)\l<cfgAlias>$128: T.class_of(Integer) = alias <C Integer>\l<blockReturnTemp>$116: T::Private::Methods::DeclBuilder = <statTemp>$117: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$128: T.class_of(Integer))\l<blockReturnTemp>$129: T.noreturn = blockreturn<sig> <blockReturnTemp>$116: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_25" -> "bb::<Class:ControlFlow>#<static-init>_22" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_26" [
+        shape = rectangle;
         color = black;
         label = "block[id=26, rubyBlockId=7](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$134: Sorbet::Private::Static::Void, <selfRestore>$135: T.class_of(ControlFlow))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -540,18 +586,21 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_26" -> "bb::<Class:ControlFlow>#<static-init>_27" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_27" [
+        shape = rectangle;
         color = black;
         label = "block[id=27, rubyBlockId=0](<block-pre-call-temp>$134: Sorbet::Private::Static::Void, <selfRestore>$135: T.class_of(ControlFlow))\l<statTemp>$130: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$134, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$135\l<cfgAlias>$154: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$156: Sorbet::Private::Static::Void = <cfgAlias>$154: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))\l<selfRestore>$157: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_27" -> "bb::<Class:ControlFlow>#<static-init>_30" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_29" [
+        shape = rectangle;
         color = black;
         label = "block[id=29, rubyBlockId=7](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$134: Sorbet::Private::Static::Void, <selfRestore>$135: T.class_of(ControlFlow))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$141: Symbol(:a) = :a\l<cfgAlias>$144: T.class_of(T) = alias <C T>\l<cfgAlias>$146: T.class_of(Integer) = alias <C Integer>\l<cfgAlias>$148: T.class_of(NilClass) = alias <C NilClass>\l<hashTemp>$142: <Type: T.nilable(Integer)> = <cfgAlias>$144: T.class_of(T).any(<cfgAlias>$146: T.class_of(Integer), <cfgAlias>$148: T.class_of(NilClass))\l<statTemp>$139: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$141: Symbol(:a), <hashTemp>$142: <Type: T.nilable(Integer)>)\l<cfgAlias>$150: T.class_of(Integer) = alias <C Integer>\l<blockReturnTemp>$138: T::Private::Methods::DeclBuilder = <statTemp>$139: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$150: T.class_of(Integer))\l<blockReturnTemp>$151: T.noreturn = blockreturn<sig> <blockReturnTemp>$138: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_29" -> "bb::<Class:ControlFlow>#<static-init>_26" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_30" [
+        shape = rectangle;
         color = black;
         label = "block[id=30, rubyBlockId=8](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$156: Sorbet::Private::Static::Void, <selfRestore>$157: T.class_of(ControlFlow))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -560,18 +609,21 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_30" -> "bb::<Class:ControlFlow>#<static-init>_31" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_31" [
+        shape = rectangle;
         color = black;
         label = "block[id=31, rubyBlockId=0](<block-pre-call-temp>$156: Sorbet::Private::Static::Void, <selfRestore>$157: T.class_of(ControlFlow))\l<statTemp>$152: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$156, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$157\l<cfgAlias>$176: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$178: Sorbet::Private::Static::Void = <cfgAlias>$176: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))\l<selfRestore>$179: T.class_of(ControlFlow) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_31" -> "bb::<Class:ControlFlow>#<static-init>_34" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_33" [
+        shape = rectangle;
         color = black;
         label = "block[id=33, rubyBlockId=8](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$156: Sorbet::Private::Static::Void, <selfRestore>$157: T.class_of(ControlFlow))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$163: Symbol(:a) = :a\l<cfgAlias>$166: T.class_of(T) = alias <C T>\l<cfgAlias>$168: T.class_of(Integer) = alias <C Integer>\l<cfgAlias>$170: T.class_of(NilClass) = alias <C NilClass>\l<hashTemp>$164: <Type: T.nilable(Integer)> = <cfgAlias>$166: T.class_of(T).any(<cfgAlias>$168: T.class_of(Integer), <cfgAlias>$170: T.class_of(NilClass))\l<statTemp>$161: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$163: Symbol(:a), <hashTemp>$164: <Type: T.nilable(Integer)>)\l<cfgAlias>$172: T.class_of(Integer) = alias <C Integer>\l<blockReturnTemp>$160: T::Private::Methods::DeclBuilder = <statTemp>$161: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$172: T.class_of(Integer))\l<blockReturnTemp>$173: T.noreturn = blockreturn<sig> <blockReturnTemp>$160: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_33" -> "bb::<Class:ControlFlow>#<static-init>_30" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_34" [
+        shape = rectangle;
         color = black;
         label = "block[id=34, rubyBlockId=9](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$178: Sorbet::Private::Static::Void, <selfRestore>$179: T.class_of(ControlFlow))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -580,12 +632,14 @@ subgraph "cluster_::<Class:ControlFlow>#<static-init>" {
     "bb::<Class:ControlFlow>#<static-init>_34" -> "bb::<Class:ControlFlow>#<static-init>_35" [style="tapered"];
 
     "bb::<Class:ControlFlow>#<static-init>_35" [
+        shape = rectangle;
         color = black;
         label = "block[id=35, rubyBlockId=0](<block-pre-call-temp>$178: Sorbet::Private::Static::Void, <selfRestore>$179: T.class_of(ControlFlow))\l<statTemp>$174: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$178, sig>\l<self>: T.class_of(ControlFlow) = <selfRestore>$179\l<cfgAlias>$199: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$201: T.class_of(T) = alias <C T>\l<statTemp>$196: T.class_of(ControlFlow) = <self>: T.class_of(ControlFlow).extend(<cfgAlias>$199: T.class_of(T::Sig))\l<cfgAlias>$204: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$206: Symbol(:orZero0) = :orZero0\l<statTemp>$207: Symbol(:normal) = :normal\l<statTemp>$202: Symbol(:orZero0) = <cfgAlias>$204: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(ControlFlow), <statTemp>$206: Symbol(:orZero0), <statTemp>$207: Symbol(:normal))\l<cfgAlias>$210: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$212: Symbol(:orZero0a) = :orZero0a\l<statTemp>$213: Symbol(:normal) = :normal\l<statTemp>$208: Symbol(:orZero0a) = <cfgAlias>$210: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(ControlFlow), <statTemp>$212: Symbol(:orZero0a), <statTemp>$213: Symbol(:normal))\l<cfgAlias>$216: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$218: Symbol(:orZero0n) = :orZero0n\l<statTemp>$219: Symbol(:normal) = :normal\l<statTemp>$214: Symbol(:orZero0n) = <cfgAlias>$216: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(ControlFlow), <statTemp>$218: Symbol(:orZero0n), <statTemp>$219: Symbol(:normal))\l<cfgAlias>$222: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$224: Symbol(:orZero1n) = :orZero1n\l<statTemp>$225: Symbol(:normal) = :normal\l<statTemp>$220: Symbol(:orZero1n) = <cfgAlias>$222: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(ControlFlow), <statTemp>$224: Symbol(:orZero1n), <statTemp>$225: Symbol(:normal))\l<cfgAlias>$228: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$230: Symbol(:orZero2) = :orZero2\l<statTemp>$231: Symbol(:normal) = :normal\l<statTemp>$226: Symbol(:orZero2) = <cfgAlias>$228: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(ControlFlow), <statTemp>$230: Symbol(:orZero2), <statTemp>$231: Symbol(:normal))\l<cfgAlias>$234: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$236: Symbol(:orZero3) = :orZero3\l<statTemp>$237: Symbol(:normal) = :normal\l<statTemp>$232: Symbol(:orZero3) = <cfgAlias>$234: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(ControlFlow), <statTemp>$236: Symbol(:orZero3), <statTemp>$237: Symbol(:normal))\l<cfgAlias>$240: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$242: Symbol(:orZero3n) = :orZero3n\l<statTemp>$243: Symbol(:normal) = :normal\l<statTemp>$238: Symbol(:orZero3n) = <cfgAlias>$240: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(ControlFlow), <statTemp>$242: Symbol(:orZero3n), <statTemp>$243: Symbol(:normal))\l<cfgAlias>$246: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$248: Symbol(:orZero4) = :orZero4\l<statTemp>$249: Symbol(:normal) = :normal\l<statTemp>$244: Symbol(:orZero4) = <cfgAlias>$246: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(ControlFlow), <statTemp>$248: Symbol(:orZero4), <statTemp>$249: Symbol(:normal))\l<cfgAlias>$252: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$254: Symbol(:orZero5) = :orZero5\l<statTemp>$255: Symbol(:normal) = :normal\l<statTemp>$250: Symbol(:orZero5) = <cfgAlias>$252: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(ControlFlow), <statTemp>$254: Symbol(:orZero5), <statTemp>$255: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:ControlFlow>#<static-init>_35" -> "bb::<Class:ControlFlow>#<static-init>_1" [style="bold"];
     "bb::<Class:ControlFlow>#<static-init>_37" [
+        shape = rectangle;
         color = black;
         label = "block[id=37, rubyBlockId=9](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$178: Sorbet::Private::Static::Void, <selfRestore>$179: T.class_of(ControlFlow))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$185: Symbol(:a) = :a\l<cfgAlias>$188: T.class_of(T) = alias <C T>\l<cfgAlias>$190: T.class_of(Integer) = alias <C Integer>\l<cfgAlias>$192: T.class_of(NilClass) = alias <C NilClass>\l<hashTemp>$186: <Type: T.nilable(Integer)> = <cfgAlias>$188: T.class_of(T).any(<cfgAlias>$190: T.class_of(Integer), <cfgAlias>$192: T.class_of(NilClass))\l<statTemp>$183: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$185: Symbol(:a), <hashTemp>$186: <Type: T.nilable(Integer)>)\l<cfgAlias>$194: T.class_of(Integer) = alias <C Integer>\l<blockReturnTemp>$182: T::Private::Methods::DeclBuilder = <statTemp>$183: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$194: T.class_of(Integer))\l<blockReturnTemp>$195: T.noreturn = blockreturn<sig> <blockReturnTemp>$182: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];

--- a/test/testdata/infer/fields.rb.cfg.exp
+++ b/test/testdata/infer/fields.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "fields.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(Foo) = alias <C Foo>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(Foo))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(Foo) = alias <C Foo>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(Foo))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::Foo#initialize" {
     label = "::Foo#initialize";
     color = blue;
-    "bb::Foo#initialize_0" [shape = invhouse];
-    "bb::Foo#initialize_1" [shape = parallelogram];
 
     "bb::Foo#initialize_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l@ivar$3: Integer = alias @ivar\l<self>: Foo = cast(<self>: NilClass, Foo);\l<cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$8: T.class_of(Integer) = alias <C Integer>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$8: T.class_of(Integer))\l<castTemp>$9: Integer(0) = 0\l@ivar$3: Integer = cast(<castTemp>$9: Integer(0), Integer);\l<returnMethodTemp>$2: Integer = @ivar$3\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
     ];
 
     "bb::Foo#initialize_0" -> "bb::Foo#initialize_1" [style="bold"];
     "bb::Foo#initialize_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::Foo#initialize" {
 subgraph "cluster_::Foo#foo" {
     label = "::Foo#foo";
     color = blue;
-    "bb::Foo#foo_0" [shape = invhouse];
-    "bb::Foo#foo_1" [shape = parallelogram];
 
     "bb::Foo#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l@ivar$4: Integer = alias @ivar\l<self>: Foo = cast(<self>: NilClass, Foo);\l@ivar$4: Integer(2) = 2\l@ivar$4: Integer = \"ss\"\l<returnMethodTemp>$2: Integer = @ivar$4\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
     ];
 
     "bb::Foo#foo_0" -> "bb::Foo#foo_1" [style="bold"];
     "bb::Foo#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::Foo#foo" {
 subgraph "cluster_::<Class:Foo>#<static-init>" {
     label = "::<Class:Foo>#<static-init>";
     color = blue;
-    "bb::<Class:Foo>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Foo>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Foo>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Foo) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Foo>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:initialize) = :initialize\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:initialize) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Foo), <statTemp>$7: Symbol(:initialize), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:foo) = :foo\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:foo) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Foo), <statTemp>$13: Symbol(:foo), <statTemp>$14: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Foo>#<static-init>_0" -> "bb::<Class:Foo>#<static-init>_1" [style="bold"];
     "bb::<Class:Foo>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/hashes.rb.cfg.exp
+++ b/test/testdata/infer/hashes.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "hashes.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(Foo) = alias <C Foo>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(Foo))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(Foo) = alias <C Foo>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(Foo))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,10 +22,9 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::Foo#bar" {
     label = "::Foo#bar";
     color = blue;
-    "bb::Foo#bar_0" [shape = invhouse];
-    "bb::Foo#bar_1" [shape = parallelogram];
 
     "bb::Foo#bar_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Foo = cast(<self>: NilClass, Foo);\lcond: T.untyped = load_arg(cond)\lcond: T.untyped\l"
     ];
@@ -34,24 +33,28 @@ subgraph "cluster_::Foo#bar" {
     "bb::Foo#bar_0" -> "bb::Foo#bar_3" [style="tapered"];
 
     "bb::Foo#bar_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<returnMethodTemp>$2)\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::Foo#bar_1" -> "bb::Foo#bar_1" [style="bold"];
     "bb::Foo#bar_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\l<magic>$5: T.class_of(<Magic>) = alias <C <Magic>>\ls: {} = <magic>$5: T.class_of(<Magic>).<build-hash>()\l<unconditional>\l"
     ];
 
     "bb::Foo#bar_2" -> "bb::Foo#bar_4" [style="bold"];
     "bb::Foo#bar_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0]()\l<magic>$6: T.class_of(<Magic>) = alias <C <Magic>>\ls: {} = <magic>$6: T.class_of(<Magic>).<build-hash>()\l<unconditional>\l"
     ];
 
     "bb::Foo#bar_3" -> "bb::Foo#bar_4" [style="bold"];
     "bb::Foo#bar_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](s: {})\lr: {} = s\l<returnMethodTemp>$2: T.noreturn = return r: {}\l<unconditional>\l"
     ];
@@ -62,16 +65,16 @@ subgraph "cluster_::Foo#bar" {
 subgraph "cluster_::<Class:Foo>#<static-init>" {
     label = "::<Class:Foo>#<static-init>";
     color = blue;
-    "bb::<Class:Foo>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Foo>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Foo>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Foo) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Foo>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:bar) = :bar\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:bar) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Foo), <statTemp>$6: Symbol(:bar), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:bar)\l<unconditional>\l"
     ];
 
     "bb::<Class:Foo>#<static-init>_0" -> "bb::<Class:Foo>#<static-init>_1" [style="bold"];
     "bb::<Class:Foo>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/huge_unions.rb.cfg.exp
+++ b/test/testdata/infer/huge_unions.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "huge_unions.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(C1) = alias <C C1>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(C1))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(C1) = alias <C C1>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(C1))\l<cfgAlias>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$19: T.class_of(C2) = alias <C C2>\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$19: T.class_of(C2))\l<cfgAlias>$22: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$24: T.class_of(C2) = alias <C C2>\l<statTemp>$20: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$24: T.class_of(C2))\l<cfgAlias>$28: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$30: T.class_of(C3) = alias <C C3>\l<statTemp>$26: Sorbet::Private::Static::Void = <cfgAlias>$28: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$30: T.class_of(C3))\l<cfgAlias>$33: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$35: T.class_of(C3) = alias <C C3>\l<statTemp>$31: Sorbet::Private::Static::Void = <cfgAlias>$33: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$35: T.class_of(C3))\l<cfgAlias>$39: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$41: T.class_of(C4) = alias <C C4>\l<statTemp>$37: Sorbet::Private::Static::Void = <cfgAlias>$39: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$41: T.class_of(C4))\l<cfgAlias>$44: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$46: T.class_of(C4) = alias <C C4>\l<statTemp>$42: Sorbet::Private::Static::Void = <cfgAlias>$44: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$46: T.class_of(C4))\l<cfgAlias>$50: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$52: T.class_of(C5) = alias <C C5>\l<statTemp>$48: Sorbet::Private::Static::Void = <cfgAlias>$50: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$52: T.class_of(C5))\l<cfgAlias>$55: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$57: T.class_of(C5) = alias <C C5>\l<statTemp>$53: Sorbet::Private::Static::Void = <cfgAlias>$55: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$57: T.class_of(C5))\l<cfgAlias>$61: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$63: T.class_of(C6) = alias <C C6>\l<statTemp>$59: Sorbet::Private::Static::Void = <cfgAlias>$61: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$63: T.class_of(C6))\l<cfgAlias>$66: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$68: T.class_of(C6) = alias <C C6>\l<statTemp>$64: Sorbet::Private::Static::Void = <cfgAlias>$66: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$68: T.class_of(C6))\l<cfgAlias>$72: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$74: T.class_of(C7) = alias <C C7>\l<statTemp>$70: Sorbet::Private::Static::Void = <cfgAlias>$72: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$74: T.class_of(C7))\l<cfgAlias>$77: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$79: T.class_of(C7) = alias <C C7>\l<statTemp>$75: Sorbet::Private::Static::Void = <cfgAlias>$77: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$79: T.class_of(C7))\l<cfgAlias>$83: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$85: T.class_of(C8) = alias <C C8>\l<statTemp>$81: Sorbet::Private::Static::Void = <cfgAlias>$83: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$85: T.class_of(C8))\l<cfgAlias>$88: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$90: T.class_of(C8) = alias <C C8>\l<statTemp>$86: Sorbet::Private::Static::Void = <cfgAlias>$88: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$90: T.class_of(C8))\l<cfgAlias>$94: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$96: T.class_of(C9) = alias <C C9>\l<statTemp>$92: Sorbet::Private::Static::Void = <cfgAlias>$94: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$96: T.class_of(C9))\l<cfgAlias>$99: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$101: T.class_of(C9) = alias <C C9>\l<statTemp>$97: Sorbet::Private::Static::Void = <cfgAlias>$99: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$101: T.class_of(C9))\l<cfgAlias>$105: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$107: T.class_of(C10) = alias <C C10>\l<statTemp>$103: Sorbet::Private::Static::Void = <cfgAlias>$105: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$107: T.class_of(C10))\l<cfgAlias>$110: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$112: T.class_of(C10) = alias <C C10>\l<statTemp>$108: Sorbet::Private::Static::Void = <cfgAlias>$110: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$112: T.class_of(C10))\l<cfgAlias>$116: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$118: T.class_of(C11) = alias <C C11>\l<statTemp>$114: Sorbet::Private::Static::Void = <cfgAlias>$116: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$118: T.class_of(C11))\l<cfgAlias>$121: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$123: T.class_of(C11) = alias <C C11>\l<statTemp>$119: Sorbet::Private::Static::Void = <cfgAlias>$121: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$123: T.class_of(C11))\l<cfgAlias>$127: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$129: T.class_of(C12) = alias <C C12>\l<statTemp>$125: Sorbet::Private::Static::Void = <cfgAlias>$127: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$129: T.class_of(C12))\l<cfgAlias>$132: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$134: T.class_of(C12) = alias <C C12>\l<statTemp>$130: Sorbet::Private::Static::Void = <cfgAlias>$132: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$134: T.class_of(C12))\l<cfgAlias>$138: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$140: T.class_of(C13) = alias <C C13>\l<statTemp>$136: Sorbet::Private::Static::Void = <cfgAlias>$138: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$140: T.class_of(C13))\l<cfgAlias>$143: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$145: T.class_of(C13) = alias <C C13>\l<statTemp>$141: Sorbet::Private::Static::Void = <cfgAlias>$143: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$145: T.class_of(C13))\l<cfgAlias>$149: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$151: T.class_of(C13) = alias <C C13>\l<statTemp>$147: Sorbet::Private::Static::Void = <cfgAlias>$149: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$151: T.class_of(C13))\l<cfgAlias>$154: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$156: T.class_of(C13) = alias <C C13>\l<statTemp>$152: Sorbet::Private::Static::Void = <cfgAlias>$154: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$156: T.class_of(C13))\l<cfgAlias>$160: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$162: T.class_of(C13) = alias <C C13>\l<statTemp>$158: Sorbet::Private::Static::Void = <cfgAlias>$160: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$162: T.class_of(C13))\l<cfgAlias>$165: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$167: T.class_of(C13) = alias <C C13>\l<statTemp>$163: Sorbet::Private::Static::Void = <cfgAlias>$165: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$167: T.class_of(C13))\l<cfgAlias>$171: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$173: T.class_of(C13) = alias <C C13>\l<statTemp>$169: Sorbet::Private::Static::Void = <cfgAlias>$171: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$173: T.class_of(C13))\l<cfgAlias>$176: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$178: T.class_of(C13) = alias <C C13>\l<statTemp>$174: Sorbet::Private::Static::Void = <cfgAlias>$176: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$178: T.class_of(C13))\l<cfgAlias>$182: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$184: T.class_of(C13) = alias <C C13>\l<statTemp>$180: Sorbet::Private::Static::Void = <cfgAlias>$182: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$184: T.class_of(C13))\l<cfgAlias>$187: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$189: T.class_of(C13) = alias <C C13>\l<statTemp>$185: Sorbet::Private::Static::Void = <cfgAlias>$187: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$189: T.class_of(C13))\l<cfgAlias>$193: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$195: T.class_of(C13) = alias <C C13>\l<statTemp>$191: Sorbet::Private::Static::Void = <cfgAlias>$193: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$195: T.class_of(C13))\l<cfgAlias>$198: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$200: T.class_of(C13) = alias <C C13>\l<statTemp>$196: Sorbet::Private::Static::Void = <cfgAlias>$198: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$200: T.class_of(C13))\l<cfgAlias>$204: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$206: T.class_of(C13) = alias <C C13>\l<statTemp>$202: Sorbet::Private::Static::Void = <cfgAlias>$204: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$206: T.class_of(C13))\l<cfgAlias>$209: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$211: T.class_of(C13) = alias <C C13>\l<statTemp>$207: Sorbet::Private::Static::Void = <cfgAlias>$209: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$211: T.class_of(C13))\l<cfgAlias>$215: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$217: T.class_of(C14) = alias <C C14>\l<statTemp>$213: Sorbet::Private::Static::Void = <cfgAlias>$215: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$217: T.class_of(C14))\l<cfgAlias>$220: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$222: T.class_of(C14) = alias <C C14>\l<statTemp>$218: Sorbet::Private::Static::Void = <cfgAlias>$220: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$222: T.class_of(C14))\l<cfgAlias>$226: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$228: T.class_of(C15) = alias <C C15>\l<statTemp>$224: Sorbet::Private::Static::Void = <cfgAlias>$226: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$228: T.class_of(C15))\l<cfgAlias>$231: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$233: T.class_of(C15) = alias <C C15>\l<statTemp>$229: Sorbet::Private::Static::Void = <cfgAlias>$231: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$233: T.class_of(C15))\l<cfgAlias>$237: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$239: T.class_of(C16) = alias <C C16>\l<statTemp>$235: Sorbet::Private::Static::Void = <cfgAlias>$237: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$239: T.class_of(C16))\l<cfgAlias>$242: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$244: T.class_of(C16) = alias <C C16>\l<statTemp>$240: Sorbet::Private::Static::Void = <cfgAlias>$242: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$244: T.class_of(C16))\l<cfgAlias>$248: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$250: T.class_of(C17) = alias <C C17>\l<statTemp>$246: Sorbet::Private::Static::Void = <cfgAlias>$248: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$250: T.class_of(C17))\l<cfgAlias>$253: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$255: T.class_of(C17) = alias <C C17>\l<statTemp>$251: Sorbet::Private::Static::Void = <cfgAlias>$253: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$255: T.class_of(C17))\l<cfgAlias>$259: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$261: T.class_of(C18) = alias <C C18>\l<statTemp>$257: Sorbet::Private::Static::Void = <cfgAlias>$259: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$261: T.class_of(C18))\l<cfgAlias>$264: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$266: T.class_of(C18) = alias <C C18>\l<statTemp>$262: Sorbet::Private::Static::Void = <cfgAlias>$264: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$266: T.class_of(C18))\l<cfgAlias>$270: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$272: T.class_of(C19) = alias <C C19>\l<statTemp>$268: Sorbet::Private::Static::Void = <cfgAlias>$270: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$272: T.class_of(C19))\l<cfgAlias>$275: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$277: T.class_of(C19) = alias <C C19>\l<statTemp>$273: Sorbet::Private::Static::Void = <cfgAlias>$275: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$277: T.class_of(C19))\l<cfgAlias>$281: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$283: T.class_of(C20) = alias <C C20>\l<statTemp>$279: Sorbet::Private::Static::Void = <cfgAlias>$281: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$283: T.class_of(C20))\l<cfgAlias>$286: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$288: T.class_of(C20) = alias <C C20>\l<statTemp>$284: Sorbet::Private::Static::Void = <cfgAlias>$286: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$288: T.class_of(C20))\l<cfgAlias>$292: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$294: T.class_of(A) = alias <C A>\l<statTemp>$290: Sorbet::Private::Static::Void = <cfgAlias>$292: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$294: T.class_of(A))\l<cfgAlias>$297: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$299: T.class_of(A) = alias <C A>\l<statTemp>$295: Sorbet::Private::Static::Void = <cfgAlias>$297: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$299: T.class_of(A))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::<Class:C1>#<static-init>" {
     label = "::<Class:C1>#<static-init>";
     color = blue;
-    "bb::<Class:C1>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C1>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C1>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C1) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C1>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C1>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C1>#<static-init>_0" -> "bb::<Class:C1>#<static-init>_1" [style="bold"];
     "bb::<Class:C1>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::<Class:C1>#<static-init>" {
 subgraph "cluster_::<Class:C2>#<static-init>" {
     label = "::<Class:C2>#<static-init>";
     color = blue;
-    "bb::<Class:C2>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C2>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C2>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C2) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C2>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C2>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C2>#<static-init>_0" -> "bb::<Class:C2>#<static-init>_1" [style="bold"];
     "bb::<Class:C2>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::<Class:C2>#<static-init>" {
 subgraph "cluster_::<Class:C3>#<static-init>" {
     label = "::<Class:C3>#<static-init>";
     color = blue;
-    "bb::<Class:C3>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C3>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C3>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C3) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C3>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C3>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C3>#<static-init>_0" -> "bb::<Class:C3>#<static-init>_1" [style="bold"];
     "bb::<Class:C3>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,16 +82,16 @@ subgraph "cluster_::<Class:C3>#<static-init>" {
 subgraph "cluster_::<Class:C4>#<static-init>" {
     label = "::<Class:C4>#<static-init>";
     color = blue;
-    "bb::<Class:C4>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C4>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C4>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C4) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C4>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C4>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C4>#<static-init>_0" -> "bb::<Class:C4>#<static-init>_1" [style="bold"];
     "bb::<Class:C4>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -102,16 +102,16 @@ subgraph "cluster_::<Class:C4>#<static-init>" {
 subgraph "cluster_::<Class:C5>#<static-init>" {
     label = "::<Class:C5>#<static-init>";
     color = blue;
-    "bb::<Class:C5>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C5>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C5>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C5) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C5>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C5>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C5>#<static-init>_0" -> "bb::<Class:C5>#<static-init>_1" [style="bold"];
     "bb::<Class:C5>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -122,16 +122,16 @@ subgraph "cluster_::<Class:C5>#<static-init>" {
 subgraph "cluster_::<Class:C6>#<static-init>" {
     label = "::<Class:C6>#<static-init>";
     color = blue;
-    "bb::<Class:C6>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C6>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C6>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C6) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C6>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C6>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C6>#<static-init>_0" -> "bb::<Class:C6>#<static-init>_1" [style="bold"];
     "bb::<Class:C6>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -142,16 +142,16 @@ subgraph "cluster_::<Class:C6>#<static-init>" {
 subgraph "cluster_::<Class:C7>#<static-init>" {
     label = "::<Class:C7>#<static-init>";
     color = blue;
-    "bb::<Class:C7>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C7>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C7>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C7) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C7>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C7>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C7>#<static-init>_0" -> "bb::<Class:C7>#<static-init>_1" [style="bold"];
     "bb::<Class:C7>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -162,16 +162,16 @@ subgraph "cluster_::<Class:C7>#<static-init>" {
 subgraph "cluster_::<Class:C8>#<static-init>" {
     label = "::<Class:C8>#<static-init>";
     color = blue;
-    "bb::<Class:C8>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C8>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C8>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C8) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C8>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C8>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C8>#<static-init>_0" -> "bb::<Class:C8>#<static-init>_1" [style="bold"];
     "bb::<Class:C8>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -182,16 +182,16 @@ subgraph "cluster_::<Class:C8>#<static-init>" {
 subgraph "cluster_::<Class:C9>#<static-init>" {
     label = "::<Class:C9>#<static-init>";
     color = blue;
-    "bb::<Class:C9>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C9>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C9>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C9) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C9>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C9>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C9>#<static-init>_0" -> "bb::<Class:C9>#<static-init>_1" [style="bold"];
     "bb::<Class:C9>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -202,16 +202,16 @@ subgraph "cluster_::<Class:C9>#<static-init>" {
 subgraph "cluster_::<Class:C10>#<static-init>" {
     label = "::<Class:C10>#<static-init>";
     color = blue;
-    "bb::<Class:C10>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C10>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C10>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C10) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C10>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C10>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C10>#<static-init>_0" -> "bb::<Class:C10>#<static-init>_1" [style="bold"];
     "bb::<Class:C10>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -222,16 +222,16 @@ subgraph "cluster_::<Class:C10>#<static-init>" {
 subgraph "cluster_::<Class:C11>#<static-init>" {
     label = "::<Class:C11>#<static-init>";
     color = blue;
-    "bb::<Class:C11>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C11>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C11>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C11) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C11>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C11>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C11>#<static-init>_0" -> "bb::<Class:C11>#<static-init>_1" [style="bold"];
     "bb::<Class:C11>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -242,16 +242,16 @@ subgraph "cluster_::<Class:C11>#<static-init>" {
 subgraph "cluster_::<Class:C12>#<static-init>" {
     label = "::<Class:C12>#<static-init>";
     color = blue;
-    "bb::<Class:C12>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C12>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C12>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C12) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C12>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C12>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C12>#<static-init>_0" -> "bb::<Class:C12>#<static-init>_1" [style="bold"];
     "bb::<Class:C12>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -262,16 +262,16 @@ subgraph "cluster_::<Class:C12>#<static-init>" {
 subgraph "cluster_::<Class:C13>#<static-init>" {
     label = "::<Class:C13>#<static-init>";
     color = blue;
-    "bb::<Class:C13>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C13>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C13>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C13) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C13>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C13>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C13>#<static-init>_0" -> "bb::<Class:C13>#<static-init>_1" [style="bold"];
     "bb::<Class:C13>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -282,16 +282,16 @@ subgraph "cluster_::<Class:C13>#<static-init>" {
 subgraph "cluster_::<Class:C13>#<static-init>" {
     label = "::<Class:C13>#<static-init>";
     color = blue;
-    "bb::<Class:C13>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C13>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C13>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C13) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C13>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C13>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C13>#<static-init>_0" -> "bb::<Class:C13>#<static-init>_1" [style="bold"];
     "bb::<Class:C13>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -302,16 +302,16 @@ subgraph "cluster_::<Class:C13>#<static-init>" {
 subgraph "cluster_::<Class:C13>#<static-init>" {
     label = "::<Class:C13>#<static-init>";
     color = blue;
-    "bb::<Class:C13>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C13>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C13>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C13) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C13>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C13>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C13>#<static-init>_0" -> "bb::<Class:C13>#<static-init>_1" [style="bold"];
     "bb::<Class:C13>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -322,16 +322,16 @@ subgraph "cluster_::<Class:C13>#<static-init>" {
 subgraph "cluster_::<Class:C13>#<static-init>" {
     label = "::<Class:C13>#<static-init>";
     color = blue;
-    "bb::<Class:C13>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C13>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C13>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C13) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C13>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C13>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C13>#<static-init>_0" -> "bb::<Class:C13>#<static-init>_1" [style="bold"];
     "bb::<Class:C13>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -342,16 +342,16 @@ subgraph "cluster_::<Class:C13>#<static-init>" {
 subgraph "cluster_::<Class:C13>#<static-init>" {
     label = "::<Class:C13>#<static-init>";
     color = blue;
-    "bb::<Class:C13>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C13>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C13>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C13) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C13>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C13>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C13>#<static-init>_0" -> "bb::<Class:C13>#<static-init>_1" [style="bold"];
     "bb::<Class:C13>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -362,16 +362,16 @@ subgraph "cluster_::<Class:C13>#<static-init>" {
 subgraph "cluster_::<Class:C13>#<static-init>" {
     label = "::<Class:C13>#<static-init>";
     color = blue;
-    "bb::<Class:C13>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C13>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C13>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C13) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C13>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C13>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C13>#<static-init>_0" -> "bb::<Class:C13>#<static-init>_1" [style="bold"];
     "bb::<Class:C13>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -382,16 +382,16 @@ subgraph "cluster_::<Class:C13>#<static-init>" {
 subgraph "cluster_::<Class:C13>#<static-init>" {
     label = "::<Class:C13>#<static-init>";
     color = blue;
-    "bb::<Class:C13>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C13>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C13>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C13) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C13>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C13>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C13>#<static-init>_0" -> "bb::<Class:C13>#<static-init>_1" [style="bold"];
     "bb::<Class:C13>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -402,16 +402,16 @@ subgraph "cluster_::<Class:C13>#<static-init>" {
 subgraph "cluster_::<Class:C14>#<static-init>" {
     label = "::<Class:C14>#<static-init>";
     color = blue;
-    "bb::<Class:C14>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C14>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C14>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C14) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C14>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C14>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C14>#<static-init>_0" -> "bb::<Class:C14>#<static-init>_1" [style="bold"];
     "bb::<Class:C14>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -422,16 +422,16 @@ subgraph "cluster_::<Class:C14>#<static-init>" {
 subgraph "cluster_::<Class:C15>#<static-init>" {
     label = "::<Class:C15>#<static-init>";
     color = blue;
-    "bb::<Class:C15>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C15>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C15>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C15) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C15>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C15>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C15>#<static-init>_0" -> "bb::<Class:C15>#<static-init>_1" [style="bold"];
     "bb::<Class:C15>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -442,16 +442,16 @@ subgraph "cluster_::<Class:C15>#<static-init>" {
 subgraph "cluster_::<Class:C16>#<static-init>" {
     label = "::<Class:C16>#<static-init>";
     color = blue;
-    "bb::<Class:C16>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C16>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C16>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C16) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C16>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C16>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C16>#<static-init>_0" -> "bb::<Class:C16>#<static-init>_1" [style="bold"];
     "bb::<Class:C16>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -462,16 +462,16 @@ subgraph "cluster_::<Class:C16>#<static-init>" {
 subgraph "cluster_::<Class:C17>#<static-init>" {
     label = "::<Class:C17>#<static-init>";
     color = blue;
-    "bb::<Class:C17>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C17>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C17>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C17) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C17>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C17>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C17>#<static-init>_0" -> "bb::<Class:C17>#<static-init>_1" [style="bold"];
     "bb::<Class:C17>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -482,16 +482,16 @@ subgraph "cluster_::<Class:C17>#<static-init>" {
 subgraph "cluster_::<Class:C18>#<static-init>" {
     label = "::<Class:C18>#<static-init>";
     color = blue;
-    "bb::<Class:C18>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C18>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C18>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C18) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C18>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C18>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C18>#<static-init>_0" -> "bb::<Class:C18>#<static-init>_1" [style="bold"];
     "bb::<Class:C18>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -502,16 +502,16 @@ subgraph "cluster_::<Class:C18>#<static-init>" {
 subgraph "cluster_::<Class:C19>#<static-init>" {
     label = "::<Class:C19>#<static-init>";
     color = blue;
-    "bb::<Class:C19>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C19>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C19>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C19) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C19>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C19>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C19>#<static-init>_0" -> "bb::<Class:C19>#<static-init>_1" [style="bold"];
     "bb::<Class:C19>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -522,16 +522,16 @@ subgraph "cluster_::<Class:C19>#<static-init>" {
 subgraph "cluster_::<Class:C20>#<static-init>" {
     label = "::<Class:C20>#<static-init>";
     color = blue;
-    "bb::<Class:C20>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C20>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C20>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C20) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C20>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C20>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C20>#<static-init>_0" -> "bb::<Class:C20>#<static-init>_1" [style="bold"];
     "bb::<Class:C20>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -542,10 +542,9 @@ subgraph "cluster_::<Class:C20>#<static-init>" {
 subgraph "cluster_::<Class:A>#send_beta_invitation" {
     label = "::<Class:A>#send_beta_invitation";
     color = blue;
-    "bb::<Class:A>#send_beta_invitation_0" [shape = invhouse];
-    "bb::<Class:A>#send_beta_invitation_1" [shape = parallelogram];
 
     "bb::<Class:A>#send_beta_invitation_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\linvite: T.untyped = load_arg(invite)\l<statTemp>$6: Integer(1) = 1\l<ifTemp>$5: T::Boolean = <statTemp>$6: Integer(1).===(invite: T.untyped)\l<ifTemp>$5: T::Boolean\l"
     ];
@@ -554,18 +553,21 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_0" -> "bb::<Class:A>#send_beta_invitation_3" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0](<returnMethodTemp>$2)\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_1" -> "bb::<Class:A>#send_beta_invitation_1" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\l<cfgAlias>$8: T.class_of(C1) = alias <C C1>\lr: T.class_of(C1) = <cfgAlias>$8\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_2" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$10: Integer(2) = 2\l<ifTemp>$9: T::Boolean = <statTemp>$10: Integer(2).===(invite: T.untyped)\l<ifTemp>$9: T::Boolean\l"
     ];
@@ -574,12 +576,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_3" -> "bb::<Class:A>#send_beta_invitation_5" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0]()\l<cfgAlias>$12: T.class_of(C2) = alias <C C2>\lr: T.class_of(C2) = <cfgAlias>$12\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_4" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$14: Integer(3) = 3\l<ifTemp>$13: T::Boolean = <statTemp>$14: Integer(3).===(invite: T.untyped)\l<ifTemp>$13: T::Boolean\l"
     ];
@@ -588,12 +592,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_5" -> "bb::<Class:A>#send_beta_invitation_7" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=0]()\l<cfgAlias>$16: T.class_of(C3) = alias <C C3>\lr: T.class_of(C3) = <cfgAlias>$16\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_6" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$18: Integer(4) = 4\l<ifTemp>$17: T::Boolean = <statTemp>$18: Integer(4).===(invite: T.untyped)\l<ifTemp>$17: T::Boolean\l"
     ];
@@ -602,12 +608,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_7" -> "bb::<Class:A>#send_beta_invitation_9" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=0]()\l<cfgAlias>$20: T.class_of(C4) = alias <C C4>\lr: T.class_of(C4) = <cfgAlias>$20\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_8" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$22: Integer(5) = 5\l<ifTemp>$21: T::Boolean = <statTemp>$22: Integer(5).===(invite: T.untyped)\l<ifTemp>$21: T::Boolean\l"
     ];
@@ -616,12 +624,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_9" -> "bb::<Class:A>#send_beta_invitation_11" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=0]()\l<cfgAlias>$24: T.class_of(C5) = alias <C C5>\lr: T.class_of(C5) = <cfgAlias>$24\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_10" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$26: Integer(6) = 6\l<ifTemp>$25: T::Boolean = <statTemp>$26: Integer(6).===(invite: T.untyped)\l<ifTemp>$25: T::Boolean\l"
     ];
@@ -630,12 +640,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_11" -> "bb::<Class:A>#send_beta_invitation_13" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_12" [
+        shape = rectangle;
         color = black;
         label = "block[id=12, rubyBlockId=0]()\l<cfgAlias>$28: T.class_of(C6) = alias <C C6>\lr: T.class_of(C6) = <cfgAlias>$28\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_12" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_13" [
+        shape = rectangle;
         color = black;
         label = "block[id=13, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$30: Integer(7) = 7\l<ifTemp>$29: T::Boolean = <statTemp>$30: Integer(7).===(invite: T.untyped)\l<ifTemp>$29: T::Boolean\l"
     ];
@@ -644,12 +656,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_13" -> "bb::<Class:A>#send_beta_invitation_15" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_14" [
+        shape = rectangle;
         color = black;
         label = "block[id=14, rubyBlockId=0]()\l<cfgAlias>$32: T.class_of(C7) = alias <C C7>\lr: T.class_of(C7) = <cfgAlias>$32\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_14" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_15" [
+        shape = rectangle;
         color = black;
         label = "block[id=15, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$34: Integer(8) = 8\l<ifTemp>$33: T::Boolean = <statTemp>$34: Integer(8).===(invite: T.untyped)\l<ifTemp>$33: T::Boolean\l"
     ];
@@ -658,12 +672,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_15" -> "bb::<Class:A>#send_beta_invitation_17" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_16" [
+        shape = rectangle;
         color = black;
         label = "block[id=16, rubyBlockId=0]()\l<cfgAlias>$36: T.class_of(C8) = alias <C C8>\lr: T.class_of(C8) = <cfgAlias>$36\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_16" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_17" [
+        shape = rectangle;
         color = black;
         label = "block[id=17, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$38: Integer(9) = 9\l<ifTemp>$37: T::Boolean = <statTemp>$38: Integer(9).===(invite: T.untyped)\l<ifTemp>$37: T::Boolean\l"
     ];
@@ -672,12 +688,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_17" -> "bb::<Class:A>#send_beta_invitation_19" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_18" [
+        shape = rectangle;
         color = black;
         label = "block[id=18, rubyBlockId=0]()\l<cfgAlias>$40: T.class_of(C9) = alias <C C9>\lr: T.class_of(C9) = <cfgAlias>$40\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_18" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_19" [
+        shape = rectangle;
         color = black;
         label = "block[id=19, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$42: Integer(10) = 10\l<ifTemp>$41: T::Boolean = <statTemp>$42: Integer(10).===(invite: T.untyped)\l<ifTemp>$41: T::Boolean\l"
     ];
@@ -686,12 +704,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_19" -> "bb::<Class:A>#send_beta_invitation_21" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_20" [
+        shape = rectangle;
         color = black;
         label = "block[id=20, rubyBlockId=0]()\l<cfgAlias>$44: T.class_of(C10) = alias <C C10>\lr: T.class_of(C10) = <cfgAlias>$44\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_20" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_21" [
+        shape = rectangle;
         color = black;
         label = "block[id=21, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$46: Integer(11) = 11\l<ifTemp>$45: T::Boolean = <statTemp>$46: Integer(11).===(invite: T.untyped)\l<ifTemp>$45: T::Boolean\l"
     ];
@@ -700,12 +720,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_21" -> "bb::<Class:A>#send_beta_invitation_23" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_22" [
+        shape = rectangle;
         color = black;
         label = "block[id=22, rubyBlockId=0]()\l<cfgAlias>$48: T.class_of(C11) = alias <C C11>\lr: T.class_of(C11) = <cfgAlias>$48\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_22" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_23" [
+        shape = rectangle;
         color = black;
         label = "block[id=23, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$50: Integer(12) = 12\l<ifTemp>$49: T::Boolean = <statTemp>$50: Integer(12).===(invite: T.untyped)\l<ifTemp>$49: T::Boolean\l"
     ];
@@ -714,12 +736,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_23" -> "bb::<Class:A>#send_beta_invitation_25" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_24" [
+        shape = rectangle;
         color = black;
         label = "block[id=24, rubyBlockId=0]()\l<cfgAlias>$52: T.class_of(C12) = alias <C C12>\lr: T.class_of(C12) = <cfgAlias>$52\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_24" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_25" [
+        shape = rectangle;
         color = black;
         label = "block[id=25, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$54: Integer(13) = 13\l<ifTemp>$53: T::Boolean = <statTemp>$54: Integer(13).===(invite: T.untyped)\l<ifTemp>$53: T::Boolean\l"
     ];
@@ -728,12 +752,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_25" -> "bb::<Class:A>#send_beta_invitation_27" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_26" [
+        shape = rectangle;
         color = black;
         label = "block[id=26, rubyBlockId=0]()\l<cfgAlias>$56: T.class_of(C13) = alias <C C13>\lr: T.class_of(C13) = <cfgAlias>$56\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_26" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_27" [
+        shape = rectangle;
         color = black;
         label = "block[id=27, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$58: Integer(14) = 14\l<ifTemp>$57: T::Boolean = <statTemp>$58: Integer(14).===(invite: T.untyped)\l<ifTemp>$57: T::Boolean\l"
     ];
@@ -742,12 +768,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_27" -> "bb::<Class:A>#send_beta_invitation_29" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_28" [
+        shape = rectangle;
         color = black;
         label = "block[id=28, rubyBlockId=0]()\l<cfgAlias>$60: T.class_of(C14) = alias <C C14>\lr: T.class_of(C14) = <cfgAlias>$60\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_28" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_29" [
+        shape = rectangle;
         color = black;
         label = "block[id=29, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$62: Integer(15) = 15\l<ifTemp>$61: T::Boolean = <statTemp>$62: Integer(15).===(invite: T.untyped)\l<ifTemp>$61: T::Boolean\l"
     ];
@@ -756,12 +784,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_29" -> "bb::<Class:A>#send_beta_invitation_31" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_30" [
+        shape = rectangle;
         color = black;
         label = "block[id=30, rubyBlockId=0]()\l<cfgAlias>$64: T.class_of(C15) = alias <C C15>\lr: T.class_of(C15) = <cfgAlias>$64\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_30" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_31" [
+        shape = rectangle;
         color = black;
         label = "block[id=31, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$66: Integer(16) = 16\l<ifTemp>$65: T::Boolean = <statTemp>$66: Integer(16).===(invite: T.untyped)\l<ifTemp>$65: T::Boolean\l"
     ];
@@ -770,12 +800,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_31" -> "bb::<Class:A>#send_beta_invitation_33" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_32" [
+        shape = rectangle;
         color = black;
         label = "block[id=32, rubyBlockId=0]()\l<cfgAlias>$68: T.class_of(C16) = alias <C C16>\lr: T.class_of(C16) = <cfgAlias>$68\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_32" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_33" [
+        shape = rectangle;
         color = black;
         label = "block[id=33, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$70: Integer(17) = 17\l<ifTemp>$69: T::Boolean = <statTemp>$70: Integer(17).===(invite: T.untyped)\l<ifTemp>$69: T::Boolean\l"
     ];
@@ -784,12 +816,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_33" -> "bb::<Class:A>#send_beta_invitation_35" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_34" [
+        shape = rectangle;
         color = black;
         label = "block[id=34, rubyBlockId=0]()\l<cfgAlias>$72: T.class_of(C17) = alias <C C17>\lr: T.class_of(C17) = <cfgAlias>$72\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_34" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_35" [
+        shape = rectangle;
         color = black;
         label = "block[id=35, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$74: Integer(18) = 18\l<ifTemp>$73: T::Boolean = <statTemp>$74: Integer(18).===(invite: T.untyped)\l<ifTemp>$73: T::Boolean\l"
     ];
@@ -798,12 +832,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_35" -> "bb::<Class:A>#send_beta_invitation_37" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_36" [
+        shape = rectangle;
         color = black;
         label = "block[id=36, rubyBlockId=0]()\l<cfgAlias>$76: T.class_of(C18) = alias <C C18>\lr: T.class_of(C18) = <cfgAlias>$76\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_36" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_37" [
+        shape = rectangle;
         color = black;
         label = "block[id=37, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$78: Integer(19) = 19\l<ifTemp>$77: T::Boolean = <statTemp>$78: Integer(19).===(invite: T.untyped)\l<ifTemp>$77: T::Boolean\l"
     ];
@@ -812,12 +848,14 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_37" -> "bb::<Class:A>#send_beta_invitation_39" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_38" [
+        shape = rectangle;
         color = black;
         label = "block[id=38, rubyBlockId=0]()\l<cfgAlias>$80: T.class_of(C19) = alias <C C19>\lr: T.class_of(C19) = <cfgAlias>$80\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_38" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_39" [
+        shape = rectangle;
         color = black;
         label = "block[id=39, rubyBlockId=0](<self>: T.class_of(A), invite: T.untyped)\l<statTemp>$82: Integer(20) = 20\l<ifTemp>$81: T::Boolean = <statTemp>$82: Integer(20).===(invite: T.untyped)\l<ifTemp>$81: T::Boolean\l"
     ];
@@ -826,18 +864,21 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
     "bb::<Class:A>#send_beta_invitation_39" -> "bb::<Class:A>#send_beta_invitation_41" [style="tapered"];
 
     "bb::<Class:A>#send_beta_invitation_40" [
+        shape = rectangle;
         color = black;
         label = "block[id=40, rubyBlockId=0]()\l<cfgAlias>$84: T.class_of(C20) = alias <C C20>\lr: T.class_of(C20) = <cfgAlias>$84\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_40" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_41" [
+        shape = rectangle;
         color = black;
         label = "block[id=41, rubyBlockId=0](<self>: T.class_of(A))\l<statTemp>$86: String(\"Bla bla bla\") = \"Bla bla bla\"\l<statTemp>$3: T.noreturn = <self>: T.class_of(A).raise(<statTemp>$86: String(\"Bla bla bla\"))\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#send_beta_invitation_41" -> "bb::<Class:A>#send_beta_invitation_61" [style="bold"];
     "bb::<Class:A>#send_beta_invitation_61" [
+        shape = rectangle;
         color = black;
         label = "block[id=61, rubyBlockId=0](r: T.any(T.class_of(C1), T.class_of(C2), T.class_of(C3), T.class_of(C4), T.class_of(C5), T.class_of(C6), T.class_of(C7), T.class_of(C8), T.class_of(C9), T.class_of(C10), T.class_of(C11), T.class_of(C12), T.class_of(C13), T.class_of(C14), T.class_of(C15), T.class_of(C16), T.class_of(C17), T.class_of(C18), T.class_of(C19), T.class_of(C20)))\ls: T.any(T.class_of(C1), T.class_of(C2), T.class_of(C3), T.class_of(C4), T.class_of(C5), T.class_of(C6), T.class_of(C7), T.class_of(C8), T.class_of(C9), T.class_of(C10), T.class_of(C11), T.class_of(C12), T.class_of(C13), T.class_of(C14), T.class_of(C15), T.class_of(C16), T.class_of(C17), T.class_of(C18), T.class_of(C19), T.class_of(C20)) = r\l<returnMethodTemp>$2: T.noreturn = return s: T.any(T.class_of(C1), T.class_of(C2), T.class_of(C3), T.class_of(C4), T.class_of(C5), T.class_of(C6), T.class_of(C7), T.class_of(C8), T.class_of(C9), T.class_of(C10), T.class_of(C11), T.class_of(C12), T.class_of(C13), T.class_of(C14), T.class_of(C15), T.class_of(C16), T.class_of(C17), T.class_of(C18), T.class_of(C19), T.class_of(C20))\l<unconditional>\l"
     ];
@@ -848,16 +889,16 @@ subgraph "cluster_::<Class:A>#send_beta_invitation" {
 subgraph "cluster_::<Class:A>#<static-init>" {
     label = "::<Class:A>#<static-init>";
     color = blue;
-    "bb::<Class:A>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:send_beta_invitation) = :send_beta_invitation\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:send_beta_invitation) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(A), <statTemp>$6: Symbol(:send_beta_invitation), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:send_beta_invitation)\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
     "bb::<Class:A>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/infer1.rb.cfg.exp
+++ b/test/testdata/infer/infer1.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "infer1.rb" {
 subgraph "cluster_::Object#baz1" {
     label = "::Object#baz1";
     color = blue;
-    "bb::Object#baz1_0" [shape = invhouse];
-    "bb::Object#baz1_1" [shape = parallelogram];
 
     "bb::Object#baz1_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\la: String(\"foo\") = \"foo\"\lb: T.nilable(Integer) = a: String(\"foo\").getbyte(a: String(\"foo\"))\l<returnMethodTemp>$2: T.nilable(Integer) = b\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
     ];
 
     "bb::Object#baz1_0" -> "bb::Object#baz1_1" [style="bold"];
     "bb::Object#baz1_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::Object#baz1" {
 subgraph "cluster_::Object#baz2" {
     label = "::Object#baz2";
     color = blue;
-    "bb::Object#baz2_0" [shape = invhouse];
-    "bb::Object#baz2_1" [shape = parallelogram];
 
     "bb::Object#baz2_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\la: String(\"foo\") = \"foo\"\l<statTemp>$5: String(\"foo\") = \"foo\"\lb: T.nilable(Integer) = a: String(\"foo\").getbyte(<statTemp>$5: String(\"foo\"))\l<returnMethodTemp>$2: T.nilable(Integer) = b\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
     ];
 
     "bb::Object#baz2_0" -> "bb::Object#baz2_1" [style="bold"];
     "bb::Object#baz2_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::Object#baz2" {
 subgraph "cluster_::Object#baz3" {
     label = "::Object#baz3";
     color = blue;
-    "bb::Object#baz3_0" [shape = invhouse];
-    "bb::Object#baz3_1" [shape = parallelogram];
 
     "bb::Object#baz3_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<statTemp>$3: String(\"foo\") = \"foo\"\l<statTemp>$4: String(\"foo\") = \"foo\"\lb: T.nilable(Integer) = <statTemp>$3: String(\"foo\").getbyte(<statTemp>$4: String(\"foo\"))\l<returnMethodTemp>$2: T.nilable(Integer) = b\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
     ];
 
     "bb::Object#baz3_0" -> "bb::Object#baz3_1" [style="bold"];
     "bb::Object#baz3_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::Object#baz3" {
 subgraph "cluster_::Object#baz4" {
     label = "::Object#baz4";
     color = blue;
-    "bb::Object#baz4_0" [shape = invhouse];
-    "bb::Object#baz4_1" [shape = parallelogram];
 
     "bb::Object#baz4_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<statTemp>$3: T.untyped = <self>: Object.a()\l<statTemp>$5: String(\"foo\") = \"foo\"\lb: T.untyped = <statTemp>$3: T.untyped.getbyte(<statTemp>$5: String(\"foo\"))\l<returnMethodTemp>$2: T.untyped = b\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Object#baz4_0" -> "bb::Object#baz4_1" [style="bold"];
     "bb::Object#baz4_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,10 +82,9 @@ subgraph "cluster_::Object#baz4" {
 subgraph "cluster_::Object#baz5" {
     label = "::Object#baz5";
     color = blue;
-    "bb::Object#baz5_0" [shape = invhouse];
-    "bb::Object#baz5_1" [shape = parallelogram];
 
     "bb::Object#baz5_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\lcond: T.untyped = load_arg(cond)\lcond: T.untyped\l"
     ];
@@ -94,24 +93,28 @@ subgraph "cluster_::Object#baz5" {
     "bb::Object#baz5_0" -> "bb::Object#baz5_3" [style="tapered"];
 
     "bb::Object#baz5_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#baz5_1" -> "bb::Object#baz5_1" [style="bold"];
     "bb::Object#baz5_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\lb: Integer(1) = 1\l<unconditional>\l"
     ];
 
     "bb::Object#baz5_2" -> "bb::Object#baz5_4" [style="bold"];
     "bb::Object#baz5_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0]()\lb: String(\"foo\") = \"foo\"\l<unconditional>\l"
     ];
 
     "bb::Object#baz5_3" -> "bb::Object#baz5_4" [style="bold"];
     "bb::Object#baz5_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](b: T.any(Integer, String))\l<statTemp>$5: T.any(Integer, String) = b\l<statTemp>$6: Integer(1) = 1\lb: T.untyped = <statTemp>$5: T.any(Integer, String).getbyte(<statTemp>$6: Integer(1))\l<returnMethodTemp>$2: T.untyped = b\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
@@ -122,10 +125,9 @@ subgraph "cluster_::Object#baz5" {
 subgraph "cluster_::Object#baz6" {
     label = "::Object#baz6";
     color = blue;
-    "bb::Object#baz6_0" [shape = invhouse];
-    "bb::Object#baz6_1" [shape = parallelogram];
 
     "bb::Object#baz6_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\lcond: T.untyped = load_arg(cond)\lcond: T.untyped\l"
     ];
@@ -134,24 +136,28 @@ subgraph "cluster_::Object#baz6" {
     "bb::Object#baz6_0" -> "bb::Object#baz6_3" [style="tapered"];
 
     "bb::Object#baz6_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#baz6_1" -> "bb::Object#baz6_1" [style="bold"];
     "bb::Object#baz6_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\lb: Integer(1) = 1\l<unconditional>\l"
     ];
 
     "bb::Object#baz6_2" -> "bb::Object#baz6_4" [style="bold"];
     "bb::Object#baz6_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0]()\lb: String(\"foo\") = \"foo\"\l<unconditional>\l"
     ];
 
     "bb::Object#baz6_3" -> "bb::Object#baz6_4" [style="bold"];
     "bb::Object#baz6_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](b: T.any(Integer, String))\l<statTemp>$5: String(\"foo\") = \"foo\"\l<statTemp>$6: T.any(Integer, String) = b\lb: T.nilable(Integer) = <statTemp>$5: String(\"foo\").getbyte(<statTemp>$6: T.any(Integer, String))\l<returnMethodTemp>$2: T.nilable(Integer) = b\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
     ];
@@ -162,10 +168,9 @@ subgraph "cluster_::Object#baz6" {
 subgraph "cluster_::Object#baz7" {
     label = "::Object#baz7";
     color = blue;
-    "bb::Object#baz7_0" [shape = invhouse];
-    "bb::Object#baz7_1" [shape = parallelogram];
 
     "bb::Object#baz7_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\lcond: T.untyped = load_arg(cond)\lcond: T.untyped\l"
     ];
@@ -174,18 +179,21 @@ subgraph "cluster_::Object#baz7" {
     "bb::Object#baz7_0" -> "bb::Object#baz7_4" [style="tapered"];
 
     "bb::Object#baz7_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#baz7_1" -> "bb::Object#baz7_1" [style="bold"];
     "bb::Object#baz7_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\lb: Integer(1) = 1\l<unconditional>\l"
     ];
 
     "bb::Object#baz7_2" -> "bb::Object#baz7_4" [style="bold"];
     "bb::Object#baz7_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](b: T.nilable(Integer))\l<statTemp>$5: String(\"foo\") = \"foo\"\l<statTemp>$6: T.nilable(Integer) = b\lb: T.nilable(Integer) = <statTemp>$5: String(\"foo\").getbyte(<statTemp>$6: T.nilable(Integer))\l<returnMethodTemp>$2: T.nilable(Integer) = b\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)\l<unconditional>\l"
     ];
@@ -196,22 +204,23 @@ subgraph "cluster_::Object#baz7" {
 subgraph "cluster_::Object#baz8" {
     label = "::Object#baz8";
     color = blue;
-    "bb::Object#baz8_0" [shape = invhouse];
-    "bb::Object#baz8_1" [shape = parallelogram];
 
     "bb::Object#baz8_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<unconditional>\l"
     ];
 
     "bb::Object#baz8_0" -> "bb::Object#baz8_2" [style="bold"];
     "bb::Object#baz8_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#baz8_1" -> "bb::Object#baz8_1" [style="bold"];
     "bb::Object#baz8_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\louterLoops: 1\l<whileTemp>$3: TrueClass = true\l<whileTemp>$3: TrueClass\l"
     ];
@@ -220,12 +229,14 @@ subgraph "cluster_::Object#baz8" {
     "bb::Object#baz8_2" -> "bb::Object#baz8_3" [style="tapered"];
 
     "bb::Object#baz8_3" [
+        shape = rectangle;
         color = red;
         label = "block[id=3, rubyBlockId=0]()\l<returnMethodTemp>$2 = nil\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::Object#baz8_3" -> "bb::Object#baz8_1" [style="bold"];
     "bb::Object#baz8_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0]()\louterLoops: 1\lb: Integer(1) = 1\l<unconditional>\l"
     ];
@@ -236,16 +247,16 @@ subgraph "cluster_::Object#baz8" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:baz1) = :baz1\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:baz1) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$7: Symbol(:baz1), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:baz2) = :baz2\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:baz2) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$13: Symbol(:baz2), <statTemp>$14: Symbol(:normal))\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$19: Symbol(:baz3) = :baz3\l<statTemp>$20: Symbol(:normal) = :normal\l<statTemp>$15: Symbol(:baz3) = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$19: Symbol(:baz3), <statTemp>$20: Symbol(:normal))\l<cfgAlias>$23: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$25: Symbol(:baz4) = :baz4\l<statTemp>$26: Symbol(:normal) = :normal\l<statTemp>$21: Symbol(:baz4) = <cfgAlias>$23: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$25: Symbol(:baz4), <statTemp>$26: Symbol(:normal))\l<cfgAlias>$29: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$31: Symbol(:baz5) = :baz5\l<statTemp>$32: Symbol(:normal) = :normal\l<statTemp>$27: Symbol(:baz5) = <cfgAlias>$29: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$31: Symbol(:baz5), <statTemp>$32: Symbol(:normal))\l<cfgAlias>$35: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$37: Symbol(:baz6) = :baz6\l<statTemp>$38: Symbol(:normal) = :normal\l<statTemp>$33: Symbol(:baz6) = <cfgAlias>$35: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$37: Symbol(:baz6), <statTemp>$38: Symbol(:normal))\l<cfgAlias>$41: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$43: Symbol(:baz7) = :baz7\l<statTemp>$44: Symbol(:normal) = :normal\l<statTemp>$39: Symbol(:baz7) = <cfgAlias>$41: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$43: Symbol(:baz7), <statTemp>$44: Symbol(:normal))\l<cfgAlias>$47: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$49: Symbol(:baz8) = :baz8\l<statTemp>$50: Symbol(:normal) = :normal\l<statTemp>$45: Symbol(:baz8) = <cfgAlias>$47: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$49: Symbol(:baz8), <statTemp>$50: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/isa_generic.rb.cfg.exp
+++ b/test/testdata/infer/isa_generic.rb.cfg.exp
@@ -2,10 +2,9 @@ digraph "isa_generic.rb" {
 subgraph "cluster_::Object#f" {
     label = "::Object#f";
     color = blue;
-    "bb::Object#f_0" [shape = invhouse];
-    "bb::Object#f_1" [shape = parallelogram];
 
     "bb::Object#f_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\lx: T.any(Concrete, Other) = load_arg(x)\l<cfgAlias>$7: T.class_of(Concrete) = alias <C Concrete>\l<ifTemp>$5: T::Boolean = <cfgAlias>$7: T.class_of(Concrete).===(x: T.any(Concrete, Other))\l<ifTemp>$5: T::Boolean\l"
     ];
@@ -14,18 +13,21 @@ subgraph "cluster_::Object#f" {
     "bb::Object#f_0" -> "bb::Object#f_3" [style="tapered"];
 
     "bb::Object#f_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#f_1" -> "bb::Object#f_1" [style="bold"];
     "bb::Object#f_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](x: Concrete)\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(Concrete) = alias <C Concrete>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$13: T.class_of(Concrete))\l<castTemp>$14: Concrete = x\l<statTemp>$3: Concrete = cast(<castTemp>$14: Concrete, Concrete);\l<unconditional>\l"
     ];
 
     "bb::Object#f_2" -> "bb::Object#f_7" [style="bold"];
     "bb::Object#f_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](x: Other)\l<cfgAlias>$17: T.class_of(Other) = alias <C Other>\l<ifTemp>$15: TrueClass = <cfgAlias>$17: T.class_of(Other).===(x: Other)\l<ifTemp>$15: TrueClass\l"
     ];
@@ -34,12 +36,14 @@ subgraph "cluster_::Object#f" {
     "bb::Object#f_3" -> "bb::Object#f_7" [style="tapered"];
 
     "bb::Object#f_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](x: Other)\l<cfgAlias>$21: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$23: T.class_of(Other) = alias <C Other>\l<statTemp>$19: Sorbet::Private::Static::Void = <cfgAlias>$21: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$23: T.class_of(Other))\l<castTemp>$24: Other = x\l<statTemp>$3: Other = cast(<castTemp>$24: Other, Other);\l<unconditional>\l"
     ];
 
     "bb::Object#f_4" -> "bb::Object#f_7" [style="bold"];
     "bb::Object#f_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](x: T.any(Concrete, Other))\l<cfgAlias>$29: T.class_of(Concrete) = alias <C Concrete>\l<ifTemp>$26: T::Boolean = x: T.any(Concrete, Other).is_a?(<cfgAlias>$29: T.class_of(Concrete))\l<ifTemp>$26: T::Boolean\l"
     ];
@@ -48,12 +52,14 @@ subgraph "cluster_::Object#f" {
     "bb::Object#f_7" -> "bb::Object#f_10" [style="tapered"];
 
     "bb::Object#f_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=0](x: Concrete)\l<cfgAlias>$32: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$34: T.class_of(Concrete) = alias <C Concrete>\l<statTemp>$30: Sorbet::Private::Static::Void = <cfgAlias>$32: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$34: T.class_of(Concrete))\l<castTemp>$35: Concrete = x\l<statTemp>$25: Concrete = cast(<castTemp>$35: Concrete, Concrete);\l<unconditional>\l"
     ];
 
     "bb::Object#f_8" -> "bb::Object#f_10" [style="bold"];
     "bb::Object#f_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=0](x: T.any(Other, Concrete))\l<cfgAlias>$39: T.class_of(Other) = alias <C Other>\l<ifTemp>$36: T::Boolean = x: T.any(Other, Concrete).is_a?(<cfgAlias>$39: T.class_of(Other))\l<ifTemp>$36: T::Boolean\l"
     ];
@@ -62,12 +68,14 @@ subgraph "cluster_::Object#f" {
     "bb::Object#f_10" -> "bb::Object#f_12" [style="tapered"];
 
     "bb::Object#f_12" [
+        shape = rectangle;
         color = black;
         label = "block[id=12, rubyBlockId=0](x: Concrete)\l<cfgAlias>$42: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$44: T.class_of(Concrete) = alias <C Concrete>\l<statTemp>$40: Sorbet::Private::Static::Void = <cfgAlias>$42: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$44: T.class_of(Concrete))\l<castTemp>$45: Concrete = x\l<returnMethodTemp>$2: Concrete = cast(<castTemp>$45: Concrete, Concrete);\l<unconditional>\l"
     ];
 
     "bb::Object#f_12" -> "bb::Object#f_13" [style="bold"];
     "bb::Object#f_13" [
+        shape = rectangle;
         color = black;
         label = "block[id=13, rubyBlockId=0](<returnMethodTemp>$2: T.nilable(Concrete))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Concrete)\l<unconditional>\l"
     ];
@@ -78,10 +86,9 @@ subgraph "cluster_::Object#f" {
 subgraph "cluster_::Object#f2" {
     label = "::Object#f2";
     color = blue;
-    "bb::Object#f2_0" [shape = invhouse];
-    "bb::Object#f2_1" [shape = parallelogram];
 
     "bb::Object#f2_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\lx: T.any(Base, Other) = load_arg(x)\l<cfgAlias>$6: T.class_of(Base)[T.untyped] = alias <C Base>\l<ifTemp>$3: T::Boolean = x: T.any(Base, Other).is_a?(<cfgAlias>$6: T.class_of(Base)[T.untyped])\l<ifTemp>$3: T::Boolean\l"
     ];
@@ -90,18 +97,21 @@ subgraph "cluster_::Object#f2" {
     "bb::Object#f2_0" -> "bb::Object#f2_4" [style="tapered"];
 
     "bb::Object#f2_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Object#f2_1" -> "bb::Object#f2_1" [style="bold"];
     "bb::Object#f2_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](x: Base)\l<cfgAlias>$8: T.class_of(T) = alias <C T>\l<returnMethodTemp>$2: Base = <cfgAlias>$8: T.class_of(T).reveal_type(x: Base)\l<unconditional>\l"
     ];
 
     "bb::Object#f2_2" -> "bb::Object#f2_4" [style="bold"];
     "bb::Object#f2_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](<returnMethodTemp>$2: T.nilable(Base))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Base)\l<unconditional>\l"
     ];
@@ -112,22 +122,23 @@ subgraph "cluster_::Object#f2" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(<root>))\l<selfRestore>$8: T.class_of(<root>) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_2" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_1" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -136,18 +147,21 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_2" -> "bb::<Class:<root>>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(<root>) = <selfRestore>$8\l<cfgAlias>$25: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$27: Sorbet::Private::Static::Void = <cfgAlias>$25: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(<root>))\l<selfRestore>$28: T.class_of(<root>) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_3" -> "bb::<Class:<root>>#<static-init>_6" [style="bold"];
     "bb::<Class:<root>>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$14: Symbol(:x) = :x\l<cfgAlias>$17: T.class_of(T) = alias <C T>\l<cfgAlias>$19: T.class_of(Concrete) = alias <C Concrete>\l<cfgAlias>$21: T.class_of(Other) = alias <C Other>\l<hashTemp>$15: <Type: T.any(Concrete, Other)> = <cfgAlias>$17: T.class_of(T).any(<cfgAlias>$19: T.class_of(Concrete), <cfgAlias>$21: T.class_of(Other))\l<statTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$14: Symbol(:x), <hashTemp>$15: <Type: T.any(Concrete, Other)>)\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <statTemp>$12: T::Private::Methods::DeclBuilder.void()\l<blockReturnTemp>$22: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_5" -> "bb::<Class:<root>>#<static-init>_2" [style="bold"];
     "bb::<Class:<root>>#<static-init>_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=2](<self>: T.class_of(<root>), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(<root>))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -156,12 +170,14 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_6" -> "bb::<Class:<root>>#<static-init>_7" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](<block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(<root>))\l<statTemp>$23: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$27, sig>\l<self>: T.class_of(<root>) = <selfRestore>$28\l<cfgAlias>$46: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$48: T.class_of(T) = alias <C T>\l<statTemp>$43: T.class_of(<root>) = <self>: T.class_of(<root>).extend(<cfgAlias>$46: T.class_of(T::Sig))\l<cfgAlias>$52: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$54: T.class_of(Base)[T.untyped] = alias <C Base>\l<statTemp>$50: Sorbet::Private::Static::Void = <cfgAlias>$52: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$54: T.class_of(Base)[T.untyped])\l<cfgAlias>$57: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$59: T.class_of(Base)[T.untyped] = alias <C Base>\l<statTemp>$55: Sorbet::Private::Static::Void = <cfgAlias>$57: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$59: T.class_of(Base)[T.untyped])\l<cfgAlias>$63: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$65: T.class_of(Concrete) = alias <C Concrete>\l<statTemp>$61: Sorbet::Private::Static::Void = <cfgAlias>$63: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$65: T.class_of(Concrete))\l<cfgAlias>$68: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$70: T.class_of(Concrete) = alias <C Concrete>\l<statTemp>$66: Sorbet::Private::Static::Void = <cfgAlias>$68: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$70: T.class_of(Concrete))\l<cfgAlias>$73: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$75: T.class_of(Base)[T.untyped] = alias <C Base>\l<statTemp>$71: Sorbet::Private::Static::Void = <cfgAlias>$73: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$75: T.class_of(Base)[T.untyped])\l<cfgAlias>$79: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$81: T.class_of(Other) = alias <C Other>\l<statTemp>$77: Sorbet::Private::Static::Void = <cfgAlias>$79: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$81: T.class_of(Other))\l<cfgAlias>$84: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$86: T.class_of(Other) = alias <C Other>\l<statTemp>$82: Sorbet::Private::Static::Void = <cfgAlias>$84: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$86: T.class_of(Other))\l<cfgAlias>$89: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$91: Symbol(:f) = :f\l<statTemp>$92: Symbol(:normal) = :normal\l<statTemp>$87: Symbol(:f) = <cfgAlias>$89: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$91: Symbol(:f), <statTemp>$92: Symbol(:normal))\l<cfgAlias>$95: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$97: Symbol(:f2) = :f2\l<statTemp>$98: Symbol(:normal) = :normal\l<statTemp>$93: Symbol(:f2) = <cfgAlias>$95: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$97: Symbol(:f2), <statTemp>$98: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_7" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=2](<self>: T.class_of(<root>), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(<root>))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$34: Symbol(:x) = :x\l<cfgAlias>$37: T.class_of(T) = alias <C T>\l<cfgAlias>$39: T.class_of(Base)[T.untyped] = alias <C Base>\l<cfgAlias>$41: T.class_of(Other) = alias <C Other>\l<hashTemp>$35: <Type: T.any(Base, Other)> = <cfgAlias>$37: T.class_of(T).any(<cfgAlias>$39: T.class_of(Base)[T.untyped], <cfgAlias>$41: T.class_of(Other))\l<statTemp>$32: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$34: Symbol(:x), <hashTemp>$35: <Type: T.any(Base, Other)>)\l<blockReturnTemp>$31: T::Private::Methods::DeclBuilder = <statTemp>$32: T::Private::Methods::DeclBuilder.void()\l<blockReturnTemp>$42: T.noreturn = blockreturn<sig> <blockReturnTemp>$31: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
@@ -172,16 +188,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::<Class:Base>#<static-init>" {
     label = "::<Class:Base>#<static-init>";
     color = blue;
-    "bb::<Class:Base>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Base>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Base>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<C Klass>$10: <Type: T.class_of(Base)::Klass> = alias <C Klass>\l<self>: T.class_of(Base)[T.class_of(Base)::Klass] = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Base>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Base>> $1><C <U <AttachedClass>>>)\l    <C <U Klass>> = SelfTypeParam(<S <C <U Base>> $1><C <U Klass>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(T::Generic) = alias <C Generic>\l<cfgAlias>$8: T.class_of(T) = alias <C T>\l<statTemp>$3: T.class_of(Base)[T.class_of(Base)::Klass] = <self>: T.class_of(Base)[T.class_of(Base)::Klass].extend(<cfgAlias>$6: T.class_of(T::Generic))\l<C Klass>$10: T.untyped = <self>: T.class_of(Base)[T.class_of(Base)::Klass].type_template()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Base>#<static-init>_0" -> "bb::<Class:Base>#<static-init>_1" [style="bold"];
     "bb::<Class:Base>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -192,16 +208,16 @@ subgraph "cluster_::<Class:Base>#<static-init>" {
 subgraph "cluster_::<Class:Concrete>#<static-init>" {
     label = "::<Class:Concrete>#<static-init>";
     color = blue;
-    "bb::<Class:Concrete>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Concrete>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Concrete>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<C Klass>$10: <Type: String> = alias <C Klass>\l<self>: T.class_of(Concrete) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Concrete>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Concrete>> $1><C <U <AttachedClass>>>)\l    <C <U Klass>> = String\l  ]\l});\l<cfgAlias>$6: T.class_of(T::Generic) = alias <C Generic>\l<cfgAlias>$8: T.class_of(T) = alias <C T>\l<statTemp>$3: T.class_of(Concrete) = <self>: T.class_of(Concrete).extend(<cfgAlias>$6: T.class_of(T::Generic))\l<hashTemp>$12: Symbol(:fixed) = :fixed\l<cfgAlias>$14: T.class_of(String) = alias <C String>\l<C Klass>$10: T.untyped = <self>: T.class_of(Concrete).type_template(<hashTemp>$12: Symbol(:fixed), <cfgAlias>$14: T.class_of(String))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Concrete>#<static-init>_0" -> "bb::<Class:Concrete>#<static-init>_1" [style="bold"];
     "bb::<Class:Concrete>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -212,16 +228,16 @@ subgraph "cluster_::<Class:Concrete>#<static-init>" {
 subgraph "cluster_::<Class:Other>#<static-init>" {
     label = "::<Class:Other>#<static-init>";
     color = blue;
-    "bb::<Class:Other>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Other>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Other>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Other) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Other>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Other>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Other>#<static-init>_0" -> "bb::<Class:Other>#<static-init>_1" [style="bold"];
     "bb::<Class:Other>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/loops.rb.cfg.exp
+++ b/test/testdata/infer/loops.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "loops.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(HasLoops) = alias <C HasLoops>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(HasLoops))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(HasLoops) = alias <C HasLoops>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(HasLoops))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,22 +22,23 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::HasLoops#variable_only_inside_loop" {
     label = "::HasLoops#variable_only_inside_loop";
     color = blue;
-    "bb::HasLoops#variable_only_inside_loop_0" [shape = invhouse];
-    "bb::HasLoops#variable_only_inside_loop_1" [shape = parallelogram];
 
     "bb::HasLoops#variable_only_inside_loop_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: HasLoops = cast(<self>: NilClass, HasLoops);\l<unconditional>\l"
     ];
 
     "bb::HasLoops#variable_only_inside_loop_0" -> "bb::HasLoops#variable_only_inside_loop_2" [style="bold"];
     "bb::HasLoops#variable_only_inside_loop_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::HasLoops#variable_only_inside_loop_1" -> "bb::HasLoops#variable_only_inside_loop_1" [style="bold"];
     "bb::HasLoops#variable_only_inside_loop_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0]()\louterLoops: 1\l<whileTemp>$3: TrueClass = true\l<whileTemp>$3: TrueClass\l"
     ];
@@ -46,12 +47,14 @@ subgraph "cluster_::HasLoops#variable_only_inside_loop" {
     "bb::HasLoops#variable_only_inside_loop_2" -> "bb::HasLoops#variable_only_inside_loop_3" [style="tapered"];
 
     "bb::HasLoops#variable_only_inside_loop_3" [
+        shape = rectangle;
         color = red;
         label = "block[id=3, rubyBlockId=0]()\l<returnMethodTemp>$2 = nil\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::HasLoops#variable_only_inside_loop_3" -> "bb::HasLoops#variable_only_inside_loop_1" [style="bold"];
     "bb::HasLoops#variable_only_inside_loop_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0]()\louterLoops: 1\la: Integer(1) = 1\l<unconditional>\l"
     ];
@@ -62,22 +65,23 @@ subgraph "cluster_::HasLoops#variable_only_inside_loop" {
 subgraph "cluster_::HasLoops#incorrect_assignment" {
     label = "::HasLoops#incorrect_assignment";
     color = blue;
-    "bb::HasLoops#incorrect_assignment_0" [shape = invhouse];
-    "bb::HasLoops#incorrect_assignment_1" [shape = parallelogram];
 
     "bb::HasLoops#incorrect_assignment_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: HasLoops = cast(<self>: NilClass, HasLoops);\la: String(\"s\") = \"s\"\l<unconditional>\l"
     ];
 
     "bb::HasLoops#incorrect_assignment_0" -> "bb::HasLoops#incorrect_assignment_2" [style="bold"];
     "bb::HasLoops#incorrect_assignment_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::HasLoops#incorrect_assignment_1" -> "bb::HasLoops#incorrect_assignment_1" [style="bold"];
     "bb::HasLoops#incorrect_assignment_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](a: String(\"s\"))\louterLoops: 1\l<whileTemp>$4: TrueClass = true\l<whileTemp>$4: TrueClass\l"
     ];
@@ -86,12 +90,14 @@ subgraph "cluster_::HasLoops#incorrect_assignment" {
     "bb::HasLoops#incorrect_assignment_2" -> "bb::HasLoops#incorrect_assignment_3" [style="tapered"];
 
     "bb::HasLoops#incorrect_assignment_3" [
+        shape = rectangle;
         color = red;
         label = "block[id=3, rubyBlockId=0]()\l<returnMethodTemp>$2 = nil\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::HasLoops#incorrect_assignment_3" -> "bb::HasLoops#incorrect_assignment_1" [style="bold"];
     "bb::HasLoops#incorrect_assignment_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0](a: String(\"s\"))\louterLoops: 1\la: T.untyped = 1\l<unconditional>\l"
     ];
@@ -102,22 +108,23 @@ subgraph "cluster_::HasLoops#incorrect_assignment" {
 subgraph "cluster_::HasLoops#correct_assignment" {
     label = "::HasLoops#correct_assignment";
     color = blue;
-    "bb::HasLoops#correct_assignment_0" [shape = invhouse];
-    "bb::HasLoops#correct_assignment_1" [shape = parallelogram];
 
     "bb::HasLoops#correct_assignment_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: HasLoops = cast(<self>: NilClass, HasLoops);\la: String(\"s\") = \"s\"\l<unconditional>\l"
     ];
 
     "bb::HasLoops#correct_assignment_0" -> "bb::HasLoops#correct_assignment_2" [style="bold"];
     "bb::HasLoops#correct_assignment_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::HasLoops#correct_assignment_1" -> "bb::HasLoops#correct_assignment_1" [style="bold"];
     "bb::HasLoops#correct_assignment_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](a: String(\"s\"))\louterLoops: 1\l<whileTemp>$4: TrueClass = true\l<whileTemp>$4: TrueClass\l"
     ];
@@ -126,12 +133,14 @@ subgraph "cluster_::HasLoops#correct_assignment" {
     "bb::HasLoops#correct_assignment_2" -> "bb::HasLoops#correct_assignment_3" [style="tapered"];
 
     "bb::HasLoops#correct_assignment_3" [
+        shape = rectangle;
         color = red;
         label = "block[id=3, rubyBlockId=0]()\l<returnMethodTemp>$2 = nil\l<finalReturn> = return <returnMethodTemp>$2\l<unconditional>\l"
     ];
 
     "bb::HasLoops#correct_assignment_3" -> "bb::HasLoops#correct_assignment_1" [style="bold"];
     "bb::HasLoops#correct_assignment_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0](a: String(\"s\"))\louterLoops: 1\la: String(\"a\") = \"a\"\l<unconditional>\l"
     ];
@@ -142,16 +151,16 @@ subgraph "cluster_::HasLoops#correct_assignment" {
 subgraph "cluster_::<Class:HasLoops>#<static-init>" {
     label = "::<Class:HasLoops>#<static-init>";
     color = blue;
-    "bb::<Class:HasLoops>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:HasLoops>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:HasLoops>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(HasLoops) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U HasLoops>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U HasLoops>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:variable_only_inside_loop) = :variable_only_inside_loop\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:variable_only_inside_loop) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(HasLoops), <statTemp>$7: Symbol(:variable_only_inside_loop), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:incorrect_assignment) = :incorrect_assignment\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:incorrect_assignment) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(HasLoops), <statTemp>$13: Symbol(:incorrect_assignment), <statTemp>$14: Symbol(:normal))\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$19: Symbol(:correct_assignment) = :correct_assignment\l<statTemp>$20: Symbol(:normal) = :normal\l<statTemp>$15: Symbol(:correct_assignment) = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(HasLoops), <statTemp>$19: Symbol(:correct_assignment), <statTemp>$20: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:HasLoops>#<static-init>_0" -> "bb::<Class:HasLoops>#<static-init>_1" [style="bold"];
     "bb::<Class:HasLoops>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/meta_types.rb.cfg.exp
+++ b/test/testdata/infer/meta_types.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "meta_types.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(TestMetaType) = alias <C TestMetaType>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(TestMetaType))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(TestMetaType) = alias <C TestMetaType>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(TestMetaType))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::TestMetaType#_" {
     label = "::TestMetaType#_";
     color = blue;
-    "bb::TestMetaType#__0" [shape = invhouse];
-    "bb::TestMetaType#__1" [shape = parallelogram];
 
     "bb::TestMetaType#__0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestMetaType = cast(<self>: NilClass, TestMetaType);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::TestMetaType#__0" -> "bb::TestMetaType#__1" [style="bold"];
     "bb::TestMetaType#__1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,10 +42,9 @@ subgraph "cluster_::TestMetaType#_" {
 subgraph "cluster_::TestMetaType#testit" {
     label = "::TestMetaType#testit";
     color = blue;
-    "bb::TestMetaType#testit_0" [shape = invhouse];
-    "bb::TestMetaType#testit_1" [shape = parallelogram];
 
     "bb::TestMetaType#testit_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: TestMetaType = cast(<self>: NilClass, TestMetaType);\l<cfgAlias>$7: T.class_of(T::Array) = alias <C Array>\l<cfgAlias>$9: T.class_of(T) = alias <C T>\l<cfgAlias>$11: T.class_of(String) = alias <C String>\l<statTemp>$5: <Type: T::Array[String]> = <cfgAlias>$7: T.class_of(T::Array).[](<cfgAlias>$11: T.class_of(String))\l<statTemp>$3: NilClass = <self>: TestMetaType.puts(<statTemp>$5: <Type: T::Array[String]>)\l<ifTemp>$15: T.untyped = <self>: TestMetaType._()\l<ifTemp>$15: T.untyped\l"
     ];
@@ -54,24 +53,28 @@ subgraph "cluster_::TestMetaType#testit" {
     "bb::TestMetaType#testit_0" -> "bb::TestMetaType#testit_3" [style="tapered"];
 
     "bb::TestMetaType#testit_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::TestMetaType#testit_1" -> "bb::TestMetaType#testit_1" [style="bold"];
     "bb::TestMetaType#testit_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](<self>: TestMetaType)\l<cfgAlias>$18: T.class_of(T::Array) = alias <C Array>\l<cfgAlias>$20: T.class_of(T) = alias <C T>\l<cfgAlias>$22: T.class_of(String) = alias <C String>\l<statTemp>$14: <Type: T::Array[String]> = <cfgAlias>$18: T.class_of(T::Array).[](<cfgAlias>$22: T.class_of(String))\l<unconditional>\l"
     ];
 
     "bb::TestMetaType#testit_2" -> "bb::TestMetaType#testit_4" [style="bold"];
     "bb::TestMetaType#testit_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<self>: TestMetaType)\l<statTemp>$14: FalseClass = false\l<unconditional>\l"
     ];
 
     "bb::TestMetaType#testit_3" -> "bb::TestMetaType#testit_4" [style="bold"];
     "bb::TestMetaType#testit_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](<self>: TestMetaType, <statTemp>$14: Object)\l<statTemp>$12: NilClass = <self>: TestMetaType.puts(<statTemp>$14: Object)\l<ifTemp>$25: T.untyped = <self>: TestMetaType._()\l<ifTemp>$25: T.untyped\l"
     ];
@@ -80,18 +83,21 @@ subgraph "cluster_::TestMetaType#testit" {
     "bb::TestMetaType#testit_4" -> "bb::TestMetaType#testit_6" [style="tapered"];
 
     "bb::TestMetaType#testit_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0](<self>: TestMetaType)\l<cfgAlias>$28: T.class_of(T::Array) = alias <C Array>\l<cfgAlias>$30: T.class_of(T) = alias <C T>\l<cfgAlias>$32: T.class_of(String) = alias <C String>\l<statTemp>$24: <Type: T::Array[String]> = <cfgAlias>$28: T.class_of(T::Array).[](<cfgAlias>$32: T.class_of(String))\l<unconditional>\l"
     ];
 
     "bb::TestMetaType#testit_5" -> "bb::TestMetaType#testit_7" [style="bold"];
     "bb::TestMetaType#testit_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=0](<self>: TestMetaType)\l<cfgAlias>$34: T.class_of(T::Array) = alias <C Array>\l<cfgAlias>$36: T.class_of(T) = alias <C T>\l<cfgAlias>$38: T.class_of(Float) = alias <C Float>\l<statTemp>$24: <Type: T::Array[Float]> = <cfgAlias>$34: T.class_of(T::Array).[](<cfgAlias>$38: T.class_of(Float))\l<unconditional>\l"
     ];
 
     "bb::TestMetaType#testit_6" -> "bb::TestMetaType#testit_7" [style="bold"];
     "bb::TestMetaType#testit_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](<self>: TestMetaType, <statTemp>$24: Object)\l<returnMethodTemp>$2: NilClass = <self>: TestMetaType.puts(<statTemp>$24: Object)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
@@ -102,16 +108,16 @@ subgraph "cluster_::TestMetaType#testit" {
 subgraph "cluster_::<Class:TestMetaType>#<static-init>" {
     label = "::<Class:TestMetaType>#<static-init>";
     color = blue;
-    "bb::<Class:TestMetaType>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:TestMetaType>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:TestMetaType>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(TestMetaType) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U TestMetaType>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U TestMetaType>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:_) = :_\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:_) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestMetaType), <statTemp>$7: Symbol(:_), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:testit) = :testit\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:testit) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(TestMetaType), <statTemp>$13: Symbol(:testit), <statTemp>$14: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:TestMetaType>#<static-init>_0" -> "bb::<Class:TestMetaType>#<static-init>_1" [style="bold"];
     "bb::<Class:TestMetaType>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/rebind.rb.cfg.exp
+++ b/test/testdata/infer/rebind.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "rebind.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(C) = alias <C C>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(C))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(C) = alias <C C>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(C))\l<cfgAlias>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$19: T.class_of(B) = alias <C B>\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$19: T.class_of(B))\l<cfgAlias>$22: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$24: T.class_of(B) = alias <C B>\l<statTemp>$20: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$24: T.class_of(B))\l<cfgAlias>$28: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$30: T.class_of(A) = alias <C A>\l<statTemp>$26: Sorbet::Private::Static::Void = <cfgAlias>$28: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$30: T.class_of(A))\l<cfgAlias>$33: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$35: T.class_of(A) = alias <C A>\l<statTemp>$31: Sorbet::Private::Static::Void = <cfgAlias>$33: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$35: T.class_of(A))\l<cfgAlias>$39: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$41: T.class_of(Use) = alias <C Use>\l<statTemp>$37: Sorbet::Private::Static::Void = <cfgAlias>$39: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$41: T.class_of(Use))\l<cfgAlias>$44: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$46: T.class_of(Use) = alias <C Use>\l<statTemp>$42: Sorbet::Private::Static::Void = <cfgAlias>$44: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$46: T.class_of(Use))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::C#only_on_C" {
     label = "::C#only_on_C";
     color = blue;
-    "bb::C#only_on_C_0" [shape = invhouse];
-    "bb::C#only_on_C_1" [shape = parallelogram];
 
     "bb::C#only_on_C_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: C = cast(<self>: NilClass, C);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::C#only_on_C_0" -> "bb::C#only_on_C_1" [style="bold"];
     "bb::C#only_on_C_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::C#only_on_C" {
 subgraph "cluster_::<Class:C>#<static-init>" {
     label = "::<Class:C>#<static-init>";
     color = blue;
-    "bb::<Class:C>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:only_on_C) = :only_on_C\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:only_on_C) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(C), <statTemp>$6: Symbol(:only_on_C), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:only_on_C)\l<unconditional>\l"
     ];
 
     "bb::<Class:C>#<static-init>_0" -> "bb::<Class:C>#<static-init>_1" [style="bold"];
     "bb::<Class:C>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::<Class:C>#<static-init>" {
 subgraph "cluster_::B#only_on_B" {
     label = "::B#only_on_B";
     color = blue;
-    "bb::B#only_on_B_0" [shape = invhouse];
-    "bb::B#only_on_B_1" [shape = parallelogram];
 
     "bb::B#only_on_B_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: B = cast(<self>: NilClass, B);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::B#only_on_B_0" -> "bb::B#only_on_B_1" [style="bold"];
     "bb::B#only_on_B_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,22 +82,23 @@ subgraph "cluster_::B#only_on_B" {
 subgraph "cluster_::<Class:B>#<static-init>" {
     label = "::<Class:B>#<static-init>";
     color = blue;
-    "bb::<Class:B>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:B>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:B>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(B) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U B>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U B>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(B))\l<selfRestore>$8: T.class_of(B) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_0" -> "bb::<Class:B>#<static-init>_2" [style="bold"];
     "bb::<Class:B>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_1" -> "bb::<Class:B>#<static-init>_1" [style="bold"];
     "bb::<Class:B>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -106,12 +107,14 @@ subgraph "cluster_::<Class:B>#<static-init>" {
     "bb::<Class:B>#<static-init>_2" -> "bb::<Class:B>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:B>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(B) = <selfRestore>$8\l<cfgAlias>$26: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$28: T.class_of(T) = alias <C T>\l<statTemp>$23: T.class_of(B) = <self>: T.class_of(B).extend(<cfgAlias>$26: T.class_of(T::Sig))\l<cfgAlias>$31: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$33: Symbol(:only_on_B) = :only_on_B\l<statTemp>$34: Symbol(:normal) = :normal\l<statTemp>$29: Symbol(:only_on_B) = <cfgAlias>$31: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(B), <statTemp>$33: Symbol(:only_on_B), <statTemp>$34: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_3" -> "bb::<Class:B>#<static-init>_1" [style="bold"];
     "bb::<Class:B>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$14: Symbol(:blk) = :blk\l<cfgAlias>$19: T.class_of(T) = alias <C T>\l<statTemp>$17: T.class_of(T.proc) = <cfgAlias>$19: T.class_of(T).proc()\l<cfgAlias>$21: T.class_of(C) = alias <C C>\l<statTemp>$16: T.class_of(T.proc) = <statTemp>$17: T.class_of(T.proc).bind(<cfgAlias>$21: T.class_of(C))\l<hashTemp>$15: T.class_of(T.proc) = <statTemp>$16: T.class_of(T.proc).void()\l<statTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$14: Symbol(:blk), <hashTemp>$15: T.class_of(T.proc))\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <statTemp>$12: T::Private::Methods::DeclBuilder.void()\l<blockReturnTemp>$22: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
@@ -122,16 +125,16 @@ subgraph "cluster_::<Class:B>#<static-init>" {
 subgraph "cluster_::<Class:A>#mySig" {
     label = "::<Class:A>#mySig";
     color = blue;
-    "bb::<Class:A>#mySig_0" [shape = invhouse];
-    "bb::<Class:A>#mySig_1" [shape = parallelogram];
 
     "bb::<Class:A>#mySig_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#mySig_0" -> "bb::<Class:A>#mySig_1" [style="bold"];
     "bb::<Class:A>#mySig_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -142,22 +145,23 @@ subgraph "cluster_::<Class:A>#mySig" {
 subgraph "cluster_::<Class:A>#<static-init>" {
     label = "::<Class:A>#<static-init>";
     color = blue;
-    "bb::<Class:A>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(A))\l<selfRestore>$8: T.class_of(A) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_2" [style="bold"];
     "bb::<Class:A>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_1" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
     "bb::<Class:A>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -166,12 +170,14 @@ subgraph "cluster_::<Class:A>#<static-init>" {
     "bb::<Class:A>#<static-init>_2" -> "bb::<Class:A>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:A>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(A) = <selfRestore>$8\l<cfgAlias>$26: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$28: T.class_of(T) = alias <C T>\l<statTemp>$23: T.class_of(A) = <self>: T.class_of(A).extend(<cfgAlias>$26: T.class_of(T::Sig))\l<cfgAlias>$31: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$33: Symbol(:mySig) = :mySig\l<statTemp>$34: Symbol(:normal) = :normal\l<statTemp>$29: Symbol(:mySig) = <cfgAlias>$31: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(A), <statTemp>$33: Symbol(:mySig), <statTemp>$34: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_3" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
     "bb::<Class:A>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$14: Symbol(:blk) = :blk\l<cfgAlias>$19: T.class_of(T) = alias <C T>\l<statTemp>$17: T.class_of(T.proc) = <cfgAlias>$19: T.class_of(T).proc()\l<cfgAlias>$21: T.class_of(B) = alias <C B>\l<statTemp>$16: T.class_of(T.proc) = <statTemp>$17: T.class_of(T.proc).bind(<cfgAlias>$21: T.class_of(B))\l<hashTemp>$15: T.class_of(T.proc) = <statTemp>$16: T.class_of(T.proc).void()\l<statTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$14: Symbol(:blk), <hashTemp>$15: T.class_of(T.proc))\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <statTemp>$12: T::Private::Methods::DeclBuilder.void()\l<blockReturnTemp>$22: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
@@ -182,16 +188,16 @@ subgraph "cluster_::<Class:A>#<static-init>" {
 subgraph "cluster_::Use#only_on_Use" {
     label = "::Use#only_on_Use";
     color = blue;
-    "bb::Use#only_on_Use_0" [shape = invhouse];
-    "bb::Use#only_on_Use_1" [shape = parallelogram];
 
     "bb::Use#only_on_Use_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Use = cast(<self>: NilClass, Use);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Use#only_on_Use_0" -> "bb::Use#only_on_Use_1" [style="bold"];
     "bb::Use#only_on_Use_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -202,22 +208,23 @@ subgraph "cluster_::Use#only_on_Use" {
 subgraph "cluster_::Use#shouldRemoveSelfTemp" {
     label = "::Use#shouldRemoveSelfTemp";
     color = blue;
-    "bb::Use#shouldRemoveSelfTemp_0" [shape = invhouse];
-    "bb::Use#shouldRemoveSelfTemp_1" [shape = parallelogram];
 
     "bb::Use#shouldRemoveSelfTemp_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Use = cast(<self>: NilClass, Use);\l<block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Use.only_on_Use()\l<selfRestore>$5: Use = <self>\l<unconditional>\l"
     ];
 
     "bb::Use#shouldRemoveSelfTemp_0" -> "bb::Use#shouldRemoveSelfTemp_2" [style="bold"];
     "bb::Use#shouldRemoveSelfTemp_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Use#shouldRemoveSelfTemp_1" -> "bb::Use#shouldRemoveSelfTemp_1" [style="bold"];
     "bb::Use#shouldRemoveSelfTemp_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: Use, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -226,12 +233,14 @@ subgraph "cluster_::Use#shouldRemoveSelfTemp" {
     "bb::Use#shouldRemoveSelfTemp_2" -> "bb::Use#shouldRemoveSelfTemp_3" [style="tapered"];
 
     "bb::Use#shouldRemoveSelfTemp_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use)\l<returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, only_on_Use>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Use#shouldRemoveSelfTemp_3" -> "bb::Use#shouldRemoveSelfTemp_1" [style="bold"];
     "bb::Use#shouldRemoveSelfTemp_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: Use, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use)\louterLoops: 1\l<self>: Use = loadSelf\l<blockReturnTemp>$8: Integer(1) = 1\l<blockReturnTemp>$9: T.noreturn = blockreturn<only_on_Use> <blockReturnTemp>$8: Integer(1)\l<unconditional>\l"
     ];
@@ -242,22 +251,23 @@ subgraph "cluster_::Use#shouldRemoveSelfTemp" {
 subgraph "cluster_::Use#jumpBetweenClasses" {
     label = "::Use#jumpBetweenClasses";
     color = blue;
-    "bb::Use#jumpBetweenClasses_0" [shape = invhouse];
-    "bb::Use#jumpBetweenClasses_1" [shape = parallelogram];
 
     "bb::Use#jumpBetweenClasses_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Use = cast(<self>: NilClass, Use);\l<cfgAlias>$4: T.class_of(A) = alias <C A>\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <cfgAlias>$4: T.class_of(A).mySig()\l<selfRestore>$6: Use = <self>\l<unconditional>\l"
     ];
 
     "bb::Use#jumpBetweenClasses_0" -> "bb::Use#jumpBetweenClasses_2" [style="bold"];
     "bb::Use#jumpBetweenClasses_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Use#jumpBetweenClasses_1" -> "bb::Use#jumpBetweenClasses_1" [style="bold"];
     "bb::Use#jumpBetweenClasses_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: Use, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -266,18 +276,21 @@ subgraph "cluster_::Use#jumpBetweenClasses" {
     "bb::Use#jumpBetweenClasses_2" -> "bb::Use#jumpBetweenClasses_3" [style="tapered"];
 
     "bb::Use#jumpBetweenClasses_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use)\l<returnMethodTemp>$2: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$5, mySig>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Sorbet::Private::Static::Void\l<unconditional>\l"
     ];
 
     "bb::Use#jumpBetweenClasses_3" -> "bb::Use#jumpBetweenClasses_1" [style="bold"];
     "bb::Use#jumpBetweenClasses_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: Use, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use)\louterLoops: 1\l<self>: B = loadSelf\l<statTemp>$10: T.untyped = <self>: B.only_on_Use()\l<statTemp>$12: T.untyped = <self>: B.mySig()\l<block-pre-call-temp>$15: Sorbet::Private::Static::Void = <self>: B.only_on_B()\l<selfRestore>$16: B = <self>\l<unconditional>\l"
     ];
 
     "bb::Use#jumpBetweenClasses_5" -> "bb::Use#jumpBetweenClasses_6" [style="bold"];
     "bb::Use#jumpBetweenClasses_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=2](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$15: Sorbet::Private::Static::Void, <selfRestore>$16: B)\louterLoops: 2\l<block-call>: NilClass\l"
     ];
@@ -286,12 +299,14 @@ subgraph "cluster_::Use#jumpBetweenClasses" {
     "bb::Use#jumpBetweenClasses_6" -> "bb::Use#jumpBetweenClasses_7" [style="tapered"];
 
     "bb::Use#jumpBetweenClasses_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=1](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$15: Sorbet::Private::Static::Void, <selfRestore>$16: B)\louterLoops: 1\l<blockReturnTemp>$9: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$15, only_on_B>\l<self>: B = <selfRestore>$16\l<blockReturnTemp>$24: T.noreturn = blockreturn<mySig> <blockReturnTemp>$9: Sorbet::Private::Static::Void\l<unconditional>\l"
     ];
 
     "bb::Use#jumpBetweenClasses_7" -> "bb::Use#jumpBetweenClasses_2" [style="bold"];
     "bb::Use#jumpBetweenClasses_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=2](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$15: Sorbet::Private::Static::Void, <selfRestore>$16: B)\louterLoops: 2\l<self>: C = loadSelf\l<statTemp>$20: T.untyped = <self>: C.only_on_B()\l<blockReturnTemp>$19: T.untyped = <self>: C.only_on_C()\l<blockReturnTemp>$23: T.noreturn = blockreturn<only_on_B> <blockReturnTemp>$19: T.untyped\l<unconditional>\l"
     ];
@@ -302,16 +317,16 @@ subgraph "cluster_::Use#jumpBetweenClasses" {
 subgraph "cluster_::<Class:Use>#<static-init>" {
     label = "::<Class:Use>#<static-init>";
     color = blue;
-    "bb::<Class:Use>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Use>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Use>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Use) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Use>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Use>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$8: T.class_of(T) = alias <C T>\l<statTemp>$3: T.class_of(Use) = <self>: T.class_of(Use).extend(<cfgAlias>$6: T.class_of(T::Sig))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:only_on_Use) = :only_on_Use\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:only_on_Use) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Use), <statTemp>$13: Symbol(:only_on_Use), <statTemp>$14: Symbol(:normal))\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$19: Symbol(:shouldRemoveSelfTemp) = :shouldRemoveSelfTemp\l<statTemp>$20: Symbol(:normal) = :normal\l<statTemp>$15: Symbol(:shouldRemoveSelfTemp) = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Use), <statTemp>$19: Symbol(:shouldRemoveSelfTemp), <statTemp>$20: Symbol(:normal))\l<cfgAlias>$23: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$25: Symbol(:jumpBetweenClasses) = :jumpBetweenClasses\l<statTemp>$26: Symbol(:normal) = :normal\l<statTemp>$21: Symbol(:jumpBetweenClasses) = <cfgAlias>$23: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Use), <statTemp>$25: Symbol(:jumpBetweenClasses), <statTemp>$26: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Use>#<static-init>_0" -> "bb::<Class:Use>#<static-init>_1" [style="bold"];
     "bb::<Class:Use>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/self_type.rb.cfg.exp
+++ b/test/testdata/infer/self_type.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "self_type.rb" {
 subgraph "cluster_::Object#rnd" {
     label = "::Object#rnd";
     color = blue;
-    "bb::Object#rnd_0" [shape = invhouse];
-    "bb::Object#rnd_1" [shape = parallelogram];
 
     "bb::Object#rnd_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Object#rnd_0" -> "bb::Object#rnd_1" [style="bold"];
     "bb::Object#rnd_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,10 +22,9 @@ subgraph "cluster_::Object#rnd" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(Parent) = alias <C Parent>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(Parent))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(Parent) = alias <C Parent>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(Parent))\l<cfgAlias>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$19: T.class_of(Normal) = alias <C Normal>\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$19: T.class_of(Normal))\l<cfgAlias>$22: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$24: T.class_of(Normal) = alias <C Normal>\l<statTemp>$20: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$24: T.class_of(Normal))\l<cfgAlias>$27: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$29: T.class_of(Parent) = alias <C Parent>\l<statTemp>$25: Sorbet::Private::Static::Void = <cfgAlias>$27: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$29: T.class_of(Parent))\l<cfgAlias>$33: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$35: T.class_of(Generic) = alias <C Generic>\l<statTemp>$31: Sorbet::Private::Static::Void = <cfgAlias>$33: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$35: T.class_of(Generic))\l<cfgAlias>$38: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$40: T.class_of(Generic) = alias <C Generic>\l<statTemp>$36: Sorbet::Private::Static::Void = <cfgAlias>$38: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$40: T.class_of(Generic))\l<cfgAlias>$43: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$45: T.class_of(Parent) = alias <C Parent>\l<statTemp>$41: Sorbet::Private::Static::Void = <cfgAlias>$43: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$45: T.class_of(Parent))\l<cfgAlias>$49: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$51: T.class_of(Normal) = alias <C Normal>\l<statTemp>$47: Sorbet::Private::Static::Void = <cfgAlias>$49: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$51: T.class_of(Normal))\l<cfgAlias>$55: T.class_of(Normal) = alias <C Normal>\l<statTemp>$53: Normal = <cfgAlias>$55: T.class_of(Normal).new()\l<castTemp>$52: Normal = <statTemp>$53: Normal.returns_self()\l<statTemp>$46: Normal = cast(<castTemp>$52: Normal, Normal);\l<cfgAlias>$59: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$62: T.class_of(Generic) = alias <C Generic>\l<cfgAlias>$64: T.class_of(String) = alias <C String>\l<statTemp>$60: <Type: Generic[String]> = <cfgAlias>$62: T.class_of(Generic).[](<cfgAlias>$64: T.class_of(String))\l<statTemp>$57: Sorbet::Private::Static::Void = <cfgAlias>$59: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$60: <Type: Generic[String]>)\l<cfgAlias>$69: T.class_of(Generic) = alias <C Generic>\l<cfgAlias>$71: T.class_of(String) = alias <C String>\l<statTemp>$67: <Type: Generic[String]> = <cfgAlias>$69: T.class_of(Generic).[](<cfgAlias>$71: T.class_of(String))\l<statTemp>$66: Generic[String] = <statTemp>$67: <Type: Generic[String]>.new()\l<castTemp>$65: Generic[String] = <statTemp>$66: Generic[String].returns_self()\l<statTemp>$56: Generic[String] = cast(<castTemp>$65: Generic[String], AppliedType {\l  klass = <C <U Generic>>\l  targs = [\l    <C <U TM>> = String\l  ]\l});\l<cfgAlias>$75: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$77: T.class_of(B) = alias <C B>\l<statTemp>$73: Sorbet::Private::Static::Void = <cfgAlias>$75: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$77: T.class_of(B))\l<cfgAlias>$80: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$82: T.class_of(B) = alias <C B>\l<statTemp>$78: Sorbet::Private::Static::Void = <cfgAlias>$80: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$82: T.class_of(B))\l<cfgAlias>$86: T.class_of(Generic) = alias <C Generic>\l<cfgAlias>$88: T.class_of(String) = alias <C String>\l<statTemp>$84: <Type: Generic[String]> = <cfgAlias>$86: T.class_of(Generic).[](<cfgAlias>$88: T.class_of(String))\la: Generic[String] = <statTemp>$84: <Type: Generic[String]>.new()\l<cfgAlias>$93: T.class_of(B) = alias <C B>\l<ifTemp>$90: T::Boolean = a: Generic[String].is_a?(<cfgAlias>$93: T.class_of(B))\l<ifTemp>$90: T::Boolean\l"
     ];
@@ -34,24 +33,28 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_4" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_1" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=0](<self>: T.class_of(<root>), a: T.all(Generic[String], B))\l<cfgAlias>$96: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$99: T.class_of(T) = alias <C T>\l<cfgAlias>$102: T.class_of(Generic) = alias <C Generic>\l<cfgAlias>$104: T.class_of(String) = alias <C String>\l<statTemp>$100: <Type: Generic[String]> = <cfgAlias>$102: T.class_of(Generic).[](<cfgAlias>$104: T.class_of(String))\l<cfgAlias>$106: T.class_of(B) = alias <C B>\l<statTemp>$97: <Type: T.all(Generic[String], B)> = <cfgAlias>$99: T.class_of(T).all(<statTemp>$100: <Type: Generic[String]>, <cfgAlias>$106: T.class_of(B))\l<statTemp>$94: Sorbet::Private::Static::Void = <cfgAlias>$96: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$97: <Type: T.all(Generic[String], B)>)\l<castTemp>$107: T.all(Generic[String], B) = a: T.all(Generic[String], B).returns_self()\l<statTemp>$89: T.all(Generic[String], B) = cast(<castTemp>$107: T.all(Generic[String], B), AppliedType {\l      klass = <C <U Generic>>\l      targs = [\l        <C <U TM>> = String\l      ]\l    } & B);\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_2" -> "bb::<Class:<root>>#<static-init>_4" [style="bold"];
     "bb::<Class:<root>>#<static-init>_4" [
+        shape = rectangle;
         color = black;
         label = "block[id=4, rubyBlockId=0](<self>: T.class_of(<root>))\l<cfgAlias>$112: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$114: T.class_of(Array) = alias <C Array>\l<statTemp>$110: Sorbet::Private::Static::Void = <cfgAlias>$112: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$114: T.class_of(Array))\l<cfgAlias>$117: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$119: T.class_of(Array) = alias <C Array>\l<statTemp>$115: Sorbet::Private::Static::Void = <cfgAlias>$117: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$119: T.class_of(Array))\l<cfgAlias>$123: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$126: T.class_of(Integer) = alias <C Integer>\l<cfgAlias>$128: T.class_of(Integer) = alias <C Integer>\l<magic>$129: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$124: [T.class_of(Integer), T.class_of(Integer)] = <magic>$129: T.class_of(<Magic>).<build-array>(<cfgAlias>$126: T.class_of(Integer), <cfgAlias>$128: T.class_of(Integer))\l<statTemp>$121: Sorbet::Private::Static::Void = <cfgAlias>$123: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$124: [T.class_of(Integer), T.class_of(Integer)])\l<arrayTemp>$132: Integer(1) = 1\l<arrayTemp>$133: Integer(2) = 2\l<magic>$134: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$131: [Integer(1), Integer(2)] = <magic>$134: T.class_of(<Magic>).<build-array>(<arrayTemp>$132: Integer(1), <arrayTemp>$133: Integer(2))\l<castTemp>$130: [Integer(1), Integer(2)] = <statTemp>$131: [Integer(1), Integer(2)].returns_self()\l<statTemp>$120: [Integer, Integer] = cast(<castTemp>$130: [Integer(1), Integer(2)], TupleType {\l  0 = Integer\l  1 = Integer\l});\l<cfgAlias>$138: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$140: T.class_of(A) = alias <C A>\l<statTemp>$136: Sorbet::Private::Static::Void = <cfgAlias>$138: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$140: T.class_of(A))\l<cfgAlias>$143: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$145: T.class_of(A) = alias <C A>\l<statTemp>$141: Sorbet::Private::Static::Void = <cfgAlias>$143: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$145: T.class_of(A))\l<cfgAlias>$149: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$151: T.class_of(B) = alias <C B>\l<statTemp>$147: Sorbet::Private::Static::Void = <cfgAlias>$149: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$151: T.class_of(B))\l<cfgAlias>$154: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$156: T.class_of(B) = alias <C B>\l<statTemp>$152: Sorbet::Private::Static::Void = <cfgAlias>$154: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$156: T.class_of(B))\l<cfgAlias>$159: T.class_of(A) = alias <C A>\ls: A = <cfgAlias>$159: T.class_of(A).new()\l<cfgAlias>$162: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$164: Symbol(:rnd) = :rnd\l<statTemp>$165: Symbol(:normal) = :normal\l<statTemp>$160: Symbol(:rnd) = <cfgAlias>$162: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$164: Symbol(:rnd), <statTemp>$165: Symbol(:normal))\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_4" -> "bb::<Class:<root>>#<static-init>_5" [style="bold"];
     "bb::<Class:<root>>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=0](<self>: T.class_of(<root>), s: A)\louterLoops: 1\l<whileTemp>$167: T.untyped = <self>: T.class_of(<root>).rnd()\l<whileTemp>$167: T.untyped\l"
     ];
@@ -60,12 +63,14 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_5" -> "bb::<Class:<root>>#<static-init>_7" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](<self>: T.class_of(<root>), s: A)\l<statTemp>$175: NilClass = <self>: T.class_of(<root>).puts(s: A)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_7" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_8" [
+        shape = rectangle;
         color = black;
         label = "block[id=8, rubyBlockId=0](<self>: T.class_of(<root>), s: A)\louterLoops: 1\l<cfgAlias>$173: T.class_of(B) = alias <C B>\l<ifTemp>$170: T::Boolean = s: A.is_a?(<cfgAlias>$173: T.class_of(B))\l<ifTemp>$170: T::Boolean\l"
     ];
@@ -74,6 +79,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_8" -> "bb::<Class:<root>>#<static-init>_5" [style="tapered"];
 
     "bb::<Class:<root>>#<static-init>_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=0](<self>: T.class_of(<root>), s: T.all(A, B))\louterLoops: 1\l<statTemp>$174: T.all(A, B) = s\ls: T.all(A, B) = <statTemp>$174: T.all(A, B).returns_self()\l<unconditional>\l"
     ];
@@ -84,16 +90,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::Parent#returns_self" {
     label = "::Parent#returns_self";
     color = blue;
-    "bb::Parent#returns_self_0" [shape = invhouse];
-    "bb::Parent#returns_self_1" [shape = parallelogram];
 
     "bb::Parent#returns_self_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Parent = cast(<self>: NilClass, Parent);\l<returnMethodTemp>$2: Parent = <self>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Parent\l<unconditional>\l"
     ];
 
     "bb::Parent#returns_self_0" -> "bb::Parent#returns_self_1" [style="bold"];
     "bb::Parent#returns_self_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -104,22 +110,23 @@ subgraph "cluster_::Parent#returns_self" {
 subgraph "cluster_::<Class:Parent>#<static-init>" {
     label = "::<Class:Parent>#<static-init>";
     color = blue;
-    "bb::<Class:Parent>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Parent>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Parent>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Parent) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Parent>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Parent>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Parent))\l<selfRestore>$8: T.class_of(Parent) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Parent>#<static-init>_0" -> "bb::<Class:Parent>#<static-init>_2" [style="bold"];
     "bb::<Class:Parent>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:Parent>#<static-init>_1" -> "bb::<Class:Parent>#<static-init>_1" [style="bold"];
     "bb::<Class:Parent>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Parent), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Parent))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -128,12 +135,14 @@ subgraph "cluster_::<Class:Parent>#<static-init>" {
     "bb::<Class:Parent>#<static-init>_2" -> "bb::<Class:Parent>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:Parent>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Parent))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(Parent) = <selfRestore>$8\l<cfgAlias>$20: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$22: T.class_of(T) = alias <C T>\l<statTemp>$17: T.class_of(Parent) = <self>: T.class_of(Parent).extend(<cfgAlias>$20: T.class_of(T::Sig))\l<cfgAlias>$25: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$27: Symbol(:returns_self) = :returns_self\l<statTemp>$28: Symbol(:normal) = :normal\l<statTemp>$23: Symbol(:returns_self) = <cfgAlias>$25: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Parent), <statTemp>$27: Symbol(:returns_self), <statTemp>$28: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Parent>#<static-init>_3" -> "bb::<Class:Parent>#<static-init>_1" [style="bold"];
     "bb::<Class:Parent>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Parent), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Parent))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<cfgAlias>$15: T.class_of(T) = alias <C T>\l<statTemp>$13: T.untyped = <cfgAlias>$15: T.class_of(T).self_type()\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$13: T.untyped)\l<blockReturnTemp>$16: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
@@ -144,16 +153,16 @@ subgraph "cluster_::<Class:Parent>#<static-init>" {
 subgraph "cluster_::<Class:Normal>#<static-init>" {
     label = "::<Class:Normal>#<static-init>";
     color = blue;
-    "bb::<Class:Normal>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Normal>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Normal>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Normal) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Normal>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Normal>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Normal>#<static-init>_0" -> "bb::<Class:Normal>#<static-init>_1" [style="bold"];
     "bb::<Class:Normal>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -164,16 +173,16 @@ subgraph "cluster_::<Class:Normal>#<static-init>" {
 subgraph "cluster_::Generic#bad" {
     label = "::Generic#bad";
     color = blue;
-    "bb::Generic#bad_0" [shape = invhouse];
-    "bb::Generic#bad_1" [shape = parallelogram];
 
     "bb::Generic#bad_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Generic[Generic::TM] = cast(<self>: NilClass, AppliedType {\l  klass = <C <U Generic>>\l  targs = [\l    <C <U TM>> = SelfTypeParam(<C <U Generic>><C <U TM>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Generic) = alias <C Generic>\l<cfgAlias>$8: T.class_of(T) = alias <C T>\l<statTemp>$6: <Type: T.untyped> = <cfgAlias>$8: T.class_of(T).untyped()\l<statTemp>$3: <Type: Generic[T.untyped]> = <cfgAlias>$5: T.class_of(Generic).[](<statTemp>$6: <Type: T.untyped>)\l<returnMethodTemp>$2: Generic[T.untyped] = <statTemp>$3: <Type: Generic[T.untyped]>.new()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Generic[T.untyped]\l<unconditional>\l"
     ];
 
     "bb::Generic#bad_0" -> "bb::Generic#bad_1" [style="bold"];
     "bb::Generic#bad_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -184,22 +193,23 @@ subgraph "cluster_::Generic#bad" {
 subgraph "cluster_::<Class:Generic>#<static-init>" {
     label = "::<Class:Generic>#<static-init>";
     color = blue;
-    "bb::<Class:Generic>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Generic>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Generic>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<C TM>$27: <Type: Generic::TM> = alias <C TM>\l<self>: T.class_of(Generic) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Generic>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Generic>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Generic))\l<selfRestore>$8: T.class_of(Generic) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Generic>#<static-init>_0" -> "bb::<Class:Generic>#<static-init>_2" [style="bold"];
     "bb::<Class:Generic>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:Generic>#<static-init>_1" -> "bb::<Class:Generic>#<static-init>_1" [style="bold"];
     "bb::<Class:Generic>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Generic), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Generic), <C TM>$27: <Type: Generic::TM>)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -208,12 +218,14 @@ subgraph "cluster_::<Class:Generic>#<static-init>" {
     "bb::<Class:Generic>#<static-init>_2" -> "bb::<Class:Generic>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:Generic>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Generic), <C TM>$27: <Type: Generic::TM>)\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(Generic) = <selfRestore>$8\l<cfgAlias>$23: T.class_of(T::Generic) = alias <C Generic>\l<cfgAlias>$25: T.class_of(T) = alias <C T>\l<statTemp>$20: T.class_of(Generic) = <self>: T.class_of(Generic).extend(<cfgAlias>$23: T.class_of(T::Generic))\l<C TM>$27: T.untyped = <self>: T.class_of(Generic).type_member()\l<cfgAlias>$31: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$33: Symbol(:bad) = :bad\l<statTemp>$34: Symbol(:normal) = :normal\l<statTemp>$29: Symbol(:bad) = <cfgAlias>$31: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Generic), <statTemp>$33: Symbol(:bad), <statTemp>$34: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Generic>#<static-init>_3" -> "bb::<Class:Generic>#<static-init>_1" [style="bold"];
     "bb::<Class:Generic>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Generic), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Generic), <C TM>$27: <Type: Generic::TM>)\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<cfgAlias>$15: T.class_of(Generic) = alias <C Generic>\l<cfgAlias>$18: T.class_of(T) = alias <C T>\l<statTemp>$16: T.untyped = <cfgAlias>$18: T.class_of(T).self_type()\l<statTemp>$13: <Type: Generic[T.untyped]> = <cfgAlias>$15: T.class_of(Generic).[](<statTemp>$16: T.untyped)\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$13: <Type: Generic[T.untyped]>)\l<blockReturnTemp>$19: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
@@ -224,16 +236,16 @@ subgraph "cluster_::<Class:Generic>#<static-init>" {
 subgraph "cluster_::<Class:B>#<static-init>" {
     label = "::<Class:B>#<static-init>";
     color = blue;
-    "bb::<Class:B>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:B>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:B>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(B) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U B>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U B>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_0" -> "bb::<Class:B>#<static-init>_1" [style="bold"];
     "bb::<Class:B>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -244,16 +256,16 @@ subgraph "cluster_::<Class:B>#<static-init>" {
 subgraph "cluster_::Array#returns_self" {
     label = "::Array#returns_self";
     color = blue;
-    "bb::Array#returns_self_0" [shape = invhouse];
-    "bb::Array#returns_self_1" [shape = parallelogram];
 
     "bb::Array#returns_self_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T::Array[Array::Elem] = cast(<self>: NilClass, AppliedType {\l  klass = <C <U Array>>\l  targs = [\l    <C <U Elem>> = SelfTypeParam(<C <U Array>><C <U Elem>>)\l  ]\l});\l<returnMethodTemp>$2: T::Array[Array::Elem] = <self>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Array[Array::Elem]\l<unconditional>\l"
     ];
 
     "bb::Array#returns_self_0" -> "bb::Array#returns_self_1" [style="bold"];
     "bb::Array#returns_self_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -264,22 +276,23 @@ subgraph "cluster_::Array#returns_self" {
 subgraph "cluster_::<Class:Array>#<static-init>" {
     label = "::<Class:Array>#<static-init>";
     color = blue;
-    "bb::<Class:Array>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Array>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Array>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Array) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Array>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Array>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Array))\l<selfRestore>$8: T.class_of(Array) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Array>#<static-init>_0" -> "bb::<Class:Array>#<static-init>_2" [style="bold"];
     "bb::<Class:Array>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:Array>#<static-init>_1" -> "bb::<Class:Array>#<static-init>_1" [style="bold"];
     "bb::<Class:Array>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Array), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Array))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -288,12 +301,14 @@ subgraph "cluster_::<Class:Array>#<static-init>" {
     "bb::<Class:Array>#<static-init>_2" -> "bb::<Class:Array>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:Array>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Array))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(Array) = <selfRestore>$8\l<cfgAlias>$20: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$22: T.class_of(T) = alias <C T>\l<statTemp>$17: T.class_of(Array) = <self>: T.class_of(Array).extend(<cfgAlias>$20: T.class_of(T::Sig))\l<cfgAlias>$25: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$27: Symbol(:returns_self) = :returns_self\l<statTemp>$28: Symbol(:normal) = :normal\l<statTemp>$23: Symbol(:returns_self) = <cfgAlias>$25: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Array), <statTemp>$27: Symbol(:returns_self), <statTemp>$28: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Array>#<static-init>_3" -> "bb::<Class:Array>#<static-init>_1" [style="bold"];
     "bb::<Class:Array>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Array), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Array))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<cfgAlias>$15: T.class_of(T) = alias <C T>\l<statTemp>$13: T.untyped = <cfgAlias>$15: T.class_of(T).self_type()\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$13: T.untyped)\l<blockReturnTemp>$16: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
@@ -304,16 +319,16 @@ subgraph "cluster_::<Class:Array>#<static-init>" {
 subgraph "cluster_::<Class:A>#<static-init>" {
     label = "::<Class:A>#<static-init>";
     color = blue;
-    "bb::<Class:A>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
     "bb::<Class:A>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -324,16 +339,16 @@ subgraph "cluster_::<Class:A>#<static-init>" {
 subgraph "cluster_::B#returns_self" {
     label = "::B#returns_self";
     color = blue;
-    "bb::B#returns_self_0" [shape = invhouse];
-    "bb::B#returns_self_1" [shape = parallelogram];
 
     "bb::B#returns_self_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: B = cast(<self>: NilClass, B);\l<returnMethodTemp>$2: B = <self>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: B\l<unconditional>\l"
     ];
 
     "bb::B#returns_self_0" -> "bb::B#returns_self_1" [style="bold"];
     "bb::B#returns_self_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -344,22 +359,23 @@ subgraph "cluster_::B#returns_self" {
 subgraph "cluster_::<Class:B>#<static-init>" {
     label = "::<Class:B>#<static-init>";
     color = blue;
-    "bb::<Class:B>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:B>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:B>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(B) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U B>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U B>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(B))\l<selfRestore>$8: T.class_of(B) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_0" -> "bb::<Class:B>#<static-init>_2" [style="bold"];
     "bb::<Class:B>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_1" -> "bb::<Class:B>#<static-init>_1" [style="bold"];
     "bb::<Class:B>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -368,12 +384,14 @@ subgraph "cluster_::<Class:B>#<static-init>" {
     "bb::<Class:B>#<static-init>_2" -> "bb::<Class:B>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:B>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(B) = <selfRestore>$8\l<cfgAlias>$20: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$22: T.class_of(T) = alias <C T>\l<statTemp>$17: T.class_of(B) = <self>: T.class_of(B).extend(<cfgAlias>$20: T.class_of(T::Sig))\l<cfgAlias>$25: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$27: Symbol(:returns_self) = :returns_self\l<statTemp>$28: Symbol(:normal) = :normal\l<statTemp>$23: Symbol(:returns_self) = <cfgAlias>$25: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(B), <statTemp>$27: Symbol(:returns_self), <statTemp>$28: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:B>#<static-init>_3" -> "bb::<Class:B>#<static-init>_1" [style="bold"];
     "bb::<Class:B>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<cfgAlias>$15: T.class_of(T) = alias <C T>\l<statTemp>$13: T.untyped = <cfgAlias>$15: T.class_of(T).self_type()\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$13: T.untyped)\l<blockReturnTemp>$16: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];

--- a/test/testdata/infer/sigil.rb.cfg.exp
+++ b/test/testdata/infer/sigil.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "sigil.rb" {
 subgraph "cluster_::Object#foo" {
     label = "::Object#foo";
     color = blue;
-    "bb::Object#foo_0" [shape = invhouse];
-    "bb::Object#foo_1" [shape = parallelogram];
 
     "bb::Object#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Object = cast(<self>: NilClass, Object);\l<statTemp>$3: String(\"3\") = \"3\"\l<statTemp>$4: Integer(3) = 3\l<returnMethodTemp>$2: String = <statTemp>$3: String(\"3\").+(<statTemp>$4: Integer(3))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: String\l<unconditional>\l"
     ];
 
     "bb::Object#foo_0" -> "bb::Object#foo_1" [style="bold"];
     "bb::Object#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::Object#foo" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:foo) = :foo\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:foo) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(<root>), <statTemp>$6: Symbol(:foo), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/singleton_methods.rb.cfg.exp
+++ b/test/testdata/infer/singleton_methods.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "singleton_methods.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(Foo) = alias <C Foo>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(Foo))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(Foo) = alias <C Foo>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(Foo))\l<cfgAlias>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$19: T.class_of(Bar) = alias <C Bar>\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$19: T.class_of(Bar))\l<cfgAlias>$22: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$24: T.class_of(Bar) = alias <C Bar>\l<statTemp>$20: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$24: T.class_of(Bar))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::<Class:Foo>#bar" {
     label = "::<Class:Foo>#bar";
     color = blue;
-    "bb::<Class:Foo>#bar_0" [shape = invhouse];
-    "bb::<Class:Foo>#bar_1" [shape = parallelogram];
 
     "bb::<Class:Foo>#bar_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Foo) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Foo>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: Integer(1) = 1\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::<Class:Foo>#bar_0" -> "bb::<Class:Foo>#bar_1" [style="bold"];
     "bb::<Class:Foo>#bar_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::<Class:Foo>#bar" {
 subgraph "cluster_::<Class:Foo>#<static-init>" {
     label = "::<Class:Foo>#<static-init>";
     color = blue;
-    "bb::<Class:Foo>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Foo>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Foo>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Foo) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Foo>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:bar) = :bar\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:bar) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(Foo), <statTemp>$6: Symbol(:bar), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:bar)\l<unconditional>\l"
     ];
 
     "bb::<Class:Foo>#<static-init>_0" -> "bb::<Class:Foo>#<static-init>_1" [style="bold"];
     "bb::<Class:Foo>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::<Class:Foo>#<static-init>" {
 subgraph "cluster_::Bar#baz" {
     label = "::Bar#baz";
     color = blue;
-    "bb::Bar#baz_0" [shape = invhouse];
-    "bb::Bar#baz_1" [shape = parallelogram];
 
     "bb::Bar#baz_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Bar = cast(<self>: NilClass, Bar);\l<cfgAlias>$4: T.class_of(Foo) = alias <C Foo>\l<returnMethodTemp>$2: T.untyped = <cfgAlias>$4: T.class_of(Foo).bar()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Bar#baz_0" -> "bb::Bar#baz_1" [style="bold"];
     "bb::Bar#baz_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,16 +82,16 @@ subgraph "cluster_::Bar#baz" {
 subgraph "cluster_::<Class:Bar>#<static-init>" {
     label = "::<Class:Bar>#<static-init>";
     color = blue;
-    "bb::<Class:Bar>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Bar>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Bar>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Bar) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Bar>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Bar>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:baz) = :baz\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:baz) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Bar), <statTemp>$6: Symbol(:baz), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:baz)\l<unconditional>\l"
     ];
 
     "bb::<Class:Bar>#<static-init>_0" -> "bb::<Class:Bar>#<static-init>_1" [style="bold"];
     "bb::<Class:Bar>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/singleton_of_singleton.rb.cfg.exp
+++ b/test/testdata/infer/singleton_of_singleton.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "singleton_of_singleton.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$7: T.class_of(A) = alias <C A>\l<statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$7: T.class_of(A))\l<cfgAlias>$10: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$12: T.class_of(A) = alias <C A>\l<statTemp>$8: Sorbet::Private::Static::Void = <cfgAlias>$10: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$12: T.class_of(A))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::<Class:A>#foo" {
     label = "::<Class:A>#foo";
     color = blue;
-    "bb::<Class:A>#foo_0" [shape = invhouse];
-    "bb::<Class:A>#foo_1" [shape = parallelogram];
 
     "bb::<Class:A>#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:bar) = :bar\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:bar) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(A), <statTemp>$6: Symbol(:bar), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:bar)\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#foo_0" -> "bb::<Class:A>#foo_1" [style="bold"];
     "bb::<Class:A>#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::<Class:A>#foo" {
 subgraph "cluster_::<Class:A>#bar" {
     label = "::<Class:A>#bar";
     color = blue;
-    "bb::<Class:A>#bar_0" [shape = invhouse];
-    "bb::<Class:A>#bar_1" [shape = parallelogram];
 
     "bb::<Class:A>#bar_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<returnMethodTemp>$2: T.class_of(A) = <self>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.class_of(A)\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#bar_0" -> "bb::<Class:A>#bar_1" [style="bold"];
     "bb::<Class:A>#bar_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::<Class:A>#bar" {
 subgraph "cluster_::<Class:A>#<static-init>" {
     label = "::<Class:A>#<static-init>";
     color = blue;
-    "bb::<Class:A>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:foo) = :foo\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:foo) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(A), <statTemp>$6: Symbol(:foo), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
     "bb::<Class:A>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/infer/transitive.rb.cfg.exp
+++ b/test/testdata/infer/transitive.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "transitive.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(A) = alias <C A>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(A))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(A) = alias <C A>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(A))\l<cfgAlias>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$19: T.class_of(Bar) = alias <C Bar>\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$19: T.class_of(Bar))\l<cfgAlias>$22: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$24: T.class_of(Bar) = alias <C Bar>\l<statTemp>$20: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$24: T.class_of(Bar))\l<cfgAlias>$27: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$29: T.class_of(A) = alias <C A>\l<statTemp>$25: Sorbet::Private::Static::Void = <cfgAlias>$27: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$29: T.class_of(A))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::A#foo" {
     label = "::A#foo";
     color = blue;
-    "bb::A#foo_0" [shape = invhouse];
-    "bb::A#foo_1" [shape = parallelogram];
 
     "bb::A#foo_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: A = cast(<self>: NilClass, A);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::A#foo_0" -> "bb::A#foo_1" [style="bold"];
     "bb::A#foo_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,22 +42,23 @@ subgraph "cluster_::A#foo" {
 subgraph "cluster_::<Class:A>#<static-init>" {
     label = "::<Class:A>#<static-init>";
     color = blue;
-    "bb::<Class:A>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:A>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:A>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(A) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U A>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U A>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(A))\l<selfRestore>$8: T.class_of(A) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_0" -> "bb::<Class:A>#<static-init>_2" [style="bold"];
     "bb::<Class:A>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_1" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
     "bb::<Class:A>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -66,12 +67,14 @@ subgraph "cluster_::<Class:A>#<static-init>" {
     "bb::<Class:A>#<static-init>_2" -> "bb::<Class:A>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:A>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(A) = <selfRestore>$8\l<cfgAlias>$19: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$21: T.class_of(T) = alias <C T>\l<statTemp>$16: T.class_of(A) = <self>: T.class_of(A).extend(<cfgAlias>$19: T.class_of(T::Sig))\l<cfgAlias>$24: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$26: Symbol(:foo) = :foo\l<statTemp>$27: Symbol(:normal) = :normal\l<statTemp>$22: Symbol(:foo) = <cfgAlias>$24: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(A), <statTemp>$26: Symbol(:foo), <statTemp>$27: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:A>#<static-init>_3" -> "bb::<Class:A>#<static-init>_1" [style="bold"];
     "bb::<Class:A>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<cfgAlias>$14: T.class_of(Integer) = alias <C Integer>\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$14: T.class_of(Integer))\l<blockReturnTemp>$15: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
@@ -82,16 +85,16 @@ subgraph "cluster_::<Class:A>#<static-init>" {
 subgraph "cluster_::Bar#baz" {
     label = "::Bar#baz";
     color = blue;
-    "bb::Bar#baz_0" [shape = invhouse];
-    "bb::Bar#baz_1" [shape = parallelogram];
 
     "bb::Bar#baz_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Bar = cast(<self>: NilClass, Bar);\l<returnMethodTemp>$2: Integer = <self>: Bar.foo()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
     ];
 
     "bb::Bar#baz_0" -> "bb::Bar#baz_1" [style="bold"];
     "bb::Bar#baz_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -102,22 +105,23 @@ subgraph "cluster_::Bar#baz" {
 subgraph "cluster_::<Class:Bar>#<static-init>" {
     label = "::<Class:Bar>#<static-init>";
     color = blue;
-    "bb::<Class:Bar>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Bar>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Bar>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Bar) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Bar>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Bar>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Bar))\l<selfRestore>$8: T.class_of(Bar) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Bar>#<static-init>_0" -> "bb::<Class:Bar>#<static-init>_2" [style="bold"];
     "bb::<Class:Bar>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:Bar>#<static-init>_1" -> "bb::<Class:Bar>#<static-init>_1" [style="bold"];
     "bb::<Class:Bar>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Bar), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Bar))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -126,12 +130,14 @@ subgraph "cluster_::<Class:Bar>#<static-init>" {
     "bb::<Class:Bar>#<static-init>_2" -> "bb::<Class:Bar>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:Bar>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Bar))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(Bar) = <selfRestore>$8\l<cfgAlias>$23: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$25: T.class_of(T) = alias <C T>\l<statTemp>$20: T.class_of(Bar) = <self>: T.class_of(Bar).extend(<cfgAlias>$23: T.class_of(T::Sig))\l<cfgAlias>$28: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$30: Symbol(:baz) = :baz\l<statTemp>$31: Symbol(:normal) = :normal\l<statTemp>$26: Symbol(:baz) = <cfgAlias>$28: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Bar), <statTemp>$30: Symbol(:baz), <statTemp>$31: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Bar>#<static-init>_3" -> "bb::<Class:Bar>#<static-init>_1" [style="bold"];
     "bb::<Class:Bar>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Bar), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Bar))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$14: Symbol(:arg) = :arg\l<cfgAlias>$16: T.class_of(Integer) = alias <C Integer>\l<statTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$14: Symbol(:arg), <cfgAlias>$16: T.class_of(Integer))\l<cfgAlias>$18: T.class_of(Integer) = alias <C Integer>\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <statTemp>$12: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$18: T.class_of(Integer))\l<blockReturnTemp>$19: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];

--- a/test/testdata/infer/zsuper.rb.cfg.exp
+++ b/test/testdata/infer/zsuper.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "zsuper.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(Foo) = alias <C Foo>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(Foo))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(Foo) = alias <C Foo>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(Foo))\l<cfgAlias>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$19: T.class_of(Bar) = alias <C Bar>\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$19: T.class_of(Bar))\l<cfgAlias>$22: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$24: T.class_of(Bar) = alias <C Bar>\l<statTemp>$20: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$24: T.class_of(Bar))\l<cfgAlias>$27: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$29: T.class_of(Foo) = alias <C Foo>\l<statTemp>$25: Sorbet::Private::Static::Void = <cfgAlias>$27: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$29: T.class_of(Foo))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::Foo#baz" {
     label = "::Foo#baz";
     color = blue;
-    "bb::Foo#baz_0" [shape = invhouse];
-    "bb::Foo#baz_1" [shape = parallelogram];
 
     "bb::Foo#baz_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Foo = cast(<self>: NilClass, Foo);\la: T.untyped = load_arg(a)\l<returnMethodTemp>$2: NilClass = <self>: Foo.puts(a: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::Foo#baz_0" -> "bb::Foo#baz_1" [style="bold"];
     "bb::Foo#baz_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::Foo#baz" {
 subgraph "cluster_::<Class:Foo>#<static-init>" {
     label = "::<Class:Foo>#<static-init>";
     color = blue;
-    "bb::<Class:Foo>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Foo>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Foo>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Foo) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Foo>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:baz) = :baz\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:baz) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Foo), <statTemp>$6: Symbol(:baz), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:baz)\l<unconditional>\l"
     ];
 
     "bb::<Class:Foo>#<static-init>_0" -> "bb::<Class:Foo>#<static-init>_1" [style="bold"];
     "bb::<Class:Foo>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,22 +62,23 @@ subgraph "cluster_::<Class:Foo>#<static-init>" {
 subgraph "cluster_::Bar#baz" {
     label = "::Bar#baz";
     color = blue;
-    "bb::Bar#baz_0" [shape = invhouse];
-    "bb::Bar#baz_1" [shape = parallelogram];
 
     "bb::Bar#baz_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Bar = cast(<self>: NilClass, Bar);\lb: T.untyped = load_arg(b)\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: Bar.super(b: T.untyped)\l<selfRestore>$6: Bar = <self>\l<unconditional>\l"
     ];
 
     "bb::Bar#baz_0" -> "bb::Bar#baz_2" [style="bold"];
     "bb::Bar#baz_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Bar#baz_1" -> "bb::Bar#baz_1" [style="bold"];
     "bb::Bar#baz_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -86,12 +87,14 @@ subgraph "cluster_::Bar#baz" {
     "bb::Bar#baz_2" -> "bb::Bar#baz_3" [style="tapered"];
 
     "bb::Bar#baz_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar)\l<returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$5, super>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Bar#baz_3" -> "bb::Bar#baz_1" [style="bold"];
     "bb::Bar#baz_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar)\louterLoops: 1\l<self>: Bar = loadSelf\l<blk>$7: T.untyped = load_yield_params(super)\l<blk>$8: Integer(0) = 0\la$1: T.untyped = <blk>$7: T.untyped.[](<blk>$8: Integer(0))\l<blockReturnTemp>$9: NilClass = <self>: Bar.puts(a$1: T.untyped)\l<blockReturnTemp>$12: T.noreturn = blockreturn<super> <blockReturnTemp>$9: NilClass\l<unconditional>\l"
     ];
@@ -102,16 +105,16 @@ subgraph "cluster_::Bar#baz" {
 subgraph "cluster_::<Class:Bar>#<static-init>" {
     label = "::<Class:Bar>#<static-init>";
     color = blue;
-    "bb::<Class:Bar>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Bar>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Bar>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Bar) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Bar>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Bar>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:baz) = :baz\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:baz) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Bar), <statTemp>$6: Symbol(:baz), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:baz)\l<unconditional>\l"
     ];
 
     "bb::<Class:Bar>#<static-init>_0" -> "bb::<Class:Bar>#<static-init>_1" [style="bold"];
     "bb::<Class:Bar>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/namer/module_function.rb.cfg.exp
+++ b/test/testdata/namer/module_function.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "module_function.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(Funcs) = alias <C Funcs>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(Funcs))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(Funcs) = alias <C Funcs>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(Funcs))\l<cfgAlias>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$19: T.class_of(C) = alias <C C>\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$19: T.class_of(C))\l<cfgAlias>$22: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$24: T.class_of(C) = alias <C C>\l<statTemp>$20: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$24: T.class_of(C))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::Funcs#f" {
     label = "::Funcs#f";
     color = blue;
-    "bb::Funcs#f_0" [shape = invhouse];
-    "bb::Funcs#f_1" [shape = parallelogram];
 
     "bb::Funcs#f_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Funcs = cast(<self>: NilClass, Funcs);\lx: Integer = load_arg(x)\l<returnMethodTemp>$2: Integer = x\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer\l<unconditional>\l"
     ];
 
     "bb::Funcs#f_0" -> "bb::Funcs#f_1" [style="bold"];
     "bb::Funcs#f_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::Funcs#f" {
 subgraph "cluster_::<Class:Funcs>#f" {
     label = "::<Class:Funcs>#f";
     color = blue;
-    "bb::<Class:Funcs>#f_0" [shape = invhouse];
-    "bb::<Class:Funcs>#f_1" [shape = parallelogram];
 
     "bb::<Class:Funcs>#f_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Funcs) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Funcs>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Funcs>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#f_0" -> "bb::<Class:Funcs>#f_1" [style="bold"];
     "bb::<Class:Funcs>#f_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::<Class:Funcs>#f" {
 subgraph "cluster_::Funcs#g" {
     label = "::Funcs#g";
     color = blue;
-    "bb::Funcs#g_0" [shape = invhouse];
-    "bb::Funcs#g_1" [shape = parallelogram];
 
     "bb::Funcs#g_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Funcs = cast(<self>: NilClass, Funcs);\ls: Symbol = load_arg(s)\l<returnMethodTemp>$2: Symbol = s\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol\l<unconditional>\l"
     ];
 
     "bb::Funcs#g_0" -> "bb::Funcs#g_1" [style="bold"];
     "bb::Funcs#g_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,16 +82,16 @@ subgraph "cluster_::Funcs#g" {
 subgraph "cluster_::<Class:Funcs>#g" {
     label = "::<Class:Funcs>#g";
     color = blue;
-    "bb::<Class:Funcs>#g_0" [shape = invhouse];
-    "bb::<Class:Funcs>#g_1" [shape = parallelogram];
 
     "bb::<Class:Funcs>#g_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Funcs) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Funcs>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Funcs>> $1><C <U <AttachedClass>>>)\l  ]\l});\ls: Symbol = load_arg(s)\l<returnMethodTemp>$2: Symbol = s\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#g_0" -> "bb::<Class:Funcs>#g_1" [style="bold"];
     "bb::<Class:Funcs>#g_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -102,16 +102,16 @@ subgraph "cluster_::<Class:Funcs>#g" {
 subgraph "cluster_::Funcs#h" {
     label = "::Funcs#h";
     color = blue;
-    "bb::Funcs#h_0" [shape = invhouse];
-    "bb::Funcs#h_1" [shape = parallelogram];
 
     "bb::Funcs#h_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Funcs = cast(<self>: NilClass, Funcs);\ls: String = load_arg(s)\l<returnMethodTemp>$2: String = s\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: String\l<unconditional>\l"
     ];
 
     "bb::Funcs#h_0" -> "bb::Funcs#h_1" [style="bold"];
     "bb::Funcs#h_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -122,16 +122,16 @@ subgraph "cluster_::Funcs#h" {
 subgraph "cluster_::<Class:Funcs>#h" {
     label = "::<Class:Funcs>#h";
     color = blue;
-    "bb::<Class:Funcs>#h_0" [shape = invhouse];
-    "bb::<Class:Funcs>#h_1" [shape = parallelogram];
 
     "bb::<Class:Funcs>#h_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Funcs) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Funcs>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Funcs>> $1><C <U <AttachedClass>>>)\l  ]\l});\ls: String = load_arg(s)\l<returnMethodTemp>$2: String = s\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: String\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#h_0" -> "bb::<Class:Funcs>#h_1" [style="bold"];
     "bb::<Class:Funcs>#h_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -142,22 +142,23 @@ subgraph "cluster_::<Class:Funcs>#h" {
 subgraph "cluster_::<Class:Funcs>#<static-init>" {
     label = "::<Class:Funcs>#<static-init>";
     color = blue;
-    "bb::<Class:Funcs>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Funcs>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Funcs>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Funcs) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Funcs>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Funcs>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Funcs))\l<selfRestore>$8: T.class_of(Funcs) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_0" -> "bb::<Class:Funcs>#<static-init>_2" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_1" -> "bb::<Class:Funcs>#<static-init>_1" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(Funcs), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Funcs))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -166,18 +167,21 @@ subgraph "cluster_::<Class:Funcs>#<static-init>" {
     "bb::<Class:Funcs>#<static-init>_2" -> "bb::<Class:Funcs>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:Funcs>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Funcs))\l<statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$8\l<cfgAlias>$22: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$24: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Funcs))\l<selfRestore>$25: T.class_of(Funcs) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_3" -> "bb::<Class:Funcs>#<static-init>_6" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(Funcs), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Funcs))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$14: Symbol(:x) = :x\l<cfgAlias>$16: T.class_of(Integer) = alias <C Integer>\l<statTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$14: Symbol(:x), <cfgAlias>$16: T.class_of(Integer))\l<cfgAlias>$18: T.class_of(Integer) = alias <C Integer>\l<blockReturnTemp>$11: T::Private::Methods::DeclBuilder = <statTemp>$12: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$18: T.class_of(Integer))\l<blockReturnTemp>$19: T.noreturn = blockreturn<sig> <blockReturnTemp>$11: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_5" -> "bb::<Class:Funcs>#<static-init>_2" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_6" [
+        shape = rectangle;
         color = black;
         label = "block[id=6, rubyBlockId=2](<self>: T.class_of(Funcs), <block-pre-call-temp>$24: Sorbet::Private::Static::Void, <selfRestore>$25: T.class_of(Funcs))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -186,18 +190,21 @@ subgraph "cluster_::<Class:Funcs>#<static-init>" {
     "bb::<Class:Funcs>#<static-init>_6" -> "bb::<Class:Funcs>#<static-init>_7" [style="tapered"];
 
     "bb::<Class:Funcs>#<static-init>_7" [
+        shape = rectangle;
         color = black;
         label = "block[id=7, rubyBlockId=0](<block-pre-call-temp>$24: Sorbet::Private::Static::Void, <selfRestore>$25: T.class_of(Funcs))\l<statTemp>$20: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$24, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$25\l<cfgAlias>$39: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$41: Sorbet::Private::Static::Void = <cfgAlias>$39: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Funcs))\l<selfRestore>$42: T.class_of(Funcs) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_7" -> "bb::<Class:Funcs>#<static-init>_10" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_9" [
+        shape = rectangle;
         color = black;
         label = "block[id=9, rubyBlockId=2](<self>: T.class_of(Funcs), <block-pre-call-temp>$24: Sorbet::Private::Static::Void, <selfRestore>$25: T.class_of(Funcs))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$31: Symbol(:s) = :s\l<cfgAlias>$33: T.class_of(Symbol) = alias <C Symbol>\l<statTemp>$29: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$31: Symbol(:s), <cfgAlias>$33: T.class_of(Symbol))\l<cfgAlias>$35: T.class_of(Symbol) = alias <C Symbol>\l<blockReturnTemp>$28: T::Private::Methods::DeclBuilder = <statTemp>$29: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$35: T.class_of(Symbol))\l<blockReturnTemp>$36: T.noreturn = blockreturn<sig> <blockReturnTemp>$28: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_9" -> "bb::<Class:Funcs>#<static-init>_6" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_10" [
+        shape = rectangle;
         color = black;
         label = "block[id=10, rubyBlockId=3](<self>: T.class_of(Funcs), <block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(Funcs))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -206,18 +213,21 @@ subgraph "cluster_::<Class:Funcs>#<static-init>" {
     "bb::<Class:Funcs>#<static-init>_10" -> "bb::<Class:Funcs>#<static-init>_11" [style="tapered"];
 
     "bb::<Class:Funcs>#<static-init>_11" [
+        shape = rectangle;
         color = black;
         label = "block[id=11, rubyBlockId=0](<block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(Funcs))\l<statTemp>$37: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$41, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$42\l<cfgAlias>$56: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$58: Sorbet::Private::Static::Void = <cfgAlias>$56: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Funcs))\l<selfRestore>$59: T.class_of(Funcs) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_11" -> "bb::<Class:Funcs>#<static-init>_14" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_13" [
+        shape = rectangle;
         color = black;
         label = "block[id=13, rubyBlockId=3](<self>: T.class_of(Funcs), <block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(Funcs))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$48: Symbol(:s) = :s\l<cfgAlias>$50: T.class_of(Symbol) = alias <C Symbol>\l<statTemp>$46: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$48: Symbol(:s), <cfgAlias>$50: T.class_of(Symbol))\l<cfgAlias>$52: T.class_of(Symbol) = alias <C Symbol>\l<blockReturnTemp>$45: T::Private::Methods::DeclBuilder = <statTemp>$46: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$52: T.class_of(Symbol))\l<blockReturnTemp>$53: T.noreturn = blockreturn<sig> <blockReturnTemp>$45: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_13" -> "bb::<Class:Funcs>#<static-init>_10" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_14" [
+        shape = rectangle;
         color = black;
         label = "block[id=14, rubyBlockId=4](<self>: T.class_of(Funcs), <block-pre-call-temp>$58: Sorbet::Private::Static::Void, <selfRestore>$59: T.class_of(Funcs))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -226,18 +236,21 @@ subgraph "cluster_::<Class:Funcs>#<static-init>" {
     "bb::<Class:Funcs>#<static-init>_14" -> "bb::<Class:Funcs>#<static-init>_15" [style="tapered"];
 
     "bb::<Class:Funcs>#<static-init>_15" [
+        shape = rectangle;
         color = black;
         label = "block[id=15, rubyBlockId=0](<block-pre-call-temp>$58: Sorbet::Private::Static::Void, <selfRestore>$59: T.class_of(Funcs))\l<statTemp>$54: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$58, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$59\l<cfgAlias>$73: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<block-pre-call-temp>$75: Sorbet::Private::Static::Void = <cfgAlias>$73: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Funcs))\l<selfRestore>$76: T.class_of(Funcs) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_15" -> "bb::<Class:Funcs>#<static-init>_18" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_17" [
+        shape = rectangle;
         color = black;
         label = "block[id=17, rubyBlockId=4](<self>: T.class_of(Funcs), <block-pre-call-temp>$58: Sorbet::Private::Static::Void, <selfRestore>$59: T.class_of(Funcs))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$65: Symbol(:s) = :s\l<cfgAlias>$67: T.class_of(String) = alias <C String>\l<statTemp>$63: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$65: Symbol(:s), <cfgAlias>$67: T.class_of(String))\l<cfgAlias>$69: T.class_of(String) = alias <C String>\l<blockReturnTemp>$62: T::Private::Methods::DeclBuilder = <statTemp>$63: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$69: T.class_of(String))\l<blockReturnTemp>$70: T.noreturn = blockreturn<sig> <blockReturnTemp>$62: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_17" -> "bb::<Class:Funcs>#<static-init>_14" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_18" [
+        shape = rectangle;
         color = black;
         label = "block[id=18, rubyBlockId=5](<self>: T.class_of(Funcs), <block-pre-call-temp>$75: Sorbet::Private::Static::Void, <selfRestore>$76: T.class_of(Funcs))\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -246,12 +259,14 @@ subgraph "cluster_::<Class:Funcs>#<static-init>" {
     "bb::<Class:Funcs>#<static-init>_18" -> "bb::<Class:Funcs>#<static-init>_19" [style="tapered"];
 
     "bb::<Class:Funcs>#<static-init>_19" [
+        shape = rectangle;
         color = black;
         label = "block[id=19, rubyBlockId=0](<block-pre-call-temp>$75: Sorbet::Private::Static::Void, <selfRestore>$76: T.class_of(Funcs))\l<statTemp>$71: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$75, sig>\l<self>: T.class_of(Funcs) = <selfRestore>$76\l<cfgAlias>$91: T.class_of(T::Sig) = alias <C Sig>\l<cfgAlias>$93: T.class_of(T) = alias <C T>\l<statTemp>$88: T.class_of(Funcs) = <self>: T.class_of(Funcs).extend(<cfgAlias>$91: T.class_of(T::Sig))\l<cfgAlias>$96: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$98: Symbol(:f) = :f\l<statTemp>$99: Symbol(:normal) = :normal\l<statTemp>$94: Symbol(:f) = <cfgAlias>$96: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Funcs), <statTemp>$98: Symbol(:f), <statTemp>$99: Symbol(:normal))\l<statTemp>$102: Symbol(:f) = :f\l<statTemp>$100: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$102: Symbol(:f))\l<cfgAlias>$105: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$107: Symbol(:f) = :f\l<statTemp>$108: Symbol(:normal) = :normal\l<statTemp>$103: Symbol(:f) = <cfgAlias>$105: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(Funcs), <statTemp>$107: Symbol(:f), <statTemp>$108: Symbol(:normal))\l<cfgAlias>$113: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$115: Symbol(:g) = :g\l<statTemp>$116: Symbol(:normal) = :normal\l<statTemp>$111: Symbol(:g) = <cfgAlias>$113: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Funcs), <statTemp>$115: Symbol(:g), <statTemp>$116: Symbol(:normal))\l<statTemp>$109: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$111: Symbol(:g))\l<cfgAlias>$119: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$121: Symbol(:g) = :g\l<statTemp>$122: Symbol(:normal) = :normal\l<statTemp>$117: Symbol(:g) = <cfgAlias>$119: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(Funcs), <statTemp>$121: Symbol(:g), <statTemp>$122: Symbol(:normal))\l<cfgAlias>$127: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$129: Symbol(:h) = :h\l<statTemp>$130: Symbol(:normal) = :normal\l<statTemp>$125: Symbol(:h) = <cfgAlias>$127: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Funcs), <statTemp>$129: Symbol(:h), <statTemp>$130: Symbol(:normal))\l<statTemp>$123: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$125: Symbol(:h))\l<cfgAlias>$133: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$135: Symbol(:h) = :h\l<statTemp>$136: Symbol(:normal) = :normal\l<statTemp>$131: Symbol(:h) = <cfgAlias>$133: T.class_of(Sorbet::Private::Static).keep_self_def(<self>: T.class_of(Funcs), <statTemp>$135: Symbol(:h), <statTemp>$136: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Funcs>#<static-init>_19" -> "bb::<Class:Funcs>#<static-init>_1" [style="bold"];
     "bb::<Class:Funcs>#<static-init>_21" [
+        shape = rectangle;
         color = black;
         label = "block[id=21, rubyBlockId=5](<self>: T.class_of(Funcs), <block-pre-call-temp>$75: Sorbet::Private::Static::Void, <selfRestore>$76: T.class_of(Funcs))\louterLoops: 1\l<self>: T::Private::Methods::DeclBuilder = loadSelf\l<hashTemp>$82: Symbol(:s) = :s\l<cfgAlias>$84: T.class_of(String) = alias <C String>\l<statTemp>$80: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$82: Symbol(:s), <cfgAlias>$84: T.class_of(String))\l<cfgAlias>$86: T.class_of(String) = alias <C String>\l<blockReturnTemp>$79: T::Private::Methods::DeclBuilder = <statTemp>$80: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$86: T.class_of(String))\l<blockReturnTemp>$87: T.noreturn = blockreturn<sig> <blockReturnTemp>$79: T::Private::Methods::DeclBuilder\l<unconditional>\l"
     ];
@@ -262,16 +277,16 @@ subgraph "cluster_::<Class:Funcs>#<static-init>" {
 subgraph "cluster_::C#test_calls" {
     label = "::C#test_calls";
     color = blue;
-    "bb::C#test_calls_0" [shape = invhouse];
-    "bb::C#test_calls_1" [shape = parallelogram];
 
     "bb::C#test_calls_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: C = cast(<self>: NilClass, C);\l<statTemp>$5: Integer(0) = 0\l<statTemp>$3: Integer = <self>: C.f(<statTemp>$5: Integer(0))\l<cfgAlias>$8: T.class_of(Funcs) = alias <C Funcs>\l<statTemp>$9: Integer(0) = 0\l<statTemp>$6: T.untyped = <cfgAlias>$8: T.class_of(Funcs).f(<statTemp>$9: Integer(0))\l<statTemp>$12: Symbol(:f) = :f\l<statTemp>$10: Symbol = <self>: C.g(<statTemp>$12: Symbol(:f))\l<cfgAlias>$15: T.class_of(Funcs) = alias <C Funcs>\l<statTemp>$16: Symbol(:f) = :f\l<statTemp>$13: Symbol = <cfgAlias>$15: T.class_of(Funcs).g(<statTemp>$16: Symbol(:f))\l<statTemp>$19: String(\"hello\") = \"hello\"\l<statTemp>$17: String = <self>: C.h(<statTemp>$19: String(\"hello\"))\l<cfgAlias>$22: T.class_of(Funcs) = alias <C Funcs>\l<statTemp>$23: String(\"world\") = \"world\"\l<statTemp>$20: String = <cfgAlias>$22: T.class_of(Funcs).h(<statTemp>$23: String(\"world\"))\l<cfgAlias>$25: T.class_of(C) = alias <C C>\l<returnMethodTemp>$2: T.untyped = <cfgAlias>$25: T.class_of(C).f()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::C#test_calls_0" -> "bb::C#test_calls_1" [style="bold"];
     "bb::C#test_calls_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -282,16 +297,16 @@ subgraph "cluster_::C#test_calls" {
 subgraph "cluster_::<Class:C>#<static-init>" {
     label = "::<Class:C>#<static-init>";
     color = blue;
-    "bb::<Class:C>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:C>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:C>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(C) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U C>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U C>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(Funcs) = alias <C Funcs>\l<statTemp>$3: T.class_of(C) = <self>: T.class_of(C).include(<cfgAlias>$6: T.class_of(Funcs))\l<cfgAlias>$9: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$11: Symbol(:test_calls) = :test_calls\l<statTemp>$12: Symbol(:normal) = :normal\l<statTemp>$7: Symbol(:test_calls) = <cfgAlias>$9: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(C), <statTemp>$11: Symbol(:test_calls), <statTemp>$12: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:C>#<static-init>_0" -> "bb::<Class:C>#<static-init>_1" [style="bold"];
     "bb::<Class:C>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/namer/redefines_object.rb.cfg.exp
+++ b/test/testdata/namer/redefines_object.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "redefines_object.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(Object) = alias <C Object>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(Object))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(Object) = alias <C Object>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(Object))\l<cfgAlias>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$19: T.class_of(Trigger) = alias <C Trigger>\l<statTemp>$15: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$19: T.class_of(Trigger))\l<cfgAlias>$22: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$24: T.class_of(Trigger) = alias <C Trigger>\l<statTemp>$20: Sorbet::Private::Static::Void = <cfgAlias>$22: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$24: T.class_of(Trigger))\l<cfgAlias>$28: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$30: T.class_of(Foo) = alias <C Foo>\l<statTemp>$26: Sorbet::Private::Static::Void = <cfgAlias>$28: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$30: T.class_of(Foo))\l<cfgAlias>$33: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$35: T.class_of(Foo) = alias <C Foo>\l<statTemp>$31: Sorbet::Private::Static::Void = <cfgAlias>$33: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$35: T.class_of(Foo))\l<cfgAlias>$38: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$40: T.class_of(Bar) = alias <C Bar>\l<statTemp>$36: Sorbet::Private::Static::Void = <cfgAlias>$38: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$40: T.class_of(Bar))\l<cfgAlias>$44: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$46: T.class_of(Bar) = alias <C Bar>\l<statTemp>$42: Sorbet::Private::Static::Void = <cfgAlias>$44: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$46: T.class_of(Bar))\l<cfgAlias>$49: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$51: T.class_of(Bar) = alias <C Bar>\l<statTemp>$47: Sorbet::Private::Static::Void = <cfgAlias>$49: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$51: T.class_of(Bar))\l<cfgAlias>$54: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$56: T.class_of(Foo) = alias <C Foo>\l<statTemp>$52: Sorbet::Private::Static::Void = <cfgAlias>$54: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$56: T.class_of(Foo))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::<Class:Object>#<static-init>" {
     label = "::<Class:Object>#<static-init>";
     color = blue;
-    "bb::<Class:Object>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Object>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Object>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Object) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Object>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Object>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Object>#<static-init>_0" -> "bb::<Class:Object>#<static-init>_1" [style="bold"];
     "bb::<Class:Object>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::<Class:Object>#<static-init>" {
 subgraph "cluster_::Trigger#trigger" {
     label = "::Trigger#trigger";
     color = blue;
-    "bb::Trigger#trigger_0" [shape = invhouse];
-    "bb::Trigger#trigger_1" [shape = parallelogram];
 
     "bb::Trigger#trigger_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l@__fake_logger$3: T.untyped = alias <C <undeclared-field-stub>> (@__fake_logger)\l<self>: Trigger = cast(<self>: NilClass, Trigger);\l<returnMethodTemp>$2: T.untyped = @__fake_logger$3\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Trigger#trigger_0" -> "bb::Trigger#trigger_1" [style="bold"];
     "bb::Trigger#trigger_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::Trigger#trigger" {
 subgraph "cluster_::<Class:Trigger>#<static-init>" {
     label = "::<Class:Trigger>#<static-init>";
     color = blue;
-    "bb::<Class:Trigger>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Trigger>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Trigger>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Trigger) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Trigger>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Trigger>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$6: Symbol(:trigger) = :trigger\l<statTemp>$7: Symbol(:normal) = :normal\l<returnMethodTemp>$2: Symbol(:trigger) = <cfgAlias>$4: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Trigger), <statTemp>$6: Symbol(:trigger), <statTemp>$7: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:trigger)\l<unconditional>\l"
     ];
 
     "bb::<Class:Trigger>#<static-init>_0" -> "bb::<Class:Trigger>#<static-init>_1" [style="bold"];
     "bb::<Class:Trigger>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,16 +82,16 @@ subgraph "cluster_::<Class:Trigger>#<static-init>" {
 subgraph "cluster_::<Class:Foo>#<static-init>" {
     label = "::<Class:Foo>#<static-init>";
     color = blue;
-    "bb::<Class:Foo>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Foo>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Foo>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Foo) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Foo>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Foo>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Foo>#<static-init>_0" -> "bb::<Class:Foo>#<static-init>_1" [style="bold"];
     "bb::<Class:Foo>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -102,16 +102,16 @@ subgraph "cluster_::<Class:Foo>#<static-init>" {
 subgraph "cluster_::<Class:Bar>#<static-init>" {
     label = "::<Class:Bar>#<static-init>";
     color = blue;
-    "bb::<Class:Bar>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Bar>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Bar>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Bar) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Bar>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Bar>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Bar>#<static-init>_0" -> "bb::<Class:Bar>#<static-init>_1" [style="bold"];
     "bb::<Class:Bar>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/namer/yield.rb.cfg.exp
+++ b/test/testdata/namer/yield.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "yield.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(Main) = alias <C Main>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(Main))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(Main) = alias <C Main>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(Main))\l<cfgAlias>$17: T.class_of(Main) = alias <C Main>\l<statTemp>$15: Main = <cfgAlias>$17: T.class_of(Main).new()\l<statTemp>$14: T.untyped = <statTemp>$15: Main.main()\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,16 +22,16 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::Main#yielder" {
     label = "::Main#yielder";
     color = blue;
-    "bb::Main#yielder_0" [shape = invhouse];
-    "bb::Main#yielder_1" [shape = parallelogram];
 
     "bb::Main#yielder_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Main = cast(<self>: NilClass, Main);\l<blk>: T.untyped = load_arg(<blk>)\l<statTemp>$5: Integer(1) = 1\la: T.untyped = <blk>: T.untyped.call(<statTemp>$5: Integer(1))\l<returnMethodTemp>$2: T.untyped = <blk>: T.untyped.call(a: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Main#yielder_0" -> "bb::Main#yielder_1" [style="bold"];
     "bb::Main#yielder_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -42,16 +42,16 @@ subgraph "cluster_::Main#yielder" {
 subgraph "cluster_::Main#blockpass" {
     label = "::Main#blockpass";
     color = blue;
-    "bb::Main#blockpass_0" [shape = invhouse];
-    "bb::Main#blockpass_1" [shape = parallelogram];
 
     "bb::Main#blockpass_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Main = cast(<self>: NilClass, Main);\lblk: T.untyped = load_arg(blk)\l<statTemp>$5: Integer(1) = 1\la: T.untyped = blk: T.untyped.call(<statTemp>$5: Integer(1))\l<returnMethodTemp>$2: T.untyped = blk: T.untyped.call(a: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Main#blockpass_0" -> "bb::Main#blockpass_1" [style="bold"];
     "bb::Main#blockpass_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -62,16 +62,16 @@ subgraph "cluster_::Main#blockpass" {
 subgraph "cluster_::Main#mixed" {
     label = "::Main#mixed";
     color = blue;
-    "bb::Main#mixed_0" [shape = invhouse];
-    "bb::Main#mixed_1" [shape = parallelogram];
 
     "bb::Main#mixed_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Main = cast(<self>: NilClass, Main);\lblk: T.untyped = load_arg(blk)\l<statTemp>$5: Integer(1) = 1\la: T.untyped = blk: T.untyped.call(<statTemp>$5: Integer(1))\l<returnMethodTemp>$2: T.untyped = blk: T.untyped.call(a: T.untyped)\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Main#mixed_0" -> "bb::Main#mixed_1" [style="bold"];
     "bb::Main#mixed_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,22 +82,23 @@ subgraph "cluster_::Main#mixed" {
 subgraph "cluster_::Main#blockyield" {
     label = "::Main#blockyield";
     color = blue;
-    "bb::Main#blockyield_0" [shape = invhouse];
-    "bb::Main#blockyield_1" [shape = parallelogram];
 
     "bb::Main#blockyield_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Main = cast(<self>: NilClass, Main);\l<blk>: T.untyped = load_arg(<blk>)\l<block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Main.yielder()\l<selfRestore>$5: Main = <self>\l<unconditional>\l"
     ];
 
     "bb::Main#blockyield_0" -> "bb::Main#blockyield_2" [style="bold"];
     "bb::Main#blockyield_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Main#blockyield_1" -> "bb::Main#blockyield_1" [style="bold"];
     "bb::Main#blockyield_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: Main, <blk>: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -106,12 +107,14 @@ subgraph "cluster_::Main#blockyield" {
     "bb::Main#blockyield_2" -> "bb::Main#blockyield_3" [style="tapered"];
 
     "bb::Main#blockyield_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main)\l<returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, yielder>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Main#blockyield_3" -> "bb::Main#blockyield_1" [style="bold"];
     "bb::Main#blockyield_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: Main, <blk>: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main)\louterLoops: 1\l<self>: Main = loadSelf\l<blk>$6: T.untyped = load_yield_params(yielder)\l<blk>$7: Integer(0) = 0\li$1: T.untyped = <blk>$6: T.untyped.[](<blk>$7: Integer(0))\l<blockReturnTemp>$8: T.untyped = <blk>: T.untyped.call(i$1: T.untyped)\l<blockReturnTemp>$11: T.noreturn = blockreturn<yielder> <blockReturnTemp>$8: T.untyped\l<unconditional>\l"
     ];
@@ -122,22 +125,23 @@ subgraph "cluster_::Main#blockyield" {
 subgraph "cluster_::Main#main" {
     label = "::Main#main";
     color = blue;
-    "bb::Main#main_0" [shape = invhouse];
-    "bb::Main#main_1" [shape = parallelogram];
 
     "bb::Main#main_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: Main = cast(<self>: NilClass, Main);\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: Main.lambda()\l<selfRestore>$6: Main = <self>\l<unconditional>\l"
     ];
 
     "bb::Main#main_0" -> "bb::Main#main_2" [style="bold"];
     "bb::Main#main_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::Main#main_1" -> "bb::Main#main_1" [style="bold"];
     "bb::Main#main_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -146,12 +150,14 @@ subgraph "cluster_::Main#main" {
     "bb::Main#main_2" -> "bb::Main#main_3" [style="tapered"];
 
     "bb::Main#main_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main)\ll: T.proc.params(arg0: T.untyped).returns(T.untyped) = Solve<<block-pre-call-temp>$5, lambda>\l<self>: Main = <selfRestore>$6\l<cfgAlias>$16: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$18: Symbol(:yielder) = :yielder\l<statTemp>$14: T.untyped = <cfgAlias>$16: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$18: Symbol(:yielder), l: T.proc.params(arg0: T.untyped).returns(T.untyped))\l<cfgAlias>$22: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$24: Symbol(:blockpass) = :blockpass\l<statTemp>$20: T.untyped = <cfgAlias>$22: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$24: Symbol(:blockpass), l: T.proc.params(arg0: T.untyped).returns(T.untyped))\l<cfgAlias>$28: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$30: Symbol(:mixed) = :mixed\l<statTemp>$26: T.untyped = <cfgAlias>$28: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$30: Symbol(:mixed), l: T.proc.params(arg0: T.untyped).returns(T.untyped))\l<cfgAlias>$33: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$35: Symbol(:blockyield) = :blockyield\l<returnMethodTemp>$2: T.untyped = <cfgAlias>$33: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$35: Symbol(:blockyield), l: T.proc.params(arg0: T.untyped).returns(T.untyped))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Main#main_3" -> "bb::Main#main_1" [style="bold"];
     "bb::Main#main_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main)\louterLoops: 1\l<self>: Main = loadSelf\l<blk>$7: T.untyped = load_yield_params(lambda)\l<blk>$8: Integer(0) = 0\lx$1: T.untyped = <blk>$7: T.untyped.[](<blk>$8: Integer(0))\l<statTemp>$10: NilClass = <self>: Main.puts(x$1: T.untyped)\l<blockReturnTemp>$9: Integer(3) = 3\l<blockReturnTemp>$13: T.noreturn = blockreturn<lambda> <blockReturnTemp>$9: Integer(3)\l<unconditional>\l"
     ];
@@ -162,16 +168,16 @@ subgraph "cluster_::Main#main" {
 subgraph "cluster_::<Class:Main>#<static-init>" {
     label = "::<Class:Main>#<static-init>";
     color = blue;
-    "bb::<Class:Main>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:Main>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:Main>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(Main) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U Main>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U Main>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$7: Symbol(:yielder) = :yielder\l<statTemp>$8: Symbol(:normal) = :normal\l<statTemp>$3: Symbol(:yielder) = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Main), <statTemp>$7: Symbol(:yielder), <statTemp>$8: Symbol(:normal))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$13: Symbol(:blockpass) = :blockpass\l<statTemp>$14: Symbol(:normal) = :normal\l<statTemp>$9: Symbol(:blockpass) = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Main), <statTemp>$13: Symbol(:blockpass), <statTemp>$14: Symbol(:normal))\l<cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$19: Symbol(:mixed) = :mixed\l<statTemp>$20: Symbol(:normal) = :normal\l<statTemp>$15: Symbol(:mixed) = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Main), <statTemp>$19: Symbol(:mixed), <statTemp>$20: Symbol(:normal))\l<cfgAlias>$23: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$25: Symbol(:blockyield) = :blockyield\l<statTemp>$26: Symbol(:normal) = :normal\l<statTemp>$21: Symbol(:blockyield) = <cfgAlias>$23: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Main), <statTemp>$25: Symbol(:blockyield), <statTemp>$26: Symbol(:normal))\l<cfgAlias>$29: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$31: Symbol(:main) = :main\l<statTemp>$32: Symbol(:normal) = :normal\l<statTemp>$27: Symbol(:main) = <cfgAlias>$29: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(Main), <statTemp>$31: Symbol(:main), <statTemp>$32: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:Main>#<static-init>_0" -> "bb::<Class:Main>#<static-init>_1" [style="bold"];
     "bb::<Class:Main>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];

--- a/test/testdata/rewriter/t_enum_snapshot.rb.cfg.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.cfg.exp
@@ -2,16 +2,16 @@ digraph "t_enum_snapshot.rb" {
 subgraph "cluster_::<Class:<root>>#<static-init>" {
     label = "::<Class:<root>>#<static-init>";
     color = blue;
-    "bb::<Class:<root>>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:<root>>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:<root>>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U <root>>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U <root>>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$8: T.class_of(MyEnum) = alias <C MyEnum>\l<statTemp>$4: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$8: T.class_of(MyEnum))\l<cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$13: T.class_of(MyEnum) = alias <C MyEnum>\l<statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$13: T.class_of(MyEnum))\l<cfgAlias>$16: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$18: T.class_of(T::Enum) = alias <C Enum>\l<cfgAlias>$20: T.class_of(T) = alias <C T>\l<statTemp>$14: Sorbet::Private::Static::Void = <cfgAlias>$16: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$18: T.class_of(T::Enum))\l<cfgAlias>$24: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$26: T.class_of(NotAnEnum) = alias <C NotAnEnum>\l<statTemp>$22: Sorbet::Private::Static::Void = <cfgAlias>$24: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$26: T.class_of(NotAnEnum))\l<cfgAlias>$29: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$31: T.class_of(NotAnEnum) = alias <C NotAnEnum>\l<statTemp>$27: Sorbet::Private::Static::Void = <cfgAlias>$29: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$31: T.class_of(NotAnEnum))\l<cfgAlias>$35: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$37: T.class_of(EnumsDoEnum) = alias <C EnumsDoEnum>\l<statTemp>$33: Sorbet::Private::Static::Void = <cfgAlias>$35: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$37: T.class_of(EnumsDoEnum))\l<cfgAlias>$40: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$42: T.class_of(EnumsDoEnum) = alias <C EnumsDoEnum>\l<statTemp>$38: Sorbet::Private::Static::Void = <cfgAlias>$40: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$42: T.class_of(EnumsDoEnum))\l<cfgAlias>$45: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$47: T.class_of(T::Enum) = alias <C Enum>\l<cfgAlias>$49: T.class_of(T) = alias <C T>\l<statTemp>$43: Sorbet::Private::Static::Void = <cfgAlias>$45: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$47: T.class_of(T::Enum))\l<cfgAlias>$53: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$55: T.class_of(BadConsts) = alias <C BadConsts>\l<statTemp>$51: Sorbet::Private::Static::Void = <cfgAlias>$53: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$55: T.class_of(BadConsts))\l<cfgAlias>$58: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$60: T.class_of(BadConsts) = alias <C BadConsts>\l<statTemp>$56: Sorbet::Private::Static::Void = <cfgAlias>$58: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$60: T.class_of(BadConsts))\l<cfgAlias>$63: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$65: T.class_of(T::Enum) = alias <C Enum>\l<cfgAlias>$67: T.class_of(T) = alias <C T>\l<statTemp>$61: Sorbet::Private::Static::Void = <cfgAlias>$63: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$65: T.class_of(T::Enum))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -22,22 +22,23 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 subgraph "cluster_::<Class:MyEnum>#<static-init>" {
     label = "::<Class:MyEnum>#<static-init>";
     color = blue;
-    "bb::<Class:MyEnum>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:MyEnum>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:MyEnum>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<C X>$35: MyEnum::X = alias <C X>\l<C Y>$61: MyEnum::Y = alias <C Y>\l<C Z>$88: MyEnum::Z = alias <C Z>\l<self>: T.class_of(MyEnum) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U MyEnum>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U MyEnum>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(T::Helpers) = alias <C Helpers>\l<statTemp>$3: T.class_of(MyEnum) = <self>: T.class_of(MyEnum).extend(<cfgAlias>$6: T.class_of(T::Helpers))\l<statTemp>$7: Sorbet::Private::Static::Void = <self>: T.class_of(MyEnum).abstract!()\l<statTemp>$9: Sorbet::Private::Static::Void = <self>: T.class_of(MyEnum).sealed!()\l<block-pre-call-temp>$13: Sorbet::Private::Static::Void = <self>: T.class_of(MyEnum).enums()\l<selfRestore>$14: T.class_of(MyEnum) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:MyEnum>#<static-init>_0" -> "bb::<Class:MyEnum>#<static-init>_2" [style="bold"];
     "bb::<Class:MyEnum>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:MyEnum>#<static-init>_1" -> "bb::<Class:MyEnum>#<static-init>_1" [style="bold"];
     "bb::<Class:MyEnum>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(MyEnum), <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(MyEnum), <C X>$35: MyEnum::X, <C Y>$61: MyEnum::Y, <C Z>$88: MyEnum::Z)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -46,12 +47,14 @@ subgraph "cluster_::<Class:MyEnum>#<static-init>" {
     "bb::<Class:MyEnum>#<static-init>_2" -> "bb::<Class:MyEnum>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:MyEnum>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(MyEnum))\l<statTemp>$11: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$13, enums>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:MyEnum>#<static-init>_3" -> "bb::<Class:MyEnum>#<static-init>_1" [style="bold"];
     "bb::<Class:MyEnum>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(MyEnum), <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(MyEnum), <C X>$35: MyEnum::X, <C Y>$61: MyEnum::Y, <C Z>$88: MyEnum::Z)\louterLoops: 1\l<self>: T.class_of(MyEnum) = loadSelf\l<cfgAlias>$21: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$23: T.class_of(MyEnum::X) = alias <C X$1>\l<statTemp>$19: Sorbet::Private::Static::Void = <cfgAlias>$21: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$23: T.class_of(MyEnum::X))\l<cfgAlias>$26: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$28: T.class_of(MyEnum::X) = alias <C X$1>\l<statTemp>$24: Sorbet::Private::Static::Void = <cfgAlias>$26: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$28: T.class_of(MyEnum::X))\l<cfgAlias>$31: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$33: T.class_of(MyEnum) = alias <C MyEnum>\l<statTemp>$29: Sorbet::Private::Static::Void = <cfgAlias>$31: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$33: T.class_of(MyEnum))\l<cfgAlias>$38: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$40: T.class_of(MyEnum::X) = alias <C X$1>\l<statTemp>$36: Sorbet::Private::Static::Void = <cfgAlias>$38: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$40: T.class_of(MyEnum::X))\l<cfgAlias>$43: T.class_of(MyEnum::X) = alias <C X$1>\l<castTemp>$41: MyEnum::X = <cfgAlias>$43: T.class_of(MyEnum::X).new()\l<C X>$35: MyEnum::X = <castTemp>$41\l<cfgAlias>$47: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$49: T.class_of(MyEnum::Y) = alias <C Y$1>\l<statTemp>$45: Sorbet::Private::Static::Void = <cfgAlias>$47: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$49: T.class_of(MyEnum::Y))\l<cfgAlias>$52: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$54: T.class_of(MyEnum::Y) = alias <C Y$1>\l<statTemp>$50: Sorbet::Private::Static::Void = <cfgAlias>$52: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$54: T.class_of(MyEnum::Y))\l<cfgAlias>$57: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$59: T.class_of(MyEnum) = alias <C MyEnum>\l<statTemp>$55: Sorbet::Private::Static::Void = <cfgAlias>$57: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$59: T.class_of(MyEnum))\l<cfgAlias>$64: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$66: T.class_of(MyEnum::Y) = alias <C Y$1>\l<statTemp>$62: Sorbet::Private::Static::Void = <cfgAlias>$64: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$66: T.class_of(MyEnum::Y))\l<cfgAlias>$69: T.class_of(MyEnum::Y) = alias <C Y$1>\l<statTemp>$70: String(\"y\") = \"y\"\l<castTemp>$67: MyEnum::Y = <cfgAlias>$69: T.class_of(MyEnum::Y).new(<statTemp>$70: String(\"y\"))\l<C Y>$61: MyEnum::Y = <castTemp>$67\l<cfgAlias>$74: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$76: T.class_of(MyEnum::Z) = alias <C Z$1>\l<statTemp>$72: Sorbet::Private::Static::Void = <cfgAlias>$74: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$76: T.class_of(MyEnum::Z))\l<cfgAlias>$79: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$81: T.class_of(MyEnum::Z) = alias <C Z$1>\l<statTemp>$77: Sorbet::Private::Static::Void = <cfgAlias>$79: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$81: T.class_of(MyEnum::Z))\l<cfgAlias>$84: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$86: T.class_of(MyEnum) = alias <C MyEnum>\l<statTemp>$82: Sorbet::Private::Static::Void = <cfgAlias>$84: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$86: T.class_of(MyEnum))\l<cfgAlias>$91: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$93: T.class_of(MyEnum::Z) = alias <C Z$1>\l<statTemp>$89: Sorbet::Private::Static::Void = <cfgAlias>$91: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$93: T.class_of(MyEnum::Z))\l<cfgAlias>$96: T.class_of(MyEnum::Z) = alias <C Z$1>\l<castTemp>$94: MyEnum::Z = <cfgAlias>$96: T.class_of(MyEnum::Z).new(<self>: T.class_of(MyEnum))\l<C Z>$88: MyEnum::Z = <castTemp>$94\l<blockReturnTemp>$17: NilClass = nil\l<blockReturnTemp>$98: T.noreturn = blockreturn<enums> <blockReturnTemp>$17: NilClass\l<unconditional>\l"
     ];
@@ -62,16 +65,16 @@ subgraph "cluster_::<Class:MyEnum>#<static-init>" {
 subgraph "cluster_::MyEnum::<Class:X>#<static-init>" {
     label = "::MyEnum::<Class:X>#<static-init>";
     color = blue;
-    "bb::MyEnum::<Class:X>#<static-init>_0" [shape = invhouse];
-    "bb::MyEnum::<Class:X>#<static-init>_1" [shape = parallelogram];
 
     "bb::MyEnum::<Class:X>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(MyEnum::X) = cast(<self>: NilClass, AppliedType {\l  klass = <C <U MyEnum>><S <C <E <C <U X>> $1>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<C <U MyEnum>><S <C <E <C <U X>> $1>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::MyEnum::<Class:X>#<static-init>_0" -> "bb::MyEnum::<Class:X>#<static-init>_1" [style="bold"];
     "bb::MyEnum::<Class:X>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -82,16 +85,16 @@ subgraph "cluster_::MyEnum::<Class:X>#<static-init>" {
 subgraph "cluster_::MyEnum::<Class:Y>#<static-init>" {
     label = "::MyEnum::<Class:Y>#<static-init>";
     color = blue;
-    "bb::MyEnum::<Class:Y>#<static-init>_0" [shape = invhouse];
-    "bb::MyEnum::<Class:Y>#<static-init>_1" [shape = parallelogram];
 
     "bb::MyEnum::<Class:Y>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(MyEnum::Y) = cast(<self>: NilClass, AppliedType {\l  klass = <C <U MyEnum>><S <C <E <C <U Y>> $1>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<C <U MyEnum>><S <C <E <C <U Y>> $1>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::MyEnum::<Class:Y>#<static-init>_0" -> "bb::MyEnum::<Class:Y>#<static-init>_1" [style="bold"];
     "bb::MyEnum::<Class:Y>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -102,16 +105,16 @@ subgraph "cluster_::MyEnum::<Class:Y>#<static-init>" {
 subgraph "cluster_::MyEnum::<Class:Z>#<static-init>" {
     label = "::MyEnum::<Class:Z>#<static-init>";
     color = blue;
-    "bb::MyEnum::<Class:Z>#<static-init>_0" [shape = invhouse];
-    "bb::MyEnum::<Class:Z>#<static-init>_1" [shape = parallelogram];
 
     "bb::MyEnum::<Class:Z>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(MyEnum::Z) = cast(<self>: NilClass, AppliedType {\l  klass = <C <U MyEnum>><S <C <E <C <U Z>> $1>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<C <U MyEnum>><S <C <E <C <U Z>> $1>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::MyEnum::<Class:Z>#<static-init>_0" -> "bb::MyEnum::<Class:Z>#<static-init>_1" [style="bold"];
     "bb::MyEnum::<Class:Z>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -122,22 +125,23 @@ subgraph "cluster_::MyEnum::<Class:Z>#<static-init>" {
 subgraph "cluster_::<Class:NotAnEnum>#<static-init>" {
     label = "::<Class:NotAnEnum>#<static-init>";
     color = blue;
-    "bb::<Class:NotAnEnum>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:NotAnEnum>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:NotAnEnum>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<C X>$10: T.untyped = alias <C X>\l<C Y>$17: NotAnEnum = alias <C Y>\l<self>: T.class_of(NotAnEnum) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U NotAnEnum>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U NotAnEnum>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: T.class_of(NotAnEnum).enums()\l<selfRestore>$5: T.class_of(NotAnEnum) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:NotAnEnum>#<static-init>_0" -> "bb::<Class:NotAnEnum>#<static-init>_2" [style="bold"];
     "bb::<Class:NotAnEnum>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:NotAnEnum>#<static-init>_1" -> "bb::<Class:NotAnEnum>#<static-init>_1" [style="bold"];
     "bb::<Class:NotAnEnum>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(NotAnEnum), <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum), <C X>$10: T.untyped, <C Y>$17: NotAnEnum)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -146,12 +150,14 @@ subgraph "cluster_::<Class:NotAnEnum>#<static-init>" {
     "bb::<Class:NotAnEnum>#<static-init>_2" -> "bb::<Class:NotAnEnum>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:NotAnEnum>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum))\l<returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, enums>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::<Class:NotAnEnum>#<static-init>_3" -> "bb::<Class:NotAnEnum>#<static-init>_1" [style="bold"];
     "bb::<Class:NotAnEnum>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(NotAnEnum), <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum), <C X>$10: T.untyped, <C Y>$17: NotAnEnum)\louterLoops: 1\l<self>: T.class_of(NotAnEnum) = loadSelf\l<cfgAlias>$12: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$15: T.class_of(<Magic>) = alias <C <Magic>>\l<statTemp>$13: T.attached_class (of NotAnEnum) = <cfgAlias>$15: T.class_of(<Magic>).<self-new>(<self>: T.class_of(NotAnEnum))\l<C X>$10: T.attached_class (of NotAnEnum) = <cfgAlias>$12: T.class_of(<Magic>).<suggest-type>(<statTemp>$13: T.attached_class (of NotAnEnum))\l<cfgAlias>$20: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$18: Sorbet::Private::Static::Void = <cfgAlias>$20: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<self>: T.class_of(NotAnEnum))\l<cfgAlias>$24: T.class_of(<Magic>) = alias <C <Magic>>\l<castTemp>$22: T.attached_class (of NotAnEnum) = <cfgAlias>$24: T.class_of(<Magic>).<self-new>(<self>: T.class_of(NotAnEnum))\l<C Y>$17: NotAnEnum = cast(<castTemp>$22: T.attached_class (of NotAnEnum), NotAnEnum);\l<blockReturnTemp>$8: NotAnEnum = <C Y>$17\l<blockReturnTemp>$26: T.noreturn = blockreturn<enums> <blockReturnTemp>$8: NotAnEnum\l<unconditional>\l"
     ];
@@ -162,16 +168,16 @@ subgraph "cluster_::<Class:NotAnEnum>#<static-init>" {
 subgraph "cluster_::EnumsDoEnum#something_outside" {
     label = "::EnumsDoEnum#something_outside";
     color = blue;
-    "bb::EnumsDoEnum#something_outside_0" [shape = invhouse];
-    "bb::EnumsDoEnum#something_outside_1" [shape = parallelogram];
 
     "bb::EnumsDoEnum#something_outside_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: EnumsDoEnum = cast(<self>: NilClass, EnumsDoEnum);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::EnumsDoEnum#something_outside_0" -> "bb::EnumsDoEnum#something_outside_1" [style="bold"];
     "bb::EnumsDoEnum#something_outside_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -182,22 +188,23 @@ subgraph "cluster_::EnumsDoEnum#something_outside" {
 subgraph "cluster_::<Class:EnumsDoEnum>#<static-init>" {
     label = "::<Class:EnumsDoEnum>#<static-init>";
     color = blue;
-    "bb::<Class:EnumsDoEnum>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:EnumsDoEnum>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:EnumsDoEnum>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<C X>$35: EnumsDoEnum::X = alias <C X>\l<C Y>$61: EnumsDoEnum::Y = alias <C Y>\l<C Z>$88: EnumsDoEnum::Z = alias <C Z>\l<self>: T.class_of(EnumsDoEnum) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U EnumsDoEnum>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U EnumsDoEnum>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(T::Helpers) = alias <C Helpers>\l<statTemp>$3: T.class_of(EnumsDoEnum) = <self>: T.class_of(EnumsDoEnum).extend(<cfgAlias>$6: T.class_of(T::Helpers))\l<statTemp>$7: Sorbet::Private::Static::Void = <self>: T.class_of(EnumsDoEnum).abstract!()\l<statTemp>$9: Sorbet::Private::Static::Void = <self>: T.class_of(EnumsDoEnum).sealed!()\l<block-pre-call-temp>$13: Sorbet::Private::Static::Void = <self>: T.class_of(EnumsDoEnum).enums()\l<selfRestore>$14: T.class_of(EnumsDoEnum) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:EnumsDoEnum>#<static-init>_0" -> "bb::<Class:EnumsDoEnum>#<static-init>_2" [style="bold"];
     "bb::<Class:EnumsDoEnum>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:EnumsDoEnum>#<static-init>_1" -> "bb::<Class:EnumsDoEnum>#<static-init>_1" [style="bold"];
     "bb::<Class:EnumsDoEnum>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(EnumsDoEnum), <C X>$35: EnumsDoEnum::X, <C Y>$61: EnumsDoEnum::Y, <C Z>$88: EnumsDoEnum::Z)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -206,12 +213,14 @@ subgraph "cluster_::<Class:EnumsDoEnum>#<static-init>" {
     "bb::<Class:EnumsDoEnum>#<static-init>_2" -> "bb::<Class:EnumsDoEnum>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:EnumsDoEnum>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(EnumsDoEnum))\l<statTemp>$11: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$13, enums>\l<self>: T.class_of(EnumsDoEnum) = <selfRestore>$14\l<cfgAlias>$101: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<statTemp>$103: Symbol(:something_outside) = :something_outside\l<statTemp>$104: Symbol(:normal) = :normal\l<statTemp>$99: Symbol(:something_outside) = <cfgAlias>$101: T.class_of(Sorbet::Private::Static).keep_def(<self>: T.class_of(EnumsDoEnum), <statTemp>$103: Symbol(:something_outside), <statTemp>$104: Symbol(:normal))\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:EnumsDoEnum>#<static-init>_3" -> "bb::<Class:EnumsDoEnum>#<static-init>_1" [style="bold"];
     "bb::<Class:EnumsDoEnum>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(EnumsDoEnum), <C X>$35: EnumsDoEnum::X, <C Y>$61: EnumsDoEnum::Y, <C Z>$88: EnumsDoEnum::Z)\louterLoops: 1\l<self>: T.class_of(EnumsDoEnum) = loadSelf\l<cfgAlias>$21: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$23: T.class_of(EnumsDoEnum::X) = alias <C X$1>\l<statTemp>$19: Sorbet::Private::Static::Void = <cfgAlias>$21: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$23: T.class_of(EnumsDoEnum::X))\l<cfgAlias>$26: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$28: T.class_of(EnumsDoEnum::X) = alias <C X$1>\l<statTemp>$24: Sorbet::Private::Static::Void = <cfgAlias>$26: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$28: T.class_of(EnumsDoEnum::X))\l<cfgAlias>$31: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$33: T.class_of(EnumsDoEnum) = alias <C EnumsDoEnum>\l<statTemp>$29: Sorbet::Private::Static::Void = <cfgAlias>$31: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$33: T.class_of(EnumsDoEnum))\l<cfgAlias>$38: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$40: T.class_of(EnumsDoEnum::X) = alias <C X$1>\l<statTemp>$36: Sorbet::Private::Static::Void = <cfgAlias>$38: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$40: T.class_of(EnumsDoEnum::X))\l<cfgAlias>$43: T.class_of(EnumsDoEnum::X) = alias <C X$1>\l<castTemp>$41: EnumsDoEnum::X = <cfgAlias>$43: T.class_of(EnumsDoEnum::X).new()\l<C X>$35: EnumsDoEnum::X = <castTemp>$41\l<cfgAlias>$47: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$49: T.class_of(EnumsDoEnum::Y) = alias <C Y$1>\l<statTemp>$45: Sorbet::Private::Static::Void = <cfgAlias>$47: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$49: T.class_of(EnumsDoEnum::Y))\l<cfgAlias>$52: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$54: T.class_of(EnumsDoEnum::Y) = alias <C Y$1>\l<statTemp>$50: Sorbet::Private::Static::Void = <cfgAlias>$52: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$54: T.class_of(EnumsDoEnum::Y))\l<cfgAlias>$57: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$59: T.class_of(EnumsDoEnum) = alias <C EnumsDoEnum>\l<statTemp>$55: Sorbet::Private::Static::Void = <cfgAlias>$57: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$59: T.class_of(EnumsDoEnum))\l<cfgAlias>$64: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$66: T.class_of(EnumsDoEnum::Y) = alias <C Y$1>\l<statTemp>$62: Sorbet::Private::Static::Void = <cfgAlias>$64: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$66: T.class_of(EnumsDoEnum::Y))\l<cfgAlias>$69: T.class_of(EnumsDoEnum::Y) = alias <C Y$1>\l<statTemp>$70: String(\"y\") = \"y\"\l<castTemp>$67: EnumsDoEnum::Y = <cfgAlias>$69: T.class_of(EnumsDoEnum::Y).new(<statTemp>$70: String(\"y\"))\l<C Y>$61: EnumsDoEnum::Y = <castTemp>$67\l<cfgAlias>$74: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$76: T.class_of(EnumsDoEnum::Z) = alias <C Z$1>\l<statTemp>$72: Sorbet::Private::Static::Void = <cfgAlias>$74: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$76: T.class_of(EnumsDoEnum::Z))\l<cfgAlias>$79: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$81: T.class_of(EnumsDoEnum::Z) = alias <C Z$1>\l<statTemp>$77: Sorbet::Private::Static::Void = <cfgAlias>$79: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$81: T.class_of(EnumsDoEnum::Z))\l<cfgAlias>$84: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$86: T.class_of(EnumsDoEnum) = alias <C EnumsDoEnum>\l<statTemp>$82: Sorbet::Private::Static::Void = <cfgAlias>$84: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$86: T.class_of(EnumsDoEnum))\l<cfgAlias>$91: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$93: T.class_of(EnumsDoEnum::Z) = alias <C Z$1>\l<statTemp>$89: Sorbet::Private::Static::Void = <cfgAlias>$91: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$93: T.class_of(EnumsDoEnum::Z))\l<cfgAlias>$96: T.class_of(EnumsDoEnum::Z) = alias <C Z$1>\l<castTemp>$94: EnumsDoEnum::Z = <cfgAlias>$96: T.class_of(EnumsDoEnum::Z).new(<self>: T.class_of(EnumsDoEnum))\l<C Z>$88: EnumsDoEnum::Z = <castTemp>$94\l<blockReturnTemp>$17: NilClass = nil\l<blockReturnTemp>$98: T.noreturn = blockreturn<enums> <blockReturnTemp>$17: NilClass\l<unconditional>\l"
     ];
@@ -222,16 +231,16 @@ subgraph "cluster_::<Class:EnumsDoEnum>#<static-init>" {
 subgraph "cluster_::EnumsDoEnum::<Class:X>#<static-init>" {
     label = "::EnumsDoEnum::<Class:X>#<static-init>";
     color = blue;
-    "bb::EnumsDoEnum::<Class:X>#<static-init>_0" [shape = invhouse];
-    "bb::EnumsDoEnum::<Class:X>#<static-init>_1" [shape = parallelogram];
 
     "bb::EnumsDoEnum::<Class:X>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(EnumsDoEnum::X) = cast(<self>: NilClass, AppliedType {\l  klass = <C <U EnumsDoEnum>><S <C <E <C <U X>> $1>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<C <U EnumsDoEnum>><S <C <E <C <U X>> $1>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::EnumsDoEnum::<Class:X>#<static-init>_0" -> "bb::EnumsDoEnum::<Class:X>#<static-init>_1" [style="bold"];
     "bb::EnumsDoEnum::<Class:X>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -242,16 +251,16 @@ subgraph "cluster_::EnumsDoEnum::<Class:X>#<static-init>" {
 subgraph "cluster_::EnumsDoEnum::<Class:Y>#<static-init>" {
     label = "::EnumsDoEnum::<Class:Y>#<static-init>";
     color = blue;
-    "bb::EnumsDoEnum::<Class:Y>#<static-init>_0" [shape = invhouse];
-    "bb::EnumsDoEnum::<Class:Y>#<static-init>_1" [shape = parallelogram];
 
     "bb::EnumsDoEnum::<Class:Y>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(EnumsDoEnum::Y) = cast(<self>: NilClass, AppliedType {\l  klass = <C <U EnumsDoEnum>><S <C <E <C <U Y>> $1>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<C <U EnumsDoEnum>><S <C <E <C <U Y>> $1>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::EnumsDoEnum::<Class:Y>#<static-init>_0" -> "bb::EnumsDoEnum::<Class:Y>#<static-init>_1" [style="bold"];
     "bb::EnumsDoEnum::<Class:Y>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -262,16 +271,16 @@ subgraph "cluster_::EnumsDoEnum::<Class:Y>#<static-init>" {
 subgraph "cluster_::EnumsDoEnum::<Class:Z>#<static-init>" {
     label = "::EnumsDoEnum::<Class:Z>#<static-init>";
     color = blue;
-    "bb::EnumsDoEnum::<Class:Z>#<static-init>_0" [shape = invhouse];
-    "bb::EnumsDoEnum::<Class:Z>#<static-init>_1" [shape = parallelogram];
 
     "bb::EnumsDoEnum::<Class:Z>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(EnumsDoEnum::Z) = cast(<self>: NilClass, AppliedType {\l  klass = <C <U EnumsDoEnum>><S <C <E <C <U Z>> $1>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<C <U EnumsDoEnum>><S <C <E <C <U Z>> $1>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::EnumsDoEnum::<Class:Z>#<static-init>_0" -> "bb::EnumsDoEnum::<Class:Z>#<static-init>_1" [style="bold"];
     "bb::EnumsDoEnum::<Class:Z>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -282,22 +291,23 @@ subgraph "cluster_::EnumsDoEnum::<Class:Z>#<static-init>" {
 subgraph "cluster_::<Class:BadConsts>#<static-init>" {
     label = "::<Class:BadConsts>#<static-init>";
     color = blue;
-    "bb::<Class:BadConsts>#<static-init>_0" [shape = invhouse];
-    "bb::<Class:BadConsts>#<static-init>_1" [shape = parallelogram];
 
     "bb::<Class:BadConsts>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<C Before>$28: BadConsts::Before = alias <C Before>\l<C StaticField1>$38: Integer(1) = alias <C StaticField1>\l<C Inside>$63: BadConsts::Inside = alias <C Inside>\l<C StaticField2>$73: Integer(2) = alias <C StaticField2>\l<C After>$92: BadConsts::After = alias <C After>\l<C StaticField3>$102: Integer(3) = alias <C StaticField3>\l<C StaticField4>$104: Integer = alias <C StaticField4>\l<self>: T.class_of(BadConsts) = cast(<self>: NilClass, AppliedType {\l  klass = <S <C <U BadConsts>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<S <C <U BadConsts>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<cfgAlias>$6: T.class_of(T::Helpers) = alias <C Helpers>\l<statTemp>$3: T.class_of(BadConsts) = <self>: T.class_of(BadConsts).extend(<cfgAlias>$6: T.class_of(T::Helpers))\l<statTemp>$7: Sorbet::Private::Static::Void = <self>: T.class_of(BadConsts).abstract!()\l<statTemp>$9: Sorbet::Private::Static::Void = <self>: T.class_of(BadConsts).sealed!()\l<cfgAlias>$14: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$16: T.class_of(BadConsts::Before) = alias <C Before$1>\l<statTemp>$12: Sorbet::Private::Static::Void = <cfgAlias>$14: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$16: T.class_of(BadConsts::Before))\l<cfgAlias>$19: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$21: T.class_of(BadConsts::Before) = alias <C Before$1>\l<statTemp>$17: Sorbet::Private::Static::Void = <cfgAlias>$19: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$21: T.class_of(BadConsts::Before))\l<cfgAlias>$24: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$26: T.class_of(BadConsts) = alias <C BadConsts>\l<statTemp>$22: Sorbet::Private::Static::Void = <cfgAlias>$24: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$26: T.class_of(BadConsts))\l<cfgAlias>$31: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$33: T.class_of(BadConsts::Before) = alias <C Before$1>\l<statTemp>$29: Sorbet::Private::Static::Void = <cfgAlias>$31: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$33: T.class_of(BadConsts::Before))\l<cfgAlias>$36: T.class_of(BadConsts::Before) = alias <C Before$1>\l<castTemp>$34: BadConsts::Before = <cfgAlias>$36: T.class_of(BadConsts::Before).new()\l<C Before>$28: BadConsts::Before = <castTemp>$34\l<C StaticField1>$38: Integer(1) = 1\l<block-pre-call-temp>$41: Sorbet::Private::Static::Void = <self>: T.class_of(BadConsts).enums()\l<selfRestore>$42: T.class_of(BadConsts) = <self>\l<unconditional>\l"
     ];
 
     "bb::<Class:BadConsts>#<static-init>_0" -> "bb::<Class:BadConsts>#<static-init>_2" [style="bold"];
     "bb::<Class:BadConsts>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:BadConsts>#<static-init>_1" -> "bb::<Class:BadConsts>#<static-init>_1" [style="bold"];
     "bb::<Class:BadConsts>#<static-init>_2" [
+        shape = rectangle;
         color = black;
         label = "block[id=2, rubyBlockId=1](<self>: T.class_of(BadConsts), <block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(BadConsts), <C Inside>$63: BadConsts::Inside, <C StaticField2>$73: Integer(2), <C After>$92: BadConsts::After, <C StaticField3>$102: Integer(3), <C StaticField4>$104: Integer)\louterLoops: 1\l<block-call>: NilClass\l"
     ];
@@ -306,12 +316,14 @@ subgraph "cluster_::<Class:BadConsts>#<static-init>" {
     "bb::<Class:BadConsts>#<static-init>_2" -> "bb::<Class:BadConsts>#<static-init>_3" [style="tapered"];
 
     "bb::<Class:BadConsts>#<static-init>_3" [
+        shape = rectangle;
         color = black;
         label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(BadConsts), <C After>$92: BadConsts::After, <C StaticField3>$102: Integer(3), <C StaticField4>$104: Integer)\l<statTemp>$39: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$41, enums>\l<cfgAlias>$78: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$80: T.class_of(BadConsts::After) = alias <C After$1>\l<statTemp>$76: Sorbet::Private::Static::Void = <cfgAlias>$78: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$80: T.class_of(BadConsts::After))\l<cfgAlias>$83: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$85: T.class_of(BadConsts::After) = alias <C After$1>\l<statTemp>$81: Sorbet::Private::Static::Void = <cfgAlias>$83: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$85: T.class_of(BadConsts::After))\l<cfgAlias>$88: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$90: T.class_of(BadConsts) = alias <C BadConsts>\l<statTemp>$86: Sorbet::Private::Static::Void = <cfgAlias>$88: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$90: T.class_of(BadConsts))\l<cfgAlias>$95: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$97: T.class_of(BadConsts::After) = alias <C After$1>\l<statTemp>$93: Sorbet::Private::Static::Void = <cfgAlias>$95: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$97: T.class_of(BadConsts::After))\l<cfgAlias>$100: T.class_of(BadConsts::After) = alias <C After$1>\l<castTemp>$98: BadConsts::After = <cfgAlias>$100: T.class_of(BadConsts::After).new()\l<C After>$92: BadConsts::After = <castTemp>$98\l<C StaticField3>$102: Integer(3) = 3\l<cfgAlias>$107: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$109: T.class_of(Integer) = alias <C Integer>\l<statTemp>$105: Sorbet::Private::Static::Void = <cfgAlias>$107: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$109: T.class_of(Integer))\l<castTemp>$110: Integer(1) = 1\l<C StaticField4>$104: Integer = cast(<castTemp>$110: Integer(1), Integer);\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::<Class:BadConsts>#<static-init>_3" -> "bb::<Class:BadConsts>#<static-init>_1" [style="bold"];
     "bb::<Class:BadConsts>#<static-init>_5" [
+        shape = rectangle;
         color = black;
         label = "block[id=5, rubyBlockId=1](<self>: T.class_of(BadConsts), <block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(BadConsts), <C Inside>$63: BadConsts::Inside, <C StaticField2>$73: Integer(2), <C After>$92: BadConsts::After, <C StaticField3>$102: Integer(3), <C StaticField4>$104: Integer)\louterLoops: 1\l<self>: T.class_of(BadConsts) = loadSelf\l<cfgAlias>$49: T.class_of(<Magic>) = alias <C <Magic>>\l<cfgAlias>$51: T.class_of(BadConsts::Inside) = alias <C Inside$1>\l<statTemp>$47: Sorbet::Private::Static::Void = <cfgAlias>$49: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$51: T.class_of(BadConsts::Inside))\l<cfgAlias>$54: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$56: T.class_of(BadConsts::Inside) = alias <C Inside$1>\l<statTemp>$52: Sorbet::Private::Static::Void = <cfgAlias>$54: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$56: T.class_of(BadConsts::Inside))\l<cfgAlias>$59: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$61: T.class_of(BadConsts) = alias <C BadConsts>\l<statTemp>$57: Sorbet::Private::Static::Void = <cfgAlias>$59: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$61: T.class_of(BadConsts))\l<cfgAlias>$66: T.class_of(Sorbet::Private::Static) = alias <C Static>\l<cfgAlias>$68: T.class_of(BadConsts::Inside) = alias <C Inside$1>\l<statTemp>$64: Sorbet::Private::Static::Void = <cfgAlias>$66: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$68: T.class_of(BadConsts::Inside))\l<cfgAlias>$71: T.class_of(BadConsts::Inside) = alias <C Inside$1>\l<castTemp>$69: BadConsts::Inside = <cfgAlias>$71: T.class_of(BadConsts::Inside).new()\l<C Inside>$63: BadConsts::Inside = <castTemp>$69\l<C StaticField2>$73: Integer(2) = 2\l<blockReturnTemp>$45: NilClass = nil\l<blockReturnTemp>$74: T.noreturn = blockreturn<enums> <blockReturnTemp>$45: NilClass\l<unconditional>\l"
     ];
@@ -322,16 +334,16 @@ subgraph "cluster_::<Class:BadConsts>#<static-init>" {
 subgraph "cluster_::BadConsts::<Class:Before>#<static-init>" {
     label = "::BadConsts::<Class:Before>#<static-init>";
     color = blue;
-    "bb::BadConsts::<Class:Before>#<static-init>_0" [shape = invhouse];
-    "bb::BadConsts::<Class:Before>#<static-init>_1" [shape = parallelogram];
 
     "bb::BadConsts::<Class:Before>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(BadConsts::Before) = cast(<self>: NilClass, AppliedType {\l  klass = <C <U BadConsts>><S <C <E <C <U Before>> $1>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<C <U BadConsts>><S <C <E <C <U Before>> $1>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::BadConsts::<Class:Before>#<static-init>_0" -> "bb::BadConsts::<Class:Before>#<static-init>_1" [style="bold"];
     "bb::BadConsts::<Class:Before>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -342,16 +354,16 @@ subgraph "cluster_::BadConsts::<Class:Before>#<static-init>" {
 subgraph "cluster_::BadConsts::<Class:Inside>#<static-init>" {
     label = "::BadConsts::<Class:Inside>#<static-init>";
     color = blue;
-    "bb::BadConsts::<Class:Inside>#<static-init>_0" [shape = invhouse];
-    "bb::BadConsts::<Class:Inside>#<static-init>_1" [shape = parallelogram];
 
     "bb::BadConsts::<Class:Inside>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(BadConsts::Inside) = cast(<self>: NilClass, AppliedType {\l  klass = <C <U BadConsts>><S <C <E <C <U Inside>> $1>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<C <U BadConsts>><S <C <E <C <U Inside>> $1>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::BadConsts::<Class:Inside>#<static-init>_0" -> "bb::BadConsts::<Class:Inside>#<static-init>_1" [style="bold"];
     "bb::BadConsts::<Class:Inside>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];
@@ -362,16 +374,16 @@ subgraph "cluster_::BadConsts::<Class:Inside>#<static-init>" {
 subgraph "cluster_::BadConsts::<Class:After>#<static-init>" {
     label = "::BadConsts::<Class:After>#<static-init>";
     color = blue;
-    "bb::BadConsts::<Class:After>#<static-init>_0" [shape = invhouse];
-    "bb::BadConsts::<Class:After>#<static-init>_1" [shape = parallelogram];
 
     "bb::BadConsts::<Class:After>#<static-init>_0" [
+        shape = invhouse;
         color = black;
         label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(BadConsts::After) = cast(<self>: NilClass, AppliedType {\l  klass = <C <U BadConsts>><S <C <E <C <U After>> $1>> $1>\l  targs = [\l    <C <U <AttachedClass>>> = SelfTypeParam(<C <U BadConsts>><S <C <E <C <U After>> $1>> $1><C <U <AttachedClass>>>)\l  ]\l});\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass\l<unconditional>\l"
     ];
 
     "bb::BadConsts::<Class:After>#<static-init>_0" -> "bb::BadConsts::<Class:After>#<static-init>_1" [style="bold"];
     "bb::BadConsts::<Class:After>#<static-init>_1" [
+        shape = parallelogram;
         color = black;
         label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
     ];


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Makes CFGs take up less space when visualized.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Exp files change. Example:

**Before**

<img width="1171" alt="Screen Shot 2021-05-21 at 4 05 21 PM" src="https://user-images.githubusercontent.com/5544532/119205912-836b6100-ba4e-11eb-9894-71dd5113c462.png">

**After**

<img width="1095" alt="Screen Shot 2021-05-21 at 4 05 36 PM" src="https://user-images.githubusercontent.com/5544532/119205909-80707080-ba4e-11eb-84c0-4e8b0fe8e358.png">


