### PR TITLE
Fix Enumerable#take signature

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -1651,7 +1651,7 @@ module Enumerable
     params(
         n: Integer,
     )
-    .returns(T.nilable(T::Array[Elem]))
+    .returns(T::Array[Elem])
   end
   def take(n); end
 


### PR DESCRIPTION
`Enumerable#take` always [returns an array](https://ruby-doc.org/core-3.0.2/Enumerable.html#method-i-take), even if the input is empty.

For example with `irb`:

```rb
[].cycle          # => #<Enumerator: []:cycle>
[].cycle.take(10) # => []
```

Sorbet on the other hand, sees this as a nilable type:

```rb
T.reveal_type([].cycle)          # Revealed type: T::Enumerator[T.untyped]
T.reveal_type([].cycle.take(10)) # Revealed type: T.nilable(T::Array[T.untyped])
```

This behaviour seems to be related to the [`Enumerable#take` signature](https://github.com/sorbet/sorbet/blob/master/rbi/core/enumerable.rbi#L1650-L1656) since `Enumerable` is [included in `Enumerator`](https://github.com/sorbet/sorbet/blob/master/rbi/core/enumerator.rbi#L100).

Making the return type of `Enumerable#take` not nilable fixes the behaviour: 

```rb
T.reveal_type([].cycle)          # Revealed type: T::Enumerator[T.untyped]
T.reveal_type([].cycle.take(10)) # Revealed type: T::Array[T.untyped]
```

### Motivation

Fixes #4380.

### Test plan

See included automated tests.
