### PR TITLE
add a note to `@var = T.cast(...)` errors to suggest a way forward

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1731,6 +1731,12 @@ class ResolveTypeMembersAndFieldsWalk {
         } else if (cast->cast != core::Names::let()) {
             if (auto e = ctx.beginError(cast->loc, core::errors::Resolver::ConstantAssertType)) {
                 e.setHeader("Use `{}` to specify the type of constants", "T.let");
+                if (cast->cast == core::Names::cast()) {
+                    e.addErrorNote("If you really want to use `T.cast`, "
+                                   "assign to an intermediate variable first and then "
+                                   "assign that variable to `{}`",
+                                   asgn.lhs.toString(ctx));
+                }
             }
         }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1731,6 +1731,9 @@ class ResolveTypeMembersAndFieldsWalk {
         } else if (cast->cast != core::Names::let()) {
             if (auto e = ctx.beginError(cast->loc, core::errors::Resolver::ConstantAssertType)) {
                 e.setHeader("Use `{}` to specify the type of constants", "T.let");
+                auto rhsLoc = core::Loc(ctx.file, asgn.rhs.loc());
+                auto argSource = core::Loc(ctx.file, cast->arg.loc()).source(ctx).value();
+                e.replaceWith("Replace with `T.let`", rhsLoc, "T.let({}, {})", argSource, cast->type.show(ctx));
                 if (cast->cast == core::Names::cast()) {
                     e.addErrorNote("If you really want to use `T.cast`, "
                                    "assign to an intermediate variable first and then "

--- a/test/cli/ivar-with-cast/ivar-with-cast.out
+++ b/test/cli/ivar-with-cast/ivar-with-cast.out
@@ -1,0 +1,6 @@
+test/cli/ivar-with-cast/ivar-with-cast.rb:6: Use `T.let` to specify the type of constants https://srb.help/5013
+     6 |    @val = T.cast(0, Integer)
+                   ^^^^^^^^^^^^^^^^^^
+  Note:
+    If you really want to use `T.cast`, assign to an intermediate variable first and then assign that variable to `@val`
+Errors: 1

--- a/test/cli/ivar-with-cast/ivar-with-cast.out
+++ b/test/cli/ivar-with-cast/ivar-with-cast.out
@@ -1,6 +1,10 @@
 test/cli/ivar-with-cast/ivar-with-cast.rb:6: Use `T.let` to specify the type of constants https://srb.help/5013
      6 |    @val = T.cast(0, Integer)
                    ^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/ivar-with-cast/ivar-with-cast.rb:6: Replace with `T.let(0, Integer)`
+     6 |    @val = T.cast(0, Integer)
+                   ^^^^^^^^^^^^^^^^^^
   Note:
     If you really want to use `T.cast`, assign to an intermediate variable first and then assign that variable to `@val`
 Errors: 1

--- a/test/cli/ivar-with-cast/ivar-with-cast.rb
+++ b/test/cli/ivar-with-cast/ivar-with-cast.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class A
+  extend T::Sig
+  def initialize
+    @val = T.cast(0, Integer)
+  end
+end

--- a/test/cli/ivar-with-cast/ivar-with-cast.rb
+++ b/test/cli/ivar-with-cast/ivar-with-cast.rb
@@ -6,3 +6,12 @@ class A
     @val = T.cast(0, Integer)
   end
 end
+
+class B
+  extend T::Sig
+
+  sig {params(v: T.nilable(Integer)).void}
+  def initialize(v)
+    @val = T.must(v)
+  end
+end

--- a/test/cli/ivar-with-cast/ivar-with-cast.sh
+++ b/test/cli/ivar-with-cast/ivar-with-cast.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+main/sorbet --silence-dev-message test/cli/ivar-with-cast/ivar-with-cast.rb 2>&1


### PR DESCRIPTION
### Motivation

Fixes #4017.

We updated the docs for this (https://srb.help/5013), presumably after the original bug was filed.  But it's nice to save somebody a click.  (I don't know how to do an autocorrect that involves temporary variables, so I opted to leave that up to the user -- and they may want to use `T.let` in any event.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
