### PR TITLE
Allow Dir.mkdir to take a Pathname

### DIFF
--- a/rbi/core/dir.rbi
+++ b/rbi/core/dir.rbi
@@ -344,7 +344,7 @@ class Dir < Object
   # ```
   sig do
     params(
-        arg0: String,
+        arg0: T.any(String, Pathname),
         arg1: Integer,
     )
     .returns(Integer)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I wanted to provide a Pathname to `Dir.mkdir` but Sorbet did not allow it, just like #3492.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

`Dir.mkdir(Pathname.new("foo"))` did what it was supposed to.

### Input

[→ View on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0ADir.mkdir(Pathname.new(%22foo%22)))

```ruby
# typed: true
Dir.mkdir(Pathname.new("foo"))
```

### Observed output

```
Sorbet LogoExamples ☰Playground for Sorbet Type Checker
12
# typed: true
Dir.mkdir(Pathname.new("foo"))
editor.rb:2: Expected String but found Pathname for argument arg0 https://srb.help/7002
     2 |Dir.mkdir(Pathname.new("foo"))
                  ^^^^^^^^^^^^^^^^^^^
  Expected String for argument arg0 of method Dir.mkdir:
    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#L347:
     347 |        arg0: String,
                  ^^^^
  Got Pathname originating from:
    editor.rb:2:
     2 |Dir.mkdir(Pathname.new("foo"))
                  ^^^^^^^^^^^^^^^^^^^
Errors: 1
```

### Expected behaviour

```
No errors! Great job.
```