### PR TITLE
Fix else block conditional in builder walk

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -257,7 +257,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 if (thenEnd != cctx.inWhat.deadBlock() || elseEnd != cctx.inWhat.deadBlock()) {
                     if (thenEnd == cctx.inWhat.deadBlock()) {
                         ret = elseEnd;
-                    } else if (thenEnd == cctx.inWhat.deadBlock()) {
+                    } else if (elseEnd == cctx.inWhat.deadBlock()) {
                         ret = thenEnd;
                     } else {
                         ret = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);


### PR DESCRIPTION
This conditional branch is never reached because the condition is identical to the previous one. This PR updates the conditional to check against the right block.

### Test plan

Existing tests will cover this.