### PR TITLE
Release binaries for macOS 12 Monterey (Darwin 21)

### DIFF
--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -33,7 +33,7 @@ sed -i.bak "s/0\\.0\\.0/${release_version}/" sorbet-static.gemspec
 if [[ "mac" == "$platform" ]]; then
     # Our binary should work on almost all OSes. The oldest v8 publishes is -14
     # so I'm going with that for now.
-    for i in {14..20}; do
+    for i in {14..21}; do
         sed -i.bak "s/Gem::Platform::CURRENT/'universal-darwin-$i'/" sorbet-static.gemspec
         gem build sorbet-static.gemspec
         mv sorbet-static.gemspec.bak sorbet-static.gemspec


### PR DESCRIPTION
### Motivation
Upcoming macOS 12 Monterey reports as Darwin 21 and so a new binary release is needed.


### Test plan
Just following what was previously done for macOS 11 Big Sur (Darwin 20) in https://github.com/sorbet/sorbet/pull/3369
