### PR TITLE
make UnresolvedClassType's constructor more efficient

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -892,7 +892,7 @@ public:
     const core::SymbolRef scope;
     const std::vector<core::NameRef> names;
     UnresolvedClassType(SymbolRef scope, std::vector<core::NameRef> names)
-        : ClassType(core::Symbols::untyped()), scope(scope), names(names){};
+        : ClassType(core::Symbols::untyped()), scope(scope), names(std::move(names)){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const;
     u4 hash(const GlobalState &gs) const;


### PR DESCRIPTION
### Motivation

Don't allocate when you don't need to.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
