### PR TITLE
pack ResolutionItem more tightly

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -107,10 +107,12 @@ private:
     struct ResolutionItem {
         shared_ptr<Nesting> scope;
         core::FileRef file;
-        ast::ConstantLit *out;
         bool resolutionFailed = false;
+        ast::ConstantLit *out;
 
         ResolutionItem() = default;
+        ResolutionItem(const shared_ptr<Nesting> &scope, core::FileRef file, ast::ConstantLit *lit)
+            : scope(scope), file(file), out(lit) {}
         ResolutionItem(ResolutionItem &&rhs) noexcept = default;
         ResolutionItem &operator=(ResolutionItem &&rhs) noexcept = default;
 


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Taking up less space with one of resolver's data structures seems like a good thing.  This change combined with #4292 takes ~2% off the resolving time (~50ms) on Stripe's codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
