### PR TITLE
Do not use endless range in sorbet-runtime

### DIFF
--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -84,7 +84,8 @@ module T::Utils
       when 0 then nil
       when 1 then non_nil_types.first
       else
-        T::Types::Union::Private::Pool.union_of_types(non_nil_types[0], non_nil_types[1], non_nil_types[2..])
+        size = non_nil_types.size - 1
+        T::Types::Union::Private::Pool.union_of_types(non_nil_types[0], non_nil_types[1], non_nil_types[2..size])
       end
     else
       nil


### PR DESCRIPTION
### Motivation

Remove usage of end-less range so sorbet-runtime still work with 2.5.

The end-less range was introduced [here](https://github.com/sorbet/sorbet/pull/4252/files#diff-3701c6bc454263c98078696834aa766aa480276e0498b92b5eefb374047ec413R87) and can be rewritten with an explicit end.

### Test plan

See included automated tests.
