### PR TITLE
Break ties to favor then branch, not else branch

### DIFF
--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -423,7 +423,7 @@ int CFGBuilder::topoSortFwd(vector<BasicBlock *> &target, int nextFree, BasicBlo
         return nextFree;
     } else {
         currentBB->fwdId = -2;
-        if (currentBB->bexit.thenb->outerLoops > currentBB->bexit.elseb->outerLoops) {
+        if (currentBB->bexit.thenb->outerLoops >= currentBB->bexit.elseb->outerLoops) {
             nextFree = topoSortFwd(target, nextFree, currentBB->bexit.elseb);
             nextFree = topoSortFwd(target, nextFree, currentBB->bexit.thenb);
         } else {

--- a/test/cli/error-order/error-order.out
+++ b/test/cli/error-order/error-order.out
@@ -1,11 +1,3 @@
-test/cli/error-order/error-order.rb:6: Revealed type: `String("this error second")` https://srb.help/7014
-     6 |  T.reveal_type('this error second')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Got `String("this error second")` originating from:
-    test/cli/error-order/error-order.rb:6:
-     6 |  T.reveal_type('this error second')
-                        ^^^^^^^^^^^^^^^^^^^
-
 test/cli/error-order/error-order.rb:4: Revealed type: `String("this error first")` https://srb.help/7014
      4 |  T.reveal_type('this error first')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,5 +5,13 @@ test/cli/error-order/error-order.rb:4: Revealed type: `String("this error first"
     test/cli/error-order/error-order.rb:4:
      4 |  T.reveal_type('this error first')
                         ^^^^^^^^^^^^^^^^^^
+
+test/cli/error-order/error-order.rb:6: Revealed type: `String("this error second")` https://srb.help/7014
+     6 |  T.reveal_type('this error second')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `String("this error second")` originating from:
+    test/cli/error-order/error-order.rb:6:
+     6 |  T.reveal_type('this error second')
+                        ^^^^^^^^^^^^^^^^^^^
 Errors: 2
 expected to fail!

--- a/test/cli/error-order/error-order.out
+++ b/test/cli/error-order/error-order.out
@@ -1,0 +1,17 @@
+test/cli/error-order/error-order.rb:6: Revealed type: `String("this error second")` https://srb.help/7014
+     6 |  T.reveal_type('this error second')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `String("this error second")` originating from:
+    test/cli/error-order/error-order.rb:6:
+     6 |  T.reveal_type('this error second')
+                        ^^^^^^^^^^^^^^^^^^^
+
+test/cli/error-order/error-order.rb:4: Revealed type: `String("this error first")` https://srb.help/7014
+     4 |  T.reveal_type('this error first')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `String("this error first")` originating from:
+    test/cli/error-order/error-order.rb:4:
+     4 |  T.reveal_type('this error first')
+                        ^^^^^^^^^^^^^^^^^^
+Errors: 2
+expected to fail!

--- a/test/cli/error-order/error-order.rb
+++ b/test/cli/error-order/error-order.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+if T.unsafe(nil)
+  T.reveal_type('this error first')
+else
+  T.reveal_type('this error second')
+end

--- a/test/cli/error-order/error-order.sh
+++ b/test/cli/error-order/error-order.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if ! main/sorbet --silence-dev-message test/cli/error-order/error-order.rb 2>&1 ; then
+  echo 'expected to fail!'
+  exit 1
+fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed that we tend to report errors from the `else` branch before the `then`
branch. We can break ties the other way to make it less likely for that to
happen.

The CFG is processed in an approximate forward toposort of the CFG, so in
general it's not always possible or desirable to show errors from earlier lines
before later lines, but breaking ties this way seems to work slightly better.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See commits for before/after diff.