### PR TITLE
Add an error if a `void` type is used in a conditional

### DIFF
--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -40,6 +40,7 @@ constexpr ErrorClass GenericArgumentKeywordArgs{7032, StrictLevel::True};
 constexpr ErrorClass KeywordArgHashWithoutSplat{7033, StrictLevel::True};
 constexpr ErrorClass UnnecessarySafeNavigation{7034, StrictLevel::True};
 constexpr ErrorClass TakesNoBlock{7035, StrictLevel::True};
+constexpr ErrorClass InvalidVoidUsage{7036, StrictLevel::True};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 } // namespace sorbet::core::errors::Infer
 #endif

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -270,11 +270,13 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
             pair.second.knowledge.emitKnowledgeSizeMetric();
         }
 
-        core::TypePtr conditionalType = current.getTypeAndOrigin(ctx, bb->bexit.cond.variable).type;
+        auto conditionalType = current.getTypeAndOrigin(ctx, bb->bexit.cond.variable);
 
-        if (!conditionalType.isUntyped() && core::Types::isSubType(ctx, core::Types::void_(), conditionalType)) {
+        if (!conditionalType.type.isUntyped() && conditionalType.type != core::Types::Object() &&
+            core::Types::isSubType(ctx, core::Types::void_(), conditionalType.type)) {
             if (auto e = ctx.beginError(bb->bexit.loc, core::errors::Infer::InvalidVoidUsage)) {
                 e.setHeader("Can't use void types in conditional");
+                e.addErrorSection(conditionalType.explainGot(ctx, core::Loc(ctx.file, bb->bexit.loc)));
             }
         }
     }

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -269,6 +269,14 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
         for (auto &pair : current.vars()) {
             pair.second.knowledge.emitKnowledgeSizeMetric();
         }
+
+        core::TypePtr conditionalType = current.getTypeAndOrigin(ctx, bb->bexit.cond.variable).type;
+
+        if (!conditionalType.isUntyped() && core::Types::isSubType(ctx, core::Types::void_(), conditionalType)) {
+            if (auto e = ctx.beginError(bb->bexit.loc, core::errors::Infer::InvalidVoidUsage)) {
+                e.setHeader("Can't use void types in conditional");
+            }
+        }
     }
     if (startErrorCount == ctx.state.totalErrors()) {
         counterInc("infer.methods_typechecked.no_errors");

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -271,8 +271,10 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
         }
 
         auto conditionalType = current.getTypeAndOrigin(ctx, bb->bexit.cond.variable);
+        core::TypePtr basicObject = core::make_type<core::ClassType>(core::Symbols::BasicObject());
 
         if (!conditionalType.type.isUntyped() && conditionalType.type != core::Types::Object() &&
+            conditionalType.type != basicObject &&
             core::Types::isSubType(ctx, core::Types::void_(), conditionalType.type)) {
             if (auto e = ctx.beginError(bb->bexit.loc, core::errors::Infer::InvalidVoidUsage)) {
                 e.setHeader("Can't use `{}` types in conditional", "void");

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -275,7 +275,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
         if (!conditionalType.type.isUntyped() && conditionalType.type != core::Types::Object() &&
             core::Types::isSubType(ctx, core::Types::void_(), conditionalType.type)) {
             if (auto e = ctx.beginError(bb->bexit.loc, core::errors::Infer::InvalidVoidUsage)) {
-                e.setHeader("Can't use void types in conditional");
+                e.setHeader("Can't use `{}` types in conditional", "void");
                 e.addErrorSection(conditionalType.explainGot(ctx, core::Loc(ctx.file, bb->bexit.loc)));
             }
         }

--- a/test/testdata/infer/lub_between_self_params.rb
+++ b/test/testdata/infer/lub_between_self_params.rb
@@ -25,5 +25,6 @@ class Child < Parent
     self["foo"] || self["bar"]
 #        ^^^^^ error: Expected `Child::A` but found `String("foo")` for argument `k`
 #                       ^^^^^ error: This code is unreachable
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Can't use void types in conditional
   end
 end

--- a/test/testdata/infer/lub_between_self_params.rb
+++ b/test/testdata/infer/lub_between_self_params.rb
@@ -25,6 +25,6 @@ class Child < Parent
     self["foo"] || self["bar"]
 #        ^^^^^ error: Expected `Child::A` but found `String("foo")` for argument `k`
 #                       ^^^^^ error: This code is unreachable
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Can't use void types in conditional
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Can't use `void` types in conditional
   end
 end

--- a/test/testdata/infer/void_final.rb
+++ b/test/testdata/infer/void_final.rb
@@ -10,7 +10,7 @@ end
 sig {void}
 def main
   result = returns_void
-  if result
+  if result # error: Can't use void types in conditional
     T.reveal_type(result) # error: Revealed type: `Sorbet::Private::Static::Void`
   else
     T.reveal_type(result) # error: This code is unreachable

--- a/test/testdata/infer/void_final.rb
+++ b/test/testdata/infer/void_final.rb
@@ -10,7 +10,7 @@ end
 sig {void}
 def main
   result = returns_void
-  if result # error: Can't use void types in conditional
+  if result # error: Can't use `void` types in conditional
     T.reveal_type(result) # error: Revealed type: `Sorbet::Private::Static::Void`
   else
     T.reveal_type(result) # error: This code is unreachable

--- a/test/testdata/infer/void_in_conditional.rb
+++ b/test/testdata/infer/void_in_conditional.rb
@@ -1,0 +1,39 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig { void }
+  def self.foo; end
+end
+
+class B
+  extend T::Sig
+
+  sig { void }
+  def self.foo; end
+end
+
+class C
+  extend T::Sig
+
+  sig { void }
+  def self.foo; end
+end
+
+if A.foo
+ # ^^^^^ error: Can't use void types in conditional
+  puts "Dead code"
+end
+
+if B.foo
+ # ^^^^^ error: Can't use void types in conditional
+  puts "Dead code"
+else
+  puts "More dead code" # error: This code is unreachable
+end
+
+unless C.foo
+     # ^^^^^ error: Can't use void types in conditional
+  puts "Dead code" # error: This code is unreachable
+end

--- a/test/testdata/infer/void_in_conditional.rb
+++ b/test/testdata/infer/void_in_conditional.rb
@@ -21,6 +21,20 @@ class C
   def self.foo; end
 end
 
+class NoErrorBasicObject
+  extend T::Sig
+
+  sig { returns(BasicObject) }
+  def self.foo; end
+end
+
+class NoErrorObject
+  extend T::Sig
+
+  sig { returns(Object) }
+  def self.foo; end
+end
+
 if A.foo
  # ^^^^^ error: Can't use `void` types in conditional
   puts "Dead code"
@@ -36,4 +50,12 @@ end
 unless C.foo
      # ^^^^^ error: Can't use `void` types in conditional
   puts "Dead code" # error: This code is unreachable
+end
+
+if NoErrorBasicObject.foo
+  puts "code"
+end
+
+if NoErrorObject.foo
+  puts "code"
 end

--- a/test/testdata/infer/void_in_conditional.rb
+++ b/test/testdata/infer/void_in_conditional.rb
@@ -22,18 +22,18 @@ class C
 end
 
 if A.foo
- # ^^^^^ error: Can't use void types in conditional
+ # ^^^^^ error: Can't use `void` types in conditional
   puts "Dead code"
 end
 
 if B.foo
- # ^^^^^ error: Can't use void types in conditional
+ # ^^^^^ error: Can't use `void` types in conditional
   puts "Dead code"
 else
   puts "More dead code" # error: This code is unreachable
 end
 
 unless C.foo
-     # ^^^^^ error: Can't use void types in conditional
+     # ^^^^^ error: Can't use `void` types in conditional
   puts "Dead code" # error: This code is unreachable
 end


### PR DESCRIPTION
Closes #2913

Add an error if a `void` type is used in a conditional.

Notes:
- I explored marking all condition branches as dead, but decided not to go forward with that idea because: it's better to report a single error in the conditional when `void` is used, instead of reporting the `void` error + the dead code errors
- Additionally, marking both branches of a conditional as dead marks the entire rest of the code as dead as well, which is also not a great experience
- I saved previous places where the error has been reported to avoid duplicates. When we are processing an if else statement, both the if and the else branches report the same error about the same parent conditional. Please, let me know if there's a better way of preventing these duplicates

This implementation will avoid marking the conditional branches as dead, but will report the error for using `void` in the conditional. After fixing that error, then any other dead code violations will still show up.

```ruby
sig { void }
def foo
  # something for which the return is not important
end

if foo # Can't use void types in conditional
end
```

### Motivation

Void types shouldn't be used in conditionals, since `void` indicates that they do not return anything useful.

### Test plan

See included automated tests.