### PR TITLE
Change unwrap_nilable to allow for larger unions

### DIFF
--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -79,10 +79,11 @@ module T::Utils
     case type
     when T::Types::Union
       non_nil_types = type.types.reject {|t| t == Nilable::NIL_TYPE}
-      if non_nil_types.length == 1
-        non_nil_types.first
+      case non_nil_types.length
+      when 0 then nil
+      when 1 then non_nil_types.first
       else
-        nil
+        T::Types::Union::Private::Pool.union_of_types(non_nil_types[0], non_nil_types[1], non_nil_types[2..])
       end
     else
       nil

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -79,7 +79,7 @@ module T::Utils
     case type
     when T::Types::Union
       non_nil_types = type.types.reject {|t| t == Nilable::NIL_TYPE}
-      return nil if types.types.length == non_nil_types.length
+      return nil if type.types.length == non_nil_types.length
       case non_nil_types.length
       when 0 then nil
       when 1 then non_nil_types.first

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -79,6 +79,7 @@ module T::Utils
     case type
     when T::Types::Union
       non_nil_types = type.types.reject {|t| t == Nilable::NIL_TYPE}
+      return nil if types.types.length == non_nil_types.length
       case non_nil_types.length
       when 0 then nil
       when 1 then non_nil_types.first

--- a/gems/sorbet-runtime/test/types/utils.rb
+++ b/gems/sorbet-runtime/test/types/utils.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+module Opus::Types::Test
+  class UtilsTest < Critic::Unit::UnitTest
+    describe 'T::Utils.unwrap_nilable' do
+      it 'unwraps when multiple elements' do
+        type = T.any(String, NilClass, Float)
+        # require 'pry'; binding.pry
+        unwrapped = T.must(T::Utils.unwrap_nilable(type))
+
+        assert(T.any(String, Float).subtype_of?(unwrapped))
+        assert(unwrapped.subtype_of?(T.any(String, Float)))
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reported as a bug internally at Stripe: http://go/Ugw2yoeo

cc @jnovak-stripe 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Verified that this works on Stripe's codebase.

http://go/builds/bui_JdplkLGHwx1j31

### Rollout plan

At least one person was attempting to workaround this bug in a way that caused failures after this bug was fixed.

Also, some generated, checked-in files change in response to this change. This means when we upgrade in Stripe's codebase, we will have to bump the version and make changes in lock step (instead of fixing the errors ahead of time, and bumping after.

No one else is making changes to sorbet-runtime right now, so this should not be disruptive.