### PR TITLE
Force exception variables to escape

### DIFF
--- a/compiler/IREmitter/Exceptions.cc
+++ b/compiler/IREmitter/Exceptions.cc
@@ -91,6 +91,10 @@ public:
         // Clear out the variable that we store the current exception in
         Payload::varSet(cs, exceptionValue, Payload::rubyNil(state.cs, state.builder), builder, irctx, rubyBlockId);
 
+        // We require that the exception value escapes, so that we can read/write it with
+        // sorbet_readLocal/sorbet_writeLocal.
+        ENFORCE(irctx.escapedVariableIndices.contains(exceptionValue));
+
         return state;
     }
 

--- a/test/testdata/compiler/exceptions/unused_block.rb
+++ b/test/testdata/compiler/exceptions/unused_block.rb
@@ -2,6 +2,12 @@
 # typed: true
 # compiled: true
 
+# This tests what happens when the variable introduced to hold the exception
+# value doesn't end up in the closure for the function. The body of the
+# begin/ensure clause on line 11 unconditionally returns, which causes the
+# conditional branch at the end of that block based on the exception value to
+# disappear.
+
 def test
   begin
     return true
@@ -9,3 +15,5 @@ def test
     puts "ensure"
   end
 end
+
+puts test


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Force exception values to live on the ruby stack by adding an artificial reference in a different ruby block.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We need to ensure that exception variables are stored in the ruby stack for fixing issues with exception handling.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
