### PR TITLE
wip: better error messages for unsupported tuple/shape types in prop types

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -13,5 +13,6 @@ constexpr ErrorClass TEnumConstNotEnumValue{3506, StrictLevel::False};
 constexpr ErrorClass BadTestEach{3507, StrictLevel::True};
 constexpr ErrorClass PropForeignStrict{3508, StrictLevel::False};
 constexpr ErrorClass ComputedBySymbol{3509, StrictLevel::False};
+constexpr ErrorClass InvalidPropType{3510, StrictLevel::False};
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -196,8 +196,14 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
             return nullopt;
         }
 
-        ret.type = ASTUtil::dupType(send->args[1]);
+        const ast::ExpressionPtr *failure = nullptr;
+        ret.type = ASTUtil::dupType(send->args[1], &failure);
         if (ret.type == nullptr) {
+            if (failure != nullptr) {
+                if (auto e = ctx.beginError(failure->loc(), core::errors::Rewriter::InvalidPropType)) {
+                    e.setHeader("Invalid type in prop type descriptor");
+                }
+            }
             return nullopt;
         }
     }

--- a/rewriter/Util.h
+++ b/rewriter/Util.h
@@ -8,7 +8,7 @@
 namespace sorbet::rewriter {
 class ASTUtil {
 public:
-    static ast::ExpressionPtr dupType(const ast::ExpressionPtr &orig);
+    static ast::ExpressionPtr dupType(const ast::ExpressionPtr &orig, const ast::ExpressionPtr **failing = nullptr);
     static bool hasHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name);
     static bool hasTruthyHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name);
 

--- a/test/testdata/rewriter/coerce_in_prop.rb
+++ b/test/testdata/rewriter/coerce_in_prop.rb
@@ -8,4 +8,5 @@
 
     prop :supported_payment_methods1, T.coerce(PAYMENT_METHODS_HASH) # error-with-dupes: Unsupported method `T.coerce`
     prop :supported_payment_methods2, T.coerce({a: Integer})
+                                             # ^^^^^^^^^^^^ error: Invalid type in prop type descriptor
   end

--- a/test/testdata/rewriter/fuzz_dup_type_not_constant.rb
+++ b/test/testdata/rewriter/fuzz_dup_type_not_constant.rb
@@ -1,2 +1,3 @@
 # typed: false
 prop :a, b::A
+       # ^ error: Invalid type in prop type descriptor

--- a/test/testdata/rewriter/prop.rb
+++ b/test/testdata/rewriter/prop.rb
@@ -3,6 +3,7 @@ class NotAODM
     def self.prop(*args); end
     prop
     prop :foo, :not_a_string
+             # ^^^^^^^^^^^^^ error: Invalid type in prop type descriptor
     prop "not_a_symbol", String
     prop :foo, String, "not_a_hash"
     prop "too", String, {}, "many"
@@ -145,4 +146,11 @@ def main
     T.reveal_type(AdvancedODM.new.ifunset_nilable) # error: Revealed type: `T.nilable(String)`
     AdvancedODM.new.ifunset = nil # error: does not match expected type
     AdvancedODM.new.ifunset_nilable = nil
+end
+
+class NoTuples < T::Struct
+  extend T::Sig
+
+  const :tuples, [Integer, String] # error: Invalid type in prop type descriptor
+  const :array_tuples, T::Array[[String, Integer]] # error: Invalid type in prop type descriptor
 end

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -8636,5 +8636,167 @@ ClassDef{
         Literal{ value = :normal }
       ]
     }
+
+    ClassDef{
+      kind = class
+      name = UnresolvedConstantLit{
+        scope = EmptyTree
+        cnst = <C <U NoTuples>>
+      }<<C <U <todo sym>>>>
+      ancestors = [UnresolvedConstantLit{
+          scope = UnresolvedConstantLit{
+            scope = EmptyTree
+            cnst = <C <U T>>
+          }
+          cnst = <C <U Struct>>
+        }]
+      rhs = [
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = (module ::Sorbet::Private::Static)
+          }
+          fun = <U sig>
+          block = Block {
+            args = [
+            ]
+            body = Send{
+              recv = Local{
+                localVariable = <U <self>>
+              }
+              fun = <U void>
+              block = nullptr
+              pos_args = 0
+              args = [
+              ]
+            }
+          }
+          pos_args = 1
+          args = [
+            ConstantLit{
+              orig = nullptr
+              symbol = (module ::T::Sig::WithoutRuntime)
+            }
+          ]
+        }
+
+        MethodDef{
+          flags = {rewriter}
+          name = <U initialize><<U <todo method>>>
+          args = [BlockArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Send{
+            recv = Local{
+              localVariable = <U <self>>
+            }
+            fun = <U super>
+            block = nullptr
+            pos_args = 1
+            args = [
+              ZSuperArgs{ }
+            ]
+          }
+        }
+
+        Send{
+          recv = ConstantLit{
+            orig = nullptr
+            symbol = (module ::Sorbet::Private::Static)
+          }
+          fun = <U keep_def>
+          block = nullptr
+          pos_args = 3
+          args = [
+            Local{
+              localVariable = <U <self>>
+            }
+            Literal{ value = :initialize }
+            Literal{ value = :normal }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U extend>
+          block = nullptr
+          pos_args = 1
+          args = [
+            UnresolvedConstantLit{
+              scope = UnresolvedConstantLit{
+                scope = EmptyTree
+                cnst = <C <U T>>
+              }
+              cnst = <C <U Sig>>
+            }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U const>
+          block = nullptr
+          pos_args = 2
+          args = [
+            Literal{ value = :tuples }
+            Array{
+              elems = [
+                UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U Integer>>
+                }
+                UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U String>>
+                }
+              ]
+            }
+          ]
+        }
+
+        Send{
+          recv = Local{
+            localVariable = <U <self>>
+          }
+          fun = <U const>
+          block = nullptr
+          pos_args = 2
+          args = [
+            Literal{ value = :array_tuples }
+            Send{
+              recv = UnresolvedConstantLit{
+                scope = UnresolvedConstantLit{
+                  scope = EmptyTree
+                  cnst = <C <U T>>
+                }
+                cnst = <C <U Array>>
+              }
+              fun = <U []>
+              block = nullptr
+              pos_args = 1
+              args = [
+                Array{
+                  elems = [
+                    UnresolvedConstantLit{
+                      scope = EmptyTree
+                      cnst = <C <U String>>
+                    }
+                    UnresolvedConstantLit{
+                      scope = EmptyTree
+                      cnst = <C <U Integer>>
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -904,4 +904,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::Sorbet::Private::Static.keep_def(<self>, :main, :normal)
+
+  class <emptyTree>::<C NoTuples><<C <todo sym>>> < (<emptyTree>::<C T>::<C Struct>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def initialize<<todo method>>(&<blk>)
+      <self>.super(ZSuperArgs)
+    end
+
+    ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <self>.const(:tuples, [<emptyTree>::<C Integer>, <emptyTree>::<C String>])
+
+    <self>.const(:array_tuples, <emptyTree>::<C T>::<C Array>.[]([<emptyTree>::<C String>, <emptyTree>::<C Integer>]))
+  end
 end

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -1,210 +1,217 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=148:4}
+    method <S <C <U <root>>> $1><N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=156:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U AdvancedODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=38:18}
-    method <C <U AdvancedODM>><U array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
+  class <C <U AdvancedODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=39:1 end=39:18}
+    method <C <U AdvancedODM>><U array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=44:5 end=44:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U array=> (array, <blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
-      argument array<> -> T::Array[T.untyped] @ Loc {file=test/testdata/rewriter/prop.rb start=43:11 end=43:16}
+    method <C <U AdvancedODM>><U array=> (array, <blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=44:5 end=44:23}
+      argument array<> -> T::Array[T.untyped] @ Loc {file=test/testdata/rewriter/prop.rb start=44:11 end=44:16}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U const> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=48:5 end=48:25}
+    method <C <U AdvancedODM>><U const> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=49:5 end=49:25}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U const_explicit> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=47:5 end=47:50}
+    method <C <U AdvancedODM>><U const_explicit> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=48:5 end=48:50}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U default> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=40:5 end=40:39}
+    method <C <U AdvancedODM>><U default> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:39}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U default=> (default, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=40:5 end=40:39}
-      argument default<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=40:11 end=40:18}
+    method <C <U AdvancedODM>><U default=> (default, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:39}
+      argument default<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=41:11 end=41:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U empty_hash_rules> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=60:5 end=60:39}
+    method <C <U AdvancedODM>><U empty_hash_rules> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=61:5 end=61:39}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U empty_hash_rules=> (empty_hash_rules, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=60:5 end=60:39}
-      argument empty_hash_rules<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=60:11 end=60:27}
+    method <C <U AdvancedODM>><U empty_hash_rules=> (empty_hash_rules, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=61:5 end=61:39}
+      argument empty_hash_rules<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=61:11 end=61:27}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U enum_prop> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=50:5 end=50:56}
+    method <C <U AdvancedODM>><U enum_prop> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=51:5 end=51:56}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U enum_prop=> (enum_prop, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=50:5 end=50:56}
-      argument enum_prop<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=50:11 end=50:20}
+    method <C <U AdvancedODM>><U enum_prop=> (enum_prop, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=51:5 end=51:56}
+      argument enum_prop<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=51:11 end=51:20}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
+    method <C <U AdvancedODM>><U foreign> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:49}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign=> (foreign, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
-      argument foreign<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
+    method <C <U AdvancedODM>><U foreign=> (foreign, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:49}
+      argument foreign<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
+    method <C <U AdvancedODM>><U foreign_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:49}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
+    method <C <U AdvancedODM>><U foreign_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:49}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_invalid> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
+    method <C <U AdvancedODM>><U foreign_invalid> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=56:5 end=56:65}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_invalid=> (foreign_invalid, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
-      argument foreign_invalid<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
+    method <C <U AdvancedODM>><U foreign_invalid=> (foreign_invalid, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=56:5 end=56:65}
+      argument foreign_invalid<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=56:11 end=56:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_invalid_> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
+    method <C <U AdvancedODM>><U foreign_invalid_> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=56:5 end=56:65}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=56:11 end=56:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_invalid_!> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
+    method <C <U AdvancedODM>><U foreign_invalid_!> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=56:5 end=56:65}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=56:11 end=56:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_lazy> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
+    method <C <U AdvancedODM>><U foreign_lazy> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:59}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_lazy=> (foreign_lazy, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
-      argument foreign_lazy<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
+    method <C <U AdvancedODM>><U foreign_lazy=> (foreign_lazy, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:59}
+      argument foreign_lazy<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_lazy_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
-      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_lazy_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
-      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_proc> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
-      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_proc=> (foreign_proc, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
-      argument foreign_proc<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
-      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_proc_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
+    method <C <U AdvancedODM>><U foreign_lazy_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:59}
       argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U foreign_proc_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
+    method <C <U AdvancedODM>><U foreign_lazy_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:59}
       argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U hash_of> (<blk>) -> AppliedType {       klass = <C <U Hash>>       targs = [         <C <U K>> = Symbol         <C <U V>> = String         <C <U Elem>> = TupleType {             0 = Symbol             1 = String           }       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:43}
+    method <C <U AdvancedODM>><U foreign_proc> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:61}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U hash_of=> (hash_of, <blk>) -> AppliedType {       klass = <C <U Hash>>       targs = [         <C <U K>> = Symbol         <C <U V>> = String         <C <U Elem>> = TupleType {             0 = Symbol             1 = String           }       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:43}
-      argument hash_of<> -> T::Hash[Symbol, String] @ Loc {file=test/testdata/rewriter/prop.rb start=45:11 end=45:18}
+    method <C <U AdvancedODM>><U foreign_proc=> (foreign_proc, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:61}
+      argument foreign_proc<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U hash_rules> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=61:5 end=61:62}
+    method <C <U AdvancedODM>><U foreign_proc_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:61}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U hash_rules=> (hash_rules, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=61:5 end=61:62}
-      argument hash_rules<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=61:11 end=61:21}
+    method <C <U AdvancedODM>><U foreign_proc_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:61}
+      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U ifunset> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=57:5 end=57:39}
+    method <C <U AdvancedODM>><U hash_of> (<blk>) -> AppliedType {       klass = <C <U Hash>>       targs = [         <C <U K>> = Symbol         <C <U V>> = String         <C <U Elem>> = TupleType {             0 = Symbol             1 = String           }       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=46:5 end=46:43}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U ifunset=> (ifunset, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=57:5 end=57:39}
-      argument ifunset<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=57:11 end=57:18}
+    method <C <U AdvancedODM>><U hash_of=> (hash_of, <blk>) -> AppliedType {       klass = <C <U Hash>>       targs = [         <C <U K>> = Symbol         <C <U V>> = String         <C <U Elem>> = TupleType {             0 = Symbol             1 = String           }       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=46:5 end=46:43}
+      argument hash_of<> -> T::Hash[Symbol, String] @ Loc {file=test/testdata/rewriter/prop.rb start=46:11 end=46:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U ifunset_nilable> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=58:5 end=58:58}
+    method <C <U AdvancedODM>><U hash_rules> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=62:5 end=62:62}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U ifunset_nilable=> (ifunset_nilable, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=58:5 end=58:58}
-      argument ifunset_nilable<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=58:11 end=58:26}
+    method <C <U AdvancedODM>><U hash_rules=> (hash_rules, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=62:5 end=62:62}
+      argument hash_rules<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=62:11 end=62:21}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U t_array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = String       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=44:5 end=44:36}
+    method <C <U AdvancedODM>><U ifunset> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=58:5 end=58:39}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U t_array=> (t_array, <blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = String       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=44:5 end=44:36}
-      argument t_array<> -> T::Array[String] @ Loc {file=test/testdata/rewriter/prop.rb start=44:11 end=44:18}
+    method <C <U AdvancedODM>><U ifunset=> (ifunset, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=58:5 end=58:39}
+      argument ifunset<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=58:11 end=58:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U t_nilable> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:39}
+    method <C <U AdvancedODM>><U ifunset_nilable> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=59:5 end=59:58}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>><U t_nilable=> (t_nilable, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:39}
-      argument t_nilable<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=41:11 end=41:20}
+    method <C <U AdvancedODM>><U ifunset_nilable=> (ifunset_nilable, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=59:5 end=59:58}
+      argument ifunset_nilable<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=59:11 end=59:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U AdvancedODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:7 end=38:18}
-    type-member(+) <S <C <U AdvancedODM>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U AdvancedODM>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AdvancedODM) @ Loc {file=test/testdata/rewriter/prop.rb start=38:7 end=38:18}
-    method <S <C <U AdvancedODM>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=62:4}
+    method <C <U AdvancedODM>><U t_array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = String       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:36}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <C <U AdvancedODM>><U t_array=> (t_array, <blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = String       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:36}
+      argument t_array<> -> T::Array[String] @ Loc {file=test/testdata/rewriter/prop.rb start=45:11 end=45:18}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <C <U AdvancedODM>><U t_nilable> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=42:5 end=42:39}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <C <U AdvancedODM>><U t_nilable=> (t_nilable, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=42:5 end=42:39}
+      argument t_nilable<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=42:11 end=42:20}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+  class <S <C <U AdvancedODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=39:7 end=39:18}
+    type-member(+) <S <C <U AdvancedODM>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U AdvancedODM>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=AdvancedODM) @ Loc {file=test/testdata/rewriter/prop.rb start=39:7 end=39:18}
+    method <S <C <U AdvancedODM>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=39:1 end=63:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U EncryptedProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=86:1 end=86:20}
-    method <C <U EncryptedProp>><U bar> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:56}
+  class <C <U EncryptedProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=87:20}
+    method <C <U EncryptedProp>><U bar> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=91:3 end=91:56}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U encrypted_bar> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:56}
+    method <C <U EncryptedProp>><U encrypted_bar> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=91:3 end=91:56}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U encrypted_foo> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=89:3 end=89:22}
+    method <C <U EncryptedProp>><U encrypted_foo> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U encrypted_foo=> (foo, <blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=89:3 end=89:22}
-      argument foo<> -> T.nilable(Opus::DB::Model::Mixins::Encryptable::EncryptedValue) @ Loc {file=test/testdata/rewriter/prop.rb start=89:19 end=89:22}
+    method <C <U EncryptedProp>><U encrypted_foo=> (foo, <blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:22}
+      argument foo<> -> T.nilable(Opus::DB::Model::Mixins::Encryptable::EncryptedValue) @ Loc {file=test/testdata/rewriter/prop.rb start=90:19 end=90:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U foo> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=89:3 end=89:22}
+    method <C <U EncryptedProp>><U foo> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U EncryptedProp>><U foo=> (foo, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=89:3 end=89:22}
-      argument foo<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=89:19 end=89:22}
+    method <C <U EncryptedProp>><U foo=> (foo, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:22}
+      argument foo<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=90:19 end=90:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U EncryptedProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=86:7 end=86:20}
-    type-member(+) <S <C <U EncryptedProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U EncryptedProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=EncryptedProp) @ Loc {file=test/testdata/rewriter/prop.rb start=86:7 end=86:20}
-    method <S <C <U EncryptedProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=86:1 end=91:4}
+  class <S <C <U EncryptedProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:7 end=87:20}
+    type-member(+) <S <C <U EncryptedProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U EncryptedProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=EncryptedProp) @ Loc {file=test/testdata/rewriter/prop.rb start=87:7 end=87:20}
+    method <S <C <U EncryptedProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=92:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <S <C <U EncryptedProp>> $1><U encrypted_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=88:3 end=88:35}
-      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=88:27 end=88:31}
+    method <S <C <U EncryptedProp>> $1><U encrypted_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=89:3 end=89:35}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=89:27 end=89:31}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U ForeignClass>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=35:1 end=35:19}
-  class <S <C <U ForeignClass>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=35:7 end=35:19}
-    type-member(+) <S <C <U ForeignClass>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U ForeignClass>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=ForeignClass) @ Loc {file=test/testdata/rewriter/prop.rb start=35:7 end=35:19}
-    method <S <C <U ForeignClass>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=35:1 end=36:4}
+  class <C <U ForeignClass>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=36:1 end=36:19}
+  class <S <C <U ForeignClass>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=36:7 end=36:19}
+    type-member(+) <S <C <U ForeignClass>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U ForeignClass>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=ForeignClass) @ Loc {file=test/testdata/rewriter/prop.rb start=36:7 end=36:19}
+    method <S <C <U ForeignClass>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=36:1 end=37:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+  class <C <U NoTuples>> < <C <U T>><C <U Struct>> () @ Loc {file=test/testdata/rewriter/prop.rb start=151:1 end=151:27}
+    method <C <U NoTuples>><U initialize> (<blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/prop.rb start=151:1 end=151:27}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+  class <S <C <U NoTuples>> $1>[<C <U <AttachedClass>>>] < <C <U T>><S <C <U Struct>> $1> (<C <U Sig>>) @ Loc {file=test/testdata/rewriter/prop.rb start=151:7 end=151:15}
+    type-member(+) <S <C <U NoTuples>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U NoTuples>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=NoTuples) @ Loc {file=test/testdata/rewriter/prop.rb start=151:7 end=151:15}
+    method <S <C <U NoTuples>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=151:1 end=156:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U NotAODM>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=2:14}
   class <S <C <U NotAODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=2:7 end=2:14}
     type-member(+) <S <C <U NotAODM>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U NotAODM>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=NotAODM) @ Loc {file=test/testdata/rewriter/prop.rb start=2:7 end=2:14}
-    method <S <C <U NotAODM>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=21:4}
+    method <S <C <U NotAODM>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=22:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <S <C <U NotAODM>> $1><U prop> (args, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=3:5 end=3:25}
       argument args<repeated> @ Loc {file=test/testdata/rewriter/prop.rb start=3:20 end=3:24}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
-    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=93:1 end=93:9}
+    method <C <U Object>><U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=94:1 end=94:9}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U PropHelpers>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=64:1 end=64:18}
-    method <C <U PropHelpers>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:15}
+  class <C <U PropHelpers>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=65:1 end=65:18}
+    method <C <U PropHelpers>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=70:3 end=70:15}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers>><U created=> (created, <blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:15}
-      argument created<> -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:10}
+    method <C <U PropHelpers>><U created=> (created, <blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=70:3 end=70:15}
+      argument created<> -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=70:3 end=70:10}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers>><U token> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=68:3 end=68:13}
+    method <C <U PropHelpers>><U token> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:13}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers>><U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=68:3 end=68:13}
-      argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=68:3 end=68:8}
+    method <C <U PropHelpers>><U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:13}
+      argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:8}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U PropHelpers>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=64:7 end=64:18}
-    type-member(+) <S <C <U PropHelpers>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U PropHelpers>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=PropHelpers) @ Loc {file=test/testdata/rewriter/prop.rb start=64:7 end=64:18}
-    method <S <C <U PropHelpers>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=64:1 end=70:4}
+  class <S <C <U PropHelpers>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=65:7 end=65:18}
+    type-member(+) <S <C <U PropHelpers>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U PropHelpers>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=PropHelpers) @ Loc {file=test/testdata/rewriter/prop.rb start=65:7 end=65:18}
+    method <S <C <U PropHelpers>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=65:1 end=71:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <S <C <U PropHelpers>> $1><U created_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=67:3 end=67:33}
-      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=67:25 end=67:29}
+    method <S <C <U PropHelpers>> $1><U created_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=68:3 end=68:33}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=68:25 end=68:29}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <S <C <U PropHelpers>> $1><U token_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=66:3 end=66:31}
-      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=66:23 end=66:27}
+    method <S <C <U PropHelpers>> $1><U token_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=67:3 end=67:31}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=67:23 end=67:27}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U PropHelpers2>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=72:1 end=72:19}
-    method <C <U PropHelpers2>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=77:3 end=77:32}
+  class <C <U PropHelpers2>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=73:1 end=73:19}
+    method <C <U PropHelpers2>><U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=78:3 end=78:32}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers2>><U token> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=76:3 end=76:25}
+    method <C <U PropHelpers2>><U token> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=77:3 end=77:25}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U PropHelpers2>><U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=76:3 end=76:25}
-      argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=76:15 end=76:20}
+    method <C <U PropHelpers2>><U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=77:3 end=77:25}
+      argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=77:15 end=77:20}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U PropHelpers2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=72:7 end=72:19}
-    type-member(+) <S <C <U PropHelpers2>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U PropHelpers2>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=PropHelpers2) @ Loc {file=test/testdata/rewriter/prop.rb start=72:7 end=72:19}
-    method <S <C <U PropHelpers2>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=72:1 end=78:4}
+  class <S <C <U PropHelpers2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=73:7 end=73:19}
+    type-member(+) <S <C <U PropHelpers2>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U PropHelpers2>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=PropHelpers2) @ Loc {file=test/testdata/rewriter/prop.rb start=73:7 end=73:19}
+    method <S <C <U PropHelpers2>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=73:1 end=79:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <S <C <U PropHelpers2>> $1><U created_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=75:3 end=75:33}
-      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=75:25 end=75:29}
+    method <S <C <U PropHelpers2>> $1><U created_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=76:3 end=76:33}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=76:25 end=76:29}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <S <C <U PropHelpers2>> $1><U timestamped_token_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=74:3 end=74:43}
-      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=74:35 end=74:39}
+    method <S <C <U PropHelpers2>> $1><U timestamped_token_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=75:3 end=75:43}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=75:35 end=75:39}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U ShardingProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=80:1 end=80:19}
-    method <C <U ShardingProp>><U merchant> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=83:3 end=83:16}
+  class <C <U ShardingProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=81:1 end=81:19}
+    method <C <U ShardingProp>><U merchant> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=84:3 end=84:16}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U ShardingProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:19}
-    type-member(+) <S <C <U ShardingProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U ShardingProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=ShardingProp) @ Loc {file=test/testdata/rewriter/prop.rb start=80:7 end=80:19}
-    method <S <C <U ShardingProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=80:1 end=84:4}
+  class <S <C <U ShardingProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=81:7 end=81:19}
+    type-member(+) <S <C <U ShardingProp>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U ShardingProp>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=ShardingProp) @ Loc {file=test/testdata/rewriter/prop.rb start=81:7 end=81:19}
+    method <S <C <U ShardingProp>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=81:1 end=85:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <S <C <U ShardingProp>> $1><U merchant_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=82:3 end=82:34}
-      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=82:26 end=82:30}
+    method <S <C <U ShardingProp>> $1><U merchant_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=83:3 end=83:34}
+      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=83:26 end=83:30}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U SomeODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:1 end=23:14}
-    method <C <U SomeODM>><U foo> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=27:5 end=27:22}
+  class <C <U SomeODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=24:1 end=24:14}
+    method <C <U SomeODM>><U foo> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=28:5 end=28:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U SomeODM>><U foo2> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=30:5 end=30:13}
+    method <C <U SomeODM>><U foo2> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=31:5 end=31:13}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U SomeODM>><U foo2=> (arg0, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=32:5 end=32:20}
-      argument arg0<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=31:17 end=31:21}
+    method <C <U SomeODM>><U foo2=> (arg0, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=33:5 end=33:20}
+      argument arg0<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=32:17 end=32:21}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U SomeODM>><U foo=> (foo, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=27:5 end=27:22}
-      argument foo<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=27:11 end=27:14}
+    method <C <U SomeODM>><U foo=> (foo, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=28:5 end=28:22}
+      argument foo<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=28:11 end=28:14}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U SomeODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>, <C <U Sig>>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:7 end=23:14}
-    type-member(+) <S <C <U SomeODM>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U SomeODM>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=SomeODM) @ Loc {file=test/testdata/rewriter/prop.rb start=23:7 end=23:14}
-    method <S <C <U SomeODM>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:1 end=33:4}
+  class <S <C <U SomeODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>, <C <U Sig>>) @ Loc {file=test/testdata/rewriter/prop.rb start=24:7 end=24:14}
+    type-member(+) <S <C <U SomeODM>> $1><C <U <AttachedClass>>> -> LambdaParam(<S <C <U SomeODM>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=SomeODM) @ Loc {file=test/testdata/rewriter/prop.rb start=24:7 end=24:14}
+    method <S <C <U SomeODM>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=24:1 end=34:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
 

--- a/test/testdata/rewriter/prop_prohibit_shapes_and_tuples.rb
+++ b/test/testdata/rewriter/prop_prohibit_shapes_and_tuples.rb
@@ -3,6 +3,10 @@
 class A
   # We don't support shape or tuple types for props, and the way that manifests
   # is that the prop rewrite pass just skips these two declarations.
-  prop :shape, {a: Integer, b: String} # error: Method `prop` does not exist
-  prop :tuple, [Integer, String] # error: Method `prop` does not exist
+  prop :shape, {a: Integer, b: String}
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `prop` does not exist
+             # ^^^^^^^^^^^^^^^^^^^^^^^ error: Invalid type in prop type descriptor
+  prop :tuple, [Integer, String]
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `prop` does not exist
+             # ^^^^^^^^^^^^^^^^^ error: Invalid type in prop type descriptor
 end

--- a/test/testdata/rewriter/prop_skipped.rb
+++ b/test/testdata/rewriter/prop_skipped.rb
@@ -3,6 +3,7 @@
 class A < T::Struct
   # This prop won't be processed by the Prop dsl, as it contains a shape type
   const :foo, T::Array[{foo: Integer}]
+                     # ^^^^^^^^^^^^^^ error: Invalid type in prop type descriptor
 end
 
   A.new(foo: [])


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The current behavior is that we silently drop the prop from any kind of codegen, and people get weird errors about calls to `initialize` or somesuch.  We should at least issue an error message to let them know bad things are happening at the source of the problem.

The PR thus far illustrates the basic idea, but I think the Right Thing to do is have `dupType` take a `std::optional<FailureContext> &`.  We can fill in the optional with information about the actual expression that failed and its send context (if any).  If there is a send context, we can use that to generate error messages about unsupported shape types if we have the right kind of expression, etc.  If there's not a send context, but the failing expression is the top-level expression, we can generate error messages about unsupported shape types if we have the right kind of expression.  Otherwise, we'll just issue the generic message this PR currently has.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
