### PR TITLE
[Ruby 3.0] Import new tests for args assocs

### DIFF
--- a/test/whitequark/test_args_assocs_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_args_assocs_2.parse-tree-whitequark.exp
@@ -1,0 +1,6 @@
+s(:send,
+  s(:self), :[],
+  s(:hash,
+    s(:pair,
+      s(:sym, :bar),
+      s(:int, "1"))))

--- a/test/whitequark/test_args_assocs_2.rb
+++ b/test/whitequark/test_args_assocs_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+self[:bar => 1]

--- a/test/whitequark/test_args_assocs_3.parse-tree-whitequark.exp
+++ b/test/whitequark/test_args_assocs_3.parse-tree-whitequark.exp
@@ -1,0 +1,7 @@
+s(:send,
+  s(:self), :[]=,
+  s(:lvar, :foo),
+  s(:hash,
+    s(:pair,
+      s(:sym, :a),
+      s(:int, "1"))))

--- a/test/whitequark/test_args_assocs_3.rb
+++ b/test/whitequark/test_args_assocs_3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+self.[]= foo, :a => 1

--- a/test/whitequark/test_args_assocs_4.parse-tree-whitequark.exp
+++ b/test/whitequark/test_args_assocs_4.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:yield,
+  s(:hash,
+    s(:pair,
+      s(:sym, :foo),
+      s(:int, "42"))))

--- a/test/whitequark/test_args_assocs_4.rb
+++ b/test/whitequark/test_args_assocs_4.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+yield(:foo => 42)

--- a/test/whitequark/test_args_assocs_5.parse-tree-whitequark.exp
+++ b/test/whitequark/test_args_assocs_5.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:super,
+  s(:hash,
+    s(:pair,
+      s(:sym, :foo),
+      s(:int, "42"))))

--- a/test/whitequark/test_args_assocs_5.rb
+++ b/test/whitequark/test_args_assocs_5.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+super(:foo => 42)

--- a/test/whitequark/test_args_assocs_legacy_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_args_assocs_legacy_0.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:send, nil, :fun,
+  s(:hash,
+    s(:pair,
+      s(:sym, :foo),
+      s(:int, "1"))))

--- a/test/whitequark/test_args_assocs_legacy_0.rb
+++ b/test/whitequark/test_args_assocs_legacy_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+fun(:foo => 1)

--- a/test/whitequark/test_args_assocs_legacy_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_args_assocs_legacy_1.parse-tree-whitequark.exp
@@ -1,0 +1,7 @@
+s(:send, nil, :fun,
+  s(:hash,
+    s(:pair,
+      s(:sym, :foo),
+      s(:int, "1"))),
+  s(:block_pass,
+    s(:lvar, :baz)))

--- a/test/whitequark/test_args_assocs_legacy_1.rb
+++ b/test/whitequark/test_args_assocs_legacy_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+fun(:foo => 1, &baz)

--- a/test/whitequark/test_args_assocs_legacy_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_args_assocs_legacy_2.parse-tree-whitequark.exp
@@ -1,0 +1,6 @@
+s(:send,
+  s(:self), :[],
+  s(:hash,
+    s(:pair,
+      s(:sym, :bar),
+      s(:int, "1"))))

--- a/test/whitequark/test_args_assocs_legacy_2.rb
+++ b/test/whitequark/test_args_assocs_legacy_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+self[:bar => 1]

--- a/test/whitequark/test_args_assocs_legacy_3.parse-tree-whitequark.exp
+++ b/test/whitequark/test_args_assocs_legacy_3.parse-tree-whitequark.exp
@@ -1,0 +1,7 @@
+s(:send,
+  s(:self), :[]=,
+  s(:lvar, :foo),
+  s(:hash,
+    s(:pair,
+      s(:sym, :a),
+      s(:int, "1"))))

--- a/test/whitequark/test_args_assocs_legacy_3.rb
+++ b/test/whitequark/test_args_assocs_legacy_3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+self.[]= foo, :a => 1

--- a/test/whitequark/test_args_assocs_legacy_4.parse-tree-whitequark.exp
+++ b/test/whitequark/test_args_assocs_legacy_4.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:yield,
+  s(:hash,
+    s(:pair,
+      s(:sym, :foo),
+      s(:int, "42"))))

--- a/test/whitequark/test_args_assocs_legacy_4.rb
+++ b/test/whitequark/test_args_assocs_legacy_4.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+yield(:foo => 42)

--- a/test/whitequark/test_args_assocs_legacy_5.parse-tree-whitequark.exp
+++ b/test/whitequark/test_args_assocs_legacy_5.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:super,
+  s(:hash,
+    s(:pair,
+      s(:sym, :foo),
+      s(:int, "42"))))

--- a/test/whitequark/test_args_assocs_legacy_5.rb
+++ b/test/whitequark/test_args_assocs_legacy_5.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+super(:foo => 42)


### PR DESCRIPTION
Starting the work to update the parser for Ruby 3.0. These new `args_assocs` tests are all passing without any code modifications.

Note: only edit I made was changing the argument nodes from `kwargs` to `hash`, since that's the node type we are currently emitting.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.