### PR TITLE
Add .checked(:compiled)

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -112,7 +112,7 @@ module T::Configuration
   # statically, so that methods don't have to guard themselves from being
   # called incorrectly by untyped code.
   #
-  # @param [:never, :tests, :always] default_checked_level
+  # @param [:compiled, :never, :tests, :always] default_checked_level
   def self.default_checked_level=(default_checked_level)
     T::Private::RuntimeLevels.default_checked_level = default_checked_level
   end

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -112,7 +112,7 @@ module T::Configuration
   # statically, so that methods don't have to guard themselves from being
   # called incorrectly by untyped code.
   #
-  # @param [:compiled, :never, :tests, :always] default_checked_level
+  # @param [:never, :compiled, :tests, :always] default_checked_level
   def self.default_checked_level=(default_checked_level)
     T::Private::RuntimeLevels.default_checked_level = default_checked_level
   end

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -88,8 +88,8 @@ module T::Private::Methods
       if !decl.checked.equal?(ARG_NOT_PROVIDED)
         raise BuilderError.new("You can't call .checked multiple times in a signature.")
       end
-      if level == :never && !decl.on_failure.equal?(ARG_NOT_PROVIDED)
-        raise BuilderError.new("You can't use .checked(:never) with .on_failure because .on_failure will have no effect.")
+      if (level == :never || level == :compiled) && !decl.on_failure.equal?(ARG_NOT_PROVIDED)
+        raise BuilderError.new("You can't use .checked(:#{level}) with .on_failure because .on_failure will have no effect.")
       end
       if !T::Private::RuntimeLevels::LEVELS.include?(level)
         raise BuilderError.new("Invalid `checked` level '#{level}'. Use one of: #{T::Private::RuntimeLevels::LEVELS}.")
@@ -106,8 +106,8 @@ module T::Private::Methods
       if !decl.on_failure.equal?(ARG_NOT_PROVIDED)
         raise BuilderError.new("You can't call .on_failure multiple times in a signature.")
       end
-      if decl.checked == :never
-        raise BuilderError.new("You can't use .on_failure with .checked(:never) because .on_failure will have no effect.")
+      if decl.checked == :never || decl.checked == :compiled
+        raise BuilderError.new("You can't use .on_failure with .checked(:#{decl.checked}) because .on_failure will have no effect.")
       end
 
       decl.on_failure = args
@@ -209,7 +209,7 @@ module T::Private::Methods
       end
       if decl.checked.equal?(ARG_NOT_PROVIDED)
         default_checked_level = T::Private::RuntimeLevels.default_checked_level
-        if default_checked_level == :never && !decl.on_failure.equal?(ARG_NOT_PROVIDED)
+        if (default_checked_level == :never || default_checked_level == :compiled) && !decl.on_failure.equal?(ARG_NOT_PROVIDED)
           raise BuilderError.new("To use .on_failure you must additionally call .checked(:tests) or .checked(:always), otherwise, the .on_failure has no effect.")
         end
         decl.checked = default_checked_level

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -174,7 +174,7 @@ module T::Private::Methods::SignatureValidation
     return if signature.override_allow_incompatible
     return if super_signature.mode == Modes.untyped
     return unless [signature, super_signature].all? do |sig|
-      sig.check_level == :always || (sig.check_level == :tests && T::Private::RuntimeLevels.check_tests?)
+      sig.check_level == :always || sig.check_level == :compiled || (sig.check_level == :tests && T::Private::RuntimeLevels.check_tests?)
     end
     mode_noun = super_signature.mode == Modes.abstract ? 'implementation' : 'override'
 

--- a/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
+++ b/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
@@ -12,6 +12,8 @@ module T::Private::RuntimeLevels
     # Don't even validate in tests, b/c too expensive,
     # or b/c we fully trust the static typing
     :never,
+    # Only validate when compiled. Equivalent to :never in sorbet-runtime
+    :compiled,
   ].freeze
 
   @check_tests = false

--- a/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
+++ b/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
@@ -12,7 +12,8 @@ module T::Private::RuntimeLevels
     # Don't even validate in tests, b/c too expensive,
     # or b/c we fully trust the static typing
     :never,
-    # Only validate when compiled. Equivalent to :never in sorbet-runtime
+    # Validate the sig when the file is using the Sorbet Compiler.
+    # Behaves like :never when interpreted.
     :compiled,
   ].freeze
 

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -233,6 +233,20 @@ module Opus::Types::Test
             mod.test_method(:llamas) # wrong, but ignored
           end
 
+          it '`compiled` is not checked' do
+            mod = Module.new do
+              extend T::Sig
+              sig do
+                params({x: Integer})
+                .returns(String)
+                .checked(:compiled)
+              end
+              def self.test_method(x); end
+            end
+
+            mod.test_method(:llamas) # wrong, but ignored
+          end
+
           def make_mod
             Module.new do
               extend T::Sig
@@ -353,6 +367,19 @@ module Opus::Types::Test
             end
             assert_includes(ex.message, "To use .on_failure you must additionally call .checked(:tests) or .checked(:always), otherwise, the .on_failure has no effect")
           end
+
+          it 'forbids .on_failure if default_checked_level is :compiled' do
+            T::Private::RuntimeLevels.instance_variable_set(:@default_checked_level, :compiled)
+
+            ex = assert_raises do
+              Class.new do
+                extend T::Sig
+                sig {void.on_failure(:soft, notify: 'me')}
+                def self.foo; end; foo
+              end
+            end
+            assert_includes(ex.message, "To use .on_failure you must additionally call .checked(:tests) or .checked(:always), otherwise, the .on_failure has no effect")
+          end
         end
       end
 
@@ -400,6 +427,17 @@ module Opus::Types::Test
         assert_includes(ex.message, "You can't use .checked(:never) with .on_failure")
       end
 
+      it 'forbids .on_failure and then .checked(:compiled)' do
+        ex = assert_raises do
+          Class.new do
+            extend T::Sig
+            sig {returns(NilClass).on_failure(:soft, notify: 'me').checked(:compiled)}
+            def self.foo; end; foo
+          end
+        end
+        assert_includes(ex.message, "You can't use .checked(:compiled) with .on_failure")
+      end
+
       it 'allows .on_failure and then .checked(:tests)' do
         Class.new do
           extend T::Sig
@@ -428,6 +466,18 @@ module Opus::Types::Test
           end
         end
         assert_includes(ex.message, "You can't use .on_failure with .checked(:never)")
+      end
+
+      it 'forbids .checked(:compiled) and then .on_failure' do
+        ex = assert_raises do
+          Class.new do
+            extend T::Sig
+            # We explicitly need to test that this ordering raises a certain error
+            sig {returns(NilClass).checked(:compiled).on_failure(:soft, notify: 'me')}
+            def self.foo; end; foo
+          end
+        end
+        assert_includes(ex.message, "You can't use .on_failure with .checked(:compiled)")
       end
 
       it 'allows .checked(:tests) and then .on_failure' do

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -162,6 +162,7 @@ bool sigIsUnchecked(core::MutableContext ctx, ast::Send *sig) {
     }
 
     // Treats `.checked(:tests)` as unknown, therefore not unchecked.
+    // Also treats `.checked(:compiled)` as unknown, therefore not unchecked.
     return lit->asSymbol(ctx) == core::Names::never();
 }
 

--- a/test/testdata/compiler/checked_compiled_override.rb
+++ b/test/testdata/compiler/checked_compiled_override.rb
@@ -1,0 +1,26 @@
+# typed: true
+# frozen_string_literal: true
+# compiled: true
+
+extend T::Helpers
+
+class Parent
+  extend T::Sig
+  sig { returns(Integer).checked(:compiled) }
+  def foo
+    1
+  end
+end
+class Child < Parent
+  extend T::Sig
+  sig { returns(String).checked(:compiled) }
+  def foo
+    "a"
+  end
+end
+
+begin
+  T::Utils.run_all_sig_blocks
+rescue => e
+  puts e.message.include?("Incompatible return type in signature for override of method `foo`")
+end

--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -258,6 +258,10 @@ sig {params(xs: T::Array[String]).void.checked(:tests)}
 
 # (3) Never runs the runtime checks. Careful!
 sig {params(xs: T::Array[String]).void.checked(:never)}
+
+# (4) Runtime checks only run when the file is using the Sorbet Compiler.
+# In the interpreter, this behaves identically to checked(:never).
+sig {params(xs: T::Array[String]).void.checked(:compiled)}
 ```
 
 If `.checked(...)` is omitted on a sig, the default is `.checked(:always)`. The


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds a new `checked` option, which specifies that it will only be checked when the code is compiled.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The compiler always checks sigs at runtime, so this provides a way to specify that sigs should not be checked in both tests and production, while accurately reflecting that the sigs will be checked when compiled (which might in fact include at test time, if the Sorbet Compiler is being used to run the tests).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
