### PR TITLE
Add more cases to the infer/is_a_variable.rb test

### DIFF
--- a/test/testdata/infer/is_a_variable.rb
+++ b/test/testdata/infer/is_a_variable.rb
@@ -8,27 +8,67 @@ extend T::Sig
 class Parent; end
 class Child < Parent; end
 
+MyChild = T.let(Child, T.class_of(Parent))
+
 sig {void}
 def isa_local_variables
   parent = Parent.new
   child = T.let(Child, T.class_of(Parent))
-  if parent.is_a?(child) # always false
+  if parent.is_a?(child) # always false at runtime
     T.reveal_type(parent) # error: `Parent`
   else
-    # [bug] always reached
     T.reveal_type(parent) # error: This code is unreachable
   end
 end
 
-MyChild = T.let(Child, T.class_of(Parent))
-
 sig {void}
 def isa_static_field
   parent = Parent.new
-  if parent.is_a?(MyChild) # always false
+  if parent.is_a?(MyChild) # always false at runtime
     T.reveal_type(parent) # error: `Parent`
   else
-    # [bug] always reached
+    T.reveal_type(parent) # error: This code is unreachable
+  end
+end
+
+sig {void}
+def leq_local_variables
+  parent = Parent
+  child = T.let(Child, T.class_of(Parent))
+  if parent <= child # always false at runtime
+    T.reveal_type(parent) # error: `T.class_of(Parent)`
+  else
+    T.reveal_type(parent) # error: This code is unreachable
+  end
+end
+
+sig {void}
+def leq_static_field
+  parent = Parent
+  if parent <= MyChild # always false at runtime
+    T.reveal_type(parent) # error: `T.class_of(Parent)`
+  else
+    T.reveal_type(parent) # error: This code is unreachable
+  end
+end
+
+sig {void}
+def triple_eq_local_variables
+  parent = Parent.new
+  child = T.let(Child, T.class_of(Parent))
+  if child.===(parent) # always false at runtime
+    T.reveal_type(parent) # error: `Parent`
+  else
+    T.reveal_type(parent) # error: This code is unreachable
+  end
+end
+
+sig {void}
+def triple_eq_static_field
+  parent = Parent.new
+  if MyChild.===(parent) # always false at runtime
+    T.reveal_type(parent) # error: `Parent`
+  else
     T.reveal_type(parent) # error: This code is unreachable
   end
 end


### PR DESCRIPTION
I took a stab at trying to fix #4358 but stalled out on it.

The approach I took was to attempt to just use whether the
flow-sensitive call was on a `<cfgAlias>` variable (only created by
`cfg::Alias` instructions).

The problems I ran into were:

- Using only names wasn't powerful enough to see through static-fields.
  The only way to properly handle static fields would be to maintain a
  mapping of whether the alias that initialized a `<cfgAlias>` was
  actually a static-field symbol or not.

- I would have been fine with that, because it would have made some of
  the bugs go away, just not all of them.

  The next problem was that changing *only* `updateKnowledge` was not
  enough. For any of these methods (`Kernel#is_a?`, `Module#===`,
  `Module#<=`), if they have an intrinsic that computes the result type
  to be `TrueClass` or `FalseClass` exactly (not `T::Boolean`), that
  also introduces the same dead code error.

  So to fix the dead code error, you need to fix **both** the case in
  `updateKnowledge` and the intrinsic for that method.

  At the time of writing, only `Module#===` has such an intrinsic, but
  honestly, I'd rather **add** intrinsics for `is_a?` / `<=` (to fix
  this bug: https://github.com/sorbet/sorbet/issues/781) than I would
  like to figure out how to fix the existing ones.

  Basically: adding a halfway-working solution here would make it harder
  to fix https://github.com/sorbet/sorbet/issues/781 in the future, and
  I don't want that.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test-only change.