### PR TITLE
Remove unnecessary calls to rb_hash_dup when keyword args are directly passed through to another method call

### DIFF
--- a/compiler/Passes/Lowerings.cc
+++ b/compiler/Passes/Lowerings.cc
@@ -658,8 +658,7 @@ public:
         auto *sorbetGlobalConstDupHashFn = mod.getFunction("sorbet_globalConstDupHash");
         auto *sorbetSendFn = mod.getFunction("sorbet_i_send");
 
-        if (rbHashDupFn == nullptr || rbHashNewFn == nullptr || rbToHashTypeFn == nullptr ||
-            sorbetGlobalConstDupHashFn == nullptr || sorbetSendFn == nullptr) {
+        if (rbHashDupFn == nullptr || rbToHashTypeFn == nullptr || sorbetSendFn == nullptr) {
             return false;
         }
 
@@ -704,8 +703,14 @@ public:
                         continue;
                     }
 
-                    if (!detectLiteralHash(mod, sorbetGlobalConstDupHashFn, toHashCall) &&
-                        !detectPassThroughCase(mod, rbHashDupFn, rbHashNewFn, toHashCall)) {
+                    bool shouldRemoveDup = false;
+                    if (sorbetGlobalConstDupHashFn && detectLiteralHash(mod, sorbetGlobalConstDupHashFn, toHashCall)) {
+                        shouldRemoveDup = true;
+                    }
+                    if (rbHashNewFn && detectPassThroughCase(mod, rbHashDupFn, rbHashNewFn, toHashCall)) {
+                        shouldRemoveDup = true;
+                    }
+                    if (!shouldRemoveDup) {
                         continue;
                     }
 

--- a/compiler/Passes/Lowerings.cc
+++ b/compiler/Passes/Lowerings.cc
@@ -619,9 +619,13 @@ public:
             if (phiArg == nullptr) {
                 return false;
             }
+            // If we see a Hash.new, we can skip processing this branch of the phi, since there's nothing else to follow
+            // backwards.
             if (phiArg->getCalledFunction() == rbHashNewFn) {
                 continue;
             }
+            // If we see a function other than Hash.new or rb_hash_dup, we should abort, and not do anything,
+            // because the expected phi node only has calls to those 2.
             if (phiArg->getCalledFunction() != rbHashDupFn) {
                 return false;
             }

--- a/test/run_compiled.sh
+++ b/test/run_compiled.sh
@@ -64,11 +64,12 @@ if [ -z "${llvmir:-}" ]; then
   # run_sorbet.sh would probably be better.
   export llvmir
 
-  compiled_out_dir=$llvmir
-  export compiled_out_dir
 elif [[ ! -d "$llvmir" ]]; then
   fatal "llvm output directory '${llvmir}' does not exist"
 fi
+
+compiled_out_dir=$llvmir
+export compiled_out_dir
 
 # ensure that the extension is built
 "test/run_sorbet.sh" -i "$llvmir" "${rb_files[@]}"

--- a/test/testdata/compiler/kwargs_splat_hash_no_dup.rb
+++ b/test/testdata/compiler/kwargs_splat_hash_no_dup.rb
@@ -4,17 +4,32 @@
 # run_filecheck: INITIAL
 # run_filecheck: LOWERED
 
-def foo(**kwargs)
-  puts kwargs
-end
+# We look for sorbet_magic_toHashDup instead of rb_to_hash_type followed by rb_hash_dup,
+# because in the INITIAL stage, sorbet_magic_toHashDup has not been inlined yet.
 
-# INITIAL-LABEL: call i64 @rb_to_hash_type
-# INITIAL: call i64 @rb_hash_dup
+# INITIAL-LABEL: define i64 @"func_Object#foo"
+# INITIAL: call i64 @sorbet_magic_toHashDup
 # INITIAL{LITERAL}: }
 
-# LOWERED-LABEL: call i64 @rb_to_hash_type
+# LOWERED-LABEL: define i64 @"func_Object#foo"
+# LOWERED: call i64 @rb_to_hash_type
 # LOWERED-NOT: call i64 @rb_hash_dup
 # LOWERED{LITERAL}: }
 
-args = {a: 1, b: 2}
-foo(**args)
+def foo(**kwargs)
+  puts(**kwargs)
+end
+
+# INITIAL-LABEL: define i64 @"func_Object#main"
+# INITIAL: call i64 @sorbet_magic_toHashDup
+# INITIAL{LITERAL}: }
+
+# LOWERED-LABEL: define i64 @"func_Object#main"
+# LOWERED: call i64 @rb_to_hash_type
+# LOWERED-NOT: call i64 @rb_hash_dup
+# LOWERED{LITERAL}: }
+
+def main
+  args = {a: 1, b: 2}
+  foo(**args)
+end

--- a/test/testdata/ruby_benchmark/stripe/kwargs_splat_pass_through.rb
+++ b/test/testdata/ruby_benchmark/stripe/kwargs_splat_pass_through.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+def bar(**kwargs)
+end
+
+def foo(**args)
+  bar(**args)
+end
+
+args = {a: 1, b: 2}
+i = 0
+while i < 1_000_000
+  foo(**args)
+  i += 1
+end
+
+puts i


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

Follow up PR to stripe/sorbet_llvm#520

This PR handles the following case:
```ruby
def foo(**args)
  bar(**args)
end
```
Here, the keyword args are being directly passed through to `bar`, so there's no need to duplicate them again.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Benchmark (on `master`):
```
ruby vm startup time: 0.129
stripe/while_1_000_000.rb       0.136   0.144
stripe/kwargs_splat_pass_through.rb     0.545   0.351
stripe/kwargs_splat_pass_through.rb - baseline  0.409   0.207
```
Benchmark (on this branch):

```
ruby vm startup time: 0.122
stripe/while_1_000_000.rb       0.135   0.133
stripe/kwargs_splat_pass_through.rb     0.538   0.292
stripe/kwargs_splat_pass_through.rb - baseline  0.403   0.159
```