### PR TITLE
Replace an endless range with an ordinal one in sorbet-runtime

### DIFF
--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -84,7 +84,7 @@ module T::Utils
       when 0 then nil
       when 1 then non_nil_types.first
       else
-        T::Types::Union::Private::Pool.union_of_types(non_nil_types[0], non_nil_types[1], non_nil_types[2..])
+        T::Types::Union::Private::Pool.union_of_types(non_nil_types[0], non_nil_types[1], non_nil_types[2..-1])
       end
     else
       nil


### PR DESCRIPTION
The fix is needed for compatibility with ruby <= 2.5, as endless ranges are introduced in ruby 2.6.
