### PR TITLE
subtyping lub: use 'only 2nd is proxy' to handle 'only 1st is proxy' case

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -404,21 +404,12 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             ENFORCE(result != nullptr);
             return result;
         } else {
-            bool allowProxyInLub = isa_type<TupleType>(t1) || isa_type<ShapeType>(t1);
             // only 1st is proxy
-            TypePtr und = t1.underlying(gs);
-            if (isSubType(gs, und, t2)) {
-                return t2;
-            } else if (allowProxyInLub) {
-                return OrType::make_shared(t1, t2);
-            } else {
-                return lub(gs, t2, und);
-            }
+            return lub(gs, t2, t1);
         }
     } else if (is_proxy_type(t2)) {
         // only 2nd is proxy
         bool allowProxyInLub = isa_type<TupleType>(t2) || isa_type<ShapeType>(t2);
-        // only 1st is proxy
         TypePtr und = t2.underlying(gs);
         if (isSubType(gs, und, t1)) {
             return t1;


### PR DESCRIPTION
Call `lub(gs, t2, t1)` itself when only `t1` is a proxy type (leveraging the handling when only `t2` is a proxy type) as the result should be symmetric. This is to avoid duplication and potential deviation in implementation.

### Motivation

While working on #4490, I noticed an incorrect comment "// only 1st is proxy" (following a correct comment "// only 2nd is proxy") indicating a copy/paste from another case. This was originally fixed up in the PR #4491 for #4490 but realizing that more work will likely need to be done on that, split this change out on its own.

### Test plan

This is a refactoring only and is covered by passing existing automated tests.
