### PR TITLE
factor out fresh name generation into DesugarContext

### DIFF
--- a/test/testdata/desugar/pattern_matching_array.rb.desugar-tree.exp
+++ b/test/testdata/desugar/pattern_matching_array.rb.desugar-tree.exp
@@ -2,7 +2,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   expr = []
 
   begin
-    <assignTemp>$1 = expr
+    <assignTemp>$2 = expr
     if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       begin
         a = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")

--- a/test/testdata/desugar/pattern_matching_assign.rb.desugar-tree.exp
+++ b/test/testdata/desugar/pattern_matching_assign.rb.desugar-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(expr)
 
   x = begin
-    <assignTemp>$1 = expr
+    <assignTemp>$2 = expr
     if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       begin
         s = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")

--- a/test/testdata/desugar/pattern_matching_const.rb.desugar-tree.exp
+++ b/test/testdata/desugar/pattern_matching_const.rb.desugar-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C B> = nil
 
   begin
-    <assignTemp>$1 = nil
+    <assignTemp>$2 = nil
     if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       <emptyTree>
     else

--- a/test/testdata/desugar/pattern_matching_guards.rb.desugar-tree.exp
+++ b/test/testdata/desugar/pattern_matching_guards.rb.desugar-tree.exp
@@ -2,7 +2,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   x = nil
 
   y = begin
-    <assignTemp>$1 = nil
+    <assignTemp>$2 = nil
     if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       1
     else

--- a/test/testdata/desugar/pattern_matching_hash.rb.desugar-tree.exp
+++ b/test/testdata/desugar/pattern_matching_hash.rb.desugar-tree.exp
@@ -2,7 +2,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   expr = {}
 
   begin
-    <assignTemp>$2 = expr
+    <assignTemp>$3 = expr
     if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       begin
         a = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")

--- a/test/testdata/desugar/pattern_matching_pins.rb.desugar-tree.exp
+++ b/test/testdata/desugar/pattern_matching_pins.rb.desugar-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   c = ""
 
   begin
-    <assignTemp>$1 = nil
+    <assignTemp>$2 = nil
     if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       <emptyTree>
     else


### PR DESCRIPTION
### Motivation

It's silly to have to repeat `dctx.ctx.state.freshNameUnique(...)` everywhere; we can make things shorter and more consistent.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  The exp files change in one place because one call was using post-increment on `dctx.uniqueCounter` instead of pre-increment.
