### PR TITLE
Autogen: Shrink `Reference` by 32 bits, use cast_tree_nonnull, avoid vector copying

### DIFF
--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -37,8 +37,9 @@ class AutogenWalk {
     }
 
     // Convert a constant literal into a fully qualified name
-    vector<core::NameRef> constantName(core::Context ctx, ast::ConstantLit *cnst) {
+    vector<core::NameRef> constantName(core::Context ctx, ast::ConstantLit &cnstRef) {
         vector<core::NameRef> out;
+        auto *cnst = &cnstRef;
         while (cnst != nullptr && cnst->original != nullptr) {
             auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(cnst->original);
             out.emplace_back(original.cnst);
@@ -178,7 +179,8 @@ public:
     }
 
     // `true` if the constant is fully qualified and can be traced back to the root scope, `false` otherwise
-    bool isCBaseConstant(ast::ConstantLit *cnst) {
+    bool isCBaseConstant(ast::ConstantLit &cnstRef) {
+        auto *cnst = &cnstRef;
         while (cnst != nullptr && cnst->original != nullptr) {
             auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(cnst->original);
             cnst = ast::cast_tree<ast::ConstantLit>(original.scope);
@@ -190,14 +192,14 @@ public:
     }
 
     ast::ExpressionPtr postTransformConstantLit(core::Context ctx, ast::ExpressionPtr tree) {
-        auto *original = ast::cast_tree<ast::ConstantLit>(tree);
+        auto &original = ast::cast_tree_nonnull<ast::ConstantLit>(tree);
 
         if (!ignoring.empty()) {
             // this is either a constant in a `keepForIde` node (in which case we don't care) or it was an `include` or
             // an `extend` which already got handled in `preTransformClassDef` (in which case don't handle it again)
             return tree;
         }
-        if (original->original == nullptr) {
+        if (original.original == nullptr) {
             return tree;
         }
 
@@ -216,14 +218,14 @@ public:
             ref.nesting.pop_back();
             ref.scope = nesting.back();
         }
-        ref.loc = original->loc;
+        ref.loc = original.loc;
 
         // the reference location is the location of constant, but this might get updated if the reference corresponds
         // to the definition of the constant, because in that case we'll later on extend the location to cover the whole
         // class or assignment
-        ref.definitionLoc = original->loc;
+        ref.definitionLoc = original.loc;
         ref.name = QualifiedName::fromFullName(constantName(ctx, original));
-        auto sym = original->symbol;
+        auto sym = original.symbol;
         if (!sym.isClassOrModule() || sym != core::Symbols::StubModule()) {
             ref.resolved = QualifiedName::fromFullName(symbolName(ctx, sym));
         }

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -102,7 +102,7 @@ public:
         // update that reference with the relevant metadata so we know 1. it's the defining ref and 2. it encompasses
         // the entire class, not just the constant name
         refs[it->second.id()].is_defining_ref = true;
-        refs[it->second.id()].definitionLoc = core::Loc(ctx.file, original.loc);
+        refs[it->second.id()].definitionLoc = original.loc;
 
         auto ait = original.ancestors.begin();
         // if this is a class, then the first ancestor is the parent class
@@ -216,12 +216,12 @@ public:
             ref.nesting.pop_back();
             ref.scope = nesting.back();
         }
-        ref.loc = core::Loc(ctx.file, original->loc);
+        ref.loc = original->loc;
 
         // the reference location is the location of constant, but this might get updated if the reference corresponds
         // to the definition of the constant, because in that case we'll later on extend the location to cover the whole
         // class or assignment
-        ref.definitionLoc = core::Loc(ctx.file, original->loc);
+        ref.definitionLoc = original->loc;
         ref.name = QualifiedName::fromFullName(constantName(ctx, original));
         auto sym = original->symbol;
         if (!sym.isClassOrModule() || sym != core::Symbols::StubModule()) {
@@ -273,7 +273,7 @@ public:
         // ...and mark that this is the defining ref for that one
         def.defining_ref = ref.id;
         ref.is_defining_ref = true;
-        ref.definitionLoc = core::Loc(ctx.file, original.loc);
+        ref.definitionLoc = original.loc;
 
         // Constant definitions always count as non-empty behavior-defining definitions
         def.defines_behavior = true;

--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -8,7 +8,7 @@ using namespace std;
 
 namespace sorbet::autogen {
 
-QualifiedName QualifiedName::fromFullName(vector<core::NameRef> name) {
+QualifiedName QualifiedName::fromFullName(vector<core::NameRef> &&name) {
     if (name.size() < 3 || name.front() != core::Names::Constants::PackageRegistry()) {
         return {move(name), nullopt};
     }

--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -143,8 +143,8 @@ string ParsedFile::toString(const core::GlobalState &gs) const {
 
                        ref.id.id(), fmt::map_join(refFullName, " ", nameToString),
                        fmt::map_join(ref.name.nameParts, " ", nameToString), fmt::join(nestingStrings, " "),
-                       fmt::map_join(ref.resolved.nameParts, " ", nameToString), ref.loc.filePosToString(gs),
-                       (int)ref.is_defining_ref);
+                       fmt::map_join(ref.resolved.nameParts, " ", nameToString),
+                       core::Loc(tree.file, ref.loc).filePosToString(gs), (int)ref.is_defining_ref);
 
         if (ref.parent_of.exists()) {
             auto parentOfFullName = showFullName(gs, ref.parent_of);

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -14,7 +14,7 @@ struct QualifiedName {
     std::vector<core::NameRef> nameParts;
     std::optional<core::NameRef> package;
 
-    static QualifiedName fromFullName(std::vector<core::NameRef> fullName);
+    static QualifiedName fromFullName(std::vector<core::NameRef> &&fullName);
 
     bool empty() const {
         return nameParts.empty();

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -132,8 +132,8 @@ struct Reference {
     QualifiedName resolved;
 
     // loc and definitionLoc will differ if this is a defining ref, otherwise they will be the same
-    core::Loc loc;
-    core::Loc definitionLoc;
+    core::LocOffsets loc;
+    core::LocOffsets definitionLoc;
 
     // this is always true
     // TODO(gdritter): delete this, of course

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -104,7 +104,7 @@ void MsgpackWriter::packReference(core::Context ctx, ParsedFile &pf, Reference &
     mpack_finish_array(&writer);
 
     // expression_range
-    auto expression_range = ref.definitionLoc.position(ctx);
+    auto expression_range = core::Loc(ctx.file, ref.definitionLoc).position(ctx);
     packRange(expression_range.first.line, expression_range.second.line);
     // expression_pos_range
     packRange(ref.loc.beginPos(), ref.loc.endPos());


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Three minor autogen optimizations. They do not have a significant impact on runtime:

* Use `LocOffsets` rather than `Loc` in `Reference`. All `Loc` within a `Reference` are from its `FileRef`.
* Use `cast_tree_nonnull` when we know a cast will not fail. It avoids a runtime check.
* Avoid vector copying in `QualifiedName` abstraction. Instead, have it consume the vector so it gets `move`d into place.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reducing autogen runtime.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
