### PR TITLE
Call rb_hash_update directly instead of through rb_funcallv

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -110,6 +110,8 @@ SORBET_ALIVE(VALUE, sorbet_rb_array_square_br_slowpath,
              (VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk, VALUE closure));
 SORBET_ALIVE(VALUE, rb_ary_compact_bang_forwarder, (VALUE recv));
 
+SORBET_ALIVE(void, sorbet_hashUpdate, (VALUE hash, VALUE other));
+
 SORBET_ALIVE(VALUE, sorbet_rb_int_plus_slowpath, (VALUE, VALUE));
 SORBET_ALIVE(VALUE, sorbet_rb_int_minus_slowpath, (VALUE, VALUE));
 
@@ -587,12 +589,6 @@ void sorbet_hashStore(VALUE hash, VALUE key, VALUE value) {
 SORBET_INLINE
 VALUE sorbet_hashGet(VALUE hash, VALUE key) {
     return rb_hash_aref(hash, key);
-}
-
-SORBET_INLINE
-void sorbet_hashUpdate(VALUE hash, VALUE other) {
-    // TODO(trevor) inline a definition of `merge!` here
-    rb_funcall(hash, rb_intern2("merge!", 6), 1, other);
 }
 
 // possible return values for `func`:

--- a/compiler/IREmitter/Payload/patches/hash.c
+++ b/compiler/IREmitter/Payload/patches/hash.c
@@ -18,3 +18,8 @@ long sorbet_hash_string(VALUE a) {
 VALUE sorbet_rb_hash_any_forwarder(int argc, VALUE *argv, VALUE hash) {
     return rb_hash_any_p(argc, argv, hash);
 }
+
+// Avoid dispatch through the VM by calling the body of `rb_hash_update` directly.
+void sorbet_hashUpdate(VALUE hash, VALUE other) {
+    rb_hash_update(1, &other, hash);
+}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Move the definition of sorbet_updateHash into a hash.c patch, so that we can access the c implementation directly and avoid emitting a call to rb_funcallv.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Code cleanliness.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
