### PR TITLE
Update Dir::Tmpname signatures

### DIFF
--- a/rbi/stdlib/dir.rbi
+++ b/rbi/stdlib/dir.rbi
@@ -89,24 +89,21 @@ end
 module Dir::Tmpname
   sig do
     params(
-      basename: ::T.untyped,
-      tmpdir: ::T.untyped,
-      max_try: ::T.untyped,
-      opts: ::T.untyped,
+      basename: T.any(String, T::Array[String]),
+      tmpdir: T.nilable(String),
+      max_try: T.nilable(Integer),
+      opts: T.untyped,
+      blk: T.proc.params(
+        path: String,
+        n: T.nilable(Integer),
+        opts: T::Hash[Symbol, T.untyped],
+        origdir: T.nilable(String)
+      ).void
     )
-    .returns(::T.untyped)
+    .returns(String)
   end
-  def self.create(basename, tmpdir=T.unsafe(nil), max_try: T.unsafe(nil), **opts); end
+  def self.create(basename, tmpdir=nil, max_try: nil, **opts, &blk); end
 
-  sig do
-    params(
-      _: ::T.untyped,
-      n: ::T.untyped,
-    )
-    .returns(::T.untyped)
-  end
-  def self.make_tmpname(_, n); end
-
-  sig {returns(::T.untyped)}
+  sig {returns(String)}
   def self.tmpdir(); end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These were untyped and also missing the block parameter.

`Dir::Tmpname.make_tmpname` no longer exists - it was removed in Ruby 2.5. How do you usually handle this? Keep it but adjust the signature as if it was Ruby 2.4?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested on Homebrew's codebase.
