### PR TITLE
Ignore `\r` when parsing the `typed: ...` line

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *.rbi diff=ruby
 *.md diff=markdown
 test/**/*.out diff
+test/cli/windows-line-endings/windows-line-endings.rb eol=crlf

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -77,6 +77,9 @@ StrictLevel File::fileSigil(string_view source) {
         while (end < source.size() && source[end] != ' ' && source[end] != '\n') {
             ++end;
         }
+        if (source[end - 1] == '\r') {
+            end -= 1;
+        }
 
         string_view suffix = source.substr(start, end - start);
         if (suffix == "ignore") {

--- a/test/cli/windows-line-endings/windows-line-endings.out
+++ b/test/cli/windows-line-endings/windows-line-endings.out
@@ -1,0 +1,2 @@
+ASCII text, with CRLF line terminators
+No errors! Great job.

--- a/test/cli/windows-line-endings/windows-line-endings.rb
+++ b/test/cli/windows-line-endings/windows-line-endings.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+extend T::Sig
+
+sig {params(x: Integer).void}
+def foo(x)
+  puts(x + 1)
+end

--- a/test/cli/windows-line-endings/windows-line-endings.sh
+++ b/test/cli/windows-line-endings/windows-line-endings.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+file --brief "$(realpath test/cli/windows-line-endings/windows-line-endings.rb)"
+
+main/sorbet --silence-dev-message test/cli/windows-line-endings/windows-line-endings.rb 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #1372 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
