### PR TITLE
return T::Boolean for Module.=== with an untyped arg

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3057,7 +3057,7 @@ public:
         }
         auto rhs = args.args[0]->type;
         if (rhs.isUntyped()) {
-            res.returnType = rhs;
+            res.returnType = Types::Boolean();
             return;
         }
 

--- a/test/testdata/infer/module_tripleeq-untyped-arg.rb
+++ b/test/testdata/infer/module_tripleeq-untyped-arg.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+T.reveal_type(Integer.===(T.unsafe(nil))) # error: Revealed type: `T::Boolean`


### PR DESCRIPTION
### Motivation

Fixes #4173.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
