### PR TITLE
rework tag initialization slightly

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -2313,6 +2313,12 @@ void sorbet_throwReturn(VALUE retval) {
 // This is invoked at the beginning of a method's body, and is analogous to EC_PUSH_TAG + EC_EXEC_TAG
 // https://github.com/ruby/ruby/blob/5445e0435260b449decf2ac16f9d09bae3cafe72/eval_intern.h#L130-L135
 // https://github.com/ruby/ruby/blob/5445e0435260b449decf2ac16f9d09bae3cafe72/eval_intern.h#L181-L182
+//
+// Note that we're calling `setjmp` here, but we're returning from this function and
+// expecting `longjmp`'ing to `tag->buf` to still work correctly.  We can do this
+// because this function will be inlined, meaning that `tag->buf` will reflect the
+// state of this function's caller and `tag->buf` will be valid for the lifetime of
+// this function's caller.
 SORBET_INLINE
 enum ruby_tag_type sorbet_initializeTag(struct rb_vm_tag *tag) {
     rb_execution_context_t *ec = GET_EC();

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -147,11 +147,6 @@ SORBET_ALIVE(VALUE, sorbet_magic_mergeHashHelper, (VALUE, VALUE));
 SORBET_ALIVE(VALUE, sorbet_vm_getivar, (VALUE obj, ID id, struct iseq_inline_iv_cache_entry *cache));
 SORBET_ALIVE(void, sorbet_vm_setivar, (VALUE obj, ID id, VALUE val, struct iseq_inline_iv_cache_entry *cache));
 
-SORBET_ALIVE(enum ruby_tag_type, sorbet_initializeTag, (struct rb_vm_tag * tag));
-SORBET_ALIVE(VALUE, sorbet_processThrowReturnSetJmp,
-             (enum ruby_tag_type state, rb_control_frame_t *cfp, struct rb_vm_tag *tag));
-SORBET_ALIVE(void, sorbet_teardownTagForThrowReturn, (struct rb_vm_tag * tag));
-
 SORBET_ALIVE(void, sorbet_vm_register_sig,
              (VALUE isSelf, VALUE method, VALUE self, VALUE arg, rb_block_call_func_t block));
 SORBET_ALIVE(void, sorbet_vm_define_method,
@@ -2346,6 +2341,7 @@ enum ruby_tag_type sorbet_initializeTag(struct rb_vm_tag *tag) {
     // (i.e. a "abnormal" return from setjmp).
     return state;
 }
+KEEP_ALIVE(sorbet_initializeTag)
 
 // Used by method and static init functions, for setjmp handling for returns from block statements.
 //
@@ -2388,6 +2384,7 @@ VALUE sorbet_processThrowReturnSetJmp(enum ruby_tag_type state, rb_control_frame
 
     return retval;
 }
+KEEP_ALIVE(sorbet_processThrowReturnSetJmp)
 
 SORBET_INLINE
 void sorbet_teardownTagForThrowReturn(struct rb_vm_tag *tag) {
@@ -2396,6 +2393,7 @@ void sorbet_teardownTagForThrowReturn(struct rb_vm_tag *tag) {
     // inlined from EC_POP_TAG
     ec->tag = tag->prev;
 }
+KEEP_ALIVE(sorbet_teardownTagForThrowReturn)
 
 // ****
 // ****                       sorbet_ruby version information fallback


### PR DESCRIPTION
### Motivation

The way `sorbet_initializeTag` and `sorbet_processThrowReturnSetJmp` are written make at least `sorbet_initializeTag` tricky to reuse.  A new caller must remember to handle some of the tag reset bits and tag push bits performed by `sorbet_processThrowReturnSetJmp`.  I think it would be easier to understand if `sorbet_initializeTag` worked a little more like `EC_PUSH_TAG` + `EC_EXEC_TAG`.

Thus this PR, which moves more of the tag handling into `sorbet_initializeTag`.  I'm not too worried about performing extra branches to test `state`: jump threading is a thing and LLVM is pretty smart.  A new user of `sorbet_initializeTag` now can handle the return value directly as a clue to what kind of processing they need to do, and they don't have to remember to push or pop tags as necessary.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I need to fixup some of the exp tests, which will rely on #4466 landing.
