### PR TITLE
Docs: Document 5037

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -465,6 +465,10 @@ See [5014](#5014). 5036 is the same error as [5014](#5014) but slightly modified
 to allow more common Ruby idioms to pass by in `# typed: true` (5036 is only
 reported in `# typed: strict`).
 
+## 5037
+
+Sorbet does not support aliasing a method from a parent class. See [this issue](https://github.com/sorbet/sorbet/issues/2378) for more details.
+
 ## 5041
 
 Sorbet does not allow inheriting from a class which inherits from `T::Struct`.


### PR DESCRIPTION
Hey, and big thanks for sorbet! 👋 

I'm experimenting with it in [@Datadog's `ddtrace` gem](https://github.com/DataDog/dd-trace-rb) and got a bit confused by error 5037 as I really couldn't see what was wrong.

As I was searching for older issues if anyone had reported this, it turns out that they did, multiple times (sorbet#3888, sorbet#2378, sorbet#1443). So I decided to sent a PR your way to add this to the main error documentation, so that others in the future don't lose time on this.

Hope this is reasonable, and let me know your feedback :)