### PR TITLE
split out a function for computing values for escaped variable access

### DIFF
--- a/compiler/IREmitter/Payload.h
+++ b/compiler/IREmitter/Payload.h
@@ -70,6 +70,10 @@ public:
     static void varSet(CompilerState &cs, cfg::LocalRef local, llvm::Value *var, llvm::IRBuilderBase &builder,
                        const IREmitterContext &irctx, int rubyBlockId);
 
+    static std::tuple<llvm::Value *, llvm::Value *> escapedVariableIndexAndLevel(CompilerState &cs, cfg::LocalRef local,
+                                                                                 const IREmitterContext &irctx,
+                                                                                 int rubyBlockId);
+
     static llvm::Value *retrySingleton(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx);
     static llvm::Value *voidSingleton(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx);
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It turns out to properly solve #4493, we're going to need to rewrite most of the exception handling in C.  This ought to be straightforward, except that we need to access the `exceptionValue` local in the midst of the exception handling.  I am very wary of just saying "pass in a pointer to the location of `exceptionValue`", because I'm not convinced that said location would remain stable during the exception handling region's execution (e.g. local variable storage moves from the Ruby stack to the heap, and we're stuck with the wrong location).

Fortunately, given #4488, such support is straightforward.  We just need the change in this PR, which is to split out enough of the escaped variable access handling to a separate function so that we can pass these values to an appropriate C function.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
