### PR TITLE
Add signature to Hash#compact

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2937,6 +2937,47 @@ public:
     }
 } Array_zip;
 
+class Hash_compact : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        TypePtr keyType;
+        TypePtr valueType;
+        if (auto *ap = cast_type<AppliedType>(args.thisType)) {
+            ENFORCE(ap->klass == Symbols::Hash() || ap->klass.data(gs)->derivesFrom(gs, Symbols::Hash()));
+            ENFORCE(!ap->targs.empty());
+            keyType = ap->targs[0];
+            valueType = ap->targs[1];
+        } else {
+            ENFORCE(false, "Hash#compact on unexpected type: {}", args.selfType.show(gs));
+        }
+        auto nonNilableValueType = Types::approximateSubtract(gs, valueType, Types::nilClass());
+        vector<TypePtr> tupleArgs{keyType, nonNilableValueType};
+        vector<TypePtr> targs{keyType, nonNilableValueType, make_type<TupleType>(move(tupleArgs))};
+        res.returnType = make_type<AppliedType>(Symbols::Hash(), move(targs));
+    }
+} Hash_compact;
+
+class Shape_compact : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        if (auto *ap = cast_type<ShapeType>(args.thisType)) {
+            // There's not much we can do here, even though the method might remove some key/value pairs,
+            // we don't have information about which ones at this point.
+            // This method exists just to shapes don't go through `Hash_compact`, which would
+            // break this common idiom:
+            // ```ruby
+            // my_params = {foo: 1, bar: nil}.compact
+            // my_method(my_params)
+            // ```
+            // If `my_method takes` keyword args `foo` and `bar`, using the Hash_compact would say:
+            // `Passing a hash where the specific keys are unknown to a method taking keyword arguments`
+            res.returnType = Types::untypedUntracked();
+        } else {
+            ENFORCE(false, "Shape#compact on unexpected type: {}", args.selfType.show(gs));
+        }
+    }
+} Shape_compact;
+
 class Kernel_proc : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
@@ -3075,11 +3116,14 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::Shape(), Intrinsic::Kind::Instance, Names::squareBracketsEq(), &Shape_squareBracketsEq},
     {Symbols::Shape(), Intrinsic::Kind::Instance, Names::merge(), &Shape_merge},
     {Symbols::Shape(), Intrinsic::Kind::Instance, Names::toHash(), &Shape_to_hash},
+    {Symbols::Shape(), Intrinsic::Kind::Instance, Names::compact(), &Shape_compact},
 
     {Symbols::Array(), Intrinsic::Kind::Instance, Names::flatten(), &Array_flatten},
     {Symbols::Array(), Intrinsic::Kind::Instance, Names::product(), &Array_product},
     {Symbols::Array(), Intrinsic::Kind::Instance, Names::compact(), &Array_compact},
     {Symbols::Array(), Intrinsic::Kind::Instance, Names::zip(), &Array_zip},
+
+    {Symbols::Hash(), Intrinsic::Kind::Instance, Names::compact(), &Hash_compact},
 
     {Symbols::Kernel(), Intrinsic::Kind::Instance, Names::proc(), &Kernel_proc},
     {Symbols::Kernel(), Intrinsic::Kind::Instance, Names::lambda(), &Kernel_proc},

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -327,6 +327,8 @@ class Hash < Object
   sig {returns(T::Hash[K, V])}
   def clear(); end
 
+  ### This is implemented in C++ to fix the return type
+  
   # Returns a new hash with the nil values/key pairs removed
   #
   # ```ruby
@@ -334,6 +336,7 @@ class Hash < Object
   # h.compact     #=> { a: 1, b: false }
   # h             #=> { a: 1, b: false, c: nil }
   # ```
+  sig {returns(T::Hash[K, T.untyped])}
   def compact; end
 
   # Removes all nil values from the hash. Returns nil if no changes were made,

--- a/test/testdata/infer/compact.rb
+++ b/test/testdata/infer/compact.rb
@@ -1,16 +1,23 @@
 # typed: true
 
-T.assert_type!(
-  [1, nil].compact,
-  T::Array[Integer],
-)
+T.reveal_type([1, nil].compact) # error: Revealed type: `T::Array[Integer]`
 
-T.assert_type!(
-  [1, 2, 3].compact,
-  T::Array[Integer],
-)
+T.reveal_type([1, 2, 3].compact) # error: Revealed type: `T::Array[Integer]`
 
-T.assert_type!(
-  [[1], nil].compact,
-  T::Array[[Integer]],
-)
+T.reveal_type([[1], nil].compact)  # error: Revealed type: `T::Array[[Integer(1)]]`
+
+T.reveal_type(T::Hash[Symbol, T.nilable(Integer)].new.compact) # error: Revealed type: `T::Hash[Symbol, Integer]`
+
+T.reveal_type(T::Hash[String, T.nilable(Integer)].new.compact) # error: Revealed type: `T::Hash[String, Integer]`
+
+T.reveal_type({foo: 1, bar: 2}) # error: Revealed type: `{foo: Integer(1), bar: Integer(2)} (shape of T::Hash[T.untyped, T.untyped])`
+
+T.reveal_type({foo: 1, bar: 2}.compact) # error: Revealed type: `T.untyped`
+
+T.reveal_type({foo: 1, bar: nil}.compact) # error: Revealed type: `T.untyped`
+
+T.reveal_type({foo: 1, bar: T.let(nil, T.nilable(Integer))}.compact) # error: Revealed type: `T.untyped`
+
+def my_method(foo:, bar:); end
+
+my_method({foo: 1, bar: nil}.compact)


### PR DESCRIPTION
### Motivation
Having types after applying `compact` to a `Hash`


### Test plan
See included automated tests.
