### PR TITLE
Add mode parameter to CSV's `foreach` rbi

### DIFF
--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -269,6 +269,7 @@ class CSV < Object
   sig do
     params(
         path: T.any(String, ::Sorbet::Private::Static::IOLike),
+        mode: String,
         options: T::Hash[Symbol, BasicObject],
         blk: T.proc.params(arg0: T.any(T::Array[T.nilable(T.untyped)], CSV::Row)).void,
     )
@@ -277,11 +278,12 @@ class CSV < Object
   sig do
     params(
         path: T.any(String, ::Sorbet::Private::Static::IOLike),
+        mode: String,
         options: T::Hash[Symbol, BasicObject],
     )
     .returns(T::Enumerator[T.any(T::Array[T.nilable(T.untyped)], CSV::Row)])
   end
-  def self.foreach(path, options=T.unsafe(nil), &blk); end
+  def self.foreach(path, mode="r", options=T.unsafe(nil), &blk); end
 
   # This constructor will wrap either a
   # [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html) or

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -283,7 +283,7 @@ class CSV < Object
     )
     .returns(T::Enumerator[T.any(T::Array[T.nilable(T.untyped)], CSV::Row)])
   end
-  def self.foreach(path, mode="r", options=T.unsafe(nil), &blk); end
+  def self.foreach(path, mode="r", **options, &blk); end
 
   # This constructor will wrap either a
   # [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html) or

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -270,7 +270,7 @@ class CSV < Object
     params(
         path: T.any(String, ::Sorbet::Private::Static::IOLike),
         mode: String,
-        options: T::Hash[Symbol, BasicObject],
+        options: BasicObject,
         blk: T.proc.params(arg0: T.any(T::Array[T.nilable(T.untyped)], CSV::Row)).void,
     )
     .void
@@ -279,7 +279,7 @@ class CSV < Object
     params(
         path: T.any(String, ::Sorbet::Private::Static::IOLike),
         mode: String,
-        options: T::Hash[Symbol, BasicObject],
+        options: BasicObject,
     )
     .returns(T::Enumerator[T.any(T::Array[T.nilable(T.untyped)], CSV::Row)])
   end

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -271,17 +271,9 @@ class CSV < Object
         path: T.any(String, ::Sorbet::Private::Static::IOLike),
         mode: String,
         options: BasicObject,
-        blk: T.proc.params(arg0: T.any(T::Array[T.nilable(T.untyped)], CSV::Row)).void,
+        blk: T.nilable(T.proc.params(arg0: T.any(T::Array[T.nilable(T.untyped)], CSV::Row)).void),
     )
-    .void
-  end
-  sig do
-    params(
-        path: T.any(String, ::Sorbet::Private::Static::IOLike),
-        mode: String,
-        options: BasicObject,
-    )
-    .returns(T::Enumerator[T.any(T::Array[T.nilable(T.untyped)], CSV::Row)])
+    .returns(T.nilable(T::Enumerator[T.any(T::Array[T.nilable(T.untyped)], CSV::Row)]))
   end
   def self.foreach(path, mode="r", **options, &blk); end
 

--- a/test/testdata/rbi/csv.rb
+++ b/test/testdata/rbi/csv.rb
@@ -1,8 +1,9 @@
 # typed: true
 require 'csv'
 
-T.assert_type!(CSV.foreach('source.csv', headers: true), T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)])
-T.assert_type!(CSV.foreach('source.csv', headers: true, col_sep: ','), T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)])
+T.assert_type!(CSV.foreach('source.csv', headers: true), T.nilable(T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)]))
+T.assert_type!(CSV.foreach('source.csv', 'r:bom|utf-8'), T.nilable(T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)]))
+T.assert_type!(CSV.foreach('source.csv', headers: true, col_sep: ','), T.nilable(T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)]))
 CSV.foreach('source.csv') do |row|
   T.assert_type!(row, T.any(T::Array[T.untyped], CSV::Row))
 end


### PR DESCRIPTION
This PR corrects the RBI for CSV's `foreach` method. This method accepts a second argument `mode` (see https://docs.ruby-lang.org/en/2.7.0/CSV.html#method-c-foreach), but the RBI does not currently include that argument.

### Motivation
The RBI for CSV's `foreach` method is incorrect and does not match the underlying method.

