### PR TITLE
Upgrade spdlog to version 1.9.0

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -400,7 +400,7 @@ namespace {
 void printTabs(fmt::memory_buffer &to, int count) {
     int i = 0;
     while (i < count) {
-        fmt::format_to(to, "  ");
+        fmt::format_to(std::back_inserter(to), "  ");
         i++;
     }
 }
@@ -411,21 +411,21 @@ template <class T> void printElems(const core::GlobalState &gs, fmt::memory_buff
     for (auto &a : args) {
         if (!first) {
             if (isa_tree<ShadowArg>(a) && !didshadow) {
-                fmt::format_to(buf, "; ");
+                fmt::format_to(std::back_inserter(buf), "; ");
                 didshadow = true;
             } else {
-                fmt::format_to(buf, ", ");
+                fmt::format_to(std::back_inserter(buf), ", ");
             }
         }
         first = false;
-        fmt::format_to(buf, "{}", a.toStringWithTabs(gs, tabs + 1));
+        fmt::format_to(std::back_inserter(buf), "{}", a.toStringWithTabs(gs, tabs + 1));
     }
 };
 
 template <class T> void printArgs(const core::GlobalState &gs, fmt::memory_buffer &buf, T &args, int tabs) {
-    fmt::format_to(buf, "(");
+    fmt::format_to(std::back_inserter(buf), "(");
     printElems(gs, buf, args, tabs);
-    fmt::format_to(buf, ")");
+    fmt::format_to(std::back_inserter(buf), ")");
 }
 
 } // namespace
@@ -433,97 +433,97 @@ template <class T> void printArgs(const core::GlobalState &gs, fmt::memory_buffe
 string ClassDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     if (kind == ClassDef::Kind::Module) {
-        fmt::format_to(buf, "module ");
+        fmt::format_to(std::back_inserter(buf), "module ");
     } else {
-        fmt::format_to(buf, "class ");
+        fmt::format_to(std::back_inserter(buf), "class ");
     }
-    fmt::format_to(buf, "{}<{}> < ", name.toStringWithTabs(gs, tabs),
+    fmt::format_to(std::back_inserter(buf), "{}<{}> < ", name.toStringWithTabs(gs, tabs),
                    this->symbol.dataAllowingNone(gs)->name.toString(gs));
     printArgs(gs, buf, this->ancestors, tabs);
 
     if (this->rhs.empty()) {
-        fmt::format_to(buf, "{}", '\n');
+        fmt::format_to(std::back_inserter(buf), "{}", '\n');
     }
 
     for (auto &a : this->rhs) {
-        fmt::format_to(buf, "{}", '\n');
+        fmt::format_to(std::back_inserter(buf), "{}", '\n');
         printTabs(buf, tabs + 1);
-        fmt::format_to(buf, "{}\n", a.toStringWithTabs(gs, tabs + 1));
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.toStringWithTabs(gs, tabs + 1));
     }
 
     printTabs(buf, tabs);
-    fmt::format_to(buf, "end");
+    fmt::format_to(std::back_inserter(buf), "end");
     return fmt::to_string(buf);
 }
 
 string ClassDef::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "kind = {}\n", kind == ClassDef::Kind::Module ? "module" : "class");
+    fmt::format_to(std::back_inserter(buf), "kind = {}\n", kind == ClassDef::Kind::Module ? "module" : "class");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "name = {}<{}>\n", name.showRaw(gs, tabs + 1),
+    fmt::format_to(std::back_inserter(buf), "name = {}<{}>\n", name.showRaw(gs, tabs + 1),
                    this->symbol.dataAllowingNone(gs)->name.showRaw(gs));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "ancestors = [");
+    fmt::format_to(std::back_inserter(buf), "ancestors = [");
     bool first = true;
     for (auto &a : this->ancestors) {
         if (!first) {
-            fmt::format_to(buf, ", ");
+            fmt::format_to(std::back_inserter(buf), ", ");
         }
         first = false;
-        fmt::format_to(buf, "{}", a.showRaw(gs, tabs + 2));
+        fmt::format_to(std::back_inserter(buf), "{}", a.showRaw(gs, tabs + 2));
     }
-    fmt::format_to(buf, "]\n");
+    fmt::format_to(std::back_inserter(buf), "]\n");
 
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "rhs = [\n");
+    fmt::format_to(std::back_inserter(buf), "rhs = [\n");
 
     for (auto &a : this->rhs) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRaw(gs, tabs + 2));
         if (&a != &this->rhs.back()) {
-            fmt::format_to(buf, "{}", '\n');
+            fmt::format_to(std::back_inserter(buf), "{}", '\n');
         }
     }
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "]\n");
+    fmt::format_to(std::back_inserter(buf), "]\n");
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return fmt::to_string(buf);
 }
 
 string InsSeq::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "begin\n");
+    fmt::format_to(std::back_inserter(buf), "begin\n");
     for (auto &a : this->stats) {
         printTabs(buf, tabs + 1);
-        fmt::format_to(buf, "{}\n", a.toStringWithTabs(gs, tabs + 1));
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.toStringWithTabs(gs, tabs + 1));
     }
 
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "{}\n", expr.toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "{}\n", expr.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "end");
+    fmt::format_to(std::back_inserter(buf), "end");
     return fmt::to_string(buf);
 }
 
 string InsSeq::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "stats = [\n");
+    fmt::format_to(std::back_inserter(buf), "stats = [\n");
     for (auto &a : this->stats) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRaw(gs, tabs + 2));
     }
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "],\n");
+    fmt::format_to(std::back_inserter(buf), "],\n");
 
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "expr = {}\n", expr.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "expr = {}\n", expr.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return fmt::to_string(buf);
 }
 
@@ -531,45 +531,45 @@ string MethodDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
     fmt::memory_buffer buf;
 
     if (this->flags.isSelfMethod) {
-        fmt::format_to(buf, "def self.");
+        fmt::format_to(std::back_inserter(buf), "def self.");
     } else {
-        fmt::format_to(buf, "def ");
+        fmt::format_to(std::back_inserter(buf), "def ");
     }
-    fmt::format_to(buf, "{}", name.toString(gs));
+    fmt::format_to(std::back_inserter(buf), "{}", name.toString(gs));
     const auto data = this->symbol.data(gs);
     if (name != data->name) {
-        fmt::format_to(buf, "<{}>", data->name.toString(gs));
+        fmt::format_to(std::back_inserter(buf), "<{}>", data->name.toString(gs));
     }
-    fmt::format_to(buf, "(");
+    fmt::format_to(std::back_inserter(buf), "(");
     bool first = true;
     if (this->symbol == core::Symbols::todoMethod()) {
         for (auto &a : this->args) {
             if (!first) {
-                fmt::format_to(buf, ", ");
+                fmt::format_to(std::back_inserter(buf), ", ");
             }
             first = false;
-            fmt::format_to(buf, "{}", a.toStringWithTabs(gs, tabs + 1));
+            fmt::format_to(std::back_inserter(buf), "{}", a.toStringWithTabs(gs, tabs + 1));
         }
     } else {
         for (auto &a : data->arguments()) {
             if (!first) {
-                fmt::format_to(buf, ", ");
+                fmt::format_to(std::back_inserter(buf), ", ");
             }
             first = false;
-            fmt::format_to(buf, "{}", a.argumentName(gs));
+            fmt::format_to(std::back_inserter(buf), "{}", a.argumentName(gs));
         }
     }
-    fmt::format_to(buf, ")\n");
+    fmt::format_to(std::back_inserter(buf), ")\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "{}\n", this->rhs.toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "{}\n", this->rhs.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "end");
+    fmt::format_to(std::back_inserter(buf), "end");
     return fmt::to_string(buf);
 }
 
 string MethodDef::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
 
     auto stringifiedFlags = vector<string>{};
@@ -579,102 +579,103 @@ string MethodDef::showRaw(const core::GlobalState &gs, int tabs) {
     if (this->flags.isRewriterSynthesized) {
         stringifiedFlags.emplace_back("rewriter");
     }
-    fmt::format_to(buf, "flags = {{{}}}\n", fmt::join(stringifiedFlags, ", "));
+    fmt::format_to(std::back_inserter(buf), "flags = {{{}}}\n", fmt::join(stringifiedFlags, ", "));
 
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "name = {}<{}>\n", name.showRaw(gs), this->symbol.data(gs)->name.showRaw(gs));
+    fmt::format_to(std::back_inserter(buf), "name = {}<{}>\n", name.showRaw(gs),
+                   this->symbol.data(gs)->name.showRaw(gs));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "args = [");
+    fmt::format_to(std::back_inserter(buf), "args = [");
     bool first = true;
     if (this->symbol == core::Symbols::todoMethod()) {
         for (auto &a : this->args) {
             if (!first) {
-                fmt::format_to(buf, ", ");
+                fmt::format_to(std::back_inserter(buf), ", ");
             }
             first = false;
-            fmt::format_to(buf, "{}", a.showRaw(gs, tabs + 2));
+            fmt::format_to(std::back_inserter(buf), "{}", a.showRaw(gs, tabs + 2));
         }
     } else {
         for (auto &a : this->args) {
             if (!first) {
-                fmt::format_to(buf, ", ");
+                fmt::format_to(std::back_inserter(buf), ", ");
             }
             first = false;
-            fmt::format_to(buf, "{}", a.showRaw(gs, tabs + 2));
+            fmt::format_to(std::back_inserter(buf), "{}", a.showRaw(gs, tabs + 2));
         }
     }
-    fmt::format_to(buf, "]\n");
+    fmt::format_to(std::back_inserter(buf), "]\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "rhs = {}\n", this->rhs.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "rhs = {}\n", this->rhs.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return fmt::to_string(buf);
 }
 
 string If::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
 
-    fmt::format_to(buf, "if {}\n", this->cond.toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "if {}\n", this->cond.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "{}\n", this->thenp.toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "{}\n", this->thenp.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "else\n");
+    fmt::format_to(std::back_inserter(buf), "else\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "{}\n", this->elsep.toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "{}\n", this->elsep.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "end");
+    fmt::format_to(std::back_inserter(buf), "end");
     return fmt::to_string(buf);
 }
 
 string If::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
 
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "cond = {}\n", this->cond.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "cond = {}\n", this->cond.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "thenp = {}\n", this->thenp.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "thenp = {}\n", this->thenp.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "elsep = {}\n", this->elsep.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "elsep = {}\n", this->elsep.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return fmt::to_string(buf);
 }
 
 string Assign::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
 
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "lhs = {}\n", this->lhs.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "lhs = {}\n", this->lhs.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "rhs = {}\n", this->rhs.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "rhs = {}\n", this->rhs.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return fmt::to_string(buf);
 }
 
 string While::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
 
-    fmt::format_to(buf, "while {}\n", this->cond.toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "while {}\n", this->cond.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "{}\n", this->body.toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "{}\n", this->body.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "end");
+    fmt::format_to(std::back_inserter(buf), "end");
     return fmt::to_string(buf);
 }
 
 string While::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
 
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "cond = {}\n", this->cond.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "cond = {}\n", this->cond.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "body = {}\n", this->body.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "body = {}\n", this->body.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return fmt::to_string(buf);
 }
 
@@ -689,13 +690,13 @@ string UnresolvedConstantLit::toStringWithTabs(const core::GlobalState &gs, int 
 string UnresolvedConstantLit::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
 
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "scope = {}\n", this->scope.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "scope = {}\n", this->scope.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "cnst = {}\n", this->cnst.showRaw(gs));
+    fmt::format_to(std::back_inserter(buf), "cnst = {}\n", this->cnst.showRaw(gs));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return fmt::to_string(buf);
 }
 
@@ -709,20 +710,22 @@ string ConstantLit::toStringWithTabs(const core::GlobalState &gs, int tabs) cons
 string ConstantLit::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
 
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "orig = {}\n", this->original ? this->original.showRaw(gs, tabs + 1) : "nullptr");
+    fmt::format_to(std::back_inserter(buf), "orig = {}\n",
+                   this->original ? this->original.showRaw(gs, tabs + 1) : "nullptr");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "symbol = ({} {})\n", this->symbol.showKind(gs), this->symbol.showFullName(gs));
+    fmt::format_to(std::back_inserter(buf), "symbol = ({} {})\n", this->symbol.showKind(gs),
+                   this->symbol.showFullName(gs));
     if (!resolutionScopes.empty()) {
         printTabs(buf, tabs + 1);
-        fmt::format_to(buf, "resolutionScopes = [{}]\n",
+        fmt::format_to(std::back_inserter(buf), "resolutionScopes = [{}]\n",
                        fmt::map_join(this->resolutionScopes.begin(), this->resolutionScopes.end(), ", ",
                                      [&](auto sym) { return sym.showFullName(gs); }));
     }
     printTabs(buf, tabs);
 
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return fmt::to_string(buf);
 }
 
@@ -736,11 +739,11 @@ string Local::nodeName() {
 
 string Local::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "localVariable = {}\n", this->localVariable.showRaw(gs));
+    fmt::format_to(std::back_inserter(buf), "localVariable = {}\n", this->localVariable.showRaw(gs));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return fmt::to_string(buf);
 }
 
@@ -750,28 +753,28 @@ string UnresolvedIdent::toStringWithTabs(const core::GlobalState &gs, int tabs) 
 
 string UnresolvedIdent::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "kind = ");
+    fmt::format_to(std::back_inserter(buf), "kind = ");
     switch (this->kind) {
         case Kind::Local:
-            fmt::format_to(buf, "Local");
+            fmt::format_to(std::back_inserter(buf), "Local");
             break;
         case Kind::Instance:
-            fmt::format_to(buf, "Instance");
+            fmt::format_to(std::back_inserter(buf), "Instance");
             break;
         case Kind::Class:
-            fmt::format_to(buf, "Class");
+            fmt::format_to(std::back_inserter(buf), "Class");
             break;
         case Kind::Global:
-            fmt::format_to(buf, "Global");
+            fmt::format_to(std::back_inserter(buf), "Global");
             break;
     }
-    fmt::format_to(buf, "{}", '\n');
+    fmt::format_to(std::back_inserter(buf), "{}", '\n');
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "name = {}\n", this->name.showRaw(gs));
+    fmt::format_to(std::back_inserter(buf), "name = {}\n", this->name.showRaw(gs));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
 
     return fmt::to_string(buf);
 }
@@ -837,96 +840,96 @@ string Assign::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
 
 string RescueCase::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "rescue");
+    fmt::format_to(std::back_inserter(buf), "rescue");
     bool first = true;
     for (auto &exception : this->exceptions) {
         if (first) {
             first = false;
-            fmt::format_to(buf, " ");
+            fmt::format_to(std::back_inserter(buf), " ");
         } else {
-            fmt::format_to(buf, ", ");
+            fmt::format_to(std::back_inserter(buf), ", ");
         }
-        fmt::format_to(buf, "{}", exception.toStringWithTabs(gs, tabs));
+        fmt::format_to(std::back_inserter(buf), "{}", exception.toStringWithTabs(gs, tabs));
     }
-    fmt::format_to(buf, " => {}\n", this->var.toStringWithTabs(gs, tabs));
+    fmt::format_to(std::back_inserter(buf), " => {}\n", this->var.toStringWithTabs(gs, tabs));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "{}", this->body.toStringWithTabs(gs, tabs));
+    fmt::format_to(std::back_inserter(buf), "{}", this->body.toStringWithTabs(gs, tabs));
     return fmt::to_string(buf);
 }
 
 string RescueCase::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "exceptions = [\n");
+    fmt::format_to(std::back_inserter(buf), "exceptions = [\n");
     for (auto &a : exceptions) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRaw(gs, tabs + 2));
     }
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "]\n");
+    fmt::format_to(std::back_inserter(buf), "]\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "var = {}\n", this->var.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "var = {}\n", this->var.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "body = {}\n", this->body.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "body = {}\n", this->body.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return fmt::to_string(buf);
 }
 
 string Rescue::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}", this->body.toStringWithTabs(gs, tabs));
+    fmt::format_to(std::back_inserter(buf), "{}", this->body.toStringWithTabs(gs, tabs));
     for (auto &rescueCase : this->rescueCases) {
-        fmt::format_to(buf, "\n");
+        fmt::format_to(std::back_inserter(buf), "\n");
         printTabs(buf, tabs - 1);
-        fmt::format_to(buf, "{}", rescueCase.toStringWithTabs(gs, tabs));
+        fmt::format_to(std::back_inserter(buf), "{}", rescueCase.toStringWithTabs(gs, tabs));
     }
     if (!isa_tree<EmptyTree>(this->else_)) {
-        fmt::format_to(buf, "\n");
+        fmt::format_to(std::back_inserter(buf), "\n");
         printTabs(buf, tabs - 1);
-        fmt::format_to(buf, "else\n");
+        fmt::format_to(std::back_inserter(buf), "else\n");
         printTabs(buf, tabs);
-        fmt::format_to(buf, "{}", this->else_.toStringWithTabs(gs, tabs));
+        fmt::format_to(std::back_inserter(buf), "{}", this->else_.toStringWithTabs(gs, tabs));
     }
     if (!isa_tree<EmptyTree>(this->ensure)) {
-        fmt::format_to(buf, "\n");
+        fmt::format_to(std::back_inserter(buf), "\n");
         printTabs(buf, tabs - 1);
-        fmt::format_to(buf, "ensure\n");
+        fmt::format_to(std::back_inserter(buf), "ensure\n");
         printTabs(buf, tabs);
-        fmt::format_to(buf, "{}", this->ensure.toStringWithTabs(gs, tabs));
+        fmt::format_to(std::back_inserter(buf), "{}", this->ensure.toStringWithTabs(gs, tabs));
     }
     return fmt::to_string(buf);
 }
 
 string Rescue::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "body = {}\n", this->body.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "body = {}\n", this->body.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "rescueCases = [\n");
+    fmt::format_to(std::back_inserter(buf), "rescueCases = [\n");
     for (auto &a : rescueCases) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRaw(gs, tabs + 2));
     }
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "]\n");
+    fmt::format_to(std::back_inserter(buf), "]\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "else = {}\n", this->else_.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "else = {}\n", this->else_.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "ensure = {}\n", this->ensure.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "ensure = {}\n", this->ensure.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return fmt::to_string(buf);
 }
 
 string Send::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}.{}", this->recv.toStringWithTabs(gs, tabs), this->fun.toString(gs));
+    fmt::format_to(std::back_inserter(buf), "{}.{}", this->recv.toStringWithTabs(gs, tabs), this->fun.toString(gs));
     printArgs(gs, buf, this->args, tabs);
     if (this->block != nullptr) {
-        fmt::format_to(buf, "{}", this->block.toStringWithTabs(gs, tabs));
+        fmt::format_to(std::back_inserter(buf), "{}", this->block.toStringWithTabs(gs, tabs));
     }
 
     return fmt::to_string(buf);
@@ -934,53 +937,54 @@ string Send::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
 
 string Send::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "recv = {}\n", this->recv.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "recv = {}\n", this->recv.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "fun = {}\n", this->fun.showRaw(gs));
+    fmt::format_to(std::back_inserter(buf), "fun = {}\n", this->fun.showRaw(gs));
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "block = ");
+    fmt::format_to(std::back_inserter(buf), "block = ");
     if (this->block) {
-        fmt::format_to(buf, "{}\n", this->block.showRaw(gs, tabs + 1));
+        fmt::format_to(std::back_inserter(buf), "{}\n", this->block.showRaw(gs, tabs + 1));
     } else {
-        fmt::format_to(buf, "nullptr\n");
+        fmt::format_to(std::back_inserter(buf), "nullptr\n");
     }
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "pos_args = {}\n", this->numPosArgs);
+    fmt::format_to(std::back_inserter(buf), "pos_args = {}\n", this->numPosArgs);
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "args = [\n");
+    fmt::format_to(std::back_inserter(buf), "args = [\n");
     for (auto &a : args) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRaw(gs, tabs + 2));
     }
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "]\n");
+    fmt::format_to(std::back_inserter(buf), "]\n");
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
 
     return fmt::to_string(buf);
 }
 
 string Cast::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "T.{}", this->cast.toString(gs));
-    fmt::format_to(buf, "({}, {})", this->arg.toStringWithTabs(gs, tabs), this->type.toStringWithTabs(gs, tabs));
+    fmt::format_to(std::back_inserter(buf), "T.{}", this->cast.toString(gs));
+    fmt::format_to(std::back_inserter(buf), "({}, {})", this->arg.toStringWithTabs(gs, tabs),
+                   this->type.toStringWithTabs(gs, tabs));
 
     return fmt::to_string(buf);
 }
 
 string Cast::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 2);
-    fmt::format_to(buf, "cast = {},\n", this->cast.showRaw(gs));
+    fmt::format_to(std::back_inserter(buf), "cast = {},\n", this->cast.showRaw(gs));
     printTabs(buf, tabs + 2);
-    fmt::format_to(buf, "arg = {}\n", this->arg.showRaw(gs, tabs + 2));
+    fmt::format_to(std::back_inserter(buf), "arg = {}\n", this->arg.showRaw(gs, tabs + 2));
     printTabs(buf, tabs + 2);
-    fmt::format_to(buf, "type = {},\n", this->type.toString(gs));
+    fmt::format_to(std::back_inserter(buf), "type = {},\n", this->type.toString(gs));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}\n");
+    fmt::format_to(std::back_inserter(buf), "}}\n");
 
     return fmt::to_string(buf);
 }
@@ -991,44 +995,44 @@ string ZSuperArgs::showRaw(const core::GlobalState &gs, int tabs) {
 
 string Hash::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "pairs = [\n");
+    fmt::format_to(std::back_inserter(buf), "pairs = [\n");
     int i = -1;
     for (auto &key : keys) {
         i++;
         auto &value = values[i];
 
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "[\n");
+        fmt::format_to(std::back_inserter(buf), "[\n");
         printTabs(buf, tabs + 3);
-        fmt::format_to(buf, "key = {}\n", key.showRaw(gs, tabs + 3));
+        fmt::format_to(std::back_inserter(buf), "key = {}\n", key.showRaw(gs, tabs + 3));
         printTabs(buf, tabs + 3);
-        fmt::format_to(buf, "value = {}\n", value.showRaw(gs, tabs + 3));
+        fmt::format_to(std::back_inserter(buf), "value = {}\n", value.showRaw(gs, tabs + 3));
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "]\n");
+        fmt::format_to(std::back_inserter(buf), "]\n");
     }
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "]\n");
+    fmt::format_to(std::back_inserter(buf), "]\n");
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
 
     return fmt::to_string(buf);
 }
 
 string Array::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "elems = [\n");
+    fmt::format_to(std::back_inserter(buf), "elems = [\n");
     for (auto &a : elems) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRaw(gs, tabs + 2));
     }
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "]\n");
+    fmt::format_to(std::back_inserter(buf), "]\n");
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
 
     return fmt::to_string(buf);
 }
@@ -1039,59 +1043,59 @@ string ZSuperArgs::toStringWithTabs(const core::GlobalState &gs, int tabs) const
 
 string Hash::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{{");
+    fmt::format_to(std::back_inserter(buf), "{{");
     bool first = true;
     int i = -1;
     for (auto &key : this->keys) {
         i++;
         auto &value = this->values[i];
         if (!first) {
-            fmt::format_to(buf, ", ");
+            fmt::format_to(std::back_inserter(buf), ", ");
         }
         first = false;
-        fmt::format_to(buf, "{}", key.toStringWithTabs(gs, tabs + 1));
-        fmt::format_to(buf, " => ");
-        fmt::format_to(buf, "{}", value.toStringWithTabs(gs, tabs + 1));
+        fmt::format_to(std::back_inserter(buf), "{}", key.toStringWithTabs(gs, tabs + 1));
+        fmt::format_to(std::back_inserter(buf), " => ");
+        fmt::format_to(std::back_inserter(buf), "{}", value.toStringWithTabs(gs, tabs + 1));
     }
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return fmt::to_string(buf);
 }
 
 string Array::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "[");
+    fmt::format_to(std::back_inserter(buf), "[");
     printElems(gs, buf, this->elems, tabs);
-    fmt::format_to(buf, "]");
+    fmt::format_to(std::back_inserter(buf), "]");
     return fmt::to_string(buf);
 }
 
 string Block::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, " do |");
+    fmt::format_to(std::back_inserter(buf), " do |");
     printElems(gs, buf, this->args, tabs + 1);
-    fmt::format_to(buf, "|\n");
+    fmt::format_to(std::back_inserter(buf), "|\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "{}\n", this->body.toStringWithTabs(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "{}\n", this->body.toStringWithTabs(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "end");
+    fmt::format_to(std::back_inserter(buf), "end");
     return fmt::to_string(buf);
 }
 
 string Block::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{} {{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{} {{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "args = [\n");
+    fmt::format_to(std::back_inserter(buf), "args = [\n");
     for (auto &a : this->args) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(buf, "{}\n", a.showRaw(gs, tabs + 2));
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRaw(gs, tabs + 2));
     }
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "]\n");
+    fmt::format_to(std::back_inserter(buf), "]\n");
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "body = {}\n", this->body.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "body = {}\n", this->body.showRaw(gs, tabs + 1));
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return fmt::to_string(buf);
 }
 
@@ -1105,9 +1109,9 @@ string KeywordArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const
 
 string OptionalArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}", this->expr.toStringWithTabs(gs, tabs));
+    fmt::format_to(std::back_inserter(buf), "{}", this->expr.toStringWithTabs(gs, tabs));
     if (this->default_) {
-        fmt::format_to(buf, " = {}", this->default_.toStringWithTabs(gs, tabs));
+        fmt::format_to(std::back_inserter(buf), " = {}", this->default_.toStringWithTabs(gs, tabs));
     }
     return fmt::to_string(buf);
 }
@@ -1261,15 +1265,15 @@ string KeywordArg::nodeName() {
 
 string OptionalArg::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{}{{\n", nodeName());
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(buf, "expr = {}\n", expr.showRaw(gs, tabs + 1));
+    fmt::format_to(std::back_inserter(buf), "expr = {}\n", expr.showRaw(gs, tabs + 1));
     if (default_) {
         printTabs(buf, tabs + 1);
-        fmt::format_to(buf, "default_ = {}\n", default_.showRaw(gs, tabs + 1));
+        fmt::format_to(std::back_inserter(buf), "default_ = {}\n", default_.showRaw(gs, tabs + 1));
     }
     printTabs(buf, tabs);
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
 
     return fmt::to_string(buf);
 }

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -16,7 +16,7 @@ namespace {
 string spacesForTabLevel(int tabs) {
     fmt::memory_buffer ss;
     for (int i = 0; i < tabs; i++) {
-        fmt::format_to(ss, "&nbsp;");
+        fmt::format_to(std::back_inserter(ss), "&nbsp;");
     }
     return to_string(ss);
 }

--- a/common/Counters.cc
+++ b/common/Counters.cc
@@ -304,7 +304,7 @@ string getCounterStatistics() {
 
     fmt::memory_buffer buf;
 
-    fmt::format_to(buf, "Counters and Histograms: \n");
+    fmt::format_to(std::back_inserter(buf), "Counters and Histograms: \n");
 
     for (auto &cat : counterState.countersByCategory) {
         CounterImpl::CounterType sum = 0;
@@ -315,7 +315,7 @@ string getCounterStatistics() {
         }
         fast_sort(sorted, [](const auto &e1, const auto &e2) -> bool { return e1.first > e2.first; });
 
-        fmt::format_to(buf, " {}\n{:<36.36} Total :{:15}\n", cat.first, "", sum);
+        fmt::format_to(std::back_inserter(buf), " {}\n{:<36.36} Total :{:15}\n", cat.first, "", sum);
 
         if (sum == 0) {
             sum = 1;
@@ -323,9 +323,10 @@ string getCounterStatistics() {
         for (auto &e : sorted) {
             auto perc = e.first * 100.0 / sum;
             string hashes((int)(MAX_STAT_WIDTH * 1.0 * e.first / sum), '#');
-            fmt::format_to(buf, "  {:>40.40} :{:15}, {:3.1f}% {}\n", e.second, e.first, perc, hashes);
+            fmt::format_to(std::back_inserter(buf), "  {:>40.40} :{:15}, {:3.1f}% {}\n", e.second, e.first, perc,
+                           hashes);
         }
-        fmt::format_to(buf, "\n");
+        fmt::format_to(std::back_inserter(buf), "\n");
     }
 
     for (auto &hist : counterState.histograms) {
@@ -337,7 +338,7 @@ string getCounterStatistics() {
         }
         fast_sort(sorted, [](const auto &e1, const auto &e2) -> bool { return e1.first < e2.first; });
 
-        fmt::format_to(buf, " {}\n{:<36.36} Total :{:15}\n", hist.first, "", sum);
+        fmt::format_to(std::back_inserter(buf), " {}\n{:<36.36} Total :{:15}\n", hist.first, "", sum);
 
         CounterImpl::CounterType header = 0;
         auto it = sorted.begin();
@@ -349,27 +350,29 @@ string getCounterStatistics() {
         if (it != sorted.begin()) {
             auto perc = header * 100.0 / sum;
             string hashes((int)(MAX_STAT_WIDTH * 1.0 * header / sum), '#');
-            fmt::format_to(buf, "  <{:>39.39} :{:15}, {:5.1f}% {}\n", to_string(it->first), header, perc, hashes);
+            fmt::format_to(std::back_inserter(buf), "  <{:>39.39} :{:15}, {:5.1f}% {}\n", to_string(it->first), header,
+                           perc, hashes);
         }
 
         while (it != sorted.end() && (sum - header) * 1.0 / sum > cutoff) {
             header += it->second;
             auto perc = it->second * 100.0 / sum;
             string hashes((int)(MAX_STAT_WIDTH * 1.0 * it->second / sum), '#');
-            fmt::format_to(buf, "  {:>40.40} :{:15}, {:5.1f}% {}\n", to_string(it->first), it->second, perc, hashes);
+            fmt::format_to(std::back_inserter(buf), "  {:>40.40} :{:15}, {:5.1f}% {}\n", to_string(it->first),
+                           it->second, perc, hashes);
             it++;
         }
         if (it != sorted.end()) {
             auto perc = (sum - header) * 100.0 / sum;
             string hashes((int)(MAX_STAT_WIDTH * 1.0 * (sum - header) / sum), '#');
-            fmt::format_to(buf, "  >={:>38.38} :{:15}, {:5.1f}% {}\n", to_string(it->first), sum - header, perc,
-                           hashes);
+            fmt::format_to(std::back_inserter(buf), "  >={:>38.38} :{:15}, {:5.1f}% {}\n", to_string(it->first),
+                           sum - header, perc, hashes);
         }
-        fmt::format_to(buf, "\n");
+        fmt::format_to(std::back_inserter(buf), "\n");
     }
 
     {
-        fmt::format_to(buf, "Timings: \n");
+        fmt::format_to(std::back_inserter(buf), "Timings: \n");
         vector<pair<string, string>> sortedTimings;
         UnorderedMap<string, vector<double>> timings;
         for (const auto &e : counterState.timings) {
@@ -394,13 +397,13 @@ string getCounterStatistics() {
         }
         fast_sort(sortedTimings, [](const auto &e1, const auto &e2) -> bool { return e1.first < e2.first; });
 
-        fmt::format_to(buf, "{}",
+        fmt::format_to(std::back_inserter(buf), "{}",
                        fmt::map_join(
                            sortedTimings, "", [](const auto &el) -> auto { return el.second; }));
     }
 
     {
-        fmt::format_to(buf, "Counters: \n");
+        fmt::format_to(std::back_inserter(buf), "Counters: \n");
 
         vector<pair<string, string>> sortedOther;
         for (auto &e : counterState.counters) {
@@ -410,7 +413,7 @@ string getCounterStatistics() {
 
         fast_sort(sortedOther, [](const auto &e1, const auto &e2) -> bool { return e1.first < e2.first; });
 
-        fmt::format_to(buf, "{}",
+        fmt::format_to(std::back_inserter(buf), "{}",
                        fmt::map_join(
                            sortedOther, "", [](const auto &el) -> auto { return el.second; }));
     }

--- a/common/JSON.cc
+++ b/common/JSON.cc
@@ -40,16 +40,16 @@ string JSON::escape(string from) {
                 if (0x00 <= ch && ch <= 0x1f) {
                     string_view toAdd(from.data() + firstUnusedChar, currentChar - firstUnusedChar);
                     firstUnusedChar = currentChar + 1;
-                    fmt::format_to(buf, "{}\\u{:04x}", toAdd, ch);
+                    fmt::format_to(std::back_inserter(buf), "{}\\u{:04x}", toAdd, ch);
                 }
                 continue;
         }
         string_view toAdd(from.data() + firstUnusedChar, currentChar - firstUnusedChar);
         firstUnusedChar = currentChar + 1;
-        fmt::format_to(buf, "{}{}", toAdd, special);
+        fmt::format_to(std::back_inserter(buf), "{}{}", toAdd, special);
     }
     string_view toAdd(from.data() + firstUnusedChar, from.size() - firstUnusedChar);
-    fmt::format_to(buf, "{}", toAdd);
+    fmt::format_to(std::back_inserter(buf), "{}", toAdd);
 
     return to_string(buf);
 }

--- a/common/os/linux.cc
+++ b/common/os/linux.cc
@@ -37,7 +37,7 @@ string addr2line(string_view programName, void const *const *addr, int count) {
     for (int i = 3; i < count; ++i) {
         char buf[4096];
         symbolize_pc(const_cast<void *>(addr[i]), "%p in %f %s:%l:%c", buf, sizeof(buf));
-        fmt::format_to(os, "  #{} {}\n", i, buf);
+        fmt::format_to(std::back_inserter(os), "  #{} {}\n", i, buf);
     }
     return to_string(os);
 }

--- a/core/ErrorFlusherStdout.cc
+++ b/core/ErrorFlusherStdout.cc
@@ -19,10 +19,10 @@ void ErrorFlusherStdout::flushErrors(spdlog::logger &logger, const GlobalState &
 
             auto &out = error->error->isCritical() ? critical : nonCritical;
             if (out.size() != 0) {
-                fmt::format_to(out, "\n\n");
+                fmt::format_to(std::back_inserter(out), "\n\n");
             }
             ENFORCE(error->text.has_value());
-            fmt::format_to(out, "{}", error->text.value_or(""));
+            fmt::format_to(std::back_inserter(out), "{}", error->text.value_or(""));
 
             for (auto &autocorrect : error->error->autocorrects) {
                 autocorrects.emplace_back(move(autocorrect));

--- a/core/TypeConstraint.cc
+++ b/core/TypeConstraint.cc
@@ -265,7 +265,7 @@ string TypeConstraint::toString(const core::GlobalState &gs) const {
     auto collated = this->collateBounds(gs);
 
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "bounds: [{}]\n",
+    fmt::format_to(std::back_inserter(buf), "bounds: [{}]\n",
                    fmt::map_join(
                        collated.begin(), collated.end(), ", ", [&gs](auto entry) -> auto {
                            const auto &[sym, bounds] = entry;
@@ -274,7 +274,7 @@ string TypeConstraint::toString(const core::GlobalState &gs) const {
                            auto upper = upperBound != nullptr ? upperBound.show(gs) : "_";
                            return fmt::format("{} <: {} <: {}", lower, sym.show(gs), upper);
                        }));
-    fmt::format_to(buf, "solution: [{}]\n",
+    fmt::format_to(std::back_inserter(buf), "solution: [{}]\n",
                    fmt::map_join(
                        this->solution.begin(), this->solution.end(), ", ", [&gs](auto pair) -> auto {
                            return fmt::format("{}: {}", pair.first.show(gs), pair.second.show(gs));

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -79,13 +79,13 @@ string TupleType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     auto thisTabs = buildTabs(tabs);
     auto nestedTabs = buildTabs(tabs + 1);
-    fmt::format_to(buf, "TupleType {{\n");
+    fmt::format_to(std::back_inserter(buf), "TupleType {{\n");
     int i = -1;
     for (auto &el : this->elems) {
         i++;
-        fmt::format_to(buf, "{}{} = {}\n", nestedTabs, i, el.toStringWithTabs(gs, tabs + 3));
+        fmt::format_to(std::back_inserter(buf), "{}{} = {}\n", nestedTabs, i, el.toStringWithTabs(gs, tabs + 3));
     }
-    fmt::format_to(buf, "{}}}", thisTabs);
+    fmt::format_to(std::back_inserter(buf), "{}}}", thisTabs);
     return to_string(buf);
 }
 
@@ -101,39 +101,39 @@ string ShapeType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     auto thisTabs = buildTabs(tabs);
     auto nestedTabs = buildTabs(tabs + 1);
-    fmt::format_to(buf, "ShapeType {{\n");
+    fmt::format_to(std::back_inserter(buf), "ShapeType {{\n");
     auto valueIterator = this->values.begin();
     for (auto &el : this->keys) {
-        fmt::format_to(buf, "{}{} => {}\n", nestedTabs, el.toStringWithTabs(gs, tabs + 2),
+        fmt::format_to(std::back_inserter(buf), "{}{} => {}\n", nestedTabs, el.toStringWithTabs(gs, tabs + 2),
                        (*valueIterator).toStringWithTabs(gs, tabs + 3));
         ++valueIterator;
     }
-    fmt::format_to(buf, "{}}}", thisTabs);
+    fmt::format_to(std::back_inserter(buf), "{}}}", thisTabs);
     return to_string(buf);
 }
 
 string ShapeType::show(const GlobalState &gs) const {
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "{{");
+    fmt::format_to(std::back_inserter(buf), "{{");
     auto valueIterator = this->values.begin();
     bool first = true;
     for (auto &key : this->keys) {
         if (first) {
             first = false;
         } else {
-            fmt::format_to(buf, ", ");
+            fmt::format_to(std::back_inserter(buf), ", ");
         }
         auto underlying = cast_type_nonnull<LiteralType>(key).underlying(gs);
         ClassOrModuleRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
         if (undSymbol == Symbols::Symbol()) {
-            fmt::format_to(buf, "{}: {}", cast_type_nonnull<LiteralType>(key).asName(gs).show(gs),
+            fmt::format_to(std::back_inserter(buf), "{}: {}", cast_type_nonnull<LiteralType>(key).asName(gs).show(gs),
                            (*valueIterator).show(gs));
         } else {
-            fmt::format_to(buf, "{} => {}", key.show(gs), (*valueIterator).show(gs));
+            fmt::format_to(std::back_inserter(buf), "{} => {}", key.show(gs), (*valueIterator).show(gs));
         }
         ++valueIterator;
     }
-    fmt::format_to(buf, "}}");
+    fmt::format_to(std::back_inserter(buf), "}}");
     return to_string(buf);
 }
 
@@ -331,22 +331,22 @@ string AppliedType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     auto nestedTabs = buildTabs(tabs + 1);
     auto twiceNestedTabs = buildTabs(tabs + 2);
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "AppliedType {{\n{}klass = {}\n{}targs = [\n", nestedTabs, this->klass.toStringFullName(gs),
-                   nestedTabs);
+    fmt::format_to(std::back_inserter(buf), "AppliedType {{\n{}klass = {}\n{}targs = [\n", nestedTabs,
+                   this->klass.toStringFullName(gs), nestedTabs);
 
     int i = -1;
     for (auto &targ : this->targs) {
         ++i;
         if (i < this->klass.data(gs)->typeMembers().size()) {
             auto tyMem = this->klass.data(gs)->typeMembers()[i];
-            fmt::format_to(buf, "{}{} = {}\n", twiceNestedTabs, tyMem.data(gs)->name.showRaw(gs),
+            fmt::format_to(std::back_inserter(buf), "{}{} = {}\n", twiceNestedTabs, tyMem.data(gs)->name.showRaw(gs),
                            targ.toStringWithTabs(gs, tabs + 3));
         } else {
             // this happens if we try to print type before resolver has processed stdlib
-            fmt::format_to(buf, "{}EARLY_TYPE_MEMBER\n", twiceNestedTabs);
+            fmt::format_to(std::back_inserter(buf), "{}EARLY_TYPE_MEMBER\n", twiceNestedTabs);
         }
     }
-    fmt::format_to(buf, "{}]\n{}}}", nestedTabs, thisTabs);
+    fmt::format_to(std::back_inserter(buf), "{}]\n{}}}", nestedTabs, thisTabs);
 
     return to_string(buf);
 }
@@ -354,20 +354,20 @@ string AppliedType::toStringWithTabs(const GlobalState &gs, int tabs) const {
 string AppliedType::show(const GlobalState &gs) const {
     fmt::memory_buffer buf;
     if (this->klass == Symbols::Array()) {
-        fmt::format_to(buf, "T::Array");
+        fmt::format_to(std::back_inserter(buf), "T::Array");
     } else if (this->klass == Symbols::Hash()) {
-        fmt::format_to(buf, "T::Hash");
+        fmt::format_to(std::back_inserter(buf), "T::Hash");
     } else if (this->klass == Symbols::Enumerable()) {
-        fmt::format_to(buf, "T::Enumerable");
+        fmt::format_to(std::back_inserter(buf), "T::Enumerable");
     } else if (this->klass == Symbols::Enumerator()) {
-        fmt::format_to(buf, "T::Enumerator");
+        fmt::format_to(std::back_inserter(buf), "T::Enumerator");
     } else if (this->klass == Symbols::Range()) {
-        fmt::format_to(buf, "T::Range");
+        fmt::format_to(std::back_inserter(buf), "T::Range");
     } else if (this->klass == Symbols::Set()) {
-        fmt::format_to(buf, "T::Set");
+        fmt::format_to(std::back_inserter(buf), "T::Set");
     } else {
         if (std::optional<int> procArity = Types::getProcArity(*this)) {
-            fmt::format_to(buf, "T.proc");
+            fmt::format_to(std::back_inserter(buf), "T.proc");
 
             // The first element in targs is the return type.
             // The rest are the arguments (in the correct order)
@@ -377,28 +377,28 @@ string AppliedType::show(const GlobalState &gs) const {
             targs_it++;
 
             if (*procArity > 0) {
-                fmt::format_to(buf, ".params(");
+                fmt::format_to(std::back_inserter(buf), ".params(");
             }
 
             int arg_num = 0;
-            fmt::format_to(buf, "{}",
+            fmt::format_to(std::back_inserter(buf), "{}",
                            fmt::map_join(
                                targs_it, this->targs.end(), ", ", [&](auto targ) -> auto {
                                    return fmt::format("arg{}: {}", arg_num++, targ.show(gs));
                                }));
 
             if (*procArity > 0) {
-                fmt::format_to(buf, ")");
+                fmt::format_to(std::back_inserter(buf), ")");
             }
 
             if (return_type == core::Types::void_()) {
-                fmt::format_to(buf, ".void");
+                fmt::format_to(std::back_inserter(buf), ".void");
             } else {
-                fmt::format_to(buf, ".returns({})", return_type.show(gs));
+                fmt::format_to(std::back_inserter(buf), ".returns({})", return_type.show(gs));
             }
             return to_string(buf);
         } else {
-            fmt::format_to(buf, "{}", this->klass.show(gs));
+            fmt::format_to(std::back_inserter(buf), "{}", this->klass.show(gs));
         }
     }
     auto targs = this->targs;
@@ -420,7 +420,8 @@ string AppliedType::show(const GlobalState &gs) const {
     }
 
     if (!targs.empty()) {
-        fmt::format_to(buf, "[{}]", fmt::map_join(targs, ", ", [&](auto targ) { return targ.show(gs); }));
+        fmt::format_to(std::back_inserter(buf), "[{}]",
+                       fmt::map_join(targs, ", ", [&](auto targ) { return targ.show(gs); }));
     }
     return to_string(buf);
 }

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -418,7 +418,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
         return nullopt;
     }
 
-    fmt::format_to(ss, "sig {{");
+    fmt::format_to(std::back_inserter(ss), "sig {{");
 
     ENFORCE(!methodSymbol.data(ctx)->arguments().empty(), "There should always be at least one arg (the block arg).");
     bool onlyArgumentIsBlkArg = methodSymbol.data(ctx)->arguments().size() == 1 &&
@@ -428,13 +428,13 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
         // Only need override / implementation if the parent has a sig
         if (closestMethod.exists() && closestMethod.data(ctx)->resultType != nullptr) {
             if (closestMethod.data(ctx)->isAbstract() || childNeedsOverride(ctx, methodSymbol, closestMethod)) {
-                fmt::format_to(ss, "override.");
+                fmt::format_to(std::back_inserter(ss), "override.");
             }
         }
     }
 
     if (!onlyArgumentIsBlkArg) {
-        fmt::format_to(ss, "params(");
+        fmt::format_to(std::back_inserter(ss), "params(");
 
         bool first = true;
         for (auto &argSym : methodSymbol.data(ctx)->arguments()) {
@@ -448,7 +448,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
                 continue;
             }
             if (!first) {
-                fmt::format_to(ss, ", ");
+                fmt::format_to(std::back_inserter(ss), ", ");
             }
             first = false;
             auto argType = guessedArgumentTypes[argSym.name];
@@ -466,9 +466,9 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
                 // TODO: maybe combine the old and new types in some way?
                 chosenType = oldType;
             }
-            fmt::format_to(ss, "{}: {}", argSym.argumentName(ctx), chosenType.show(ctx));
+            fmt::format_to(std::back_inserter(ss), "{}: {}", argSym.argumentName(ctx), chosenType.show(ctx));
         }
-        fmt::format_to(ss, ").");
+        fmt::format_to(std::back_inserter(ss), ").");
     }
     if (!guessedSomethingUseful) {
         return nullopt;
@@ -479,9 +479,9 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
                          !guessedReturnType.isUntyped() && !guessedReturnType.isBottom());
 
     if (suggestsVoid) {
-        fmt::format_to(ss, "void}}");
+        fmt::format_to(std::back_inserter(ss), "void}}");
     } else {
-        fmt::format_to(ss, "returns({})}}", guessedReturnType.show(ctx));
+        fmt::format_to(std::back_inserter(ss), "returns({})}}", guessedReturnType.show(ctx));
     }
 
     auto [replacementLoc, padding] = loc.findStartOfLine(ctx);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -299,10 +299,10 @@ void KnowledgeRef::removeReferencesToVar(cfg::LocalRef var) {
 string TestedKnowledge::toString(const core::GlobalState &gs, const cfg::CFG &cfg) const {
     fmt::memory_buffer buf;
     if (!_truthy->noTypeTests.empty() || !_truthy->yesTypeTests.empty()) {
-        fmt::format_to(buf, "  Being truthy entails:\n{}", _truthy->toString(gs, cfg));
+        fmt::format_to(std::back_inserter(buf), "  Being truthy entails:\n{}", _truthy->toString(gs, cfg));
     }
     if (!_falsy->noTypeTests.empty() || !_falsy->yesTypeTests.empty()) {
-        fmt::format_to(buf, "  Being falsy entails:\n{}", _falsy->toString(gs, cfg));
+        fmt::format_to(std::back_inserter(buf), "  Being falsy entails:\n{}", _falsy->toString(gs, cfg));
     }
     return to_string(buf);
 }
@@ -367,7 +367,7 @@ void TestedKnowledge::sanityCheck() const {
 string Environment::toString(const core::GlobalState &gs, const cfg::CFG &cfg) const {
     fmt::memory_buffer buf;
     if (isDead) {
-        fmt::format_to(buf, "dead={:d}\n", isDead);
+        fmt::format_to(std::back_inserter(buf), "dead={:d}\n", isDead);
     }
     vector<pair<cfg::LocalRef, VariableState>> sorted;
     for (const auto &pair : _vars) {
@@ -384,8 +384,9 @@ string Environment::toString(const core::GlobalState &gs, const cfg::CFG &cfg) c
         if (var.data(cfg)._name == core::Names::debugEnvironmentTemp()) {
             continue;
         }
-        fmt::format_to(buf, "{}: {}{}\n{}\n", var.showRaw(gs, cfg), state.typeAndOrigins.type.toStringWithTabs(gs, 0),
-                       state.knownTruthy ? " (and truthy)\n" : "", state.knowledge.toString(gs, cfg));
+        fmt::format_to(std::back_inserter(buf), "{}: {}{}\n{}\n", var.showRaw(gs, cfg),
+                       state.typeAndOrigins.type.toStringWithTabs(gs, 0), state.knownTruthy ? " (and truthy)\n" : "",
+                       state.knowledge.toString(gs, cfg));
     }
     return to_string(buf);
 }

--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -76,7 +76,7 @@ string ParsedFile::toString(const core::GlobalState &gs) const {
     fmt::memory_buffer out;
     auto nameToString = [&](const auto &nm) -> string { return nm.show(gs); };
 
-    fmt::format_to(out,
+    fmt::format_to(std::back_inserter(out),
                    "# ParsedFile: {}\n"
                    "requires: [{}]\n"
                    "## defs:\n",
@@ -99,7 +99,7 @@ string ParsedFile::toString(const core::GlobalState &gs) const {
                 break;
         }
 
-        fmt::format_to(out,
+        fmt::format_to(std::back_inserter(out),
                        "[def id={}]\n"
                        " type={}\n"
                        " defines_behavior={}\n"
@@ -109,20 +109,23 @@ string ParsedFile::toString(const core::GlobalState &gs) const {
         if (def.defining_ref.exists()) {
             auto &ref = def.defining_ref.data(*this);
             if (ref.name.package) {
-                fmt::format_to(out, " defining_pkg=[{}]\n", nameToString(*ref.name.package));
+                fmt::format_to(std::back_inserter(out), " defining_pkg=[{}]\n", nameToString(*ref.name.package));
             }
-            fmt::format_to(out, " defining_ref=[{}]\n", fmt::map_join(ref.name.nameParts, " ", nameToString));
+            fmt::format_to(std::back_inserter(out), " defining_ref=[{}]\n",
+                           fmt::map_join(ref.name.nameParts, " ", nameToString));
         }
         if (def.parent_ref.exists()) {
             auto &ref = def.parent_ref.data(*this);
-            fmt::format_to(out, " parent_ref=[{}]\n", fmt::map_join(ref.name.nameParts, " ", nameToString));
+            fmt::format_to(std::back_inserter(out), " parent_ref=[{}]\n",
+                           fmt::map_join(ref.name.nameParts, " ", nameToString));
         }
         if (def.aliased_ref.exists()) {
             auto &ref = def.aliased_ref.data(*this);
-            fmt::format_to(out, " aliased_ref=[{}]\n", fmt::map_join(ref.name.nameParts, " ", nameToString));
+            fmt::format_to(std::back_inserter(out), " aliased_ref=[{}]\n",
+                           fmt::map_join(ref.name.nameParts, " ", nameToString));
         }
     }
-    fmt::format_to(out, "## refs:\n");
+    fmt::format_to(std::back_inserter(out), "## refs:\n");
     for (auto &ref : refs) {
         vector<string> nestingStrings;
         for (auto &scope : ref.nesting) {
@@ -131,7 +134,7 @@ string ParsedFile::toString(const core::GlobalState &gs) const {
         }
 
         auto refFullName = showFullName(gs, ref.scope);
-        fmt::format_to(out,
+        fmt::format_to(std::back_inserter(out),
                        "[ref id={}]\n"
                        " scope=[{}]\n"
                        " name=[{}]\n"
@@ -147,7 +150,8 @@ string ParsedFile::toString(const core::GlobalState &gs) const {
 
         if (ref.parent_of.exists()) {
             auto parentOfFullName = showFullName(gs, ref.parent_of);
-            fmt::format_to(out, " parent_of=[{}]\n", fmt::map_join(parentOfFullName, " ", nameToString));
+            fmt::format_to(std::back_inserter(out), " parent_of=[{}]\n",
+                           fmt::map_join(parentOfFullName, " ", nameToString));
         }
     }
     return to_string(out);

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -245,7 +245,7 @@ vector<core::LocalVariable> allSimilarLocals(const core::GlobalState &gs, const 
 string methodSnippet(const core::GlobalState &gs, core::DispatchResult &dispatchResult, core::SymbolRef method,
                      const core::TypePtr &receiverType, const core::TypeConstraint *constraint, u2 totalArgs) {
     fmt::memory_buffer result;
-    fmt::format_to(result, "{}", method.data(gs)->name.shortName(gs));
+    fmt::format_to(std::back_inserter(result), "{}", method.data(gs)->name.shortName(gs));
     auto nextTabstop = 1;
 
     /* If we are completing an existing send that either has some arguments
@@ -253,7 +253,7 @@ string methodSnippet(const core::GlobalState &gs, core::DispatchResult &dispatch
      * since the rest is likely useless
      */
     if (totalArgs > 0 || dispatchResult.main.blockReturnType != nullptr) {
-        fmt::format_to(result, "${{0}}");
+        fmt::format_to(std::back_inserter(result), "${{0}}");
         return to_string(result);
     }
 
@@ -271,19 +271,19 @@ string methodSnippet(const core::GlobalState &gs, core::DispatchResult &dispatch
             continue;
         }
         if (argSym.flags.isKeyword) {
-            fmt::format_to(argBuf, "{}: ", argSym.name.shortName(gs));
+            fmt::format_to(std::back_inserter(argBuf), "{}: ", argSym.name.shortName(gs));
         }
         if (argSym.type) {
             auto resultType = getResultType(gs, argSym.type, method, receiverType, constraint).show(gs);
-            fmt::format_to(argBuf, "${{{}:{}}}", nextTabstop++, resultType);
+            fmt::format_to(std::back_inserter(argBuf), "${{{}:{}}}", nextTabstop++, resultType);
         } else {
-            fmt::format_to(argBuf, "${{{}}}", nextTabstop++);
+            fmt::format_to(std::back_inserter(argBuf), "${{{}}}", nextTabstop++);
         }
         typeAndArgNames.emplace_back(to_string(argBuf));
     }
 
     if (!typeAndArgNames.empty()) {
-        fmt::format_to(result, "({})", fmt::join(typeAndArgNames, ", "));
+        fmt::format_to(std::back_inserter(result), "({})", fmt::join(typeAndArgNames, ", "));
     }
 
     ENFORCE(!method.data(gs)->arguments().empty());
@@ -305,10 +305,10 @@ string methodSnippet(const core::GlobalState &gs, core::DispatchResult &dispatch
             }
         }
 
-        fmt::format_to(result, " do{}\n  ${{{}}}\nend", blkArgs, nextTabstop++);
+        fmt::format_to(std::back_inserter(result), " do{}\n  ${{{}}}\nend", blkArgs, nextTabstop++);
     }
 
-    fmt::format_to(result, "${{0}}");
+    fmt::format_to(std::back_inserter(result), "${{0}}");
     return to_string(result);
 }
 

--- a/main/lsp/tools/generate_lsp_messages.cc
+++ b/main/lsp/tools/generate_lsp_messages.cc
@@ -30,15 +30,15 @@ int main(int argc, char **argv) {
         fmt::memory_buffer enumHeaderBuffer;
         fmt::memory_buffer enumClassFileBuffer;
 
-        fmt::format_to(enumClassFileBuffer, "#include \"main/lsp/json_types.h\"\n");
-        fmt::format_to(enumClassFileBuffer, "#include \"main/lsp/lsp_messages_gen_helpers.h\"\n");
-        fmt::format_to(enumClassFileBuffer, "namespace sorbet::realmain::lsp {{\n");
+        fmt::format_to(std::back_inserter(enumClassFileBuffer), "#include \"main/lsp/json_types.h\"\n");
+        fmt::format_to(std::back_inserter(enumClassFileBuffer), "#include \"main/lsp/lsp_messages_gen_helpers.h\"\n");
+        fmt::format_to(std::back_inserter(enumClassFileBuffer), "namespace sorbet::realmain::lsp {{\n");
 
         // Emits enums before class definitions themselves.
         for (auto &enumType : enumTypes) {
             enumType->emit(enumHeaderBuffer, enumClassFileBuffer);
         }
-        fmt::format_to(enumClassFileBuffer, "}}\n");
+        fmt::format_to(std::back_inserter(enumClassFileBuffer), "}}\n");
 
         if (!writeFile(argv[3], enumHeaderBuffer)) {
             return 1;
@@ -54,14 +54,14 @@ int main(int argc, char **argv) {
         fmt::memory_buffer headerBuffer;
         fmt::memory_buffer classFileBuffer;
 
-        fmt::format_to(classFileBuffer, "#include \"main/lsp/json_types.h\"\n");
-        fmt::format_to(classFileBuffer, "#include \"main/lsp/lsp_messages_gen_helpers.h\"\n");
-        fmt::format_to(classFileBuffer, "namespace sorbet::realmain::lsp {{\n");
+        fmt::format_to(std::back_inserter(classFileBuffer), "#include \"main/lsp/json_types.h\"\n");
+        fmt::format_to(std::back_inserter(classFileBuffer), "#include \"main/lsp/lsp_messages_gen_helpers.h\"\n");
+        fmt::format_to(std::back_inserter(classFileBuffer), "namespace sorbet::realmain::lsp {{\n");
 
         for (auto &classType : classTypes) {
             classType->emit(headerBuffer, classFileBuffer);
         }
-        fmt::format_to(classFileBuffer, "}}\n");
+        fmt::format_to(std::back_inserter(classFileBuffer), "}}\n");
 
         // Output buffers to files.
         if (!writeFile(argv[1], headerBuffer)) {

--- a/main/lsp/tools/generate_lsp_messages.h
+++ b/main/lsp/tools/generate_lsp_messages.h
@@ -246,12 +246,13 @@ public:
     static void serializeStringToJSONValue(fmt::memory_buffer &out, std::string_view from, AssignLambda assign) {
         // Copy into document so that it owns the string.
         // Create new scope for temp var.
-        fmt::format_to(out, "{{\n");
-        fmt::format_to(out, "rapidjson::Value strCopy;\n");
-        fmt::format_to(out, "const std::string &tmpStr = {0};\n", from);
-        fmt::format_to(out, "strCopy.SetString(tmpStr.c_str(), tmpStr.length(), {0});\n", ALLOCATOR_VAR);
+        fmt::format_to(std::back_inserter(out), "{{\n");
+        fmt::format_to(std::back_inserter(out), "rapidjson::Value strCopy;\n");
+        fmt::format_to(std::back_inserter(out), "const std::string &tmpStr = {0};\n", from);
+        fmt::format_to(std::back_inserter(out), "strCopy.SetString(tmpStr.c_str(), tmpStr.length(), {0});\n",
+                       ALLOCATOR_VAR);
         assign(out, "strCopy");
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
     }
 
     bool wantMove() const {
@@ -320,9 +321,10 @@ public:
 
     void emitToJSONValue(fmt::memory_buffer &out, std::string_view from, AssignLambda assign,
                          std::string_view fieldName) {
-        fmt::format_to(out, "if ({} != \"{}\") {{\n", from, value);
-        fmt::format_to(out, "throw InvalidConstantValueError(\"{}\", \"{}\", {});\n", fieldName, value, from);
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "if ({} != \"{}\") {{\n", from, value);
+        fmt::format_to(std::back_inserter(out), "throw InvalidConstantValueError(\"{}\", \"{}\", {});\n", fieldName,
+                       value, from);
+        fmt::format_to(std::back_inserter(out), "}}\n");
         JSONStringType::serializeStringToJSONValue(out, from, assign);
     }
 };
@@ -334,11 +336,11 @@ private:
     static const std::string arrayVar;
 
     static void AssignDeserializedElementValue(fmt::memory_buffer &out, std::string_view from) {
-        fmt::format_to(out, "{}.push_back({});", arrayVar, from);
+        fmt::format_to(std::back_inserter(out), "{}.push_back({});", arrayVar, from);
     }
 
     static void AssignSerializedElementValue(fmt::memory_buffer &out, std::string_view from) {
-        fmt::format_to(out, "{}.PushBack({}, {});", arrayVar, from, ALLOCATOR_VAR);
+        fmt::format_to(std::back_inserter(out), "{}.PushBack({}, {});", arrayVar, from, ALLOCATOR_VAR);
     }
 
 public:
@@ -366,34 +368,36 @@ public:
 
     void emitFromJSONValue(fmt::memory_buffer &out, std::string_view from, AssignLambda assign,
                            std::string_view fieldName) {
-        fmt::format_to(out, "{{\n");
-        fmt::format_to(out, "auto &unwrappedVal = assertJSONField({}, \"{}\");", from, fieldName);
-        fmt::format_to(out, "if (!unwrappedVal.IsArray()) {{\n");
-        fmt::format_to(out, "throw JSONTypeError(\"{}\", \"array\", unwrappedVal);\n", fieldName, from);
+        fmt::format_to(std::back_inserter(out), "{{\n");
+        fmt::format_to(std::back_inserter(out), "auto &unwrappedVal = assertJSONField({}, \"{}\");", from, fieldName);
+        fmt::format_to(std::back_inserter(out), "if (!unwrappedVal.IsArray()) {{\n");
+        fmt::format_to(std::back_inserter(out), "throw JSONTypeError(\"{}\", \"array\", unwrappedVal);\n", fieldName,
+                       from);
         // Use else branch so we operate in new scope to avoid ArrayVar conflicts.
-        fmt::format_to(out, "}} else {{\n");
-        fmt::format_to(out, "{} {};\n", getCPPType(), arrayVar, componentType->getCPPType());
-        fmt::format_to(out, "for (auto &element : unwrappedVal.GetArray()) {{\n", from);
+        fmt::format_to(std::back_inserter(out), "}} else {{\n");
+        fmt::format_to(std::back_inserter(out), "{} {};\n", getCPPType(), arrayVar, componentType->getCPPType());
+        fmt::format_to(std::back_inserter(out), "for (auto &element : unwrappedVal.GetArray()) {{\n", from);
         // Note: All of these 'emitFromJSONValue' functions expect an optional<> type.
-        fmt::format_to(out, "auto maybeElement = std::make_optional<const rapidjson::Value *>(&element);\n");
+        fmt::format_to(std::back_inserter(out),
+                       "auto maybeElement = std::make_optional<const rapidjson::Value *>(&element);\n");
         componentType->emitFromJSONValue(out, "maybeElement", AssignDeserializedElementValue, fieldName);
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
         assign(out, fmt::format("std::move({})", arrayVar));
-        fmt::format_to(out, "}}\n");
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
     }
 
     void emitToJSONValue(fmt::memory_buffer &out, std::string_view from, AssignLambda assign,
                          std::string_view fieldName) {
         // Create new scope so our variable names don't conflict with other serialized arrays in same
         // context.
-        fmt::format_to(out, "{{\n");
-        fmt::format_to(out, "rapidjson::Value {}(rapidjson::kArrayType);\n", arrayVar);
-        fmt::format_to(out, "for (auto &element : {}) {{\n", from);
+        fmt::format_to(std::back_inserter(out), "{{\n");
+        fmt::format_to(std::back_inserter(out), "rapidjson::Value {}(rapidjson::kArrayType);\n", arrayVar);
+        fmt::format_to(std::back_inserter(out), "for (auto &element : {}) {{\n", from);
         componentType->emitToJSONValue(out, "element", AssignSerializedElementValue, fieldName);
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
         assign(out, arrayVar);
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
     }
 };
 
@@ -439,25 +443,25 @@ public:
     }
 
     void emitDeclaration(fmt::memory_buffer &out) {
-        fmt::format_to(out, "enum class {} {{\n", typeName);
+        fmt::format_to(std::back_inserter(out), "enum class {} {{\n", typeName);
         for (auto &value : enumValues) {
-            fmt::format_to(out, "{} = {},\n", value.first, value.second);
+            fmt::format_to(std::back_inserter(out), "{} = {},\n", value.first, value.second);
         }
-        fmt::format_to(out, "}};\n");
-        fmt::format_to(out, "{0} tryConvertTo{0}(int value);\n", typeName);
+        fmt::format_to(std::back_inserter(out), "}};\n");
+        fmt::format_to(std::back_inserter(out), "{0} tryConvertTo{0}(int value);\n", typeName);
     }
 
     void emitDefinition(fmt::memory_buffer &out) {
-        fmt::format_to(out, "{0} tryConvertTo{0}(int value) {{\n", typeName);
-        fmt::format_to(out, "switch (({})value) {{\n", typeName);
+        fmt::format_to(std::back_inserter(out), "{0} tryConvertTo{0}(int value) {{\n", typeName);
+        fmt::format_to(std::back_inserter(out), "switch (({})value) {{\n", typeName);
         for (auto &value : enumValues) {
-            fmt::format_to(out, "case {}:\n", enumVar(value.first));
-            fmt::format_to(out, "return {}::{};\n", typeName, value.first);
+            fmt::format_to(std::back_inserter(out), "case {}:\n", enumVar(value.first));
+            fmt::format_to(std::back_inserter(out), "return {}::{};\n", typeName, value.first);
         }
-        fmt::format_to(out, "default:\n");
-        fmt::format_to(out, "throw InvalidEnumValueError(\"{}\", value);\n", typeName);
-        fmt::format_to(out, "}}\n");
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "default:\n");
+        fmt::format_to(std::back_inserter(out), "throw InvalidEnumValueError(\"{}\", value);\n", typeName);
+        fmt::format_to(std::back_inserter(out), "}}\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
     }
 };
 
@@ -529,42 +533,44 @@ public:
     }
 
     void emitDeclaration(fmt::memory_buffer &out) {
-        fmt::format_to(out, "enum class {} {{\n", typeName);
+        fmt::format_to(std::back_inserter(out), "enum class {} {{\n", typeName);
         for (std::string_view value : enumValues) {
-            fmt::format_to(out, "{},\n", toIdentifier(value));
+            fmt::format_to(std::back_inserter(out), "{},\n", toIdentifier(value));
         }
-        fmt::format_to(out, "}};\n");
-        fmt::format_to(out, "{0} get{0}(std::string_view value);\n", typeName);
-        fmt::format_to(out, "const std::string &convert{0}ToString({0} kind);", typeName);
+        fmt::format_to(std::back_inserter(out), "}};\n");
+        fmt::format_to(std::back_inserter(out), "{0} get{0}(std::string_view value);\n", typeName);
+        fmt::format_to(std::back_inserter(out), "const std::string &convert{0}ToString({0} kind);", typeName);
     }
 
     void emitDefinition(fmt::memory_buffer &out) {
         for (std::string_view value : enumValues) {
-            fmt::format_to(out, "static const std::string {} = \"{}\";\n", enumStrVar(value), value);
+            fmt::format_to(std::back_inserter(out), "static const std::string {} = \"{}\";\n", enumStrVar(value),
+                           value);
         }
         // Map from str => enum value to facilitate conversion.
-        fmt::format_to(out, "static const UnorderedMap<std::string, {0}> StringTo{0} = {{\n", typeName);
+        fmt::format_to(std::back_inserter(out), "static const UnorderedMap<std::string, {0}> StringTo{0} = {{\n",
+                       typeName);
         for (std::string_view value : enumValues) {
-            fmt::format_to(out, "{{{}, {}}},\n", enumStrVar(value), enumVar(value));
+            fmt::format_to(std::back_inserter(out), "{{{}, {}}},\n", enumStrVar(value), enumVar(value));
         }
-        fmt::format_to(out, "}};\n");
-        fmt::format_to(out, "{0} get{0}(std::string_view value) {{\n", typeName);
-        fmt::format_to(out, "auto it = StringTo{}.find(std::string(value));\n", typeName);
-        fmt::format_to(out, "if (it == StringTo{}.end()) {{\n", typeName);
-        fmt::format_to(out, "throw InvalidStringEnumError(\"{}\", value);\n", typeName);
-        fmt::format_to(out, "}}\n");
-        fmt::format_to(out, "return it->second;\n");
-        fmt::format_to(out, "}}\n");
-        fmt::format_to(out, "const std::string &convert{0}ToString({0} kind) {{\n", typeName);
-        fmt::format_to(out, "switch (kind) {{\n");
+        fmt::format_to(std::back_inserter(out), "}};\n");
+        fmt::format_to(std::back_inserter(out), "{0} get{0}(std::string_view value) {{\n", typeName);
+        fmt::format_to(std::back_inserter(out), "auto it = StringTo{}.find(std::string(value));\n", typeName);
+        fmt::format_to(std::back_inserter(out), "if (it == StringTo{}.end()) {{\n", typeName);
+        fmt::format_to(std::back_inserter(out), "throw InvalidStringEnumError(\"{}\", value);\n", typeName);
+        fmt::format_to(std::back_inserter(out), "}}\n");
+        fmt::format_to(std::back_inserter(out), "return it->second;\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
+        fmt::format_to(std::back_inserter(out), "const std::string &convert{0}ToString({0} kind) {{\n", typeName);
+        fmt::format_to(std::back_inserter(out), "switch (kind) {{\n");
         for (std::string_view value : enumValues) {
-            fmt::format_to(out, "case {}:\n", enumVar(value));
-            fmt::format_to(out, "return {};\n", enumStrVar(value));
+            fmt::format_to(std::back_inserter(out), "case {}:\n", enumVar(value));
+            fmt::format_to(std::back_inserter(out), "return {};\n", enumStrVar(value));
         }
-        fmt::format_to(out, "default:\n");
-        fmt::format_to(out, "throw InvalidEnumValueError(\"{}\", (int) kind);\n", typeName);
-        fmt::format_to(out, "}}\n");
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "default:\n");
+        fmt::format_to(std::back_inserter(out), "throw InvalidEnumValueError(\"{}\", (int) kind);\n", typeName);
+        fmt::format_to(std::back_inserter(out), "}}\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
     }
 };
 
@@ -580,7 +586,7 @@ public:
         : jsonName(jsonName), cppName(cppName), type(type) {}
 
     void emitDeclaration(fmt::memory_buffer &out) const {
-        fmt::format_to(out, "{} {};\n", type->getCPPType(), cppName);
+        fmt::format_to(std::back_inserter(out), "{} {};\n", type->getCPPType(), cppName);
     }
 };
 
@@ -615,28 +621,28 @@ public:
                            std::string_view fieldName) {
         // Check for presence of field.
         // N.B.: Treat null fields as missing. Emacs fills in optional fields with `null` values.
-        fmt::format_to(out, "if ({0} && !(*{0})->IsNull()) {{\n", from);
+        fmt::format_to(std::back_inserter(out), "if ({0} && !(*{0})->IsNull()) {{\n", from);
         const std::string innerCPPType = innerType->getCPPType();
         AssignLambda assignOptional = [innerCPPType, assign](fmt::memory_buffer &out, std::string_view from) -> void {
             assign(out, fmt::format("std::make_optional<{}>({})", innerCPPType, from));
         };
         innerType->emitFromJSONValue(out, from, assignOptional, fieldName);
-        fmt::format_to(out, "}} else {{\n");
+        fmt::format_to(std::back_inserter(out), "}} else {{\n");
         // Ensures that optional is assigned to correct variant slot on variant types, since optional<Foo> !=
         // optional<Bar>.
         assign(out, fmt::format("std::optional<{}>(std::nullopt)", innerCPPType));
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
     }
 
     void emitToJSONValue(fmt::memory_buffer &out, std::string_view from, AssignLambda assign,
                          std::string_view fieldName) {
-        fmt::format_to(out, "if ({}.has_value()) {{\n", from);
+        fmt::format_to(std::back_inserter(out), "if ({}.has_value()) {{\n", from);
         // N.B.: Mac OSX does not support .value() on std::optional yet.
         // Dereferencing does the same thing, but does not check if the value is present.
         // But since we explicitly check `has_value()`, we're good here.
         // See: https://stackoverflow.com/a/44244070
         innerType->emitToJSONValue(out, fmt::format("(*{})", from), assign, fieldName);
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
     }
 };
 
@@ -685,16 +691,16 @@ public:
 
     void emitToJSONValue(fmt::memory_buffer &out, std::string_view from, AssignLambda assign,
                          std::string_view fieldName) {
-        fmt::format_to(out, "if ({} == nullptr) {{\n", from);
-        fmt::format_to(out, "throw NullPtrError(\"{}\");\n", fieldName);
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "if ({} == nullptr) {{\n", from);
+        fmt::format_to(std::back_inserter(out), "throw NullPtrError(\"{}\");\n", fieldName);
+        fmt::format_to(std::back_inserter(out), "}}\n");
         assign(out, fmt::format("*({}->toJSONValue({}))", from, ALLOCATOR_VAR));
     }
 
     void emitDeclaration(fmt::memory_buffer &out) {
-        fmt::format_to(out, "class {} final : public JSONBaseType {{\n", typeName);
-        fmt::format_to(out, "public:\n");
-        fmt::format_to(out,
+        fmt::format_to(std::back_inserter(out), "class {} final : public JSONBaseType {{\n", typeName);
+        fmt::format_to(std::back_inserter(out), "public:\n");
+        fmt::format_to(std::back_inserter(out),
                        "static {} fromJSONValue(const rapidjson::Value &val, std::string_view fieldName = "
                        "JSONBaseType::defaultFieldName);\n",
                        getCPPType());
@@ -704,21 +710,23 @@ public:
         auto reqFields = getRequiredFields();
         if (reqFields.size() > 0) {
             // Constructor. Only accepts non-optional fields as arguments
-            fmt::format_to(out, "{}({});\n", typeName,
+            fmt::format_to(std::back_inserter(out), "{}({});\n", typeName,
                            fmt::map_join(getRequiredFields(), ", ", [](auto field) -> std::string {
                                return fmt::format("{} {}", field->type->getCPPType(), field->cppName);
                            }));
         }
         fmt::format_to(
-            out, "std::unique_ptr<rapidjson::Value> toJSONValue(rapidjson::MemoryPoolAllocator<> &alloc) const;\n");
-        fmt::format_to(out, "{}\n", fmt::join(extraMethodDefinitions.begin(), extraMethodDefinitions.end(), "\n"));
-        fmt::format_to(out, "}};\n");
+            std::back_inserter(out),
+            "std::unique_ptr<rapidjson::Value> toJSONValue(rapidjson::MemoryPoolAllocator<> &alloc) const;\n");
+        fmt::format_to(std::back_inserter(out), "{}\n",
+                       fmt::join(extraMethodDefinitions.begin(), extraMethodDefinitions.end(), "\n"));
+        fmt::format_to(std::back_inserter(out), "}};\n");
     }
 
     void emitDefinition(fmt::memory_buffer &out) {
         auto reqFields = getRequiredFields();
         if (reqFields.size() > 0) {
-            fmt::format_to(out, "{}::{}({}): {} {{\n", typeName, typeName,
+            fmt::format_to(std::back_inserter(out), "{}::{}({}): {} {{\n", typeName, typeName,
                            fmt::map_join(reqFields, ", ",
                                          [](auto field) -> std::string {
                                              return fmt::format("{} {}", field->type->getCPPType(), field->cppName);
@@ -729,26 +737,27 @@ public:
                                }
                                return fmt::format("{}({})", field->cppName, field->cppName);
                            }));
-            fmt::format_to(out, "}}\n");
+            fmt::format_to(std::back_inserter(out), "}}\n");
         }
-        fmt::format_to(out, "{} {}::fromJSONValue(const rapidjson::Value &val, std::string_view fieldName) {{\n",
+        fmt::format_to(std::back_inserter(out),
+                       "{} {}::fromJSONValue(const rapidjson::Value &val, std::string_view fieldName) {{\n",
                        getCPPType(), typeName);
-        fmt::format_to(out, "if (!val.IsObject()) {{\n");
-        fmt::format_to(out, "throw JSONTypeError(fieldName, \"object\", val);\n");
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "if (!val.IsObject()) {{\n");
+        fmt::format_to(std::back_inserter(out), "throw JSONTypeError(fieldName, \"object\", val);\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
 
         // Process required fields first.
         for (std::shared_ptr<FieldDef> &fieldDef : reqFields) {
             std::string fieldName = fmt::format("{}.{}", typeName, fieldDef->cppName);
-            fmt::format_to(out, "auto rapidjson{} = maybeGetJSONField(val, \"{}\");\n", fieldDef->cppName,
-                           fieldDef->jsonName);
-            fmt::format_to(out, "{} {};\n", fieldDef->type->getCPPType(), fieldDef->cppName);
+            fmt::format_to(std::back_inserter(out), "auto rapidjson{} = maybeGetJSONField(val, \"{}\");\n",
+                           fieldDef->cppName, fieldDef->jsonName);
+            fmt::format_to(std::back_inserter(out), "{} {};\n", fieldDef->type->getCPPType(), fieldDef->cppName);
             AssignLambda assign = [&fieldDef](fmt::memory_buffer &out, std::string_view from) -> void {
-                fmt::format_to(out, "{} = {};\n", fieldDef->cppName, from);
+                fmt::format_to(std::back_inserter(out), "{} = {};\n", fieldDef->cppName, from);
             };
             fieldDef->type->emitFromJSONValue(out, fmt::format("rapidjson{}", fieldDef->cppName), assign, fieldName);
         }
-        fmt::format_to(out, "{} rv = std::make_unique<{}>({});\n", getCPPType(), typeName,
+        fmt::format_to(std::back_inserter(out), "{} rv = std::make_unique<{}>({});\n", getCPPType(), typeName,
                        fmt::map_join(reqFields, ", ", [](auto field) -> std::string {
                            if (field->type->wantMove()) {
                                return fmt::format("move({})", field->cppName);
@@ -761,32 +770,34 @@ public:
         for (std::shared_ptr<FieldDef> &fieldDef : fieldDefs) {
             if (dynamic_cast<JSONOptionalType *>(fieldDef->type.get())) {
                 std::string fieldName = fmt::format("{}.{}", typeName, fieldDef->cppName);
-                fmt::format_to(out, "auto rapidjson{} = maybeGetJSONField(val, \"{}\");\n", fieldDef->cppName,
-                               fieldDef->jsonName);
+                fmt::format_to(std::back_inserter(out), "auto rapidjson{} = maybeGetJSONField(val, \"{}\");\n",
+                               fieldDef->cppName, fieldDef->jsonName);
                 AssignLambda assign = [&fieldDef](fmt::memory_buffer &out, std::string_view from) -> void {
-                    fmt::format_to(out, "rv->{} = {};\n", fieldDef->cppName, from);
+                    fmt::format_to(std::back_inserter(out), "rv->{} = {};\n", fieldDef->cppName, from);
                 };
                 fieldDef->type->emitFromJSONValue(out, fmt::format("rapidjson{}", fieldDef->cppName), assign,
                                                   fieldName);
             }
         }
-        fmt::format_to(out, "return rv;\n");
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "return rv;\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
 
-        fmt::format_to(out,
+        fmt::format_to(std::back_inserter(out),
                        "std::unique_ptr<rapidjson::Value> {}::toJSONValue(rapidjson::MemoryPoolAllocator<> "
                        "&{}) const {{\n",
                        typeName, ALLOCATOR_VAR);
-        fmt::format_to(out, "auto rv = std::make_unique<rapidjson::Value>(rapidjson::kObjectType);\n");
+        fmt::format_to(std::back_inserter(out),
+                       "auto rv = std::make_unique<rapidjson::Value>(rapidjson::kObjectType);\n");
         for (std::shared_ptr<FieldDef> &fieldDef : fieldDefs) {
             std::string fieldName = fmt::format("{}.{}", typeName, fieldDef->cppName);
             AssignLambda assign = [&fieldDef](fmt::memory_buffer &out, std::string_view from) -> void {
-                fmt::format_to(out, "rv->AddMember(\"{}\", {}, {});\n", fieldDef->jsonName, from, ALLOCATOR_VAR);
+                fmt::format_to(std::back_inserter(out), "rv->AddMember(\"{}\", {}, {});\n", fieldDef->jsonName, from,
+                               ALLOCATOR_VAR);
             };
             fieldDef->type->emitToJSONValue(out, fieldDef->cppName, assign, fieldName);
         }
-        fmt::format_to(out, "return rv;\n");
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "return rv;\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
     }
 
     /**
@@ -883,39 +894,43 @@ public:
     void emitFromJSONValue(fmt::memory_buffer &out, std::string_view from, AssignLambda assign,
                            std::string_view fieldName) {
         auto enumType = getDiscriminantType();
-        fmt::format_to(out, "switch ({}) {{\n", fieldDef->cppName);
+        fmt::format_to(std::back_inserter(out), "switch ({}) {{\n", fieldDef->cppName);
         for (auto &variant : variantsByDiscriminant) {
             // getEnumValue will throw if the discriminant value is not in the enum.
-            fmt::format_to(out, "case {}:\n", enumType->getEnumValue(variant.first));
+            fmt::format_to(std::back_inserter(out), "case {}:\n", enumType->getEnumValue(variant.first));
             variant.second->emitFromJSONValue(out, from, assign, fieldName);
-            fmt::format_to(out, "break;\n");
+            fmt::format_to(std::back_inserter(out), "break;\n");
         }
-        fmt::format_to(out, "default:\n");
-        fmt::format_to(out, "throw InvalidDiscriminantValueError(\"{0}\", \"{1}\", convert{2}ToString({1}));\n",
-                       fieldName, fieldDef->cppName, enumType->getCPPType());
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "default:\n");
+        fmt::format_to(std::back_inserter(out),
+                       "throw InvalidDiscriminantValueError(\"{0}\", \"{1}\", convert{2}ToString({1}));\n", fieldName,
+                       fieldDef->cppName, enumType->getCPPType());
+        fmt::format_to(std::back_inserter(out), "}}\n");
     }
 
     void emitToJSONValue(fmt::memory_buffer &out, std::string_view from, AssignLambda assign,
                          std::string_view fieldName) {
         auto enumType = getDiscriminantType();
-        fmt::format_to(out, "switch ({}) {{\n", fieldDef->cppName);
+        fmt::format_to(std::back_inserter(out), "switch ({}) {{\n", fieldDef->cppName);
         for (auto &variant : variantsByDiscriminant) {
             // getEnumValue will throw if the discriminant value is not in the enum.
-            fmt::format_to(out, "case {}:\n", enumType->getEnumValue(variant.first));
-            fmt::format_to(out, "if (auto discVal = std::get_if<{}>(&{})) {{\n", variant.second->getCPPType(), from);
+            fmt::format_to(std::back_inserter(out), "case {}:\n", enumType->getEnumValue(variant.first));
+            fmt::format_to(std::back_inserter(out), "if (auto discVal = std::get_if<{}>(&{})) {{\n",
+                           variant.second->getCPPType(), from);
             variant.second->emitToJSONValue(out, "(*discVal)", assign, fieldName);
-            fmt::format_to(out, "}} else {{\n");
+            fmt::format_to(std::back_inserter(out), "}} else {{\n");
             fmt::format_to(
-                out, "throw InvalidDiscriminatedUnionValueError(\"{0}\", \"{1}\", convert{2}ToString({1}), \"{3}\");\n",
+                std::back_inserter(out),
+                "throw InvalidDiscriminatedUnionValueError(\"{0}\", \"{1}\", convert{2}ToString({1}), \"{3}\");\n",
                 fieldName, fieldDef->cppName, enumType->getCPPType(), variant.second->getCPPType());
-            fmt::format_to(out, "}}\n");
-            fmt::format_to(out, "break;\n");
+            fmt::format_to(std::back_inserter(out), "}}\n");
+            fmt::format_to(std::back_inserter(out), "break;\n");
         }
-        fmt::format_to(out, "default:\n");
-        fmt::format_to(out, "throw InvalidDiscriminantValueError(\"{0}\", \"{1}\", convert{2}ToString({1}));\n",
-                       fieldName, fieldDef->cppName, enumType->getCPPType());
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "default:\n");
+        fmt::format_to(std::back_inserter(out),
+                       "throw InvalidDiscriminantValueError(\"{0}\", \"{1}\", convert{2}ToString({1}));\n", fieldName,
+                       fieldDef->cppName, enumType->getCPPType());
+        fmt::format_to(std::back_inserter(out), "}}\n");
     }
 };
 
@@ -945,8 +960,8 @@ public:
 
     void emitFromJSONValue(fmt::memory_buffer &out, std::string_view from, AssignLambda assign,
                            std::string_view fieldName) {
-        fmt::format_to(out, "{{\n");
-        fmt::format_to(out, "auto &unwrappedValue = assertJSONField({}, \"{}\");", from, fieldName);
+        fmt::format_to(std::back_inserter(out), "{{\n");
+        fmt::format_to(std::back_inserter(out), "auto &unwrappedValue = assertJSONField({}, \"{}\");", from, fieldName);
         bool first = true;
         for (std::shared_ptr<JSONType> variant : variants) {
             std::string checkMethod;
@@ -980,17 +995,17 @@ public:
             auto condition = fmt::format("unwrappedValue.{}()", checkMethod);
             if (first) {
                 first = false;
-                fmt::format_to(out, "if ({}) {{\n", condition);
+                fmt::format_to(std::back_inserter(out), "if ({}) {{\n", condition);
             } else {
-                fmt::format_to(out, "}} else if ({}) {{\n", condition);
+                fmt::format_to(std::back_inserter(out), "}} else if ({}) {{\n", condition);
             }
             variant->emitFromJSONValue(out, from, assign, fieldName);
         }
-        fmt::format_to(out, "}} else {{\n");
-        fmt::format_to(out, "throw JSONTypeError(\"{}\", \"{}\", unwrappedValue);\n", fieldName,
+        fmt::format_to(std::back_inserter(out), "}} else {{\n");
+        fmt::format_to(std::back_inserter(out), "throw JSONTypeError(\"{}\", \"{}\", unwrappedValue);\n", fieldName,
                        sorbet::JSON::escape(getJSONType()));
-        fmt::format_to(out, "}}\n");
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
+        fmt::format_to(std::back_inserter(out), "}}\n");
     }
 
     void emitToJSONValue(fmt::memory_buffer &out, std::string_view from, AssignLambda assign,
@@ -1000,15 +1015,15 @@ public:
             auto condition = fmt::format("auto val = std::get_if<{}>(&{})", variant->getCPPType(), from);
             if (first) {
                 first = false;
-                fmt::format_to(out, "if ({}) {{\n", condition);
+                fmt::format_to(std::back_inserter(out), "if ({}) {{\n", condition);
             } else {
-                fmt::format_to(out, "}} else if ({}) {{\n", condition);
+                fmt::format_to(std::back_inserter(out), "}} else if ({}) {{\n", condition);
             }
             variant->emitToJSONValue(out, "(*val)", assign, fieldName);
         }
-        fmt::format_to(out, "}} else {{\n");
-        fmt::format_to(out, "throw MissingVariantValueError(\"{}\");\n", fieldName);
-        fmt::format_to(out, "}}\n");
+        fmt::format_to(std::back_inserter(out), "}} else {{\n");
+        fmt::format_to(std::back_inserter(out), "throw MissingVariantValueError(\"{}\");\n", fieldName);
+        fmt::format_to(std::back_inserter(out), "}}\n");
     }
 };
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -80,7 +80,7 @@ void PrinterConfig::print(const string_view &contents) const {
         fmt::print("{}", contents);
     } else {
         absl::MutexLock lck(&state->mutex);
-        fmt::format_to(state->buf, "{}", contents);
+        fmt::format_to(std::back_inserter(state->buf), "{}", contents);
     }
 };
 
@@ -245,10 +245,10 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     fmt::memory_buffer all_prints;
     fmt::memory_buffer all_stop_after;
 
-    fmt::format_to(all_prints, "Print: [{}]",
+    fmt::format_to(std::back_inserter(all_prints), "Print: [{}]",
                    fmt::map_join(
                        print_options, ", ", [](const auto &pr) -> auto { return pr.option; }));
-    fmt::format_to(all_stop_after, "Stop After: [{}]",
+    fmt::format_to(std::back_inserter(all_stop_after), "Stop After: [{}]",
                    fmt::map_join(
                        stop_after_options, ", ", [](const auto &pr) -> auto { return pr.option; }));
 

--- a/parser/Node.cc
+++ b/parser/Node.cc
@@ -12,7 +12,7 @@ namespace sorbet::parser {
 void Node::printTabs(fmt::memory_buffer &to, int count) const {
     int i = 0;
     while (i < count) {
-        fmt::format_to(to, "{}", "  ");
+        fmt::format_to(std::back_inserter(to), "{}", "  ");
         i++;
     }
 }
@@ -20,36 +20,36 @@ void Node::printTabs(fmt::memory_buffer &to, int count) const {
 void Node::printNode(fmt::memory_buffer &to, const unique_ptr<Node> &node, const core::GlobalState &gs,
                      int tabs) const {
     if (node) {
-        fmt::format_to(to, "{}\n", node->toStringWithTabs(gs, tabs));
+        fmt::format_to(std::back_inserter(to), "{}\n", node->toStringWithTabs(gs, tabs));
     } else {
-        fmt::format_to(to, "NULL\n");
+        fmt::format_to(std::back_inserter(to), "NULL\n");
     }
 }
 
 void Node::printNodeJSON(fmt::memory_buffer &to, const unique_ptr<Node> &node, const core::GlobalState &gs,
                          int tabs) const {
     if (node) {
-        fmt::format_to(to, "{}", node->toJSON(gs, tabs));
+        fmt::format_to(std::back_inserter(to), "{}", node->toJSON(gs, tabs));
     } else {
-        fmt::format_to(to, "null");
+        fmt::format_to(std::back_inserter(to), "null");
     }
 }
 
 void Node::printNodeJSONWithLocs(fmt::memory_buffer &to, const unique_ptr<Node> &node, const core::GlobalState &gs,
                                  core::FileRef file, int tabs) const {
     if (node) {
-        fmt::format_to(to, "{}", node->toJSONWithLocs(gs, file, tabs));
+        fmt::format_to(std::back_inserter(to), "{}", node->toJSONWithLocs(gs, file, tabs));
     } else {
-        fmt::format_to(to, "null");
+        fmt::format_to(std::back_inserter(to), "null");
     }
 }
 
 void Node::printNodeWhitequark(fmt::memory_buffer &to, const unique_ptr<Node> &node, const core::GlobalState &gs,
                                int tabs) const {
     if (node) {
-        fmt::format_to(to, "{}", node->toWhitequark(gs, tabs));
+        fmt::format_to(std::back_inserter(to), "{}", node->toWhitequark(gs, tabs));
     } else {
-        fmt::format_to(to, "nil");
+        fmt::format_to(std::back_inserter(to), "nil");
     }
 }
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -499,7 +499,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             [&]() {
                 fmt::memory_buffer buf;
                 for (const auto &[file, editedSource] : toWrite) {
-                    fmt::format_to(buf, "# -- {} --\n{}# ------------------------------\n",
+                    fmt::format_to(std::back_inserter(buf), "# -- {} --\n{}# ------------------------------\n",
                                    core::File::censorFilePathForSnapshotTests(file.data(*gs).path()), editedSource);
                 }
                 return to_string(buf);

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -30,10 +30,10 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "spdlog",
-        urls = _github_public_urls("gabime/spdlog/archive/c2b47430fb210c8822177407b9e4b82d4ef7455d.zip"),  # v1.3.1
-        sha256 = "08b7e0f1d7c62a56dfbac5678979967690ccd9e074acd3762a2a49d8731961e6",
+        urls = _github_public_urls("gabime/spdlog/archive/61ed2a670e40e9a865edc20b088422a469bdab9e.zip"),  # v1.9.0
+        sha256 = "0ec124d1bb4bb57a7f43f814622f7c907619e3cacbb6e04c62634a98880f5971",
         build_file = "@com_stripe_ruby_typer//third_party:spdlog.BUILD",
-        strip_prefix = "spdlog-c2b47430fb210c8822177407b9e4b82d4ef7455d",
+        strip_prefix = "spdlog-61ed2a670e40e9a865edc20b088422a469bdab9e",
     )
 
     # We don't use this directly, but protobuf will skip defining its own


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Upgrade spdlog to 1.9.0, which includes fmt-8.0.

The update to fmt-8.0 made this a little bit of a noisy upgrade, as they deprecated an overload for `fmt::format_to` that we were relying on. The solution is to apply `std::back_inserter` to the first argument, but that made the diff pretty big.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We were on version 1.3.1, which was released in January 2019.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
