### PR TITLE
Add a sig for Array#collect!

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -834,6 +834,13 @@ class Array < Object
   #
   # Also aliased as:
   # [`map!`](https://docs.ruby-lang.org/en/2.7.0/Array.html#method-i-map-21)
+  sig do
+    type_parameters(:U).params(
+        blk: T.proc.params(arg0: Elem).returns(T.type_parameter(:U)),
+    )
+    .returns(T::Array[T.type_parameter(:U)])
+  end
+  sig {returns(T::Enumerator[Elem])}
   def collect!(&blk); end
 
   # When invoked with a block, yields all combinations of length `n` of elements


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
There was no signature for `Array#collect!`. Luckily `Array#map!` is an alias to it, so their signatures will be the same.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
More signatures for core methods.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
