### PR TITLE
Autogen: Faster CRC calculations with a table.

### DIFF
--- a/main/autogen/BUILD
+++ b/main/autogen/BUILD
@@ -3,12 +3,14 @@ cc_library(
     srcs = [
         "autogen.cc",
         "autoloader.cc",
+        "crc.cc",
         "packages.cc",
         "subclasses.cc",
     ],
     hdrs = [
         "autogen.h",
         "autoloader.h",
+        "crc.h",
         "packages.h",
         "subclasses.h",
     ],

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -4,8 +4,7 @@
 #include "ast/treemap/treemap.h"
 #include "common/formatting.h"
 #include "main/autogen/autoloader.h"
-
-#include "CRC.h"
+#include "main/autogen/crc.h"
 
 using namespace std;
 namespace sorbet::autogen {
@@ -326,13 +325,13 @@ public:
 
 // Convert a Sorbet `ParsedFile` into an Autogen `ParsedFile` by walking it as above and also recording the checksum of
 // the current file
-ParsedFile Autogen::generate(core::Context ctx, ast::ParsedFile tree) {
+ParsedFile Autogen::generate(core::Context ctx, ast::ParsedFile tree, const CRCBuilder &crcBuilder) {
     AutogenWalk walk;
     tree.tree = ast::TreeMap::apply(ctx, walk, move(tree.tree));
     auto pf = walk.parsedFile();
     pf.path = string(tree.file.data(ctx).path());
     auto src = tree.file.data(ctx).source();
-    pf.cksum = CRC::Calculate(src.data(), src.size(), CRC::CRC_32());
+    pf.cksum = crcBuilder.crc32(src);
     pf.tree = move(tree);
     return pf;
 }

--- a/main/autogen/autogen.h
+++ b/main/autogen/autogen.h
@@ -1,6 +1,7 @@
 #ifndef AUTOGEN_H
 #define AUTOGEN_H
 
+#include "main/autogen/crc.h"
 #include "main/autogen/data/definitions.h"
 #include "main/options/options.h"
 
@@ -8,7 +9,7 @@ namespace sorbet::autogen {
 
 class Autogen final {
 public:
-    static ParsedFile generate(core::Context ctx, ast::ParsedFile tree);
+    static ParsedFile generate(core::Context ctx, ast::ParsedFile tree, const CRCBuilder &crcBuilder);
     Autogen() = delete;
 };
 

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -388,6 +388,7 @@ void DefTreeBuilder::collapseSameFileDefs(const core::GlobalState &gs, const Aut
     }
 }
 
+// TODO: Why not check each subdir? Don't do recursively.
 void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, const AutoloaderConfig &alCfg, const std::string &path,
                                     const DefTree &root) {
     UnorderedSet<string> toDelete; // Remove from this set as we write files

--- a/main/autogen/crc.cc
+++ b/main/autogen/crc.cc
@@ -1,0 +1,30 @@
+#include "main/autogen/crc.h"
+#include "CRC.h"
+
+using namespace std;
+
+namespace sorbet::autogen {
+
+class CRCBuilderImpl : public CRCBuilder {
+    const CRC::Table<std::uint32_t, 32> lookupTable;
+
+public:
+    CRCBuilderImpl() : lookupTable(CRC::CRC_32()) {}
+    ~CRCBuilderImpl(){
+        // see https://eli.thegreenplace.net/2010/11/13/pure-virtual-destructors-in-c
+    };
+
+    u4 crc32(string_view data) const override {
+        return CRC::Calculate(data.data(), data.size(), this->lookupTable);
+    }
+};
+
+CRCBuilder::~CRCBuilder() {
+    // see https://eli.thegreenplace.net/2010/11/13/pure-virtual-destructors-in-c
+}
+
+shared_ptr<CRCBuilder> CRCBuilder::create() {
+    return make_shared<CRCBuilderImpl>();
+}
+
+} // namespace sorbet::autogen

--- a/main/autogen/crc.h
+++ b/main/autogen/crc.h
@@ -1,0 +1,27 @@
+#ifndef AUTOGEN_CRC_H
+#define AUTOGEN_CRC_H
+
+#include "common/common.h"
+
+namespace sorbet::autogen {
+
+/**
+ * Efficiently calculates CRCs using a lookup table.
+ */
+class CRCBuilder {
+public:
+    static std::shared_ptr<CRCBuilder> create();
+
+    CRCBuilder() = default;
+    virtual ~CRCBuilder() = 0;
+    // No need to copy; CRCBuilder can be shared between threads.
+    CRCBuilder(CRCBuilder &) = delete;
+    CRCBuilder(const CRCBuilder &) = delete;
+    CRCBuilder &operator=(CRCBuilder &&) = delete;
+    CRCBuilder &operator=(const CRCBuilder &) = delete;
+
+    virtual sorbet::u4 crc32(std::string_view data) const = 0;
+};
+
+} // namespace sorbet::autogen
+#endif // AUTOGEN_CRC_H

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -9,6 +9,7 @@
 #include "common/web_tracer_framework/tracing.h"
 #include "main/autogen/autogen.h"
 #include "main/autogen/autoloader.h"
+#include "main/autogen/crc.h"
 #include "main/autogen/packages.h"
 #include "main/autogen/subclasses.h"
 #include "main/lsp/LSPInput.h"
@@ -217,8 +218,9 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
     for (int i = 0; i < indexed.size(); ++i) {
         fileq->push(move(i), 1);
     }
+    auto crcBuilder = autogen::CRCBuilder::create();
 
-    workers.multiplexJob("runAutogen", [&gs, &opts, &indexed, &autoloaderCfg, fileq, resultq]() {
+    workers.multiplexJob("runAutogen", [&gs, &opts, &indexed, &autoloaderCfg, crcBuilder, fileq, resultq]() {
         AutogenResult out;
         int n = 0;
         {
@@ -233,7 +235,7 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
                 }
 
                 core::Context ctx(gs, core::Symbols::root(), tree.file);
-                auto pf = autogen::Autogen::generate(ctx, move(tree));
+                auto pf = autogen::Autogen::generate(ctx, move(tree), *crcBuilder);
                 tree = move(pf.tree);
 
                 AutogenResult::Serialized serialized;

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -27,6 +27,7 @@
 #include "infer/infer.h"
 #include "local_vars/local_vars.h"
 #include "main/autogen/autogen.h"
+#include "main/autogen/crc.h"
 #include "namer/namer.h"
 #include "packager/packager.h"
 #include "parser/parser.h"
@@ -314,9 +315,10 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             *gs, "autogen",
             [&]() {
                 stringstream payload;
+                auto crcBuilder = autogen::CRCBuilder::create();
                 for (auto &tree : trees) {
                     core::Context ctx(*gs, core::Symbols::root(), tree.file);
-                    auto pf = autogen::Autogen::generate(ctx, move(tree));
+                    auto pf = autogen::Autogen::generate(ctx, move(tree), *crcBuilder);
                     tree = move(pf.tree);
                     payload << pf.toString(ctx);
                 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Autogen: Calculate CRCs with a table. `perf` seemed convinced that CRC calculations take up ~50% of `Autogen::generate`'s time, and with this optimization it only takes up ~30%. Oddly, end-to-end time for worker threads is only mildly impacted -- so there could be some measurement error here.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed!

We can improve CRC calculations by a further 10X by using hardware instructions (see https://github.com/komrad36/CRC#option-11-1-byte-hardware-accelerated, thanks to @froydnj!), but I'll leave that to a future PR since it involves landing cargo-culted CRC code from that markdown file. It also slots nicely into this CRCBuilder abstraction.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
