### PR TITLE
fix typo: s/interpretted/interpreted/g

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -134,7 +134,7 @@ Every compiler test works like this:
 These Ruby file tests live in `test/testdata/`.
 
 Thus, it's very important to **print things** in tests. If a test doesn't print
-anything, then both the interpretted and compiled output will be empty and the
+anything, then both the interpreted and compiled output will be empty and the
 test will pass even if the compiler did something completely wrong.
 
 ### Verifying LLVM IR

--- a/test/test_corpus_runner.sh
+++ b/test/test_corpus_runner.sh
@@ -207,7 +207,7 @@ else
   filter_stderr < "$rberr" > "$rberr_filtered"
   filter_stderr < "$stderr" > "$stderr_filtered"
   if ! diff -au "$rberr_filtered" "$stderr_filtered" > stderr.diff; then
-    attn  "├─ Diff (interpretted vs compiled, filtered):"
+    attn  "├─ Diff (interpreted vs compiled, filtered):"
     < stderr.diff indent_and_nest
     attn  "├─ Full compiled output (except bazel paths shortened):"
     < "$stderr" shorten_bazel | indent_and_nest
@@ -224,9 +224,9 @@ else
   if [ -z "$expect_fail" ]; then
     echo ""
     success "Test passed."
-    info    "├─ stdout (interpretted):"
+    info    "├─ stdout (interpreted):"
     < "$rbout" indent_and_nest
-    info    "├─ stderr (interpretted):"
+    info    "├─ stderr (interpreted):"
     < "$rberr" shorten_bazel | indent_and_nest
     success "└─ 🎉"
 
@@ -236,9 +236,9 @@ else
     error  "Disabled test did not fail."
     info   "This could mean that a recent change has made this test start passing."
     info   "If that's the case, great! Please move this test out of the disabled folder to catch future regressions."
-    info   "├─ stdout (interpretted):"
+    info   "├─ stdout (interpreted):"
     < "$rbout" indent_and_nest
-    info   "├─ stderr (interpretted):"
+    info   "├─ stderr (interpreted):"
     < "$rberr" shorten_bazel | indent_and_nest
     error "└─ ❌"
 

--- a/test/testdata/compiler/stack_frame_exception_arguments.rb
+++ b/test/testdata/compiler/stack_frame_exception_arguments.rb
@@ -26,10 +26,10 @@ rescue TypeError => exn
   # former crash we were seeing to happen.
   #
   # But the problem is that the backtrace information will necessarily have
-  # different information in interpretted vs compiled (because there's no
+  # different information in interpreted vs compiled (because there's no
   # runtime sig wrapping code). So the logic below basically says that "this
-  # code doesn't crash both when interpretted and when compiled," rather than
-  # "the interpretted and compiled behavior are identical"
+  # code doesn't crash both when interpreted and when compiled," rather than
+  # "the interpreted and compiled behavior are identical"
   first_line = exn.backtrace&.fetch(0)
   if first_line =~ /call_validation_error_handler_default/
     puts 'ok'


### PR DESCRIPTION
### Motivation

Fewer spelling mistakes is more better.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
