### PR TITLE
Don't recursively dispatch on MetaType

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1255,7 +1255,7 @@ DispatchResult MetaType::dispatchCall(const GlobalState &gs, const DispatchArgs 
                     }
                 }
             }
-            return dispatchCallProxyType(gs, underlying(gs), args);
+            return DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noMethod());
     }
 }
 

--- a/test/testdata/resolver/requires_ancestor_calls_types.rb
+++ b/test/testdata/resolver/requires_ancestor_calls_types.rb
@@ -224,10 +224,8 @@ module Test10
     def m2
       T.attached_class.foo
     # ^^^^^^^^^^^^^^^^^^^^ error: Call to method `foo` on `T.untyped` mistakes a type for a value
-    # ^^^^^^^^^^^^^^^^^^^^ error: Method `foo` does not exist on `Object` component of `<Type: T.untyped>`
       T.class_of(M2).foo
     # ^^^^^^^^^^^^^^^^^^ error: Call to method `foo` on `T.class_of(Test10::M2)`
-    # ^^^^^^^^^^^^^^^^^^ error: Method `foo` does not exist on `Object` component
     end
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This just leads to nonsensical errors, like the two that are now gone from the linked file.

I tested this on Stripe's codebase to make sure that no one was actually relying on dispatching to the underlying type (which is good, because it wouldn't really make sense). We already emit an error for this codepath otherwise.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.