### PR TITLE
Autogen: Parallelize writing autoloader file outputs.

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -2,6 +2,8 @@
 #include "absl/strings/match.h"
 #include "common/FileOps.h"
 #include "common/Timer.h"
+#include "common/concurrency/ConcurrentQueue.h"
+#include "common/concurrency/WorkerPool.h"
 #include "common/formatting.h"
 #include "common/sort.h"
 #include "core/GlobalState.h"
@@ -127,9 +129,9 @@ string DefTree::fullName(const core::GlobalState &gs) const {
                        fmt::map_join(qname.nameParts, "::", [&](core::NameRef nr) -> string { return nr.show(gs); }));
 }
 
-string join(string path, string file) {
+string join(string_view path, string file) {
     if (file.empty()) {
-        return path;
+        return string(path);
     }
     return fmt::format("{}/{}", path, file);
 }
@@ -388,32 +390,26 @@ void DefTreeBuilder::collapseSameFileDefs(const core::GlobalState &gs, const Aut
     }
 }
 
-// TODO: Why not check each subdir? Don't do recursively.
-void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, const AutoloaderConfig &alCfg, const std::string &path,
-                                    const DefTree &root) {
-    UnorderedSet<string> toDelete; // Remove from this set as we write files
-    if (FileOps::exists(path)) {
-        vector<string> existingFiles = FileOps::listFilesInDir(path, {".rb"}, true, {}, {});
-        toDelete.insert(make_move_iterator(existingFiles.begin()), make_move_iterator(existingFiles.end()));
-    }
-    write(gs, alCfg, path, toDelete, root);
-    for (const auto &file : toDelete) {
-        FileOps::removeFile(file);
-    }
-}
+namespace {
+struct RenderAutoloadTask {
+    string filePath;
+    const DefTree &node;
+};
 
-void AutoloadWriter::write(const core::GlobalState &gs, const AutoloaderConfig &alCfg, const std::string &path,
-                           UnorderedSet<std::string> &toDelete, const DefTree &node) {
+// This function has two duties:
+// * It creates autoload rendering tasks which will occur in a later parallel phase.
+// * It creates subdirectories when needed, as they are required to write the autoloader output.
+void populateAutoloadTasksAndCreateDirectories(const core::GlobalState &gs, vector<RenderAutoloadTask> &tasks,
+                                               const AutoloaderConfig &alCfg, string_view path, const DefTree &node) {
     string name = node.root() ? "root" : node.name().show(gs);
     string filePath = join(path, fmt::format("{}.rb", name));
     if (!alCfg.packagedAutoloader || !node.root()) {
-        FileOps::writeIfDifferent(filePath, node.renderAutoloadSrc(gs, alCfg));
+        tasks.emplace_back(RenderAutoloadTask{filePath, node});
     }
-    toDelete.erase(filePath);
     if (!node.children.empty()) {
         auto subdir = join(path, node.root() ? "" : name);
-        if (!node.root() && !FileOps::dirExists(subdir)) {
-            FileOps::createDir(subdir);
+        if (!node.root()) {
+            FileOps::ensureDir(subdir);
         }
         for (auto &[_, child] : node.children) {
             if (alCfg.packagedAutoloader && node.root()) {
@@ -426,11 +422,63 @@ void AutoloadWriter::write(const core::GlobalState &gs, const AutoloaderConfig &
                 string packageName = namespaceName.substr(0, namespaceName.size() - suffixLen);
                 auto pkgSubdir = join(subdir, packageName);
                 FileOps::ensureDir(pkgSubdir);
-                write(gs, alCfg, pkgSubdir, toDelete, *child);
+                populateAutoloadTasksAndCreateDirectories(gs, tasks, alCfg, pkgSubdir, *child);
             } else {
-                write(gs, alCfg, subdir, toDelete, *child);
+                populateAutoloadTasksAndCreateDirectories(gs, tasks, alCfg, subdir, *child);
             }
         }
+    }
+}
+}; // namespace
+
+void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &workers, const AutoloaderConfig &alCfg,
+                                    const std::string &path, const DefTree &root) {
+    vector<RenderAutoloadTask> tasks;
+    populateAutoloadTasksAndCreateDirectories(gs, tasks, alCfg, path, root);
+
+    if (FileOps::exists(path)) {
+        // Clear out files that we do not plan to write.
+        vector<string> existingFiles = FileOps::listFilesInDir(path, {".rb"}, true, {}, {});
+        UnorderedSet<string> existingFilesSet(make_move_iterator(existingFiles.begin()),
+                                              make_move_iterator(existingFiles.end()));
+        for (auto &task : tasks) {
+            existingFilesSet.erase(task.filePath);
+        }
+        for (const auto &file : existingFilesSet) {
+            FileOps::removeFile(file);
+        }
+    }
+
+    // Parallelize writing the files.
+    auto inputq = make_shared<ConcurrentBoundedQueue<int>>(tasks.size());
+    auto outputq = make_shared<BlockingBoundedQueue<CounterState>>(tasks.size());
+    for (int i = 0; i < tasks.size(); ++i) {
+        inputq->push(move(i), 1);
+    }
+
+    workers.multiplexJob("runAutogenWriteAutoloads", [&gs, &tasks, &alCfg, inputq, outputq]() {
+        int n = 0;
+        {
+            Timer timeit(gs.tracer(), "autogenWriteAutoloadsWorker");
+            int idx = 0;
+
+            for (auto result = inputq->try_pop(idx); !result.done(); result = inputq->try_pop(idx)) {
+                ++n;
+                auto &task = tasks[idx];
+                FileOps::writeIfDifferent(task.filePath, task.node.renderAutoloadSrc(gs, alCfg));
+            }
+        }
+
+        outputq->push(getAndClearThreadCounters(), n);
+    });
+
+    CounterState out;
+    for (auto res = outputq->wait_pop_timed(out, WorkerPool::BLOCK_INTERVAL(), gs.tracer()); !res.done();
+         res = outputq->wait_pop_timed(out, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+        if (!res.gotItem()) {
+            continue;
+        }
+        counterConsume(move(out));
     }
 }
 

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -5,6 +5,10 @@
 #include "main/options/options.h"
 #include <string_view>
 
+namespace sorbet {
+class WorkerPool;
+}
+
 namespace sorbet::autogen {
 
 // Contains same information as `realmain::options::AutoloaderConfig` except with `core::NameRef`s
@@ -123,15 +127,11 @@ private:
 
 class AutoloadWriter {
 public:
-    static void writeAutoloads(const core::GlobalState &gs, const AutoloaderConfig &, const std::string &path,
-                               const DefTree &root);
+    static void writeAutoloads(const core::GlobalState &gs, WorkerPool &workers, const AutoloaderConfig &,
+                               const std::string &path, const DefTree &root);
 
     static void writePackageAutoloads(const core::GlobalState &gs, const AutoloaderConfig &, const std::string &path,
                                       const std::vector<Package> &packages);
-
-private:
-    static void write(const core::GlobalState &gs, const AutoloaderConfig &, const std::string &path,
-                      UnorderedSet<std::string> &toDelete, const DefTree &node);
 };
 
 } // namespace sorbet::autogen

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -306,7 +306,8 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
         }
         {
             Timer timeit(logger, "autogenAutoloaderWrite");
-            autogen::AutoloadWriter::writeAutoloads(gs, autoloaderCfg, opts.print.AutogenAutoloader.outputPath, root);
+            autogen::AutoloadWriter::writeAutoloads(gs, workers, autoloaderCfg, opts.print.AutogenAutoloader.outputPath,
+                                                    root);
         }
     }
 


### PR DESCRIPTION
Autogen: Parallelize writing autoloader file outputs.

Significantly speeds up autogen on Stripe's codebase.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed up autogen.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
