### PR TITLE
provide internal methods to separate signature building from method definition

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -77,7 +77,7 @@ module T::Private::Methods
   end
 
   def self.start_proc
-    DeclBuilder.new(PROC_TYPE)
+    DeclBuilder.new(PROC_TYPE, false)
   end
 
   def self.finalize_proc(decl)
@@ -348,7 +348,7 @@ module T::Private::Methods
   end
 
   def self.run_builder(declaration_block)
-    builder = DeclBuilder.new(declaration_block.mod)
+    builder = DeclBuilder.new(declaration_block.mod, declaration_block.raw)
     builder
       .instance_exec(&declaration_block.blk)
       .finalize!
@@ -379,6 +379,7 @@ module T::Private::Methods
         check_level: current_declaration.checked,
         on_failure: current_declaration.on_failure,
         override_allow_incompatible: current_declaration.override_allow_incompatible,
+        defined_raw: current_declaration.raw,
       )
 
       SignatureValidation.validate(signature)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -33,18 +33,18 @@ module T::Private::Methods
 
   def self.declare_sig(mod, arg, &blk)
     # caller_depth is 2: 1 to get to our caller and 1 to get to sig()'s caller.
-    T::Private::DeclState.current.active_declaration = __declare_sig_internal(mod, arg, caller_depth: 2, &blk)
+    T::Private::DeclState.current.active_declaration = _declare_sig_internal(mod, arg, caller_depth: 2, &blk)
 
     nil
   end
 
   # See tests for how to use this.  But you shouldn't be using this.
-  def self.__declare_sig(mod, arg=nil, &blk)
+  def self._declare_sig(mod, arg=nil, &blk)
     # caller_depth is 1: 1 to get to our caller.
-    __declare_sig_internal(mod, arg, caller_depth: 1, raw: true, &blk)
+    _declare_sig_internal(mod, arg, caller_depth: 1, raw: true, &blk)
   end
 
-  private_class_method def self.__declare_sig_internal(mod, arg, caller_depth:, raw: false, &blk)
+  private_class_method def self._declare_sig_internal(mod, arg, caller_depth:, raw: false, &blk)
     install_hooks(mod)
 
     if T::Private::DeclState.current.active_declaration
@@ -61,9 +61,9 @@ module T::Private::Methods
     DeclarationBlock.new(mod, loc, blk, arg == :final, raw)
   end
 
-  def self.__with_declared_signature(mod, declblock, &blk)
+  def self._with_declared_signature(mod, declblock, &blk)
     # If declblock is provided, this code is equivalent to the check in
-    # __declare_sig_internal, above.
+    # _declare_sig_internal, above.
     # If declblock is not provided and we have an active declaration, we are
     # obviously doing something wrong.
     if T::Private::DeclState.current.active_declaration

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -31,20 +31,18 @@ module T::Private::Methods
 
   DeclarationBlock = Struct.new(:mod, :loc, :blk, :final, :raw)
 
-  def self.declare_sig(mod, arg, &blk)
-    # caller_depth is 2: 1 to get to our caller and 1 to get to sig()'s caller.
-    T::Private::DeclState.current.active_declaration = _declare_sig_internal(mod, arg, caller_depth: 2, &blk)
+  def self.declare_sig(mod, loc, arg, &blk)
+    T::Private::DeclState.current.active_declaration = _declare_sig_internal(mod, loc, arg, &blk)
 
     nil
   end
 
   # See tests for how to use this.  But you shouldn't be using this.
   def self._declare_sig(mod, arg=nil, &blk)
-    # caller_depth is 1: 1 to get to our caller.
-    _declare_sig_internal(mod, arg, caller_depth: 1, raw: true, &blk)
+    _declare_sig_internal(mod, caller_locations(1, 1).first, arg, raw: true, &blk)
   end
 
-  private_class_method def self._declare_sig_internal(mod, arg, caller_depth:, raw: false, &blk)
+  private_class_method def self._declare_sig_internal(mod, loc, arg, raw: false, &blk)
     install_hooks(mod)
 
     if T::Private::DeclState.current.active_declaration
@@ -55,8 +53,6 @@ module T::Private::Methods
     if !arg.nil? && arg != :final
       raise "Invalid argument to `sig`: #{arg}"
     end
-
-    loc = caller_locations(caller_depth + 1, 1).first
 
     DeclarationBlock.new(mod, loc, blk, arg == :final, raw)
   end

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -27,6 +27,8 @@ module T::Private::Methods::CallValidation
           )
         end
       end
+    # Do nothing in this case; this method was not wrapped in _on_method_added.
+    elsif method_sig.defined_raw
     # Note, this logic is duplicated (intentionally, for micro-perf) at `Methods._on_method_added`,
     # make sure to keep changes in sync.
     # This is a trapdoor point for each method:

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -2,7 +2,7 @@
 # typed: true
 
 module T::Private::Methods
-  Declaration = Struct.new(:mod, :params, :returns, :bind, :mode, :checked, :finalized, :on_failure, :override_allow_incompatible, :type_parameters)
+  Declaration = Struct.new(:mod, :params, :returns, :bind, :mode, :checked, :finalized, :on_failure, :override_allow_incompatible, :type_parameters, :raw)
 
   class DeclBuilder
     attr_reader :decl
@@ -15,7 +15,7 @@ module T::Private::Methods
       end
     end
 
-    def initialize(mod)
+    def initialize(mod, raw)
       # TODO RUBYPLAT-1278 - with ruby 2.5, use kwargs here
       @decl = Declaration.new(
         mod,
@@ -28,6 +28,7 @@ module T::Private::Methods
         ARG_NOT_PROVIDED, # on_failure
         nil, # override_allow_incompatible
         ARG_NOT_PROVIDED, # type_parameters
+        raw
       )
     end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -5,7 +5,8 @@ class T::Private::Methods::Signature
   attr_reader :method, :method_name, :arg_types, :kwarg_types, :block_type, :block_name,
               :rest_type, :rest_name, :keyrest_type, :keyrest_name, :bind,
               :return_type, :mode, :req_arg_count, :req_kwarg_names, :has_rest, :has_keyrest,
-              :check_level, :parameters, :on_failure, :override_allow_incompatible
+              :check_level, :parameters, :on_failure, :override_allow_incompatible,
+              :defined_raw
 
   def self.new_untyped(method:, mode: T::Private::Methods::Modes.untyped, parameters: method.parameters)
     # Using `Untyped` ensures we'll get an error if we ever try validation on these.
@@ -32,7 +33,7 @@ class T::Private::Methods::Signature
     )
   end
 
-  def initialize(method:, method_name:, raw_arg_types:, raw_return_type:, bind:, mode:, check_level:, on_failure:, parameters: method.parameters, override_allow_incompatible: false)
+  def initialize(method:, method_name:, raw_arg_types:, raw_return_type:, bind:, mode:, check_level:, on_failure:, parameters: method.parameters, override_allow_incompatible: false, defined_raw: false)
     @method = method
     @method_name = method_name
     @arg_types = []
@@ -54,6 +55,7 @@ class T::Private::Methods::Signature
     @parameters = parameters
     @on_failure = on_failure
     @override_allow_incompatible = override_allow_incompatible
+    @defined_raw = defined_raw
 
     declared_param_names = raw_arg_types.keys
     # If sig params are declared but there is a single parameter with a missing name

--- a/gems/sorbet-runtime/lib/types/sig.rb
+++ b/gems/sorbet-runtime/lib/types/sig.rb
@@ -25,6 +25,6 @@ module T::Sig
   # {T::Helpers}
   T::Sig::WithoutRuntime.sig {params(arg0: T.nilable(Symbol), blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
   def sig(arg0=nil, &blk)
-    T::Private::Methods.declare_sig(self, caller_locations(1, 1).first, arg0, &blk)
+    T::Private::Methods.declare_sig(self, Kernel.caller_locations(1, 1).first, arg0, &blk)
   end
 end

--- a/gems/sorbet-runtime/lib/types/sig.rb
+++ b/gems/sorbet-runtime/lib/types/sig.rb
@@ -25,6 +25,6 @@ module T::Sig
   # {T::Helpers}
   T::Sig::WithoutRuntime.sig {params(arg0: T.nilable(Symbol), blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
   def sig(arg0=nil, &blk)
-    T::Private::Methods.declare_sig(self, Kernel.caller_locations(1, 1).first, arg0, &blk)
+    T::Private::Methods.declare_sig(self, Kernel.caller_locations(1, 1)&.first, arg0, &blk)
   end
 end

--- a/gems/sorbet-runtime/lib/types/sig.rb
+++ b/gems/sorbet-runtime/lib/types/sig.rb
@@ -25,6 +25,6 @@ module T::Sig
   # {T::Helpers}
   T::Sig::WithoutRuntime.sig {params(arg0: T.nilable(Symbol), blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void}
   def sig(arg0=nil, &blk)
-    T::Private::Methods.declare_sig(self, arg0, &blk)
+    T::Private::Methods.declare_sig(self, caller_locations(1, 1).first, arg0, &blk)
   end
 end

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -125,6 +125,278 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
     assert_match(/^The method `foo` on #<Class:#<Class:0x[0-9a-f]+>> was declared as final and cannot be redefined$/, err.message)
   end
 
+  it "forbids redefining a secretly-declared final instance method with a final sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        extend T::Helpers
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def i_am_secretly_final; end
+        end
+
+        sig(:final) {void}
+        def i_am_secretly_final; end
+      end
+    end
+    assert_redefined_err('i_am_secretly_final', CLASS_REGEX_STR, __LINE__ - 7, __LINE__ - 3, err)
+  end
+
+  it "forbids redefining a secretly-declared final instance method with a regular sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        extend T::Helpers
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def i_am_secretly_final; end
+        end
+
+        sig {void}
+        def i_am_secretly_final; end
+      end
+    end
+    assert_redefined_err('i_am_secretly_final', CLASS_REGEX_STR, __LINE__ - 7, __LINE__ - 3, err)
+  end
+
+  it "forbids redefining a secretly-declared final instance method with no sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        extend T::Helpers
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def i_am_secretly_final; end
+        end
+
+        def i_am_secretly_final; end
+      end
+    end
+    assert_redefined_err('i_am_secretly_final', CLASS_REGEX_STR, __LINE__ - 6, __LINE__ - 3, err)
+  end
+
+  it "forbids redefining a secretly-declared final instance method with a secretly-declared final method" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        extend T::Helpers
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def i_am_secretly_final; end
+        end
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def i_am_secretly_final; end
+        end
+      end
+    end
+    assert_redefined_err('i_am_secretly_final', CLASS_REGEX_STR, __LINE__ - 12, __LINE__ - 4, err)
+  end
+
+  it "forbids redefining a secretly-declared final instance method with a secretly-declared method with a regular sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        extend T::Helpers
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def i_am_secretly_final; end
+        end
+
+        built_sig = T::Private::Methods.__declare_sig(self) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def i_am_secretly_final; end
+        end
+      end
+    end
+    assert_redefined_err('i_am_secretly_final', CLASS_REGEX_STR, __LINE__ - 12, __LINE__ - 4, err)
+  end
+
+  it "forbids redefining a secretly-declared final instance method with a secretly-declared method with no sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        extend T::Helpers
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def i_am_secretly_final; end
+        end
+
+        T::Private::Methods.__with_declared_signature(self, nil) do
+          def i_am_secretly_final; end
+        end
+      end
+    end
+    assert_redefined_err('i_am_secretly_final', CLASS_REGEX_STR, __LINE__ - 8, __LINE__ - 4, err)
+  end
+
+  it "forbids redefining a secretly-declared final class method with a final sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        extend T::Helpers
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def self.i_am_secretly_final2; end
+        end
+
+        sig(:final) {void}
+        def self.i_am_secretly_final2; end
+      end
+    end
+    assert_redefined_err('i_am_secretly_final2', CLASS_CLASS_REGEX_STR, __LINE__ - 7, __LINE__ - 3, err)
+  end
+
+  it "forbids redefining a secretly-declared final class method with a regular sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        extend T::Helpers
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def self.i_am_secretly_final2; end
+        end
+
+        sig {void}
+        def self.i_am_secretly_final2; end
+      end
+    end
+    assert_redefined_err('i_am_secretly_final2', CLASS_CLASS_REGEX_STR, __LINE__ - 7, __LINE__ - 3, err)
+  end
+
+  it "forbids redefining a secretly-declared final class method with no sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        extend T::Helpers
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def self.i_am_secretly_final2; end
+        end
+
+        def self.i_am_secretly_final2; end
+      end
+    end
+    assert_redefined_err('i_am_secretly_final2', CLASS_CLASS_REGEX_STR, __LINE__ - 6, __LINE__ - 3, err)
+  end
+
+  it "forbids redefining a secretly-declared final class method with a secretly-declared final method" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        extend T::Helpers
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def self.i_am_secretly_final2; end
+        end
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def self.i_am_secretly_final2; end
+        end
+      end
+    end
+    assert_redefined_err('i_am_secretly_final2', CLASS_CLASS_REGEX_STR, __LINE__ - 12, __LINE__ - 4, err)
+  end
+
+  it "forbids redefining a secretly-declared final class method with a secretly-declared method with a regular sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        extend T::Helpers
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def self.i_am_secretly_final2; end
+        end
+
+        built_sig = T::Private::Methods.__declare_sig(self) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def self.i_am_secretly_final2; end
+        end
+      end
+    end
+    assert_redefined_err('i_am_secretly_final2', CLASS_CLASS_REGEX_STR, __LINE__ - 12, __LINE__ - 4, err)
+  end
+
+  it "forbids redefining a secretly-declared final class method with a secretly-declared method with no sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Sig
+        extend T::Helpers
+
+        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+          void
+        end
+
+        T::Private::Methods.__with_declared_signature(self, built_sig) do
+          def self.i_am_secretly_final2; end
+        end
+
+        T::Private::Methods.__with_declared_signature(self, nil) do
+          def self.i_am_secretly_final2; end
+        end
+      end
+    end
+    assert_redefined_err('i_am_secretly_final2', CLASS_CLASS_REGEX_STR, __LINE__ - 8, __LINE__ - 4, err)
+  end
+
   it "forbids redefinition with .checked(:never)" do
     err = assert_raises(RuntimeError) do
       c = Class.new do

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -131,11 +131,11 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         extend T::Helpers
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def i_am_secretly_final; end
         end
 
@@ -152,11 +152,11 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         extend T::Helpers
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def i_am_secretly_final; end
         end
 
@@ -173,11 +173,11 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         extend T::Helpers
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def i_am_secretly_final; end
         end
 
@@ -193,19 +193,19 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         extend T::Helpers
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def i_am_secretly_final; end
         end
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def i_am_secretly_final; end
         end
       end
@@ -219,19 +219,19 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         extend T::Helpers
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def i_am_secretly_final; end
         end
 
-        built_sig = T::Private::Methods.__declare_sig(self) do
+        built_sig = T::Private::Methods._declare_sig(self) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def i_am_secretly_final; end
         end
       end
@@ -245,15 +245,15 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         extend T::Helpers
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def i_am_secretly_final; end
         end
 
-        T::Private::Methods.__with_declared_signature(self, nil) do
+        T::Private::Methods._with_declared_signature(self, nil) do
           def i_am_secretly_final; end
         end
       end
@@ -267,11 +267,11 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         extend T::Helpers
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def self.i_am_secretly_final2; end
         end
 
@@ -288,11 +288,11 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         extend T::Helpers
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def self.i_am_secretly_final2; end
         end
 
@@ -309,11 +309,11 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         extend T::Helpers
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def self.i_am_secretly_final2; end
         end
 
@@ -329,19 +329,19 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         extend T::Helpers
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def self.i_am_secretly_final2; end
         end
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def self.i_am_secretly_final2; end
         end
       end
@@ -355,19 +355,19 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         extend T::Helpers
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def self.i_am_secretly_final2; end
         end
 
-        built_sig = T::Private::Methods.__declare_sig(self) do
+        built_sig = T::Private::Methods._declare_sig(self) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def self.i_am_secretly_final2; end
         end
       end
@@ -381,15 +381,15 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend T::Sig
         extend T::Helpers
 
-        built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        built_sig = T::Private::Methods._declare_sig(self, :final) do
           void
         end
 
-        T::Private::Methods.__with_declared_signature(self, built_sig) do
+        T::Private::Methods._with_declared_signature(self, built_sig) do
           def self.i_am_secretly_final2; end
         end
 
-        T::Private::Methods.__with_declared_signature(self, nil) do
+        T::Private::Methods._with_declared_signature(self, nil) do
           def self.i_am_secretly_final2; end
         end
       end

--- a/gems/sorbet-runtime/test/types/final_module.rb
+++ b/gems/sorbet-runtime/test/types/final_module.rb
@@ -208,28 +208,4 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
       final!
     end
   end
-
-  it "can use secret flag to declare final class methods without sigs" do
-    c = Class.new do
-      extend T::Helpers
-      final!
-
-      T::Private::Methods._with_declaring_final_method_INTERNAL do
-        def self.i_am_secretly_final; end
-      end
-    end
-    c.i_am_secretly_final
-  end
-
-  it "can use secret flag to declare final instance methods without sigs" do
-    c = Class.new do
-      extend T::Helpers
-      final!
-
-      T::Private::Methods._with_declaring_final_method_INTERNAL do
-        def i_am_secretly_final; end
-      end
-    end
-    c.new.i_am_secretly_final
-  end
 end

--- a/gems/sorbet-runtime/test/types/final_module.rb
+++ b/gems/sorbet-runtime/test/types/final_module.rb
@@ -94,6 +94,20 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
     assert_match(/^#<Module:0x[0-9a-f]+> was declared as final but its method `foo` was not declared as final$/, err.message)
   end
 
+  it "forbids declaring a module as final but secretly declaring an instance method as not final" do
+    err = assert_raises(RuntimeError) do
+      Module.new do
+        extend T::Helpers
+        final!
+
+        T::Private::Methods.__with_declared_signature(self, nil) do
+          def foo; end
+        end
+      end
+    end
+    assert_match(/^#<Module:0x[0-9a-f]+> was declared as final but its method `foo` was not declared as final$/, err.message)
+  end
+
   it "forbids declaring a module as final but not its class method as final" do
     err = assert_raises(RuntimeError) do
       Module.new do
@@ -101,6 +115,20 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
         final!
         extend T::Sig
         def self.foo; end
+      end
+    end
+    assert_match(/^#<Class:#<Module:0x[0-9a-f]+>> was declared as final but its method `foo` was not declared as final$/, err.message)
+  end
+
+  it "forbids declaring a module as final but secretly declaring a class method as not final" do
+    err = assert_raises(RuntimeError) do
+      Module.new do
+        extend T::Helpers
+        final!
+
+        T::Private::Methods.__with_declared_signature(self, nil) do
+          def self.foo; end
+        end
       end
     end
     assert_match(/^#<Class:#<Module:0x[0-9a-f]+>> was declared as final but its method `foo` was not declared as final$/, err.message)
@@ -207,5 +235,41 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
       extend T::Helpers
       final!
     end
+  end
+
+  it "can use secret helpers to declare final class methods without sigs" do
+    c = Class.new do
+      extend T::Helpers
+      final!
+
+      built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        returns(Integer)
+      end
+
+      T::Private::Methods.__with_declared_signature(self, built_sig) do
+        def self.i_am_secretly_final
+          4242
+        end
+      end
+    end
+    assert_equal(4242, c.i_am_secretly_final)
+  end
+
+  it "can use secret helpers to declare final instance methods without sigs" do
+    c = Class.new do
+      extend T::Helpers
+      final!
+
+      built_sig = T::Private::Methods.__declare_sig(self, :final) do
+        returns(Integer)
+      end
+
+      T::Private::Methods.__with_declared_signature(self, built_sig) do
+        def i_am_secretly_final
+          1337
+        end
+      end
+    end
+    assert_equal(1337, c.new.i_am_secretly_final)
   end
 end

--- a/gems/sorbet-runtime/test/types/final_module.rb
+++ b/gems/sorbet-runtime/test/types/final_module.rb
@@ -100,7 +100,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
         extend T::Helpers
         final!
 
-        T::Private::Methods.__with_declared_signature(self, nil) do
+        T::Private::Methods._with_declared_signature(self, nil) do
           def foo; end
         end
       end
@@ -126,7 +126,7 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
         extend T::Helpers
         final!
 
-        T::Private::Methods.__with_declared_signature(self, nil) do
+        T::Private::Methods._with_declared_signature(self, nil) do
           def self.foo; end
         end
       end
@@ -242,11 +242,11 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
       extend T::Helpers
       final!
 
-      built_sig = T::Private::Methods.__declare_sig(self, :final) do
+      built_sig = T::Private::Methods._declare_sig(self, :final) do
         returns(Integer)
       end
 
-      T::Private::Methods.__with_declared_signature(self, built_sig) do
+      T::Private::Methods._with_declared_signature(self, built_sig) do
         def self.i_am_secretly_final
           4242
         end
@@ -260,11 +260,11 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
       extend T::Helpers
       final!
 
-      built_sig = T::Private::Methods.__declare_sig(self, :final) do
+      built_sig = T::Private::Methods._declare_sig(self, :final) do
         returns(Integer)
       end
 
-      T::Private::Methods.__with_declared_signature(self, built_sig) do
+      T::Private::Methods._with_declared_signature(self, built_sig) do
         def i_am_secretly_final
           1337
         end

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -558,6 +558,46 @@ module Opus::Types::Test
       end
     end
 
+    describe 'secretly-defined methods with sigs' do
+      # The behavior of methods defined via this interface is special: we expect
+      # that the methods themselves will perform argument validation.  The sig
+      # itself should only be registered to the method so that the rest of sorbet-runtime
+      # continues to work "normally".
+      it 'should not raise errors on return type mismatch' do
+        c = Class.new do
+          extend T::Sig
+
+          built_sig = T::Private::Methods.__declare_sig(self) do
+            returns(Integer)
+          end
+
+          T::Private::Methods.__with_declared_signature(self, built_sig) do
+            def bad_return
+              "ok"
+            end
+          end
+        end
+        assert_equal("ok", c.new.bad_return)
+      end
+
+      it 'should not raise errors on argument type mismatch' do
+        c = Class.new do
+          extend T::Sig
+
+          built_sig = T::Private::Methods.__declare_sig(self) do
+            params(x: Integer).returns(Symbol)
+          end
+
+          T::Private::Methods.__with_declared_signature(self, built_sig) do
+            def bad_arg(x)
+              :ok
+            end
+          end
+        end
+        assert_equal(:ok, c.new.bad_arg("wrong arg type"))
+      end
+    end
+
     # These tests should behave identically with and without a declaration
     [false, true].each do |using_declaration|
       describe "handling missing args (using_declaration=#{using_declaration}" do

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -578,6 +578,9 @@ module Opus::Types::Test
           end
         end
         assert_equal("ok", c.new.bad_return)
+        # Force the sig block to be actually run.
+        T::Utils.signature_for_method(c.instance_method(:bad_return))
+        assert_equal("ok", c.new.bad_return)
       end
 
       it 'should not raise errors on argument type mismatch' do
@@ -594,6 +597,9 @@ module Opus::Types::Test
             end
           end
         end
+        assert_equal(:ok, c.new.bad_arg("wrong arg type"))
+        # Force the sig block to be actually run.
+        T::Utils.signature_for_method(c.instance_method(:bad_arg))
         assert_equal(:ok, c.new.bad_arg("wrong arg type"))
       end
     end

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -567,11 +567,11 @@ module Opus::Types::Test
         c = Class.new do
           extend T::Sig
 
-          built_sig = T::Private::Methods.__declare_sig(self) do
+          built_sig = T::Private::Methods._declare_sig(self) do
             returns(Integer)
           end
 
-          T::Private::Methods.__with_declared_signature(self, built_sig) do
+          T::Private::Methods._with_declared_signature(self, built_sig) do
             def bad_return
               "ok"
             end
@@ -587,11 +587,11 @@ module Opus::Types::Test
         c = Class.new do
           extend T::Sig
 
-          built_sig = T::Private::Methods.__declare_sig(self) do
+          built_sig = T::Private::Methods._declare_sig(self) do
             params(x: Integer).returns(Symbol)
           end
 
-          T::Private::Methods.__with_declared_signature(self, built_sig) do
+          T::Private::Methods._with_declared_signature(self, built_sig) do
             def bad_arg(x)
               :ok
             end

--- a/gems/sorbet-runtime/test/types/utils.rb
+++ b/gems/sorbet-runtime/test/types/utils.rb
@@ -22,6 +22,15 @@ module Opus::Types::Test
         assert_nil(T::Utils.signature_for_method(c.instance_method(:no_sig)))
       end
 
+      it 'returns nil on secretly-defined methods with no sigs' do
+        c = Class.new do
+          T::Private::Methods.__with_declared_signature(self, nil) do
+            def no_sig; end
+          end
+        end
+        assert_nil(T::Utils.signature_for_method(c.instance_method(:no_sig)))
+      end
+
       it 'returns things on methods with sigs' do
         c = Class.new do
           extend T::Sig

--- a/gems/sorbet-runtime/test/types/utils.rb
+++ b/gems/sorbet-runtime/test/types/utils.rb
@@ -24,7 +24,7 @@ module Opus::Types::Test
 
       it 'returns nil on secretly-defined methods with no sigs' do
         c = Class.new do
-          T::Private::Methods.__with_declared_signature(self, nil) do
+          T::Private::Methods._with_declared_signature(self, nil) do
             def no_sig; end
           end
         end

--- a/gems/sorbet-runtime/test/types/utils.rb
+++ b/gems/sorbet-runtime/test/types/utils.rb
@@ -45,6 +45,25 @@ module Opus::Types::Test
         assert_equal(:sigfun, sfm.method_name)
         assert_equal('Integer', sfm.return_type.name)
       end
+
+      it 'returns things on secretly-defined methods with sigs' do
+        c = Class.new do
+          built_sig = T::Private::Methods._declare_sig(self) do
+            returns(Integer)
+          end
+
+          T::Private::Methods._with_declared_signature(self, built_sig) do
+            def sigfun
+              85
+            end
+          end
+        end
+        sfm = T::Utils.signature_for_method(c.instance_method(:sigfun))
+        refute_nil(sfm)
+        assert_equal(:sigfun, sfm.method.name)
+        assert_equal(:sigfun, sfm.method_name)
+        assert_equal('Integer', sfm.return_type.name)
+      end
     end
   end
 end


### PR DESCRIPTION

### Motivation

This PR wants to do basically the same thing as #4260.  Except that #4260's approach was a) not tested well enough :dug-shame: and b) not complete enough even in the limited scope for final methods.  Specifically for final methods, just saying "hey, this thing is a final method" is not enough: final method checking also ties deeply into having signatures associated with methods.  #4260 didn't address that side of things at all.

Instead, this PR proposes that we have secret internal hooks to build declaration blocks for signatures and to activate those declaration blocks for whatever method the user wants to define.  This approach is more general than #4260, more useful (there are plenty of reasons to want signatures attached to methods, not just yes/no for final), and...well, actually works.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  We have somehow gotten away with mostly not having tests for `T::Utils.signature_for_method`; I can add a test or two demonstrating that this approach actually sticks a signature on methods defined via this private backdoor.
