### PR TITLE
Make `check_type_recursive!` public

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/casts.rb
+++ b/gems/sorbet-runtime/lib/types/private/casts.rb
@@ -2,14 +2,6 @@
 # typed: false
 
 module T::Private
-  # Dynamically confirm that `value` is recursively a valid value of
-  # type `type`, including recursively through collections. Note that
-  # in some cases this runtime check can be very expensive, especially
-  # with large collections of objects.
-  def self.check_type_recursive!(value, type)
-    T::Private::Casts.cast_recursive(value, type, cast_method: "T.check_type_recursive!")
-  end
-
   module Casts
     def self.cast(value, type, cast_method:)
       begin

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -27,6 +27,14 @@ module T::Utils
     end
   end
 
+  # Dynamically confirm that `value` is recursively a valid value of
+  # type `type`, including recursively through collections. Note that
+  # in some cases this runtime check can be very expensive, especially
+  # with large collections of objects.
+  def self.check_type_recursive!(value, type)
+    T::Private::Casts.cast_recursive(value, type, cast_method: "T.check_type_recursive!")
+  end
+
   # Returns the set of all methods (public, protected, private) defined on a module or its
   # ancestors, excluding Object and its ancestors. Overrides of methods from Object (and its
   # ancestors) are included.

--- a/gems/sorbet-runtime/test/types/casts.rb
+++ b/gems/sorbet-runtime/test/types/casts.rb
@@ -52,7 +52,7 @@ module Opus::Types::Test
 
       it "does do recursive type-checking of arrays with `check_type_recursive!`" do
         assert_raises(TypeError) do
-          T::Private.check_type_recursive!([1], T::Array[String])
+          T::Utils.check_type_recursive!([1], T::Array[String])
         end
       end
 
@@ -62,7 +62,7 @@ module Opus::Types::Test
 
       it "does do recursive type-checking of arrays with `check_type_recursive!`" do
         assert_raises(TypeError) do
-          T::Private.check_type_recursive!({x: "y"}, T::Hash[Symbol, Integer])
+          T::Utils.check_type_recursive!({x: "y"}, T::Hash[Symbol, Integer])
         end
       end
     end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -184,6 +184,7 @@ module T::Utils
   def self.signature_for_instance_method(mod, method_name); end
   def self.unwrap_nilable(type); end
   def self.wrap_method_with_call_validation_if_needed(mod, method_sig, original_method); end
+  def self.check_type_recursive!(value, type); end
 
   # only one caller; delete
   def self.methods_excluding_object(mod); end

--- a/rbi/sorbet/tprivate.rbi
+++ b/rbi/sorbet/tprivate.rbi
@@ -5,11 +5,6 @@
 #
 # Use them at your own risk.
 
-module T::Private
-  sig {params(value: T.untyped, type: T.untyped).returns(BasicObject)}
-  def self.check_type_recursive!(value, type); end
-end
-
 module T::Private::Types
 end
 

--- a/test/testdata/namer/redefines_module_as_static_field.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/redefines_module_as_static_field.rb.symbol-table-raw.exp
@@ -19,7 +19,7 @@ class <C <U <root>>> < <C <U Object>> ()
       static-field <C <U T>><C <U AbstractUtils>><M <C <U Methods>> $1> -> AliasType { symbol = <C <U T>><C <U Private>><C <U Methods>> } @ Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=27:3 end=27:28}
       class <C <U T>><C <U AbstractUtils>><S <C <U Methods>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=30:3 end=30:49}
         type-member(+) <C <U T>><C <U AbstractUtils>><S <C <U Methods>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U T>><C <U AbstractUtils>><S <C <U Methods>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=T::AbstractUtils::Methods) @ Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=30:3 end=30:49}
-    module <C <U T>><C <U Private>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/tprivate.rbi start=removed end=removed}, Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=7:1 end=7:18})
+    module <C <U T>><C <U Private>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=7:1 end=7:18}
       module <C <U T>><C <U Private>><C <U Methods>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ (Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=10:1 end=10:27}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/tprivate.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/builder.rbi start=removed end=removed})
         module <C <U T>><C <U Private>><C <U Methods>><C <U Modes>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=16:1 end=16:34}
         class <C <U T>><C <U Private>><C <U Methods>><S <C <U Modes>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=16:8 end=16:34}
@@ -31,4 +31,7 @@ class <C <U <root>>> < <C <U Object>> ()
           type-member(+) <C <U T>><C <U Private>><C <U Methods>><S <C <U SignatureValidation>> $1><C <U <AttachedClass>>> -> LambdaParam(<C <U T>><C <U Private>><C <U Methods>><S <C <U SignatureValidation>> $1><C <U <AttachedClass>>>, lower=T.noreturn, upper=T::Private::Methods::SignatureValidation) @ Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=13:8 end=13:48}
           method <C <U T>><C <U Private>><C <U Methods>><S <C <U SignatureValidation>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=13:1 end=14:4}
             argument <blk><block> @ Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=??? end=???}
+    class <C <U T>><S <C <U Private>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> ()
+      method <C <U T>><S <C <U Private>> $1><U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=7:1 end=8:4}
+        argument <blk><block> @ Loc {file=test/testdata/namer/redefines_module_as_static_field.rb start=??? end=???}
 

--- a/test/testdata/resolver/sig_bad.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/sig_bad.rb.symbol-table-raw.exp
@@ -27,7 +27,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <S <C <U A>> $1><U unsupported> (<blk>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=13:3 end=13:23}
       argument <blk><block> @ Loc {file=test/testdata/resolver/sig_bad.rb start=??? end=???}
   module <C <U T>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi start=removed end=removed}
-    module <C <U T>><C <U Private>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/tprivate.rbi start=removed end=removed}
+    module <C <U T>><C <U Private>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> ()
       module <C <U T>><C <U Private>><C <U Methods>> < <C <U Sorbet>><C <U Private>><C <U Static>><C <U ImplicitModuleSuperclass>> () @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/tprivate.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/builder.rbi start=removed end=removed})
         class <C <U T>><C <U Private>><C <U Methods>><C <U DeclBuilder>> < <C <U Object>> () @ (Loc {file=test/testdata/resolver/sig_bad.rb start=5:1 end=5:39}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/builder.rbi start=removed end=removed})
           method <C <U T>><C <U Private>><C <U Methods>><C <U DeclBuilder>><U unsupported> (<blk>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=6:3 end=6:18}


### PR DESCRIPTION
Move `check_type_recursive!` from `T::Private` to `T::Utils`.

### Motivation
Per discussion in Stripe Slack, we have no strong reason to keep this private and a few legitimate use cases for calling it outside Sorbet internals.

This is a breaking change, but that's explicitly the contract of `T::Private`, and it seems pretty simple to `sed` on upgrade.

### Test plan
Updated existing tests.