### PR TITLE
Disallow calling 'new' on certain metatypes

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -755,6 +755,9 @@ public:
 
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr underlying(const GlobalState &gs) const;
+
+private:
+    bool canCallNew(const GlobalState &gs) const;
 };
 CheckSize(MetaType, 16, 8);
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -755,9 +755,6 @@ public:
 
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr underlying(const GlobalState &gs) const;
-
-private:
-    bool canCallNew(const GlobalState &gs) const;
 };
 CheckSize(MetaType, 16, 8);
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -528,8 +528,9 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         return DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noMethod());
     } else if (symbol == Symbols::DeclBuilderForProcsSingleton() && args.name.rawId() == Names::new_().rawId()) {
         if (!args.suppressErrors) {
-            if (auto e = gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::UnknownMethod)) {
-                e.setHeader("Cannot call `{}` on declaration builder type `{}`", Names::new_().show(gs),
+            if (auto e =
+                    gs.beginError(core::Loc(args.locs.file, args.locs.call), errors::Infer::MetaTypeDispatchCall)) {
+                e.setHeader("Call to method `{}` on `{}` mistakes a type for a value", Names::new_().show(gs),
                             symbol.show(gs));
             }
         }

--- a/test/cli/suggest-class-new-not-singleton/suggest-class-new-not-singleton.out
+++ b/test/cli/suggest-class-new-not-singleton/suggest-class-new-not-singleton.out
@@ -1,0 +1,51 @@
+suggest-class-new-not-singleton.rb:3: Cannot call `new` on type `T.class_of(String)` https://srb.help/7030
+     3 |T.class_of(String).new
+        ^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest-class-new-not-singleton.rb:3: Replaced with `String`
+     3 |T.class_of(String).new
+        ^^^^^^^^^^^^^^^^^^
+
+suggest-class-new-not-singleton.rb:4: Cannot call `new` on type `T.class_of(Integer)` https://srb.help/7030
+     4 |T.class_of(Integer).new
+        ^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest-class-new-not-singleton.rb:4: Replaced with `Integer`
+     4 |T.class_of(Integer).new
+        ^^^^^^^^^^^^^^^^^^^
+
+suggest-class-new-not-singleton.rb:5: Cannot call `new` on type `T.class_of(T::Array)` https://srb.help/7030
+     5 |T.class_of(T::Array).new
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest-class-new-not-singleton.rb:5: Replaced with `T::Array`
+     5 |T.class_of(T::Array).new
+        ^^^^^^^^^^^^^^^^^^^^
+
+suggest-class-new-not-singleton.rb:6: Cannot call `new` on type `T.class_of(Array)` https://srb.help/7030
+     6 |T.class_of(T::Array[String]).new
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest-class-new-not-singleton.rb:6: Replaced with `Array`
+     6 |T.class_of(T::Array[String]).new
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+suggest-class-new-not-singleton.rb:8: Cannot call `new` on type `T.class_of(String)` https://srb.help/7030
+     8 |x.new
+        ^^^^^
+  Autocorrect: Done
+    suggest-class-new-not-singleton.rb:8: Replaced with `String`
+     8 |x.new
+        ^
+Errors: 5
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+String.new
+Integer.new
+T::Array.new
+Array.new
+x = T.class_of(String)
+String.new

--- a/test/cli/suggest-class-new-not-singleton/suggest-class-new-not-singleton.out
+++ b/test/cli/suggest-class-new-not-singleton/suggest-class-new-not-singleton.out
@@ -1,4 +1,4 @@
-suggest-class-new-not-singleton.rb:3: Cannot call `new` on type `T.class_of(String)` https://srb.help/7030
+suggest-class-new-not-singleton.rb:3: Call to method `new` on `T.class_of(String)` mistakes a type for a value https://srb.help/7030
      3 |T.class_of(String).new
         ^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -6,7 +6,7 @@ suggest-class-new-not-singleton.rb:3: Cannot call `new` on type `T.class_of(Stri
      3 |T.class_of(String).new
         ^^^^^^^^^^^^^^^^^^
 
-suggest-class-new-not-singleton.rb:4: Cannot call `new` on type `T.class_of(Integer)` https://srb.help/7030
+suggest-class-new-not-singleton.rb:4: Call to method `new` on `T.class_of(Integer)` mistakes a type for a value https://srb.help/7030
      4 |T.class_of(Integer).new
         ^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -14,7 +14,7 @@ suggest-class-new-not-singleton.rb:4: Cannot call `new` on type `T.class_of(Inte
      4 |T.class_of(Integer).new
         ^^^^^^^^^^^^^^^^^^^
 
-suggest-class-new-not-singleton.rb:5: Cannot call `new` on type `T.class_of(T::Array)` https://srb.help/7030
+suggest-class-new-not-singleton.rb:5: Call to method `new` on `T.class_of(T::Array)` mistakes a type for a value https://srb.help/7030
      5 |T.class_of(T::Array).new
         ^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -22,7 +22,7 @@ suggest-class-new-not-singleton.rb:5: Cannot call `new` on type `T.class_of(T::A
      5 |T.class_of(T::Array).new
         ^^^^^^^^^^^^^^^^^^^^
 
-suggest-class-new-not-singleton.rb:6: Cannot call `new` on type `T.class_of(Array)` https://srb.help/7030
+suggest-class-new-not-singleton.rb:6: Call to method `new` on `T.class_of(Array)` mistakes a type for a value https://srb.help/7030
      6 |T.class_of(T::Array[String]).new
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -30,7 +30,7 @@ suggest-class-new-not-singleton.rb:6: Cannot call `new` on type `T.class_of(Arra
      6 |T.class_of(T::Array[String]).new
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-suggest-class-new-not-singleton.rb:8: Cannot call `new` on type `T.class_of(String)` https://srb.help/7030
+suggest-class-new-not-singleton.rb:8: Call to method `new` on `T.class_of(String)` mistakes a type for a value https://srb.help/7030
      8 |x.new
         ^^^^^
   Autocorrect: Done

--- a/test/cli/suggest-class-new-not-singleton/suggest-class-new-not-singleton.rb
+++ b/test/cli/suggest-class-new-not-singleton/suggest-class-new-not-singleton.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+T.class_of(String).new
+T.class_of(Integer).new
+T.class_of(T::Array).new
+T.class_of(T::Array[String]).new
+x = T.class_of(String)
+x.new

--- a/test/cli/suggest-class-new-not-singleton/suggest-class-new-not-singleton.sh
+++ b/test/cli/suggest-class-new-not-singleton/suggest-class-new-not-singleton.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+tmp="$(mktemp -d)"
+infile="test/cli/suggest-class-new-not-singleton/suggest-class-new-not-singleton.rb"
+cp "$infile" "$tmp"
+
+cwd="$(pwd)"
+cd "$tmp" || exit 1
+
+if "$cwd/main/sorbet" --silence-dev-message -a suggest-class-new-not-singleton.rb 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+# Also cat the file, to make that the autocorrect applied
+cat suggest-class-new-not-singleton.rb
+
+rm suggest-class-new-not-singleton.rb
+rm "$tmp"

--- a/test/testdata/infer/metatype_new.rb
+++ b/test/testdata/infer/metatype_new.rb
@@ -1,0 +1,37 @@
+# typed: true
+
+class MyGeneric
+  extend T::Generic
+
+  X = type_member
+end
+
+MyArrayString = T.type_alias {T::Array[String]}
+
+# -- good --
+
+String.new
+T::Array[String].new
+MyGeneric.new
+MyGeneric[Integer].new
+
+# -- bad, but we can't detect them yet --
+
+MyArrayString.new                  # Type alias is unwound by the type we get to MetaType::dispatchCall
+
+# -- bad --
+
+T.any(Integer, String).new         # error: Cannot call `new` on type `T.any(Integer, String)`
+T.all(Kernel, Comparable).new      # error: Cannot call `new` on type `T.all(Kernel, Comparable)`
+T.nilable(String).new              # error: Cannot call `new` on type `T.nilable(String)`
+
+T.untyped.new                      # error: Cannot call `new` on type `T.untyped`
+T.self_type.new                    # error: Cannot call `new` on type `T.untyped`
+
+T.class_of(String).new             # error: Cannot call `new` on type `T.class_of(String)`
+T.class_of(MyGeneric).new          # error: Cannot call `new` on type `T.class_of(MyGeneric)`
+T.class_of(MyGeneric[Integer]).new # error: Cannot call `new` on type `T.class_of(MyGeneric)`
+
+T.proc.void.new                    # error: Cannot call `new` on declaration builder type
+
+T.noreturn.new                     # error: Cannot call `new` on type `T.noreturn`

--- a/test/testdata/infer/metatype_new.rb
+++ b/test/testdata/infer/metatype_new.rb
@@ -28,17 +28,20 @@ MyArrayString.new                  # Type alias is unwound by the type we get to
 
 # -- bad --
 
-T.any(Integer, String).new         # error: Cannot call `new` on type `T.any(Integer, String)`
-T.all(Kernel, Comparable).new      # error: Cannot call `new` on type `T.all(Kernel, Comparable)`
-T.nilable(String).new              # error: Cannot call `new` on type `T.nilable(String)`
+T.any(Integer, String).new         # error: Call to method `new` on `T.any(Integer, String)` mistakes a type for a value
+T.all(Kernel, Comparable).new      # error: Call to method `new` on `T.all(Kernel, Comparable)` mistakes a type for a value
+T.nilable(String).new              # error: Call to method `new` on `T.nilable(String)` mistakes a type for a value
 
-T.untyped.new                      # error: Cannot call `new` on type `T.untyped`
-T.self_type.new                    # error: Cannot call `new` on type `T.untyped`
+T.untyped.new                      # error: Call to method `new` on `T.untyped` mistakes a type for a value
+T.self_type.new                    # error: Call to method `new` on `T.untyped` mistakes a type for a value
 
-T.class_of(String).new             # error: Cannot call `new` on type `T.class_of(String)`
-T.class_of(MyGeneric).new          # error: Cannot call `new` on type `T.class_of(MyGeneric)`
-T.class_of(MyGeneric[Integer]).new # error: Cannot call `new` on type `T.class_of(MyGeneric)`
+T.class_of(String).new             # error: Call to method `new` on `T.class_of(String)` mistakes a type for a value
+T.class_of(MyGeneric).new          # error: Call to method `new` on `T.class_of(MyGeneric)` mistakes a type for a value
 
-T.proc.void.new                    # error: Cannot call `new` on declaration builder type
+# Note: the following shouldn't actually parse, but does due to a bug (https://github.com/sorbet/sorbet/issues/4377).
+# If you fix that bug, please feel free to delete the following line.
+T.class_of(MyGeneric[Integer]).new # error: Call to method `new` on `T.class_of(MyGeneric)` mistakes a type for a value
 
-T.noreturn.new                     # error: Cannot call `new` on type `T.noreturn`
+T.proc.void.new                    # error: Call to method `new` on `T.class_of(T.proc)` mistakes a type for a value
+
+T.noreturn.new                     # error: Call to method `new` on `T.noreturn` mistakes a type for a value

--- a/test/testdata/infer/metatype_new.rb
+++ b/test/testdata/infer/metatype_new.rb
@@ -6,6 +6,12 @@ class MyGeneric
   X = type_member
 end
 
+class MyOtherGeneric
+  extend T::Generic
+
+  X = type_template
+end
+
 MyArrayString = T.type_alias {T::Array[String]}
 
 # -- good --
@@ -14,6 +20,7 @@ String.new
 T::Array[String].new
 MyGeneric.new
 MyGeneric[Integer].new
+MyOtherGeneric.new
 
 # -- bad, but we can't detect them yet --
 


### PR DESCRIPTION
This makes it an error to call `new` on certain metatypes, like `T.any`, `T.or`, and a few others.

Not quite sure if this approach is as comprehensive as it should be!


### Motivation
Closes #4172


### Test plan
See included automated tests.
