### PR TITLE
add some desugar tests for &&= and ||=

### DIFF
--- a/test/testdata/desugar/andand_type_merge.rb
+++ b/test/testdata/desugar/andand_type_merge.rb
@@ -1,0 +1,23 @@
+# typed: strict
+
+extend T::Sig
+
+Pair = T.type_alias do
+  T.any(Integer, String)
+end
+
+sig {params(x: Pair).returns(String)}
+def create(x)
+  case x
+  when String
+    x
+  else
+    x.to_s
+  end
+end
+
+sig {params(pair: T.nilable(Pair)).void}
+def f(pair)
+  pair &&= create(pair)
+  T.reveal_type(pair) # error: Revealed type: `T.nilable(String)`
+end

--- a/test/testdata/desugar/andand_unreachable.rb
+++ b/test/testdata/desugar/andand_unreachable.rb
@@ -1,0 +1,16 @@
+# typed: strict
+
+extend T::Sig
+
+sig {returns(Integer)}
+def int
+  5
+end
+
+sig {params(x: T.nilable(Integer)).void}
+def f(x)
+  if !x.nil?
+    x &&= int
+    T.reveal_type(x) # error: Revealed type: `Integer`
+  end
+end

--- a/test/testdata/desugar/oror_classvar.rb
+++ b/test/testdata/desugar/oror_classvar.rb
@@ -1,0 +1,19 @@
+# typed: true
+
+extend T::Sig
+
+class Config
+  @@supported_methods ||= T.let(nil, T.nilable(T::Array[String]))
+
+  extend T::Sig
+
+  sig {returns(T::Array[String])}
+  def self.supported_methods
+    @@supported_methods ||= begin
+                              temp = T.let(['fast', 'slow', 'special'].uniq.freeze, T.nilable(T::Array[String]))
+                              temp
+                            end
+    T.reveal_type(@@supported_methods) # error: Revealed type: `T.nilable(T::Array[String])`
+    T.must(@@supported_methods)
+  end
+end

--- a/test/testdata/desugar/oror_classvar.rb.desugar-tree.exp
+++ b/test/testdata/desugar/oror_classvar.rb.desugar-tree.exp
@@ -1,0 +1,32 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+  class <emptyTree>::<C Config><<C <todo sym>>> < (::<todo sym>)
+    if @@supported_methods
+      @@supported_methods
+    else
+      @@supported_methods = <emptyTree>::<C T>.let(nil, <emptyTree>::<C T>.nilable(<emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>)))
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <self>.sig() do ||
+      <self>.returns(<emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>))
+    end
+
+    def self.supported_methods<<todo method>>(&<blk>)
+      begin
+        if @@supported_methods
+          @@supported_methods
+        else
+          @@supported_methods = begin
+            temp = <emptyTree>::<C T>.let(["fast", "slow", "special"].uniq().freeze(), <emptyTree>::<C T>.nilable(<emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>)))
+            temp
+          end
+        end
+        <emptyTree>::<C T>.reveal_type(@@supported_methods)
+        <emptyTree>::<C T>.must(@@supported_methods)
+      end
+    end
+  end
+end

--- a/test/testdata/desugar/oror_ivar.rb
+++ b/test/testdata/desugar/oror_ivar.rb
@@ -1,0 +1,12 @@
+# typed: strict
+
+module Config
+  extend T::Sig
+
+  sig {returns(T::Array[String])}
+  def self.supported_methods
+    @supported_methods ||= T.let(['fast', 'slow', 'special'].uniq.freeze, T.nilable(T::Array[String]))
+    T.reveal_type(@supported_methods) # error: Revealed type: `T.nilable(T::Array[String])`
+    T.must(@supported_methods)
+  end
+end

--- a/test/testdata/desugar/oror_ivar.rb.desugar-tree.exp
+++ b/test/testdata/desugar/oror_ivar.rb.desugar-tree.exp
@@ -1,0 +1,21 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C Config><<C <todo sym>>> < ()
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <self>.sig() do ||
+      <self>.returns(<emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>))
+    end
+
+    def self.supported_methods<<todo method>>(&<blk>)
+      begin
+        if @supported_methods
+          @supported_methods
+        else
+          @supported_methods = <emptyTree>::<C T>.let(["fast", "slow", "special"].uniq().freeze(), <emptyTree>::<C T>.nilable(<emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>)))
+        end
+        <emptyTree>::<C T>.reveal_type(@supported_methods)
+        <emptyTree>::<C T>.must(@supported_methods)
+      end
+    end
+  end
+end

--- a/test/testdata/desugar/oror_newlocal.rb
+++ b/test/testdata/desugar/oror_newlocal.rb
@@ -1,0 +1,15 @@
+# typed: strict
+extend T::Sig
+
+sig {returns(Integer)}
+def int
+  5
+end
+
+sig {returns(Integer)}
+def newlocal
+  x ||= int
+  T.reveal_type(x) # error: Revealed type: `Integer`
+  x
+end
+

--- a/test/testdata/desugar/oror_t_let.rb
+++ b/test/testdata/desugar/oror_t_let.rb
@@ -1,0 +1,12 @@
+# typed: true
+extend T::Sig
+
+def returns_untyped; end
+
+sig {params(customer: T.nilable(Integer)).returns(Integer)}
+def call(customer)
+  customer ||= T.let(returns_untyped, Integer)
+  T.reveal_type(customer) # error: Revealed type: `Integer`
+  customer
+end
+


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These all came up as problematic cases when debugging #4274, and it seemed reasonable to add them to the tree now so that we can be aware we would be changing behavior later.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
