### PR TITLE
Fixes required to get Stripe's codebase to typecheck

### DIFF
--- a/rbi/stdlib/logger.rbi
+++ b/rbi/stdlib/logger.rbi
@@ -436,13 +436,14 @@ class Logger
       progname: T.nilable(String),
       formatter: T.nilable(FormatterProcType),
       datetime_format: T.nilable(String),
-      shift_period_suffix: T.nilable(String)
+      shift_period_suffix: T.nilable(String),
+      binmode: T.untyped,
     ).void
   end
   def initialize(
     logdev, shift_age = 0, shift_size = 1048576, level: DEBUG,
     progname: nil, formatter: nil, datetime_format: nil,
-    shift_period_suffix: '%Y%m%d'
+    shift_period_suffix: '%Y%m%d', binmode: false
   )
     @level = T.let(T.unsafe(nil), T.nilable(Integer))
     @progname = T.let(T.unsafe(nil), T.nilable(String))
@@ -672,7 +673,7 @@ class Logger::LogDevice
   def create_logfile(filename); end
   def dev; end
   def filename; end
-  def initialize(log = nil, shift_age: nil, shift_size: nil, shift_period_suffix: nil); end
+  def initialize(log = nil, shift_age: nil, shift_size: nil, shift_period_suffix: nil, binmode: false); end
   def lock_shift_log; end
   def open_logfile(filename); end
   def reopen(log = nil); end

--- a/rbi/stdlib/optparse.rbi
+++ b/rbi/stdlib/optparse.rbi
@@ -1593,8 +1593,8 @@ class OptionParser
     # which caused the error.
     Reason = T.let(nil, T.untyped)
 
-    sig {params(args: T.untyped).void}
-    def initialize(*args); end
+    sig {params(args: T.untyped, additional: T.untyped).void}
+    def initialize(*args, additional: nil); end
 
     sig {returns(T.untyped)}
     def args(); end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I recently re-ran the script to regenerate all Gem RBIs on Stripe's
codebase, and found a few conflicting method definitions. I checked that
the autogenerated RBI was correct w.r.t. the source—these arguments do
exist at runtime.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests