### PR TITLE
Remove obsolete --llvm-ir-folder flag

### DIFF
--- a/plugin_injector/plugin_injector.cc
+++ b/plugin_injector/plugin_injector.cc
@@ -371,10 +371,6 @@ public:
             cxxopts::value<string>());
         optsBuilder.add_options("compiler")("llvm-ir-dir", "Output LLVM IR to directory, which must already exist",
                                             cxxopts::value<string>());
-        // TODO(aprocter): Remove this once we no longer need it for backwards compatibility in the Stripe codebase.
-        optsBuilder.add_options("compiler")("llvm-ir-folder",
-                                            "(DEPRECATED) Sets the value for both --compiled-out-dir and --llvm-ir-dir",
-                                            cxxopts::value<string>());
         optsBuilder.add_options("compiler")("force-compiled", "Force all files to this compiled level",
                                             cxxopts::value<bool>());
     };
@@ -405,18 +401,6 @@ public:
                 throw EarlyReturnWithCode(1);
             }
 
-            irOutputDir = outputDir;
-        }
-        // TODO(aprocter): Remove this once we no longer need it for backwards compatibility in the Stripe codebase.
-        if (providedOptions.count("llvm-ir-folder") > 0) {
-            auto outputDir = providedOptions["llvm-ir-folder"].as<string>();
-
-            if (!FileOps::dirExists(outputDir)) {
-                fmt::print("Missing output directory {}\n", outputDir);
-                throw EarlyReturnWithCode(1);
-            }
-
-            compiledOutputDir = outputDir;
             irOutputDir = outputDir;
         }
         if (providedOptions.count("force-compiled") > 0) {

--- a/test/cli/compiler/output-flags/expected.out
+++ b/test/cli/compiler/output-flags/expected.out
@@ -11,10 +11,3 @@ Files in $irdir:
 ./hello.rb.ll
 ./hello.rb.lll
 ./hello.rb.llo
-legacy --llvm-ir-folder flag...
-No errors! Great job.
-Files in $irdir:
-./hello.rb.ll
-./hello.rb.lll
-./hello.rb.llo
-./hello.rb.so

--- a/test/cli/compiler/output-flags/test.sh
+++ b/test/cli/compiler/output-flags/test.sh
@@ -48,15 +48,3 @@ popd >/dev/null
 
 rm -rf "$sodir"
 rm -rf "$irdir"
-
-echo "legacy --llvm-ir-folder flag..."
-
-irdir="$(mktemp -d)"
-sorbet --silence-dev-message --llvm-ir-folder="$irdir" hello.rb
-
-echo "Files in \$irdir:"
-pushd "$irdir" >/dev/null
-find . -type f -print | sort
-popd >/dev/null
-
-rm -rf "$irdir"


### PR DESCRIPTION
### Motivation
Deprecated flag, don't need it anymore (we've migrated Stripe-internal stuff off of it).


### Test plan
See included automated tests.
