### PR TITLE
shrink some autogen enums

### DIFF
--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -49,7 +49,7 @@ struct AutoloaderConfig;
 struct NamedDefinition;
 class DefTree;
 
-enum class ClassKind { Class, Module };
+enum class ClassKind : u1 { Class, Module };
 
 // A reference to a specific `Definition` inside of a `ParsedFile`.
 struct DefinitionRef {

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -88,7 +88,7 @@ struct ReferenceRef {
 
 // A constant definition---a class, module, constant definition, or constant alias---along with relevant metadata
 struct Definition {
-    enum class Type : u8 { Module, Class, Casgn, Alias };
+    enum class Type : u1 { Module, Class, Casgn, Alias };
 
     // the reference to this definition. Once `AutogenWalk` is completed and a full `ParsedFile` has been created, it
     // should always be the case that


### PR DESCRIPTION
### Motivation

Less space is more better.  I think this shrinks `Reference` by 8 bytes or so and `Definition` by 12?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
