### PR TITLE
Remove usage of endless range

### DIFF
--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -84,7 +84,7 @@ module T::Utils
       when 0 then nil
       when 1 then non_nil_types.first
       else
-        T::Types::Union::Private::Pool.union_of_types(non_nil_types[0], non_nil_types[1], non_nil_types[2..])
+        T::Types::Union::Private::Pool.union_of_types(non_nil_types[0], non_nil_types[1], non_nil_types[2, non_nil_types.length])
       end
     else
       nil


### PR DESCRIPTION
This replaces the use of an endless range to index into an array, with the start index and number of elements to extract.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Endless ranges were introduced in Ruby `2.6`, but `sorbet-runtime` only depends on Ruby `>= 2.3.0`. This is causing errors in CI pipelines testing compatibility with old versions of Ruby.

The alternative would be to bump the minimum version of Ruby instead, but it seemed like an easy fix and allows us to maintain backwards compatibility.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is a refactor, so (I assume) should be covered by existing tests.
