### PR TITLE
Update `Array#[]=` signature

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -631,6 +631,14 @@ class Array < Object
   end
   sig do
     params(
+      arg0: Integer,
+      arg1: Integer,
+      arg2: T::Array[Elem],
+    )
+    .returns(T::Array[Elem])
+  end
+  sig do
+    params(
         arg0: T::Range[Integer],
         arg1: Elem,
     )


### PR DESCRIPTION
**Note:** If there is something obvious that I missed, feel free to close this without further answers.

I presume I found a missing overload signature for a stdlib method. This seems to depend on how the array was created tho, I'm providing a sorbet.run example [here][1]. I presume that's because we can know the Elem type for Array.new but not for square brackets.

**Edit:** Providing [another example][2] to clarify that `T::Boolean` vs `FalseClass` is irrelevant in the other example

### Motivation

I would like to use the missing overload in a strictly typed file.

### Test plan

I have not tested this at all, not even sure where would I begin, happy to do if you go thru with the change.

[1]: https://sorbet.run/#%23%20typed%3A%20strict%0Aextend%20T%3A%3ASig%0A%0AArray.new(5%2C%20false)%5B1%2C%202%5D%20%3D%20%5Btrue%2C%20false%5D%0A%5Bfalse%2C%20false%2C%20false%2C%20false%5D%5B1%2C%202%5D%20%3D%20%5Btrue%2C%20false%5D%0A
[2]: https://sorbet.run/#%23%20typed%3A%20strict%0Aextend%20T%3A%3ASig%0A%0AArray.new(5%2C%201)%5B1%2C%202%5D%20%3D%20%5Btrue%2C%20false%5D%0A%5B1%2C%202%2C%203%2C%204%5D%5B1%2C%202%5D%20%3D%20%5B5%2C%206%5D%0A