### PR TITLE
Fix escaping new lines inside heredocs

### DIFF
--- a/test/whitequark/test_parser_bug_640_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_parser_bug_640_0.parse-tree-whitequark.exp
@@ -1,0 +1,2 @@
+s(:str, "bazqux
+")

--- a/test/whitequark/test_parser_bug_640_0.rb
+++ b/test/whitequark/test_parser_bug_640_0.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+<<~FOO
+  baz\
+  qux
+FOO

--- a/test/whitequark/test_slash_slash_n_escaping_in_literals_0.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_slash_slash_n_escaping_in_literals_0.rb.parse-tree-whitequark.exp
@@ -1,4 +1,3 @@
 s(:dstr,
-  s(:str, "a\
-"),
+  s(:str, "a"),
   s(:str, "b"))

--- a/test/whitequark/test_slash_slash_n_escaping_in_literals_1.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_slash_slash_n_escaping_in_literals_1.rb.parse-tree-whitequark.exp
@@ -1,5 +1,4 @@
 s(:dstr,
-  s(:str, "a\
-"),
+  s(:str, "a"),
   s(:str, "b
 "))

--- a/test/whitequark/test_slash_slash_n_escaping_in_literals_2.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_slash_slash_n_escaping_in_literals_2.rb.parse-tree-whitequark.exp
@@ -1,4 +1,3 @@
 s(:dstr,
-  s(:str, "a\
-"),
+  s(:str, "a"),
   s(:str, "b"))

--- a/test/whitequark/test_slash_slash_n_escaping_in_literals_21.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_slash_slash_n_escaping_in_literals_21.rb.parse-tree-whitequark.exp
@@ -1,2 +1,2 @@
-s(:str, "a  b
+s(:str, "ab
 ")

--- a/third_party/parser/cc/lexer.rl
+++ b/third_party/parser/cc/lexer.rl
@@ -1080,7 +1080,7 @@ void lexer::set_state_expr_value() {
         // treat '\' as a line continuation, but still dedent the body, so the heredoc above becomes "12\n".
         // This information is emitted as is, without escaping,
         // later this escape sequence (\\\n) gets handled manually in the dedenter
-        std::string str = gsub(tok(), "\\\n", "");
+        auto str = tok();
         current_literal.extend_string(str, ts, te);
       } else if (current_literal.support_line_continuation_via_slash() && escaped_char == '\n') {
         // Heredocs, regexp and a few other types of literals support line


### PR DESCRIPTION
Fix escaping new lines inside heredocs. Our behavior was slightly different than [whitequark's implementation](https://github.com/whitequark/parser/blob/7ecddb67b2f82df92e424d36b6642cb887148cbc/lib/parser/lexer/dedenter.rb#L36) for squiggly heredocs and other literals.

### Test plan

See included automated tests.