### PR TITLE
Fix run_compiled.sh

### DIFF
--- a/test/run_compiled.sh
+++ b/test/run_compiled.sh
@@ -71,7 +71,7 @@ elif [[ ! -d "$llvmir" ]]; then
 fi
 
 # ensure that the extension is built
-"test/run_sorbet.sh" -i "$llvmir" "${rb_files[@]}"
+"test/run_sorbet.sh" -s "$llvmir" -i "$llvmir" "${rb_files[@]}"
 
 if [[ "$llvmir" != /* ]]; then
   llvmir="$PWD/$llvmir"

--- a/test/run_sorbet.sh
+++ b/test/run_sorbet.sh
@@ -32,7 +32,7 @@ else
   compiled_out_dir=''
 fi
 
-while getopts ":hdsi:" opt; do
+while getopts ":hds:i:" opt; do
   case $opt in
     h)
       usage


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Make the -i flag on run_compiled.sh set both -i and -s on run_sorbet.sh


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fix run_compiled.sh after the addition of the -s flag for shared object outputs


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.