### PR TITLE
preallocate and avoid copying in reserveFiles

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -273,8 +273,9 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
 vector<core::FileRef> reserveFiles(unique_ptr<core::GlobalState> &gs, const vector<string> &files) {
     Timer timeit(gs->tracer(), "reserveFiles");
     vector<core::FileRef> ret;
+    ret.reserve(files.size());
     core::UnfreezeFileTable unfreezeFiles(*gs);
-    for (auto f : files) {
+    for (auto &f : files) {
         auto fileRef = gs->findFileByPath(f);
         if (!fileRef.exists()) {
             fileRef = gs->reserveFileRef(f);


### PR DESCRIPTION

### Motivation

++speed.  This change is good for ~10% of "reserveFiles" time on Stripe's codebase -- which is only ~12ms, but hey, a win is a win.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
