### PR TITLE
update bits around update_compiler_exp.sh

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -206,8 +206,8 @@ idea is that you should skim the diffs, make sure they look appropriate given
 what was meant to change, and then record the new exp files with this command:
 
 ```bash
-# Only reproducible if run on Linux, not macOS
-tools/scripts/update_exp_files.sh
+# Can only be run on Linux.
+tools/scripts/update_compiler_exp.sh
 ```
 
 The expectations files are somewhat platform dependent, so they must be recorded

--- a/test/validate_exp.sh
+++ b/test/validate_exp.sh
@@ -80,12 +80,14 @@ for ext in "${exts[@]}"; do
       if ($llvm_diff_path "$exp" "$actual" 2>&1 || true) | "$ruby" "$diff_diff" > "$diff_out" ; then
         if grep "exists only in" "$diff_out" > /dev/null ; then
           cat "$diff_out"
+          info "If this was an expected difference, you need to run tools/scripts/update_compiler_exp.sh"
           fatal "* $(basename "$exp")"
         else
           success "* $(basename "$exp")"
         fi
       else
         cat "$diff_out"
+        info "If this was an expected difference, you need to run tools/scripts/update_compiler_exp.sh"
         fatal "* $(basename "$exp")"
       fi
     fi

--- a/tools/scripts/update_compiler_exp.sh
+++ b/tools/scripts/update_compiler_exp.sh
@@ -11,6 +11,11 @@ if ! command -v parallel &> /dev/null; then
   exit 1
 fi
 
+if [ $(uname -s) != Linux ] ; then
+  echo "This script can only be run on Linux"
+  exit 1
+fi
+
 COMMAND_FILE="$(mktemp)"
 trap 'rm -f "$COMMAND_FILE"' EXIT
 

--- a/tools/scripts/update_compiler_exp.sh
+++ b/tools/scripts/update_compiler_exp.sh
@@ -11,7 +11,7 @@ if ! command -v parallel &> /dev/null; then
   exit 1
 fi
 
-if [ $(uname -s) != Linux ] ; then
+if [ "$(uname -s)" != Linux ] ; then
   echo "This script can only be run on Linux"
   exit 1
 fi


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Our documentation didn't mention this script, nor did anything enforce that the script needed to be run on Linux.  Let's fix that.

I also added an informative message to `test/validate_exp.sh` about what you need to do if you see failures.  You can see that message in action here:

https://buildkite.com/sorbet/sorbet/builds/16751

It would be nice to get it to show up pretty and styled in the buildkite output, but I am not sure how to do that.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
