### PR TITLE
do bulk erasing in extractClassInit

### DIFF
--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -35,14 +35,14 @@ bool shouldExtract(core::Context ctx, const ast::ExpressionPtr &what) {
 ast::ExpressionPtr extractClassInit(core::Context ctx, ast::ClassDef *klass) {
     ast::InsSeq::STATS_store inits;
 
-    for (auto it = klass->rhs.begin(); it != klass->rhs.end(); /* nothing */) {
-        if (!shouldExtract(ctx, *it)) {
-            ++it;
-            continue;
+    auto it = remove_if(klass->rhs.begin(), klass->rhs.end(), [&](ast::ExpressionPtr &expr) {
+        bool b = shouldExtract(ctx, expr);
+        if (b) {
+            inits.emplace_back(std::move(expr));
         }
-        inits.emplace_back(std::move(*it));
-        it = klass->rhs.erase(it);
-    }
+        return b;
+    });
+    klass->rhs.erase(it, klass->rhs.end());
 
     if (inits.empty()) {
         return ast::MK::EmptyTree();


### PR DESCRIPTION


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We shouldn't erase single elements at a time from `klass->rhs` in this function; it's more efficient to let `std::remove_if` shift everything around in linear time and erase everything in one go.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This should be equivalent to the existing code, so existing tests should suffice.