### PR TITLE
Autogen: Avoid sorting autoloader output, add missing timers, poll more frequently for completed work

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -271,8 +271,8 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
     autogen::DefTree root;
     AutogenResult out;
     vector<pair<int, AutogenResult::Serialized>> merged;
-    for (auto res = resultq->wait_pop_timed(out, chrono::seconds{1}, *logger); !res.done();
-         res = resultq->wait_pop_timed(out, chrono::seconds{1}, *logger)) {
+    for (auto res = resultq->wait_pop_timed(out, WorkerPool::BLOCK_INTERVAL(), *logger); !res.done();
+         res = resultq->wait_pop_timed(out, WorkerPool::BLOCK_INTERVAL(), *logger)) {
         if (!res.gotItem()) {
             continue;
         }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -286,12 +286,15 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
         }
     }
 
-    for (auto &elem : merged) {
-        if (opts.print.Autogen.enabled) {
-            opts.print.Autogen.print(elem.strval);
-        }
-        if (opts.print.AutogenMsgPack.enabled) {
-            opts.print.AutogenMsgPack.print(elem.msgpack);
+    {
+        Timer timeit(logger, "autogenDependencyDBPrint");
+        for (auto &elem : merged) {
+            if (opts.print.Autogen.enabled) {
+                opts.print.Autogen.print(elem.strval);
+            }
+            if (opts.print.AutogenMsgPack.enabled) {
+                opts.print.AutogenMsgPack.print(elem.msgpack);
+            }
         }
     }
     if (opts.print.AutogenAutoloader.enabled) {
@@ -343,6 +346,7 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
     }
 
     if (opts.autoloaderConfig.packagedAutoloader) {
+        Timer timeit(logger, "autogenPackageAutoloads");
         autogen::AutoloadWriter::writePackageAutoloads(gs, autoloaderCfg, opts.print.AutogenAutoloader.outputPath,
                                                        packageq);
     }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -214,6 +214,7 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
 
     auto resultq = make_shared<BlockingBoundedQueue<AutogenResult>>(indexed.size());
     auto fileq = make_shared<ConcurrentBoundedQueue<int>>(indexed.size());
+    vector<AutogenResult::Serialized> merged(indexed.size());
     for (int i = 0; i < indexed.size(); ++i) {
         fileq->push(move(i), 1);
     }
@@ -270,27 +271,27 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
 
     autogen::DefTree root;
     AutogenResult out;
-    vector<pair<int, AutogenResult::Serialized>> merged;
     for (auto res = resultq->wait_pop_timed(out, WorkerPool::BLOCK_INTERVAL(), *logger); !res.done();
          res = resultq->wait_pop_timed(out, WorkerPool::BLOCK_INTERVAL(), *logger)) {
         if (!res.gotItem()) {
             continue;
         }
         counterConsume(move(out.counters));
-        merged.insert(merged.end(), make_move_iterator(out.prints.begin()), make_move_iterator(out.prints.end()));
+        for (auto &print : out.prints) {
+            merged[print.first] = move(print.second);
+        }
         if (opts.print.AutogenAutoloader.enabled) {
             Timer timeit(logger, "autogenAutoloaderDefTreeMerge");
             root = autogen::DefTreeBuilder::merge(gs, move(root), move(*out.defTree));
         }
     }
-    fast_sort(merged, [](const auto &lhs, const auto &rhs) -> bool { return lhs.first < rhs.first; });
 
     for (auto &elem : merged) {
         if (opts.print.Autogen.enabled) {
-            opts.print.Autogen.print(elem.second.strval);
+            opts.print.Autogen.print(elem.strval);
         }
         if (opts.print.AutogenMsgPack.enabled) {
-            opts.print.AutogenMsgPack.print(elem.second.msgpack);
+            opts.print.AutogenMsgPack.print(elem.msgpack);
         }
     }
     if (opts.print.AutogenAutoloader.enabled) {
@@ -308,7 +309,7 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
         Timer timeit(logger, "autogenClasslistPrint");
         vector<string> mergedClasslist;
         for (auto &el : merged) {
-            auto &v = el.second.classlist;
+            auto &v = el.classlist;
             mergedClasslist.insert(mergedClasslist.end(), make_move_iterator(v.begin()), make_move_iterator(v.end()));
         }
         fast_sort(mergedClasslist);
@@ -321,12 +322,12 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
         // Merge the {Parent: Set{Child1, Child2}} maps from each thread
         autogen::Subclasses::Map childMap;
         for (const auto &el : merged) {
-            if (!el.second.subclasses) {
+            if (!el.subclasses) {
                 // File doesn't define any Child < Parent relationships
                 continue;
             }
 
-            for (const auto &[parentName, children] : *el.second.subclasses) {
+            for (const auto &[parentName, children] : *el.subclasses) {
                 if (!parentName.empty()) {
                     childMap[parentName].entries.insert(children.entries.begin(), children.entries.end());
                     childMap[parentName].classKind = children.classKind;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Autogen: Avoid sorting autoloader output, add missing timers, and poll more frequently for results.

@nroman-stripe Feel free to reassign or ask someone else to review if appropriate!

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed up autogen and improve our ability to trace where time is going. The increased polling frequency ensures that autogen remains snappy even if we make the parallel section faster than 1 second.

This is the first PR containing optimizations from:
https://github.com/sorbet/sorbet/pull/4301

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
