### PR TITLE
Refactor packager to use prefix map for looking up packages

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -139,8 +139,7 @@ public:
         auto curPrefixPos = path.find_last_of('/');
 
         while (curPrefixPos != std::string::npos) {
-            path = path.substr(0, curPrefixPos + 1);
-            const auto &it = packageInfoByPathPrefix.find(path);
+            const auto &it = packageInfoByPathPrefix.find(path.substr(0, curPrefixPos + 1));
 
             if (it != packageInfoByPathPrefix.end()) {
                 return it->second.get();

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -107,7 +107,7 @@ public:
      * Given a file of type PACKAGE, return its PackageInfo or nullptr if one does not exist.
      */
     const PackageInfo *getPackageByFile(core::Context ctx, core::FileRef packageFile) const {
-        const auto path = packageFile.data(ctx).path();
+        const std::string_view path = packageFile.data(ctx).path();
         const auto &it = packageInfoByPathPrefix.find(path.substr(0, path.find_last_of('/') + 1));
         if (it == packageInfoByPathPrefix.end()) {
             return nullptr;
@@ -135,8 +135,8 @@ public:
             Exception::raise("Cannot map files to packages until all packages are added and PackageDB is finalized");
         }
 
-        auto path = ctx.file.data(ctx).path();
-        auto curPrefixPos = path.find_last_of('/');
+        std::string_view path = ctx.file.data(ctx).path();
+        int curPrefixPos = path.find_last_of('/');
 
         while (curPrefixPos != std::string::npos) {
             const auto &it = packageInfoByPathPrefix.find(path.substr(0, curPrefixPos + 1));

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -137,18 +137,15 @@ public:
         }
 
         auto path = ctx.file.data(ctx).path();
-        string pathStr = path.data();
-        auto curPrefixPos = pathStr.find_last_of('/');
+        auto curPrefixPos = path.find_last_of('/');
 
         while (curPrefixPos != std::string::npos) {
-            pathStr.resize(curPrefixPos + 1);
-
-            const auto &it = packageInfoByPathPrefix.find(pathStr);
+            const auto &it = packageInfoByPathPrefix.find(path.substr(0, curPrefixPos + 1));
             if (it != packageInfoByPathPrefix.end()) {
                 return it->second.get();
             }
 
-            curPrefixPos = pathStr.find_last_of('/', curPrefixPos - 1);
+            curPrefixPos = path.find_last_of('/', curPrefixPos - 1);
         }
 
         return nullptr;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -135,17 +135,20 @@ public:
         if (!finalized) {
             Exception::raise("Cannot map files to packages until all packages are added and PackageDB is finalized");
         }
+
         auto path = ctx.file.data(ctx).path();
-        auto curPrefixPos = path.find_last_of('/');
+        string pathStr = path.data();
+        auto curPrefixPos = pathStr.find_last_of('/');
 
         while (curPrefixPos != std::string::npos) {
-            const auto &it = packageInfoByPathPrefix.find(path.substr(0, curPrefixPos + 1));
+            pathStr.resize(curPrefixPos + 1);
 
+            const auto &it = packageInfoByPathPrefix.find(pathStr);
             if (it != packageInfoByPathPrefix.end()) {
                 return it->second.get();
             }
 
-            curPrefixPos = path.find_last_of('/', curPrefixPos - 1);
+            curPrefixPos = pathStr.find_last_of('/', curPrefixPos - 1);
         }
 
         return nullptr;

--- a/test/testdata/packager/deeply_nested_packages/__package.rb
+++ b/test/testdata/packager/deeply_nested_packages/__package.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# typed: strict
+# enable-packager: true
+
+class Package < PackageSpec
+  import Package::Subpackage
+  export Package::PackageClass
+  export Package::InnerClass
+end

--- a/test/testdata/packager/deeply_nested_packages/mainpackage.rb
+++ b/test/testdata/packager/deeply_nested_packages/mainpackage.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Package::PackageClass
+    extend T::Sig
+
+    sig {returns(Package::Subpackage::SubpackageClass)}
+    def self.subpkg_class
+        Package::Subpackage::SubpackageClass.new()
+    end
+end

--- a/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
@@ -1,0 +1,72 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Package>::<C Subpackage>)
+
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>)
+
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C InnerClass>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
+      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Package>::<C PackageClass><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.returns(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
+      end
+
+      def self.subpkg_class<<todo method>>(&<blk>)
+        <emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>.new()
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_self_def(<self>, :subpkg_class, :normal)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Package>::<C InnerClass><<C <todo sym>>> < (::<todo sym>)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Package>::<C Subpackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Package>)
+
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C InnerClass>
+    end
+
+    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.returns(<emptyTree>::<C Package>::<C PackageClass>)
+      end
+
+      def self.package_class<<todo method>>(&<blk>)
+        return <emptyTree>::<C Package>::<C PackageClass>.new()
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_self_def(<self>, :package_class, :normal)
+    end
+  end
+end

--- a/test/testdata/packager/deeply_nested_packages/subdirectory/inner_class.rb
+++ b/test/testdata/packager/deeply_nested_packages/subdirectory/inner_class.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Package::InnerClass
+end

--- a/test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/__package.rb
+++ b/test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Package::Subpackage < PackageSpec
+  import Package
+  export Package::Subpackage::SubpackageClass
+end

--- a/test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/subpackage.rb
+++ b/test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/subpackage.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Package::Subpackage::SubpackageClass
+  extend T::Sig
+
+  sig {returns(Package::PackageClass)}
+  def self.package_class
+    return Package::PackageClass.new()
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Replaces the primary data structure of `packager` to be a map of path prefix -> package rather than a sorted vector of packages. Lookups now involve finding package in a map rather than iterating over the sorted vector.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We want to allow packages to have multiple file paths (in addition to the default one where the `__package.rb` file lives). This change will make the multiple file paths implementation easier, as you could then map from multiple path prefixes to the same package.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested with existing packager tests + added a new packager test which creates a file in a subfolder and a depth-2 nested package.