### PR TITLE
DidYouMean::SpellChecker.initialize: correct parameter type

### DIFF
--- a/rbi/gems/didyoumean.rbi
+++ b/rbi/gems/didyoumean.rbi
@@ -44,7 +44,7 @@ class DidYouMean::NullChecker < Object
 end
 
 class DidYouMean::SpellChecker < Object
-  sig {params(dictionary: T::Array[T.any(String, Symbol)]).returns(DidYouMean::SpellChecker)}
+  sig {params(dictionary: T::Enumerable[T.any(String, Symbol)]).returns(DidYouMean::SpellChecker)}
   def initialize(dictionary:)
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Currently `DidYouMean::SpellChecker.initialize` parameter type described as `T::Array` which doesn't allow to pass `Set` to it. From a code perspective, there's should be no problems with sets (the parameter uses only with `#select` call https://github.com/ruby/did_you_mean/blob/f1573d602f9e47510f5b00eeccbad906032ebea7/lib/did_you_mean/spell_checker.rb#L16).

See https://sorbet.run/#%23%20typed%3A%20true%0A%0Adef%20main%0A%20%20items%20%3D%20Set.new%20%25w%5Bemail%20fail%20eval%5D%0A%20%20spell_checker%20%3D%20DidYouMean%3A%3ASpellChecker.new(dictionary%3A%20items)%0A%0A%20%20spell_checker.correct('meail')%0A%20%20spell_checker.correct('afil')%0Aend%0A

Initially, types for `DidYouMean` modules were added in https://github.com/sorbet/sorbet/pull/2439

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I'm not sure what we could additionally test here
