### PR TITLE
Allow various T::Types::Base operations on MetaType

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -141,6 +141,13 @@ NameDef names[] = {
     {"revealType", "reveal_type"},
     {"absurd"},
     {"nonForcingIsA_p", "non_forcing_is_a?"},
+    {"valid_p", "valid?"},
+    {"recursivelyValid_p", "recursively_valid?"},
+    {"subtypeOf_p", "subtype_of?"},
+    {"describeObj", "describe_obj"},
+    {"errorMessageForObj", "error_message_for_obj"},
+    {"errorMessageForObjRecursive", "error_message_for_obj_recursive"},
+    {"validate_bang", "validate!"},
     // end T keywords
 
     // Ruby DSL methods which we understand

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1314,6 +1314,18 @@ DispatchResult MetaType::dispatchCall(const GlobalState &gs, const DispatchArgs 
             original.main.sendTp = wrapped;
             return original;
         }
+        case Names::valid_p().rawId():
+        case Names::recursivelyValid_p().rawId():
+        case Names::subtypeOf_p().rawId():
+        case Names::describeObj().rawId():
+        case Names::errorMessageForObj().rawId():
+        case Names::errorMessageForObjRecursive().rawId():
+        case Names::validate_bang().rawId(): {
+            // These are methods on `T::Types::Base`. Don't report an error, but also for the time
+            // being don't even attempt to type the result properly. We can break these out and
+            // handle them better in the future if we want to.
+            return DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noMethod());
+        }
         default:
             if (auto e = gs.beginError(args.callLoc(), errors::Infer::MetaTypeDispatchCall)) {
                 e.setHeader("Call to method `{}` on `{}` mistakes a type for a value", args.name.show(gs),

--- a/test/testdata/infer/call_on_metatype.rb
+++ b/test/testdata/infer/call_on_metatype.rb
@@ -26,10 +26,10 @@ T.class_of(Integer, String).foo # error: Too many arguments
 
 # T::Types::Base methods
 x = nil
-T.nilable(Integer).valid?(x) # error: mistakes a type for a value
-T.nilable(Integer).recursively_valid?(x) # error: mistakes a type for a value
-T.nilable(Integer).subtype_of?(x) # error: mistakes a type for a value
-T.nilable(Integer).describe_obj(x) # error: mistakes a type for a value
-T.nilable(Integer).error_message_for_obj(x) # error: mistakes a type for a value
-T.nilable(Integer).error_message_for_obj_recursive(x) # error: mistakes a type for a value
-T.nilable(Integer).validate!(x) # error: mistakes a type for a value
+T.nilable(Integer).valid?(x)
+T.nilable(Integer).recursively_valid?(x)
+T.nilable(Integer).subtype_of?(x)
+T.nilable(Integer).describe_obj(x)
+T.nilable(Integer).error_message_for_obj(x)
+T.nilable(Integer).error_message_for_obj_recursive(x)
+T.nilable(Integer).validate!(x)

--- a/test/testdata/infer/call_on_metatype.rb
+++ b/test/testdata/infer/call_on_metatype.rb
@@ -23,3 +23,13 @@ puts (T.proc.void + 1) # error: Method `+` does not exist on `T.class_of(T.proc)
 # Edge cases. Do anything but crash.
 T.class_of.foo # error: Not enough arguments
 T.class_of(Integer, String).foo # error: Too many arguments
+
+# T::Types::Base methods
+x = nil
+T.nilable(Integer).valid?(x) # error: mistakes a type for a value
+T.nilable(Integer).recursively_valid?(x) # error: mistakes a type for a value
+T.nilable(Integer).subtype_of?(x) # error: mistakes a type for a value
+T.nilable(Integer).describe_obj(x) # error: mistakes a type for a value
+T.nilable(Integer).error_message_for_obj(x) # error: mistakes a type for a value
+T.nilable(Integer).error_message_for_obj_recursive(x) # error: mistakes a type for a value
+T.nilable(Integer).validate!(x) # error: mistakes a type for a value

--- a/test/testdata/infer/call_on_metatype.rb
+++ b/test/testdata/infer/call_on_metatype.rb
@@ -26,10 +26,17 @@ T.class_of(Integer, String).foo # error: Too many arguments
 
 # T::Types::Base methods
 x = nil
-T.nilable(Integer).valid?(x)
-T.nilable(Integer).recursively_valid?(x)
-T.nilable(Integer).subtype_of?(x)
-T.nilable(Integer).describe_obj(x)
-T.nilable(Integer).error_message_for_obj(x)
-T.nilable(Integer).error_message_for_obj_recursive(x)
-T.nilable(Integer).validate!(x)
+y = T.nilable(Integer).valid?(x)
+T.reveal_type(y) # error: `T.untyped`
+y = T.nilable(Integer).recursively_valid?(x)
+T.reveal_type(y) # error: `T.untyped`
+y = T.nilable(Integer).subtype_of?(x)
+T.reveal_type(y) # error: `T.untyped`
+y = T.nilable(Integer).describe_obj(x)
+T.reveal_type(y) # error: `T.untyped`
+y = T.nilable(Integer).error_message_for_obj(x)
+T.reveal_type(y) # error: `T.untyped`
+y = T.nilable(Integer).error_message_for_obj_recursive(x)
+T.reveal_type(y) # error: `T.untyped`
+y = T.nilable(Integer).validate!(x)
+T.reveal_type(y) # error: `T.untyped`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

cc @djudd-stripe

There are a handful of operations on MetaTypes that are actually supported,
because they're implemented on `T::Types::Base`. Those get used from time to
time when people are doing metaprogramming.

We might want to ascribe better types to their results, but for now I've left
them as `T.untyped`.

As a suggestion for future implementation, we could do something similar to how
we define intrinsics for `ShapeType` or `TupleType`: invent a special magic
symbol that holds the intrinsics, and attempt to forward the dispatch to one of
those intrinsics in `MetaType::dispatchCall`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.