### PR TITLE
Fix bad indent in documentation example

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -575,7 +575,7 @@ methods at runtime through meta-programming:
 class Base
   def self.data_accessor(key)
     define_method(key) do
-	  data[key]
+      data[key]
     end
   end
 


### PR DESCRIPTION
### Motivation

This line from #4415 I pushed yesterday was using mixed tab+spaces indent.

This doesn't show in the output but is visible in the Markdown source.

Sorry about that 🙏 

### Test plan

See included automated tests.
