### PR TITLE
lub: Better reduce AndTypes created during type inference.

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -605,7 +605,7 @@ private:
     friend bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
                                                 const TypePtr &t2, UntypedMode mode);
     friend TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
-    friend TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
+    friend TypePtr lubDistributeOrs(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);

--- a/core/Types.h
+++ b/core/Types.h
@@ -605,6 +605,7 @@ private:
     friend bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
                                                 const TypePtr &t2, UntypedMode mode);
     friend TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
+    friend TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);

--- a/core/Types.h
+++ b/core/Types.h
@@ -605,7 +605,7 @@ private:
     friend bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
                                                 const TypePtr &t2, UntypedMode mode);
     friend TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
-    friend TypePtr lubDistributeOrs(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
+    friend TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);

--- a/core/Types.h
+++ b/core/Types.h
@@ -605,7 +605,6 @@ private:
     friend bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
                                                 const TypePtr &t2, UntypedMode mode);
     friend TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
-    friend TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -108,10 +108,9 @@ TypePtr filterOrComponents(const TypePtr &originalType, const InlinedVector<Type
 TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
     InlinedVector<TypePtr, 4> originalOrComponents;
     InlinedVector<TypePtr, 4> typesConsumed;
-    auto *o1 = cast_type<OrType>(t1);
-    ENFORCE(o1 != nullptr);
-    fillInOrComponents(originalOrComponents, o1->left);
-    fillInOrComponents(originalOrComponents, o1->right);
+    const auto o1 = cast_type_nonnull<OrType>(t1);
+    fillInOrComponents(originalOrComponents, o1.left);
+    fillInOrComponents(originalOrComponents, o1.right);
 
     for (auto &component : originalOrComponents) {
         auto lubbed = Types::any(gs, component, t2);

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -105,12 +105,7 @@ TypePtr filterOrComponents(const TypePtr &originalType, const InlinedVector<Type
     }
 }
 
-TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const TypePtr &t2);
 TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
-    if (isa_type<OrType>(t2)) {
-        return lubDistributeOrSquared(gs, t1, t2);
-    }
-
     InlinedVector<TypePtr, 4> originalOrComponents;
     InlinedVector<TypePtr, 4> typesConsumed;
     auto *o1 = cast_type<OrType>(t1);
@@ -146,7 +141,7 @@ TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr 
     return OrType::make_shared(move(remainingTypes), underlying(gs, t2));
 }
 
-TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
+TypePtr lubDistributeOrs(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
     auto o1 = cast_type_nonnull<OrType>(t1);
     InlinedVector<TypePtr, 4> original1OrComponents;
     fillInOrComponents(original1OrComponents, o1.left);
@@ -186,23 +181,23 @@ TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &t1, const T
     }
 
     if (types1Consumed.empty() && types2Consumed.empty()) {
-        categoryCounterInc("lubDistributeOrSquared.outcome", "worst");
+        categoryCounterInc("lubDistributeOrs.outcome", "worst");
         return OrType::make_shared(t1, underlying(gs, t2));
     }
 
     if (types2Consumed.size() == original2OrComponents.size()) {
-        categoryCounterInc("lubDistributeOrSquared.outcome", "t1");
+        categoryCounterInc("lubDistributeOrs.outcome", "t1");
         // t2 <: t1
         return t1;
     }
 
     if (types1Consumed.size() == original1OrComponents.size()) {
-        categoryCounterInc("lubDistributeOrSquared.outcome", "t2");
+        categoryCounterInc("lubDistributeOrs.outcome", "t2");
         // t1 <: t2
         return t2;
     }
 
-    categoryCounterInc("lubDistributeOr.outcome", "consumedComponent");
+    categoryCounterInc("lubDistributeOrs.outcome", "consumedComponent");
     auto t1Filtered = filterOrComponents(t1, types1Consumed);
     auto t2Filtered = filterOrComponents(t2, types2Consumed);
     return OrType::make_shared(t1Filtered, t2Filtered);
@@ -311,6 +306,10 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     }
 
     if (auto *o2 = cast_type<OrType>(t2)) { // 3, 5, 6
+        if (auto *o1 = cast_type<OrType>(t1)) {
+            categoryCounterInc("lub", "<or>");
+            return lubDistributeOrs(gs, t2, t1);
+        }
         categoryCounterInc("lub", "or>");
         return lubDistributeOr(gs, t2, t1);
     } else if (auto *a2 = cast_type<AndType>(t2)) { // 2, 4

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -154,14 +154,8 @@ TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const T
 
     TypePtr combined = o1;
     for (const TypePtr &component : original2OrComponents) {
-        if (isa_type<OrType>(combined)) {
-            TypePtr combined2 = lubDistributeOr(gs, combined, component);
-            combined = move(combined2);
-        } else {
-            // TODO: When do we hit this case?
-            TypePtr combined2 = Types::lub(gs, combined, component);
-            combined = move(combined2);
-        }
+        TypePtr combined2 = lubDistributeOr(gs, combined, component);
+        combined = move(combined2);
     }
     return combined;
 }

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -105,10 +105,10 @@ TypePtr filterOrComponents(const TypePtr &originalType, const InlinedVector<Type
     }
 }
 
-TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const TypePtr &t2);
+TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const OrType &o2);
 TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
-    if (isa_type<OrType>(t2)) {
-        return lubDistributeOrSquared(gs, t1, t2);
+    if (auto *o2 = cast_type<OrType>(t2)) {
+        return lubDistributeOrSquared(gs, t1, *o2);
     }
 
     InlinedVector<TypePtr, 4> originalOrComponents;
@@ -146,8 +146,7 @@ TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr 
     return OrType::make_shared(move(remainingTypes), underlying(gs, t2));
 }
 
-TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const TypePtr &t2) {
-    auto o2 = cast_type_nonnull<OrType>(t2);
+TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const OrType &o2) {
     InlinedVector<TypePtr, 4> original2OrComponents;
     fillInOrComponents(original2OrComponents, o2.left);
     fillInOrComponents(original2OrComponents, o2.right);

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -153,8 +153,7 @@ TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const O
 
     TypePtr combined = o1;
     for (const TypePtr &component : original2OrComponents) {
-        TypePtr combined2 = lubDistributeOr(gs, combined, component);
-        combined = move(combined2);
+        combined = lubDistributeOr(gs, combined, component);
     }
     return combined;
 }

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -153,7 +153,8 @@ TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const O
 
     TypePtr combined = o1;
     for (const TypePtr &component : original2OrComponents) {
-        combined = lubDistributeOr(gs, combined, component);
+        TypePtr combined2 = lubDistributeOr(gs, combined, component);
+        combined = move(combined2);
     }
     return combined;
 }

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -154,8 +154,14 @@ TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const T
 
     TypePtr combined = o1;
     for (const TypePtr &component : original2OrComponents) {
-        TypePtr combined2 = lubDistributeOr(gs, combined, component);
-        combined = move(combined2);
+        if (isa_type<OrType>(combined)) {
+            TypePtr combined2 = lubDistributeOr(gs, combined, component);
+            combined = move(combined2);
+        } else {
+            // TODO: When do we hit this case?
+            TypePtr combined2 = Types::lub(gs, combined, component);
+            combined = move(combined2);
+        }
     }
     return combined;
 }

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -146,66 +146,24 @@ TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr 
     return OrType::make_shared(move(remainingTypes), underlying(gs, t2));
 }
 
-TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
-    auto o1 = cast_type_nonnull<OrType>(t1);
-    InlinedVector<TypePtr, 4> original1OrComponents;
-    fillInOrComponents(original1OrComponents, o1.left);
-    fillInOrComponents(original1OrComponents, o1.right);
-
+TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const TypePtr &t2) {
     auto o2 = cast_type_nonnull<OrType>(t2);
     InlinedVector<TypePtr, 4> original2OrComponents;
     fillInOrComponents(original2OrComponents, o2.left);
     fillInOrComponents(original2OrComponents, o2.right);
 
-    InlinedVector<TypePtr, 4> types1Consumed;
-    InlinedVector<TypePtr, 4> types2Consumed;
-
-    for (const TypePtr &o2Component : original2OrComponents) {
-        auto nextT1Consumed = types1Consumed.begin();
-        for (const TypePtr &o1Component : original1OrComponents) {
-            // Ignore components that have been consumed.
-            // We take advantage of the fact that types1Consumed is in the same order as original1OrComponents.
-            if (nextT1Consumed != types1Consumed.end() && *nextT1Consumed == o1Component) {
-                nextT1Consumed++;
-                continue;
-            }
-
-            auto lubbed = Types::any(gs, o1Component, o2Component);
-            if (lubbed == o1Component) {
-                // lubbed == o1Component, so o2Component <: o1Component and t2 <: t1
-                // Thus, we don't need to include o2Component in the final OrType; it's subsumed by t1.
-                types2Consumed.emplace_back(o2Component);
-                // We don't have to iterate over any more o1Components to find a match for o2.
-                break;
-            } else if (lubbed == o2Component) {
-                // lubbed == o2Component, so o1Component <: t2
-                // Thus, we don't need to include o1Component in the final OrType; it's subsumed by t2.
-                types1Consumed.emplace_back(o1Component);
-            }
+    TypePtr combined = o1;
+    for (const TypePtr &component : original2OrComponents) {
+        if (isa_type<OrType>(combined)) {
+            TypePtr combined2 = lubDistributeOr(gs, combined, component);
+            combined = move(combined2);
+        } else {
+            // TODO: When do we hit this case?
+            TypePtr combined2 = Types::lub(gs, combined, component);
+            combined = move(combined2);
         }
     }
-
-    if (types1Consumed.empty() && types2Consumed.empty()) {
-        categoryCounterInc("lubDistributeOrSquared.outcome", "worst");
-        return OrType::make_shared(t1, underlying(gs, t2));
-    }
-
-    if (types2Consumed.size() == original2OrComponents.size()) {
-        categoryCounterInc("lubDistributeOrSquared.outcome", "t1");
-        // t2 <: t1
-        return t1;
-    }
-
-    if (types1Consumed.size() == original1OrComponents.size()) {
-        categoryCounterInc("lubDistributeOrSquared.outcome", "t2");
-        // t1 <: t2
-        return t2;
-    }
-
-    categoryCounterInc("lubDistributeOr.outcome", "consumedComponent");
-    auto t1Filtered = filterOrComponents(t1, types1Consumed);
-    auto t2Filtered = filterOrComponents(t2, types2Consumed);
-    return OrType::make_shared(t1Filtered, t2Filtered);
+    return combined;
 }
 
 TypePtr glbDistributeAnd(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -219,6 +219,14 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         categoryCounterInc("lub", "or>");
         return lubDistributeOr(gs, t2, t1);
     } else if (auto *a2 = cast_type<AndType>(t2)) { // 2, 4
+        if (auto *a1 = cast_type<AndType>(t1)) {
+            // Check if a1 and a2 are equivalent. This helps simplify T.all types created during type inference.
+            if ((a1->left == a2->left && a1->right == a2->right) || (a1->left == a2->right && a1->right == a2->left)) {
+                categoryCounterInc("lub", "<and>");
+                return t2;
+            }
+        }
+
         categoryCounterInc("lub", "and>");
         auto t1d = underlying(gs, t1);
         auto t2filtered = dropLubComponents(gs, t2, t1d);

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -105,12 +105,7 @@ TypePtr filterOrComponents(const TypePtr &originalType, const InlinedVector<Type
     }
 }
 
-TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const OrType &o2);
 TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
-    if (auto *o2 = cast_type<OrType>(t2)) {
-        return lubDistributeOrSquared(gs, t1, *o2);
-    }
-
     InlinedVector<TypePtr, 4> originalOrComponents;
     InlinedVector<TypePtr, 4> typesConsumed;
     auto *o1 = cast_type<OrType>(t1);
@@ -144,18 +139,6 @@ TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr 
     }
     categoryCounterInc("lubDistributeOr.outcome", "consumedComponent");
     return OrType::make_shared(move(remainingTypes), underlying(gs, t2));
-}
-
-TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const OrType &o2) {
-    InlinedVector<TypePtr, 4> original2OrComponents;
-    fillInOrComponents(original2OrComponents, o2.left);
-    fillInOrComponents(original2OrComponents, o2.right);
-
-    TypePtr combined = o1;
-    for (const TypePtr &component : original2OrComponents) {
-        combined = lubDistributeOr(gs, combined, component);
-    }
-    return combined;
 }
 
 TypePtr glbDistributeAnd(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -108,9 +108,10 @@ TypePtr filterOrComponents(const TypePtr &originalType, const InlinedVector<Type
 TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
     InlinedVector<TypePtr, 4> originalOrComponents;
     InlinedVector<TypePtr, 4> typesConsumed;
-    const auto o1 = cast_type_nonnull<OrType>(t1);
-    fillInOrComponents(originalOrComponents, o1.left);
-    fillInOrComponents(originalOrComponents, o1.right);
+    auto *o1 = cast_type<OrType>(t1);
+    ENFORCE(o1 != nullptr);
+    fillInOrComponents(originalOrComponents, o1->left);
+    fillInOrComponents(originalOrComponents, o1->right);
 
     for (auto &component : originalOrComponents) {
         auto lubbed = Types::any(gs, component, t2);

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -105,10 +105,10 @@ TypePtr filterOrComponents(const TypePtr &originalType, const InlinedVector<Type
     }
 }
 
-TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const OrType &o2);
+TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const TypePtr &t2);
 TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
-    if (auto *o2 = cast_type<OrType>(t2)) {
-        return lubDistributeOrSquared(gs, t1, *o2);
+    if (isa_type<OrType>(t2)) {
+        return lubDistributeOrSquared(gs, t1, t2);
     }
 
     InlinedVector<TypePtr, 4> originalOrComponents;
@@ -146,7 +146,8 @@ TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr 
     return OrType::make_shared(move(remainingTypes), underlying(gs, t2));
 }
 
-TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const OrType &o2) {
+TypePtr lubDistributeOrSquared(const GlobalState &gs, const TypePtr &o1, const TypePtr &t2) {
+    auto o2 = cast_type_nonnull<OrType>(t2);
     InlinedVector<TypePtr, 4> original2OrComponents;
     fillInOrComponents(original2OrComponents, o2.left);
     fillInOrComponents(original2OrComponents, o2.right);

--- a/test/testdata/infer/lub_and_glb_corner_cases.rb
+++ b/test/testdata/infer/lub_and_glb_corner_cases.rb
@@ -3,10 +3,15 @@
 module Main
   module Boolean
   end
-  T4 = T.type_alias{T.any(T.all(Boolean, T.nilable(FalseClass)), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, T.nilable(FalseClass)), FalseClass, T.all(Boolean, NilClass), TrueClass)}
+  # T4 = T.type_alias{T.any(T.all(Boolean, T.nilable(FalseClass)), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, T.nilable(FalseClass)), FalseClass, T.all(Boolean, NilClass), TrueClass)}
+
+  T5 = T.type_alias{T.any(T.all(Boolean, T.nilable(FalseClass)), T.all(Boolean, NilClass))}
+  T6 = T.type_alias{T.any(T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, T.nilable(FalseClass)), FalseClass, T.all(Boolean, NilClass), TrueClass)}
+  T7 = T.type_alias{T.any(T5, T6)}
 
   def equivalent_and_types_lub
-    T.reveal_type(T4) # error: Revealed type: `<Type: T.any(T.all(Main::Boolean, T.nilable(FalseClass)), FalseClass, T.all(Main::Boolean, NilClass), TrueClass)>`
+    # T.reveal_type(T4)
+    T.reveal_type(T7) # error: Revealed type: `<Type: T.any(FalseClass, TrueClass, T.all(Main::Boolean, T.nilable(FalseClass)), T.all(Main::Boolean, NilClass))>`
   end
   
 end

--- a/test/testdata/infer/lub_and_glb_corner_cases.rb
+++ b/test/testdata/infer/lub_and_glb_corner_cases.rb
@@ -1,6 +1,80 @@
 # typed: true
 
+module A
+end
+module B
+end
+module C
+end
+module D
+end
+
 module Main
+  def cross_product
+      ret = T.cast(nil, T.any(
+          T.all(A, T.any(C, D)),
+          T.all(B, T.any(C, D)),
+      ))
+      T.assert_type!(ret, T.all(T.any(A, B), T.any(C, D)))
+  end
+
+  def demorgans
+      ret = T.cast(nil, T.all(
+          T.any(A, B),
+          T.any(B, C),
+      ))
+      T.assert_type!(ret, T.any(B, T.all(A, C)))
+  end
+
+  def any_of_all
+      ret = T.cast(nil, T.any(
+          T.any(A, T.all(B, C)),
+          D,
+      ))
+      T.assert_type!(ret, T.any(A, T.all(B, C), D))
+  end
+
+  T.assert_type!(1, T.any(Integer, NilClass, String, Integer)) # exists to tigger a sanity check
+
+  def generic_class_glb_bottom
+    ret = T.cast(nil, T.all(String, T::Hash[String, String]))
+    foo # error: This code is unreachable
+  end
+
+  def generic_class_glb_collapse
+    ret = T.cast(nil, T.all(Object, T::Hash[String, String]))
+    T.assert_type!(ret, T::Hash[String, String])
+
+    T.assert_type!(0, T.all(Object, T::Hash[String, String])) # error: does not have asserted type `T::Hash[String, String]`
+  end
+
+  def generic_class_module_glb
+    T.assert_type!(0, T.all(A, T::Hash[String, String])) # error: does not have asserted type `T.all(T::Hash[String, String], A)`
+  end
+
+  def generic_class_lub(b)
+    if b == 1
+      xs = T::Array[T.nilable(String)].new
+    elsif b == 2
+      xs = nil
+    else
+      xs = T::Array[T.untyped].new
+    end
+
+    # T.any(nil, T::Array[T.nilable(String)], T::Array[T.untyped]) => T.nilable(T::Array[T.untyped])
+    T.reveal_type(xs) # error: Revealed type: `T.nilable(T::Array[T.untyped])`
+  end
+
+  def generic_class_nilable_array_tuple_lub
+    a = T.let(nil, T.nilable(T::Array[Float]))
+    b = T.let(nil, T.nilable(T::Array[Integer]))
+    T.reveal_type([a, b]) # error: Revealed type: `[T.nilable(T::Array[Float]), T.nilable(T::Array[Integer])] (2-tuple)`
+    # This reproduces a bug in Sorbet. In the buggy version, the above T.reveal_type passes,
+    # but the below statement would not error.
+    [a, b].each(&:lazy)
+    #            ^^^^^ error: Method `lazy` does not exist on `NilClass`
+  end
+
   module Boolean
   end
   T4 = T.type_alias{T.any(T.all(Boolean, T.nilable(FalseClass)), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, T.nilable(FalseClass)), FalseClass, T.all(Boolean, NilClass), TrueClass)}
@@ -8,5 +82,5 @@ module Main
   def equivalent_and_types_lub
     T.reveal_type(T4) # error: Revealed type: `<Type: T.any(T.all(Main::Boolean, T.nilable(FalseClass)), FalseClass, T.all(Main::Boolean, NilClass), TrueClass)>`
   end
-  
+
 end

--- a/test/testdata/infer/lub_and_glb_corner_cases.rb
+++ b/test/testdata/infer/lub_and_glb_corner_cases.rb
@@ -86,7 +86,14 @@ module Main
   T2 = T.type_alias{T.all(Cat, Dog)}
   T3 = T.type_alias{T.any(T1, T2)}
 
+
+  module Boolean
+  end
+  T4 = T.type_alias{T.any(T.all(Boolean, T.nilable(FalseClass)), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, T.nilable(FalseClass)), FalseClass, T.all(Boolean, NilClass), TrueClass)}
+
   def equivalent_and_types_lub
     T.reveal_type(T3) # error: Revealed type: `<Type: T.all(Main::Cat, Main::Dog)>`
+    T.reveal_type(T4) # error: Revealed type: `<Type: T.any(T.all(Main::Boolean, T.nilable(FalseClass)), T.all(Main::Boolean, NilClass), FalseClass, TrueClass)>`
   end
+  
 end

--- a/test/testdata/infer/lub_and_glb_corner_cases.rb
+++ b/test/testdata/infer/lub_and_glb_corner_cases.rb
@@ -3,15 +3,10 @@
 module Main
   module Boolean
   end
-  # T4 = T.type_alias{T.any(T.all(Boolean, T.nilable(FalseClass)), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, T.nilable(FalseClass)), FalseClass, T.all(Boolean, NilClass), TrueClass)}
-
-  T5 = T.type_alias{T.any(T.all(Boolean, T.nilable(FalseClass)), T.all(Boolean, NilClass))}
-  T6 = T.type_alias{T.any(T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, T.nilable(FalseClass)), FalseClass, T.all(Boolean, NilClass), TrueClass)}
-  T7 = T.type_alias{T.any(T5, T6)}
+  T4 = T.type_alias{T.any(T.all(Boolean, T.nilable(FalseClass)), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, T.nilable(FalseClass)), FalseClass, T.all(Boolean, NilClass), TrueClass)}
 
   def equivalent_and_types_lub
-    # T.reveal_type(T4)
-    T.reveal_type(T7) # error: Revealed type: `<Type: T.any(FalseClass, TrueClass, T.all(Main::Boolean, T.nilable(FalseClass)), T.all(Main::Boolean, NilClass))>`
+    T.reveal_type(T4) # error: Revealed type: `<Type: T.any(T.all(Main::Boolean, T.nilable(FalseClass)), FalseClass, T.all(Main::Boolean, NilClass), TrueClass)>`
   end
   
 end

--- a/test/testdata/infer/lub_and_glb_corner_cases.rb
+++ b/test/testdata/infer/lub_and_glb_corner_cases.rb
@@ -60,7 +60,7 @@ module Main
     else
       xs = T::Array[T.untyped].new
     end
-
+    
     # T.any(nil, T::Array[T.nilable(String)], T::Array[T.untyped]) => T.nilable(T::Array[T.untyped])
     T.reveal_type(xs) # error: Revealed type: `T.nilable(T::Array[T.untyped])`
   end

--- a/test/testdata/infer/lub_and_glb_corner_cases.rb
+++ b/test/testdata/infer/lub_and_glb_corner_cases.rb
@@ -74,4 +74,19 @@ module Main
     [a, b].each(&:lazy)
     #            ^^^^^ error: Method `lazy` does not exist on `NilClass`
   end
+
+
+  module Cat
+  end
+  
+  module Dog
+  end
+
+  T1 = T.type_alias{T.all(Cat, Dog)}
+  T2 = T.type_alias{T.all(Cat, Dog)}
+  T3 = T.type_alias{T.any(T1, T2)}
+
+  def equivalent_and_types_lub
+    T.reveal_type(T3) # error: Revealed type: `<Type: T.all(Main::Cat, Main::Dog)>`
+  end
 end

--- a/test/testdata/infer/lub_and_glb_corner_cases.rb
+++ b/test/testdata/infer/lub_and_glb_corner_cases.rb
@@ -1,99 +1,12 @@
 # typed: true
 
-module A
-end
-module B
-end
-module C
-end
-module D
-end
-
 module Main
-  def cross_product
-      ret = T.cast(nil, T.any(
-          T.all(A, T.any(C, D)),
-          T.all(B, T.any(C, D)),
-      ))
-      T.assert_type!(ret, T.all(T.any(A, B), T.any(C, D)))
-  end
-
-  def demorgans
-      ret = T.cast(nil, T.all(
-          T.any(A, B),
-          T.any(B, C),
-      ))
-      T.assert_type!(ret, T.any(B, T.all(A, C)))
-  end
-
-  def any_of_all
-      ret = T.cast(nil, T.any(
-          T.any(A, T.all(B, C)),
-          D,
-      ))
-      T.assert_type!(ret, T.any(A, T.all(B, C), D))
-  end
-
-  T.assert_type!(1, T.any(Integer, NilClass, String, Integer)) # exists to tigger a sanity check
-
-  def generic_class_glb_bottom
-    ret = T.cast(nil, T.all(String, T::Hash[String, String]))
-    foo # error: This code is unreachable
-  end
-
-  def generic_class_glb_collapse
-    ret = T.cast(nil, T.all(Object, T::Hash[String, String]))
-    T.assert_type!(ret, T::Hash[String, String])
-
-    T.assert_type!(0, T.all(Object, T::Hash[String, String])) # error: does not have asserted type `T::Hash[String, String]`
-  end
-
-  def generic_class_module_glb
-    T.assert_type!(0, T.all(A, T::Hash[String, String])) # error: does not have asserted type `T.all(T::Hash[String, String], A)`
-  end
-
-  def generic_class_lub(b)
-    if b == 1
-      xs = T::Array[T.nilable(String)].new
-    elsif b == 2
-      xs = nil
-    else
-      xs = T::Array[T.untyped].new
-    end
-    
-    # T.any(nil, T::Array[T.nilable(String)], T::Array[T.untyped]) => T.nilable(T::Array[T.untyped])
-    T.reveal_type(xs) # error: Revealed type: `T.nilable(T::Array[T.untyped])`
-  end
-
-  def generic_class_nilable_array_tuple_lub
-    a = T.let(nil, T.nilable(T::Array[Float]))
-    b = T.let(nil, T.nilable(T::Array[Integer]))
-    T.reveal_type([a, b]) # error: Revealed type: `[T.nilable(T::Array[Float]), T.nilable(T::Array[Integer])] (2-tuple)`
-    # This reproduces a bug in Sorbet. In the buggy version, the above T.reveal_type passes,
-    # but the below statement would not error.
-    [a, b].each(&:lazy)
-    #            ^^^^^ error: Method `lazy` does not exist on `NilClass`
-  end
-
-
-  module Cat
-  end
-  
-  module Dog
-  end
-
-  T1 = T.type_alias{T.all(Cat, Dog)}
-  T2 = T.type_alias{T.all(Cat, Dog)}
-  T3 = T.type_alias{T.any(T1, T2)}
-
-
   module Boolean
   end
   T4 = T.type_alias{T.any(T.all(Boolean, T.nilable(FalseClass)), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, T.nilable(FalseClass)), FalseClass, T.all(Boolean, NilClass), TrueClass)}
 
   def equivalent_and_types_lub
-    T.reveal_type(T3) # error: Revealed type: `<Type: T.all(Main::Cat, Main::Dog)>`
-    T.reveal_type(T4) # error: Revealed type: `<Type: T.any(T.all(Main::Boolean, T.nilable(FalseClass)), T.all(Main::Boolean, NilClass), FalseClass, TrueClass)>`
+    T.reveal_type(T4) # error: Revealed type: `<Type: T.any(T.all(Main::Boolean, T.nilable(FalseClass)), FalseClass, T.all(Main::Boolean, NilClass), TrueClass)>`
   end
   
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

lub: Better reduce AndTypes created during type inference.

Adds the following support to `lub`:

* When lubbing an `AndType` and an `OrType`, call `lubDistributeOr` if our `AndType` lub attempt fails rather than making a new `OrType`.
* When lubbing an `AndType` and an `AndType`, check if their parts are (deeply) referentially equivalent.

There are tests that demonstrate the change.

Not handled in this PR is the following scenario:

* lubbing an `OrType` and an `OrType`

Attempts to handle this use-case ended up being too expensive to land, and changed the types that Sorbet inferred causing type errors on Stripe's codebase. I may pursue this change in a subsequent PR, as type inference still produces some `T.any` types with redundant members.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Type inference creates AndTypes which get nested into OrTypes. This process causes `lub` to get called in a few scenarios that, prior to this change, it was ill-equipped to deal with:

* An `AndType` and an `OrType`.
* An `AndType` and an `AndType` that are equivalent.

One particular file at Stripe spent a lot of time lubbing these types together, which resulted in monstrous types such as the following (note: `Boolean` != `T::Boolean` in this case; Stripe has a legacy module named `Boolean`):

```
T.any(T.all(Boolean, T.nilable(FalseClass)), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, NilClass), T.all(Boolean, T.nilable(FalseClass)), FalseClass, T.all(Boolean, NilClass), TrueClass)
``` 

All of this time spent in lub added up to a long typechecking time. The changes in this PR halves the time it spends in typechecking.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
