### PR TITLE
sorbet-runtime: Add some .checked(:tests) debug information

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -457,7 +457,7 @@ module T::Private::Methods
   end
 
   def self.all_checked_tests_sigs
-    @signatures_by_method.select {|key, sig| sig.check_level == :tests}.values
+    @signatures_by_method.values.select {|sig| sig.check_level == :tests}
   end
 
   # the module target is adding the methods from the module source to itself. we need to check that for all instance

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -456,6 +456,10 @@ module T::Private::Methods
     end
   end
 
+  def self.all_checked_tests_sigs
+    @signatures_by_method.select {|key, sig| sig.check_level == :tests}.values
+  end
+
   # the module target is adding the methods from the module source to itself. we need to check that for all instance
   # methods M on source, M is not defined on any of target's ancestors.
   def self._hook_impl(target, singleton_class, source)

--- a/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
+++ b/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
@@ -31,8 +31,11 @@ module T::Private::RuntimeLevels
 
   def self.enable_checking_in_tests
     if !@check_tests && @wrapped_tests_with_validation
+      all_checked_tests_sigs = T::Private::Methods.all_checked_tests_sigs
+      locations = all_checked_tests_sigs.map {|sig| sig.method.source_location.join(':')}.join("\n- ")
       raise "Toggle `:tests`-level runtime type checking earlier. " \
-        "There are already some methods wrapped with `sig.checked(:tests)`." \
+        "There are already some methods wrapped with `sig.checked(:tests)`:\n" \
+        "- #{locations}"
     end
 
     _toggle_checking_tests(true)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I added `.checked(:tests)` to a bunch of sigs with a codemod and didn't know
which sigs were the problem. This patch worked to show me the locations of the
bad sigs.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested this by applying the change to Stripe's codebase, and also by changing
the test to print the full message. The error has line numbers (intentionally),
which will make this test brittle to slight refactorings if we checked for
equality in the test.

This test is at least covered by regression tests that says I didn't break
sorbet-runtime in making this change, but I don't plan to write a test that
guarantees no one never breaks this feature, unless you feel strongly.