### PR TITLE
Faster and more correct Symbol::findMemberFuzzyMatchConstant

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -723,8 +723,10 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatchConstant(const Glo
                     // order the recommendations from this scope.
                     // We order in decreasing symbol ID order because `result` is later reversed and we want earlier
                     // ID'd symbols to be recommended first.
-                    fast_sort(scopeBest, [&](auto lhs, auto rhs) -> bool { return lhs.symbol._id > rhs.symbol._id; });
-                    for (auto item : scopeBest) {
+                    fast_sort(scopeBest, [&](const auto &lhs, const auto &rhs) -> bool {
+                        return lhs.symbol._id > rhs.symbol._id;
+                    });
+                    for (auto &item : scopeBest) {
                         result.emplace_back(item);
                     }
                 }
@@ -775,7 +777,8 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatchConstant(const Glo
         // deterministic order.
         // We order in decreasing symbol ID order because `result` is later reversed and we want earlier
         // ID'd symbols to be recommended first.
-        fast_sort(globalBest, [&](auto lhs, auto rhs) -> bool { return lhs.symbol._id > rhs.symbol._id; });
+        fast_sort(globalBest,
+                  [&](const auto &lhs, const auto &rhs) -> bool { return lhs.symbol._id > rhs.symbol._id; });
         for (auto &e : globalBest) {
             result.emplace_back(e);
         }

--- a/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/expected/err.log
+++ b/gems/sorbet/test/snapshot/partial/project-with-tapioca-and-rbis/expected/err.log
@@ -8,10 +8,6 @@ lib/test.rb:3: Unable to resolve constant `Parlour` https://srb.help/5002
      3 |FOO = Parlour # We expect `Parlour` to be undefined here since we didn't load any gem RBI
               ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    lib/test.rb:3: Replace with `Gem::RequestSet::Lockfile::Parser`
-     3 |FOO = Parlour # We expect `Parlour` to be undefined here since we didn't load any gem RBI
-              ^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
     lib/test.rb:3: Replace with `JSON::Ext::Parser`
      3 |FOO = Parlour # We expect `Parlour` to be undefined here since we didn't load any gem RBI
               ^^^^^^^
@@ -19,13 +15,17 @@ lib/test.rb:3: Unable to resolve constant `Parlour` https://srb.help/5002
     lib/test.rb:3: Replace with `Psych::Parser`
      3 |FOO = Parlour # We expect `Parlour` to be undefined here since we didn't load any gem RBI
               ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/rubygems.rbi#L5017: Did you mean: `Gem::RequestSet::Lockfile::Parser`?
-    5017 |class Gem::RequestSet::Lockfile::Parser
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    lib/test.rb:3: Replace with `Racc::Parser`
+     3 |FOO = Parlour # We expect `Parlour` to be undefined here since we didn't load any gem RBI
+              ^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi#L974: Did you mean: `JSON::Ext::Parser`?
      974 |class JSON::Ext::Parser
           ^^^^^^^^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi#L1712: Did you mean: `Psych::Parser`?
     1712 |class Psych::Parser
           ^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/racc.rbi#L3: Did you mean: `Racc::Parser`?
+     3 |class Racc::Parser
+        ^^^^^^^^^^^^^^^^^^
 Errors: 1

--- a/test/cli/constant-fuzzy/constant-fuzzy.out
+++ b/test/cli/constant-fuzzy/constant-fuzzy.out
@@ -6,37 +6,30 @@ test/cli/constant-fuzzy/constant-fuzzy.rb:3: Unable to resolve constant `Yieldr`
      3 |Yieldr.foo(Intege, Int)
         ^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `Shell`
+    test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `File`
      3 |Yieldr.foo(Intege, Int)
         ^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `Ripper`
+    test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `Dir`
      3 |Yieldr.foo(Intege, Int)
         ^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/enumerator.rbi#L868: Did you mean: `Enumerator::Yielder`?
      868 |class Enumerator::Yielder < Object
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/shell.rbi#L77: Did you mean: `Shell`?
-    77 |class Shell
-        ^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/ripper.rbi#L78: Did you mean: `Ripper`?
-    78 |class Ripper
-        ^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/file.rbi#L33: Did you mean: `File`?
+    33 |class File < IO
+        ^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#L11: Did you mean: `Dir`?
+    11 |class Dir < Object
+        ^^^^^^^^^^^^^^^^^^
 
 test/cli/constant-fuzzy/constant-fuzzy.rb:3: Unable to resolve constant `Intege` https://srb.help/5002
-     3 |Yieldr.foo(Intege, Int)
-                   ^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `Date`
      3 |Yieldr.foo(Intege, Int)
                    ^^^^^^
   Autocorrect: Use `-a` to autocorrect
     test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `Integer`
      3 |Yieldr.foo(Intege, Int)
                    ^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/date.rbi#L159: Did you mean: `Date`?
-     159 |class Date
-          ^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L8: Did you mean: `Integer`?
      8 |class Integer < Numeric
         ^^^^^^^^^^^^^^^^^^^^^^^
@@ -45,26 +38,26 @@ test/cli/constant-fuzzy/constant-fuzzy.rb:3: Unable to resolve constant `Int` ht
      3 |Yieldr.foo(Intege, Int)
                            ^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `IRB`
-     3 |Yieldr.foo(Intege, Int)
-                           ^^^
-  Autocorrect: Use `-a` to autocorrect
-    test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `IO`
+    test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `Set`
      3 |Yieldr.foo(Intege, Int)
                            ^^^
   Autocorrect: Use `-a` to autocorrect
     test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `Net`
      3 |Yieldr.foo(Intege, Int)
                            ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/irb.rbi#L409: Did you mean: `IRB`?
-     409 |module IRB
-          ^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/io.rbi#L116: Did you mean: `IO`?
-     116 |class IO < Object
-          ^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `IO`
+     3 |Yieldr.foo(Intege, Int)
+                           ^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#L60: Did you mean: `Set`?
+    60 |class Set < Object
+        ^^^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#L3: Did you mean: `Net`?
      3 |module Net
         ^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/io.rbi#L116: Did you mean: `IO`?
+     116 |class IO < Object
+          ^^^^^^^^^^^^^^^^^
 
 test/cli/constant-fuzzy/constant-fuzzy.rb:7: Unable to resolve constant `Constant` https://srb.help/5002
      7 |module A::B; Constant; end

--- a/test/cli/no-did-you-mean/no-did-you-mean.out
+++ b/test/cli/no-did-you-mean/no-did-you-mean.out
@@ -2,250 +2,250 @@ test/cli/no-did-you-mean/no-did-you-mean.rb:205: Unable to resolve constant `MyC
      205 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:205: Replace with `Class`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:205: Replace with `MyClass1`
      205 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:205: Replace with `MyClass9`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:205: Replace with `MyClass2`
      205 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:205: Replace with `MyClass8`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:205: Replace with `MyClass3`
      205 |p MyClass
             ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#L71: Did you mean: `Class`?
-    71 |class Class < Module
-        ^^^^^^^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:11: Did you mean: `MyClass9`?
-    11 |class MyClass9; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:3: Did you mean: `MyClass1`?
+     3 |class MyClass1; end
         ^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:10: Did you mean: `MyClass8`?
-    10 |class MyClass8; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:4: Did you mean: `MyClass2`?
+     4 |class MyClass2; end
+        ^^^^^^^^^^^^^^
+    test/cli/no-did-you-mean/no-did-you-mean.rb:5: Did you mean: `MyClass3`?
+     5 |class MyClass3; end
         ^^^^^^^^^^^^^^
 
 test/cli/no-did-you-mean/no-did-you-mean.rb:206: Unable to resolve constant `MyClass` https://srb.help/5002
      206 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:206: Replace with `Class`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:206: Replace with `MyClass1`
      206 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:206: Replace with `MyClass9`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:206: Replace with `MyClass2`
      206 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:206: Replace with `MyClass8`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:206: Replace with `MyClass3`
      206 |p MyClass
             ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#L71: Did you mean: `Class`?
-    71 |class Class < Module
-        ^^^^^^^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:11: Did you mean: `MyClass9`?
-    11 |class MyClass9; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:3: Did you mean: `MyClass1`?
+     3 |class MyClass1; end
         ^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:10: Did you mean: `MyClass8`?
-    10 |class MyClass8; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:4: Did you mean: `MyClass2`?
+     4 |class MyClass2; end
+        ^^^^^^^^^^^^^^
+    test/cli/no-did-you-mean/no-did-you-mean.rb:5: Did you mean: `MyClass3`?
+     5 |class MyClass3; end
         ^^^^^^^^^^^^^^
 
 test/cli/no-did-you-mean/no-did-you-mean.rb:207: Unable to resolve constant `MyClass` https://srb.help/5002
      207 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:207: Replace with `Class`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:207: Replace with `MyClass1`
      207 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:207: Replace with `MyClass9`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:207: Replace with `MyClass2`
      207 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:207: Replace with `MyClass8`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:207: Replace with `MyClass3`
      207 |p MyClass
             ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#L71: Did you mean: `Class`?
-    71 |class Class < Module
-        ^^^^^^^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:11: Did you mean: `MyClass9`?
-    11 |class MyClass9; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:3: Did you mean: `MyClass1`?
+     3 |class MyClass1; end
         ^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:10: Did you mean: `MyClass8`?
-    10 |class MyClass8; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:4: Did you mean: `MyClass2`?
+     4 |class MyClass2; end
+        ^^^^^^^^^^^^^^
+    test/cli/no-did-you-mean/no-did-you-mean.rb:5: Did you mean: `MyClass3`?
+     5 |class MyClass3; end
         ^^^^^^^^^^^^^^
 
 test/cli/no-did-you-mean/no-did-you-mean.rb:208: Unable to resolve constant `MyClass` https://srb.help/5002
      208 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:208: Replace with `Class`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:208: Replace with `MyClass1`
      208 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:208: Replace with `MyClass9`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:208: Replace with `MyClass2`
      208 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:208: Replace with `MyClass8`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:208: Replace with `MyClass3`
      208 |p MyClass
             ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#L71: Did you mean: `Class`?
-    71 |class Class < Module
-        ^^^^^^^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:11: Did you mean: `MyClass9`?
-    11 |class MyClass9; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:3: Did you mean: `MyClass1`?
+     3 |class MyClass1; end
         ^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:10: Did you mean: `MyClass8`?
-    10 |class MyClass8; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:4: Did you mean: `MyClass2`?
+     4 |class MyClass2; end
+        ^^^^^^^^^^^^^^
+    test/cli/no-did-you-mean/no-did-you-mean.rb:5: Did you mean: `MyClass3`?
+     5 |class MyClass3; end
         ^^^^^^^^^^^^^^
 
 test/cli/no-did-you-mean/no-did-you-mean.rb:209: Unable to resolve constant `MyClass` https://srb.help/5002
      209 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:209: Replace with `Class`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:209: Replace with `MyClass1`
      209 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:209: Replace with `MyClass9`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:209: Replace with `MyClass2`
      209 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:209: Replace with `MyClass8`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:209: Replace with `MyClass3`
      209 |p MyClass
             ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#L71: Did you mean: `Class`?
-    71 |class Class < Module
-        ^^^^^^^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:11: Did you mean: `MyClass9`?
-    11 |class MyClass9; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:3: Did you mean: `MyClass1`?
+     3 |class MyClass1; end
         ^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:10: Did you mean: `MyClass8`?
-    10 |class MyClass8; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:4: Did you mean: `MyClass2`?
+     4 |class MyClass2; end
+        ^^^^^^^^^^^^^^
+    test/cli/no-did-you-mean/no-did-you-mean.rb:5: Did you mean: `MyClass3`?
+     5 |class MyClass3; end
         ^^^^^^^^^^^^^^
 
 test/cli/no-did-you-mean/no-did-you-mean.rb:210: Unable to resolve constant `MyClass` https://srb.help/5002
      210 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:210: Replace with `Class`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:210: Replace with `MyClass1`
      210 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:210: Replace with `MyClass9`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:210: Replace with `MyClass2`
      210 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:210: Replace with `MyClass8`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:210: Replace with `MyClass3`
      210 |p MyClass
             ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#L71: Did you mean: `Class`?
-    71 |class Class < Module
-        ^^^^^^^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:11: Did you mean: `MyClass9`?
-    11 |class MyClass9; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:3: Did you mean: `MyClass1`?
+     3 |class MyClass1; end
         ^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:10: Did you mean: `MyClass8`?
-    10 |class MyClass8; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:4: Did you mean: `MyClass2`?
+     4 |class MyClass2; end
+        ^^^^^^^^^^^^^^
+    test/cli/no-did-you-mean/no-did-you-mean.rb:5: Did you mean: `MyClass3`?
+     5 |class MyClass3; end
         ^^^^^^^^^^^^^^
 
 test/cli/no-did-you-mean/no-did-you-mean.rb:211: Unable to resolve constant `MyClass` https://srb.help/5002
      211 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:211: Replace with `Class`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:211: Replace with `MyClass1`
      211 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:211: Replace with `MyClass9`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:211: Replace with `MyClass2`
      211 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:211: Replace with `MyClass8`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:211: Replace with `MyClass3`
      211 |p MyClass
             ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#L71: Did you mean: `Class`?
-    71 |class Class < Module
-        ^^^^^^^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:11: Did you mean: `MyClass9`?
-    11 |class MyClass9; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:3: Did you mean: `MyClass1`?
+     3 |class MyClass1; end
         ^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:10: Did you mean: `MyClass8`?
-    10 |class MyClass8; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:4: Did you mean: `MyClass2`?
+     4 |class MyClass2; end
+        ^^^^^^^^^^^^^^
+    test/cli/no-did-you-mean/no-did-you-mean.rb:5: Did you mean: `MyClass3`?
+     5 |class MyClass3; end
         ^^^^^^^^^^^^^^
 
 test/cli/no-did-you-mean/no-did-you-mean.rb:212: Unable to resolve constant `MyClass` https://srb.help/5002
      212 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:212: Replace with `Class`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:212: Replace with `MyClass1`
      212 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:212: Replace with `MyClass9`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:212: Replace with `MyClass2`
      212 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:212: Replace with `MyClass8`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:212: Replace with `MyClass3`
      212 |p MyClass
             ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#L71: Did you mean: `Class`?
-    71 |class Class < Module
-        ^^^^^^^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:11: Did you mean: `MyClass9`?
-    11 |class MyClass9; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:3: Did you mean: `MyClass1`?
+     3 |class MyClass1; end
         ^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:10: Did you mean: `MyClass8`?
-    10 |class MyClass8; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:4: Did you mean: `MyClass2`?
+     4 |class MyClass2; end
+        ^^^^^^^^^^^^^^
+    test/cli/no-did-you-mean/no-did-you-mean.rb:5: Did you mean: `MyClass3`?
+     5 |class MyClass3; end
         ^^^^^^^^^^^^^^
 
 test/cli/no-did-you-mean/no-did-you-mean.rb:213: Unable to resolve constant `MyClass` https://srb.help/5002
      213 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:213: Replace with `Class`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:213: Replace with `MyClass1`
      213 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:213: Replace with `MyClass9`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:213: Replace with `MyClass2`
      213 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:213: Replace with `MyClass8`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:213: Replace with `MyClass3`
      213 |p MyClass
             ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#L71: Did you mean: `Class`?
-    71 |class Class < Module
-        ^^^^^^^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:11: Did you mean: `MyClass9`?
-    11 |class MyClass9; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:3: Did you mean: `MyClass1`?
+     3 |class MyClass1; end
         ^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:10: Did you mean: `MyClass8`?
-    10 |class MyClass8; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:4: Did you mean: `MyClass2`?
+     4 |class MyClass2; end
+        ^^^^^^^^^^^^^^
+    test/cli/no-did-you-mean/no-did-you-mean.rb:5: Did you mean: `MyClass3`?
+     5 |class MyClass3; end
         ^^^^^^^^^^^^^^
 
 test/cli/no-did-you-mean/no-did-you-mean.rb:214: Unable to resolve constant `MyClass` https://srb.help/5002
      214 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:214: Replace with `Class`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:214: Replace with `MyClass1`
      214 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:214: Replace with `MyClass9`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:214: Replace with `MyClass2`
      214 |p MyClass
             ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/no-did-you-mean/no-did-you-mean.rb:214: Replace with `MyClass8`
+    test/cli/no-did-you-mean/no-did-you-mean.rb:214: Replace with `MyClass3`
      214 |p MyClass
             ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#L71: Did you mean: `Class`?
-    71 |class Class < Module
-        ^^^^^^^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:11: Did you mean: `MyClass9`?
-    11 |class MyClass9; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:3: Did you mean: `MyClass1`?
+     3 |class MyClass1; end
         ^^^^^^^^^^^^^^
-    test/cli/no-did-you-mean/no-did-you-mean.rb:10: Did you mean: `MyClass8`?
-    10 |class MyClass8; end
+    test/cli/no-did-you-mean/no-did-you-mean.rb:4: Did you mean: `MyClass2`?
+     4 |class MyClass2; end
+        ^^^^^^^^^^^^^^
+    test/cli/no-did-you-mean/no-did-you-mean.rb:5: Did you mean: `MyClass3`?
+     5 |class MyClass3; end
         ^^^^^^^^^^^^^^
 
 test/cli/no-did-you-mean/no-did-you-mean.rb:215: Unable to resolve constant `MyClass` https://srb.help/5002

--- a/test/cli/suggest-new/suggest-new.out
+++ b/test/cli/suggest-new/suggest-new.out
@@ -2,11 +2,11 @@ test/cli/suggest-new/suggest-new.rb:9: Method `ABC` does not exist on `T.class_o
      9 |ABC(1)
         ^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/suggest-new/suggest-new.rb:9: Replace with `ABE.new`
+    test/cli/suggest-new/suggest-new.rb:9: Replace with `ABD.new`
      9 |ABC(1)
         ^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/suggest-new/suggest-new.rb:9: Replace with `ABD.new`
+    test/cli/suggest-new/suggest-new.rb:9: Replace with `ABE.new`
      9 |ABC(1)
         ^^^
 Errors: 1

--- a/test/cli/suggest-not-stub/suggest-not-stub.out
+++ b/test/cli/suggest-not-stub/suggest-not-stub.out
@@ -6,17 +6,17 @@ test/cli/suggest-not-stub/suggest-not-stub.rb:6: Unable to resolve constant `B` 
      6 |B
         ^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/suggest-not-stub/suggest-not-stub.rb:6: Replace with `A`
-     6 |B
-        ^
-  Autocorrect: Use `-a` to autocorrect
     test/cli/suggest-not-stub/suggest-not-stub.rb:6: Replace with `T`
      6 |B
         ^
-    test/cli/suggest-not-stub/suggest-not-stub.rb:2: Did you mean: `A`?
-     2 |class A
-        ^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/suggest-not-stub/suggest-not-stub.rb:6: Replace with `A`
+     6 |B
+        ^
     https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L16: Did you mean: `T`?
     16 |module T
         ^^^^^^^^
+    test/cli/suggest-not-stub/suggest-not-stub.rb:2: Did you mean: `A`?
+     2 |class A
+        ^^^^^^^
 Errors: 2

--- a/test/testdata/lsp/missing_typed_sigil.A.rbedited
+++ b/test/testdata/lsp/missing_typed_sigil.A.rbedited
@@ -12,7 +12,7 @@ class Hello
 end
 
 def main
-  puts Gem.new
+  puts Hello.new
   #    ^^^^ error: Unable to resolve constant `Helo`
-  #    ^^^^ apply-code-action: [A] Replace with `Gem`
+  #    ^^^^ apply-code-action: [A] Replace with `Hello`
 end

--- a/test/testdata/lsp/missing_typed_sigil.rb
+++ b/test/testdata/lsp/missing_typed_sigil.rb
@@ -14,5 +14,5 @@ end
 def main
   puts Helo.new
   #    ^^^^ error: Unable to resolve constant `Helo`
-  #    ^^^^ apply-code-action: [A] Replace with `Gem`
+  #    ^^^^ apply-code-action: [A] Replace with `Hello`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Speed up fuzzy constant match and fix a significant bug.
    
Fuzzy constant match called `Symbol::membersStableOrderSlow` to deterministically loop through a symbol's members. As the name implies, this method is expensive; it sorts members by their string names. When Sorbet generates many errors, this function call dominates runtime (by >80%).
    
However, this function call is not needed to ensure deterministic fuzzy matches! We can cheaply sort and tiebreak after finding the best matches in a given scope.
    
Unfortunately, I noticed that this method has some peculiar behavior:
* Rather than pick one best candidate per scope (as a comment at the top of the method says), it picks `n` semi-arbitrary best candidates within the scope that happen to beat "betterThan". This behavior creates a dependency between iteration order and the contents of `result`, and ensures that less-than-ideal matches are presented to the user.
* The function sorts the candidates to place the suggestions with the smallest edit distance first, __and then reverses the vector__ to place the largest edit distances first. As a result, Sorbet would recommend the _worst_ replacements first!
  * Look at `constant-fuzzy.out` to see how we used to recommend `Date` over `Integer` for `Intege` (!!!)
    
I have changed the behavior to:
* Pick the single best candidates in the current scope that beats out candidates from inner scopes, and sort them by symbol ID to tiebreak.
* Place the items with the smallest edit distance _first_ in the result vector without extraneous sorting.
    
From the changes in test output, I believe this will significantly improve Sorbet's autocorrect suggestions _and_ is a massive perf win when Sorbet generates many errors.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

See https://github.com/sorbet/sorbet/pull/4239#issuecomment-853243842

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
