### PR TITLE
fix fixnum/NaN comparisons for <= and >=

### DIFF
--- a/compiler/IREmitter/Payload/patches/numeric.c
+++ b/compiler/IREmitter/Payload/patches/numeric.c
@@ -36,16 +36,7 @@ VALUE sorbet_rb_int_minus_slowpath(VALUE recv, VALUE y) {
 
 VALUE sorbet_rb_int_gt_slowpath(VALUE recv, VALUE y) {
     if (LIKELY(FIXNUM_P(recv))) {
-        if (LIKELY(FIXNUM_P(y))) {
-            if (FIX2LONG(recv) > FIX2LONG(y)) {
-                return Qtrue;
-            }
-            return Qfalse;
-        } else if (RB_TYPE_P(y, T_BIGNUM)) {
-            return rb_big_cmp(y, recv) == INT2FIX(-1) ? Qtrue : Qfalse;
-        } else if (RB_TYPE_P(y, T_FLOAT)) {
-            return rb_integer_float_cmp(recv, y) == INT2FIX(+1) ? Qtrue : Qfalse;
-        }
+        return fix_gt(recv, y);
     } else if (RB_TYPE_P(recv, T_BIGNUM)) {
         return rb_big_gt(recv, y);
     }
@@ -54,16 +45,7 @@ VALUE sorbet_rb_int_gt_slowpath(VALUE recv, VALUE y) {
 
 VALUE sorbet_rb_int_lt_slowpath(VALUE recv, VALUE y) {
     if (LIKELY(FIXNUM_P(recv))) {
-        if (LIKELY(FIXNUM_P(y))) {
-            if (FIX2LONG(recv) < FIX2LONG(y)) {
-                return Qtrue;
-            }
-            return Qfalse;
-        } else if (RB_TYPE_P(y, T_BIGNUM)) {
-            return rb_big_cmp(y, recv) == INT2FIX(+1) ? Qtrue : Qfalse;
-        } else if (RB_TYPE_P(y, T_FLOAT)) {
-            return rb_integer_float_cmp(recv, y) == INT2FIX(-1) ? Qtrue : Qfalse;
-        }
+        return fix_lt(recv, y);
     } else if (RB_TYPE_P(recv, T_BIGNUM)) {
         return rb_big_lt(recv, y);
     }
@@ -72,16 +54,7 @@ VALUE sorbet_rb_int_lt_slowpath(VALUE recv, VALUE y) {
 
 VALUE sorbet_rb_int_ge_slowpath(VALUE recv, VALUE y) {
     if (LIKELY(FIXNUM_P(recv))) {
-        if (LIKELY(FIXNUM_P(y))) {
-            if (FIX2LONG(recv) >= FIX2LONG(y)) {
-                return Qtrue;
-            }
-            return Qfalse;
-        } else if (RB_TYPE_P(y, T_BIGNUM)) {
-            return rb_big_cmp(y, recv) == INT2FIX(+1) ? Qfalse : Qtrue;
-        } else if (RB_TYPE_P(y, T_FLOAT)) {
-            return rb_integer_float_cmp(recv, y) == INT2FIX(-1) ? Qfalse : Qtrue;
-        }
+        return fix_ge(recv, y);
     } else if (RB_TYPE_P(recv, T_BIGNUM)) {
         return rb_big_ge(recv, y);
     }
@@ -90,16 +63,7 @@ VALUE sorbet_rb_int_ge_slowpath(VALUE recv, VALUE y) {
 
 VALUE sorbet_rb_int_le_slowpath(VALUE recv, VALUE y) {
     if (LIKELY(FIXNUM_P(recv))) {
-        if (LIKELY(FIXNUM_P(y))) {
-            if (FIX2LONG(recv) <= FIX2LONG(y)) {
-                return Qtrue;
-            }
-            return Qfalse;
-        } else if (RB_TYPE_P(y, T_BIGNUM)) {
-            return rb_big_cmp(y, recv) == INT2FIX(-1) ? Qfalse : Qtrue;
-        } else if (RB_TYPE_P(y, T_FLOAT)) {
-            return rb_integer_float_cmp(recv, y) == INT2FIX(+1) ? Qfalse : Qtrue;
-        }
+        return fix_le(recv, y);
     } else if (RB_TYPE_P(recv, T_BIGNUM)) {
         return rb_big_le(recv, y);
     }

--- a/test/testdata/compiler/intrinsics/int_eq.rb
+++ b/test/testdata/compiler/intrinsics/int_eq.rb
@@ -5,7 +5,7 @@
 
 T::Sig::WithoutRuntime.sig{params(x: Integer, y: T.untyped).returns(T::Boolean)}
 def test(x, y)
-  x < y
+  x == y
 end
 
 puts(test(10, 20))

--- a/test/testdata/compiler/intrinsics/int_ge.rb
+++ b/test/testdata/compiler/intrinsics/int_ge.rb
@@ -7,11 +7,30 @@ def test(x, y)
   x >= y
 end
 
+puts(test(10, 20))
 puts(test(10, 10))
 puts(test(10, 0))
 puts(test(10, 10.0))
 puts(test(10, 0.0))
+puts(test(10, 20.0))
+puts(test(10, -0.0))
 puts(test(10, 100**100))
+puts(test(10, Float::NAN))
+puts(test(10, Float::INFINITY))
+puts(test(10, -Float::INFINITY))
+
+# Workaround 2**75 being Numeric according to Sorbet.
+big = T.cast(2**75, Integer)
+puts(test(big, big + 1))
+puts(test(big, big))
+puts(test(big, big - 1))
+puts(test(big, 0))
+puts(test(big, big.to_f + 1))
+puts(test(big, big.to_f))
+puts(test(big, big.to_f - 1))
+puts(test(big, Float::NAN))
+puts(test(big, Float::INFINITY))
+puts(test(big, -Float::INFINITY))
 
 begin
   test(10, "foo")

--- a/test/testdata/compiler/intrinsics/int_gt.rb
+++ b/test/testdata/compiler/intrinsics/int_gt.rb
@@ -8,11 +8,30 @@ def test(x, y)
   x > y
 end
 
+puts(test(10, 20))
 puts(test(10, 10))
 puts(test(10, 0))
 puts(test(10, 10.0))
 puts(test(10, 0.0))
+puts(test(10, 20.0))
+puts(test(10, -0.0))
 puts(test(10, 100**100))
+puts(test(10, Float::NAN))
+puts(test(10, Float::INFINITY))
+puts(test(10, -Float::INFINITY))
+
+# Workaround 2**75 being Numeric according to Sorbet.
+big = T.cast(2**75, Integer)
+puts(test(big, big + 1))
+puts(test(big, big))
+puts(test(big, big - 1))
+puts(test(big, 0))
+puts(test(big, big.to_f + 1))
+puts(test(big, big.to_f))
+puts(test(big, big.to_f - 1))
+puts(test(big, Float::NAN))
+puts(test(big, Float::INFINITY))
+puts(test(big, -Float::INFINITY))
 
 begin
   test(10, "foo")

--- a/test/testdata/compiler/intrinsics/int_le.rb
+++ b/test/testdata/compiler/intrinsics/int_le.rb
@@ -8,11 +8,30 @@ def test(x, y)
   x <= y
 end
 
+puts(test(10, 20))
 puts(test(10, 10))
 puts(test(10, 0))
 puts(test(10, 10.0))
 puts(test(10, 0.0))
+puts(test(10, 20.0))
+puts(test(10, -0.0))
 puts(test(10, 100**100))
+puts(test(10, Float::NAN))
+puts(test(10, Float::INFINITY))
+puts(test(10, -Float::INFINITY))
+
+# Workaround 2**75 being Numeric according to Sorbet.
+big = T.cast(2**75, Integer)
+puts(test(big, big + 1))
+puts(test(big, big))
+puts(test(big, big - 1))
+puts(test(big, 0))
+puts(test(big, big.to_f + 1))
+puts(test(big, big.to_f))
+puts(test(big, big.to_f - 1))
+puts(test(big, Float::NAN))
+puts(test(big, Float::INFINITY))
+puts(test(big, -Float::INFINITY))
 
 begin
   test(10, "foo")

--- a/test/testdata/compiler/intrinsics/int_minus.rb
+++ b/test/testdata/compiler/intrinsics/int_minus.rb
@@ -10,6 +10,9 @@ puts(1 - T.unsafe(100 ** 100))
 
 # FIXNUM, T_FLOAT
 puts(1 - T.unsafe(1.0))
+puts(1 - T.unsafe(Float::NAN))
+puts(1 - T.unsafe(Float::INFINITY))
+puts(1 - T.unsafe(-Float::INFINITY))
 
 # T_BIGNUM, *
 puts(T.cast(100*100, Integer) - 1)

--- a/test/testdata/compiler/intrinsics/int_ne.rb
+++ b/test/testdata/compiler/intrinsics/int_ne.rb
@@ -5,7 +5,7 @@
 
 T::Sig::WithoutRuntime.sig{params(x: Integer, y: T.untyped).returns(T::Boolean)}
 def test(x, y)
-  x < y
+  x != y
 end
 
 puts(test(10, 20))

--- a/test/testdata/compiler/intrinsics/int_plus.rb
+++ b/test/testdata/compiler/intrinsics/int_plus.rb
@@ -10,6 +10,9 @@ puts(1 + T.unsafe(100 ** 100))
 
 # FIXNUM, T_FLOAT
 puts(1 + T.unsafe(1.0))
+puts(1 + T.unsafe(Float::NAN))
+puts(1 + T.unsafe(Float::INFINITY))
+puts(1 + T.unsafe(-Float::INFINITY))
 
 # T_BIGNUM, *
 puts(T.cast(100*100, Integer) + 1)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

(This is pulled over from the original Sorbet compiler repo; @aprocter-stripe  OK'd this PR there, but resubmitting since we've merged everything.)

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Our slowpath code was not handling NaNs correctly in the fixnum comparison case for some comparison functions. `int_ge.rb` and `int_le.rb` failed with the added tests in baf3a33

I added more tests everywhere to a) make sure we didn't have problems elsewhere and b) completeness.

I assume we copied code from the static functions in numeric.c because the slowpath code was written for the codegen payload at a time when we didn't want to export static functions from `libruby.so`. But now that we directly patch files in the Ruby source, we can reuse the code in numeric.c without copying and avoid subtle bugs like this one.

I suppose we could use `rb_int_gt` etc. directly in our slowpath functions; I have no strong feelings on the matter, though using them is slightly more correct if somebody decided to subclass `Integer` (?!).  I don't think we should handle this case -- we decided in previous discussion not to.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
