### PR TITLE
provide more precise location for (most) kwargs

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1030,7 +1030,6 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 // argument has no location.  The latter also inhibits type-driven
                 // autocorrects from kicking in.
                 bool argInBounds = kwaValue < ait;
-                // Note: it's OK to compute with kwaValue even if it's out-of-bounds.
                 auto kwargOffset = kwaValue - args.args.begin();
                 auto originLoc = argInBounds ? args.argLoc(kwargOffset) : kwargsLoc;
                 auto argLoc = argInBounds ? args.argLoc(kwargOffset) : Loc::none();

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1013,7 +1013,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 ENFORCE(!sawKwSplat);
                 auto kwaValue = kwait + (offset * 2) + 1;
                 TypeAndOrigins tpe;
-                ENFORCE(args.args.size() == args.locs.args.size(), "what?!");
+                ENFORCE(args.args.size() == args.locs.args.size(), "Send arg and loc vectors did not match in length");
                 // This in-bounds check is unusual, but it's necessary for cases
                 // where we are processing a kwarg that comes from a non-kwsplat
                 // shapely-typed hash.  In such cases, our kwargOffset will appear to

--- a/test/cli/autocorrect/autocorrect.out
+++ b/test/cli/autocorrect/autocorrect.out
@@ -6,6 +6,10 @@
 < "hi" + foo
 ---
 > "hi" + T.must(foo)
+10c10
+< int(a: foo)
+---
+> int(a: T.must(foo))
 12,15c12,15
 < foo.bar ||= "a"
 < foo.bar &&= "a"

--- a/test/cli/kwarg-loc/kwarg-loc.out
+++ b/test/cli/kwarg-loc/kwarg-loc.out
@@ -1,22 +1,14 @@
-kwarg-loc.rb:17: Expected `Integer` but found `String("1")` for argument `d` https://srb.help/7002
-    17 |  a: 1,
-    18 |  b: 1,
-    19 |  c: 1,
+kwarg-loc.rb:20: Expected `Integer` but found `String("1")` for argument `d` https://srb.help/7002
     20 |  d: "1",
-    21 |  e: 1,
-    22 |  f: 1,
+             ^^^
   Expected `Integer` for argument `d` of method `Object#foo`:
     kwarg-loc.rb:8:
      8 |    d: Integer,
             ^
   Got `String("1")` originating from:
-    kwarg-loc.rb:17:
-    17 |  a: 1,
-    18 |  b: 1,
-    19 |  c: 1,
+    kwarg-loc.rb:20:
     20 |  d: "1",
-    21 |  e: 1,
-    22 |  f: 1,
+             ^^^
 
 kwarg-loc.rb:42: Expected `Integer` but found `String("1")` for argument `d` https://srb.help/7002
     42 |  "1",

--- a/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
+++ b/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
@@ -1,6 +1,6 @@
 suggest_t_unsafe.rb:25: Expected `String` but found `T.nilable(String)` for argument `str` https://srb.help/7002
     25 |  takes_string_kw(str: nilable_string)
-                          ^^^^^^^^^^^^^^^^^^^
+                               ^^^^^^^^^^^^^^
   Expected `String` for argument `str` of method `Object#takes_string_kw`:
     suggest_t_unsafe.rb:19:
     19 |sig {params(str: String).void}
@@ -8,7 +8,11 @@ suggest_t_unsafe.rb:25: Expected `String` but found `T.nilable(String)` for argu
   Got `T.nilable(String)` originating from:
     suggest_t_unsafe.rb:25:
     25 |  takes_string_kw(str: nilable_string)
-                          ^^^^^^^^^^^^^^^^^^^
+                               ^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest_t_unsafe.rb:25: Replaced with `T.unsafe(nilable_string)`
+    25 |  takes_string_kw(str: nilable_string)
+                               ^^^^^^^^^^^^^^
 
 suggest_t_unsafe.rb:8: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
      8 |foo[0]
@@ -105,14 +109,14 @@ def takes_string_kw(str:); end
 sig {params(nilable_string: T.nilable(String)).void}
 def takes_nilable_string(nilable_string)
   # This used to crash Sorbet, because there was no Loc for the `str` argument
-  takes_string_kw(str: nilable_string)
+  takes_string_kw(str: T.unsafe(nilable_string))
 end
 
 --------------------------------------------------------------------------
 
 suggest_t_unsafe.rb:25: Expected `String` but found `T.nilable(String)` for argument `str` https://srb.help/7002
     25 |  takes_string_kw(str: nilable_string)
-                          ^^^^^^^^^^^^^^^^^^^
+                               ^^^^^^^^^^^^^^
   Expected `String` for argument `str` of method `Object#takes_string_kw`:
     suggest_t_unsafe.rb:19:
     19 |sig {params(str: String).void}
@@ -120,7 +124,11 @@ suggest_t_unsafe.rb:25: Expected `String` but found `T.nilable(String)` for argu
   Got `T.nilable(String)` originating from:
     suggest_t_unsafe.rb:25:
     25 |  takes_string_kw(str: nilable_string)
-                          ^^^^^^^^^^^^^^^^^^^
+                               ^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest_t_unsafe.rb:25: Replaced with `custom_wrapper(nilable_string)`
+    25 |  takes_string_kw(str: nilable_string)
+                               ^^^^^^^^^^^^^^
 
 suggest_t_unsafe.rb:8: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
      8 |foo[0]
@@ -217,5 +225,5 @@ def takes_string_kw(str:); end
 sig {params(nilable_string: T.nilable(String)).void}
 def takes_nilable_string(nilable_string)
   # This used to crash Sorbet, because there was no Loc for the `str` argument
-  takes_string_kw(str: nilable_string)
+  takes_string_kw(str: custom_wrapper(nilable_string))
 end

--- a/test/testdata/infer/arg_matching.rb
+++ b/test/testdata/infer/arg_matching.rb
@@ -51,7 +51,7 @@ class TestArgs
     kwarg(1, {})
   # ^^^^^^^^^^^^ error: Missing required keyword argument `b`
     kwarg(1, b: "hi")
-    #        ^^^^^^^ error: Expected `Integer` but found `String("hi")` for argument `b`
+    #           ^^^^ error: Expected `Integer` but found `String("hi")` for argument `b`
     kwarg(1, any)
     kwarg(1, a_hash)
   # ^^^^^^^^^^^^^^^^ error: Passing a hash where the specific keys are unknown

--- a/test/testdata/infer/star_star_args.rb
+++ b/test/testdata/infer/star_star_args.rb
@@ -37,11 +37,11 @@ class Main
         one_kwarg(foo: 1, a: "a")
 
         one_kwarg(foo: "bad", a: "bad")
-        #         ^^^^^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `String("bad")` for argument `foo`
+        #              ^^^^^ error: Expected `Integer` but found `String("bad")` for argument `foo`
         one_kwarg(foo: 1, a: 1)
         #         ^^^^^^^^^^^^ error: Expected `String` but found `Integer(1)` for argument `args`
         one_kwarg(foo: "bad", a: 1)
-        #         ^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `String("bad")` for argument `foo`
+        #              ^^^^^ error: Expected `Integer` but found `String("bad")` for argument `foo`
         #         ^^^^^^^^^^^^^^^^ error: Expected `String` but found `Integer(1)` for argument `args`
         with_type
         with_type(a: 1)

--- a/test/testdata/lsp/method_call_errors.rb
+++ b/test/testdata/lsp/method_call_errors.rb
@@ -10,5 +10,5 @@ end
 
 test(
   a: 10
-# ^^^^^ error: Expected `String` but found `Integer(10)`
+#    ^^ error: Expected `String` but found `Integer(10)`
 )

--- a/test/testdata/rbi/io.rb
+++ b/test/testdata/rbi/io.rb
@@ -13,5 +13,5 @@ def test_io_read_encoding(file_name)
   IO.read(file_name, encoding: Encoding::ASCII_8BIT)
   IO.read(file_name, encoding: Encoding::ASCII_8BIT.to_s)
   IO.read(file_name, encoding: 42)
-  #                  ^^^^^^^^^^^^ error: Expected `T.any(String, Encoding)` but found `Integer(42)` for argument `encoding`
+  #                            ^^ error: Expected `T.any(String, Encoding)` but found `Integer(42)` for argument `encoding`
 end

--- a/test/testdata/rewriter/t_struct/default.rb
+++ b/test/testdata/rewriter/t_struct/default.rb
@@ -6,7 +6,7 @@ end
 
 T.reveal_type(Default.new.foo) # error: Revealed type: `Integer`
 Default.new(foo: "no")
-#           ^^^^^^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
+#                ^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
   Default.new(foo: 3, bar: 4)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `bar` passed for method `Default#initialize`
 T.reveal_type(Default.new(foo: 3).foo) # error: Revealed type: `Integer`

--- a/test/testdata/rewriter/t_struct/nilable.rb
+++ b/test/testdata/rewriter/t_struct/nilable.rb
@@ -6,7 +6,7 @@ end
 
 T.reveal_type(Nilable.new.foo) # error: Revealed type: `T.nilable(Integer)`
 Nilable.new(foo: "no")
-#           ^^^^^^^^^ error: Expected `T.nilable(Integer)` but found `String("no")` for argument `foo`
+#                ^^^^ error: Expected `T.nilable(Integer)` but found `String("no")` for argument `foo`
   Nilable.new(foo: 3, bar: 4)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `bar` passed for method `Nilable#initialize`
 T.reveal_type(Nilable.new(foo: 3).foo) # error: Revealed type: `T.nilable(Integer)`

--- a/test/testdata/rewriter/t_struct/normal.rb
+++ b/test/testdata/rewriter/t_struct/normal.rb
@@ -6,7 +6,7 @@ end
 
 Normal.new # error: Missing required keyword argument `foo` for method `Normal#initialize`
 Normal.new(foo: "no")
-#          ^^^^^^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
+#               ^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
   Normal.new(foo: 3, bar: 4)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `bar` passed for method `Normal#initialize`
 T.reveal_type(Normal.new(foo: 3).foo) # error: Revealed type: `Integer`

--- a/test/testdata/rewriter/t_struct/override.rb
+++ b/test/testdata/rewriter/t_struct/override.rb
@@ -16,7 +16,7 @@ end
 
 Override.new # error: Missing required keyword argument `foo` for method `Override#initialize`
 Override.new(foo: "no")
-#            ^^^^^^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
+#                 ^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
   Override.new(foo: 3, bar: 4)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `bar` passed for method `Override#initialize`
 T.reveal_type(Override.new(foo: 3).foo) # error: Revealed type: `String`

--- a/test/testdata/rewriter/t_struct/root.rb
+++ b/test/testdata/rewriter/t_struct/root.rb
@@ -6,7 +6,7 @@ end
 
 Root.new # error: Missing required keyword argument `foo` for method `Root#initialize`
 Root.new(foo: "no")
-#        ^^^^^^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
+#             ^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
   Root.new(foo: 3, bar: 4)
 # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `bar` passed for method `Root#initialize`
 T.reveal_type(Root.new(foo: 3).foo) # error: Revealed type: `Integer`


### PR DESCRIPTION
### Motivation

Fixes #4387, which makes wrong kwargs in the IDE autocorrectable, etc.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I did not include the testcase from #4387 because I felt that the existing testcases covered everything already.  For reference, the new output is:

```
froydnj@pyro:~/src/sorbet$ ./bazel-bin/main/sorbet 4387.rb
4387.rb:12: Expected Integer but found T.nilable(Integer) for argument package https://srb.help/7002
    12 |    A.new(package: pkg, name: pkg)
                           ^^^
  Expected Integer for argument package of method A#initialize:
    4387.rb:5:
     5 |  sig {params(package: Integer, name: Integer).void}
                      ^^^^^^^
  Got T.nilable(Integer) originating from:
    4387.rb:12:
    12 |    A.new(package: pkg, name: pkg)
                           ^^^
  Autocorrect: Use `-a` to autocorrect
    4387.rb:12: Replace with T.must(pkg)
    12 |    A.new(package: pkg, name: pkg)
                           ^^^

4387.rb:12: Expected Integer but found T.nilable(Integer) for argument name https://srb.help/7002
    12 |    A.new(package: pkg, name: pkg)
                                      ^^^
  Expected Integer for argument name of method A#initialize:
    4387.rb:5:
     5 |  sig {params(package: Integer, name: Integer).void}
                                        ^^^^
  Got T.nilable(Integer) originating from:
    4387.rb:12:
    12 |    A.new(package: pkg, name: pkg)
                                      ^^^
  Autocorrect: Use `-a` to autocorrect
    4387.rb:12: Replace with T.must(pkg)
    12 |    A.new(package: pkg, name: pkg)
                                      ^^^
Errors: 2
```

The major difference in this output from the "expected result" output in the report in #4387 is that the initial error ("Expected Integer but found...") in the "expected result" would highlight both the keyword and the value in the call ("package: pkg") rather than just the value ("pkg", as above)