### PR TITLE
Add support for desugaring regex backreferences

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2085,7 +2085,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             },
             [&](parser::Backref *backref) {
                 auto recv = MK::Constant(loc, core::Symbols::Magic());
-                result = MK::Send0(loc, std::move(recv), core::Names::regexBackref());
+                auto arg = MK::Symbol(backref->loc, backref->name);
+                result = MK::Send1(loc, std::move(recv), core::Names::regexBackref(), std::move(arg));
             },
             [&](parser::EFlipflop *eflipflop) {
                 auto res = unsupportedNode(dctx, eflipflop);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2084,7 +2084,10 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(res);
             },
             [&](parser::Backref *backref) {
-                auto res = unsupportedNode(dctx, backref);
+                // Desugar backref expression as T.let(nil, T.nilable(String))
+                auto value = MK::Nil(loc);
+                auto type = MK::Nilable(loc, MK::Constant(loc, core::Symbols::String()));
+                ExpressionPtr res = MK::Let(loc, std::move(value), std::move(type));
                 result = std::move(res);
             },
             [&](parser::EFlipflop *eflipflop) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2084,11 +2084,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(res);
             },
             [&](parser::Backref *backref) {
-                // Desugar backref expression as T.let(nil, T.nilable(String))
-                auto value = MK::Nil(loc);
-                auto type = MK::Nilable(loc, MK::Constant(loc, core::Symbols::String()));
-                ExpressionPtr res = MK::Let(loc, std::move(value), std::move(type));
-                result = std::move(res);
+                auto recv = MK::Constant(loc, core::Symbols::Magic());
+                result = MK::Send0(loc, std::move(recv), core::Names::regexBackref());
             },
             [&](parser::EFlipflop *eflipflop) {
                 auto res = unsupportedNode(dctx, eflipflop);

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -504,8 +504,9 @@ void GlobalState::initEmpty() {
                  .untypedArg(Names::arg2())
                  .buildWithResult(Types::rangeOfUntyped());
 
-    // Synthesize <Magic>,<regex-backref>() => T.nilable(String)
+    // Synthesize <Magic>.<regex-backref>(arg0: T.untyped) => T.nilable(String)
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::regexBackref())
+                 .untypedArg(Names::arg0())
                  .buildWithResult(Types::any(*this, Types::nilClass(), Types::String()));
 
     // Synthesize <Magic>.<splat>(a: T.untyped) => Untyped

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -504,6 +504,10 @@ void GlobalState::initEmpty() {
                  .untypedArg(Names::arg2())
                  .buildWithResult(Types::rangeOfUntyped());
 
+    // Synthesize <Magic>,<regex-backref>() => T.nilable(String)
+    method = enterMethod(*this, Symbols::MagicSingleton(), Names::regexBackref())
+                 .buildWithResult(Types::any(*this, Types::nilClass(), Types::String()));
+
     // Synthesize <Magic>.<splat>(a: T.untyped) => Untyped
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::splat())
                  .untypedArg(Names::arg0())

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -884,7 +884,7 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 200;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 38;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 39;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 3;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 98;

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -385,6 +385,8 @@ NameDef names[] = {
     // Pattern matching
     {"patternMatch", "<pattern-match>"},
 
+    {"regexBackref", "<regex-backref>"},
+
     {"staticInit", "<static-init>"},
 
     {"require"},

--- a/test/testdata/desugar/backref.rb
+++ b/test/testdata/desugar/backref.rb
@@ -20,3 +20,12 @@ T.reveal_type(x6) # error: Revealed type: `T.untyped`
 
 x7 = $9 # contains the 9th match group;
 T.reveal_type(x7) # error: Revealed type: `T.untyped`
+
+class TestNotPinningBackrefs
+  /foo/.match("foo") do |m|
+    x = $&
+    T.reveal_type(x) # error: Revealed type: `T.nilable(String)`
+    x = false
+    T.reveal_type(x) # error: Revealed type: `FalseClass`
+  end
+end

--- a/test/testdata/desugar/backref.rb
+++ b/test/testdata/desugar/backref.rb
@@ -1,0 +1,22 @@
+# typed: true
+
+x1 = $~ # is equivalent to ::last_match;
+T.reveal_type(x1) # error: Revealed type: `T.untyped`
+
+x2 = $& # contains the complete matched text;
+T.reveal_type(x2) # error: Revealed type: `T.nilable(String)`
+
+x3 = $` # contains string before match;
+T.reveal_type(x3) # error: Revealed type: `T.nilable(String)`
+
+x4 = $' # contains string after match;
+T.reveal_type(x4) # error: Revealed type: `T.nilable(String)`
+
+x5 = $+ # contains last capture group;
+T.reveal_type(x5) # error: Revealed type: `T.nilable(String)`
+
+x6 = $1 # contains the first match group;
+T.reveal_type(x6) # error: Revealed type: `T.untyped`
+
+x7 = $9 # contains the 9th match group;
+T.reveal_type(x7) # error: Revealed type: `T.untyped`


### PR DESCRIPTION
Desugar backref expressions as `T.let(nil, T.nilable(String))`
Resolve https://github.com/sorbet/sorbet/issues/1856

### Motivation

These come up from time to time. When they do, we're required to set a file as `typed: ignore` or refactor in order to have sorbet run happily.

### Test plan

See included automated tests.