### PR TITLE
add some ENFORCEs around args and corresponding locs

### DIFF
--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -76,6 +76,7 @@ Send::Send(LocalRef recv, core::NameRef fun, core::LocOffsets receiverLoc, u2 nu
       argLocs(std::move(argLocs)), link(move(link)) {
     ENFORCE(numPosArgs <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs,
             args.size());
+    ENFORCE(args.size() == this->argLocs.size(), "Should have a loc for every arg");
 
     this->args.resize(args.size());
     int i = 0;

--- a/core/Types.h
+++ b/core/Types.h
@@ -834,12 +834,11 @@ struct DispatchArgs {
 
     DispatchArgs(NameRef name, const CallLocs &locs, u2 numPosArgs, InlinedVector<const TypeAndOrigins *, 2> &args,
                  const TypePtr &selfType, const TypeAndOrigins &fullType, const TypePtr &thisType,
-                 const std::shared_ptr<const SendAndBlockLink> &block, Loc originForUninitialized,
-                 bool isPrivateOk);
+                 const std::shared_ptr<const SendAndBlockLink> &block, Loc originForUninitialized, bool isPrivateOk);
     DispatchArgs(NameRef name, const CallLocs &locs, u2 numPosArgs, InlinedVector<const TypeAndOrigins *, 2> &args,
                  const TypePtr &selfType, const TypeAndOrigins &fullType, const TypePtr &thisType,
-                 const std::shared_ptr<const SendAndBlockLink> &block, Loc originForUninitialized,
-                 bool isPrivateOk, bool suppressErrors);
+                 const std::shared_ptr<const SendAndBlockLink> &block, Loc originForUninitialized, bool isPrivateOk,
+                 bool suppressErrors);
 
     Loc callLoc() const {
         return core::Loc(locs.file, locs.call);

--- a/core/Types.h
+++ b/core/Types.h
@@ -832,6 +832,15 @@ struct DispatchArgs {
     // unreported errors is expensive!
     bool suppressErrors = false;
 
+    DispatchArgs(NameRef name, const CallLocs &locs, u2 numPosArgs, InlinedVector<const TypeAndOrigins *, 2> &args,
+                 const TypePtr &selfType, const TypeAndOrigins &fullType, const TypePtr &thisType,
+                 const std::shared_ptr<const SendAndBlockLink> &block, Loc originForUninitialized,
+                 bool isPrivateOk);
+    DispatchArgs(NameRef name, const CallLocs &locs, u2 numPosArgs, InlinedVector<const TypeAndOrigins *, 2> &args,
+                 const TypePtr &selfType, const TypeAndOrigins &fullType, const TypePtr &thisType,
+                 const std::shared_ptr<const SendAndBlockLink> &block, Loc originForUninitialized,
+                 bool isPrivateOk, bool suppressErrors);
+
     Loc callLoc() const {
         return core::Loc(locs.file, locs.call);
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2330,7 +2330,7 @@ public:
 
         auto &arg = args.args[0];
         InlinedVector<LocOffsets, 2> argLocs{args.locs.receiver};
-        CallLocs locs{args.locs.file, args.locs.call, args.locs.call, argLocs};
+        CallLocs locs{args.locs.file, args.locs.call, args.locs.receiver, argLocs};
         InlinedVector<const TypeAndOrigins *, 2> innerArgs;
 
         DispatchArgs dispatch{core::Names::toA(), locs,      0,

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2329,7 +2329,7 @@ public:
         ENFORCE(args.args.size() == 1);
 
         auto &arg = args.args[0];
-        InlinedVector<LocOffsets, 2> argLocs{args.locs.receiver};
+        InlinedVector<LocOffsets, 2> argLocs;
         CallLocs locs{args.locs.file, args.locs.call, args.locs.receiver, argLocs};
         InlinedVector<const TypeAndOrigins *, 2> innerArgs;
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -769,6 +769,23 @@ core::ClassOrModuleRef Types::getRepresentedClass(const GlobalState &gs, const T
     return singleton.data(gs)->attachedClass(gs);
 }
 
+DispatchArgs::DispatchArgs(NameRef name, const CallLocs &locs, u2 numPosArgs, InlinedVector<const TypeAndOrigins *, 2> &args,
+             const TypePtr &selfType, const TypeAndOrigins &fullType, const TypePtr &thisType,
+             const std::shared_ptr<const SendAndBlockLink> &block, Loc originForUninitialized,
+             bool isPrivateOk)
+    : DispatchArgs(name, locs, numPosArgs, args, selfType, fullType, thisType, block, originForUninitialized, isPrivateOk, false) {
+}
+
+DispatchArgs::DispatchArgs(NameRef name, const CallLocs &locs, u2 numPosArgs, InlinedVector<const TypeAndOrigins *, 2> &args,
+             const TypePtr &selfType, const TypeAndOrigins &fullType, const TypePtr &thisType,
+             const std::shared_ptr<const SendAndBlockLink> &block, Loc originForUninitialized,
+             bool isPrivateOk, bool suppressErrors)
+    : name(name), locs(locs), numPosArgs(numPosArgs), args(args), selfType(selfType), fullType(fullType),
+      thisType(thisType), block(block), originForUninitialized(originForUninitialized),
+      isPrivateOk(isPrivateOk), suppressErrors(suppressErrors) {
+    ENFORCE(this->args.size() == this->locs.args.size(), "Should have a loc for every arg");
+}
+
 DispatchArgs DispatchArgs::withSelfRef(const TypePtr &newSelfRef) const {
     return DispatchArgs{
         name, locs, numPosArgs, args, newSelfRef, fullType, newSelfRef, block, originForUninitialized, suppressErrors};

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -769,20 +769,22 @@ core::ClassOrModuleRef Types::getRepresentedClass(const GlobalState &gs, const T
     return singleton.data(gs)->attachedClass(gs);
 }
 
-DispatchArgs::DispatchArgs(NameRef name, const CallLocs &locs, u2 numPosArgs, InlinedVector<const TypeAndOrigins *, 2> &args,
-             const TypePtr &selfType, const TypeAndOrigins &fullType, const TypePtr &thisType,
-             const std::shared_ptr<const SendAndBlockLink> &block, Loc originForUninitialized,
-             bool isPrivateOk)
-    : DispatchArgs(name, locs, numPosArgs, args, selfType, fullType, thisType, block, originForUninitialized, isPrivateOk, false) {
-}
+DispatchArgs::DispatchArgs(NameRef name, const CallLocs &locs, u2 numPosArgs,
+                           InlinedVector<const TypeAndOrigins *, 2> &args, const TypePtr &selfType,
+                           const TypeAndOrigins &fullType, const TypePtr &thisType,
+                           const std::shared_ptr<const SendAndBlockLink> &block, Loc originForUninitialized,
+                           bool isPrivateOk)
+    : DispatchArgs(name, locs, numPosArgs, args, selfType, fullType, thisType, block, originForUninitialized,
+                   isPrivateOk, false) {}
 
-DispatchArgs::DispatchArgs(NameRef name, const CallLocs &locs, u2 numPosArgs, InlinedVector<const TypeAndOrigins *, 2> &args,
-             const TypePtr &selfType, const TypeAndOrigins &fullType, const TypePtr &thisType,
-             const std::shared_ptr<const SendAndBlockLink> &block, Loc originForUninitialized,
-             bool isPrivateOk, bool suppressErrors)
+DispatchArgs::DispatchArgs(NameRef name, const CallLocs &locs, u2 numPosArgs,
+                           InlinedVector<const TypeAndOrigins *, 2> &args, const TypePtr &selfType,
+                           const TypeAndOrigins &fullType, const TypePtr &thisType,
+                           const std::shared_ptr<const SendAndBlockLink> &block, Loc originForUninitialized,
+                           bool isPrivateOk, bool suppressErrors)
     : name(name), locs(locs), numPosArgs(numPosArgs), args(args), selfType(selfType), fullType(fullType),
-      thisType(thisType), block(block), originForUninitialized(originForUninitialized),
-      isPrivateOk(isPrivateOk), suppressErrors(suppressErrors) {
+      thisType(thisType), block(block), originForUninitialized(originForUninitialized), isPrivateOk(isPrivateOk),
+      suppressErrors(suppressErrors) {
     ENFORCE(this->args.size() == this->locs.args.size(), "Should have a loc for every arg");
 }
 


### PR DESCRIPTION
### Motivation

I added these `ENFORCE`s to debug things and they found an actual problem (4089c9e).  I figure we might as well keep them around permanently.  I've also wanted an actual constructor for `DispatchArgs` for a while and I'm glad I found an excuse to add it!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
