### PR TITLE
Prohibit calls on `T.attached_class`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1338,6 +1338,23 @@ public:
     }
 } T_self_type;
 
+class T_attached_class : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        // We don't currently have a way to get the `self` of the method that we're currently type
+        // checking (we only have things that can be seen directly from this single dispatch: the
+        // receiver and the args' types). This means that currently we can't do better than using
+        // `T.untyped` here.
+        //
+        // In the future, we might want to fix this similar to how we did with `<Magic>.<self-new>`,
+        // by e.g. rewriting `T.attached_class` to `<Magic>.<attached-class>(<self>)`, which would
+        // then let us have access to `self` in this intrinsic.
+        //
+        // https://github.com/sorbet/sorbet/issues/4352
+        res.returnType = make_type<MetaType>(Types::untypedUntracked());
+    }
+} T_attached_class;
+
 class T_must : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
@@ -3067,6 +3084,7 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::T(), Intrinsic::Kind::Singleton, Names::noreturn(), &T_noreturn},
     {Symbols::T(), Intrinsic::Kind::Singleton, Names::classOf(), &T_class_of},
     {Symbols::T(), Intrinsic::Kind::Singleton, Names::selfType(), &T_self_type},
+    {Symbols::T(), Intrinsic::Kind::Singleton, Names::attachedClass(), &T_attached_class},
 
     {Symbols::T(), Intrinsic::Kind::Singleton, Names::proc(), &T_proc},
 

--- a/test/testdata/infer/attached_class_metatype.rb
+++ b/test/testdata/infer/attached_class_metatype.rb
@@ -1,0 +1,24 @@
+# typed: true
+
+class Parent
+  extend T::Sig
+
+  sig {returns(T::Array[T.attached_class])}
+  def self.make_multi
+    T.attached_class.to_s # error: Call to method `to_s` on `T.untyped` mistakes a type for a value
+
+    xs = T::Array[T.attached_class].new
+
+    xs << new
+    xs << new
+
+    # Should actually be `T::Array[T.attached_class (of Parent)]`
+    # See https://github.com/sorbet/sorbet/issues/4352
+    T.reveal_type(xs) # error: Revealed type: `T::Array[T.untyped]`
+  end
+end
+
+class Child < Parent; end
+
+T.reveal_type(Parent.make_multi) # error: Revealed type: `T::Array[Parent]`
+T.reveal_type(Child.make_multi) # error: Revealed type: `T::Array[Child]`

--- a/test/testdata/resolver/requires_ancestor_calls_types.rb
+++ b/test/testdata/resolver/requires_ancestor_calls_types.rb
@@ -223,6 +223,8 @@ module Test10
 
     def m2
       T.attached_class.foo
+    # ^^^^^^^^^^^^^^^^^^^^ error: Call to method `foo` on `T.untyped` mistakes a type for a value
+    # ^^^^^^^^^^^^^^^^^^^^ error: Method `foo` does not exist on `Object` component of `<Type: T.untyped>`
       T.class_of(M2).foo
     # ^^^^^^^^^^^^^^^^^^ error: Call to method `foo` on `T.class_of(Test10::M2)`
     # ^^^^^^^^^^^^^^^^^^ error: Method `foo` does not exist on `Object` component


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #4345

Unfortunately, does not fix everything.
See https://github.com/sorbet/sorbet/issues/4352


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.