### PR TITLE
Allow passing in a keyword splat if one of the declared args is a keyword splat

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -915,9 +915,9 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             auto kwSplatTPO = TypeAndOrigins{kwSplatType, kwSplatArg->origins};
 
             if (hasKwSplatParam && !hasKwParam) {
-                if (auto e = matchArgType(gs, *constr, args.callLoc(), args.receiverLoc(), symbol, method,
-                                          kwSplatTPO, *kwSplatParam, args.selfType, targs, kwargsLoc,
-                                          args.originForUninitialized, args.args.size() == 1)) {
+                if (auto e = matchArgType(gs, *constr, args.callLoc(), args.receiverLoc(), symbol, method, kwSplatTPO,
+                                          *kwSplatParam, args.selfType, targs, kwargsLoc, args.originForUninitialized,
+                                          args.args.size() == 1)) {
                     result.main.errors.emplace_back(std::move(e));
                 }
             } else {

--- a/test/testdata/infer/kwargs_splat.rb
+++ b/test/testdata/infer/kwargs_splat.rb
@@ -40,3 +40,26 @@ untyped_values_hash = T.let(shaped_hash, T::Hash[Symbol, T.untyped])
 # Ensure that constructing a kwargs hash with untyped keys works
 untyped = T.unsafe(:y)
 f(3, **untyped_hash, untyped => 20)
+
+sig {params(x: Integer, y: Integer, kw_splat: BasicObject).void}
+def h(x, y:, **kw_splat)
+  puts x
+  puts y
+  puts kw_splat
+end
+
+untyped_values_hash = T.let({}, T::Hash[Symbol, T.untyped])
+  h(1, y: 2, **untyped_values_hash)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Passing a hash where the specific keys are unknown to a method taking keyword arguments
+
+sig {params(kw_splat: T::Hash[Symbol, String]).void}
+def i(**kw_splat)
+  puts kw_splat
+end
+
+string_values_hash = T.let({}, T::Hash[Symbol, String])
+i(**string_values_hash)
+
+integer_values_hash = T.let({}, T::Hash[Symbol, Integer])
+i(**integer_values_hash)
+# ^^^^^^^^^^^^^^^^^^^^^ error: Expected `T::Hash[Symbol, String]` but found `T::Hash[Symbol, Integer]` for argument `kw_splat`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #4404 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
