### PR TITLE
avoid accessing uninitialized memory in genDescendantsMap

### DIFF
--- a/main/autogen/subclasses.cc
+++ b/main/autogen/subclasses.cc
@@ -156,11 +156,11 @@ vector<string> Subclasses::genDescendantsMap(Subclasses::Map &childMap, vector<s
 
         auto descendants = Subclasses::descendantsOf(childMap, parentName);
         if (!descendants) {
+            // Initialize an empty entry associated with parentName.
             descendantsMap[parentName];
-            continue;
+        } else {
+            descendantsMap.emplace(parentName, std::move(*descendants));
         }
-
-        descendantsMap.emplace(parentName, std::move(*descendants));
     }
 
     return Subclasses::serializeSubclassMap(descendantsMap, parentNames);

--- a/main/autogen/subclasses.cc
+++ b/main/autogen/subclasses.cc
@@ -157,6 +157,7 @@ vector<string> Subclasses::genDescendantsMap(Subclasses::Map &childMap, vector<s
         auto descendants = Subclasses::descendantsOf(childMap, parentName);
         if (!descendants) {
             descendantsMap[parentName];
+            continue;
         }
 
         descendantsMap.emplace(parentName, std::move(*descendants));


### PR DESCRIPTION
(Why, yes, browser, I did mean hitting enter in the title field to submit the entire form...)

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This fixes something relatively harmless, but also reduces the "what?!" factor when reading the code.

In the current code, we check `descendants`, an `optional<SubclassInfo>` for `Some`.  If it's `None`, we insert an empty entry in `descendantsMap`...but then we go on to access the contained `SubclassInfo` in the `optional`, which is not there.

I think this is not a problem currently because `emplace` won't modify existing entries, and we already created an empty one, so providing a reference to uninitialized memory is harmless.  Nonetheless, reading the current code is confusing, and we should fix that.

(Fun note: the tests passed with continuing regardless of whether we inserted the empty entry in `descendantsMap` or not...I left it there for now.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
