### PR TITLE
Copy fewer strings in `listFilesInDir`

### DIFF
--- a/common/common.cc
+++ b/common/common.cc
@@ -276,11 +276,10 @@ void appendFilesInDir(string_view basePath, string_view path, const sorbet::Unor
                              relativeIgnorePatterns);
         } else {
             auto dotLocation = fullPath.rfind('.');
-            // Note: Can't call substr with an index > string length, so explicitly check if a dot isn't found.
             if (dotLocation != string::npos) {
-                auto ext = fullPath.substr(dotLocation);
+                string_view ext(fullPath.c_str() + dotLocation, fullPath.size() - dotLocation);
                 if (extensions.contains(ext)) {
-                    result.emplace_back(fullPath);
+                    result.push_back(move(fullPath));
                 }
             }
         }

--- a/common/common.cc
+++ b/common/common.cc
@@ -248,13 +248,13 @@ bool sorbet::FileOps::isFileIgnored(string_view basePath, string_view filePath,
     return false;
 }
 
-void appendFilesInDir(string_view basePath, string_view path, const sorbet::UnorderedSet<string> &extensions,
+void appendFilesInDir(string_view basePath, const string &path, const sorbet::UnorderedSet<string> &extensions,
                       bool recursive, vector<string> &result, const std::vector<std::string> &absoluteIgnorePatterns,
                       const std::vector<std::string> &relativeIgnorePatterns) {
     DIR *dir;
     struct dirent *entry;
 
-    if ((dir = opendir(string(path).c_str())) == nullptr) {
+    if ((dir = opendir(path.c_str())) == nullptr) {
         switch (errno) {
             case ENOTDIR:
                 throw sorbet::FileNotDirException();
@@ -291,7 +291,10 @@ vector<string> sorbet::FileOps::listFilesInDir(string_view path, const Unordered
                                                const std::vector<std::string> &absoluteIgnorePatterns,
                                                const std::vector<std::string> &relativeIgnorePatterns) {
     vector<string> result;
-    appendFilesInDir(path, path, extensions, recursive, result, absoluteIgnorePatterns, relativeIgnorePatterns);
+    // Mini-optimization: appendFilesInDir needs to grab a c_str from path, so we pass in a string reference to avoid
+    // copying.
+    string pathStr(path);
+    appendFilesInDir(path, pathStr, extensions, recursive, result, absoluteIgnorePatterns, relativeIgnorePatterns);
     fast_sort(result);
     return result;
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Small optimizations to listFilesInDir:

* Don't copy the `path` string on every invocation.
* Don't copy the file extension into a new string; create a view instead.
* Don't copy the file path into the vector -- move it instead.

These optimizations do not seem to significantly impact runtime, so you can push back on them if you'd like.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Looking at ways to speed up this function, which takes a nontrivial amount of time in autogen.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
