### PR TITLE
Fail for llvm parsing errors in diff-diff.rb

### DIFF
--- a/test/compiler_tests.bzl
+++ b/test/compiler_tests.bzl
@@ -120,6 +120,7 @@ def compiler_tests(suite_name, all_paths, extra_args = [], tags = []):
                 name = validate_exp,
                 srcs = sources_name,
                 exp_files = exps_name,
+                expected_failure = tests[name]["disabled"],
                 extension = extension,
                 tags = tags + extra_tags,
                 size = "small",
@@ -335,13 +336,14 @@ def _validate_exp_test_impl(ctx):
 
         cat "{sorbet_log}"
 
-        {validate_exp} --build_dir="{build_dir}" {sources}
+        {validate_exp} --build_dir="{build_dir}" --expected_failure="{expected_failure}" {sources}
         """.format(
             build_log = output.log.short_path,
             sorbet_log = output.stdout.short_path,
             validate_exp = ctx.executable._validate_exp.short_path,
             build_dir = output.build.short_path,
             sources = " ".join([file.short_path for file in ctx.files.srcs]),
+            expected_failure = ctx.attr.expected_failure,
         ),
         is_executable = True,
     )
@@ -357,6 +359,9 @@ validate_exp_test = rule(
         ),
         "exp_files": attr.label(
             mandatory = True,
+        ),
+        "expected_failure": attr.bool(
+            default = False,
         ),
         "extension": attr.label(
             mandatory = True,

--- a/test/diff-diff.rb
+++ b/test/diff-diff.rb
@@ -28,6 +28,8 @@ module DiffDiff
     end
   end
 
+  LINE_ERROR = %r{llvm-diff: [^ ]+:\d+:\d+: error: }
+
   # Determine if this is a real failure, or differences introduced as a result
   # of the `llvm-diff` bug https://bugs.llvm.org/show_bug.cgi?id=48137
   def self.sanitize(io)
@@ -61,6 +63,9 @@ module DiffDiff
         # encountering a function that only exists in one file or the other will
         # cause `llvm-diff` to return a non-zero exit code
         real_failure ||= line.include? 'exists only in'
+
+        # encountering an error when parsing either file
+        real_failure ||= line.match? LINE_ERROR
 
         lines << line
       end

--- a/test/testdata/compiler/disabled/validate_exp_tests/test.llo.exp
+++ b/test/testdata/compiler/disabled/validate_exp_tests/test.llo.exp
@@ -1,0 +1,234 @@
+; ModuleID = 'payload'
+source_filename = "llvm-link"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux_gnu"
+
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
+%struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%struct.list_node = type { %struct.list_node*, %struct.list_node* }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
+%struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
+%struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
+%struct.anon.0 = type { i16, [2 x i8] }
+%struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
+%struct.rb_iseq_location_struct = type { i64, i64, i64, i64, i32, %struct.rb_code_location_struct }
+%struct.rb_code_location_struct = type { %struct.rb_code_position_struct, %struct.rb_code_position_struct }
+%struct.rb_code_position_struct = type { i32, i32 }
+%struct.iseq_insn_info = type { %struct.iseq_insn_info_entry*, i32*, i32, %struct.succ_index_table* }
+%struct.iseq_insn_info_entry = type opaque
+%struct.succ_index_table = type opaque
+%struct.iseq_catch_table = type opaque
+%union.iseq_inline_storage_entry = type { %struct.iseq_inline_cache_entry }
+%struct.iseq_inline_cache_entry = type { i64, %struct.rb_cref_struct*, i64 }
+%struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
+%struct.rb_scope_visi_struct = type { i8, [3 x i8] }
+%struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
+%struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
+%union.anon.15 = type { i32 }
+%struct.rb_call_info = type { i64, i32, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
+%struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
+%struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
+%struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
+%struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
+%struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
+%struct.__sigset_t = type { [16 x i64] }
+%struct.rb_calling_info = type { i64, i64, i32, i32 }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
+%struct.rb_unblock_callback = type { void (i8*)*, i8* }
+%struct.rb_mutex_struct = type opaque
+%struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
+%struct.rb_fiber_struct = type opaque
+%struct.anon.5 = type { [65 x i64] }
+%struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
+%struct.rb_event_hook_struct = type opaque
+%struct.rb_postponed_job_struct = type opaque
+%struct.list_head = type { %struct.list_node }
+%union.pthread_mutex_t = type { %struct.__pthread_mutex_s }
+%struct.__pthread_mutex_s = type { i32, i32, i32, i32, i32, i16, i16, %struct.__pthread_internal_list }
+%struct.__pthread_internal_list = type { %struct.__pthread_internal_list*, %struct.__pthread_internal_list* }
+%struct.rb_objspace = type opaque
+%struct.rb_at_exit_list = type { void (%struct.rb_vm_struct*)*, %struct.rb_at_exit_list* }
+%struct.st_table = type { i8, i8, i8, i32, %struct.st_hash_type*, i64, i64*, i64, i64, %struct.st_table_entry* }
+%struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
+%struct.st_table_entry = type opaque
+%struct.rb_builtin_function = type opaque
+%struct.anon.6 = type { i64, i64, i64, i64 }
+%struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
+%struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
+%struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
+%struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
+%struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
+
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
+@rb_eRuntimeError = external local_unnamed_addr global i64, align 8
+@.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@"stackFramePrecomputed_func_<root>.<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
+@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
+@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
+@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
+@"rubyStrFrozen_test/testdata/compiler/disabled/validate_exp_tests/test.rb" = internal unnamed_addr global i64 0, align 8
+@"str_test/testdata/compiler/disabled/validate_exp_tests/test.rb" = private unnamed_addr constant [59 x i8] c"test/testdata/compiler/disabled/validate_exp_tests/test.rb\00", align 1
+@iseqEncodedArray = internal global [6 x i64] zeroinitializer
+@fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
+@"rubyStrFrozen_Hello!" = internal unnamed_addr global i64 0, align 8
+@"str_Hello!" = private unnamed_addr constant [7 x i8] c"Hello!\00", align 1
+@ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
+@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
+@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
+
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
+
+declare i64 @sorbet_readRealpath() local_unnamed_addr #0
+
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+
+declare i64 @rb_fstring_new(i8*, i64) local_unnamed_addr #0
+
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+
+; Function Attrs: noreturn
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
+
+; Function Attrs: nounwind ssp uwtable
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #4
+  unreachable
+}
+
+; Function Attrs: nounwind ssp uwtable
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #4
+  unreachable
+}
+
+; Function Attrs: sspreq
+define void @Init_test() local_unnamed_addr #3 {
+entry:
+  %locals.i.i = alloca i64, i32 0, align 8
+
+  ; Call a function that doesn't exist to force a error that won't show up as a diff
+  %realpath = tail call i64 @sorbet_readRealpath_fake()
+
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #5
+  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #5
+  store i64 %1, i64* @rubyIdPrecomputed_puts, align 8
+  %2 = tail call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #5
+  tail call void @rb_gc_register_mark_object(i64 %2) #5
+  store i64 %2, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %3 = tail call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([59 x i8], [59 x i8]* @"str_test/testdata/compiler/disabled/validate_exp_tests/test.rb", i64 0, i64 0), i64 noundef 58) #5
+  tail call void @rb_gc_register_mark_object(i64 %3) #5
+  store i64 %3, i64* @"rubyStrFrozen_test/testdata/compiler/disabled/validate_exp_tests/test.rb", align 8
+  tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 6)
+  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %"rubyStr_test/testdata/compiler/disabled/validate_exp_tests/test.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/disabled/validate_exp_tests/test.rb", align 8
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/disabled/validate_exp_tests/test.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152", align 8
+  %5 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @"str_Hello!", i64 0, i64 0), i64 noundef 6) #5
+  call void @rb_gc_register_mark_object(i64 %5) #5
+  store i64 %5, i64* @"rubyStrFrozen_Hello!", align 8
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !8
+  %6 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !13
+  %7 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %6, i64 0, i32 18
+  %8 = load i64, i64* %7, align 8, !tbaa !15
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !25
+  %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152", align 8
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %12, align 8, !tbaa !28
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4
+  %14 = load i64*, i64** %13, align 8, !tbaa !30
+  %15 = load i64, i64* %14, align 8, !tbaa !4
+  %16 = and i64 %15, -33
+  store i64 %16, i64* %14, align 8, !tbaa !4
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %9, %struct.rb_control_frame_struct* %11, %struct.rb_iseq_struct* %stackFrame.i) #5
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
+  store i64* getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %17, align 8, !dbg !31, !tbaa !13
+  %"rubyStr_Hello!.i" = load i64, i64* @"rubyStrFrozen_Hello!", align 8, !dbg !32
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !8
+  %19 = load i64*, i64** %18, align 8, !dbg !8
+  store i64 %8, i64* %19, align 8, !dbg !8, !tbaa !4
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !8
+  store i64 %"rubyStr_Hello!.i", i64* %20, align 8, !dbg !8, !tbaa !4
+  %21 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !8
+  store i64* %21, i64** %18, align 8, !dbg !8
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !8
+  ret void
+}
+
+attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { sspreq }
+attributes #4 = { noreturn nounwind }
+attributes #5 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
+!2 = !DIFile(filename: "test/testdata/compiler/disabled/validate_exp_tests/test.rb", directory: ".")
+!3 = !{}
+!4 = !{!5, !5, i64 0}
+!5 = !{!"long", !6, i64 0}
+!6 = !{!"omnipotent char", !7, i64 0}
+!7 = !{!"Simple C/C++ TBAA"}
+!8 = !DILocation(line: 5, column: 1, scope: !9)
+!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$152", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
+!10 = !DISubroutineType(types: !11)
+!11 = !{!12}
+!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!13 = !{!14, !14, i64 0}
+!14 = !{!"any pointer", !6, i64 0}
+!15 = !{!16, !5, i64 400}
+!16 = !{!"rb_vm_struct", !5, i64 0, !17, i64 8, !14, i64 192, !14, i64 200, !14, i64 208, !21, i64 216, !6, i64 224, !18, i64 264, !18, i64 280, !18, i64 296, !18, i64 312, !5, i64 328, !20, i64 336, !20, i64 340, !20, i64 344, !20, i64 344, !20, i64 344, !20, i64 344, !20, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !14, i64 456, !14, i64 464, !22, i64 472, !23, i64 992, !14, i64 1016, !14, i64 1024, !20, i64 1032, !20, i64 1036, !18, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !20, i64 1136, !14, i64 1144, !14, i64 1152, !14, i64 1160, !14, i64 1168, !14, i64 1176, !14, i64 1184, !20, i64 1192, !24, i64 1200, !6, i64 1232}
+!17 = !{!"rb_global_vm_lock_struct", !14, i64 0, !6, i64 8, !18, i64 48, !14, i64 64, !20, i64 72, !6, i64 80, !6, i64 128, !20, i64 176, !20, i64 180}
+!18 = !{!"list_head", !19, i64 0}
+!19 = !{!"list_node", !14, i64 0, !14, i64 8}
+!20 = !{!"int", !6, i64 0}
+!21 = !{!"long long", !6, i64 0}
+!22 = !{!"", !6, i64 0}
+!23 = !{!"rb_hook_list_struct", !14, i64 0, !20, i64 8, !20, i64 12, !20, i64 16}
+!24 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
+!25 = !{!26, !14, i64 16}
+!26 = !{!"rb_execution_context_struct", !14, i64 0, !5, i64 8, !14, i64 16, !14, i64 24, !14, i64 32, !20, i64 40, !20, i64 44, !14, i64 48, !14, i64 56, !14, i64 64, !5, i64 72, !5, i64 80, !14, i64 88, !5, i64 96, !14, i64 104, !14, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !27, i64 152}
+!27 = !{!"", !14, i64 0, !14, i64 8, !5, i64 16, !6, i64 24}
+!28 = !{!29, !14, i64 16}
+!29 = !{!"rb_control_frame_struct", !14, i64 0, !14, i64 8, !14, i64 16, !5, i64 24, !14, i64 32, !14, i64 40, !14, i64 48}
+!30 = !{!29, !14, i64 32}
+!31 = !DILocation(line: 0, scope: !9)
+!32 = !DILocation(line: 5, column: 6, scope: !9)

--- a/test/testdata/compiler/disabled/validate_exp_tests/test.rb
+++ b/test/testdata/compiler/disabled/validate_exp_tests/test.rb
@@ -7,4 +7,4 @@
 # this manner wouldn't cause diff-diff.rb to report an error, so this exercises
 # that case to ensure that it's failing properly.
 
-puts "Hello!"
+puts __dir__

--- a/test/testdata/compiler/disabled/validate_exp_tests/test.rb
+++ b/test/testdata/compiler/disabled/validate_exp_tests/test.rb
@@ -7,4 +7,8 @@
 # this manner wouldn't cause diff-diff.rb to report an error, so this exercises
 # that case to ensure that it's failing properly.
 
-puts __dir__
+# The oracle test needs to fail as well, but it's not the failure we're
+# interested in. Since the tests will never be run at the same time and their
+# output will be compared, it's sufficient to print out the current time to
+# guarantee a failure for the oracle test.
+puts Time.new

--- a/test/testdata/compiler/disabled/validate_exp_tests/test.rb
+++ b/test/testdata/compiler/disabled/validate_exp_tests/test.rb
@@ -1,0 +1,10 @@
+# compiled: true
+# frozen_string_literal: true
+# typed: true
+
+# This test is expected to fail, as its exp file has an error in it. This error
+# will cause the llvm to fail to validate before a diff is performed. Failing in
+# this manner wouldn't cause diff-diff.rb to report an error, so this exercises
+# that case to ensure that it's failing properly.
+
+puts "Hello!"

--- a/test/validate_exp.sh
+++ b/test/validate_exp.sh
@@ -97,7 +97,6 @@ for ext in "${exts[@]}"; do
       # spurious errors from its output. This will also take over returning the
       # correct exit code if it discovers that all of the differences were
       # related to the bug.
-      passed=
       if ($llvm_diff_path "$exp" "$actual" 2>&1 || true) | "$ruby" "$diff_diff" > "$diff_out" ; then
         if grep "exists only in" "$diff_out" > /dev/null ; then
           cat "$diff_out"

--- a/test/validate_exp.sh
+++ b/test/validate_exp.sh
@@ -77,7 +77,9 @@ for ext in "${exts[@]}"; do
       # spurious errors from its output. This will also take over returning the
       # correct exit code if it discovers that all of the differences were
       # related to the bug.
-      if ($llvm_diff_path "$exp" "$actual" 2>&1 || true) | "$ruby" "$diff_diff" > "$diff_out" ; then
+      out="${diff_dir}/thing"
+      if ($llvm_diff_path "$exp" "$actual" 2>&1 || true) | tee "$out" | "$ruby" "$diff_diff" > "$diff_out" ; then
+        cat "$diff_out"
         if grep "exists only in" "$diff_out" > /dev/null ; then
           cat "$diff_out"
           info "If this was an expected difference, you need to run tools/scripts/update_compiler_exp.sh"

--- a/test/validate_exp.sh
+++ b/test/validate_exp.sh
@@ -70,12 +70,15 @@ pushd "$build_dir/" > /dev/null
 something_failed() {
   if [ -n "${expected_failure}" ]; then
     success "Disabled test failed as expected."
+    info    "* $1"
+    echo ""
     info    "To make this failing test fail the build, move it out of the disabled folder"
     echo ""
     exit 0
   else
     echo ""
-    error "Test failed."
+    error "Test failed:"
+    error "* $1"
     echo ""
     exit 1
   fi
@@ -101,7 +104,7 @@ for ext in "${exts[@]}"; do
         if grep "exists only in" "$diff_out" > /dev/null ; then
           cat "$diff_out"
           info "If this was an expected difference, you need to run tools/scripts/update_compiler_exp.sh"
-          something_failed
+          something_failed "$(basename "$exp")"
         else
           if [ -n "${expected_failure}" ]; then
             echo ""
@@ -117,7 +120,7 @@ for ext in "${exts[@]}"; do
       else
         cat "$diff_out"
         info "If this was an expected difference, you need to run tools/scripts/update_compiler_exp.sh"
-        something_failed
+        something_failed "$(basename "$exp")"
       fi
     fi
   fi

--- a/tools/scripts/update_compiler_exp.sh
+++ b/tools/scripts/update_compiler_exp.sh
@@ -45,6 +45,12 @@ for this_src in "${rb_src[@]}" DUMMY; do
         continue
     fi
 
+    # Don't update exp files for validate exp tests, as they are hand edited to
+    # produce llvm failures
+    if [[ "$this_base" =~ "/disabled/validate_exp_test" ]]; then
+      continue
+    fi
+
     dir="$(dirname "$this_base")"
     basename="$this_base"
     srcs=("$this_src")


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
When llvm-diff fails because of parsing errors, diff-diff.rb should fail as well. This PR fixes this bug in diff-diff.rb and adds a disabled failing test for exp validation to verify that it's working.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixing a bug in validate_exp.sh that was not reporting llvm parse errors as test failures.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
