### PR TITLE
Fix signature for FileUtils#touch.

### DIFF
--- a/rbi/stdlib/fileutils.rbi
+++ b/rbi/stdlib/fileutils.rbi
@@ -227,7 +227,7 @@ module FileUtils
   # ```
   sig do
     params(
-      list: T.any(String, Pathname, T::Array[String]),
+      list: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
       noop: T.nilable(T::Boolean),
       verbose: T.nilable(T::Boolean),
       mtime: T.nilable(Time),


### PR DESCRIPTION
### Motivation

It's also accepting Pathnames in the array:

```rb
require "fileutils"
require "pathname"

FileUtils.touch([
  Pathname.new("a"),
  "b"
])
```

### Test plan

See included automated tests.
