### PR TITLE
Add configuration option for short-circuiting type assertions during runtime

### DIFF
--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -126,7 +126,7 @@ module T
   # exception at runtime if the value doesn't match the type.
   #
   # Compared to `T.let`, `T.cast` is _trusted_ by static system.
-  def self.cast(value, type, checked: true)
+  def self.cast(value, type, checked: T::Configuration.runtime_type_assertions_enabled?)
     return value unless checked
 
     Private::Casts.cast(value, type, cast_method: "T.cast")
@@ -141,7 +141,7 @@ module T
   #
   # If `checked` is true, raises an exception at runtime if the value
   # doesn't match the type.
-  def self.let(value, type, checked: true)
+  def self.let(value, type, checked: T::Configuration.runtime_type_assertions_enabled?)
     return value unless checked
 
     Private::Casts.cast(value, type, cast_method: "T.let")
@@ -160,7 +160,7 @@ module T
   #
   # If `checked` is true, raises an exception at runtime if the value
   # doesn't match the type (this is the default).
-  def self.bind(value, type, checked: true)
+  def self.bind(value, type, checked: T::Configuration.runtime_type_assertions_enabled?)
     return value unless checked
 
     Private::Casts.cast(value, type, cast_method: "T.bind")
@@ -210,6 +210,7 @@ module T
   #
   # sig {params(arg: T.nilable(A)).returns(A)}
   def self.must(arg)
+    return arg unless T::Configuration.runtime_type_assertions_enabled?
     return arg if arg
     return arg if arg == false
 
@@ -231,6 +232,7 @@ module T
   # happens. Commonly used to assert that a case or if statement exhausts all
   # possible cases.
   def self.absurd(value)
+    return value unless T::Configuration.runtime_type_assertions_enabled?
     msg = "Control flow reached T.absurd."
 
     case value

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -523,6 +523,24 @@ module T::Configuration
     @legacy_t_enum_migration_mode || false
   end
 
+  # Disable runtime type assertions. This is useful for a bit of a performance
+  # boost at the expense of type safety during runtime.
+  # If this option is not explicity set, its default state will mean that all
+  # type assertions behave normally during runtime.
+  #
+  # Note: setting this option is potentially dangerous! Sorbet can't check all
+  # code statically.
+  def self.disable_runtime_type_assertions
+    @runtime_type_assertions_enabled = false
+  end
+  def self.enable_runtime_type_assertions
+    @runtime_type_assertions_enabled = true
+  end
+  def self.runtime_type_assertions_enabled?
+    return false if @runtime_type_assertions_enabled == false
+    true
+  end
+
   # @param [Array] sealed_violation_whitelist An array of Regexp to validate
   #   whether inheriting /including a sealed module outside the defining module
   #   should be allowed. Useful to whitelist benign violations, like shim files

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -350,5 +350,53 @@ module Opus::Types::Test
         end
       end
     end
+
+    describe 'runtime_type_assertions' do
+      describe 'when in default state' do
+        # Default behaviours for other assertions are checked
+        # elsewhere in this file
+        it 'T.cast raises an error' do
+          assert_raises(TypeError) do
+            T.cast(1, String)
+          end
+        end
+
+        it 'T.absurd raises an error' do
+          assert_raises(TypeError) do
+            T.absurd("Hello")
+          end
+        end
+      end
+
+      describe 'when overridden' do
+        before do
+          T::Configuration.disable_runtime_type_assertions
+        end
+
+        it 'T.let returns the given value without error' do
+          assert_equal 1, T.let(1, String)
+        end
+
+        it 'T.cast returns the given value without error' do
+          assert_equal 1, T.cast(1, String)
+        end
+
+        it 'T.must returns nil without error' do
+          assert_nil T.must(nil)
+        end
+
+        it 'T.absurd returns the given value without error' do
+          assert_equal "Hello", T.absurd("Hello")
+        end
+
+        it 'T.bind returns the given value without error' do
+          assert_equal 123, T.bind(123, String)
+        end
+
+        after do
+          T::Configuration.remove_instance_variable(:@runtime_type_assertions_enabled)
+        end
+      end
+    end
   end
 end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -138,6 +138,9 @@ module T::Configuration
   def self.enable_checking_for_sigs_marked_checked_tests; end
   def self.enable_final_checks_on_hooks; end
   def self.enable_legacy_t_enum_migration_mode; end
+  def self.disable_runtime_type_assertions; end
+  def self.enable_runtime_type_assertions; end
+  def self.runtime_type_assertions_enabled?; end
   def self.reset_final_checks_on_hooks; end
   sig {returns(T::Boolean)}
   def self.include_value_in_type_errors?; end


### PR DESCRIPTION
### Motivation

We patch `let`, `must`, `cast`, `bind`, and `absurd` to be a noop - basically anything that can ultimately call `inline_type_error_handler`. Having this be configurable might be handy for others.

I'm very keen for feedback on the idea, approach, and scope here for sure. If there are other calls I should capture or if the net is cast a bit too wide, let me know. I followed the pattern of `enable_legacy_t_enum_migration_mode` a few lines above in `configuration.rb`.

### Test plan

See included automated tests.
