### PR TITLE
Document error code: 7035

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -1033,4 +1033,28 @@ def foo(x, y)
 end
 ```
 
+## 7035
+
+Sorbet detected that the method `select` does not take a block. 
+Currently Sorbet does not support multiple sigs per def. Since a select could run on an object, or an array, the type would look like:
+`T.any(Model::ActiveRecord_Relation, T::Array[Model])`
+
+If you are running `select` on an array, append `.to_a` before calling select like so: 
+
+```ruby
+# typed: true
+
+extend T::Sig
+
+def get_valid_users
+  valid_ids = [1, 2, 3, 4]
+  users = User.where(id: valid_ids)
+  even_users = users.select { |u| u.id.even? } # Error: Method `User::QueryMethodsReturningAssociationRelation#select` does not take a block
+  
+  # append `.to_a`
+  even_users = users.to_a.select { |u| u.id.even? } # No Error
+end
+
+```
+
 <script src="/js/error-reference.js"></script>


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I keep getting the error code 7035 when I run a select over an array of objects rather than a single object. I've documented the fix.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests because this is a documentation change. 
