### PR TITLE
add "Did you mean" prompts for incorrect usage of type_{member,template}

### DIFF
--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -818,12 +818,30 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                             string typeStr = sym.show(ctx);
 
                             if (usedOnSourceClass) {
+                                // Autocorrects here are awkward, because we want to
+                                // offer the autocorrect at the definition of the
+                                // type_member or type_template and we only have
+                                // access to the use of the type_member or
+                                // type_template here.  We could examine the source
+                                // and attempt to identify the location for the
+                                // autocorrect, but that gets messy.
+                                //
+                                // Plus, it's not absolutely clear that the
+                                // definition is really at fault: it might be that
+                                // the user is using the wrong
+                                // type_member/type_template constant for the given
+                                // context, or they need to change the definition of
+                                // the method this use is associated with.  Try to give
+                                // them enough of a hint to decide what to do on their
+                                // own.
                                 if (ctxIsSingleton) {
                                     e.setHeader("`{}` type `{}` used in a singleton method definition", typeSource,
                                                 typeStr);
+                                    e.addErrorNote("Did you mean to use a similarly-named `type_template`?");
                                 } else {
                                     e.setHeader("`{}` type `{}` used in an instance method definition", typeSource,
                                                 typeStr);
+                                    e.addErrorNote("Did you mean to use a similarly-named `type_member`?");
                                 }
                             } else {
                                 e.setHeader("`{}` type `{}` used outside of the class definition", typeSource, typeStr);

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -837,11 +837,13 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                                 if (ctxIsSingleton) {
                                     e.setHeader("`{}` type `{}` used in a singleton method definition", typeSource,
                                                 typeStr);
-                                    e.addErrorNote("Only a `type_template` can be used in a singleton method definition.");
+                                    e.addErrorNote(
+                                        "Only a `type_template` can be used in a singleton method definition.");
                                 } else {
                                     e.setHeader("`{}` type `{}` used in an instance method definition", typeSource,
                                                 typeStr);
-                                    e.addErrorNote("Only a `type_member` can be used in an instance method definition.");
+                                    e.addErrorNote(
+                                        "Only a `type_member` can be used in an instance method definition.");
                                 }
                             } else {
                                 e.setHeader("`{}` type `{}` used outside of the class definition", typeSource, typeStr);

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -837,11 +837,11 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                                 if (ctxIsSingleton) {
                                     e.setHeader("`{}` type `{}` used in a singleton method definition", typeSource,
                                                 typeStr);
-                                    e.addErrorNote("Did you mean to use a similarly-named `type_template`?");
+                                    e.addErrorNote("Only a `type_template` can be used in a singleton method definition.");
                                 } else {
                                     e.setHeader("`{}` type `{}` used in an instance method definition", typeSource,
                                                 typeStr);
-                                    e.addErrorNote("Did you mean to use a similarly-named `type_member`?");
+                                    e.addErrorNote("Only a `type_member` can be used in an instance method definition.");
                                 }
                             } else {
                                 e.setHeader("`{}` type `{}` used outside of the class definition", typeSource, typeStr);

--- a/test/cli/type-member-template/type-member-template.out
+++ b/test/cli/type-member-template/type-member-template.out
@@ -1,0 +1,12 @@
+test/cli/type-member-template/type-member-template.rb:10: `type_template` type `T.class_of(A)::Template` used in an instance method definition https://srb.help/5027
+    10 |  sig {returns(Template)}
+                       ^^^^^^^^
+  Note:
+    Did you mean to use a similarly-named `type_member`?
+
+test/cli/type-member-template/type-member-template.rb:13: `type_member` type `A::Member` used in a singleton method definition https://srb.help/5027
+    13 |  sig {returns(Member)}
+                       ^^^^^^
+  Note:
+    Did you mean to use a similarly-named `type_template`?
+Errors: 2

--- a/test/cli/type-member-template/type-member-template.out
+++ b/test/cli/type-member-template/type-member-template.out
@@ -2,11 +2,11 @@ test/cli/type-member-template/type-member-template.rb:10: `type_template` type `
     10 |  sig {returns(Template)}
                        ^^^^^^^^
   Note:
-    Did you mean to use a similarly-named `type_member`?
+    Only a `type_member` can be used in an instance method definition.
 
 test/cli/type-member-template/type-member-template.rb:13: `type_member` type `A::Member` used in a singleton method definition https://srb.help/5027
     13 |  sig {returns(Member)}
                        ^^^^^^
   Note:
-    Did you mean to use a similarly-named `type_template`?
+    Only a `type_template` can be used in a singleton method definition.
 Errors: 2

--- a/test/cli/type-member-template/type-member-template.rb
+++ b/test/cli/type-member-template/type-member-template.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+class A
+  extend T::Sig
+  extend T::Generic
+
+  Member = type_member
+  Template = type_template
+
+  sig {returns(Template)}
+  def foo; end
+
+  sig {returns(Member)}
+  def self.foo; end
+end

--- a/test/cli/type-member-template/type-member-template.sh
+++ b/test/cli/type-member-template/type-member-template.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+main/sorbet --silence-dev-message test/cli/type-member-template/type-member-template.rb 2>&1


### PR DESCRIPTION
### Motivation

#3786 

Even though there's no autocorrects, I think we could claim #3786 as being fixed.  I wrote out the rationale for avoiding autocorrects in a comment, which might be too much, but it at least serves as a warning to the next person who comes along.

There was a recent conversation about this inside Stripe's Slack, and the suggestion there was to add a pointer to using `type_member` or `type_template` as appropriate.  I think this message qualifies.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
