### PR TITLE
Add join definition to Set

### DIFF
--- a/rbi/stdlib/set.rbi
+++ b/rbi/stdlib/set.rbi
@@ -284,6 +284,29 @@ class Set < Object
   end
   def intersection(enum); end
 
+  # Returns a string created by converting each element of the array to a
+  # string, separated by the given `separator`. If the `separator` is `nil`, it
+  # uses current `$,`. If both the `separator` and `$,` are `nil`, it uses an
+  # empty string.
+  #
+  # ```ruby
+  # [ "a", "b", "c" ].join        #=> "abc"
+  # [ "a", "b", "c" ].join("-")   #=> "a-b-c"
+  # ```
+  #
+  # For nested arrays, join is applied recursively:
+  #
+  # ```ruby
+  # [ "a", [1, 2, [:x, :y]], "b" ].join("-")   #=> "a-1-2-x-y-b"
+  # ```
+  sig do
+    params(
+        arg0: String,
+    )
+    .returns(String)
+  end
+  def join(arg0=T.unsafe(nil)); end
+
   # Deletes every element of the set for which block evaluates to false, and
   # returns self. Returns an enumerator if no block is given.
   sig do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Join is missing from the definition of `Set`. Reference: https://ruby-doc.org/stdlib-3.0.1/libdoc/set/rdoc/Set.html#method-i-join

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not familiar enough with the project to add the tests, but let me know where to do it if this changes requires it!
