### PR TITLE
--stripe-packages Test module + test_import support

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -191,7 +191,7 @@ bool File::isPackage() const {
 }
 
 bool File::isTest() const {
-    return absl::StrContains(path(), "/test/"); // TODO do we need to pre-compute?
+    return absl::EndsWith(path(), ".test.rb") || absl::StrContains(path(), "/test/"); // TODO do we need to pre-compute?
 }
 
 vector<int> &File::lineBreaks() const {

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -190,6 +190,10 @@ bool File::isPackage() const {
     return sourceType == File::Type::Package;
 }
 
+bool File::isTest() const {
+    return absl::StrContains(path(), "/test/"); // TODO do we need to pre-compute?
+}
+
 vector<int> &File::lineBreaks() const {
     ENFORCE(this->sourceType != File::Type::TombStone);
     ENFORCE(this->sourceType != File::Type::NotYetRead);

--- a/core/Files.h
+++ b/core/Files.h
@@ -90,6 +90,7 @@ public:
     bool isRBI() const;
     bool isStdlib() const;
     bool isPackage() const;
+    bool isTest() const;
 
     File(std::string &&path_, std::string &&source_, Type sourceType, u4 epoch = 0);
     File(File &&other) = delete;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -453,6 +453,11 @@ void GlobalState::initEmpty() {
                  .build();
     ENFORCE(method == Symbols::PackageSpec_import());
 
+    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::test_import())
+                 .typedArg(Names::arg0(), make_type<ClassType>(Symbols::PackageSpecSingleton()))
+                 .build();
+    ENFORCE(method == Symbols::PackageSpec_test_import());
+
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::export_()).arg(Names::arg0()).build();
     ENFORCE(method == Symbols::PackageSpec_export());
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -833,8 +833,12 @@ public:
         return MethodRef::fromRaw(6);
     }
 
-    static MethodRef PackageSpec_export() {
+    static MethodRef PackageSpec_test_import() {
         return MethodRef::fromRaw(7);
+    }
+
+    static MethodRef PackageSpec_export() {
+        return MethodRef::fromRaw(8);
     }
 
     static ClassOrModuleRef Encoding() {
@@ -846,11 +850,11 @@ public:
     }
 
     static MethodRef Class_new() {
-        return MethodRef::fromRaw(8);
+        return MethodRef::fromRaw(9);
     }
 
     static MethodRef todoMethod() {
-        return MethodRef::fromRaw(9);
+        return MethodRef::fromRaw(10);
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
@@ -884,7 +888,7 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 200;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 39;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 40;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 3;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 98;

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -401,6 +401,7 @@ NameDef names[] = {
 
     // Packager
     {"import"},
+    {"test_import"},
     {"export_", "export"},
     {"PackageSpec", "PackageSpec", true},
     {"PackageRegistry", "<PackageRegistry>", true},

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -404,7 +404,7 @@ NameDef names[] = {
     {"export_", "export"},
     {"PackageSpec", "PackageSpec", true},
     {"PackageRegistry", "<PackageRegistry>", true},
-    {"PackageMethods", "<PackageMethods>", true},
+    {"PackageTests", "<PackageTests>", true},
 
     // GlobalState initEmpty()
     {"Top", "<top>", true},
@@ -488,6 +488,7 @@ NameDef names[] = {
     {"NonForcingConstants", "NonForcingConstants", true},
     {"VERSION", "VERSION", true},
     {"Thread", "Thread", true},
+    {"Test", "Test", true}, // TODO will this break people?
 };
 
 void emit_name_header(ostream &out, NameDef &name) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -698,7 +698,8 @@ public:
         }
     }
 
-    ast::ClassDef::RHS_store makeModule(core::Context ctx, ImportType importType) { // TODO TODO better name for importType
+    ast::ClassDef::RHS_store makeModule(core::Context ctx,
+                                        ImportType importType) { // TODO TODO better name for importType
         vector<core::NameRef> parts;
         ast::ClassDef::RHS_store modRhs;
         makeModule(ctx, &root, parts, modRhs, importType, ImportTree::Source());
@@ -755,8 +756,8 @@ private:
                 //   D = <Mangled A::B>::A::B::C::D
                 // end
                 auto importLoc = node->source.importLoc;
-                auto assignRhs =
-                    prependPackageScope(parts2literal(parts, core::LocOffsets::none()), node->source.packageMangledName);
+                auto assignRhs = prependPackageScope(parts2literal(parts, core::LocOffsets::none()),
+                                                     node->source.packageMangledName);
                 auto assign = ast::MK::Assign(core::LocOffsets::none(), name2Expr(parts.back(), ast::MK::EmptyTree()),
                                               std::move(assignRhs));
 
@@ -847,11 +848,12 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
         //   <Imports>
         //   <Mangled_Pkg_A>::Pkg::A = <PackageRegistry>::<Mangled_Pkg_A>::Pkg::A
         // end
-        auto assignRhs = prependPackageScope(package->name.fullName.toLiteral(core::LocOffsets::none()), package->name.mangledName);
-        auto assign = ast::MK::Assign(
-                core::LocOffsets::none(),
-                prependScope(package->name.fullName.toLiteral(core::LocOffsets::none()), name2Expr(package->name.mangledName)),
-                std::move(assignRhs));
+        auto assignRhs =
+            prependPackageScope(package->name.fullName.toLiteral(core::LocOffsets::none()), package->name.mangledName);
+        auto assign = ast::MK::Assign(core::LocOffsets::none(),
+                                      prependScope(package->name.fullName.toLiteral(core::LocOffsets::none()),
+                                                   name2Expr(package->name.mangledName)),
+                                      std::move(assignRhs));
         testImportedPackages.emplace_back(std::move(assign));
     }
 
@@ -878,10 +880,11 @@ ast::ParsedFile rewritePackagedFile(core::Context ctx, ast::ParsedFile file, cor
     auto &rootKlass = ast::cast_tree_nonnull<ast::ClassDef>(file.tree);
     EnforcePackagePrefix enforcePrefix(pkg);
     file.tree = ast::ShallowMap::apply(ctx, enforcePrefix, move(file.tree));
+
+    auto wrapperName = isTestFile ? core::Names::Constants::PackageTests() : core::Names::Constants::PackageRegistry();
     auto moduleWrapper =
         ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),
-                        name2Expr(packageMangledName, name2Expr(core::Names::Constants::PackageRegistry())), {},
-                        std::move(rootKlass.rhs));
+                        name2Expr(packageMangledName, name2Expr(wrapperName)), {}, std::move(rootKlass.rhs));
     rootKlass.rhs.clear();
     rootKlass.rhs.emplace_back(move(moduleWrapper));
     return file;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -18,6 +18,7 @@ namespace sorbet::packager {
 namespace {
 
 constexpr string_view PACKAGE_FILE_NAME = "__package.rb"sv;
+constexpr core::NameRef TEST_NAME = core::Names::Constants::Test();
 
 struct FullyQualifiedName {
     vector<core::NameRef> parts;
@@ -25,7 +26,7 @@ struct FullyQualifiedName {
     ast::ExpressionPtr toLiteral(core::LocOffsets loc) const;
 
     FullyQualifiedName() = default;
-    FullyQualifiedName(const FullyQualifiedName &) = delete;
+    explicit FullyQualifiedName(const FullyQualifiedName &) = default;
     FullyQualifiedName(FullyQualifiedName &&) = default;
     FullyQualifiedName &operator=(const FullyQualifiedName &) = delete;
     FullyQualifiedName &operator=(FullyQualifiedName &&) = default;
@@ -46,6 +47,7 @@ struct PackageName {
     core::LocOffsets loc;
     core::NameRef mangledName = core::NameRef::noName();
     FullyQualifiedName fullName;
+    FullyQualifiedName fullTestPkgName;
 
     // Pretty print the package's (user-observable) name (e.g. Foo::Bar)
     string toString(const core::GlobalState &gs) const {
@@ -209,6 +211,8 @@ PackageName getPackageName(core::MutableContext ctx, ast::UnresolvedConstantLit 
     PackageName pName;
     pName.loc = constantLit->loc;
     pName.fullName = getFullyQualifiedName(ctx, constantLit);
+    pName.fullTestPkgName = FullyQualifiedName(pName.fullName);
+    pName.fullTestPkgName.parts.insert(pName.fullTestPkgName.parts.begin(), TEST_NAME);
 
     // Foo::Bar => Foo_Bar_Package
     auto mangledName = absl::StrCat(absl::StrJoin(pName.fullName.parts, "_", NameFormatter(ctx)), "_Package");
@@ -305,12 +309,13 @@ bool sharesPrefix(const vector<core::NameRef> &a, const vector<core::NameRef> &b
 // prefix.
 class EnforcePackagePrefix final {
     const PackageInfo *pkg;
+    const bool isTestFile;
     vector<core::NameRef> nameParts;
     int rootConsts = 0;
     int skipPush = 0;
 
 public:
-    EnforcePackagePrefix(const PackageInfo *pkg) : pkg(pkg) {
+    EnforcePackagePrefix(const PackageInfo *pkg, bool isTestFile) : pkg(pkg), isTestFile(isTestFile) {
         ENFORCE(pkg != nullptr);
     }
 
@@ -320,7 +325,7 @@ public:
             // Ignore top-level <root>
             return tree;
         }
-        const auto &pkgName = pkg->name.fullName.parts;
+        const auto &pkgName = requiredNamespace();
         if (nameParts.size() > pkgName.size()) {
             // At this depth we can stop checking the prefixes since beyond the end of the prefix.
             skipPush++;
@@ -361,7 +366,7 @@ public:
         auto &asgn = ast::cast_tree_nonnull<ast::Assign>(original);
         auto *lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn.lhs);
         if (lhs != nullptr) {
-            auto &pkgName = pkg->name.fullName.parts;
+            auto &pkgName = requiredNamespace();
             if (rootConsts == 0 && !isPrefix(pkgName, nameParts)) {
                 if (auto e = ctx.beginError(lhs->loc, core::errors::Packager::DefinitionPackageMismatch)) {
                     e.setHeader("Constants may not be defined outside of the enclosing package namespace `{}`",
@@ -399,6 +404,14 @@ private:
                 ENFORCE(scope->symbol == core::Symbols::root());
                 rootConsts--;
             }
+        }
+    }
+
+    const vector<core::NameRef> &requiredNamespace() const {
+        if (isTestFile) {
+            return pkg->name.fullTestPkgName.parts;
+        } else {
+            return pkg->name.fullName.parts;
         }
     }
 };
@@ -442,7 +455,7 @@ struct PackageInfoFinder {
         if (send.fun == core::Names::export_() && send.args.size() == 1) {
             // null indicates an invalid export.
             if (auto target = verifyConstant(ctx, core::Names::export_(), send.args[0])) {
-                exported.push_back(getFullyQualifiedName(ctx, target));
+                exported.emplace_back(getFullyQualifiedName(ctx, target));
                 // Transform the constant lit to refer to the target within the mangled package namespace.
                 send.args[0] = prependInternalPackageName(move(send.args[0]));
             }
@@ -878,7 +891,7 @@ ast::ParsedFile rewritePackagedFile(core::Context ctx, ast::ParsedFile file, cor
     }
 
     auto &rootKlass = ast::cast_tree_nonnull<ast::ClassDef>(file.tree);
-    EnforcePackagePrefix enforcePrefix(pkg);
+    EnforcePackagePrefix enforcePrefix(pkg, isTestFile);
     file.tree = ast::ShallowMap::apply(ctx, enforcePrefix, move(file.tree));
 
     auto wrapperName = isTestFile ? core::Names::Constants::PackageTests() : core::Names::Constants::PackageRegistry();

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -253,8 +253,8 @@ ast::ExpressionPtr parts2literal(const vector<core::NameRef> &parts, core::LocOf
     return name;
 }
 
-// Prefix a constant reference with a name: `Foo::Bar` -> `<name>::Foo::Bar`
-ast::ExpressionPtr prependName(ast::ExpressionPtr scope, core::NameRef name) {
+// Prepend to a scope `Foo::Bar` some prefix -> `<toPrepend>::Foo::Bar`
+ast::ExpressionPtr prependScope(ast::ExpressionPtr scope, ast::ExpressionPtr toPrepend) {
     // For `Bar::Baz::Bat`, `UnresolvedConstantLit` will contain `Bar`.
     auto *lastConstLit = ast::cast_tree<ast::UnresolvedConstantLit>(scope);
     if (lastConstLit != nullptr) {
@@ -266,13 +266,17 @@ ast::ExpressionPtr prependName(ast::ExpressionPtr scope, core::NameRef name) {
     // If `lastConstLit` is `nullptr`, then `scope` should be EmptyTree.
     ENFORCE(lastConstLit != nullptr || ast::isa_tree<ast::EmptyTree>(scope));
 
-    auto scopeToPrepend = name2Expr(name, name2Expr(core::Names::Constants::PackageRegistry()));
     if (lastConstLit == nullptr) {
-        return scopeToPrepend;
+        return toPrepend;
     } else {
-        lastConstLit->scope = move(scopeToPrepend);
+        lastConstLit->scope = move(toPrepend);
         return scope;
     }
+}
+
+// Prefix a constant reference with a name: `Foo::Bar` -> `<PackageRegistry>::<name>::Foo::Bar`
+ast::ExpressionPtr prependName(ast::ExpressionPtr scope, core::NameRef name) {
+    return prependScope(move(scope), name2Expr(name, name2Expr(core::Names::Constants::PackageRegistry())));
 }
 
 ast::UnresolvedConstantLit *verifyConstant(core::MutableContext ctx, core::NameRef fun, ast::ExpressionPtr &expr) {
@@ -547,6 +551,7 @@ struct PackageInfoFinder {
                 return ImportType::Test;
             default:
                 ENFORCE(false);
+                Exception::notImplemented();
         }
     }
 
@@ -711,7 +716,7 @@ private:
             }
             node = child.get();
         }
-        node->source = {importedPackage.name.mangledName, loc, importType}; // TODO not always normal
+        node->source = {importedPackage.name.mangledName, loc, importType};
     }
 
     void makeModule(core::Context ctx, ImportTree *node, vector<core::NameRef> &parts, ast::ClassDef::RHS_store &modRhs,
@@ -811,7 +816,7 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
         ImportTreeBuilder treeBuilder(*package);
         for (auto &import : package->importedPackageNames) {
             auto &imported = import.name;
-            auto importedPackage = packageDB.getPackageByMangledName(imported.mangledName);
+            auto *importedPackage = packageDB.getPackageByMangledName(imported.mangledName);
             if (importedPackage == nullptr) {
                 if (auto e = ctx.beginError(imported.loc, core::errors::Packager::PackageNotFound)) {
                     e.setHeader("Cannot find package `{}`", imported.toString(ctx));
@@ -834,6 +839,13 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
         testImportedPackages =
             treeBuilder.makeModule(ctx, ImportType::Test); // TODO Also need to add alias for original pkg
     }
+
+    auto assignRhs = prependName(package->name.fullName.toLiteral(core::LocOffsets::none()), package->name.mangledName);
+    auto assign = ast::MK::Assign(
+        core::LocOffsets::none(),
+        prependScope(package->name.fullName.toLiteral(core::LocOffsets::none()), name2Expr(package->name.mangledName)),
+        std::move(assignRhs));
+    testImportedPackages.emplace_back(std::move(assign));
 
     auto packageNamespace =
         ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -275,8 +275,8 @@ ast::ExpressionPtr prependScope(ast::ExpressionPtr scope, ast::ExpressionPtr toP
 }
 
 // Prefix a constant reference with a name: `Foo::Bar` -> `<PackageRegistry>::<name>::Foo::Bar`
-ast::ExpressionPtr prependName(ast::ExpressionPtr scope, core::NameRef name) {
-    return prependScope(move(scope), name2Expr(name, name2Expr(core::Names::Constants::PackageRegistry())));
+ast::ExpressionPtr prependPackageScope(ast::ExpressionPtr scope, core::NameRef mangledName) {
+    return prependScope(move(scope), name2Expr(mangledName, name2Expr(core::Names::Constants::PackageRegistry())));
 }
 
 ast::UnresolvedConstantLit *verifyConstant(core::MutableContext ctx, core::NameRef fun, ast::ExpressionPtr &expr) {
@@ -494,7 +494,7 @@ struct PackageInfoFinder {
 
     // Bar::Baz => <PackageRegistry>::Foo_Package::Bar::Baz
     ast::ExpressionPtr prependInternalPackageName(ast::ExpressionPtr scope) {
-        return prependName(move(scope), this->info->name.mangledName);
+        return prependPackageScope(move(scope), this->info->name.mangledName);
     }
 
     // Generate a list of FQNs exported by this package. No export may be a prefix of another.
@@ -698,7 +698,7 @@ public:
         }
     }
 
-    ast::ClassDef::RHS_store makeModule(core::Context ctx, ImportType importType) {
+    ast::ClassDef::RHS_store makeModule(core::Context ctx, ImportType importType) { // TODO TODO better name for importType
         vector<core::NameRef> parts;
         ast::ClassDef::RHS_store modRhs;
         makeModule(ctx, &root, parts, modRhs, importType, ImportTree::Source());
@@ -756,7 +756,7 @@ private:
                 // end
                 auto importLoc = node->source.importLoc;
                 auto assignRhs =
-                    prependName(parts2literal(parts, core::LocOffsets::none()), node->source.packageMangledName);
+                    prependPackageScope(parts2literal(parts, core::LocOffsets::none()), node->source.packageMangledName);
                 auto assign = ast::MK::Assign(core::LocOffsets::none(), name2Expr(parts.back(), ast::MK::EmptyTree()),
                                               std::move(assignRhs));
 
@@ -840,12 +840,20 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
             treeBuilder.makeModule(ctx, ImportType::Test); // TODO Also need to add alias for original pkg
     }
 
-    auto assignRhs = prependName(package->name.fullName.toLiteral(core::LocOffsets::none()), package->name.mangledName);
-    auto assign = ast::MK::Assign(
-        core::LocOffsets::none(),
-        prependScope(package->name.fullName.toLiteral(core::LocOffsets::none()), name2Expr(package->name.mangledName)),
-        std::move(assignRhs));
-    testImportedPackages.emplace_back(std::move(assign));
+    {
+        // In the test namespace for this package add an alias to give tests full access to the
+        // packaged code:
+        // module <PackageTests>
+        //   <Imports>
+        //   <Mangled_Pkg_A>::Pkg::A = <PackageRegistry>::<Mangled_Pkg_A>::Pkg::A
+        // end
+        auto assignRhs = prependPackageScope(package->name.fullName.toLiteral(core::LocOffsets::none()), package->name.mangledName);
+        auto assign = ast::MK::Assign(
+                core::LocOffsets::none(),
+                prependScope(package->name.fullName.toLiteral(core::LocOffsets::none()), name2Expr(package->name.mangledName)),
+                std::move(assignRhs));
+        testImportedPackages.emplace_back(std::move(assign));
+    }
 
     auto packageNamespace =
         ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -40,6 +40,7 @@ struct PackageName {
     core::LocOffsets loc;
     core::NameRef mangledName = core::NameRef::noName();
     FullyQualifiedName fullName;
+    bool isTestImport = false;
 
     // Pretty print the package's (user-observable) name (e.g. Foo::Bar)
     string toString(const core::GlobalState &gs) const {
@@ -185,12 +186,13 @@ FullyQualifiedName getFullyQualifiedName(core::Context ctx, ast::UnresolvedConst
 }
 
 // Gets the package name in `tree` if applicable.
-PackageName getPackageName(core::MutableContext ctx, ast::UnresolvedConstantLit *constantLit) {
+PackageName getPackageName(core::MutableContext ctx, ast::UnresolvedConstantLit *constantLit, bool isTestImport=false) {
     ENFORCE(constantLit != nullptr);
 
     PackageName pName;
     pName.loc = constantLit->loc;
     pName.fullName = getFullyQualifiedName(ctx, constantLit);
+    pName.isTestImport = isTestImport;
 
     // Foo::Bar => Foo_Bar_Package
     auto mangledName = absl::StrCat(absl::StrJoin(pName.fullName.parts, "_", NameFormatter(ctx)), "_Package");
@@ -402,7 +404,7 @@ struct PackageInfoFinder {
         }
 
         // Sanity check arguments for unrecognized methods
-        if (send.fun != core::Names::export_() && send.fun != core::Names::import()) {
+        if (!isSpecMethod(send)) {
             for (const auto &arg : send.args) {
                 if (!ast::isa_tree<ast::Literal>(arg)) {
                     if (auto e = ctx.beginError(arg.loc(), core::errors::Packager::InvalidPackageExpression)) {
@@ -426,13 +428,13 @@ struct PackageInfoFinder {
             }
         }
 
-        if (send.fun == core::Names::import() && send.args.size() == 1) {
+        if ((send.fun == core::Names::import() || send.fun == core::Names::test_import()) && send.args.size() == 1) {
             // null indicates an invalid import.
-            if (auto target = verifyConstant(ctx, core::Names::import(), send.args[0])) {
-                auto name = getPackageName(ctx, target);
+            if (auto target = verifyConstant(ctx, send.fun, send.args[0])) {
+                auto name = getPackageName(ctx, target, send.fun == core::Names::test_import());
                 if (name.mangledName == info->name.mangledName) {
                     if (auto e = ctx.beginError(target->loc, core::errors::Packager::NoSelfImport)) {
-                        e.setHeader("Package `{}` cannot import itself", info->name.toString(ctx));
+                        e.setHeader("Package `{}` cannot {} itself", info->name.toString(ctx), send.fun.toString(ctx));
                     }
                 }
                 info->importedPackageNames.emplace_back(move(name));
@@ -508,6 +510,17 @@ struct PackageInfoFinder {
 
         ENFORCE(info->exports.empty());
         std::swap(exported, info->exports);
+    }
+
+    bool isSpecMethod(const sorbet::ast::Send &send) const {
+        switch (send.fun.rawId()) {
+            case core::Names::import().rawId():
+            case core::Names::test_import().rawId():
+            case core::Names::export_().rawId():
+                return true;
+            default:
+                return false;
+        }
     }
 
     /* Forbid arbitrary computation in packages */
@@ -611,9 +624,11 @@ unique_ptr<PackageInfo> getPackageInfo(core::MutableContext ctx, ast::ParsedFile
 // For a given package, a tree that is the union of all constants exported by the packages it
 // imports.
 class ImportTree final {
+
     struct Source {
         core::NameRef packageMangledName;
         core::LocOffsets importLoc;
+        bool testOnly;
         bool exists() {
             return importLoc.exists();
         }
@@ -625,6 +640,8 @@ class ImportTree final {
     Source source;
 
 public:
+    enum class ImportType { Normal = 1, Test = 2 };
+
     ImportTree() = default;
     ImportTree(const ImportTree &) = delete;
     ImportTree(ImportTree &&) = default;
@@ -651,10 +668,10 @@ public:
         }
     }
 
-    ast::ClassDef::RHS_store makeModule(core::Context ctx) {
+    ast::ClassDef::RHS_store makeModule(core::Context ctx, ImportTree::ImportType importType) {
         vector<core::NameRef> parts;
         ast::ClassDef::RHS_store modRhs;
-        makeModule(ctx, &root, parts, modRhs, ImportTree::Source());
+        makeModule(ctx, &root, parts, modRhs, importType, ImportTree::Source());
         return modRhs;
     }
 
@@ -668,11 +685,11 @@ private:
             }
             node = child.get();
         }
-        node->source = {importedPackage.name.mangledName, loc};
+        node->source = {importedPackage.name.mangledName, loc, importedPackage.name.isTestImport};
     }
 
     void makeModule(core::Context ctx, ImportTree *node, vector<core::NameRef> &parts, ast::ClassDef::RHS_store &modRhs,
-                    ImportTree::Source parentSrc) {
+                    ImportTree::ImportType importType, ImportTree::Source parentSrc) {
         auto newParentSrc = parentSrc;
         if (node->source.exists() && !parentSrc.exists()) {
             newParentSrc = node->source;
@@ -687,7 +704,7 @@ private:
         });
         for (auto const &[nameRef, child] : childPairs) {
             parts.emplace_back(nameRef);
-            makeModule(ctx, child, parts, modRhs, newParentSrc);
+            makeModule(ctx, child, parts, modRhs, importType, newParentSrc);
             parts.pop_back();
         }
 
@@ -786,8 +803,8 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
                 treeBuilder.mergeImports(*importedPackage, imported.loc);
             }
         }
-        importedPackages = treeBuilder.makeModule(ctx);
-        testImportedPackages = treeBuilder.makeModule(ctx);
+        importedPackages = treeBuilder.makeModule(ctx, ImportTree::ImportType::Normal);
+        testImportedPackages = treeBuilder.makeModule(ctx, ImportTree::ImportType::Test); // TODO nroman
     }
 
     auto packageNamespace =

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -747,6 +747,7 @@ private:
 // ...to __package.rb files to set up the package namespace.
 ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const PackageDB &packageDB) {
     ast::ClassDef::RHS_store importedPackages;
+    ast::ClassDef::RHS_store testImportedPackages;
 
     auto package = packageDB.getPackageByFile(file.file);
     if (package == nullptr) {
@@ -786,19 +787,24 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
             }
         }
         importedPackages = treeBuilder.makeModule(ctx);
+        testImportedPackages = treeBuilder.makeModule(ctx);
     }
 
     auto packageNamespace =
         ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),
                         name2Expr(core::Names::Constants::PackageRegistry()), {}, std::move(importedPackages));
+    auto testPackageNamespace =
+        ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),
+                        name2Expr(core::Names::Constants::PackageTests()), {}, std::move(testImportedPackages));
 
     auto &rootKlass = ast::cast_tree_nonnull<ast::ClassDef>(file.tree);
     rootKlass.rhs.emplace_back(move(packageNamespace));
+    rootKlass.rhs.emplace_back(move(testPackageNamespace));
     return file;
 }
 
 ast::ParsedFile rewritePackagedFile(core::Context ctx, ast::ParsedFile file, core::NameRef packageMangledName,
-                                    const PackageInfo *pkg) {
+                                    const PackageInfo *pkg, bool isTestFile) {
     if (ast::isa_tree<ast::EmptyTree>(file.tree)) {
         // Nothing to wrap. This occurs when a file is marked typed: Ignore.
         return file;
@@ -889,10 +895,11 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
             for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
                 if (result.gotItem()) {
                     filesProcessed++;
-                    if (job.file.data(gs).sourceType == core::File::Type::Normal) {
+                    auto &file = job.file.data(gs);
+                    if (file.sourceType == core::File::Type::Normal) {
                         core::Context ctx(gs, core::Symbols::root(), job.file);
                         if (auto pkg = constPkgDB.getPackageForContext(ctx)) {
-                            job = rewritePackagedFile(ctx, move(job), pkg->name.mangledName, pkg);
+                            job = rewritePackagedFile(ctx, move(job), pkg->name.mangledName, pkg, file.isTest());
                         } else {
                             // Don't transform, but raise an error on the first line.
                             if (auto e =

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -23,6 +23,12 @@ struct FullyQualifiedName {
     vector<core::NameRef> parts;
     core::Loc loc;
     ast::ExpressionPtr toLiteral(core::LocOffsets loc) const;
+
+    FullyQualifiedName() = default;
+    FullyQualifiedName(const FullyQualifiedName &) = delete;
+    FullyQualifiedName(FullyQualifiedName &&) = default;
+    FullyQualifiedName &operator=(const FullyQualifiedName &) = delete;
+    FullyQualifiedName &operator=(FullyQualifiedName &&) = default;
 };
 
 class NameFormatter final {
@@ -40,12 +46,23 @@ struct PackageName {
     core::LocOffsets loc;
     core::NameRef mangledName = core::NameRef::noName();
     FullyQualifiedName fullName;
-    bool isTestImport = false;
 
     // Pretty print the package's (user-observable) name (e.g. Foo::Bar)
     string toString(const core::GlobalState &gs) const {
         return absl::StrJoin(fullName.parts, "::", NameFormatter(gs));
     }
+};
+
+enum class ImportType {
+    Normal,
+    Test, // test_import
+};
+
+struct Import {
+    PackageName name;
+    ImportType type;
+
+    Import(PackageName &&name, ImportType type) : name(std::move(name)), type(type) {}
 };
 
 struct PackageInfo {
@@ -55,7 +72,7 @@ struct PackageInfo {
     // loc for the package definition. Used for error messages.
     core::Loc loc;
     // The names of each package imported by this package.
-    vector<PackageName> importedPackageNames;
+    vector<Import> importedPackageNames;
     // List of exported items that form the body of this package's public API.
     // These are copied into every package that imports this package.
     vector<FullyQualifiedName> exports;
@@ -186,13 +203,12 @@ FullyQualifiedName getFullyQualifiedName(core::Context ctx, ast::UnresolvedConst
 }
 
 // Gets the package name in `tree` if applicable.
-PackageName getPackageName(core::MutableContext ctx, ast::UnresolvedConstantLit *constantLit, bool isTestImport=false) {
+PackageName getPackageName(core::MutableContext ctx, ast::UnresolvedConstantLit *constantLit) {
     ENFORCE(constantLit != nullptr);
 
     PackageName pName;
     pName.loc = constantLit->loc;
     pName.fullName = getFullyQualifiedName(ctx, constantLit);
-    pName.isTestImport = isTestImport;
 
     // Foo::Bar => Foo_Bar_Package
     auto mangledName = absl::StrCat(absl::StrJoin(pName.fullName.parts, "_", NameFormatter(ctx)), "_Package");
@@ -431,13 +447,13 @@ struct PackageInfoFinder {
         if ((send.fun == core::Names::import() || send.fun == core::Names::test_import()) && send.args.size() == 1) {
             // null indicates an invalid import.
             if (auto target = verifyConstant(ctx, send.fun, send.args[0])) {
-                auto name = getPackageName(ctx, target, send.fun == core::Names::test_import());
+                auto name = getPackageName(ctx, target);
                 if (name.mangledName == info->name.mangledName) {
                     if (auto e = ctx.beginError(target->loc, core::errors::Packager::NoSelfImport)) {
                         e.setHeader("Package `{}` cannot {} itself", info->name.toString(ctx), send.fun.toString(ctx));
                     }
                 }
-                info->importedPackageNames.emplace_back(move(name));
+                info->importedPackageNames.emplace_back(move(name), method2ImportType(send));
             }
         }
 
@@ -520,6 +536,17 @@ struct PackageInfoFinder {
                 return true;
             default:
                 return false;
+        }
+    }
+
+    ImportType method2ImportType(const ast::Send &send) const {
+        switch (send.fun.rawId()) {
+            case core::Names::import().rawId():
+                return ImportType::Normal;
+            case core::Names::test_import().rawId():
+                return ImportType::Test;
+            default:
+                ENFORCE(false);
         }
     }
 
@@ -624,11 +651,10 @@ unique_ptr<PackageInfo> getPackageInfo(core::MutableContext ctx, ast::ParsedFile
 // For a given package, a tree that is the union of all constants exported by the packages it
 // imports.
 class ImportTree final {
-
     struct Source {
         core::NameRef packageMangledName;
         core::LocOffsets importLoc;
-        bool testOnly;
+        ImportType importType;
         bool exists() {
             return importLoc.exists();
         }
@@ -640,8 +666,6 @@ class ImportTree final {
     Source source;
 
 public:
-    enum class ImportType { Normal = 1, Test = 2 };
-
     ImportTree() = default;
     ImportTree(const ImportTree &) = delete;
     ImportTree(ImportTree &&) = default;
@@ -652,23 +676,24 @@ public:
 };
 
 class ImportTreeBuilder final {
-    PackageInfo package; // The package we are building an import tree for.
+    // PackageInfo package; // The package we are building an import tree for.
+    core::NameRef pkgMangledName;
     ImportTree root;
 
 public:
-    ImportTreeBuilder(PackageInfo package) : package(package) {}
+    ImportTreeBuilder(const PackageInfo &package) : pkgMangledName(package.name.mangledName) {}
     ImportTreeBuilder(const ImportTreeBuilder &) = delete;
     ImportTreeBuilder(ImportTreeBuilder &&) = default;
     ImportTreeBuilder &operator=(const ImportTreeBuilder &) = delete;
     ImportTreeBuilder &operator=(ImportTreeBuilder &&) = default;
 
-    void mergeImports(const PackageInfo &importedPackage, core::LocOffsets loc) {
+    void mergeImports(const PackageInfo &importedPackage, const Import &import) {
         for (const auto &exportedFqn : importedPackage.exports) {
-            addImport(importedPackage, loc, exportedFqn);
+            addImport(importedPackage, import.name.loc, exportedFqn, import.type);
         }
     }
 
-    ast::ClassDef::RHS_store makeModule(core::Context ctx, ImportTree::ImportType importType) {
+    ast::ClassDef::RHS_store makeModule(core::Context ctx, ImportType importType) {
         vector<core::NameRef> parts;
         ast::ClassDef::RHS_store modRhs;
         makeModule(ctx, &root, parts, modRhs, importType, ImportTree::Source());
@@ -676,7 +701,8 @@ public:
     }
 
 private:
-    void addImport(const PackageInfo &importedPackage, core::LocOffsets loc, const FullyQualifiedName &exportFqn) {
+    void addImport(const PackageInfo &importedPackage, core::LocOffsets loc, const FullyQualifiedName &exportFqn,
+                   ImportType importType) {
         ImportTree *node = &root;
         for (auto nameRef : exportFqn.parts) {
             auto &child = node->children[nameRef];
@@ -685,11 +711,11 @@ private:
             }
             node = child.get();
         }
-        node->source = {importedPackage.name.mangledName, loc, importedPackage.name.isTestImport};
+        node->source = {importedPackage.name.mangledName, loc, importType}; // TODO not always normal
     }
 
     void makeModule(core::Context ctx, ImportTree *node, vector<core::NameRef> &parts, ast::ClassDef::RHS_store &modRhs,
-                    ImportTree::ImportType importType, ImportTree::Source parentSrc) {
+                    ImportType importType, ImportTree::Source parentSrc) {
         auto newParentSrc = parentSrc;
         if (node->source.exists() && !parentSrc.exists()) {
             newParentSrc = node->source;
@@ -717,7 +743,7 @@ private:
                                 fmt::map_join(parts, "::", [&](const auto &nr) { return nr.show(ctx); }));
                     e.addErrorLine(core::Loc(ctx.file, parentSrc.importLoc), "Conflict from");
                 }
-            } else {
+            } else if (importType == ImportType::Test || node->source.importType == ImportType::Normal) {
                 // Construct a module containing an assignment for an imported name:
                 // For name `A::B::C::D` imported from package `A::B` construct:
                 // module A::B::C
@@ -744,7 +770,7 @@ private:
     }
 
     ast::ExpressionPtr importModuleName(vector<core::NameRef> &parts, core::LocOffsets importLoc) {
-        ast::ExpressionPtr name = name2Expr(package.name.mangledName);
+        ast::ExpressionPtr name = name2Expr(pkgMangledName);
         for (auto part = parts.begin(); part < parts.end() - 1; part++) {
             name = name2Expr(*part, move(name));
         }
@@ -783,7 +809,8 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
     {
         UnorderedMap<core::NameRef, core::LocOffsets> importedNames;
         ImportTreeBuilder treeBuilder(*package);
-        for (auto &imported : package->importedPackageNames) {
+        for (auto &import : package->importedPackageNames) {
+            auto &imported = import.name;
             auto importedPackage = packageDB.getPackageByMangledName(imported.mangledName);
             if (importedPackage == nullptr) {
                 if (auto e = ctx.beginError(imported.loc, core::errors::Packager::PackageNotFound)) {
@@ -800,11 +827,12 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
                 }
             } else {
                 importedNames[imported.mangledName] = imported.loc;
-                treeBuilder.mergeImports(*importedPackage, imported.loc);
+                treeBuilder.mergeImports(*importedPackage, import);
             }
         }
-        importedPackages = treeBuilder.makeModule(ctx, ImportTree::ImportType::Normal);
-        testImportedPackages = treeBuilder.makeModule(ctx, ImportTree::ImportType::Test); // TODO nroman
+        importedPackages = treeBuilder.makeModule(ctx, ImportType::Normal);
+        testImportedPackages =
+            treeBuilder.makeModule(ctx, ImportType::Test); // TODO Also need to add alias for original pkg
     }
 
     auto packageNamespace =

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -10,6 +10,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
     end
   end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
+    end
+
+    <emptyTree>::<C A_Package$1>::<C A> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>
+  end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
@@ -17,6 +25,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    <emptyTree>::<C B_Package$1>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -34,6 +34,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BModule>
     end
   end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
+    end
+
+    module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BModule>
+    end
+
+    <emptyTree>::<C A_Package$1>::<C A> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>
+  end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C <PackageRegistry>>::<C A_Package$1><<C <todo sym>>> < ()
@@ -94,6 +106,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C B_Package$1>::<C A><<C <todo sym>>> < ()
       <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C REFERENCE>
     end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C B_Package$1>::<C A><<C <todo sym>>> < ()
+      <emptyTree>::<C AClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C AClass>
+    end
+
+    module <emptyTree>::<C B_Package$1>::<C A><<C <todo sym>>> < ()
+      <emptyTree>::<C AModule> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C AModule>
+    end
+
+    module <emptyTree>::<C B_Package$1>::<C A><<C <todo sym>>> < ()
+      <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C REFERENCE>
+    end
+
+    <emptyTree>::<C B_Package$1>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -47,6 +47,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
   end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    <emptyTree>::<C MyPackage_Package$1>::<C MyPackage> = <emptyTree>::<C <PackageRegistry>>::<C MyPackage_Package$1>::<C MyPackage>
+  end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C <PackageRegistry>>::<C MyPackage_Package$1><<C <todo sym>>> < ()

--- a/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
@@ -16,6 +16,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Constant>
     end
   end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C RootPackage_Package$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>
+    end
+
+    module <emptyTree>::<C RootPackage_Package$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>
+    end
+
+    module <emptyTree>::<C RootPackage_Package$1>::<C RootPackage>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Constant>
+    end
+
+    <emptyTree>::<C RootPackage_Package$1>::<C RootPackage> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Package$1>::<C RootPackage>
+  end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Package$1><<C <todo sym>>> < ()
@@ -52,6 +68,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -10,6 +10,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
     end
   end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
+      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
+    end
+
+    <emptyTree>::<C Package_Package$1>::<C Package> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>
+  end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1><<C <todo sym>>> < ()
@@ -39,6 +47,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
       <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
     end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
+    end
+
+    <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -18,6 +18,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C CallsBar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C CallsBar>
+    end
+
+    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C Foo>
+    end
+
+    <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -84,6 +93,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C Bar>
+    end
+
+    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C CallsFoo>
+    end
+
+    <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -16,6 +16,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C Foo>
     end
   end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+  end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1><<C <todo sym>>> < ()
@@ -78,6 +81,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
       <emptyTree>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C CallsFoo>
     end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/simple_test_import/main_lib/__package.rb
+++ b/test/testdata/packager/simple_test_import/main_lib/__package.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Project::MainLib < PackageSpec
+  import Project::Util
+  test_import Project::TestOnly
+end

--- a/test/testdata/packager/simple_test_import/main_lib/lib.rb
+++ b/test/testdata/packager/simple_test_import/main_lib/lib.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::MainLib::Lib
+end

--- a/test/testdata/packager/simple_test_import/main_lib/lib.rb
+++ b/test/testdata/packager/simple_test_import/main_lib/lib.rb
@@ -2,4 +2,9 @@
 # typed: strict
 
 class Project::MainLib::Lib
+  Project::Util::MyUtil.new
+
+  # Normal code is not allowed to access names from `test_import`
+  Project::TestOnly::SomeHelper.new
+# ^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `TestOnly`
 end

--- a/test/testdata/packager/simple_test_import/main_lib/lib.test.rb
+++ b/test/testdata/packager/simple_test_import/main_lib/lib.test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Test::Project::MainLib::LibTest
+  # Tests can access their package's code
+  Project::MainLib::Lib.new
+  # Tests can access `import`
+  Project::Util::MyUtil.new
+  # Tests can access `test_import` names
+  Project::TestOnly::SomeHelper.new # access via test_import
+end

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -26,6 +26,20 @@ end
 class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Project>::<C MainLib>::<C Lib><<C <todo sym>>> < (::<todo sym>)
+      <emptyTree>::<C Project>::<C Util>::<C MyUtil>.new()
+
+      <emptyTree>::<C Project>::<C TestOnly>::<C SomeHelper>.new()
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageTests>>::<C Project_MainLib_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Test>::<C Project>::<C MainLib>::<C LibTest><<C <todo sym>>> < (::<todo sym>)
+      <emptyTree>::<C Project>::<C MainLib>::<C Lib>.new()
+
+      <emptyTree>::<C Project>::<C Util>::<C MyUtil>.new()
+
+      <emptyTree>::<C Project>::<C TestOnly>::<C SomeHelper>.new()
     end
   end
 end

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -6,10 +6,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C TestOnly><<C <todo sym>>> < ()
-      <emptyTree>::<C SomeHelper> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>::<C SomeHelper>
-    end
-
     module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C Util><<C <todo sym>>> < ()
       <emptyTree>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>::<C MyUtil>
     end

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -19,6 +19,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C Util><<C <todo sym>>> < ()
       <emptyTree>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>::<C MyUtil>
     end
+
+    <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C MainLib> = <emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package$1>::<C Project>::<C MainLib>
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Project>::<C MainLib>::<C Lib><<C <todo sym>>> < (::<todo sym>)
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -30,6 +38,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    <emptyTree>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -47,6 +56,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    <emptyTree>::<C Project_Util_Package$1>::<C Project>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -1,0 +1,61 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Project>::<C MainLib><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Project>::<C Util>)
+
+    <self>.test_import(<emptyTree>::<C Project>::<C TestOnly>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C TestOnly><<C <todo sym>>> < ()
+      <emptyTree>::<C SomeHelper> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>::<C SomeHelper>
+    end
+
+    module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C Util><<C <todo sym>>> < ()
+      <emptyTree>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>::<C MyUtil>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C TestOnly><<C <todo sym>>> < ()
+      <emptyTree>::<C SomeHelper> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>::<C SomeHelper>
+    end
+
+    module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C Util><<C <todo sym>>> < ()
+      <emptyTree>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>::<C MyUtil>
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Project>::<C TestOnly><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>::<C SomeHelper>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Project>::<C TestOnly>::<C SomeHelper><<C <todo sym>>> < (::<todo sym>)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Project>::<C Util><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>::<C MyUtil>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Project>::<C Util>::<C MyUtil><<C <todo sym>>> < (::<todo sym>)
+    end
+  end
+end

--- a/test/testdata/packager/simple_test_import/test_only/__package.rb
+++ b/test/testdata/packager/simple_test_import/test_only/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Project::TestOnly < PackageSpec
+  export Project::TestOnly::SomeHelper
+end

--- a/test/testdata/packager/simple_test_import/test_only/some_helper.rb
+++ b/test/testdata/packager/simple_test_import/test_only/some_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::TestOnly::SomeHelper
+end

--- a/test/testdata/packager/simple_test_import/util/__package.rb
+++ b/test/testdata/packager/simple_test_import/util/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Project::Util < PackageSpec
+  export Project::Util::MyUtil
+end

--- a/test/testdata/packager/simple_test_import/util/my_util.rb
+++ b/test/testdata/packager/simple_test_import/util/my_util.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::Util::MyUtil
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
In --stripe-packages add a separate package for test code:
* Test code must be prefixed with `Test::<Package Namespace>`
* Test code is wrapped into a separate registry `<PackageTests>::<Mangled_Package_Name>`
* Test package gets an alias to see all code in it's companion normal package.
* `test_import` works like `import` but also these packages are only accessible by the test code.
* Add ability to `export Test::...` names (these only are imported into tests)

TODO

- [ ] Add more tests
- [ ] Fix bug where if there if the package is empty the alias added does not resolve (see failing tests)
- [ ] cleanup TODOs
- [ ] `export` support for `Test...` contants.

<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
