### PR TITLE
[Ruby 3.0] Add support for endless method definitions

### DIFF
--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -211,6 +211,15 @@ NodeDef nodes[] = {
                           {"args", FieldType::Node},
                           {"body", FieldType::Node}}),
     },
+    // def <expr>.name singleton-class name method def
+    {
+        "DefsHead",
+        "defshead",
+        vector<FieldDef>({
+            {"definee", FieldType::Node},
+            {"name", FieldType::Name},
+        }),
+    },
     // string with an interpolation, all nodes are concatenated in a single string
     {
         "DString",

--- a/test/testdata/parser/compare_overload_parse_error.rb
+++ b/test/testdata/parser/compare_overload_parse_error.rb
@@ -8,8 +8,3 @@ class B # error: class definition in method body
   def less_equal<=(foo) # error: unexpected token "<="
   end
 end
-
-class C # error: class definition in method body
-  def not_equal!=(foo) # error: unexpected token "="
-  end
-end

--- a/test/whitequark/test_endless_comparison_method_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_comparison_method_0.parse-tree-whitequark.exp
@@ -1,0 +1,4 @@
+s(:def, :===,
+  s(:args,
+    s(:arg, :other)),
+  s(:send, nil, :do_something))

--- a/test/whitequark/test_endless_comparison_method_0.rb
+++ b/test/whitequark/test_endless_comparison_method_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def ===(other) = do_something

--- a/test/whitequark/test_endless_comparison_method_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_comparison_method_1.parse-tree-whitequark.exp
@@ -1,0 +1,4 @@
+s(:def, :==,
+  s(:args,
+    s(:arg, :other)),
+  s(:send, nil, :do_something))

--- a/test/whitequark/test_endless_comparison_method_1.rb
+++ b/test/whitequark/test_endless_comparison_method_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def ==(other) = do_something

--- a/test/whitequark/test_endless_comparison_method_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_comparison_method_2.parse-tree-whitequark.exp
@@ -1,0 +1,4 @@
+s(:def, :!=,
+  s(:args,
+    s(:arg, :other)),
+  s(:send, nil, :do_something))

--- a/test/whitequark/test_endless_comparison_method_2.rb
+++ b/test/whitequark/test_endless_comparison_method_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def !=(other) = do_something

--- a/test/whitequark/test_endless_comparison_method_3.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_comparison_method_3.parse-tree-whitequark.exp
@@ -1,0 +1,4 @@
+s(:def, :<=,
+  s(:args,
+    s(:arg, :other)),
+  s(:send, nil, :do_something))

--- a/test/whitequark/test_endless_comparison_method_3.rb
+++ b/test/whitequark/test_endless_comparison_method_3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def <=(other) = do_something

--- a/test/whitequark/test_endless_comparison_method_4.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_comparison_method_4.parse-tree-whitequark.exp
@@ -1,0 +1,4 @@
+s(:def, :>=,
+  s(:args,
+    s(:arg, :other)),
+  s(:send, nil, :do_something))

--- a/test/whitequark/test_endless_comparison_method_4.rb
+++ b/test/whitequark/test_endless_comparison_method_4.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def >=(other) = do_something

--- a/test/whitequark/test_endless_comparison_method_5.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_comparison_method_5.parse-tree-whitequark.exp
@@ -1,0 +1,4 @@
+s(:def, :!=,
+  s(:args,
+    s(:arg, :other)),
+  s(:send, nil, :do_something))

--- a/test/whitequark/test_endless_comparison_method_5.rb
+++ b/test/whitequark/test_endless_comparison_method_5.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def !=(other) = do_something

--- a/test/whitequark/test_endless_method_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_0.parse-tree-whitequark.exp
@@ -1,0 +1,3 @@
+s(:def, :foo,
+  s(:args),
+  s(:int, "42"))

--- a/test/whitequark/test_endless_method_0.rb
+++ b/test/whitequark/test_endless_method_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo() = 42

--- a/test/whitequark/test_endless_method_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_1.parse-tree-whitequark.exp
@@ -1,0 +1,6 @@
+s(:def, :inc,
+  s(:args,
+    s(:arg, :x)),
+  s(:send,
+    s(:lvar, :x), :+,
+    s(:int, "1")))

--- a/test/whitequark/test_endless_method_1.rb
+++ b/test/whitequark/test_endless_method_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def inc(x) = x + 1

--- a/test/whitequark/test_endless_method_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_2.parse-tree-whitequark.exp
@@ -1,0 +1,4 @@
+s(:defs,
+  s(:send, nil, :obj), :foo,
+  s(:args),
+  s(:int, "42"))

--- a/test/whitequark/test_endless_method_2.rb
+++ b/test/whitequark/test_endless_method_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def obj.foo() = 42

--- a/test/whitequark/test_endless_method_3.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_3.parse-tree-whitequark.exp
@@ -1,0 +1,7 @@
+s(:defs,
+  s(:send, nil, :obj), :inc,
+  s(:args,
+    s(:arg, :x)),
+  s(:send,
+    s(:lvar, :x), :+,
+    s(:int, "1")))

--- a/test/whitequark/test_endless_method_3.rb
+++ b/test/whitequark/test_endless_method_3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def obj.inc(x) = x + 1

--- a/test/whitequark/test_endless_method_forwarded_args_legacy_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_forwarded_args_legacy_0.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:def, :foo,
+  s(:args,
+    s(:forward_arg)),
+  s(:send, nil, :bar,
+    s(:forwarded_args)))

--- a/test/whitequark/test_endless_method_forwarded_args_legacy_0.rb
+++ b/test/whitequark/test_endless_method_forwarded_args_legacy_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(...) = bar(...)

--- a/test/whitequark/test_endless_method_with_rescue_mod_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_with_rescue_mod_0.parse-tree-whitequark.exp
@@ -1,0 +1,6 @@
+s(:def, :m,
+  s(:args),
+  s(:rescue,
+    s(:int, "1"),
+    s(:resbody, nil, nil,
+      s(:int, "2")), nil))

--- a/test/whitequark/test_endless_method_with_rescue_mod_0.rb
+++ b/test/whitequark/test_endless_method_with_rescue_mod_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def m() = 1 rescue 2

--- a/test/whitequark/test_endless_method_with_rescue_mod_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_with_rescue_mod_1.parse-tree-whitequark.exp
@@ -1,0 +1,7 @@
+s(:defs,
+  s(:self), :m,
+  s(:args),
+  s(:rescue,
+    s(:int, "1"),
+    s(:resbody, nil, nil,
+      s(:int, "2")), nil))

--- a/test/whitequark/test_endless_method_with_rescue_mod_1.rb
+++ b/test/whitequark/test_endless_method_with_rescue_mod_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def self.m() = 1 rescue 2

--- a/test/whitequark/test_endless_method_without_args_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_without_args_0.parse-tree-whitequark.exp
@@ -1,0 +1,2 @@
+s(:def, :foo, nil,
+  s(:int, "42"))

--- a/test/whitequark/test_endless_method_without_args_0.rb
+++ b/test/whitequark/test_endless_method_without_args_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo = 42

--- a/test/whitequark/test_endless_method_without_args_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_without_args_1.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:def, :foo, nil,
+  s(:rescue,
+    s(:int, "42"),
+    s(:resbody, nil, nil,
+      s(:nil)), nil))

--- a/test/whitequark/test_endless_method_without_args_1.rb
+++ b/test/whitequark/test_endless_method_without_args_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo = 42 rescue nil

--- a/test/whitequark/test_endless_method_without_args_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_without_args_2.parse-tree-whitequark.exp
@@ -1,0 +1,3 @@
+s(:defs,
+  s(:self), :foo, nil,
+  s(:int, "42"))

--- a/test/whitequark/test_endless_method_without_args_2.rb
+++ b/test/whitequark/test_endless_method_without_args_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def self.foo = 42

--- a/test/whitequark/test_endless_method_without_args_3.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_without_args_3.parse-tree-whitequark.exp
@@ -1,0 +1,6 @@
+s(:defs,
+  s(:self), :foo, nil,
+  s(:rescue,
+    s(:int, "42"),
+    s(:resbody, nil, nil,
+      s(:nil)), nil))

--- a/test/whitequark/test_endless_method_without_args_3.rb
+++ b/test/whitequark/test_endless_method_without_args_3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def self.foo = 42 rescue nil

--- a/test/whitequark/test_endless_setter_0.rb
+++ b/test/whitequark/test_endless_setter_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo=() = 42 # error: setter method cannot be defined in an endless method definition

--- a/test/whitequark/test_endless_setter_1.rb
+++ b/test/whitequark/test_endless_setter_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def obj.foo=() = 42 # error: setter method cannot be defined in an endless method definition

--- a/test/whitequark/test_endless_setter_2.rb
+++ b/test/whitequark/test_endless_setter_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo=() = 42 rescue nil # error: setter method cannot be defined in an endless method definition

--- a/test/whitequark/test_endless_setter_3.rb
+++ b/test/whitequark/test_endless_setter_3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def obj.foo=() = 42 rescue nil # error: setter method cannot be defined in an endless method definition

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -201,6 +201,7 @@ using namespace std::string_literals;
   command_rhs
   compstmt
   cpath
+  defs_head
   dsym
   expr
   expr_value
@@ -212,6 +213,8 @@ using namespace std::string_literals;
   f_larglist
   f_marg
   f_opt
+  f_paren_args
+  f_opt_paren_args
   f_rest_marg
   fitem
   for_var
@@ -328,6 +331,7 @@ using namespace std::string_literals;
   blkarg_mark
   call_op
   cname
+  def_name
   do
   dot_or_colon
   f_arg_asgn
@@ -354,6 +358,7 @@ using namespace std::string_literals;
   k_return
 
 %type <delimited_list>
+  defn_head
   opt_paren_args
   paren_args
 
@@ -751,6 +756,32 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
 
                       $$ = driver.alloc.node_with_token($3, $2);
                     }
+
+        def_name: fname
+                    {
+                      driver.lex.extend_static();
+                      driver.lex.cmdarg.push(false);
+                      driver.lex.cond.push(false);
+                      driver.current_arg_stack.push("");
+
+                      $$ = $1;
+                    }
+
+        defn_head: kDEF def_name
+                    {
+                      driver.lex.context.push(Context::State::DEF);
+                      $$ = driver.alloc.delimited_node_list($1, driver.alloc.node_list(), $2);
+                    }
+
+        defs_head: kDEF singleton dot_or_colon
+                     {
+                       driver.lex.set_state_expr_fname();
+                     }
+                   def_name
+                     {
+                       driver.lex.context.push(Context::State::DEFS);
+                       $$ = driver.build.defsHead(self, $1, $2, $3, $5);
+                     }
 
     command_call: command
                 | block_command
@@ -1264,6 +1295,52 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                     {
                       $$ = driver.build.ternary(self, $1, $2, $3, $5, $6);
                     }
+                | defn_head f_opt_paren_args tEQL arg
+                    {
+                      $$ = driver.build.defEndlessMethod(self, $1->begin, $1->end, $2, $3, $4);
+
+                      driver.lex.cmdarg.pop();
+                      driver.lex.cond.pop();
+                      driver.lex.unextend();
+                      driver.lex.context.pop();
+                      driver.current_arg_stack.pop();
+                    }
+                | defn_head f_opt_paren_args tEQL arg kRESCUE_MOD arg
+                    {
+                      auto rescue_body = driver.build.rescue_body(self, $5, nullptr, nullptr, nullptr, nullptr, $6);
+                      auto method_body = driver.build.beginBody(self, $4, driver.alloc.node_list(rescue_body), nullptr, nullptr, nullptr, nullptr);
+
+                      $$ = driver.build.defEndlessMethod(self, $1->begin, $1->end, $2, $3, method_body);
+
+                      driver.lex.cmdarg.pop();
+                      driver.lex.cond.pop();
+                      driver.lex.unextend();
+                      driver.lex.context.pop();
+                      driver.current_arg_stack.pop();
+                    }
+                | defs_head f_opt_paren_args tEQL arg
+                    {
+                      $$ = driver.build.defEndlessSingleton(self, $1, $2, $3, $4);
+
+                      driver.lex.cmdarg.pop();
+                      driver.lex.cond.pop();
+                      driver.lex.unextend();
+                      driver.lex.context.pop();
+                      driver.current_arg_stack.pop();
+                    }
+                | defs_head f_opt_paren_args tEQL arg kRESCUE_MOD arg
+                    {
+                      auto rescue_body = driver.build.rescue_body(self, $5, nullptr, nullptr, nullptr, nullptr, $6);
+                      auto method_body = driver.build.beginBody(self, $4, driver.alloc.node_list(rescue_body), nullptr, nullptr, nullptr, nullptr);
+
+                      $$ = driver.build.defEndlessSingleton(self, $1, $2, $3, method_body);
+
+                      driver.lex.cmdarg.pop();
+                      driver.lex.cond.pop();
+                      driver.lex.unextend();
+                      driver.lex.context.pop();
+                      driver.current_arg_stack.pop();
+                    }
                 | primary
 
            relop: tGT | tLT | tGEQ | tLEQ
@@ -1701,17 +1778,9 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                       driver.lex.unextend();
                       driver.lex.context.pop();
                     }
-                | kDEF fname
+                | defn_head f_arglist bodystmt kEND
                     {
-                      driver.lex.extend_static();
-                      driver.lex.cmdarg.push(false);
-                      driver.lex.cond.push(false);
-                      driver.lex.context.push(Context::State::DEF);
-                      driver.current_arg_stack.push("");
-                    }
-                    f_arglist bodystmt kEND
-                    {
-                      $$ = driver.build.defMethod(self, $1, $2, $4, $5, $6);
+                      $$ = driver.build.defMethod(self, $1->begin, $1->end, $2, $3, $4);
 
                       driver.lex.cmdarg.pop();
                       driver.lex.cond.pop();
@@ -1719,21 +1788,9 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                       driver.lex.context.pop();
                       driver.current_arg_stack.pop();
                     }
-                | kDEF singleton dot_or_colon
+                | defs_head f_arglist bodystmt kEND
                     {
-                      driver.lex.set_state_expr_fname();
-                    }
-                    fname
-                    {
-                      driver.lex.extend_static();
-                      driver.lex.cmdarg.push(false);
-                      driver.lex.cond.push(false);
-                      driver.lex.context.push(Context::State::DEFS);
-                      driver.current_arg_stack.push("");
-                    }
-                    f_arglist bodystmt kEND
-                    {
-                      $$ = driver.build.defSingleton(self, $1, $2, $3, $5, $7, $8, $9);
+                      $$ = driver.build.defSingleton(self, $1, $2, $3, $4);
                       DIAGCHECK();
 
                       driver.lex.cmdarg.pop();
@@ -3089,8 +3146,13 @@ keyword_variable: kNIL
                     {
                       $$ = nullptr;
                     }
+f_opt_paren_args: f_paren_args
+                | none
+                    {
+                      $$ = driver.build.args(self, nullptr, driver.alloc.node_list(), nullptr, false);
+                    }
 
-       f_arglist: tLPAREN2 f_args rparen
+       f_paren_args: tLPAREN2 f_args rparen
                     {
                       driver.lex.set_state_expr_value();
                       $$ = driver.build.args(self, $1, $2, $3, true);
@@ -3110,6 +3172,7 @@ keyword_variable: kNIL
                       auto node_list = driver.alloc.node_list(forward_arg);
                       $$ = driver.build.args(self, $1, node_list, $3, true);
                     }
+       f_arglist: f_paren_args
                 |   {
                       $<boolean>$ = driver.lex.in_kwarg;
                       driver.lex.in_kwarg = true;

--- a/third_party/parser/codegen/generate_diagnostics.cc
+++ b/third_party/parser/codegen/generate_diagnostics.cc
@@ -44,6 +44,7 @@ tuple<string, string> MESSAGES[] = {
     {"ArgumentCvar", "formal argument cannot be a class variable"},
     {"DuplicateArgument", "duplicate argument name {}"},
     {"EmptySymbol", "empty symbol literal"},
+    {"EndlessSetter", "setter method cannot be defined in an endless method definition"},
     {"OddHash", "odd number of entries for a hash"},
     {"SingletonLiteral", "cannot define a singleton method for a literal"},
     {"DynamicConst", "dynamic constant assignment"},

--- a/third_party/parser/include/ruby_parser/builder.hh
+++ b/third_party/parser/include/ruby_parser/builder.hh
@@ -47,10 +47,13 @@ struct builder {
 	ForeignPtr(*cvar)(SelfPtr builder, const token* tok);
 	ForeignPtr(*dedentString)(SelfPtr builder, ForeignPtr node, size_t dedentLevel);
 	ForeignPtr(*def_class)(SelfPtr builder, const token* class_, ForeignPtr name, const token* lt_, ForeignPtr superclass, ForeignPtr body, const token* end_);
+	ForeignPtr(*defEndlessMethod)(SelfPtr builder, const token* def, const token* name, ForeignPtr args, const token* equal, ForeignPtr body);
+	ForeignPtr(*defEndlessSingleton)(SelfPtr builder, ForeignPtr defHead, ForeignPtr args, const token* equal, ForeignPtr body);
 	ForeignPtr(*defMethod)(SelfPtr builder, const token* def, const token* name, ForeignPtr args, ForeignPtr body, const token* end);
 	ForeignPtr(*defModule)(SelfPtr builder, const token* module, ForeignPtr name, ForeignPtr body, const token* end_);
 	ForeignPtr(*def_sclass)(SelfPtr builder, const token* class_, const token* lshft_, ForeignPtr expr, ForeignPtr body, const token* end_);
-	ForeignPtr(*defSingleton)(SelfPtr builder, const token* def, ForeignPtr definee, const token* dot, const token* name, ForeignPtr args, ForeignPtr body, const token* end);
+	ForeignPtr(*defsHead)(SelfPtr builder, const token* def, ForeignPtr definee, const token* dot, const token* name);
+	ForeignPtr(*defSingleton)(SelfPtr builder, ForeignPtr defHead, ForeignPtr args, ForeignPtr body, const token* end);
 	ForeignPtr(*encodingLiteral)(SelfPtr builder, const token* tok);
 	ForeignPtr(*false_)(SelfPtr builder, const token* tok);
 	ForeignPtr(*fileLiteral)(SelfPtr builder, const token* tok);


### PR DESCRIPTION
Add support for endless method definitions. This implements a bunch of whitequark parser changes related to endless method definitions: https://github.com/whitequark/parser/search?q=endless&type=commits

Support for these
```ruby
def foo(a, b) = a + b

def foo = 123

def self.foo(a, b) = a + b

def self.foo = 123

def foo(a, b) = a + b rescue 123

def foo=(a) = a # ERROR: Endless method definitions not allowed for setters

def self.foo=(a) = a # ERROR: Endless method definitions not allowed for setters

def <=(other) = self <= other # accepted - exception to the setter rule
```

### Motivation

Part of the effort to support Ruby 3.0.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
