### PR TITLE
Better error message for "Type members in wrong order"

### DIFF
--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -113,7 +113,13 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
                 ENFORCE(my.exists(), "resolver failed to register type member aliases");
                 if (sym.data(gs)->typeMembers()[i] != my) {
                     if (auto e = gs.beginError(my.data(gs)->loc(), core::errors::Resolver::TypeMembersInWrongOrder)) {
-                        e.setHeader("Type members in wrong order");
+                        e.setHeader("Type members for `{}` repeated in wrong order", sym.show(gs));
+                        e.addErrorLine(my.data(gs)->loc(), "Found type member with name `{}`",
+                                       my.data(gs)->name.show(gs));
+                        e.addErrorLine(sym.data(gs)->typeMembers()[i].data(gs)->loc(),
+                                       "Expected type member with name `{}`",
+                                       sym.data(gs)->typeMembers()[i].data(gs)->name.show(gs));
+                        e.addErrorLine(tp.data(gs)->loc(), "`{}` defined in parent here:", tp.data(gs)->name.show(gs));
                     }
                     int foundIdx = 0;
                     while (foundIdx < sym.data(gs)->typeMembers().size() &&

--- a/test/testdata/resolver/type_members.rb
+++ b/test/testdata/resolver/type_members.rb
@@ -44,7 +44,7 @@ end
 class BadChild1 < Parent
   extend T::Generic
   My = type_member
-  Elem = type_member # error: Type members in wrong order
+  Elem = type_member # error: Type members for `BadChild1` repeated in wrong order
 end
 
 class BadChild2 < Parent # error: must be re-declared


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Trying to debug something in Stripe's codebase, and the error message is bad.

This would have made it easier to debug.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

**Before**
<img width="470" alt="Screen Shot 2021-06-14 at 4 57 05 PM" src="https://user-images.githubusercontent.com/5544532/121973957-3cae1580-cd33-11eb-8ddb-7a5adc3d2ffc.png">

**After**
<img width="610" alt="Screen Shot 2021-06-14 at 5 05 30 PM" src="https://user-images.githubusercontent.com/5544532/121973954-3b7ce880-cd33-11eb-9ca8-5e127bc4db06.png">
