### PR TITLE
add and sort autogen subclasses in-place

### DIFF
--- a/common/sort.h
+++ b/common/sort.h
@@ -11,4 +11,11 @@ template <class Container> inline void fast_sort(Container &container) {
     pdqsort(container.begin(), container.end());
 };
 
+// You should prefer using fast_sort to this.  This function exists for the case where
+// you don't want to sort the entire container and to centralize the "hiding" of
+// pdqsort to this header.
+template <class Iterator> inline void fast_sort_range(Iterator start, Iterator end) {
+    pdqsort(start, end);
+}
+
 #endif

--- a/main/autogen/subclasses.cc
+++ b/main/autogen/subclasses.cc
@@ -112,19 +112,17 @@ vector<string> Subclasses::serializeSubclassMap(const Subclasses::Map &descendan
         auto type = children.classKind == ClassKind::Class ? "class" : "module";
         descendantsMapSerialized.emplace_back(fmt::format("{} {}", type, parentName));
 
-        vector<string> serializedChildren;
+        auto subclassesStart = descendantsMapSerialized.size();
         for (const auto &[name, type] : children.entries) {
             // Ignore Modules
             if (type == autogen::Definition::Type::Class) {
-                serializedChildren.emplace_back(fmt::format(" class {}", name));
+                descendantsMapSerialized.emplace_back(fmt::format(" class {}", name));
             } else {
-                serializedChildren.emplace_back(fmt::format(" module {}", name));
+                descendantsMapSerialized.emplace_back(fmt::format(" module {}", name));
             }
         }
 
-        fast_sort(serializedChildren);
-        descendantsMapSerialized.insert(descendantsMapSerialized.end(), make_move_iterator(serializedChildren.begin()),
-                                        make_move_iterator(serializedChildren.end()));
+        fast_sort_range(descendantsMapSerialized.begin() + subclassesStart, descendantsMapSerialized.end());
     }
 
     return descendantsMapSerialized;


### PR DESCRIPTION
### Motivation

Less memory allocation and copying data around is a good thing.

Bikeshedding welcome on `fast_sort_range` -- I know ranges are a separate thing than iterators, so maybe we want to call this `fast_sort_iterators`?  But that just sounds weird, so I went with `fast_sort_range`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  We have `test/cli/autogen-subclasses` for exercising this code.
