### PR TITLE
Fix minor grammar mistake in stdlib-generics.md

### DIFF
--- a/website/docs/stdlib-generics.md
+++ b/website/docs/stdlib-generics.md
@@ -47,7 +47,7 @@ only used as hints for the static type system, and are ignored entirely by the
 runtime type system.
 
 > **Note**: Sorbet used to take these type parameters into account during
-> runtime type-checking, but this turned out to be an common and
+> runtime type-checking, but this turned out to be a common and
 > difficult-to-debug source of performance problems: In order to verify that an
 > array contained the values it claimed it did, the Sorbet runtime used to
 > recursively check the type of every member of a collection, which would take a


### PR DESCRIPTION
Replace "an common" with "a common"

### Motivation
Just trying to make the documentation closer to perfect


### Test plan
Just updating some text, no special testing should be necessary.