### PR TITLE
use <Magic>.<rewriter-raise-unimplemented> for raising in unimplemented methods

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -409,10 +409,8 @@ public:
     }
 
     static ExpressionPtr RaiseUnimplemented(core::LocOffsets loc) {
-        auto kernel = Constant(loc, core::Symbols::Kernel());
-        auto msg = String(loc, core::Names::rewriterRaiseUnimplemented());
-        // T.unsafe so that Sorbet doesn't know this unconditionally raises (avoids introducing dead code errors)
-        auto ret = Send1(loc, Unsafe(loc, std::move(kernel)), core::Names::raise(), std::move(msg));
+        auto magic = Constant(loc, core::Symbols::Magic());
+        auto ret = Send0(loc, std::move(magic), core::Names::rewriterRaiseUnimplemented());
         cast_tree<ast::Send>(ret)->flags.isRewriterSynthesized = true;
         return ret;
     }

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -601,7 +601,7 @@ void GlobalState::initEmpty() {
                  .repeatedUntypedArg(Names::arg())
                  .buildWithResultUntyped();
 
-    // Synthesize <Magic>.<raise-unimplemented>() => T.untyped
+    // Synthesize <Magic>.<rewriter-raise-unimplemented>() => T.untyped
     method =
         enterMethod(*this, Symbols::MagicSingleton(), Names::rewriterRaiseUnimplemented()).buildWithResultUntyped();
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -601,6 +601,10 @@ void GlobalState::initEmpty() {
                  .repeatedUntypedArg(Names::arg())
                  .buildWithResultUntyped();
 
+    // Synthesize <Magic>.<raise-unimplemented>() => T.untyped
+    method =
+        enterMethod(*this, Symbols::MagicSingleton(), Names::rewriterRaiseUnimplemented()).buildWithResultUntyped();
+
     // Synthesize <DeclBuilderForProcs>.<params>(args: T.untyped) => DeclBuilderForProcs
     method = enterMethod(*this, Symbols::DeclBuilderForProcsSingleton(), Names::params())
                  .kwsplatArg(Names::arg0())

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -884,7 +884,7 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 200;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 38;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 39;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 3;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 98;

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -269,7 +269,7 @@ NameDef names[] = {
     {"normal"},
 
     {"raise"},
-    {"rewriterRaiseUnimplemented", "Sorbet rewriter pass partially unimplemented"},
+    {"rewriterRaiseUnimplemented", "<rewriter-raise-unimplemented>"},
 
     {"test"},
     // end DSL methods

--- a/test/testdata/desugar/pattern_matching_array.rb.desugar-tree.exp
+++ b/test/testdata/desugar/pattern_matching_array.rb.desugar-tree.exp
@@ -3,34 +3,34 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   begin
     <assignTemp>$1 = expr
-    if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    if ::<Magic>.<rewriter-raise-unimplemented>()
       begin
-        a = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        a = ::<Magic>.<rewriter-raise-unimplemented>()
         <emptyTree>::<C T>.reveal_type(a)
       end
     else
-      if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      if ::<Magic>.<rewriter-raise-unimplemented>()
         begin
-          b = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+          b = ::<Magic>.<rewriter-raise-unimplemented>()
           <emptyTree>::<C T>.reveal_type(b)
         end
       else
-        if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        if ::<Magic>.<rewriter-raise-unimplemented>()
           begin
-            c = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-            d = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+            c = ::<Magic>.<rewriter-raise-unimplemented>()
+            d = ::<Magic>.<rewriter-raise-unimplemented>()
             begin
               <emptyTree>::<C T>.reveal_type(c)
               <emptyTree>::<C T>.reveal_type(d)
             end
           end
         else
-          if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+          if ::<Magic>.<rewriter-raise-unimplemented>()
             begin
-              e = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-              f = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-              h = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-              g = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+              e = ::<Magic>.<rewriter-raise-unimplemented>()
+              f = ::<Magic>.<rewriter-raise-unimplemented>()
+              h = ::<Magic>.<rewriter-raise-unimplemented>()
+              g = ::<Magic>.<rewriter-raise-unimplemented>()
               begin
                 <emptyTree>::<C T>.reveal_type(e)
                 <emptyTree>::<C T>.reveal_type(f)
@@ -39,26 +39,26 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
               end
             end
           else
-            if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+            if ::<Magic>.<rewriter-raise-unimplemented>()
               begin
-                i = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+                i = ::<Magic>.<rewriter-raise-unimplemented>()
                 <emptyTree>::<C T>.reveal_type(i)
               end
             else
-              if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+              if ::<Magic>.<rewriter-raise-unimplemented>()
                 begin
-                  k = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-                  l = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+                  k = ::<Magic>.<rewriter-raise-unimplemented>()
+                  l = ::<Magic>.<rewriter-raise-unimplemented>()
                   begin
                     <emptyTree>::<C T>.reveal_type(k)
                     <emptyTree>::<C T>.reveal_type(l)
                   end
                 end
               else
-                if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+                if ::<Magic>.<rewriter-raise-unimplemented>()
                   begin
-                    m = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-                    n = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+                    m = ::<Magic>.<rewriter-raise-unimplemented>()
+                    n = ::<Magic>.<rewriter-raise-unimplemented>()
                     begin
                       <emptyTree>::<C T>.reveal_type(m)
                       <emptyTree>::<C T>.reveal_type(n)

--- a/test/testdata/desugar/pattern_matching_assign.rb.desugar-tree.exp
+++ b/test/testdata/desugar/pattern_matching_assign.rb.desugar-tree.exp
@@ -5,34 +5,34 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   x = begin
     <assignTemp>$1 = expr
-    if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    if ::<Magic>.<rewriter-raise-unimplemented>()
       begin
-        s = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        s = ::<Magic>.<rewriter-raise-unimplemented>()
         begin
           <emptyTree>::<C T>.reveal_type(s)
           1
         end
       end
     else
-      if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      if ::<Magic>.<rewriter-raise-unimplemented>()
         begin
-          x = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+          x = ::<Magic>.<rewriter-raise-unimplemented>()
           begin
             <emptyTree>::<C T>.reveal_type(x)
             1
           end
         end
       else
-        if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        if ::<Magic>.<rewriter-raise-unimplemented>()
           begin
-            expr = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+            expr = ::<Magic>.<rewriter-raise-unimplemented>()
             begin
               <emptyTree>::<C T>.reveal_type(expr)
               1
             end
           end
         else
-          if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+          if ::<Magic>.<rewriter-raise-unimplemented>()
             begin
               <emptyTree>::<C T>.reveal_type(x)
               <emptyTree>::<C T>.reveal_type(expr)

--- a/test/testdata/desugar/pattern_matching_const.rb.desugar-tree.exp
+++ b/test/testdata/desugar/pattern_matching_const.rb.desugar-tree.exp
@@ -5,31 +5,31 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   begin
     <assignTemp>$1 = nil
-    if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    if ::<Magic>.<rewriter-raise-unimplemented>()
       <emptyTree>
     else
-      if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      if ::<Magic>.<rewriter-raise-unimplemented>()
         <emptyTree>
       else
-        if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        if ::<Magic>.<rewriter-raise-unimplemented>()
           <emptyTree>
         else
-          if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+          if ::<Magic>.<rewriter-raise-unimplemented>()
             begin
-              x = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+              x = ::<Magic>.<rewriter-raise-unimplemented>()
               <emptyTree>::<C T>.reveal_type(x)
             end
           else
-            if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+            if ::<Magic>.<rewriter-raise-unimplemented>()
               begin
-                x = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+                x = ::<Magic>.<rewriter-raise-unimplemented>()
                 <emptyTree>::<C T>.reveal_type(x)
               end
             else
-              if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+              if ::<Magic>.<rewriter-raise-unimplemented>()
                 begin
-                  x = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-                  y = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+                  x = ::<Magic>.<rewriter-raise-unimplemented>()
+                  y = ::<Magic>.<rewriter-raise-unimplemented>()
                   begin
                     <emptyTree>::<C T>.reveal_type(x)
                     <emptyTree>::<C T>.reveal_type(y)

--- a/test/testdata/desugar/pattern_matching_guards.rb.desugar-tree.exp
+++ b/test/testdata/desugar/pattern_matching_guards.rb.desugar-tree.exp
@@ -3,16 +3,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   y = begin
     <assignTemp>$1 = nil
-    if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    if ::<Magic>.<rewriter-raise-unimplemented>()
       1
     else
-      if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      if ::<Magic>.<rewriter-raise-unimplemented>()
         2
       else
-        if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        if ::<Magic>.<rewriter-raise-unimplemented>()
           3
         else
-          if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+          if ::<Magic>.<rewriter-raise-unimplemented>()
             45
           else
             6

--- a/test/testdata/desugar/pattern_matching_hash.rb.desugar-tree.exp
+++ b/test/testdata/desugar/pattern_matching_hash.rb.desugar-tree.exp
@@ -3,34 +3,34 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   begin
     <assignTemp>$2 = expr
-    if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    if ::<Magic>.<rewriter-raise-unimplemented>()
       begin
-        a = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        a = ::<Magic>.<rewriter-raise-unimplemented>()
         <emptyTree>::<C T>.reveal_type(a)
       end
     else
-      if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      if ::<Magic>.<rewriter-raise-unimplemented>()
         begin
-          b = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+          b = ::<Magic>.<rewriter-raise-unimplemented>()
           <emptyTree>::<C T>.reveal_type(b)
         end
       else
-        if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        if ::<Magic>.<rewriter-raise-unimplemented>()
           begin
-            c = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-            d = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+            c = ::<Magic>.<rewriter-raise-unimplemented>()
+            d = ::<Magic>.<rewriter-raise-unimplemented>()
             begin
               <emptyTree>::<C T>.reveal_type(c)
               <emptyTree>::<C T>.reveal_type(d)
             end
           end
         else
-          if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+          if ::<Magic>.<rewriter-raise-unimplemented>()
             begin
-              i = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-              e = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-              g = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-              h = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+              i = ::<Magic>.<rewriter-raise-unimplemented>()
+              e = ::<Magic>.<rewriter-raise-unimplemented>()
+              g = ::<Magic>.<rewriter-raise-unimplemented>()
+              h = ::<Magic>.<rewriter-raise-unimplemented>()
               begin
                 <emptyTree>::<C T>.reveal_type(e)
                 <emptyTree>::<C T>.reveal_type(g)
@@ -39,11 +39,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
               end
             end
           else
-            if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+            if ::<Magic>.<rewriter-raise-unimplemented>()
               begin
-                m = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-                j = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-                l = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+                m = ::<Magic>.<rewriter-raise-unimplemented>()
+                j = ::<Magic>.<rewriter-raise-unimplemented>()
+                l = ::<Magic>.<rewriter-raise-unimplemented>()
                 begin
                   <emptyTree>::<C T>.reveal_type(j)
                   <emptyTree>::<C T>.reveal_type(l)
@@ -51,12 +51,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
                 end
               end
             else
-              if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+              if ::<Magic>.<rewriter-raise-unimplemented>()
                 begin
-                  n4 = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-                  n1 = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-                  n2 = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-                  n3 = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+                  n4 = ::<Magic>.<rewriter-raise-unimplemented>()
+                  n1 = ::<Magic>.<rewriter-raise-unimplemented>()
+                  n2 = ::<Magic>.<rewriter-raise-unimplemented>()
+                  n3 = ::<Magic>.<rewriter-raise-unimplemented>()
                   begin
                     <emptyTree>::<C T>.reveal_type(n1)
                     <emptyTree>::<C T>.reveal_type(n2)
@@ -65,13 +65,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
                   end
                 end
               else
-                if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+                if ::<Magic>.<rewriter-raise-unimplemented>()
                   begin
-                    o = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+                    o = ::<Magic>.<rewriter-raise-unimplemented>()
                     <emptyTree>::<C T>.reveal_type(o)
                   end
                 else
-                  if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+                  if ::<Magic>.<rewriter-raise-unimplemented>()
                     <emptyTree>
                   else
                     <emptyTree>

--- a/test/testdata/desugar/pattern_matching_pins.rb.desugar-tree.exp
+++ b/test/testdata/desugar/pattern_matching_pins.rb.desugar-tree.exp
@@ -7,13 +7,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   begin
     <assignTemp>$1 = nil
-    if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    if ::<Magic>.<rewriter-raise-unimplemented>()
       <emptyTree>
     else
-      if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      if ::<Magic>.<rewriter-raise-unimplemented>()
         <emptyTree>
       else
-        if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        if ::<Magic>.<rewriter-raise-unimplemented>()
           <emptyTree>
         else
           <emptyTree>

--- a/test/testdata/lsp/struct_fuzz.rb
+++ b/test/testdata/lsp/struct_fuzz.rb
@@ -4,9 +4,6 @@
 # ^^^^^^^^^^^^^^^^ error: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)`
 # ^^^^^^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(B)`
 # ^^^^^^^^^^^^^^^^ error: Method `params` does not exist on `T.class_of(B)`
-# ^^^^^^^^^^^^^^^^ error: Method `unsafe` does not exist on `T.class_of(T)`
-# ^^^^^^^^^^^^^^^^ error: Method `unsafe` does not exist on `T.class_of(T)`
-# ^^^^^^^^^^^^^^^^ error: Method `unsafe` does not exist on `T.class_of(T)`
 #                ^ error: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)`
 #                ^ error: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)`
 # these errors aren't actually what we're checking for, we just want to make sure sorbet doesn't crash on this input

--- a/test/testdata/rewriter/def_delegator.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/def_delegator.rb.rewrite-tree.exp
@@ -5,7 +5,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<todo method>>(*arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def aliased_bar<<todo method>>(*arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def baz<<todo method>>(*arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def qux<<todo method>>(*arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||
@@ -131,7 +131,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<todo method>>(*arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -139,7 +139,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def aliased_bar<<todo method>>(*arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -147,7 +147,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def baz<<todo method>>(*arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -155,7 +155,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def qux<<todo method>>(*arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     <self>.extend(<emptyTree>::<C Forwardable>)
@@ -183,7 +183,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<todo method>>(*arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -191,7 +191,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def aliased_bar<<todo method>>(*arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -199,7 +199,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def baz<<todo method>>(*arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -207,7 +207,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def qux<<todo method>>(*arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :foo, :normal)
@@ -271,7 +271,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def each<<todo method>>(*arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     <self>.extend(<emptyTree>::<C T>::<C Generic>)

--- a/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_opt_string<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def opt_string<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_opt_int_defaulted<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -45,7 +45,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def opt_int_defaulted<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -61,7 +61,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_req_string<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -69,7 +69,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def req_string<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -85,7 +85,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_implied_string<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -93,7 +93,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def implied_string<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -109,7 +109,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_no_setter<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -117,7 +117,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def no_setter<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -133,7 +133,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_class_of<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -141,7 +141,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def class_of<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -157,7 +157,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.get_root_const<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -165,7 +165,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def root_const<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.keep_self_def(<self>, :opt_string, :normal)

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -101,7 +101,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     begin
-      <emptyTree>::<C CONST> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      <emptyTree>::<C CONST> = ::<Magic>.<rewriter-raise-unimplemented>()
       begin
         "allows constants inside of IT"
         ::Sorbet::Private::Static.keep_def(<self>, :"<it \'allows constants inside of IT\'>", :normal)
@@ -109,7 +109,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     begin
-      <emptyTree>::<C C2> = ::T.let(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented"), <emptyTree>::<C Integer>)
+      <emptyTree>::<C C2> = ::T.let(::<Magic>.<rewriter-raise-unimplemented>(), <emptyTree>::<C Integer>)
       begin
         "allows let-ed constants inside of IT"
         ::Sorbet::Private::Static.keep_def(<self>, :"<it \'allows let-ed constants inside of IT\'>", :normal)

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -84,7 +84,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def <it 'succeed with a local variable but cannot type it'><<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented").each() do |value|
+      ::<Magic>.<rewriter-raise-unimplemented>().each() do |value|
         begin
           <self>.puts(value.foo())
           <emptyTree>::<C T>.reveal_type(value)

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -3297,26 +3297,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3599,26 +3587,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3686,26 +3662,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -3988,26 +3952,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4075,26 +4027,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4377,26 +4317,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4464,26 +4392,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4762,26 +4678,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4856,26 +4760,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -4921,26 +4813,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -5106,26 +4986,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -5616,26 +5484,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -7965,26 +7821,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -8056,26 +7900,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -8158,26 +7990,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -8290,26 +8110,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -8366,26 +8174,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }
@@ -8457,26 +8253,14 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            recv = Send{
-              recv = ConstantLit{
-                orig = nullptr
-                symbol = (module ::T)
-              }
-              fun = <U unsafe>
-              block = nullptr
-              pos_args = 1
-              args = [
-                ConstantLit{
-                  orig = nullptr
-                  symbol = (module ::Kernel)
-                }
-              ]
+            recv = ConstantLit{
+              orig = nullptr
+              symbol = (class ::<Magic>)
             }
-            fun = <U raise>
+            fun = <U <rewriter-raise-unimplemented>>
             block = nullptr
-            pos_args = 1
+            pos_args = 0
             args = [
-              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
             ]
           }
         }

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -302,7 +302,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def enum_prop=<<todo method>>(arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -336,7 +336,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -344,7 +344,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_!<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -378,7 +378,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_lazy_<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -386,7 +386,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_lazy_!<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -420,7 +420,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_proc_<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -428,7 +428,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_proc_!<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -462,7 +462,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_invalid_<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -470,7 +470,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_invalid_!<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -478,7 +478,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def ifunset<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -501,7 +501,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def ifunset_nilable<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -561,7 +561,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def hash_rules=<<todo method>>(arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     <self>.include(<emptyTree>::<C T>::<C Props>)
@@ -843,7 +843,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -851,7 +851,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def encrypted_foo<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -859,7 +859,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo=<<todo method>>(arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -867,7 +867,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def encrypted_foo=<<todo method>>(arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -875,7 +875,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def bar<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -883,7 +883,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def encrypted_bar<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     <self>.include(<emptyTree>::<C T>::<C Props>)

--- a/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
@@ -6,8 +6,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def num_ok<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_num_ok(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::T.assert_type!(<self>.class().compute_num_ok(::<Magic>.<rewriter-raise-unimplemented>()), <emptyTree>::<C Integer>)
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
     end
 
@@ -25,8 +25,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def missing<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_missing(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::T.assert_type!(<self>.class().compute_missing(::<Magic>.<rewriter-raise-unimplemented>()), <emptyTree>::<C Integer>)
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
     end
 
@@ -36,8 +36,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def num_wrong_value<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_num_wrong_value(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::T.assert_type!(<self>.class().compute_num_wrong_value(::<Magic>.<rewriter-raise-unimplemented>()), <emptyTree>::<C Integer>)
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
     end
 
@@ -55,8 +55,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def num_wrong_type<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_num_wrong_type(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::T.assert_type!(<self>.class().compute_num_wrong_type(::<Magic>.<rewriter-raise-unimplemented>()), <emptyTree>::<C Integer>)
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
     end
 
@@ -96,8 +96,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def num_unknown_type<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_num_unknown_type(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::T.assert_type!(<self>.class().compute_num_unknown_type(::<Magic>.<rewriter-raise-unimplemented>()), <emptyTree>::<C Integer>)
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
     end
 

--- a/test/testdata/rewriter/prop_foreign.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_foreign.rb.rewrite-tree.exp
@@ -34,7 +34,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_lazy_<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -42,7 +42,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_lazy_!<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_proc_<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -84,7 +84,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_proc_!<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -118,7 +118,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_invalid_<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -126,7 +126,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foreign_invalid_!<<todo method>>(*opts:, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     <self>.include(<emptyTree>::<C T>::<C Props>)

--- a/test/testdata/rewriter/prop_in_module.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_in_module.rb.rewrite-tree.exp
@@ -5,7 +5,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo=<<todo method>>(arg0, &<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     <self>.include(<emptyTree>::<C T>::<C Props>)

--- a/test/testdata/rewriter/singleton.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/singleton.rb.rewrite-tree.exp
@@ -5,7 +5,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.instance<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.keep_self_def(<self>, :instance, :normal)
@@ -26,7 +26,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.instance<<todo method>>(&<blk>)
-      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      ::<Magic>.<rewriter-raise-unimplemented>()
     end
 
     ::Sorbet::Private::Static.keep_self_def(<self>, :instance, :normal)

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -15,19 +15,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C RealStruct><<C <todo sym>>> < (::<todo sym>)
     class <emptyTree>::<C A><<C <todo sym>>> < (::<root>::<C Struct>)
       def foo<<todo method>>(&<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def foo=<<todo method>>(foo, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def bar<<todo method>>(&<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def bar=<<todo method>>(bar, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -35,7 +35,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def initialize<<todo method>>(foo = nil, bar = nil, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :foo, :normal)
@@ -53,19 +53,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     class <emptyTree>::<C KeywordInit><<C <todo sym>>> < (::<root>::<C Struct>)
       def foo<<todo method>>(&<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def foo=<<todo method>>(foo, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def bar<<todo method>>(&<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def bar=<<todo method>>(bar, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -73,7 +73,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def initialize<<todo method>>(foo: = nil, bar: = nil, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :foo, :normal)
@@ -133,11 +133,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C TwoStructs><<C <todo sym>>> < (::<todo sym>)
     class <emptyTree>::<C A><<C <todo sym>>> < (::<root>::<C Struct>)
       def foo<<todo method>>(&<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def foo=<<todo method>>(foo, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -145,7 +145,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def initialize<<todo method>>(foo = nil, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :foo, :normal)
@@ -159,11 +159,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     class <emptyTree>::<C B><<C <todo sym>>> < (::<root>::<C Struct>)
       def foo<<todo method>>(&<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def foo=<<todo method>>(foo, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -171,7 +171,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def initialize<<todo method>>(foo = nil, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :foo, :normal)
@@ -190,19 +190,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     class <emptyTree>::<C A><<C <todo sym>>> < (::<root>::<C Struct>)
       def foo<<todo method>>(&<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def foo=<<todo method>>(foo, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def bar<<todo method>>(&<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def bar=<<todo method>>(bar, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -210,7 +210,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def initialize<<todo method>>(foo = nil, bar = nil, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :foo, :normal)
@@ -238,11 +238,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     class <emptyTree>::<C MyStruct><<C <todo sym>>> < (::<root>::<C Struct>)
       def x<<todo method>>(&<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def x=<<todo method>>(x, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -250,7 +250,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def initialize<<todo method>>(x = nil, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :x, :normal)
@@ -270,11 +270,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     class <emptyTree>::<C MyKeywordInitStruct><<C <todo sym>>> < (::<root>::<C Struct>)
       def x<<todo method>>(&<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def x=<<todo method>>(x, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -282,7 +282,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def initialize<<todo method>>(x: = nil, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :x, :normal)
@@ -352,11 +352,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C FullyQualifiedStructUsages><<C <todo sym>>> < (::<todo sym>)
     class <emptyTree>::<C Foo><<C <todo sym>>> < (::<root>::<C Struct>)
       def a<<todo method>>(&<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def a=<<todo method>>(a, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -364,7 +364,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def initialize<<todo method>>(a = nil, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :a, :normal)
@@ -378,11 +378,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     class <emptyTree>::<C Bar><<C <todo sym>>> < (::<root>::<C Struct>)
       def a<<todo method>>(&<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       def a=<<todo method>>(a, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -390,7 +390,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def initialize<<todo method>>(a = nil, &<blk>)
-        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+        ::<Magic>.<rewriter-raise-unimplemented>()
       end
 
       ::Sorbet::Private::Static.keep_def(<self>, :a, :normal)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

Having a dedicated function to raise in unimplemented methods makes it easier to identify such raises in plugins analyzing the CFG.  You could pattern-match on the current `T.unsafe(Kernel).raise(...)` and verify that it appears in a `rewriterSynthesized` method, or somesuch, but doing things this way is much more convenient.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
