### PR TITLE
fail harder when lowering sorbet_i_getRuby{Class,Constant}

### DIFF
--- a/common/Exception.h
+++ b/common/Exception.h
@@ -10,7 +10,7 @@
 
 namespace sorbet {
 extern std::shared_ptr<spdlog::logger> fatalLogger;
-class SorbetException : std::logic_error {
+class SorbetException : public std::logic_error {
 public:
     SorbetException(const std::string &message) : logic_error(message) {}
     SorbetException(const char *message) : logic_error(message) {}

--- a/compiler/Core/OptimizerException.h
+++ b/compiler/Core/OptimizerException.h
@@ -1,0 +1,14 @@
+#include "common/Exception.h"
+
+namespace sorbet::compiler {
+// Occasionally we need to throw errors from within LLVM optimization passes,
+// where we don't have access to GlobalState and therefore cannot use failCompilation.
+// We have this separate class so that the compiler plugin can differentiate this
+// exception from AbortCompilation and know that a Sorbet-level error needs to be
+// emitted.  The user can therefore have some idea of why Sorbet failed.
+class OptimizerException : public sorbet::SorbetException {
+public:
+    OptimizerException(const std::string &message) : SorbetException(message){};
+    OptimizerException(const char *message) : SorbetException(message){};
+};
+} // namespace sorbet::compiler

--- a/compiler/Errors/Errors.h
+++ b/compiler/Errors/Errors.h
@@ -5,5 +5,6 @@
 namespace sorbet::core::errors::Compiler {
 constexpr ErrorClass Untyped{10001, StrictLevel::True};
 constexpr ErrorClass Unanalyzable{10002, StrictLevel::True};
+constexpr ErrorClass OptimizerFailure{10003, StrictLevel::True};
 } // namespace sorbet::core::errors::Compiler
 #endif

--- a/compiler/Passes/BUILD
+++ b/compiler/Passes/BUILD
@@ -11,6 +11,7 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
+        "//compiler/Core",
         "//compiler/IREmitter/Payload",
         "//compiler/Names",
         "@spdlog",

--- a/compiler/Passes/Lowerings.cc
+++ b/compiler/Passes/Lowerings.cc
@@ -7,6 +7,7 @@
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 
 #include "Passes.h"
+#include "compiler/Core/OptimizerException.h"
 #include "core/core.h"
 #include <string>
 
@@ -84,16 +85,16 @@ public:
                                      llvm::CallInst *instr) const override {
         auto elemPtr = llvm::dyn_cast<llvm::GEPOperator>(instr->getArgOperand(0));
         if (elemPtr == nullptr) {
-            return llvm::UndefValue::get(instr->getType());
+            throw OptimizerException("Unexpected argument to intrinsic");
         }
         auto global = llvm::dyn_cast<llvm::GlobalVariable>(elemPtr->getOperand(0));
 
         if (global == nullptr) {
-            return llvm::UndefValue::get(instr->getType());
+            throw OptimizerException("Unexpected argument to intrinsic");
         }
         auto initializer = llvm::dyn_cast<llvm::ConstantDataArray>(global->getInitializer());
         if (initializer == nullptr) {
-            return llvm::UndefValue::get(instr->getType());
+            throw OptimizerException("Unexpected argument to intrinsic");
         }
 
         llvm::IRBuilder<> builder(instr);


### PR DESCRIPTION
### Motivation

The current setup for lowering `sorbet_i_getRuby{Class,Constant}` emits LLVM undef instructions when encountering a shape of IR that we don't understand how to lower.  This decision results in hard-to-debug failures, as @neilparikh has experienced, and is just a bad idea from a compiler reliability perspective: we shouldn't be emitting LLVM undef (which LLVM can do whatever it likes with) if we don't understand the IR we're receiving.

Instead, we should crash and crash loudly, because getting badly-shaped IR is a bug of some kind.  This PR implements that behavior.

It is a little bit messy, because we can't use the usual `failCompilation` bits that the rest of the compiler uses.  Ideally the comments in the source code will help explain why we can't and shed light on why this approach was chosen.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
