### PR TITLE
WIP: Defer symbol table resizing until after indexing has run.

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -723,30 +723,38 @@ void GlobalState::installIntrinsics() {
     }
 }
 
-void GlobalState::preallocateTables(u4 classAndModulesSize, u4 methodsSize, u4 fieldsSize, u4 typeArgumentsSize,
-                                    u4 typeMembersSize, u4 utf8NameSize, u4 constantNameSize, u4 uniqueNameSize) {
+void GlobalState::preallocateSymbolTables(u4 classAndModulesSize, u4 methodsSize, u4 fieldsSize, u4 typeArgumentsSize,
+                                          u4 typeMembersSize) {
     u4 classAndModulesSizeScaled = nextPowerOfTwo(classAndModulesSize);
     u4 methodsSizeScaled = nextPowerOfTwo(methodsSize);
     u4 fieldsSizeScaled = nextPowerOfTwo(fieldsSize);
     u4 typeArgumentsSizeScaled = nextPowerOfTwo(typeArgumentsSize);
     u4 typeMembersSizeScaled = nextPowerOfTwo(typeMembersSize);
-    u4 utf8NameSizeScaled = nextPowerOfTwo(utf8NameSize);
-    u4 constantNameSizeScaled = nextPowerOfTwo(constantNameSize);
-    u4 uniqueNameSizeScaled = nextPowerOfTwo(uniqueNameSize);
-
     // Note: reserve is a no-op if size is < current capacity.
     classAndModules.reserve(classAndModulesSizeScaled);
     methods.reserve(methodsSizeScaled);
     fields.reserve(fieldsSizeScaled);
     typeArguments.reserve(typeArgumentsSizeScaled);
     typeMembers.reserve(typeMembersSizeScaled);
+
+    sanityCheck();
+
+    trace(fmt::format("Preallocated symbol tables. classAndModules={} methods={} fields={} typeArguments={} "
+                      "typeMembers={}",
+                      classAndModules.capacity(), methods.capacity(), fields.capacity(), typeArguments.capacity(),
+                      typeMembers.capacity()));
+}
+
+void GlobalState::preallocateNameTables(u4 utf8NameSize, u4 constantNameSize, u4 uniqueNameSize) {
+    u4 utf8NameSizeScaled = nextPowerOfTwo(utf8NameSize);
+    u4 constantNameSizeScaled = nextPowerOfTwo(constantNameSize);
+    u4 uniqueNameSizeScaled = nextPowerOfTwo(uniqueNameSize);
+
     expandNames(utf8NameSizeScaled, constantNameSizeScaled, uniqueNameSizeScaled);
     sanityCheck();
 
-    trace(fmt::format("Preallocated symbol and name tables. classAndModules={} methods={} fields={} typeArguments={} "
-                      "typeMembers={} utf8Names={} constantNames={} uniqueNames={}",
-                      classAndModules.capacity(), methods.capacity(), fields.capacity(), typeArguments.capacity(),
-                      typeMembers.capacity(), utf8Names.capacity(), constantNames.capacity(), uniqueNames.capacity()));
+    trace(fmt::format("Preallocated symbol and name tables. utf8Names={} constantNames={} uniqueNames={}",
+                      utf8Names.capacity(), constantNames.capacity(), uniqueNames.capacity()));
 }
 
 constexpr decltype(GlobalState::STRINGS_PAGE_SIZE) GlobalState::STRINGS_PAGE_SIZE;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -82,9 +82,11 @@ public:
     void initEmpty();
     void installIntrinsics();
 
-    // Expand symbol and name tables to the given lengths. Does nothing if the value is <= current capacity.
-    void preallocateTables(u4 classAndModulesSize, u4 methodsSize, u4 fieldsSize, u4 typeArgumentsSize,
-                           u4 typeMembersSize, u4 utf8NameSize, u4 constantNameSize, u4 uniqueNameSize);
+    // Expand name tables to the given lengths. Does nothing if the value is <= current capacity.
+    void preallocateNameTables(u4 utf8NameSize, u4 constantNameSize, u4 uniqueNameSize);
+    // Expand symbol tables to the given lengths. Does nothing if the value is <= current capacity.
+    void preallocateSymbolTables(u4 classAndModulesSize, u4 methodsSize, u4 fieldsSize, u4 typeArgumentsSize,
+                                 u4 typeMembersSize);
 
     GlobalState(const GlobalState &) = delete;
     GlobalState(GlobalState &&) = delete;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -347,6 +347,10 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
     // Replace error queue with one that is owned by this thread.
     finalGS->errorQueue = make_shared<core::ErrorQueue>(finalGS->errorQueue->logger, finalGS->errorQueue->tracer,
                                                         make_shared<ErrorFlusherLSP>(epoch, errorReporter));
+    // Preallocate the symbol tables in preparation for namer.
+    gs->preallocateSymbolTables(config->opts.reserveClassTableCapacity, config->opts.reserveMethodTableCapacity,
+                                config->opts.reserveFieldTableCapacity, config->opts.reserveTypeArgumentTableCapacity,
+                                config->opts.reserveTypeMemberTableCapacity);
     auto &epochManager = *finalGS->epochManager;
     // Note: Commits can only be canceled if this edit is cancelable, LSP is running across multiple threads, and the
     // cancelation feature is enabled.


### PR DESCRIPTION
WIP: Defer symbol table resizing until after indexing has run.

Indexing performs a deep copy of the GlobalState once per core, but doesn't define any symbols. It only defines names. As a result, we are wasting (number of cores - 1) * (preallocated size) * (size of Symbol) bytes of memory -- which can be large in big codebases.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduce max RSS.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Going to test this on Stripe's codebase and compare w/ the currently deployed version.
