### PR TITLE
ensure that the ensure block of a rescue is called from a single place

### DIFF
--- a/compiler/IREmitter/Exceptions.cc
+++ b/compiler/IREmitter/Exceptions.cc
@@ -82,7 +82,8 @@ public:
         // Create these phi nodes for later use.
         state.ensureValuePhi = state.builder.CreatePHI(state.builder.getInt64Ty(), 2, "ensureValue");
         state.ensureFromBodyPhi = state.builder.CreatePHI(state.builder.getInt1Ty(), 2, "ensureFromBody");
-        state.previousExceptionPhi = state.builder.CreatePHI(state.builder.getInt64Ty(), 2, "computedPreviousException");
+        state.previousExceptionPhi =
+            state.builder.CreatePHI(state.builder.getInt64Ty(), 2, "computedPreviousException");
 
         // Setup the exception handling entry block
         state.builder.SetInsertPoint(state.exceptionEntry);

--- a/test/testdata/compiler/all_arguments.llo.exp
+++ b/test/testdata/compiler/all_arguments.llo.exp
@@ -79,8 +79,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#take_arguments" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_take_arguments = internal unnamed_addr global i64 0, align 8
 @str_take_arguments = private unnamed_addr constant [15 x i8] c"take_arguments\00", align 1
@@ -199,14 +199,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #8
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #8
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #8
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #8
   unreachable
 }
 

--- a/test/testdata/compiler/block_arg_expand.llo.exp
+++ b/test/testdata/compiler/block_arg_expand.llo.exp
@@ -86,8 +86,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -150,18 +150,18 @@ declare void @rb_ary_detransient(i64) local_unnamed_addr #1
 
 declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
-
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
 declare i64 @rb_fstring_new(i8*, i64) local_unnamed_addr #1
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #3
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #3
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #3
 
 declare i64 @rb_int2big(i64) local_unnamed_addr #1
 
@@ -175,14 +175,14 @@ declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*,
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #5 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #11
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #11
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #5 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #11
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #11
   unreachable
 }
 
@@ -1488,8 +1488,8 @@ newFuncRoot:
 
 attributes #0 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { argmemonly nofree nosync nounwind willreturn }
-attributes #3 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { argmemonly nofree nosync nounwind willreturn }
 attributes #4 = { nofree nosync nounwind readnone speculatable willreturn }
 attributes #5 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #6 = { ssp }

--- a/test/testdata/compiler/block_args.llo.exp
+++ b/test/testdata/compiler/block_args.llo.exp
@@ -87,8 +87,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -136,18 +136,18 @@ declare i64 @rb_ary_new_capa(i64) local_unnamed_addr #0
 
 declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #0
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
-
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
-
 declare i64 @rb_fstring_new(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
 
 declare i64 @rb_int2big(i64) local_unnamed_addr #0
 
@@ -161,14 +161,14 @@ declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*,
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
   unreachable
 }
 
@@ -503,8 +503,8 @@ declare void @llvm.experimental.noalias.scope.decl(metadata) #7
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #8
 
 attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { argmemonly nofree nosync nounwind willreturn }
-attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn }
 attributes #3 = { nofree nosync nounwind readnone speculatable willreturn }
 attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #5 = { ssp }

--- a/test/testdata/compiler/block_no_args.llo.exp
+++ b/test/testdata/compiler/block_no_args.llo.exp
@@ -80,8 +80,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -133,14 +133,14 @@ declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*,
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #6
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #6
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #6
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #6
   unreachable
 }
 

--- a/test/testdata/compiler/block_no_args_capture.llo.exp
+++ b/test/testdata/compiler/block_no_args_capture.llo.exp
@@ -81,8 +81,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -125,18 +125,18 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
-
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
-
 declare i64 @rb_fstring_new(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
 
 declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
 
@@ -145,14 +145,14 @@ declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*,
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #8
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #8
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #8
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #8
   unreachable
 }
 
@@ -370,8 +370,8 @@ declare void @llvm.experimental.noalias.scope.decl(metadata) #6
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #7
 
 attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { argmemonly nofree nosync nounwind willreturn }
-attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn }
 attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #4 = { ssp }
 attributes #5 = { sspreq }

--- a/test/testdata/compiler/block_no_args_captures_constant.llo.exp
+++ b/test/testdata/compiler/block_no_args_captures_constant.llo.exp
@@ -82,8 +82,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
 @str_foo = private unnamed_addr constant [4 x i8] c"foo\00", align 1
@@ -163,14 +163,14 @@ declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #10
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #10
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
   unreachable
 }
 

--- a/test/testdata/compiler/block_type_checking.llo.exp
+++ b/test/testdata/compiler/block_type_checking.llo.exp
@@ -83,8 +83,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -220,14 +220,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #15
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #15
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #15
   unreachable
 }
 

--- a/test/testdata/compiler/boolean_ops.llo.exp
+++ b/test/testdata/compiler/boolean_ops.llo.exp
@@ -78,8 +78,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -120,14 +120,14 @@ declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) loc
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #5
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #5
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #5
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #5
   unreachable
 }
 

--- a/test/testdata/compiler/casts.llo.exp
+++ b/test/testdata/compiler/casts.llo.exp
@@ -79,8 +79,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#fooAll" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_fooAll = internal unnamed_addr global i64 0, align 8
 @str_fooAll = private unnamed_addr constant [7 x i8] c"fooAll\00", align 1
@@ -195,14 +195,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #13
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #13
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #13
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #13
   unreachable
 }
 

--- a/test/testdata/compiler/class.llo.exp
+++ b/test/testdata/compiler/class.llo.exp
@@ -74,8 +74,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -126,14 +126,14 @@ declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #7
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #7
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #7
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #7
   unreachable
 }
 

--- a/test/testdata/compiler/classfields.llo.exp
+++ b/test/testdata/compiler/classfields.llo.exp
@@ -79,8 +79,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -181,14 +181,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #10
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #10
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
   unreachable
 }
 

--- a/test/testdata/compiler/constant_cache.llo.exp
+++ b/test/testdata/compiler/constant_cache.llo.exp
@@ -79,8 +79,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
 @str_foo = private unnamed_addr constant [4 x i8] c"foo\00", align 1
@@ -155,14 +155,14 @@ declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
   unreachable
 }
 

--- a/test/testdata/compiler/custom_plus.llo.exp
+++ b/test/testdata/compiler/custom_plus.llo.exp
@@ -79,8 +79,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#delegate" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_delegate = internal unnamed_addr global i64 0, align 8
 @str_delegate = private unnamed_addr constant [9 x i8] c"delegate\00", align 1
@@ -178,14 +178,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
   unreachable
 }
 

--- a/test/testdata/compiler/direct_call.llo.exp
+++ b/test/testdata/compiler/direct_call.llo.exp
@@ -78,8 +78,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
 @str_foo = private unnamed_addr constant [4 x i8] c"foo\00", align 1
@@ -143,14 +143,14 @@ declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #7
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #7
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #7
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #7
   unreachable
 }
 

--- a/test/testdata/compiler/exceptions/basic.llo.exp
+++ b/test/testdata/compiler/exceptions/basic.llo.exp
@@ -82,8 +82,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @sorbet_getTRetry.retry = internal constant [25 x i8] c"T::Private::Retry::RETRY\00", align 16
 @rb_eException = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -188,18 +188,18 @@ declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
 
 declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
-
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
 declare i64 @rb_fstring_new(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
 
 declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
 
@@ -254,14 +254,14 @@ declare void @rb_exc_raise(i64) local_unnamed_addr #1
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !14
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #12
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #12
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !14
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #12
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #12
   unreachable
 }
 
@@ -606,14 +606,14 @@ exception-entry.us:                               ; preds = %sorbet_writeLocal.e
 
 35:                                               ; preds = %exception-entry.us
   call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %31, i32 noundef -3, i64 noundef 8) #11, !dbg !72
-  br label %sorbet_writeLocal.exit23.us, !dbg !72
+  br label %sorbet_writeLocal.exit20.us, !dbg !72
 
 36:                                               ; preds = %exception-entry.us
   %37 = getelementptr inbounds i64, i64* %31, i64 -3, !dbg !72
   store i64 8, i64* %37, align 8, !dbg !72, !tbaa !14
-  br label %sorbet_writeLocal.exit23.us, !dbg !72
+  br label %sorbet_writeLocal.exit20.us, !dbg !72
 
-sorbet_writeLocal.exit23.us:                      ; preds = %36, %35
+sorbet_writeLocal.exit20.us:                      ; preds = %36, %35
   call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 %13) #15, !dbg !72
   store i64 52, i64* %0, align 8, !dbg !72, !tbaa !14
   call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull align 8 %14) #15, !dbg !72
@@ -629,9 +629,9 @@ sorbet_writeLocal.exit23.us:                      ; preds = %36, %35
   call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %14) #11, !dbg !72
   call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %13) #11, !dbg !72
   %isReturnValue.us = icmp ne i64 %40, 52, !dbg !72
-  br i1 %isReturnValue.us, label %exception-body-return, label %exception-body-continue.us, !dbg !72
+  br i1 %isReturnValue.us, label %exception-body-return, label %exception-body-handlers.us, !dbg !72
 
-exception-body-continue.us:                       ; preds = %sorbet_writeLocal.exit23.us
+exception-body-handlers.us:                       ; preds = %sorbet_writeLocal.exit20.us
   %41 = load i64, i64* %exceptionValue, align 8, !dbg !72
   %42 = load i64*, i64** %5, align 8, !dbg !72, !tbaa !55
   %43 = load i64, i64* %42, align 8, !dbg !72, !tbaa !14
@@ -639,16 +639,16 @@ exception-body-continue.us:                       ; preds = %sorbet_writeLocal.e
   %45 = icmp eq i64 %44, 0, !dbg !72
   br i1 %45, label %47, label %46, !dbg !72, !prof !68
 
-46:                                               ; preds = %exception-body-continue.us
+46:                                               ; preds = %exception-body-handlers.us
   call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %42, i32 noundef -3, i64 %41) #11, !dbg !72
-  br label %sorbet_writeLocal.exit24.us, !dbg !72
+  br label %sorbet_writeLocal.exit21.us, !dbg !72
 
-47:                                               ; preds = %exception-body-continue.us
+47:                                               ; preds = %exception-body-handlers.us
   %48 = getelementptr inbounds i64, i64* %42, i64 -3, !dbg !72
   store i64 %41, i64* %48, align 8, !dbg !72, !tbaa !14
-  br label %sorbet_writeLocal.exit24.us, !dbg !72
+  br label %sorbet_writeLocal.exit21.us, !dbg !72
 
-sorbet_writeLocal.exit24.us:                      ; preds = %47, %46
+sorbet_writeLocal.exit21.us:                      ; preds = %47, %46
   %49 = icmp ne i64 %41, 8, !dbg !72
   %handler.us = select i1 %49, i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_A.test$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_A.test$block_4", !dbg !72
   call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 %23) #15, !dbg !72
@@ -663,11 +663,11 @@ sorbet_writeLocal.exit24.us:                      ; preds = %47, %46
   %50 = icmp eq i64 %41, 8, !dbg !72
   br i1 %50, label %sorbet_try.exit.us, label %51, !dbg !72
 
-51:                                               ; preds = %sorbet_writeLocal.exit24.us
+51:                                               ; preds = %sorbet_writeLocal.exit21.us
   call void @rb_set_errinfo(i64 %41) #11, !dbg !72
   br label %sorbet_try.exit.us, !dbg !72
 
-sorbet_try.exit.us:                               ; preds = %51, %sorbet_writeLocal.exit24.us
+sorbet_try.exit.us:                               ; preds = %51, %sorbet_writeLocal.exit21.us
   %52 = load i64, i64* @rb_eException, align 8, !dbg !72, !tbaa !14
   %53 = call i64 (i64 (i64)*, i64, i64 (i64, i64)*, i64, ...) @rb_rescue2(i64 (i64)* noundef nonnull @sorbet_applyExceptionClosure, i64 noundef %30, i64 (i64, i64)* noundef nonnull @sorbet_rescueStoreException, i64 %22, i64 %52, i32 0) #11, !dbg !72
   %54 = load i64, i64* %2, align 8, !dbg !72
@@ -697,13 +697,13 @@ exception-entry:                                  ; preds = %sorbet_writeLocal.e
 68:                                               ; preds = %exception-entry
   %69 = getelementptr inbounds i64, i64* %64, i64 -3, !dbg !72
   store i64 8, i64* %69, align 8, !dbg !72, !tbaa !14
-  br label %sorbet_writeLocal.exit23, !dbg !72
+  br label %sorbet_writeLocal.exit20, !dbg !72
 
 70:                                               ; preds = %exception-entry
   call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %64, i32 noundef -3, i64 noundef 8) #11, !dbg !72
-  br label %sorbet_writeLocal.exit23, !dbg !72
+  br label %sorbet_writeLocal.exit20, !dbg !72
 
-sorbet_writeLocal.exit23:                         ; preds = %68, %70
+sorbet_writeLocal.exit20:                         ; preds = %68, %70
   call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 %13) #15, !dbg !72
   store i64 52, i64* %0, align 8, !dbg !72, !tbaa !14
   call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull align 8 %14) #15, !dbg !72
@@ -720,58 +720,33 @@ sorbet_writeLocal.exit23:                         ; preds = %68, %70
   call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %14) #11, !dbg !72
   call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %13) #11, !dbg !72
   %isReturnValue = icmp ne i64 %73, 52, !dbg !72
-  br i1 %isReturnValue, label %exception-body-return, label %exception-body-continue, !dbg !72
+  br i1 %isReturnValue, label %exception-body-return, label %exception-body-handlers, !dbg !72
 
-exception-body-return:                            ; preds = %sorbet_writeLocal.exit23, %sorbet_writeLocal.exit23.us
-  %.lcssa = phi i64 [ %40, %sorbet_writeLocal.exit23.us ], [ %73, %sorbet_writeLocal.exit23 ], !dbg !72
+exception-body-return:                            ; preds = %sorbet_writeLocal.exit20, %sorbet_writeLocal.exit20.us
+  %.lcssa = phi i64 [ %40, %sorbet_writeLocal.exit20.us ], [ %73, %sorbet_writeLocal.exit20 ], !dbg !72
   call void @rb_set_errinfo(i64 %previousException), !dbg !72
-  %74 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !39
-  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 2
-  %76 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %75, align 8, !tbaa !50
-  %77 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %76, i64 0, i32 3
-  %78 = load i64, i64* %77, align 8, !tbaa !76
-  %stackFrame.i28 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.test$block_3", align 8
-  call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %74, %struct.rb_control_frame_struct* %76, %struct.rb_iseq_struct* %stackFrame.i28) #11
-  %79 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !39
-  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 2
-  %81 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %80, align 8, !tbaa !50
-  %82 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %81, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %82, align 8, !tbaa !39
-  %rubyStr_ensure.i29 = load i64, i64* @rubyStrFrozen_ensure, align 8, !dbg !77
-  %83 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !79, !tbaa !39
-  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 2, !dbg !79
-  %85 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %84, align 8, !dbg !79, !tbaa !50
-  %86 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %85, i64 0, i32 1, !dbg !79
-  %87 = load i64*, i64** %86, align 8, !dbg !79
-  store i64 %78, i64* %87, align 8, !dbg !79, !tbaa !14
-  %88 = getelementptr inbounds i64, i64* %87, i64 1, !dbg !79
-  store i64 %rubyStr_ensure.i29, i64* %88, align 8, !dbg !79, !tbaa !14
-  %89 = getelementptr inbounds i64, i64* %88, i64 1, !dbg !79
-  store i64* %89, i64** %86, align 8, !dbg !79
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.7, i64 0), !dbg !79
-  call void @sorbet_popFrame()
-  br label %normalReturn, !dbg !72
+  br label %exception-ensure, !dbg !72
 
-exception-body-continue:                          ; preds = %sorbet_writeLocal.exit23
-  %90 = load i64, i64* %exceptionValue, align 8, !dbg !72
-  %91 = load i64*, i64** %5, align 8, !dbg !72, !tbaa !55
-  %92 = load i64, i64* %91, align 8, !dbg !72, !tbaa !14
-  %93 = and i64 %92, 8, !dbg !72
-  %94 = icmp eq i64 %93, 0, !dbg !72
-  br i1 %94, label %95, label %97, !dbg !72, !prof !68
+exception-body-handlers:                          ; preds = %sorbet_writeLocal.exit20
+  %74 = load i64, i64* %exceptionValue, align 8, !dbg !72
+  %75 = load i64*, i64** %5, align 8, !dbg !72, !tbaa !55
+  %76 = load i64, i64* %75, align 8, !dbg !72, !tbaa !14
+  %77 = and i64 %76, 8, !dbg !72
+  %78 = icmp eq i64 %77, 0, !dbg !72
+  br i1 %78, label %79, label %81, !dbg !72, !prof !68
 
-95:                                               ; preds = %exception-body-continue
-  %96 = getelementptr inbounds i64, i64* %91, i64 -3, !dbg !72
-  store i64 %90, i64* %96, align 8, !dbg !72, !tbaa !14
-  br label %sorbet_writeLocal.exit24, !dbg !72
+79:                                               ; preds = %exception-body-handlers
+  %80 = getelementptr inbounds i64, i64* %75, i64 -3, !dbg !72
+  store i64 %74, i64* %80, align 8, !dbg !72, !tbaa !14
+  br label %sorbet_writeLocal.exit21, !dbg !72
 
-97:                                               ; preds = %exception-body-continue
-  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %91, i32 noundef -3, i64 %90) #11, !dbg !72
-  br label %sorbet_writeLocal.exit24, !dbg !72
+81:                                               ; preds = %exception-body-handlers
+  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %75, i32 noundef -3, i64 %74) #11, !dbg !72
+  br label %sorbet_writeLocal.exit21, !dbg !72
 
-sorbet_writeLocal.exit24:                         ; preds = %95, %97
-  %98 = icmp ne i64 %90, 8, !dbg !72
-  %handler = select i1 %98, i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_A.test$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_A.test$block_4", !dbg !72
+sorbet_writeLocal.exit21:                         ; preds = %79, %81
+  %82 = icmp ne i64 %74, 8, !dbg !72
+  %handler = select i1 %82, i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_A.test$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_A.test$block_4", !dbg !72
   call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 %23) #15, !dbg !72
   store i64 52, i64* %2, align 8, !dbg !72, !tbaa !14
   call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull align 8 %24) #15, !dbg !72
@@ -781,91 +756,91 @@ sorbet_writeLocal.exit24:                         ; preds = %95, %97
   store %struct.rb_control_frame_struct* %cfp, %struct.rb_control_frame_struct** %28, align 8, !dbg !72, !tbaa !12
   store i64* %2, i64** %29, align 8, !dbg !72, !tbaa !13
   store i64 8, i64* %exceptionValue, align 8, !dbg !72, !tbaa !14
-  %99 = icmp eq i64 %90, 8, !dbg !72
-  br i1 %99, label %sorbet_try.exit, label %100, !dbg !72
+  %83 = icmp eq i64 %74, 8, !dbg !72
+  br i1 %83, label %sorbet_try.exit, label %84, !dbg !72
 
-100:                                              ; preds = %sorbet_writeLocal.exit24
-  call void @rb_set_errinfo(i64 %90) #11, !dbg !72
+84:                                               ; preds = %sorbet_writeLocal.exit21
+  call void @rb_set_errinfo(i64 %74) #11, !dbg !72
   br label %sorbet_try.exit, !dbg !72
 
-sorbet_try.exit:                                  ; preds = %sorbet_writeLocal.exit24, %100
-  %101 = load i64, i64* @rb_eException, align 8, !dbg !72, !tbaa !14
-  %102 = call i64 (i64 (i64)*, i64, i64 (i64, i64)*, i64, ...) @rb_rescue2(i64 (i64)* noundef nonnull @sorbet_applyExceptionClosure, i64 noundef %30, i64 (i64, i64)* noundef nonnull @sorbet_rescueStoreException, i64 %22, i64 %101, i32 0) #11, !dbg !72
-  %103 = load i64, i64* %2, align 8, !dbg !72
+sorbet_try.exit:                                  ; preds = %sorbet_writeLocal.exit21, %84
+  %85 = load i64, i64* @rb_eException, align 8, !dbg !72, !tbaa !14
+  %86 = call i64 (i64 (i64)*, i64, i64 (i64, i64)*, i64, ...) @rb_rescue2(i64 (i64)* noundef nonnull @sorbet_applyExceptionClosure, i64 noundef %30, i64 (i64, i64)* noundef nonnull @sorbet_rescueStoreException, i64 %22, i64 %85, i32 0) #11, !dbg !72
+  %87 = load i64, i64* %2, align 8, !dbg !72
   call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %24) #11, !dbg !72
   call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %23) #11, !dbg !72
-  %104 = load i64, i64* %exceptionValue, align 8, !dbg !72
-  %105 = icmp ne i64 %104, 8, !dbg !72
-  %106 = load i64*, i64** %5, align 8, !dbg !72, !tbaa !55
-  %107 = getelementptr inbounds i64, i64* %106, i64 -3, !dbg !72
-  %108 = load i64, i64* %107, align 8, !dbg !72, !tbaa !14
-  %109 = icmp ne i64 %108, 8, !dbg !72
-  %110 = select i1 %109, i64 %108, i64 %previousException, !dbg !72
-  %111 = select i1 %105, i64 %104, i64 %110, !dbg !72
-  call void @rb_set_errinfo(i64 %111), !dbg !72
+  %88 = load i64, i64* %exceptionValue, align 8, !dbg !72
+  %89 = icmp ne i64 %88, 8, !dbg !72
+  %90 = load i64*, i64** %5, align 8, !dbg !72, !tbaa !55
+  %91 = getelementptr inbounds i64, i64* %90, i64 -3, !dbg !72
+  %92 = load i64, i64* %91, align 8, !dbg !72, !tbaa !14
+  %93 = icmp ne i64 %92, 8, !dbg !72
+  %94 = select i1 %93, i64 %92, i64 %previousException, !dbg !72
+  %95 = select i1 %89, i64 %88, i64 %94, !dbg !72
+  call void @rb_set_errinfo(i64 %95), !dbg !72
   %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !72
-  %shouldRetry = icmp eq i64 %103, %"<retry-singleton>", !dbg !72
-  %112 = and i1 %98, %shouldRetry, !dbg !72
-  br i1 %112, label %exception-entry, label %exception-ensure, !dbg !72
+  %shouldRetry = icmp eq i64 %87, %"<retry-singleton>", !dbg !72
+  %96 = and i1 %82, %shouldRetry, !dbg !72
+  br i1 %96, label %exception-entry, label %exception-ensure, !dbg !72
 
-exception-ensure:                                 ; preds = %sorbet_try.exit, %sorbet_try.exit.us
-  %.lcssa32 = phi i64 [ %54, %sorbet_try.exit.us ], [ %103, %sorbet_try.exit ], !dbg !72
-  %.lcssa31 = phi i64 [ %62, %sorbet_try.exit.us ], [ %111, %sorbet_try.exit ], !dbg !72
-  %113 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !39
-  %114 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 2
-  %115 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %114, align 8, !tbaa !50
-  %116 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %115, i64 0, i32 3
-  %117 = load i64, i64* %116, align 8, !tbaa !76
+exception-ensure:                                 ; preds = %sorbet_try.exit, %sorbet_try.exit.us, %exception-body-return
+  %97 = phi i64 [ %.lcssa, %exception-body-return ], [ %54, %sorbet_try.exit.us ], [ %87, %sorbet_try.exit ], !dbg !72
+  %98 = phi i64 [ 8, %exception-body-return ], [ %62, %sorbet_try.exit.us ], [ %95, %sorbet_try.exit ], !dbg !72
+  %99 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !39
+  %100 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %99, i64 0, i32 2
+  %101 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %100, align 8, !tbaa !50
+  %102 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %101, i64 0, i32 3
+  %103 = load i64, i64* %102, align 8, !tbaa !76
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.test$block_3", align 8
-  call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %113, %struct.rb_control_frame_struct* %115, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %118 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !39
-  %119 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %118, i64 0, i32 2
-  %120 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %119, align 8, !tbaa !50
-  %121 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %120, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %121, align 8, !tbaa !39
-  %rubyStr_ensure.i = load i64, i64* @rubyStrFrozen_ensure, align 8, !dbg !80
-  %122 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !82, !tbaa !39
-  %123 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %122, i64 0, i32 2, !dbg !82
-  %124 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %123, align 8, !dbg !82, !tbaa !50
-  %125 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %124, i64 0, i32 1, !dbg !82
-  %126 = load i64*, i64** %125, align 8, !dbg !82
-  store i64 %117, i64* %126, align 8, !dbg !82, !tbaa !14
-  %127 = getelementptr inbounds i64, i64* %126, i64 1, !dbg !82
-  store i64 %rubyStr_ensure.i, i64* %127, align 8, !dbg !82, !tbaa !14
-  %128 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !82
-  store i64* %128, i64** %125, align 8, !dbg !82
-  %send88 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.7, i64 0), !dbg !82
+  call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %99, %struct.rb_control_frame_struct* %101, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %104 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !39
+  %105 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %104, i64 0, i32 2
+  %106 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %105, align 8, !tbaa !50
+  %107 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %106, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %107, align 8, !tbaa !39
+  %rubyStr_ensure.i = load i64, i64* @rubyStrFrozen_ensure, align 8, !dbg !77
+  %108 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !79, !tbaa !39
+  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %108, i64 0, i32 2, !dbg !79
+  %110 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %109, align 8, !dbg !79, !tbaa !50
+  %111 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %110, i64 0, i32 1, !dbg !79
+  %112 = load i64*, i64** %111, align 8, !dbg !79
+  store i64 %103, i64* %112, align 8, !dbg !79, !tbaa !14
+  %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !79
+  store i64 %rubyStr_ensure.i, i64* %113, align 8, !dbg !79, !tbaa !14
+  %114 = getelementptr inbounds i64, i64* %113, i64 1, !dbg !79
+  store i64* %114, i64** %111, align 8, !dbg !79
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.7, i64 0), !dbg !79
   call void @sorbet_popFrame()
-  %isReturnValue13 = icmp ne i64 %.lcssa32, 52, !dbg !72
-  br i1 %isReturnValue13, label %normalReturn, label %exception-continue, !dbg !72
+  %isReturnValue11 = icmp ne i64 %97, 52, !dbg !72
+  br i1 %isReturnValue11, label %normalReturn, label %exception-continue, !dbg !72
 
 exception-continue:                               ; preds = %exception-ensure
-  %129 = icmp eq i64 %.lcssa31, 8, !dbg !72
-  br i1 %129, label %sorbet_raiseIfNotNil.exit22, label %130, !dbg !72
+  %115 = icmp eq i64 %98, 8, !dbg !72
+  br i1 %115, label %sorbet_raiseIfNotNil.exit19, label %116, !dbg !72
 
-130:                                              ; preds = %exception-continue
-  call void @rb_exc_raise(i64 %.lcssa31) #12, !dbg !72
+116:                                              ; preds = %exception-continue
+  call void @rb_exc_raise(i64 %98) #12, !dbg !72
   unreachable, !dbg !72
 
-sorbet_raiseIfNotNil.exit22:                      ; preds = %exception-continue
-  %131 = load i64*, i64** %5, align 8, !dbg !72, !tbaa !55
-  %132 = getelementptr inbounds i64, i64* %131, i64 -3, !dbg !72
-  %133 = load i64, i64* %132, align 8, !dbg !72, !tbaa !14
-  %134 = icmp eq i64 %133, 8, !dbg !72
-  br i1 %134, label %sorbet_raiseIfNotNil.exit, label %135, !dbg !72
+sorbet_raiseIfNotNil.exit19:                      ; preds = %exception-continue
+  %117 = load i64*, i64** %5, align 8, !dbg !72, !tbaa !55
+  %118 = getelementptr inbounds i64, i64* %117, i64 -3, !dbg !72
+  %119 = load i64, i64* %118, align 8, !dbg !72, !tbaa !14
+  %120 = icmp eq i64 %119, 8, !dbg !72
+  br i1 %120, label %sorbet_raiseIfNotNil.exit, label %121, !dbg !72
 
-135:                                              ; preds = %sorbet_raiseIfNotNil.exit22
-  call void @rb_exc_raise(i64 %133) #12, !dbg !72
+121:                                              ; preds = %sorbet_raiseIfNotNil.exit19
+  call void @rb_exc_raise(i64 %119) #12, !dbg !72
   unreachable, !dbg !72
 
-sorbet_raiseIfNotNil.exit:                        ; preds = %sorbet_raiseIfNotNil.exit22
+sorbet_raiseIfNotNil.exit:                        ; preds = %sorbet_raiseIfNotNil.exit19
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %4, align 8, !tbaa !39
-  %136 = getelementptr inbounds i64, i64* %131, i64 -5, !dbg !83
-  %137 = load i64, i64* %136, align 8, !dbg !83, !tbaa !14
-  br label %normalReturn, !dbg !83
+  %122 = getelementptr inbounds i64, i64* %117, i64 -5, !dbg !80
+  %123 = load i64, i64* %122, align 8, !dbg !80, !tbaa !14
+  br label %normalReturn, !dbg !80
 
-normalReturn:                                     ; preds = %exception-ensure, %exception-body-return, %sorbet_raiseIfNotNil.exit
-  %"<returnValue>.sroa.0.0" = phi i64 [ %.lcssa, %exception-body-return ], [ %137, %sorbet_raiseIfNotNil.exit ], [ %.lcssa32, %exception-ensure ], !dbg !75
+normalReturn:                                     ; preds = %exception-ensure, %sorbet_raiseIfNotNil.exit
+  %"<returnValue>.sroa.0.0" = phi i64 [ %123, %sorbet_raiseIfNotNil.exit ], [ %97, %exception-ensure ], !dbg !75
   ret i64 %"<returnValue>.sroa.0.0"
 }
 
@@ -878,7 +853,7 @@ functionEntryInitializers:
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
   %4 = load i64, i64* %3, align 8, !tbaa !76
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !39
-  %rubyStr_begin = load i64, i64* @rubyStrFrozen_begin, align 8, !dbg !84
+  %rubyStr_begin = load i64, i64* @rubyStrFrozen_begin, align 8, !dbg !81
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !26
   %6 = load i64*, i64** %5, align 8, !dbg !26
   store i64 %4, i64* %6, align 8, !dbg !26, !tbaa !14
@@ -909,7 +884,7 @@ BB5:                                              ; preds = %functionEntryInitia
   store i64* %21, i64** %18, align 8, !dbg !29
   %send25 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !29
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %pc, align 8, !dbg !29, !tbaa !39
-  %rubyStr_foo = load i64, i64* @rubyStrFrozen_foo, align 8, !dbg !85
+  %rubyStr_foo = load i64, i64* @rubyStrFrozen_foo, align 8, !dbg !82
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !30
   %23 = load i64*, i64** %22, align 8, !dbg !30
   store i64 %4, i64* %23, align 8, !dbg !30, !tbaa !14
@@ -982,31 +957,31 @@ blockExit:                                        ; preds = %78, %76, %63, %61
   ret i64 52
 
 vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
-  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !39
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2, !dbg !86
-  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !dbg !86, !tbaa !50
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4, !dbg !86
-  %31 = load i64*, i64** %30, align 8, !dbg !86
-  %32 = getelementptr inbounds i64, i64* %31, i64 -1, !dbg !86
-  %33 = load i64, i64* %32, align 8, !dbg !86, !tbaa !14
-  %34 = and i64 %33, -4, !dbg !86
-  %35 = inttoptr i64 %34 to i64*, !dbg !86
-  %36 = load i64, i64* %35, align 8, !dbg !86, !tbaa !14
-  %37 = and i64 %36, 8, !dbg !86
-  %38 = icmp eq i64 %37, 0, !dbg !86
-  br i1 %38, label %39, label %41, !dbg !86, !prof !68
+  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !83, !tbaa !39
+  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2, !dbg !83
+  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !dbg !83, !tbaa !50
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4, !dbg !83
+  %31 = load i64*, i64** %30, align 8, !dbg !83
+  %32 = getelementptr inbounds i64, i64* %31, i64 -1, !dbg !83
+  %33 = load i64, i64* %32, align 8, !dbg !83, !tbaa !14
+  %34 = and i64 %33, -4, !dbg !83
+  %35 = inttoptr i64 %34 to i64*, !dbg !83
+  %36 = load i64, i64* %35, align 8, !dbg !83, !tbaa !14
+  %37 = and i64 %36, 8, !dbg !83
+  %38 = icmp eq i64 %37, 0, !dbg !83
+  br i1 %38, label %39, label %41, !dbg !83, !prof !68
 
 39:                                               ; preds = %vm_get_ep.exit32
-  %40 = getelementptr inbounds i64, i64* %35, i64 -3, !dbg !86
-  store i64 8, i64* %40, align 8, !dbg !86, !tbaa !14
-  br label %vm_get_ep.exit30, !dbg !86
+  %40 = getelementptr inbounds i64, i64* %35, i64 -3, !dbg !83
+  store i64 8, i64* %40, align 8, !dbg !83, !tbaa !14
+  br label %vm_get_ep.exit30, !dbg !83
 
 41:                                               ; preds = %vm_get_ep.exit32
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %35, i32 noundef -3, i64 noundef 8) #11, !dbg !86
-  br label %vm_get_ep.exit30, !dbg !86
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %35, i32 noundef -3, i64 noundef 8) #11, !dbg !83
+  br label %vm_get_ep.exit30, !dbg !83
 
 vm_get_ep.exit30:                                 ; preds = %39, %41
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !87, !tbaa !39
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !84, !tbaa !39
   %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !33, !tbaa !39
   %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !33
   %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !33, !tbaa !50
@@ -1043,28 +1018,28 @@ vm_get_ep.exit30:                                 ; preds = %39, %41
 
 vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !tbaa !39
-  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !88, !tbaa !39
-  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2, !dbg !88
-  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !dbg !88, !tbaa !50
-  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %66, i64 0, i32 4, !dbg !88
-  %68 = load i64*, i64** %67, align 8, !dbg !88
-  %69 = getelementptr inbounds i64, i64* %68, i64 -1, !dbg !88
-  %70 = load i64, i64* %69, align 8, !dbg !88, !tbaa !14
-  %71 = and i64 %70, -4, !dbg !88
-  %72 = inttoptr i64 %71 to i64*, !dbg !88
-  %73 = load i64, i64* %72, align 8, !dbg !88, !tbaa !14
-  %74 = and i64 %73, 8, !dbg !88
-  %75 = icmp eq i64 %74, 0, !dbg !88
-  br i1 %75, label %76, label %78, !dbg !88, !prof !68
+  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !85, !tbaa !39
+  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2, !dbg !85
+  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !dbg !85, !tbaa !50
+  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %66, i64 0, i32 4, !dbg !85
+  %68 = load i64*, i64** %67, align 8, !dbg !85
+  %69 = getelementptr inbounds i64, i64* %68, i64 -1, !dbg !85
+  %70 = load i64, i64* %69, align 8, !dbg !85, !tbaa !14
+  %71 = and i64 %70, -4, !dbg !85
+  %72 = inttoptr i64 %71 to i64*, !dbg !85
+  %73 = load i64, i64* %72, align 8, !dbg !85, !tbaa !14
+  %74 = and i64 %73, 8, !dbg !85
+  %75 = icmp eq i64 %74, 0, !dbg !85
+  br i1 %75, label %76, label %78, !dbg !85, !prof !68
 
 76:                                               ; preds = %vm_get_ep.exit
-  %77 = getelementptr inbounds i64, i64* %72, i64 -7, !dbg !88
-  store i64 20, i64* %77, align 8, !dbg !88, !tbaa !14
-  br label %blockExit, !dbg !88
+  %77 = getelementptr inbounds i64, i64* %72, i64 -7, !dbg !85
+  store i64 20, i64* %77, align 8, !dbg !85, !tbaa !14
+  br label %blockExit, !dbg !85
 
 78:                                               ; preds = %vm_get_ep.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %72, i32 noundef -7, i64 noundef 20) #11, !dbg !88
-  br label %blockExit, !dbg !88
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %72, i32 noundef -7, i64 noundef 20) #11, !dbg !85
+  br label %blockExit, !dbg !85
 }
 
 ; Function Attrs: ssp
@@ -1076,7 +1051,7 @@ functionEntryInitializers:
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
   %4 = load i64, i64* %3, align 8, !tbaa !76
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !tbaa !39
-  %rubyStr_else = load i64, i64* @rubyStrFrozen_else, align 8, !dbg !89
+  %rubyStr_else = load i64, i64* @rubyStrFrozen_else, align 8, !dbg !86
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !34
   %6 = load i64*, i64** %5, align 8, !dbg !34
   store i64 %4, i64* %6, align 8, !dbg !34, !tbaa !14
@@ -1220,13 +1195,10 @@ attributes #15 = { nounwind willreturn }
 !77 = !DILocation(line: 18, column: 12, scope: !37, inlinedAt: !78)
 !78 = distinct !DILocation(line: 8, column: 7, scope: !28)
 !79 = !DILocation(line: 18, column: 7, scope: !37, inlinedAt: !78)
-!80 = !DILocation(line: 18, column: 12, scope: !37, inlinedAt: !81)
-!81 = distinct !DILocation(line: 8, column: 7, scope: !28)
-!82 = !DILocation(line: 18, column: 7, scope: !37, inlinedAt: !81)
-!83 = !DILocation(line: 20, column: 3, scope: !28)
-!84 = !DILocation(line: 8, column: 12, scope: !27)
-!85 = !DILocation(line: 11, column: 15, scope: !27)
-!86 = !DILocation(line: 0, scope: !32)
-!87 = !DILocation(line: 13, column: 5, scope: !32)
-!88 = !DILocation(line: 8, column: 7, scope: !32)
-!89 = !DILocation(line: 16, column: 12, scope: !35)
+!80 = !DILocation(line: 20, column: 3, scope: !28)
+!81 = !DILocation(line: 8, column: 12, scope: !27)
+!82 = !DILocation(line: 11, column: 15, scope: !27)
+!83 = !DILocation(line: 0, scope: !32)
+!84 = !DILocation(line: 13, column: 5, scope: !32)
+!85 = !DILocation(line: 8, column: 7, scope: !32)
+!86 = !DILocation(line: 16, column: 12, scope: !35)

--- a/test/testdata/compiler/final_method_child_class.llo.exp
+++ b/test/testdata/compiler/final_method_child_class.llo.exp
@@ -79,8 +79,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_getVoidSingleton.name = internal constant [30 x i8] c"T::Private::Types::Void::VOID\00", align 16
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -184,14 +184,14 @@ declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
   unreachable
 }
 

--- a/test/testdata/compiler/float-intrinsics.llo.exp
+++ b/test/testdata/compiler/float-intrinsics.llo.exp
@@ -80,8 +80,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#plus" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_plus = internal unnamed_addr global i64 0, align 8
 @str_plus = private unnamed_addr constant [5 x i8] c"plus\00", align 1
@@ -286,14 +286,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #5 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #12
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #12
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #5 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #12
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #12
   unreachable
 }
 

--- a/test/testdata/compiler/globalfields.llo.exp
+++ b/test/testdata/compiler/globalfields.llo.exp
@@ -81,8 +81,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -185,14 +185,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #10
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #10
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
   unreachable
 }
 

--- a/test/testdata/compiler/hello.llo.exp
+++ b/test/testdata/compiler/hello.llo.exp
@@ -78,8 +78,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -118,14 +118,14 @@ declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #4
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #4
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #4
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #4
   unreachable
 }
 

--- a/test/testdata/compiler/intrinsics/bang.llo.exp
+++ b/test/testdata/compiler/intrinsics/bang.llo.exp
@@ -79,8 +79,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @sorbet_bang.rb_funcallv_data = internal global %struct.rb_call_data zeroinitializer, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -160,14 +160,14 @@ declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
 
 declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
 
-declare i64 @rb_funcallv_with_cc(%struct.rb_call_data*, i64, i64, i32, i64*) local_unnamed_addr #0
-
 declare i64 @rb_fstring_new(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
+
+declare i64 @rb_funcallv_with_cc(%struct.rb_call_data*, i64, i64, i32, i64*) local_unnamed_addr #0
 
 declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
 
@@ -177,14 +177,14 @@ declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #10
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #10
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
   unreachable
 }
 

--- a/test/testdata/compiler/intrinsics/t_must.llo.exp
+++ b/test/testdata/compiler/intrinsics/t_must.llo.exp
@@ -79,12 +79,12 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eTypeError = external local_unnamed_addr global i64, align 8
-@.str.2 = private unnamed_addr constant [25 x i8] c"Passed `nil` into T.must\00", align 1
+@.str.1 = private unnamed_addr constant [25 x i8] c"Passed `nil` into T.must\00", align 1
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @sorbet_getTRetry.retry = internal constant [25 x i8] c"T::Private::Retry::RETRY\00", align 16
 @rb_eException = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -190,18 +190,18 @@ declare i64 @rb_define_module(i8*) local_unnamed_addr #0
 
 declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
-
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
 declare i64 @rb_fstring_new(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
 
 declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
 
@@ -256,14 +256,14 @@ declare void @rb_exc_raise(i64) local_unnamed_addr #1
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !14
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #15
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !14
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #15
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #15
   unreachable
 }
 
@@ -650,7 +650,7 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
   %23 = ptrtoint %struct.ExceptionClosure* %1 to i64
   br i1 %13, label %exception-entry.us, label %exception-entry, !dbg !62
 
-exception-entry.us:                               ; preds = %fillRequiredArgs, %sorbet_try.exit26.us
+exception-entry.us:                               ; preds = %fillRequiredArgs, %sorbet_try.exit22.us
   %24 = load i64*, i64** %5, align 8, !dbg !62, !tbaa !26
   %25 = load i64, i64* %24, align 8, !dbg !62, !tbaa !14
   %26 = and i64 %25, 8, !dbg !62
@@ -682,9 +682,9 @@ sorbet_writeLocal.exit.us:                        ; preds = %29, %28
   call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %7) #14, !dbg !62
   call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %6) #14, !dbg !62
   %isReturnValue.us = icmp ne i64 %33, 52, !dbg !62
-  br i1 %isReturnValue.us, label %exception-body-return, label %exception-body-continue.us, !dbg !62
+  br i1 %isReturnValue.us, label %exception-body-return, label %exception-body-handlers.us, !dbg !62
 
-exception-body-continue.us:                       ; preds = %sorbet_writeLocal.exit.us
+exception-body-handlers.us:                       ; preds = %sorbet_writeLocal.exit.us
   %34 = load i64, i64* %exceptionValue, align 8, !dbg !62
   %35 = load i64*, i64** %5, align 8, !dbg !62, !tbaa !26
   %36 = load i64, i64* %35, align 8, !dbg !62, !tbaa !14
@@ -692,16 +692,16 @@ exception-body-continue.us:                       ; preds = %sorbet_writeLocal.e
   %38 = icmp eq i64 %37, 0, !dbg !62
   br i1 %38, label %40, label %39, !dbg !62, !prof !34
 
-39:                                               ; preds = %exception-body-continue.us
+39:                                               ; preds = %exception-body-handlers.us
   call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %35, i32 noundef -3, i64 %34) #14, !dbg !62
-  br label %sorbet_writeLocal.exit22.us, !dbg !62
+  br label %sorbet_writeLocal.exit19.us, !dbg !62
 
-40:                                               ; preds = %exception-body-continue.us
+40:                                               ; preds = %exception-body-handlers.us
   %41 = getelementptr inbounds i64, i64* %35, i64 -3, !dbg !62
   store i64 %34, i64* %41, align 8, !dbg !62, !tbaa !14
-  br label %sorbet_writeLocal.exit22.us, !dbg !62
+  br label %sorbet_writeLocal.exit19.us, !dbg !62
 
-sorbet_writeLocal.exit22.us:                      ; preds = %40, %39
+sorbet_writeLocal.exit19.us:                      ; preds = %40, %39
   %42 = icmp ne i64 %34, 8, !dbg !62
   %handler.us = select i1 %42, i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_Test.test_known_nil$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_Test.test_known_nil$block_4", !dbg !62
   call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 %16) #18, !dbg !62
@@ -714,13 +714,13 @@ sorbet_writeLocal.exit22.us:                      ; preds = %40, %39
   store i64* %0, i64** %22, align 8, !dbg !62, !tbaa !13
   store i64 8, i64* %exceptionValue, align 8, !dbg !62, !tbaa !14
   %43 = icmp eq i64 %34, 8, !dbg !62
-  br i1 %43, label %sorbet_try.exit26.us, label %44, !dbg !62
+  br i1 %43, label %sorbet_try.exit22.us, label %44, !dbg !62
 
-44:                                               ; preds = %sorbet_writeLocal.exit22.us
+44:                                               ; preds = %sorbet_writeLocal.exit19.us
   call void @rb_set_errinfo(i64 %34) #14, !dbg !62
-  br label %sorbet_try.exit26.us, !dbg !62
+  br label %sorbet_try.exit22.us, !dbg !62
 
-sorbet_try.exit26.us:                             ; preds = %44, %sorbet_writeLocal.exit22.us
+sorbet_try.exit22.us:                             ; preds = %44, %sorbet_writeLocal.exit19.us
   %45 = load i64, i64* @rb_eException, align 8, !dbg !62, !tbaa !14
   %46 = call i64 (i64 (i64)*, i64, i64 (i64, i64)*, i64, ...) @rb_rescue2(i64 (i64)* noundef nonnull @sorbet_applyExceptionClosure, i64 noundef %23, i64 (i64, i64)* noundef nonnull @sorbet_rescueStoreException, i64 %15, i64 %45, i32 0) #14, !dbg !62
   %47 = load i64, i64* %0, align 8, !dbg !62
@@ -740,7 +740,7 @@ sorbet_try.exit26.us:                             ; preds = %44, %sorbet_writeLo
   %56 = and i1 %42, %shouldRetry.us, !dbg !62
   br i1 %56, label %exception-entry.us, label %exception-ensure, !dbg !62
 
-exception-entry:                                  ; preds = %fillRequiredArgs, %sorbet_try.exit26
+exception-entry:                                  ; preds = %fillRequiredArgs, %sorbet_try.exit22
   %57 = load i64*, i64** %5, align 8, !dbg !62, !tbaa !26
   %58 = load i64, i64* %57, align 8, !dbg !62, !tbaa !14
   %59 = and i64 %58, 8, !dbg !62
@@ -773,44 +773,33 @@ sorbet_writeLocal.exit:                           ; preds = %61, %63
   call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %7) #14, !dbg !62
   call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %6) #14, !dbg !62
   %isReturnValue = icmp ne i64 %66, 52, !dbg !62
-  br i1 %isReturnValue, label %exception-body-return, label %exception-body-continue, !dbg !62
+  br i1 %isReturnValue, label %exception-body-return, label %exception-body-handlers, !dbg !62
 
 exception-body-return:                            ; preds = %sorbet_writeLocal.exit, %sorbet_writeLocal.exit.us
-  %.lcssa28 = phi i64 [ %33, %sorbet_writeLocal.exit.us ], [ %66, %sorbet_writeLocal.exit ], !dbg !62
+  %.lcssa24 = phi i64 [ %33, %sorbet_writeLocal.exit.us ], [ %66, %sorbet_writeLocal.exit ], !dbg !62
   call void @rb_set_errinfo(i64 %previousException), !dbg !62
-  %stackFrame.i25 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.test_known_nil$block_3", align 8
-  %67 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !19
-  %68 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %67, i64 0, i32 2
-  %69 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %68, align 8, !tbaa !20
-  call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %67, %struct.rb_control_frame_struct* %69, %struct.rb_iseq_struct* %stackFrame.i25) #14
-  %70 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !19
-  %71 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %70, i64 0, i32 2
-  %72 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %71, align 8, !tbaa !20
-  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %72, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %73, align 8, !tbaa !19
-  call void @sorbet_popFrame()
-  br label %normalReturn, !dbg !62
+  br label %exception-ensure, !dbg !62
 
-exception-body-continue:                          ; preds = %sorbet_writeLocal.exit
-  %74 = load i64, i64* %exceptionValue, align 8, !dbg !62
-  %75 = load i64*, i64** %5, align 8, !dbg !62, !tbaa !26
-  %76 = load i64, i64* %75, align 8, !dbg !62, !tbaa !14
-  %77 = and i64 %76, 8, !dbg !62
-  %78 = icmp eq i64 %77, 0, !dbg !62
-  br i1 %78, label %79, label %81, !dbg !62, !prof !34
+exception-body-handlers:                          ; preds = %sorbet_writeLocal.exit
+  %67 = load i64, i64* %exceptionValue, align 8, !dbg !62
+  %68 = load i64*, i64** %5, align 8, !dbg !62, !tbaa !26
+  %69 = load i64, i64* %68, align 8, !dbg !62, !tbaa !14
+  %70 = and i64 %69, 8, !dbg !62
+  %71 = icmp eq i64 %70, 0, !dbg !62
+  br i1 %71, label %72, label %74, !dbg !62, !prof !34
 
-79:                                               ; preds = %exception-body-continue
-  %80 = getelementptr inbounds i64, i64* %75, i64 -3, !dbg !62
-  store i64 %74, i64* %80, align 8, !dbg !62, !tbaa !14
-  br label %sorbet_writeLocal.exit22, !dbg !62
+72:                                               ; preds = %exception-body-handlers
+  %73 = getelementptr inbounds i64, i64* %68, i64 -3, !dbg !62
+  store i64 %67, i64* %73, align 8, !dbg !62, !tbaa !14
+  br label %sorbet_writeLocal.exit19, !dbg !62
 
-81:                                               ; preds = %exception-body-continue
-  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %75, i32 noundef -3, i64 %74) #14, !dbg !62
-  br label %sorbet_writeLocal.exit22, !dbg !62
+74:                                               ; preds = %exception-body-handlers
+  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %68, i32 noundef -3, i64 %67) #14, !dbg !62
+  br label %sorbet_writeLocal.exit19, !dbg !62
 
-sorbet_writeLocal.exit22:                         ; preds = %79, %81
-  %82 = icmp ne i64 %74, 8, !dbg !62
-  %handler = select i1 %82, i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_Test.test_known_nil$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_Test.test_known_nil$block_4", !dbg !62
+sorbet_writeLocal.exit19:                         ; preds = %72, %74
+  %75 = icmp ne i64 %67, 8, !dbg !62
+  %handler = select i1 %75, i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_Test.test_known_nil$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_Test.test_known_nil$block_4", !dbg !62
   call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 %16) #18, !dbg !62
   store i64 52, i64* %0, align 8, !dbg !62, !tbaa !14
   call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull align 8 %17) #18, !dbg !62
@@ -820,77 +809,77 @@ sorbet_writeLocal.exit22:                         ; preds = %79, %81
   store %struct.rb_control_frame_struct* %cfp, %struct.rb_control_frame_struct** %21, align 8, !dbg !62, !tbaa !12
   store i64* %0, i64** %22, align 8, !dbg !62, !tbaa !13
   store i64 8, i64* %exceptionValue, align 8, !dbg !62, !tbaa !14
-  %83 = icmp eq i64 %74, 8, !dbg !62
-  br i1 %83, label %sorbet_try.exit26, label %84, !dbg !62
+  %76 = icmp eq i64 %67, 8, !dbg !62
+  br i1 %76, label %sorbet_try.exit22, label %77, !dbg !62
 
-84:                                               ; preds = %sorbet_writeLocal.exit22
-  call void @rb_set_errinfo(i64 %74) #14, !dbg !62
-  br label %sorbet_try.exit26, !dbg !62
+77:                                               ; preds = %sorbet_writeLocal.exit19
+  call void @rb_set_errinfo(i64 %67) #14, !dbg !62
+  br label %sorbet_try.exit22, !dbg !62
 
-sorbet_try.exit26:                                ; preds = %sorbet_writeLocal.exit22, %84
-  %85 = load i64, i64* @rb_eException, align 8, !dbg !62, !tbaa !14
-  %86 = call i64 (i64 (i64)*, i64, i64 (i64, i64)*, i64, ...) @rb_rescue2(i64 (i64)* noundef nonnull @sorbet_applyExceptionClosure, i64 noundef %23, i64 (i64, i64)* noundef nonnull @sorbet_rescueStoreException, i64 %15, i64 %85, i32 0) #14, !dbg !62
-  %87 = load i64, i64* %0, align 8, !dbg !62
+sorbet_try.exit22:                                ; preds = %sorbet_writeLocal.exit19, %77
+  %78 = load i64, i64* @rb_eException, align 8, !dbg !62, !tbaa !14
+  %79 = call i64 (i64 (i64)*, i64, i64 (i64, i64)*, i64, ...) @rb_rescue2(i64 (i64)* noundef nonnull @sorbet_applyExceptionClosure, i64 noundef %23, i64 (i64, i64)* noundef nonnull @sorbet_rescueStoreException, i64 %15, i64 %78, i32 0) #14, !dbg !62
+  %80 = load i64, i64* %0, align 8, !dbg !62
   call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %17) #14, !dbg !62
   call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %16) #14, !dbg !62
-  %88 = load i64, i64* %exceptionValue, align 8, !dbg !62
-  %89 = icmp ne i64 %88, 8, !dbg !62
-  %90 = load i64*, i64** %5, align 8, !dbg !62, !tbaa !26
-  %91 = getelementptr inbounds i64, i64* %90, i64 -3, !dbg !62
-  %92 = load i64, i64* %91, align 8, !dbg !62, !tbaa !14
-  %93 = icmp ne i64 %92, 8, !dbg !62
-  %94 = select i1 %93, i64 %92, i64 %previousException, !dbg !62
-  %95 = select i1 %89, i64 %88, i64 %94, !dbg !62
-  call void @rb_set_errinfo(i64 %95), !dbg !62
+  %81 = load i64, i64* %exceptionValue, align 8, !dbg !62
+  %82 = icmp ne i64 %81, 8, !dbg !62
+  %83 = load i64*, i64** %5, align 8, !dbg !62, !tbaa !26
+  %84 = getelementptr inbounds i64, i64* %83, i64 -3, !dbg !62
+  %85 = load i64, i64* %84, align 8, !dbg !62, !tbaa !14
+  %86 = icmp ne i64 %85, 8, !dbg !62
+  %87 = select i1 %86, i64 %85, i64 %previousException, !dbg !62
+  %88 = select i1 %82, i64 %81, i64 %87, !dbg !62
+  call void @rb_set_errinfo(i64 %88), !dbg !62
   %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !62
-  %shouldRetry = icmp eq i64 %87, %"<retry-singleton>", !dbg !62
-  %96 = and i1 %82, %shouldRetry, !dbg !62
-  br i1 %96, label %exception-entry, label %exception-ensure, !dbg !62
+  %shouldRetry = icmp eq i64 %80, %"<retry-singleton>", !dbg !62
+  %89 = and i1 %75, %shouldRetry, !dbg !62
+  br i1 %89, label %exception-entry, label %exception-ensure, !dbg !62
 
-exception-ensure:                                 ; preds = %sorbet_try.exit26, %sorbet_try.exit26.us
-  %.lcssa31 = phi i64 [ %47, %sorbet_try.exit26.us ], [ %87, %sorbet_try.exit26 ], !dbg !62
-  %.lcssa30 = phi i64 [ %55, %sorbet_try.exit26.us ], [ %95, %sorbet_try.exit26 ], !dbg !62
+exception-ensure:                                 ; preds = %sorbet_try.exit22, %sorbet_try.exit22.us, %exception-body-return
+  %90 = phi i64 [ %.lcssa24, %exception-body-return ], [ %47, %sorbet_try.exit22.us ], [ %80, %sorbet_try.exit22 ], !dbg !62
+  %91 = phi i64 [ 8, %exception-body-return ], [ %55, %sorbet_try.exit22.us ], [ %88, %sorbet_try.exit22 ], !dbg !62
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.test_known_nil$block_3", align 8
-  %97 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !19
-  %98 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %97, i64 0, i32 2
-  %99 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %98, align 8, !tbaa !20
-  call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %97, %struct.rb_control_frame_struct* %99, %struct.rb_iseq_struct* %stackFrame.i) #14
-  %100 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !19
-  %101 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %100, i64 0, i32 2
-  %102 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %101, align 8, !tbaa !20
-  %103 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %102, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %103, align 8, !tbaa !19
+  %92 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !19
+  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %92, i64 0, i32 2
+  %94 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %93, align 8, !tbaa !20
+  call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %92, %struct.rb_control_frame_struct* %94, %struct.rb_iseq_struct* %stackFrame.i) #14
+  %95 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !19
+  %96 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %95, i64 0, i32 2
+  %97 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %96, align 8, !tbaa !20
+  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %97, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %98, align 8, !tbaa !19
   call void @sorbet_popFrame()
-  %isReturnValue13 = icmp ne i64 %.lcssa31, 52, !dbg !62
-  br i1 %isReturnValue13, label %normalReturn, label %exception-continue, !dbg !62
+  %isReturnValue11 = icmp ne i64 %90, 52, !dbg !62
+  br i1 %isReturnValue11, label %normalReturn, label %exception-continue, !dbg !62
 
 exception-continue:                               ; preds = %exception-ensure
-  %104 = icmp eq i64 %.lcssa30, 8, !dbg !62
-  br i1 %104, label %sorbet_raiseIfNotNil.exit21, label %105, !dbg !62
+  %99 = icmp eq i64 %91, 8, !dbg !62
+  br i1 %99, label %sorbet_raiseIfNotNil.exit18, label %100, !dbg !62
 
-105:                                              ; preds = %exception-continue
-  call void @rb_exc_raise(i64 %.lcssa30) #15, !dbg !62
+100:                                              ; preds = %exception-continue
+  call void @rb_exc_raise(i64 %91) #15, !dbg !62
   unreachable, !dbg !62
 
-sorbet_raiseIfNotNil.exit21:                      ; preds = %exception-continue
-  %106 = load i64*, i64** %5, align 8, !dbg !62, !tbaa !26
-  %107 = getelementptr inbounds i64, i64* %106, i64 -3, !dbg !62
-  %108 = load i64, i64* %107, align 8, !dbg !62, !tbaa !14
-  %109 = icmp eq i64 %108, 8, !dbg !62
-  br i1 %109, label %sorbet_raiseIfNotNil.exit, label %110, !dbg !62
+sorbet_raiseIfNotNil.exit18:                      ; preds = %exception-continue
+  %101 = load i64*, i64** %5, align 8, !dbg !62, !tbaa !26
+  %102 = getelementptr inbounds i64, i64* %101, i64 -3, !dbg !62
+  %103 = load i64, i64* %102, align 8, !dbg !62, !tbaa !14
+  %104 = icmp eq i64 %103, 8, !dbg !62
+  br i1 %104, label %sorbet_raiseIfNotNil.exit, label %105, !dbg !62
 
-110:                                              ; preds = %sorbet_raiseIfNotNil.exit21
-  call void @rb_exc_raise(i64 %108) #15, !dbg !62
+105:                                              ; preds = %sorbet_raiseIfNotNil.exit18
+  call void @rb_exc_raise(i64 %103) #15, !dbg !62
   unreachable, !dbg !62
 
-sorbet_raiseIfNotNil.exit:                        ; preds = %sorbet_raiseIfNotNil.exit21
+sorbet_raiseIfNotNil.exit:                        ; preds = %sorbet_raiseIfNotNil.exit18
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %4, align 8, !tbaa !19
-  %111 = getelementptr inbounds i64, i64* %106, i64 -5, !dbg !66
-  %112 = load i64, i64* %111, align 8, !dbg !66, !tbaa !14
+  %106 = getelementptr inbounds i64, i64* %101, i64 -5, !dbg !66
+  %107 = load i64, i64* %106, align 8, !dbg !66, !tbaa !14
   br label %normalReturn, !dbg !66
 
-normalReturn:                                     ; preds = %exception-ensure, %exception-body-return, %sorbet_raiseIfNotNil.exit
-  %"<returnValue>.sroa.0.0" = phi i64 [ %.lcssa28, %exception-body-return ], [ %112, %sorbet_raiseIfNotNil.exit ], [ %.lcssa31, %exception-ensure ], !dbg !65
+normalReturn:                                     ; preds = %exception-ensure, %sorbet_raiseIfNotNil.exit
+  %"<returnValue>.sroa.0.0" = phi i64 [ %107, %sorbet_raiseIfNotNil.exit ], [ %90, %exception-ensure ], !dbg !65
   ret i64 %"<returnValue>.sroa.0.0"
 }
 
@@ -926,7 +915,7 @@ afterSend:                                        ; preds = %21, %sorbet_T_must.
 
 11:                                               ; preds = %fastSymCallIntrinsic_T_must
   %12 = load i64, i64* @rb_eTypeError, align 8, !dbg !47, !tbaa !14, !noalias !67
-  tail call void (i64, i8*, ...) @rb_raise(i64 %12, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.2, i64 0, i64 0)) #15, !dbg !47, !noalias !67
+  tail call void (i64, i8*, ...) @rb_raise(i64 %12, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #15, !dbg !47, !noalias !67
   unreachable, !dbg !47
 
 sorbet_T_must.exit:                               ; preds = %fastSymCallIntrinsic_T_must
@@ -1155,14 +1144,14 @@ exception-entry.us:                               ; preds = %sorbet_writeLocal.e
 
 35:                                               ; preds = %exception-entry.us
   call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %31, i32 noundef -3, i64 noundef 8) #14, !dbg !75
-  br label %sorbet_writeLocal.exit23.us, !dbg !75
+  br label %sorbet_writeLocal.exit20.us, !dbg !75
 
 36:                                               ; preds = %exception-entry.us
   %37 = getelementptr inbounds i64, i64* %31, i64 -3, !dbg !75
   store i64 8, i64* %37, align 8, !dbg !75, !tbaa !14
-  br label %sorbet_writeLocal.exit23.us, !dbg !75
+  br label %sorbet_writeLocal.exit20.us, !dbg !75
 
-sorbet_writeLocal.exit23.us:                      ; preds = %36, %35
+sorbet_writeLocal.exit20.us:                      ; preds = %36, %35
   call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 %13) #18, !dbg !75
   store i64 52, i64* %0, align 8, !dbg !75, !tbaa !14
   call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull align 8 %14) #18, !dbg !75
@@ -1178,9 +1167,9 @@ sorbet_writeLocal.exit23.us:                      ; preds = %36, %35
   call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %14) #14, !dbg !75
   call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %13) #14, !dbg !75
   %isReturnValue.us = icmp ne i64 %40, 52, !dbg !75
-  br i1 %isReturnValue.us, label %exception-body-return, label %exception-body-continue.us, !dbg !75
+  br i1 %isReturnValue.us, label %exception-body-return, label %exception-body-handlers.us, !dbg !75
 
-exception-body-continue.us:                       ; preds = %sorbet_writeLocal.exit23.us
+exception-body-handlers.us:                       ; preds = %sorbet_writeLocal.exit20.us
   %41 = load i64, i64* %exceptionValue, align 8, !dbg !75
   %42 = load i64*, i64** %5, align 8, !dbg !75, !tbaa !26
   %43 = load i64, i64* %42, align 8, !dbg !75, !tbaa !14
@@ -1188,16 +1177,16 @@ exception-body-continue.us:                       ; preds = %sorbet_writeLocal.e
   %45 = icmp eq i64 %44, 0, !dbg !75
   br i1 %45, label %47, label %46, !dbg !75, !prof !34
 
-46:                                               ; preds = %exception-body-continue.us
+46:                                               ; preds = %exception-body-handlers.us
   call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %42, i32 noundef -3, i64 %41) #14, !dbg !75
-  br label %sorbet_writeLocal.exit24.us, !dbg !75
+  br label %sorbet_writeLocal.exit21.us, !dbg !75
 
-47:                                               ; preds = %exception-body-continue.us
+47:                                               ; preds = %exception-body-handlers.us
   %48 = getelementptr inbounds i64, i64* %42, i64 -3, !dbg !75
   store i64 %41, i64* %48, align 8, !dbg !75, !tbaa !14
-  br label %sorbet_writeLocal.exit24.us, !dbg !75
+  br label %sorbet_writeLocal.exit21.us, !dbg !75
 
-sorbet_writeLocal.exit24.us:                      ; preds = %47, %46
+sorbet_writeLocal.exit21.us:                      ; preds = %47, %46
   %49 = icmp ne i64 %41, 8, !dbg !75
   %handler.us = select i1 %49, i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_Test.test_nilable_arg$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_Test.test_nilable_arg$block_4", !dbg !75
   call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 %23) #18, !dbg !75
@@ -1212,11 +1201,11 @@ sorbet_writeLocal.exit24.us:                      ; preds = %47, %46
   %50 = icmp eq i64 %41, 8, !dbg !75
   br i1 %50, label %sorbet_try.exit.us, label %51, !dbg !75
 
-51:                                               ; preds = %sorbet_writeLocal.exit24.us
+51:                                               ; preds = %sorbet_writeLocal.exit21.us
   call void @rb_set_errinfo(i64 %41) #14, !dbg !75
   br label %sorbet_try.exit.us, !dbg !75
 
-sorbet_try.exit.us:                               ; preds = %51, %sorbet_writeLocal.exit24.us
+sorbet_try.exit.us:                               ; preds = %51, %sorbet_writeLocal.exit21.us
   %52 = load i64, i64* @rb_eException, align 8, !dbg !75, !tbaa !14
   %53 = call i64 (i64 (i64)*, i64, i64 (i64, i64)*, i64, ...) @rb_rescue2(i64 (i64)* noundef nonnull @sorbet_applyExceptionClosure, i64 noundef %30, i64 (i64, i64)* noundef nonnull @sorbet_rescueStoreException, i64 %22, i64 %52, i32 0) #14, !dbg !75
   %54 = load i64, i64* %2, align 8, !dbg !75
@@ -1246,13 +1235,13 @@ exception-entry:                                  ; preds = %sorbet_writeLocal.e
 68:                                               ; preds = %exception-entry
   %69 = getelementptr inbounds i64, i64* %64, i64 -3, !dbg !75
   store i64 8, i64* %69, align 8, !dbg !75, !tbaa !14
-  br label %sorbet_writeLocal.exit23, !dbg !75
+  br label %sorbet_writeLocal.exit20, !dbg !75
 
 70:                                               ; preds = %exception-entry
   call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %64, i32 noundef -3, i64 noundef 8) #14, !dbg !75
-  br label %sorbet_writeLocal.exit23, !dbg !75
+  br label %sorbet_writeLocal.exit20, !dbg !75
 
-sorbet_writeLocal.exit23:                         ; preds = %68, %70
+sorbet_writeLocal.exit20:                         ; preds = %68, %70
   call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 %13) #18, !dbg !75
   store i64 52, i64* %0, align 8, !dbg !75, !tbaa !14
   call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull align 8 %14) #18, !dbg !75
@@ -1269,44 +1258,33 @@ sorbet_writeLocal.exit23:                         ; preds = %68, %70
   call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %14) #14, !dbg !75
   call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %13) #14, !dbg !75
   %isReturnValue = icmp ne i64 %73, 52, !dbg !75
-  br i1 %isReturnValue, label %exception-body-return, label %exception-body-continue, !dbg !75
+  br i1 %isReturnValue, label %exception-body-return, label %exception-body-handlers, !dbg !75
 
-exception-body-return:                            ; preds = %sorbet_writeLocal.exit23, %sorbet_writeLocal.exit23.us
-  %.lcssa = phi i64 [ %40, %sorbet_writeLocal.exit23.us ], [ %73, %sorbet_writeLocal.exit23 ], !dbg !75
+exception-body-return:                            ; preds = %sorbet_writeLocal.exit20, %sorbet_writeLocal.exit20.us
+  %.lcssa = phi i64 [ %40, %sorbet_writeLocal.exit20.us ], [ %73, %sorbet_writeLocal.exit20 ], !dbg !75
   call void @rb_set_errinfo(i64 %previousException), !dbg !75
-  %stackFrame.i28 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.test_nilable_arg$block_3", align 8
-  %74 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !19
-  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 2
-  %76 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %75, align 8, !tbaa !20
-  call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %74, %struct.rb_control_frame_struct* %76, %struct.rb_iseq_struct* %stackFrame.i28) #14
-  %77 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !19
-  %78 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 2
-  %79 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %78, align 8, !tbaa !20
-  %80 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %79, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %80, align 8, !tbaa !19
-  call void @sorbet_popFrame()
-  br label %normalReturn, !dbg !75
+  br label %exception-ensure, !dbg !75
 
-exception-body-continue:                          ; preds = %sorbet_writeLocal.exit23
-  %81 = load i64, i64* %exceptionValue, align 8, !dbg !75
-  %82 = load i64*, i64** %5, align 8, !dbg !75, !tbaa !26
-  %83 = load i64, i64* %82, align 8, !dbg !75, !tbaa !14
-  %84 = and i64 %83, 8, !dbg !75
-  %85 = icmp eq i64 %84, 0, !dbg !75
-  br i1 %85, label %86, label %88, !dbg !75, !prof !34
+exception-body-handlers:                          ; preds = %sorbet_writeLocal.exit20
+  %74 = load i64, i64* %exceptionValue, align 8, !dbg !75
+  %75 = load i64*, i64** %5, align 8, !dbg !75, !tbaa !26
+  %76 = load i64, i64* %75, align 8, !dbg !75, !tbaa !14
+  %77 = and i64 %76, 8, !dbg !75
+  %78 = icmp eq i64 %77, 0, !dbg !75
+  br i1 %78, label %79, label %81, !dbg !75, !prof !34
 
-86:                                               ; preds = %exception-body-continue
-  %87 = getelementptr inbounds i64, i64* %82, i64 -3, !dbg !75
-  store i64 %81, i64* %87, align 8, !dbg !75, !tbaa !14
-  br label %sorbet_writeLocal.exit24, !dbg !75
+79:                                               ; preds = %exception-body-handlers
+  %80 = getelementptr inbounds i64, i64* %75, i64 -3, !dbg !75
+  store i64 %74, i64* %80, align 8, !dbg !75, !tbaa !14
+  br label %sorbet_writeLocal.exit21, !dbg !75
 
-88:                                               ; preds = %exception-body-continue
-  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %82, i32 noundef -3, i64 %81) #14, !dbg !75
-  br label %sorbet_writeLocal.exit24, !dbg !75
+81:                                               ; preds = %exception-body-handlers
+  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %75, i32 noundef -3, i64 %74) #14, !dbg !75
+  br label %sorbet_writeLocal.exit21, !dbg !75
 
-sorbet_writeLocal.exit24:                         ; preds = %86, %88
-  %89 = icmp ne i64 %81, 8, !dbg !75
-  %handler = select i1 %89, i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_Test.test_nilable_arg$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_Test.test_nilable_arg$block_4", !dbg !75
+sorbet_writeLocal.exit21:                         ; preds = %79, %81
+  %82 = icmp ne i64 %74, 8, !dbg !75
+  %handler = select i1 %82, i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_Test.test_nilable_arg$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* @"func_Test.test_nilable_arg$block_4", !dbg !75
   call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 %23) #18, !dbg !75
   store i64 52, i64* %2, align 8, !dbg !75, !tbaa !14
   call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull align 8 %24) #18, !dbg !75
@@ -1316,77 +1294,77 @@ sorbet_writeLocal.exit24:                         ; preds = %86, %88
   store %struct.rb_control_frame_struct* %cfp, %struct.rb_control_frame_struct** %28, align 8, !dbg !75, !tbaa !12
   store i64* %2, i64** %29, align 8, !dbg !75, !tbaa !13
   store i64 8, i64* %exceptionValue, align 8, !dbg !75, !tbaa !14
-  %90 = icmp eq i64 %81, 8, !dbg !75
-  br i1 %90, label %sorbet_try.exit, label %91, !dbg !75
+  %83 = icmp eq i64 %74, 8, !dbg !75
+  br i1 %83, label %sorbet_try.exit, label %84, !dbg !75
 
-91:                                               ; preds = %sorbet_writeLocal.exit24
-  call void @rb_set_errinfo(i64 %81) #14, !dbg !75
+84:                                               ; preds = %sorbet_writeLocal.exit21
+  call void @rb_set_errinfo(i64 %74) #14, !dbg !75
   br label %sorbet_try.exit, !dbg !75
 
-sorbet_try.exit:                                  ; preds = %sorbet_writeLocal.exit24, %91
-  %92 = load i64, i64* @rb_eException, align 8, !dbg !75, !tbaa !14
-  %93 = call i64 (i64 (i64)*, i64, i64 (i64, i64)*, i64, ...) @rb_rescue2(i64 (i64)* noundef nonnull @sorbet_applyExceptionClosure, i64 noundef %30, i64 (i64, i64)* noundef nonnull @sorbet_rescueStoreException, i64 %22, i64 %92, i32 0) #14, !dbg !75
-  %94 = load i64, i64* %2, align 8, !dbg !75
+sorbet_try.exit:                                  ; preds = %sorbet_writeLocal.exit21, %84
+  %85 = load i64, i64* @rb_eException, align 8, !dbg !75, !tbaa !14
+  %86 = call i64 (i64 (i64)*, i64, i64 (i64, i64)*, i64, ...) @rb_rescue2(i64 (i64)* noundef nonnull @sorbet_applyExceptionClosure, i64 noundef %30, i64 (i64, i64)* noundef nonnull @sorbet_rescueStoreException, i64 %22, i64 %85, i32 0) #14, !dbg !75
+  %87 = load i64, i64* %2, align 8, !dbg !75
   call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %24) #14, !dbg !75
   call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %23) #14, !dbg !75
-  %95 = load i64, i64* %exceptionValue, align 8, !dbg !75
-  %96 = icmp ne i64 %95, 8, !dbg !75
-  %97 = load i64*, i64** %5, align 8, !dbg !75, !tbaa !26
-  %98 = getelementptr inbounds i64, i64* %97, i64 -3, !dbg !75
-  %99 = load i64, i64* %98, align 8, !dbg !75, !tbaa !14
-  %100 = icmp ne i64 %99, 8, !dbg !75
-  %101 = select i1 %100, i64 %99, i64 %previousException, !dbg !75
-  %102 = select i1 %96, i64 %95, i64 %101, !dbg !75
-  call void @rb_set_errinfo(i64 %102), !dbg !75
+  %88 = load i64, i64* %exceptionValue, align 8, !dbg !75
+  %89 = icmp ne i64 %88, 8, !dbg !75
+  %90 = load i64*, i64** %5, align 8, !dbg !75, !tbaa !26
+  %91 = getelementptr inbounds i64, i64* %90, i64 -3, !dbg !75
+  %92 = load i64, i64* %91, align 8, !dbg !75, !tbaa !14
+  %93 = icmp ne i64 %92, 8, !dbg !75
+  %94 = select i1 %93, i64 %92, i64 %previousException, !dbg !75
+  %95 = select i1 %89, i64 %88, i64 %94, !dbg !75
+  call void @rb_set_errinfo(i64 %95), !dbg !75
   %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !75
-  %shouldRetry = icmp eq i64 %94, %"<retry-singleton>", !dbg !75
-  %103 = and i1 %89, %shouldRetry, !dbg !75
-  br i1 %103, label %exception-entry, label %exception-ensure, !dbg !75
+  %shouldRetry = icmp eq i64 %87, %"<retry-singleton>", !dbg !75
+  %96 = and i1 %82, %shouldRetry, !dbg !75
+  br i1 %96, label %exception-entry, label %exception-ensure, !dbg !75
 
-exception-ensure:                                 ; preds = %sorbet_try.exit, %sorbet_try.exit.us
-  %.lcssa31 = phi i64 [ %54, %sorbet_try.exit.us ], [ %94, %sorbet_try.exit ], !dbg !75
-  %.lcssa30 = phi i64 [ %62, %sorbet_try.exit.us ], [ %102, %sorbet_try.exit ], !dbg !75
+exception-ensure:                                 ; preds = %sorbet_try.exit, %sorbet_try.exit.us, %exception-body-return
+  %97 = phi i64 [ %.lcssa, %exception-body-return ], [ %54, %sorbet_try.exit.us ], [ %87, %sorbet_try.exit ], !dbg !75
+  %98 = phi i64 [ 8, %exception-body-return ], [ %62, %sorbet_try.exit.us ], [ %95, %sorbet_try.exit ], !dbg !75
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.test_nilable_arg$block_3", align 8
-  %104 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !19
-  %105 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %104, i64 0, i32 2
-  %106 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %105, align 8, !tbaa !20
-  call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %104, %struct.rb_control_frame_struct* %106, %struct.rb_iseq_struct* %stackFrame.i) #14
-  %107 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !19
-  %108 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %107, i64 0, i32 2
-  %109 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %108, align 8, !tbaa !20
-  %110 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %110, align 8, !tbaa !19
+  %99 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !19
+  %100 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %99, i64 0, i32 2
+  %101 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %100, align 8, !tbaa !20
+  call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %99, %struct.rb_control_frame_struct* %101, %struct.rb_iseq_struct* %stackFrame.i) #14
+  %102 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !19
+  %103 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %102, i64 0, i32 2
+  %104 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %103, align 8, !tbaa !20
+  %105 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %104, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %105, align 8, !tbaa !19
   call void @sorbet_popFrame()
-  %isReturnValue13 = icmp ne i64 %.lcssa31, 52, !dbg !75
-  br i1 %isReturnValue13, label %normalReturn, label %exception-continue, !dbg !75
+  %isReturnValue11 = icmp ne i64 %97, 52, !dbg !75
+  br i1 %isReturnValue11, label %normalReturn, label %exception-continue, !dbg !75
 
 exception-continue:                               ; preds = %exception-ensure
-  %111 = icmp eq i64 %.lcssa30, 8, !dbg !75
-  br i1 %111, label %sorbet_raiseIfNotNil.exit22, label %112, !dbg !75
+  %106 = icmp eq i64 %98, 8, !dbg !75
+  br i1 %106, label %sorbet_raiseIfNotNil.exit19, label %107, !dbg !75
 
-112:                                              ; preds = %exception-continue
-  call void @rb_exc_raise(i64 %.lcssa30) #15, !dbg !75
+107:                                              ; preds = %exception-continue
+  call void @rb_exc_raise(i64 %98) #15, !dbg !75
   unreachable, !dbg !75
 
-sorbet_raiseIfNotNil.exit22:                      ; preds = %exception-continue
-  %113 = load i64*, i64** %5, align 8, !dbg !75, !tbaa !26
-  %114 = getelementptr inbounds i64, i64* %113, i64 -3, !dbg !75
-  %115 = load i64, i64* %114, align 8, !dbg !75, !tbaa !14
-  %116 = icmp eq i64 %115, 8, !dbg !75
-  br i1 %116, label %sorbet_raiseIfNotNil.exit, label %117, !dbg !75
+sorbet_raiseIfNotNil.exit19:                      ; preds = %exception-continue
+  %108 = load i64*, i64** %5, align 8, !dbg !75, !tbaa !26
+  %109 = getelementptr inbounds i64, i64* %108, i64 -3, !dbg !75
+  %110 = load i64, i64* %109, align 8, !dbg !75, !tbaa !14
+  %111 = icmp eq i64 %110, 8, !dbg !75
+  br i1 %111, label %sorbet_raiseIfNotNil.exit, label %112, !dbg !75
 
-117:                                              ; preds = %sorbet_raiseIfNotNil.exit22
-  call void @rb_exc_raise(i64 %115) #15, !dbg !75
+112:                                              ; preds = %sorbet_raiseIfNotNil.exit19
+  call void @rb_exc_raise(i64 %110) #15, !dbg !75
   unreachable, !dbg !75
 
-sorbet_raiseIfNotNil.exit:                        ; preds = %sorbet_raiseIfNotNil.exit22
+sorbet_raiseIfNotNil.exit:                        ; preds = %sorbet_raiseIfNotNil.exit19
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %4, align 8, !tbaa !19
-  %118 = getelementptr inbounds i64, i64* %113, i64 -6, !dbg !79
-  %119 = load i64, i64* %118, align 8, !dbg !79, !tbaa !14
+  %113 = getelementptr inbounds i64, i64* %108, i64 -6, !dbg !79
+  %114 = load i64, i64* %113, align 8, !dbg !79, !tbaa !14
   br label %normalReturn, !dbg !79
 
-normalReturn:                                     ; preds = %exception-ensure, %exception-body-return, %sorbet_raiseIfNotNil.exit
-  %"<returnValue>.sroa.0.0" = phi i64 [ %.lcssa, %exception-body-return ], [ %119, %sorbet_raiseIfNotNil.exit ], [ %.lcssa31, %exception-ensure ], !dbg !78
+normalReturn:                                     ; preds = %exception-ensure, %sorbet_raiseIfNotNil.exit
+  %"<returnValue>.sroa.0.0" = phi i64 [ %114, %sorbet_raiseIfNotNil.exit ], [ %97, %exception-ensure ], !dbg !78
   ret i64 %"<returnValue>.sroa.0.0"
 }
 
@@ -1452,7 +1430,7 @@ sorbet_writeLocal.exit:                           ; preds = %23, %25
 
 26:                                               ; preds = %fastSymCallIntrinsic_T_must
   %27 = load i64, i64* @rb_eTypeError, align 8, !dbg !53, !tbaa !14, !noalias !80
-  tail call void (i64, i8*, ...) @rb_raise(i64 %27, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.2, i64 0, i64 0)) #15, !dbg !53, !noalias !80
+  tail call void (i64, i8*, ...) @rb_raise(i64 %27, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #15, !dbg !53, !noalias !80
   unreachable, !dbg !53
 
 sorbet_T_must.exit:                               ; preds = %fastSymCallIntrinsic_T_must

--- a/test/testdata/compiler/literal_hash.llo.exp
+++ b/test/testdata/compiler/literal_hash.llo.exp
@@ -78,8 +78,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -159,14 +159,14 @@ declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #5
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #5
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #5
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #5
   unreachable
 }
 

--- a/test/testdata/compiler/literals.llo.exp
+++ b/test/testdata/compiler/literals.llo.exp
@@ -78,8 +78,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -128,14 +128,14 @@ declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #4
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #4
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #4
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #4
   unreachable
 }
 

--- a/test/testdata/compiler/repeated_casts.llo.exp
+++ b/test/testdata/compiler/repeated_casts.llo.exp
@@ -79,8 +79,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#doubleCast" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_doubleCast = internal unnamed_addr global i64 0, align 8
 @str_doubleCast = private unnamed_addr constant [11 x i8] c"doubleCast\00", align 1
@@ -169,14 +169,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #12
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #12
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #12
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #12
   unreachable
 }
 

--- a/test/testdata/compiler/send_with_block_param.llo.exp
+++ b/test/testdata/compiler/send_with_block_param.llo.exp
@@ -77,11 +77,11 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@.str.7 = private unnamed_addr constant [8 x i8] c"to_proc\00", align 1
+@.str.6 = private unnamed_addr constant [8 x i8] c"to_proc\00", align 1
 @sorbet_makeBlockHandlerProc.rb_funcallv_data = internal global %struct.rb_call_data zeroinitializer, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -128,8 +128,6 @@ declare i64 @rb_hash_new_with_size(i64) local_unnamed_addr #0
 
 declare void @rb_hash_bulk_insert(i64, i64*, i64) local_unnamed_addr #0
 
-declare i64 @rb_funcallv_with_cc(%struct.rb_call_data*, i64, i64, i32, i64*) local_unnamed_addr #0
-
 declare i64 @rb_fstring_new(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
@@ -137,19 +135,21 @@ declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
 
+declare i64 @rb_funcallv_with_cc(%struct.rb_call_data*, i64, i64, i32, i64*) local_unnamed_addr #0
+
 declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #6
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #6
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #6
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #6
   unreachable
 }
 
@@ -248,7 +248,7 @@ entry:
   %41 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %27) #7, !dbg !13
   %rubyId_map.i1 = load i64, i64* @rubyIdPrecomputed_map, align 8, !dbg !13
   %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_map.i1) #7, !dbg !13
-  %42 = call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @.str.7, i64 0, i64 0), i64 noundef 7) #7, !dbg !13
+  %42 = call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @.str.6, i64 0, i64 0), i64 noundef 7) #7, !dbg !13
   %43 = call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_makeBlockHandlerProc.rb_funcallv_data, i64 %28, i64 %42, i32 noundef 0, i64* noundef null) #7, !dbg !13
   %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !13
   %45 = load i64*, i64** %44, align 8, !dbg !13

--- a/test/testdata/compiler/sig_rewriter.llo.exp
+++ b/test/testdata/compiler/sig_rewriter.llo.exp
@@ -79,8 +79,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -172,14 +172,14 @@ declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
   unreachable
 }
 

--- a/test/testdata/compiler/splat_assign.llo.exp
+++ b/test/testdata/compiler/splat_assign.llo.exp
@@ -78,8 +78,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -134,14 +134,14 @@ declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) loc
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #6
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #6
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #6
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #6
   unreachable
 }
 

--- a/test/testdata/compiler/unsafe.llo.exp
+++ b/test/testdata/compiler/unsafe.llo.exp
@@ -78,8 +78,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -121,14 +121,14 @@ declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) loc
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #6
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #6
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #6
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #6
   unreachable
 }
 

--- a/test/testdata/ruby_benchmark/app_fib.llo.exp
+++ b/test/testdata/ruby_benchmark/app_fib.llo.exp
@@ -80,8 +80,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @rb_cModule = external local_unnamed_addr constant i64, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -210,14 +210,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #15
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #15
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #15
   unreachable
 }
 

--- a/test/testdata/ruby_benchmark/app_strconcat.llo.exp
+++ b/test/testdata/ruby_benchmark/app_strconcat.llo.exp
@@ -78,8 +78,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -136,14 +136,14 @@ declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) loc
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #7
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #7
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #7
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #7
   unreachable
 }
 

--- a/test/testdata/ruby_benchmark/match_gt4.llo.exp
+++ b/test/testdata/ruby_benchmark/match_gt4.llo.exp
@@ -81,8 +81,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -125,12 +125,6 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
-
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
-
 declare i64 @rb_fstring_new(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
@@ -138,7 +132,13 @@ declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 declare i64 @rb_reg_new(i8*, i64, i32) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
 
 declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
 
@@ -147,14 +147,14 @@ declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*,
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #8
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #8
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #8
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #8
   unreachable
 }
 
@@ -378,8 +378,8 @@ declare void @llvm.experimental.noalias.scope.decl(metadata) #6
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #7
 
 attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { argmemonly nofree nosync nounwind willreturn }
-attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn }
 attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #4 = { ssp }
 attributes #5 = { sspreq }

--- a/test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.llo.exp
@@ -82,8 +82,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @.str = private unnamed_addr constant [6 x i8] c"@%li\0B\00", align 1
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -229,14 +229,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #14
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #14
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #14
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #14
   unreachable
 }
 

--- a/test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.llo.exp
@@ -81,8 +81,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_getVoidSingleton.name = internal constant [30 x i8] c"T::Private::Types::Void::VOID\00", align 16
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -227,14 +227,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #14
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #14
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #14
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #14
   unreachable
 }
 

--- a/test/testdata/ruby_benchmark/stripe/prop_const_getter.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/prop_const_getter.llo.exp
@@ -89,9 +89,9 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @.str = private unnamed_addr constant [6 x i8] c"@%li\0B\00", align 1
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
-@.str.8 = private unnamed_addr constant [42 x i8] c"unimplemented super with a missing method\00", align 1
-@.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
-@.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.7 = private unnamed_addr constant [42 x i8] c"unimplemented super with a missing method\00", align 1
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -256,14 +256,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #14
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #14
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #14
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #14
   unreachable
 }
 
@@ -968,7 +968,7 @@ typeTestSuccess10:                                ; preds = %sorbet_assertNoExtr
 
 74:                                               ; preds = %typeTestSuccess10
   %75 = load i64, i64* @rb_eRuntimeError, align 8, !dbg !76, !tbaa !4
-  call void (i64, i8*, ...) @rb_raise(i64 %75, i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @.str.8, i64 0, i64 0)) #14, !dbg !76
+  call void (i64, i8*, ...) @rb_raise(i64 %75, i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @.str.7, i64 0, i64 0)) #14, !dbg !76
   unreachable, !dbg !76
 
 sorbet_callSuper.exit:                            ; preds = %typeTestSuccess10


### PR DESCRIPTION
### Motivation

`ensure` is broken in a couple different ways; see the recent testcases in #4458, and probably some other, yet to be written, testcases.  This PR is a step towards fixing those by moving the actual execution of the `ensure` block to a single place in the generated LLVM IR, rather than executing it twice along different codepaths.

Once that's done, it's much easier to wrap the bulk of the exception logic with a unwind handler (`EC_EXEC_TAG` and friends), execute the ensure handler regardless of how `EC_EXEC_TAG` returned, and `EC_JUMP_TAG` or return the actual computed value, as appropriate.  (I haven't decided whether the latter wrapping changes will be in this PR or the next.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
