### PR TITLE
fix run_benchmarks.sh for compiled-out/llvm-ir option split

### DIFF
--- a/tools/scripts/run_benchmarks.sh
+++ b/tools/scripts/run_benchmarks.sh
@@ -139,7 +139,7 @@ compile_benchmark() {
 
   rm tmp/bench/*
   cp "$benchmark" tmp/bench/target.rb
-  llvmir=. test/run_sorbet.sh tmp/bench/target.rb &>/dev/null
+  llvmir=. compiled_out_dir=. test/run_sorbet.sh tmp/bench/target.rb &>/dev/null
 }
 
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`run_benchmarks.sh` needed the same fix @neilparikh applied to `run-benchmarks.rb`.  :man_facepalming: 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
