### PR TITLE
run app_raise.rb 10_000_000 times to line up with a benchmark baseline

### DIFF
--- a/test/testdata/ruby_benchmark/app_raise.rb
+++ b/test/testdata/ruby_benchmark/app_raise.rb
@@ -2,10 +2,12 @@
 # typed: strict
 # compiled: true
 i = 0
-while i<300000
-  i += 1
+while i < 10_000_000
   begin
     raise
   rescue
   end
+  i += 1
 end
+
+p i


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

@elliottt and I were talking about this benchmark the other day and the weirdness of the benchmark with respect to our current benchmarking baselines came up.  This PR fixes that.

Just for kicks, the numbers:

```
froydnj@pyro:~/src/sorbet$ ./tools/scripts/run_benchmarks.sh -b test/testdata/ruby_benchmark/stripe/while_10_000_000.rb -f test/testdata/ruby_benchmark/app_raise.rb
[...]
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]
ruby vm startup time: .094
source  interpreted     compiled
stripe/while_10_000_000.rb      .223    .091
app_raise.rb    4.493   .092
app_raise.rb - baseline 4.270   .001
```

I feel pretty good about the compiler's exception performance for now; the IR looks like we're not taking any shortcuts.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
