### PR TITLE
Create sorbet-static-and-runtime gem

### DIFF
--- a/.buildkite/build-sorbet-static-and-runtime.sh
+++ b/.buildkite/build-sorbet-static-and-runtime.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eo pipefail
+
+pushd gems/sorbet-static-and-runtime
+
+echo "--- setup :ruby:"
+eval "$(rbenv init -)"
+
+runtime_versions=(2.6.3 2.7.2)
+
+for runtime_version in "${runtime_versions[@]}"; do
+  rbenv install --skip-existing "$runtime_version"
+  rbenv shell "$runtime_version"
+done
+
+echo "--- build"
+git_commit_count=$(git rev-list --count HEAD)
+release_version="0.5.${git_commit_count}"
+sed -i.bak "s/0\\.0\\.0/${release_version}/" sorbet-static-and-runtime.gemspec
+gem build sorbet-static-and-runtime.gemspec
+
+popd
+
+rm -rf _out_
+mkdir -p _out_/gems/
+cp gems/sorbet-static-and-runtime/sorbet-static-and-runtime-*.gem _out_/gems/

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -78,6 +78,11 @@ steps:
     artifact_paths: _out_/**/*
     <<: *elastic
 
+  - label: ":linux: build-sorbet-static-and-runtime.sh"
+    command: .buildkite/build-sorbet-static-and-runtime.sh
+    artifact_paths: _out_/**/*
+    <<: *elastic
+
   - label: ":linux: build-emscripten.sh"
     command: .buildkite/build-emscripten.sh
     artifact_paths: _out_/**/*

--- a/.buildkite/publish-ruby-gems.sh
+++ b/.buildkite/publish-ruby-gems.sh
@@ -83,3 +83,11 @@ if ! gem list --remote rubygems.org --exact 'sorbet' | grep -q "$release_version
 else
   echo "$gem_archive already published."
 fi
+
+gem_archive="_out_/gems/sorbet-static-and-runtime-$release_version.gem"
+echo "Attempting to publish $gem_archive"
+if ! gem list --remote rubygems.org --exact 'sorbet-static-and-runtime' | grep -q "$release_version"; then
+  with_backoff gem push --verbose "$gem_archive"
+else
+  echo "$gem_archive already published."
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 gems/sorbet/Gemfile.lock
 gems/sorbet-static/Gemfile.lock
 gems/sorbet-runtime/Gemfile.lock
+gems/sorbet-static-and-runtime/Gemfile.lock
 *.gem
 
 # To distribute sorbet, we copy the built C++ binary here.

--- a/gems/sorbet-static-and-runtime/README.md
+++ b/gems/sorbet-static-and-runtime/README.md
@@ -1,0 +1,3 @@
+# gems/sorbet-static-and-runtime/
+
+A simple gem depending on both `sorbet` and `sorbet-runtime` making it easier for Dependabot to update Sorbet.

--- a/gems/sorbet-static-and-runtime/sorbet-static-and-runtime.gemspec
+++ b/gems/sorbet-static-and-runtime/sorbet-static-and-runtime.gemspec
@@ -1,0 +1,18 @@
+Gem::Specification.new do |s|
+  s.name        = 'sorbet-static-and-runtime'
+  s.version     = '0.0.0'
+  s.summary     = 'A Typechecker for Ruby'
+  s.description = 'Sorbet static and runtime in one gem'
+  s.authors     = ['Stripe']
+  s.email       = 'sorbet@stripe.com'
+  s.homepage    = 'https://sorbet.org'
+  s.license     = 'Apache-2.0'
+  s.metadata = {
+    'source_code_uri' => 'https://github.com/sorbet/sorbet'
+  }
+
+  s.add_dependency 'sorbet', '0.0.0'
+  s.add_dependency 'sorbet-runtime', '0.0.0'
+
+  s.required_ruby_version = ['>= 2.3.0']
+end


### PR DESCRIPTION
### Motivation

Create a single gem that depends on both `sorbet`  and `sorbet-runtime`. Most people use both gems at the same version so this will make it easier to install/update Sorbet in many projects (especially when using Dependabot).

### Test plan

See included automated tests.
