### PR TITLE
add some tests for T::Utils.signature_with_method

### DIFF
--- a/gems/sorbet-runtime/test/types/utils.rb
+++ b/gems/sorbet-runtime/test/types/utils.rb
@@ -13,5 +13,29 @@ module Opus::Types::Test
         assert(unwrapped.subtype_of?(T.any(String, Float)))
       end
     end
+
+    describe 'T::Utils.signature_for_method' do
+      it 'returns nil on methods without sigs' do
+        c = Class.new do
+          def no_sig; end
+        end
+        assert_nil(T::Utils.signature_for_method(c.instance_method(:no_sig)))
+      end
+
+      it 'returns things on methods with sigs' do
+        c = Class.new do
+          extend T::Sig
+          sig {returns(Integer)}
+          def sigfun
+            85
+          end
+        end
+        sfm = T::Utils.signature_for_method(c.instance_method(:sigfun))
+        refute_nil(sfm)
+        assert_equal(:sigfun, sfm.method.name)
+        assert_equal(:sigfun, sfm.method_name)
+        assert_equal('Integer', sfm.return_type.name)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation

We had a single test for `signature_with_method`, now we have a few more.  Very basic, but better than nothing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
