### PR TITLE
[Ruby 3.0] Add support for find pattern

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -779,6 +779,20 @@ public:
         return make_unique<False>(tokLoc(tok));
     }
 
+    unique_ptr<Node> find_pattern(const token *lbrack_t, sorbet::parser::NodeVec elements, const token *rbrack_t) {
+        auto loc = collectionLoc(elements);
+
+        if (lbrack_t != nullptr) {
+            loc = tokLoc(lbrack_t).join(loc);
+        }
+
+        if (rbrack_t != nullptr) {
+            loc = loc.join(tokLoc(rbrack_t));
+        }
+
+        return make_unique<FindPattern>(loc, std::move(elements));
+    }
+
     unique_ptr<Node> fileLiteral(const token *tok) {
         return make_unique<FileLiteral>(tokLoc(tok));
     }
@@ -1846,6 +1860,11 @@ ForeignPtr false_(SelfPtr builder, const token *tok) {
     return build->toForeign(build->false_(tok));
 }
 
+ForeignPtr find_pattern(SelfPtr builder, const token *lbrack_t, const node_list *elements, const token *rbrack_t) {
+    auto build = cast_builder(builder);
+    return build->toForeign(build->find_pattern(lbrack_t, build->convertNodeList(elements), rbrack_t));
+}
+
 ForeignPtr fileLiteral(SelfPtr builder, const token *tok) {
     auto build = cast_builder(builder);
     return build->toForeign(build->fileLiteral(tok));
@@ -2387,6 +2406,7 @@ struct ruby_parser::builder Builder::interface = {
     defSingleton,
     encodingLiteral,
     false_,
+    find_pattern,
     fileLiteral,
     float_,
     floatComplex,

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -268,6 +268,12 @@ NodeDef nodes[] = {
         "false",
         vector<FieldDef>(),
     },
+    // Find pattern
+    {
+        "FindPattern",
+        "find_pattern",
+        vector<FieldDef>({{"elements", FieldType::NodeVec}}),
+    },
     // __FILE__
     {
         "FileLiteral",

--- a/test/whitequark/test_find_pattern_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_find_pattern_0.parse-tree-whitequark.exp
@@ -1,0 +1,12 @@
+s(:case_match,
+  s(:lvar, :foo),
+  s(:in_pattern,
+    s(:find_pattern,
+      s(:match_rest,
+        s(:match_var, :x)),
+      s(:match_as,
+        s(:int, "1"),
+        s(:match_var, :a)),
+      s(:match_rest,
+        s(:match_var, :y))), nil,
+    s(:true)), nil)

--- a/test/whitequark/test_find_pattern_0.rb
+++ b/test/whitequark/test_find_pattern_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+case foo; in [*x, 1 => a, *y] then true; end

--- a/test/whitequark/test_find_pattern_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_find_pattern_1.parse-tree-whitequark.exp
@@ -1,0 +1,10 @@
+s(:case_match,
+  s(:lvar, :foo),
+  s(:in_pattern,
+    s(:const_pattern,
+      s(:const, nil, :String),
+      s(:find_pattern,
+        s(:match_rest, nil),
+        s(:int, "1"),
+        s(:match_rest, nil))), nil,
+    s(:true)), nil)

--- a/test/whitequark/test_find_pattern_1.rb
+++ b/test/whitequark/test_find_pattern_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+case foo; in String(*, 1, *) then true; end

--- a/test/whitequark/test_find_pattern_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_find_pattern_2.parse-tree-whitequark.exp
@@ -1,0 +1,10 @@
+s(:case_match,
+  s(:lvar, :foo),
+  s(:in_pattern,
+    s(:const_pattern,
+      s(:const, nil, :Array),
+      s(:find_pattern,
+        s(:match_rest, nil),
+        s(:int, "1"),
+        s(:match_rest, nil))), nil,
+    s(:true)), nil)

--- a/test/whitequark/test_find_pattern_2.rb
+++ b/test/whitequark/test_find_pattern_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+case foo; in Array[*, 1, *] then true; end

--- a/test/whitequark/test_find_pattern_3.parse-tree-whitequark.exp
+++ b/test/whitequark/test_find_pattern_3.parse-tree-whitequark.exp
@@ -1,0 +1,8 @@
+s(:case_match,
+  s(:lvar, :foo),
+  s(:in_pattern,
+    s(:find_pattern,
+      s(:match_rest, nil),
+      s(:int, "42"),
+      s(:match_rest, nil)), nil,
+    s(:true)), nil)

--- a/test/whitequark/test_find_pattern_3.rb
+++ b/test/whitequark/test_find_pattern_3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+case foo; in *, 42, * then true; end

--- a/test/whitequark/test_pattern_matching_required_parentheses_for_in_match_0.rb
+++ b/test/whitequark/test_pattern_matching_required_parentheses_for_in_match_0.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-1 in a, b # error: unexpected token ","
+1 => a, b # error: unexpected token ","

--- a/test/whitequark/test_pattern_matching_required_parentheses_for_in_match_1.rb
+++ b/test/whitequark/test_pattern_matching_required_parentheses_for_in_match_1.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-1 in a: # error: unexpected token tLABEL
+1 => a: # error: unexpected token tLABEL

--- a/test/whitequark/test_pattern_matching_single_line_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pattern_matching_single_line_0.parse-tree-whitequark.exp
@@ -1,0 +1,6 @@
+s(:begin,
+  s(:match_pattern,
+    s(:int, "1"),
+    s(:array_pattern,
+      s(:match_var, :a))),
+  s(:lvar, :a))

--- a/test/whitequark/test_pattern_matching_single_line_0.rb
+++ b/test/whitequark/test_pattern_matching_single_line_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+1 => [a]; a

--- a/test/whitequark/test_pattern_matching_single_line_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pattern_matching_single_line_1.parse-tree-whitequark.exp
@@ -1,0 +1,6 @@
+s(:begin,
+  s(:match_pattern_p,
+    s(:int, "1"),
+    s(:array_pattern,
+      s(:match_var, :a))),
+  s(:lvar, :a))

--- a/test/whitequark/test_pattern_matching_single_line_1.rb
+++ b/test/whitequark/test_pattern_matching_single_line_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+1 in [a]; a

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -239,6 +239,7 @@ using namespace std::string_literals;
   p_kw
   p_kw_label
   p_primitive
+  p_rest
   p_top_expr_body
   p_var_ref
   p_value
@@ -308,6 +309,7 @@ using namespace std::string_literals;
   p_args_head
   p_args_post
   p_args_tail
+  p_find
   p_kwarg
   p_kwargs
   p_kwnorest
@@ -2426,6 +2428,10 @@ opt_block_args_tail:
                       list->concat($3);
                       $$ = driver.build.array_pattern(self, nullptr, list, nullptr);
                     }
+                | p_find
+                    {
+                      $$ = driver.build.find_pattern(self, nullptr, $1, nullptr);
+                    }
                 | p_args_tail
                     {
                       $$ = driver.build.array_pattern(self, nullptr, $1, nullptr);
@@ -2462,6 +2468,12 @@ opt_block_args_tail:
                       auto pattern = driver.build.array_pattern(self, nullptr, $3, nullptr);
                       $$ = driver.build.const_pattern(self, $1, $2, pattern, $4);
                     }
+                | p_const p_lparen p_find rparen
+                    {
+                      driver.pattern_hash_keys.pop();
+                      auto pattern = driver.build.find_pattern(self, nullptr, $3, nullptr);
+                      $$ = driver.build.const_pattern(self, $1, $2, pattern, $4);
+                    }
                 | p_const p_lparen p_kwargs rparen
                     {
                       driver.pattern_hash_keys.pop();
@@ -2480,6 +2492,12 @@ opt_block_args_tail:
                       auto pattern = driver.build.array_pattern(self, nullptr, $3, nullptr);
                       $$ = driver.build.const_pattern(self, $1, $2, pattern, $4);
                     }
+                | p_const p_lbracket p_find rbracket
+                    {
+                      driver.pattern_hash_keys.pop();
+                      auto pattern = driver.build.find_pattern(self, nullptr, $3, nullptr);
+                      $$ = driver.build.const_pattern(self, $1, $2, pattern, $4);
+                    }
                 | p_const p_lbracket p_kwargs rbracket
                     {
                       driver.pattern_hash_keys.pop();
@@ -2492,14 +2510,13 @@ opt_block_args_tail:
                       auto pattern = driver.build.array_pattern(self, $2, list, nullptr);
                       $$ = driver.build.const_pattern(self, $1, $2, pattern, $3);
                     }
-                | tLBRACK
+                | tLBRACK p_args rbracket
                     {
-                      driver.pattern_hash_keys.push();
+                      $$ = driver.build.array_pattern(self, $1, $2, $3);
                     }
-                  p_args rbracket
+                | tLBRACK p_find rbracket
                     {
-                      driver.pattern_hash_keys.pop();
-                      $$ = driver.build.array_pattern(self, $1, $3, $4);
+                      $$ = driver.build.find_pattern(self, $1, $2, $3);
                     }
                 | tLBRACK rbracket
                     {
@@ -2587,27 +2604,28 @@ opt_block_args_tail:
                       $$ = $1;
                       $$->emplace_back(last_item);
                     }
-     p_args_tail: tSTAR tIDENTIFIER
+     p_args_tail: p_rest
                     {
-                      auto match_rest = driver.build.match_rest(self, $1, $2);
-                      $$ = driver.alloc.node_list(match_rest);
+                      $$ = driver.alloc.node_list($1);
                     }
-                | tSTAR tIDENTIFIER tCOMMA p_args_post
+                | p_rest tCOMMA p_args_post
                     {
-                      auto match_rest = driver.build.match_rest(self, $1, $2);
-                      $$ = driver.alloc.node_list(match_rest);
-                      $$->concat($4);
-                    }
-                | tSTAR
-                    {
-                      auto match_rest = driver.build.match_rest(self, $1, nullptr);
-                      $$ = driver.alloc.node_list(match_rest);
-                    }
-                | tSTAR tCOMMA p_args_post
-                    {
-                      auto match_rest = driver.build.match_rest(self, $1, nullptr);
-                      $$ = driver.alloc.node_list(match_rest);
+                      $$ = driver.alloc.node_list($1);
                       $$->concat($3);
+                    }
+         p_find: p_rest tCOMMA p_args_post tCOMMA p_rest
+                    {
+                      $$ = driver.alloc.node_list($1);
+                      $$->concat($3);
+                      $$->emplace_back($5);
+                    }
+         p_rest: tSTAR tIDENTIFIER
+                    {
+                      $$ = driver.build.match_rest(self, $1, $2);
+                    }
+               | tSTAR
+                    {
+                      $$ = driver.build.match_rest(self, $1, nullptr);
                     }
      p_args_post: p_arg
                     {

--- a/third_party/parser/cc/lexer.rl
+++ b/third_party/parser/cc/lexer.rl
@@ -2683,7 +2683,7 @@ void lexer::set_state_expr_value() {
       '*' | '=>'
       => {
         emit_table(PUNCTUATION);
-        fgoto expr_value;
+        fnext expr_value; fbreak;
       };
 
       # When '|', '~', '!', '=>' are used as operators

--- a/third_party/parser/include/ruby_parser/builder.hh
+++ b/third_party/parser/include/ruby_parser/builder.hh
@@ -56,6 +56,7 @@ struct builder {
 	ForeignPtr(*defSingleton)(SelfPtr builder, ForeignPtr defHead, ForeignPtr args, ForeignPtr body, const token* end);
 	ForeignPtr(*encodingLiteral)(SelfPtr builder, const token* tok);
 	ForeignPtr(*false_)(SelfPtr builder, const token* tok);
+	ForeignPtr(*find_pattern)(SelfPtr builder, const token* lbrack_t, const node_list* elements, const token* rbrack_t);
 	ForeignPtr(*fileLiteral)(SelfPtr builder, const token* tok);
 	ForeignPtr(*float_)(SelfPtr builder, const token* tok);
 	ForeignPtr(*floatComplex)(SelfPtr builder, const token* tok);


### PR DESCRIPTION
Changes from whitequark
- https://github.com/whitequark/parser/pull/764/
- https://github.com/whitequark/parser/pull/714

This PR adds support for the find pattern, which is another variation of the pattern matching syntax.

The syntax works as follows: it allows finding specific matches inside structures and (optionally) assigning it to a variable. For example,
```ruby
foo = [1, 2, 3, 4, 5]

case foo; in [*x, 3 => a, *y] then true; end # foo has the element 3 inside, therefore this will return true and set a = 3

case foo; in [*x, 7 => a, *y] then true; end # foo does not have the element 7, therefore this will raise NoMatchingPatternError
```

### Motivation

Part of the effort to support Ruby 3.0.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
