### PR TITLE
do less copying around parsed sigs in resolver

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2859,7 +2859,7 @@ public:
             } else {
                 overloadSym = mdef.symbol;
             }
-            fillInInfoFromSig(ctx, overloadSym, sig.loc, move(sig.sig), isOverloaded, mdef);
+            fillInInfoFromSig(ctx, overloadSym, sig.loc, sig.sig, isOverloaded, mdef);
         }
         handleAbstractMethod(ctx, mdef);
     }
@@ -2867,7 +2867,7 @@ public:
         prodCounterInc("types.sig.count");
         auto &mdef = *job.mdef;
         bool isOverloaded = false;
-        fillInInfoFromSig(ctx, mdef.symbol, job.loc, move(job.sig), isOverloaded, mdef);
+        fillInInfoFromSig(ctx, mdef.symbol, job.loc, job.sig, isOverloaded, mdef);
         handleAbstractMethod(ctx, mdef);
     }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2562,10 +2562,7 @@ private:
         }
 
         // Get the parameters order from the signature
-        vector<ParsedSig::ArgSpec> sigParams;
-        for (auto &spec : sig.argTypes) {
-            sigParams.push_back(spec);
-        }
+        vector<ParsedSig::ArgSpec> sigParams(sig.argTypes);
 
         vector<ast::Local const *> defParams; // Parameters order from the method declaration
         bool seenOptional = false;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2623,7 +2623,7 @@ private:
             }
         }
 
-        for (auto spec : sig.argTypes) {
+        for (const auto &spec : sig.argTypes) {
             if (auto e = ctx.state.beginError(spec.loc, core::errors::Resolver::InvalidMethodSignature)) {
                 e.setHeader("Unknown argument name `{}`", spec.name.show(ctx));
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2492,7 +2492,7 @@ private:
     }
 
     static void fillInInfoFromSig(core::MutableContext ctx, core::MethodRef method, core::LocOffsets exprLoc,
-                                  ParsedSig sig, bool isOverloaded, const ast::MethodDef &mdef) {
+                                  ParsedSig &sig, bool isOverloaded, const ast::MethodDef &mdef) {
         ENFORCE(isOverloaded || mdef.symbol == method);
         ENFORCE(isOverloaded || method.data(ctx)->arguments().size() == mdef.args.size());
 
@@ -2832,7 +2832,7 @@ private:
     }
 
 public:
-    static void resolveMultiSignatureJob(core::MutableContext ctx, const ResolveMultiSignatureJob &job) {
+    static void resolveMultiSignatureJob(core::MutableContext ctx, ResolveMultiSignatureJob &job) {
         auto &sigs = job.sigs;
         auto &mdef = *job.mdef;
         ENFORCE_NO_TIMER(sigs.size() > 1);
@@ -2863,7 +2863,7 @@ public:
         }
         handleAbstractMethod(ctx, mdef);
     }
-    static void resolveSignatureJob(core::MutableContext ctx, const ResolveSignatureJob &job) {
+    static void resolveSignatureJob(core::MutableContext ctx, ResolveSignatureJob &job) {
         prodCounterInc("types.sig.count");
         auto &mdef = *job.mdef;
         bool isOverloaded = false;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2632,8 +2632,8 @@ private:
         // Check params ordering match between signature and definition
         if (sig.argTypes.empty()) {
             int j = 0;
-            for (auto spec : sigParams) {
-                auto param = defParams[j];
+            for (const auto &spec : sigParams) {
+                auto *param = defParams[j];
                 auto sname = spec.name;
                 auto dname = param->localVariable._name;
                 // TODO(jvilk): Do we need to check .show? Typically NameRef equality is equal to string equality.

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2594,7 +2594,7 @@ private:
 
             if (spec != sig.argTypes.end()) {
                 ENFORCE(spec->type != nullptr);
-                arg.type = spec->type;
+                arg.type = std::move(spec->type);
                 arg.loc = spec->loc;
                 arg.rebind = spec->rebind;
                 sig.argTypes.erase(spec);


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Make things go faster.

Each commit in this series is self-contained and can be reviewed independently.  Everything except the last one should be fairly uncontroversial, but the last one is possible a matter of taste (but is also the largest speedup).  The whole series speeds up "resolver.resolve_sigs" by ~10% (~40ms).

`fillInInfoFromSig` currently takes `ParsedSig` by value, because `fillInInfoFromSig` is going to modify the `argTypes` field:

https://github.com/sorbet/sorbet/blob/3502cd361dea95e33cf10a6127815cab8e3a0997/resolver/resolver.cc#L2596-L2603

for keeping track of signature/definition mismatches.  You can obviously modify fields of a taken-by-value struct.

You would think that we could just take `ParsedSig` by reference -- after all, the parsed sig only exists during sig resolution and is intended to be a temporary data structure.  But `resolve{Multi,}SignatureJob` take their `job` arguments by constant reference and therefore the `job.sig` field can only be taken by constant reference, barring `const_cast` tricks.  So to take `ParsedSig&`, we have to take non-const references to the jobs themselves.

I think having to modify `resolve{Multi,}SignatureJob` to take non-constant references is mostly OK, but reasonable people can differ on this.

One alternative would be for `resolve{Multi,}SignatureJob` to take their `job` arguments by _rvalue_ reference -- this would at least make it clearer to the reader and clearer to any future modifier of this code that, at the callsite to those functions, `job` is essentially going away.  And then `fillInInfoFromSig` could take `ParsedSig&&`, also indicating at the callsite that `sig` is going away.  (Note that `std::move(...)`'ing something for an rvalue reference arg _doesn't_ mean that you're actually copying anything.  You're just indicating to the compiler, "tell my callee that they can treat this as a temporary value."  Nothing would change at the actual machine code level versus an lvalue reference.)

This alternative is maybe overly clever, which is why I didn't write the code this way.  Thoughts?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
