### PR TITLE
Flow-sensitivity for `Module#<=`

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -661,7 +661,11 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
 
         auto &whoKnows = getKnowledge(local);
         whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, send->recv.variable, argType);
-        whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, send->recv.variable, argType);
+        if (send->fun == core::Names::leq()) {
+            // We only know the NoTypeTest for `<=`, not `<`, because `x < A` being false could mean
+            // that `x == A`, which would mean `x` still has type `T.class_of(A)`.
+            whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, send->recv.variable, argType);
+        }
         whoKnows.sanityCheck();
     }
 }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -640,7 +640,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         }
         whoKnows.sanityCheck();
 
-    } else if (send->fun == core::Names::lessThan()) {
+    } else if (send->fun == core::Names::lessThan() || send->fun == core::Names::leq()) {
         const auto &recvKlass = send->recv.type;
         const auto &argType = send->args[0].type;
 

--- a/test/testdata/infer/class_less_than.rb
+++ b/test/testdata/infer/class_less_than.rb
@@ -25,11 +25,11 @@ def parent_less_than_eq(x)
   if x <= Parent
     T.reveal_type(x) # error: `T.class_of(Parent)`
   else
-    T.reveal_type(x) # error: `T.class_of(Parent)`
+    T.reveal_type(x) # error: This code is unreachable
   end
 
   if x <= Child
-    T.reveal_type(x) # error: `T.class_of(Parent)`
+    T.reveal_type(x) # error: `T.class_of(Child)`
   else
     T.reveal_type(x) # error: `T.class_of(Parent)`
   end
@@ -55,12 +55,12 @@ def child_less_than_eq(x)
   if x <= Parent
     T.reveal_type(x) # error: `T.class_of(Child)`
   else
-    T.reveal_type(x) # error: `T.class_of(Child)`
+    T.reveal_type(x) # error: This code is unreachable
   end
 
   if x <= Child
     T.reveal_type(x) # error: `T.class_of(Child)`
   else
-    T.reveal_type(x) # error: `T.class_of(Child)`
+    T.reveal_type(x) # error: This code is unreachable
   end
 end

--- a/test/testdata/infer/class_less_than.rb
+++ b/test/testdata/infer/class_less_than.rb
@@ -10,7 +10,7 @@ def parent_less_than(x)
   if x < Parent
     T.reveal_type(x) # error: `T.class_of(Parent)`
   else
-    T.reveal_type(x) # error: This code is unreachable
+    T.reveal_type(x) # error: `T.class_of(Parent)`
   end
 
   if x < Child
@@ -40,13 +40,13 @@ def child_less_than(x)
   if x < Parent
     T.reveal_type(x) # error: `T.class_of(Child)`
   else
-    T.reveal_type(x) # error: This code is unreachable
+    T.reveal_type(x) # error: `T.class_of(Child)`
   end
 
   if x < Child
     T.reveal_type(x) # error: `T.class_of(Child)`
   else
-    T.reveal_type(x) # error: This code is unreachable
+    T.reveal_type(x) # error: `T.class_of(Child)`
   end
 end
 

--- a/test/testdata/infer/class_less_than.rb
+++ b/test/testdata/infer/class_less_than.rb
@@ -1,0 +1,66 @@
+# typed: true
+
+extend T::Sig
+
+class Parent; end
+class Child < Parent; end
+
+sig {params(x: T.class_of(Parent)).void}
+def parent_less_than(x)
+  if x < Parent
+    T.reveal_type(x) # error: `T.class_of(Parent)`
+  else
+    T.reveal_type(x) # error: This code is unreachable
+  end
+
+  if x < Child
+    T.reveal_type(x) # error: `T.class_of(Child)`
+  else
+    T.reveal_type(x) # error: `T.class_of(Parent)`
+  end
+end
+
+sig {params(x: T.class_of(Parent)).void}
+def parent_less_than_eq(x)
+  if x <= Parent
+    T.reveal_type(x) # error: `T.class_of(Parent)`
+  else
+    T.reveal_type(x) # error: `T.class_of(Parent)`
+  end
+
+  if x <= Child
+    T.reveal_type(x) # error: `T.class_of(Parent)`
+  else
+    T.reveal_type(x) # error: `T.class_of(Parent)`
+  end
+end
+
+sig {params(x: T.class_of(Child)).void}
+def child_less_than(x)
+  if x < Parent
+    T.reveal_type(x) # error: `T.class_of(Child)`
+  else
+    T.reveal_type(x) # error: This code is unreachable
+  end
+
+  if x < Child
+    T.reveal_type(x) # error: `T.class_of(Child)`
+  else
+    T.reveal_type(x) # error: This code is unreachable
+  end
+end
+
+sig {params(x: T.class_of(Child)).void}
+def child_less_than_eq(x)
+  if x <= Parent
+    T.reveal_type(x) # error: `T.class_of(Child)`
+  else
+    T.reveal_type(x) # error: `T.class_of(Child)`
+  end
+
+  if x <= Child
+    T.reveal_type(x) # error: `T.class_of(Child)`
+  else
+    T.reveal_type(x) # error: `T.class_of(Child)`
+  end
+end

--- a/test/testdata/infer/is_a_variable.rb
+++ b/test/testdata/infer/is_a_variable.rb
@@ -1,0 +1,34 @@
+# typed: true
+extend T::Sig
+
+# At time of writing, this test captures buggy behavior, and is just meant to
+# alert the author if their changes affect this behavior.
+# https://github.com/sorbet/sorbet/issues/4358
+
+class Parent; end
+class Child < Parent; end
+
+sig {void}
+def isa_local_variables
+  parent = Parent.new
+  child = T.let(Child, T.class_of(Parent))
+  if parent.is_a?(child) # always false
+    T.reveal_type(parent) # error: `Parent`
+  else
+    # [bug] always reached
+    T.reveal_type(parent) # error: This code is unreachable
+  end
+end
+
+MyChild = T.let(Child, T.class_of(Parent))
+
+sig {void}
+def isa_static_field
+  parent = Parent.new
+  if parent.is_a?(MyChild) # always false
+    T.reveal_type(parent) # error: `Parent`
+  else
+    # [bug] always reached
+    T.reveal_type(parent) # error: This code is unreachable
+  end
+end

--- a/test/testdata/infer/module_less_than_variable.rb
+++ b/test/testdata/infer/module_less_than_variable.rb
@@ -1,0 +1,34 @@
+# typed: true
+extend T::Sig
+
+# At time of writing, this test captures buggy behavior, and is just meant to
+# alert the author if their changes affect this behavior.
+# https://github.com/sorbet/sorbet/issues/4358
+
+class Parent; end
+class Child < Parent; end
+
+sig {void}
+def leq_local_variables
+  parent = T.let(Parent, T.class_of(Parent))
+  child = T.let(Child, T.class_of(Parent))
+  if parent <= child # always false
+    T.reveal_type(parent) # error: `T.class_of(Parent)`
+  else
+    # [bug] always reached
+    T.reveal_type(parent) # error: This code is unreachable
+  end
+end
+
+MyChild = T.let(Child, T.class_of(Parent))
+
+sig {void}
+def leq_static_field
+  parent = T.let(Parent, T.class_of(Parent))
+  if parent <= MyChild # always false
+    T.reveal_type(parent) # error: `T.class_of(Parent)`
+  else
+    # [bug] always reached
+    T.reveal_type(parent) # error: This code is unreachable
+  end
+end

--- a/website/docs/flow-sensitive.md
+++ b/website/docs/flow-sensitive.md
@@ -85,8 +85,9 @@ The complete list of constructs that affect Sorbet's flow-sensitive typing:
 - `nil?`
 - `blank?` / `present?` (these assume a Rails-compatible monkey patch on both
   `NilClass` and `Object`)
-- `Class#===` (this is how `case` on a class object works)
-- `Class#<` (like `is_a?`, but for class objects instead of instances of
+- `Module#===` (this is how `case` on a class object works)
+- `Module#<`, `Module#<=` (like `is_a?`, but for class objects instead of
+  instances of classes)
 - Negated conditions (including both `!` and `unless`)
 - Truthiness (everything but `nil` and `false` is truthy in Ruby)
 - `block_given?` (internally, this is a special case of truthiness)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a two bird with one stone kind of PR:

- Fixes #2380
- Adds support for `Module#<=` (previously, we only supported `Module#<`)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.