### PR TITLE
Implement T::Enum#=== intrinsic

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3106,7 +3106,7 @@ public:
         }
         auto lhs = args.thisType;
         ENFORCE(!lhs.isUntyped(), "lhs of T::Enum.=== must be typed");
-        if (Types::glb(gs, rhs, lhs).isBottom()) {
+        if (Types::glb(gs, rhs, lhs).isBottom() && Types::glb(gs, rhs, Types::String()).isBottom()) {
             res.returnType = Types::falseClass();
             return;
         }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3072,6 +3072,7 @@ public:
     }
 } Module_tripleEq;
 
+// Returns true if the referenced class is a child of T::Enum.
 static bool isEnumClass(const GlobalState &gs, ClassOrModuleRef klass) {
     if (!klass.exists()) {
         return false;
@@ -3081,6 +3082,8 @@ static bool isEnumClass(const GlobalState &gs, ClassOrModuleRef klass) {
     return superClass.exists() && superClass == Symbols::T_Enum();
 }
 
+// Returns true if the referenced class is a grandchild of T::Enum, i.e., one of the singleton classes for the enum
+// values.
 static bool isEnumValue(const GlobalState &gs, ClassOrModuleRef klass) {
     if (!klass.exists()) {
         return false;
@@ -3108,6 +3111,8 @@ public:
             return;
         }
 
+        // If lhs and rhs are both grandchildren of T::Enum, we can safely assume they are singleton classes created by
+        // the T::Enum rewriter, since inheriting from children of T::Enum is otherwise prohibited.
         bool must_exist = false;
         auto lhs_unwrapped = unwrapSymbol(gs, lhs, must_exist);
         auto rhs_unwrapped = unwrapSymbol(gs, rhs, must_exist);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3072,6 +3072,31 @@ public:
     }
 } Module_tripleEq;
 
+class T_Enum_tripleEq : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        if (args.args.size() != 1) {
+            return;
+        }
+        auto rhs = args.args[0]->type;
+        if (rhs.isUntyped()) {
+            res.returnType = rhs;
+            return;
+        }
+        auto lhs = args.thisType;
+        ENFORCE(!lhs.isUntyped(), "lhs of T::Enum.=== must be typed");
+        if (Types::isSubType(gs, rhs, lhs)) {
+            res.returnType = Types::trueClass();
+            return;
+        }
+        if (Types::glb(gs, rhs, lhs).isBottom()) {
+            res.returnType = Types::falseClass();
+            return;
+        }
+        res.returnType = Types::Boolean();
+    }
+} T_Enum_tripleEq;
+
 } // namespace
 
 const vector<Intrinsic> intrinsicMethods{
@@ -3150,6 +3175,7 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::Enumerable(), Intrinsic::Kind::Instance, Names::toH(), &Enumerable_toH},
 
     {Symbols::Module(), Intrinsic::Kind::Instance, Names::tripleEq(), &Module_tripleEq},
+    {Symbols::T_Enum(), Intrinsic::Kind::Instance, Names::tripleEq(), &T_Enum_tripleEq},
 };
 
 } // namespace sorbet::core

--- a/test/testdata/infer/sealed_class_enum_case.rb
+++ b/test/testdata/infer/sealed_class_enum_case.rb
@@ -1,0 +1,21 @@
+# typed: strict
+extend T::Sig
+
+class MyEnum
+  extend T::Helpers
+  abstract!
+  sealed!
+
+  class X < MyEnum; include Singleton; final!; end
+  class Y < MyEnum; include Singleton; final!; end
+end
+
+sig {params(x: MyEnum).returns(Integer)}
+def example_with_class_objects(x)
+  res = case x
+  when MyEnum::X then 1
+  when MyEnum::Y then 2
+  end
+
+  res # no error (cases are exhaustive so res is not nilable)
+end

--- a/test/testdata/infer/t_enum_case.rb
+++ b/test/testdata/infer/t_enum_case.rb
@@ -1,0 +1,19 @@
+# typed: strict
+extend T::Sig
+
+class MyEnum < T::Enum
+  enums do
+    X = new
+    Y = new
+  end
+end
+
+sig {params(x: MyEnum).returns(Integer)}
+def example(x)
+  res = case x
+  when MyEnum::X then 1
+  when MyEnum::Y then 2
+  end
+
+  res # no error (cases are exhaustive so res is not nilable)
+end

--- a/test/testdata/infer/t_enum_classes_triple_eq.rb
+++ b/test/testdata/infer/t_enum_classes_triple_eq.rb
@@ -1,0 +1,43 @@
+# typed: strict
+extend T::Sig
+
+class MyEnum < T::Enum
+  enums do
+    X = new
+    Y = new('y')
+  end
+end
+
+class OtherEnum < T::Enum
+  enums do
+    Z = new
+  end
+end
+
+sig {params(t_enum: T::Enum,
+            my_enum: MyEnum,
+            other_enum: OtherEnum,
+            x: MyEnum::X,
+            y: MyEnum::Y,
+            z: OtherEnum::Z).void}
+def f(t_enum, my_enum, other_enum, x, y, z)
+  T.reveal_type(x===x)                # error: Revealed type: `TrueClass`
+
+  T.reveal_type(t_enum===t_enum)      # error: Revealed type: `T::Boolean`
+  T.reveal_type(my_enum===my_enum)    # error: Revealed type: `T::Boolean`
+
+  T.reveal_type(t_enum===my_enum)     # error: Revealed type: `T::Boolean`
+  T.reveal_type(my_enum===t_enum)     # error: Revealed type: `T::Boolean`
+
+  T.reveal_type(t_enum===x)           # error: Revealed type: `T::Boolean`
+  T.reveal_type(x===t_enum)           # error: Revealed type: `T::Boolean`
+
+  T.reveal_type(my_enum===x)          # error: Revealed type: `T::Boolean`
+  T.reveal_type(x===my_enum)          # error: Revealed type: `T::Boolean`
+
+  T.reveal_type(x===y)                # error: Revealed type: `FalseClass`
+
+  T.reveal_type(my_enum===other_enum) # error: Revealed type: `FalseClass`
+  T.reveal_type(z===my_enum)          # error: Revealed type: `FalseClass`
+  T.reveal_type(my_enum===z)          # error: Revealed type: `FalseClass`
+end

--- a/test/testdata/infer/t_enum_classes_triple_eq.rb
+++ b/test/testdata/infer/t_enum_classes_triple_eq.rb
@@ -14,13 +14,17 @@ class OtherEnum < T::Enum
   end
 end
 
+class Stringy < String ; end
+
 sig {params(t_enum: T::Enum,
             my_enum: MyEnum,
             other_enum: OtherEnum,
             x: MyEnum::X,
             y: MyEnum::Y,
-            z: OtherEnum::Z).void}
-def f(t_enum, my_enum, other_enum, x, y, z)
+            z: OtherEnum::Z,
+            s: String,
+            stringy: Stringy).void}
+def f(t_enum, my_enum, other_enum, x, y, z, s, stringy)
   T.reveal_type(x===x)                # error: Revealed type: `TrueClass`
 
   T.reveal_type(t_enum===t_enum)      # error: Revealed type: `T::Boolean`
@@ -39,5 +43,10 @@ def f(t_enum, my_enum, other_enum, x, y, z)
 
   T.reveal_type(my_enum===other_enum) # error: Revealed type: `FalseClass`
   T.reveal_type(z===my_enum)          # error: Revealed type: `FalseClass`
-  T.reveal_type(my_enum===z)          # error: Revealed type: `FalseClass`
+  T.reveal_type(my_enum===z)          # error: Revealed type: `FalseClass
+
+  T.reveal_type(t_enum===s)           # error: Revealed type: `T::Boolean`
+  T.reveal_type(my_enum===s)          # error: Revealed type: `T::Boolean`
+  T.reveal_type(x===s)                # error: Revealed type: `T::Boolean`
+  T.reveal_type(x===stringy)          # error: Revealed type: `T::Boolean`
 end

--- a/test/testdata/infer/t_enum_subset_triple_eq.rb
+++ b/test/testdata/infer/t_enum_subset_triple_eq.rb
@@ -1,0 +1,60 @@
+# typed: true
+
+extend T::Sig
+
+# (1) Define an interface / module
+module DayOfWeek
+  extend T::Helpers
+  sealed!
+end
+
+class Weekday < T::Enum
+  # (2) include DayOfWeek when defining the Weekday enum
+  include DayOfWeek
+
+  enums do
+    Monday = new
+    Tuesday = new
+    Wednesday = new
+    Thursday = new
+    Friday = new
+  end
+end
+
+class Weekend < T::Enum
+  # (3) ditto
+  include DayOfWeek
+
+  enums do
+    Saturday = new
+    Sunday = new
+  end
+end
+
+sig {params(d: DayOfWeek, wk: Weekday, wn: Weekend).void}
+def f(d, wk, wn)
+  case d
+  when Weekday::Monday
+    T.reveal_type(Weekday::Monday===d)     # error: Revealed type: `TrueClass`
+    T.reveal_type(d===Weekday::Monday)     # error: Revealed type: `TrueClass`
+    T.reveal_type(wk===d)                  # error: Revealed type: `T::Boolean`
+    T.reveal_type(d===wk)                  # error: Revealed type: `T::Boolean`
+    T.reveal_type(wn===d)                  # error: Revealed type: `FalseClass`
+    T.reveal_type(d===wn)                  # error: Revealed type: `FalseClass`
+  when Weekend
+    T.reveal_type(Weekday::Monday===d)     # error: Revealed type: `FalseClass`
+    T.reveal_type(d===Weekday::Monday)     # error: Revealed type: `FalseClass`
+    T.reveal_type(wk===d)                  # error: Revealed type: `FalseClass`
+    T.reveal_type(d===wk)                  # error: Revealed type: `FalseClass`
+    T.reveal_type(wn===d)                  # error: Revealed type: `T::Boolean`
+    T.reveal_type(d===wn)                  # error: Revealed type: `T::Boolean`
+    case d
+    when Weekend::Saturday
+      T.reveal_type(Weekday::Monday===d)   # error: Revealed type: `FalseClass`
+      T.reveal_type(Weekend::Saturday===d) # error: Revealed type: `TrueClass`
+      T.reveal_type(Weekend::Sunday===d)   # error: Revealed type: `FalseClass`
+      T.reveal_type(wk===d)                # error: Revealed type: `FalseClass`
+      T.reveal_type(wn===d)                # error: Revealed type: `T::Boolean`
+    end
+  end
+end

--- a/test/testdata/infer/t_enum_triple_eq.rb
+++ b/test/testdata/infer/t_enum_triple_eq.rb
@@ -1,0 +1,35 @@
+# typed: strict
+extend T::Sig
+
+class MyEnum < T::Enum
+  enums do
+    X = new
+    Y = new
+    Z = new
+  end
+end
+
+T.reveal_type(MyEnum::X === MyEnum::X) # error: Revealed type: `TrueClass`
+T.reveal_type(MyEnum::X === MyEnum::Y) # error: Revealed type: `FalseClass`
+
+sig {params(x: MyEnum).void}
+def example(x)
+  if MyEnum::X === x
+    T.reveal_type(MyEnum::X === x) # error: Revealed type: `TrueClass`
+    T.reveal_type(MyEnum::Y === x) # error: Revealed type: `FalseClass`
+    T.reveal_type(MyEnum::Z === x) # error: Revealed type: `FalseClass`
+  else
+    T.reveal_type(MyEnum::X === x) # error: Revealed type: `FalseClass`
+    T.reveal_type(MyEnum::Y === x) # error: Revealed type: `T::Boolean`
+    T.reveal_type(MyEnum::Z === x) # error: Revealed type: `T::Boolean`
+    if MyEnum::Y === x
+      T.reveal_type(MyEnum::X === x) # error: Revealed type: `FalseClass`
+      T.reveal_type(MyEnum::Y === x) # error: Revealed type: `TrueClass`
+      T.reveal_type(MyEnum::Z === x) # error: Revealed type: `FalseClass`
+    else
+      T.reveal_type(MyEnum::X === x) # error: Revealed type: `FalseClass`
+      T.reveal_type(MyEnum::Y === x) # error: Revealed type: `FalseClass`
+      T.reveal_type(MyEnum::Z === x) # error: Revealed type: `TrueClass`
+    end
+  end
+end


### PR DESCRIPTION
The root of #4115 seems to be that the `case` desugars to `===` on the singletons for the enums, not the classes. Implementing an intrinsic for `T::Enum#===` seems to me like a reasonable way to fix it, ~~but I'm tossing a wip PR up first to get feedback on whether it's the right approach~~.

### Motivation
Fixes #4115

### Test plan
See included automated tests.
