### PR TITLE
make T::Enum#=== return T::Boolean always 

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3221,7 +3221,7 @@ public:
         }
         auto rhs = args.args[0]->type;
         if (rhs.isUntyped()) {
-            res.returnType = rhs;
+            res.returnType = Types::Boolean();
             return;
         }
 

--- a/test/testdata/infer/t_enum_classes_triple_eq.rb
+++ b/test/testdata/infer/t_enum_classes_triple_eq.rb
@@ -40,6 +40,7 @@ def f(t_enum, my_enum, other_enum, x, y, z, s, stringy)
   T.reveal_type(x===my_enum)          # error: Revealed type: `T::Boolean`
 
   T.reveal_type(x===y)                # error: Revealed type: `FalseClass`
+  T.reveal_type(x===T.unsafe(y))      # error: Revealed type: `T::Boolean`
 
   T.reveal_type(my_enum===other_enum) # error: Revealed type: `FalseClass`
   T.reveal_type(z===my_enum)          # error: Revealed type: `FalseClass`


### PR DESCRIPTION
### Motivation

This is just #4393, but applied to the (identical?) code in the `T::Enum.===` type deriver.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
