### PR TITLE
[Ruby 3.0] Reject ->... and ->(...) using the same error

### DIFF
--- a/third_party/parser/cc/lexer.rl
+++ b/third_party/parser/cc/lexer.rl
@@ -2332,7 +2332,11 @@ void lexer::set_state_expr_value() {
         if (version >= ruby_version::RUBY_27) {
           emit(token_type::tBDOT3, ident, ts, te);
         } else {
-          emit(token_type::tDOT3, ident, ts, te);
+          if (!lambda_stack.empty() && lambda_stack.top() == paren_nest) {
+            emit(token_type::tDOT3, ident, ts, te);
+          } else {
+            emit(token_type::tBDOT3, ident, ts, te);
+          }
         }
 
         fnext expr_beg; fbreak;

--- a/tools/scripts/import_whitequark.sh
+++ b/tools/scripts/import_whitequark.sh
@@ -14,8 +14,8 @@
 set -euo pipefail
 set -x
 
-REF=b69e8e595b804fd8e70ee1b90fc6dee81e183126
-TARGET_RUBY_VERSION="2.7"
+REF=49ed4dddfb1bf44d579fda001862149f4b9f7970
+TARGET_RUBY_VERSION="3.0"
 
 SCRIPT=$(realpath "$0")
 ROOT="$(cd "$(dirname "$SCRIPT")/../.."; pwd)"


### PR DESCRIPTION
Implement this change: https://github.com/whitequark/parser/pull/713

Based on my reviews of the commits in whitequark, this should be the last of the parser/lexer/builder changes for feature parity with Ruby 3.0 (unless I missed something 😅).

This PR updates the import whitequark script with the SHA of the latest Ruby 3.0 parser commit and sets the target as Ruby 3.0.

Additionally, it implements the brief lexer change mentioned.

### Motivation

Complete Ruby 3.0 support.

### Test plan

The existing tests that were previously imported should cover this.