### PR TITLE
Enforce that we use @platforms for constraints

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,9 @@ build --crosstool_top=@llvm_toolchain_12_0_0//:toolchain --copt=-D_LIBCPP_ENABLE
 # this flag here once flipped in Bazel again.
 build --incompatible_strict_action_env
 
+# Enforce that we don't rely on `@bazel_tools//platforms` and instead use the
+# `@platforms` repository for constraint resolution.  See
+# https://github.com/bazelbuild/bazel/issues/8622 for more information.
 build --incompatible_use_platforms_repo_for_constraints
 
 # C / C++ Options

--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,8 @@ build --crosstool_top=@llvm_toolchain_12_0_0//:toolchain --copt=-D_LIBCPP_ENABLE
 # this flag here once flipped in Bazel again.
 build --incompatible_strict_action_env
 
+build --incompatible_use_platforms_repo_for_constraints
+
 # C / C++ Options
 # Don't depend on system compiler
 build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17

--- a/third_party/abseil-platforms.patch
+++ b/third_party/abseil-platforms.patch
@@ -1,0 +1,42 @@
+diff --git a/absl/BUILD.bazel b/absl/BUILD.bazel
+index c9d4a2d..7239b5b 100644
+--- absl/BUILD.bazel
++++ absl/BUILD.bazel
+@@ -44,14 +44,14 @@ config_setting(
+ config_setting(
+     name = "osx",
+     constraint_values = [
+-        "@bazel_tools//platforms:osx",
++        "@platforms//os:osx",
+     ],
+ )
+ 
+ config_setting(
+     name = "ios",
+     constraint_values = [
+-        "@bazel_tools//platforms:ios",
++        "@platforms//os:ios",
+     ],
+ )
+ 
+diff --git a/absl/time/internal/cctz/BUILD.bazel b/absl/time/internal/cctz/BUILD.bazel
+index 45a9529..f549af6 100644
+--- absl/time/internal/cctz/BUILD.bazel
++++ absl/time/internal/cctz/BUILD.bazel
+@@ -26,14 +26,14 @@ filegroup(
+ config_setting(
+     name = "osx",
+     constraint_values = [
+-        "@bazel_tools//platforms:osx",
++        "@platforms//os:osx",
+     ],
+ )
+ 
+ config_setting(
+     name = "ios",
+     constraint_values = [
+-        "@bazel_tools//platforms:ios",
++        "@platforms//os:ios",
+     ],
+ )
+ 

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -155,9 +155,10 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "com_google_absl",
-        urls = _github_public_urls("abseil/abseil-cpp/archive/e9b9e38f67a008d66133535a72ada843bd66013f.zip"),
-        sha256 = "49c93740b3b09f73cd2f10da778ea4129d59733085393f458a4acd17774503fb",
-        strip_prefix = "abseil-cpp-e9b9e38f67a008d66133535a72ada843bd66013f",
+        urls = _github_public_urls("abseil/abseil-cpp/archive/b699707f0bfeae034e36cdfd909b66b0fcab696c.zip"),
+        sha256 = "29a165fcbf802f3cdb6d7a17327ede0af2c799a11f88611c005867e994b984e2",
+        strip_prefix = "abseil-cpp-b699707f0bfeae034e36cdfd909b66b0fcab696c",
+        patches = ["@com_stripe_ruby_typer//third_party:abseil-platforms.patch"],
     )
 
     http_archive(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Enable `--incompatible_use_platforms_repo_for_constraints` in our .bazelrc so that we get an error if we start depending on `@bazel_tools//platforms` again. Additionally, patch abseil to use the `@platforms` repository when we build it. I've opened a pull request with abseil to upstream this change at abseil/abseil-cpp#1001.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Ensuring that we don't fall back on using `@bazel_tools//platforms` anywhere.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
