### PR TITLE
Add type signature for T::Struct#serialize

### DIFF
--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -148,6 +148,7 @@ end
 module T::Props::Serializable
   def deserialize(hash, strict = nil); end
   def recursive_stringify_keys(obj); end
+  sig {params(strict: T.nilable(T::Boolean)).returns(T::Hash[String, T.untyped])}
   def serialize(strict = nil); end
   sig {params(changed_props: T.untyped).returns(T.self_type)}
   def with(changed_props); end


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This will catch this and other similar bugs: `struct.serialize.transform_keys(:to_sym)`

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Similar to https://github.com/sorbet/sorbet/pull/4137, I and others have hit a few bugs expecting T::Struct to be better typed; `struct.serialize` always returns a `T::Hash[String, T.untyped]`. 

---

> `struct.serialize` always returns a `T::Hash[String, T.untyped]`

Is this true? It should always return a hash but must the keys be strings? I follow the code: https://github.com/sorbet/sorbet/blob/ef1c143ee2c02886cdced928bda61ce88e9dc6d0/gems/sorbet-runtime/lib/types/props/serializable.rb#L42 and see the generator does String keys: https://github.com/sorbet/sorbet/blob/4f146522e25047f6527a98797672f9b1c462eced/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb#L61

I don't know if anything else is fussing this these internals though (I hope not).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
