### PR TITLE
LSP: Limit maximum number of diagnostics to report to the editor.

### DIFF
--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -173,12 +173,17 @@ u4 ErrorReporter::lastDiagnosticEpochForFile(core::FileRef file) {
 }
 
 void ErrorReporter::sanityCheck() const {
-    DEBUG_ONLY(u4 errorCount = 0; for (auto &status
-                                       : this->fileErrorStatuses) {
+    if (!debug_mode) {
+        return;
+    }
+
+    u4 errorCount = 0;
+    for (auto &status : this->fileErrorStatuses) {
         if (status.lastReportedEpoch >= this->lastFullTypecheckEpoch) {
             errorCount += status.errorCount;
         }
-    } ENFORCE(errorCount == this->clientErrorCount));
+    }
+    ENFORCE(errorCount == this->clientErrorCount);
 }
 
 ErrorEpoch::ErrorEpoch(ErrorReporter &errorReporter, u4 epoch, bool isIncremental,

--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -19,7 +19,7 @@ vector<core::FileRef> ErrorReporter::filesWithErrorsSince(u4 epoch) {
     return filesUpdatedSince;
 }
 
-void ErrorReporter::beginEpoch(u4 epoch, vector<unique_ptr<Timer>> diagnosticLatencyTimers) {
+void ErrorReporter::beginEpoch(u4 epoch, bool isIncremental, vector<unique_ptr<Timer>> diagnosticLatencyTimers) {
     ENFORCE(epochTimers.find(epoch) == epochTimers.end());
     vector<Timer> firstDiagnosticLatencyTimers;
     if (config->getClientConfig().enableTypecheckInfo) {
@@ -139,10 +139,10 @@ u4 ErrorReporter::lastDiagnosticEpochForFile(core::FileRef file) {
     return getFileErrorStatus(file).lastReportedEpoch;
 }
 
-ErrorEpoch::ErrorEpoch(ErrorReporter &errorReporter, u4 epoch,
+ErrorEpoch::ErrorEpoch(ErrorReporter &errorReporter, u4 epoch, bool isIncremental,
                        std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers)
     : errorReporter(errorReporter), epoch(epoch) {
-    errorReporter.beginEpoch(epoch, move(diagnosticLatencyTimers));
+    errorReporter.beginEpoch(epoch, isIncremental, move(diagnosticLatencyTimers));
 };
 
 ErrorEpoch::~ErrorEpoch() {

--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -12,7 +12,7 @@ vector<core::FileRef> ErrorReporter::filesWithErrorsSince(u4 epoch) {
     vector<core::FileRef> filesUpdatedSince;
     for (size_t i = 1; i < fileErrorStatuses.size(); ++i) {
         ErrorStatus fileErrorStatus = fileErrorStatuses[i];
-        if (fileErrorStatus.lastReportedEpoch >= epoch && fileErrorStatus.hasErrors) {
+        if (fileErrorStatus.lastReportedEpoch >= epoch && fileErrorStatus.errorCount > 0) {
             filesUpdatedSince.push_back(core::FileRef(i));
         }
     }
@@ -73,11 +73,11 @@ void ErrorReporter::pushDiagnostics(u4 epoch, core::FileRef file, const vector<u
     }
 
     // If errors is empty and the file had no errors previously, break
-    if (errors.empty() && fileErrorStatus.hasErrors == false) {
+    if (errors.empty() && fileErrorStatus.errorCount == 0) {
         return;
     }
 
-    fileErrorStatus.hasErrors = !errors.empty();
+    fileErrorStatus.errorCount = errors.size();
 
     const string uri = config->fileRef2Uri(gs, file);
     vector<unique_ptr<Diagnostic>> diagnostics;

--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -72,7 +72,7 @@ void ErrorReporter::pushDiagnostics(u4 epoch, core::FileRef file, const vector<u
 
     u4 errorsToReport = errors.size();
     {
-        const auto maxErrors = config->opts.lspMaxErrorsReported;
+        const auto maxErrors = config->opts.lspErrorCap;
         // N.B.: A value of 0 means no maximum is imposed.
         if (maxErrors > 0) {
             if (maxErrors > this->clientErrorCount) {

--- a/main/lsp/ErrorReporter.h
+++ b/main/lsp/ErrorReporter.h
@@ -25,6 +25,11 @@ class ErrorReporter {
     std::vector<ErrorStatus> fileErrorStatuses;
     ErrorStatus &getFileErrorStatus(core::FileRef file);
     UnorderedMap<u4, EpochTimers> epochTimers;
+    // The number of errors currently displayed in the editor. Reset whenever Sorbet begins a non-incremental epoch,
+    // which promises to retypecheck every file. Used to implement a global error limit.
+    u4 clientErrorCount = 0;
+    // Tracks the last epoch that was a full typecheck. Used to sanity check clientErrorCount.
+    u4 lastFullTypecheckEpoch = 0;
 
 public:
     ErrorReporter(std::shared_ptr<const LSPConfiguration> config);
@@ -40,6 +45,9 @@ public:
     void beginEpoch(u4 epoch, bool isIncremental, std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers);
     void endEpoch(u4 epoch, bool committed = true);
     u4 lastDiagnosticEpochForFile(core::FileRef file);
+
+    // Sanity checks error count data.
+    void sanityCheck() const;
 };
 
 class ErrorEpoch final {

--- a/main/lsp/ErrorReporter.h
+++ b/main/lsp/ErrorReporter.h
@@ -37,7 +37,7 @@ public:
     void pushDiagnostics(u4 epoch, core::FileRef file, const std::vector<std::unique_ptr<core::Error>> &errors,
                          const core::GlobalState &gs);
 
-    void beginEpoch(u4 epoch, std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers);
+    void beginEpoch(u4 epoch, bool isIncremental, std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers);
     void endEpoch(u4 epoch, bool committed = true);
     u4 lastDiagnosticEpochForFile(core::FileRef file);
 };
@@ -47,7 +47,8 @@ class ErrorEpoch final {
     u4 epoch;
 
 public:
-    ErrorEpoch(ErrorReporter &errorReporter, u4 epoch, std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers);
+    ErrorEpoch(ErrorReporter &errorReporter, u4 epoch, bool isIncremental,
+               std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers);
 
     ~ErrorEpoch();
 

--- a/main/lsp/ErrorReporter.h
+++ b/main/lsp/ErrorReporter.h
@@ -15,8 +15,8 @@ struct EpochTimers {
 struct ErrorStatus {
     // The epoch at which we last sent diagnostics for this file.
     u4 lastReportedEpoch = 0;
-    // If true, the client believes this file has errors.
-    bool hasErrors = false;
+    // The number of errors reported for this file during the last reported epoch.
+    u4 errorCount = 0;
 };
 
 class ErrorReporter {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -93,7 +93,8 @@ void LSPTypechecker::initialize(LSPFileUpdates updates, WorkerPool &workers) {
     // TODO(jvilk): Make it preemptible.
     auto committed = false;
     {
-        ErrorEpoch epoch(*errorReporter, updates.epoch, {});
+        const bool isIncremental = false;
+        ErrorEpoch epoch(*errorReporter, updates.epoch, isIncremental, {});
         committed = runSlowPath(move(updates), workers, /* cancelable */ false);
         epoch.committed = committed;
     }
@@ -138,7 +139,7 @@ bool LSPTypechecker::typecheck(LSPFileUpdates updates, WorkerPool &workers,
     const bool isFastPath = updates.canTakeFastPath;
     sendTypecheckInfo(*config, *gs, SorbetTypecheckRunStatus::Started, isFastPath, {});
     {
-        ErrorEpoch epoch(*errorReporter, updates.epoch, move(diagnosticLatencyTimers));
+        ErrorEpoch epoch(*errorReporter, updates.epoch, isFastPath, move(diagnosticLatencyTimers));
 
         if (isFastPath) {
             filesTypechecked =

--- a/main/lsp/test/error_reporter_test.cc
+++ b/main/lsp/test/error_reporter_test.cc
@@ -389,7 +389,7 @@ TEST_CASE("filesWithErrorsSince") {
 TEST_CASE("Global error limit") {
     auto opts = makeOptions("");
     // Limit is 5 for these tests.
-    opts.lspMaxErrorsReported = 5;
+    opts.lspErrorCap = 5;
     auto cs = makeConfig(opts);
     auto gs = makeGS();
     auto outputVector = dynamic_pointer_cast<LSPOutputToVector>(cs->output);

--- a/main/lsp/test/error_reporter_test.cc
+++ b/main/lsp/test/error_reporter_test.cc
@@ -459,6 +459,14 @@ TEST_CASE("Global error limit") {
         }
     }
 
+    SUBCASE("Does not impose a cap with a cap of 0") {
+        opts.lspErrorCap = 0;
+        generateErrors(fref1, errorsFile1, 100);
+        er.beginEpoch(epoch, false, {});
+        er.pushDiagnostics(epoch, fref1, errorsFile1, *gs);
+        CHECK_EQ(100, errorsReported(*outputVector));
+    }
+
     er.sanityCheck();
 }
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -321,6 +321,11 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("enable-all-beta-lsp-features",
                                     "Enable (expected-to-be-non-crashy) early-access LSP features.");
     options.add_options("advanced")(
+        "lsp-max-errors-reported",
+        "Limits the maximum number of simultaneous errors that LSP reports to the editor. Can prevent "
+        "editor slowdowns with large error lists.",
+        cxxopts::value<int>()->default_value(to_string(empty.lspMaxErrorsReported)), "limit");
+    options.add_options("advanced")(
         "ignore",
         "Ignores input files that contain the given string in their paths (relative to the input path passed to "
         "Sorbet). Strings beginning with / match against the prefix of these relative paths; others are substring "
@@ -701,6 +706,8 @@ void readOptions(Options &opts,
                 opts.lspDirsMissingFromClient.push_back(pNormalized);
             }
         }
+
+        opts.lspMaxErrorsReported = raw["lsp-max-errors-reported"].as<int>();
 
         opts.cacheDir = raw["cache-dir"].as<string>();
         if (!extractPrinters(raw, opts, logger)) {

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -320,11 +320,10 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
         "End users should prefer to use `--enable-all-beta-lsp-features`, instead.)");
     options.add_options("advanced")("enable-all-beta-lsp-features",
                                     "Enable (expected-to-be-non-crashy) early-access LSP features.");
-    options.add_options("advanced")(
-        "lsp-max-errors-reported",
-        "Limits the maximum number of simultaneous errors that LSP reports to the editor. Can prevent "
-        "editor slowdowns with large error lists.",
-        cxxopts::value<int>()->default_value(to_string(empty.lspMaxErrorsReported)), "limit");
+    options.add_options("advanced")("lsp-error-cap",
+                                    "Caps the maximum number of errors that LSP reports to the editor. Can prevent "
+                                    "editor slowdown triggered by large error lists. A cap of 0 means 'no cap'.",
+                                    cxxopts::value<int>()->default_value(to_string(empty.lspErrorCap)), "cap");
     options.add_options("advanced")(
         "ignore",
         "Ignores input files that contain the given string in their paths (relative to the input path passed to "
@@ -707,7 +706,7 @@ void readOptions(Options &opts,
             }
         }
 
-        opts.lspMaxErrorsReported = raw["lsp-max-errors-reported"].as<int>();
+        opts.lspErrorCap = raw["lsp-error-cap"].as<int>();
 
         opts.cacheDir = raw["cache-dir"].as<string>();
         if (!extractPrinters(raw, opts, logger)) {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -176,9 +176,9 @@ struct Options {
     /* The maximum number of files that are permitted to typecheck on the fast path concurrently. Not exposed on CLI.
      * Placed on Options for convenience so tests can override. */
     u4 lspMaxFilesOnFastPath = 50;
-    /* The maximum number of simultaneous errors to report to the client when in LSP mode. Prevents editor UI slowdown
+    /* The maximum number of errors to report to the client when in LSP mode. Prevents editor UI slowdown
      * related to large error lists. 0 means no limit. */
-    u4 lspMaxErrorsReported = 1000;
+    u4 lspErrorCap = 1000;
 
     std::string statsdHost;
     std::string statsdPrefix = "ruby_typer.unknown";

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -176,6 +176,9 @@ struct Options {
     /* The maximum number of files that are permitted to typecheck on the fast path concurrently. Not exposed on CLI.
      * Placed on Options for convenience so tests can override. */
     u4 lspMaxFilesOnFastPath = 50;
+    /* The maximum number of simultaneous errors to report to the client when in LSP mode. Prevents editor UI slowdown
+     * related to large error lists. 0 means no limit. */
+    u4 lspMaxErrorsReported = 1000;
 
     std::string statsdHost;
     std::string statsdPrefix = "ruby_typer.unknown";

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -79,5 +79,5 @@ TEST_CASE("DefaultConstructorMatchesReadOptions") {
     CHECK_EQ(empty.stripeMode, opts.stripeMode);
     CHECK_EQ(empty.stripePackages, opts.stripePackages);
     CHECK_EQ(empty.forceHashing, opts.forceHashing);
-    CHECK_EQ(empty.lspMaxErrorsReported, opts.lspMaxErrorsReported);
+    CHECK_EQ(empty.lspErrorCap, opts.lspErrorCap);
 }

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -79,4 +79,5 @@ TEST_CASE("DefaultConstructorMatchesReadOptions") {
     CHECK_EQ(empty.stripeMode, opts.stripeMode);
     CHECK_EQ(empty.stripePackages, opts.stripePackages);
     CHECK_EQ(empty.forceHashing, opts.forceHashing);
+    CHECK_EQ(empty.lspMaxErrorsReported, opts.lspMaxErrorsReported);
 }

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -115,11 +115,10 @@ Usage:
       --enable-all-beta-lsp-features
                                 Enable (expected-to-be-non-crashy)
                                 early-access LSP features.
-      --lsp-max-errors-reported limit
-                                Limits the maximum number of simultaneous
-                                errors that LSP reports to the editor. Can
-                                prevent editor slowdowns with large error lists.
-                                (default: 1000)
+      --lsp-error-cap cap       Caps the maximum number of errors that LSP
+                                reports to the editor. Can prevent editor
+                                slowdown triggered by large error lists. A cap of 0
+                                means 'no cap'. (default: 1000)
       --ignore string           Ignores input files that contain the given
                                 string in their paths (relative to the input
                                 path passed to Sorbet). Strings beginning with /

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -115,6 +115,11 @@ Usage:
       --enable-all-beta-lsp-features
                                 Enable (expected-to-be-non-crashy)
                                 early-access LSP features.
+      --lsp-max-errors-reported limit
+                                Limits the maximum number of simultaneous
+                                errors that LSP reports to the editor. Can
+                                prevent editor slowdowns with large error lists.
+                                (default: 1000)
       --ignore string           Ignores input files that contain the given
                                 string in their paths (relative to the input
                                 path passed to Sorbet). Strings beginning with /


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Limit the maximum number of diagnostics to report to the editor when in LSP mode. I have set the value to `1000`, but I may ratchet it down with testing on Stripe's codebase. This limit does not apply in CLI mode.

Before explaining how it works, recall that Sorbet's LSP server uses the concept of an epoch. An epoch is simply a typecheck run, which can be full (i.e., retypecheck _every_ file) or incremental (i.e., only retypecheck a subset of the files in the project). Incremental typecheck runs can _preempt_ full typecheck runs to respond to code edits during a full typecheck, so multiple epochs can be in play at once.

To manage the complexity of error reporting in the face of preemption, Sorbet's LSP server uses an `ErrorReporter` class which is responsible for sending diagnostics (i.e., typechecking errors) to the client. It does some sanity checking to avoid sending stale typechecking errors, since it is possible that a full typecheck may report errors for an older file revision _after_ it is preempted by a incremental typecheck. 

One other important detail of the LSP protocol is that servers update the set of errors in a file by sending the full list of errors in the file. That is, if a file has 5 errors, it is not possible to send 2 and then send 3 -- the server must send a complete listing. A corollary of this design decision is if a file has 0 errors but previously had >0, an empty list of diagnostics must be sent to the editor to invalidate the old errors.

With this PR, `ErrorReporter` is also responsible for limiting the number of diagnostics sent to the editor in the following manner:
* `ErrorReporter` contains a counter of the number of errors reported to the client (`clientErrorCount`).
* `clientErrorCount` is kept up-to-date as new errors are reported for files -- including when an incremental typechecking run shrinks the error count.
* `clientErrorCount` is reset to `0` whenever a full typecheck runs since that typecheck will re-report all errors in the project.

### Limitations

#### Determinism

When the limit is enforced, the set of errors reported is not guaranteed to be consistent between runs, since errors are reported in the order received from worker threads. Thus, the user may see a slightly different set of errors with each full retypecheck. Fixing this problem is somewhat at odds with error streaming.

One possible solution that could be bolted on to this effort is to stream out errors in a specific file order rather than in the order typechecked. Files enter the worker queue in a deterministic order, and we could re-sort the files on the way out into the same order. This fix would slightly reduce the responsiveness of error streaming and may not be worth the complication.


#### UX

The user does not receive an indication that Sorbet is limiting errors. `clangd` limits errors and also does not provide any user indication that it is doing so. I contemplated adding a faux error to a file that stated that errors are limited, but that is easily missed. Suggestions appreciated.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet effectively crashes VS Code when it reports thousands of errors.

Fixes https://github.com/sorbet/sorbet/issues/3604.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
