### PR TITLE
make ordering of break instructions more closely reflect runtime behavior

### DIFF
--- a/test/testdata/cfg/break.rb.cfg.exp
+++ b/test/testdata/cfg/break.rb.cfg.exp
@@ -43,7 +43,7 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_5" [
         shape = rectangle;
         color = black;
-        label = "block[id=5, rubyBlockId=1](<self>: Object, <selfRestore>$9: Object)\louterLoops: 1\l<self>: Object = loadSelf\l<blk>$10: [Integer] = load_yield_params(map)\l<blk>$11: Integer(0) = 0\lx$1: Integer = <blk>$10: [Integer].[](<blk>$11: Integer(0))\l<returnTemp>$15: Integer = x$1\l<block-break-assign>$16: Integer = x$1\ltarget: Integer = <block-break-assign>$16\l<magic>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$18: T.untyped = <magic>$17: T.class_of(<Magic>).<block-break>(<returnTemp>$15: Integer)\l<unconditional>\l"
+        label = "block[id=5, rubyBlockId=1](<self>: Object, <selfRestore>$9: Object)\louterLoops: 1\l<self>: Object = loadSelf\l<blk>$10: [Integer] = load_yield_params(map)\l<blk>$11: Integer(0) = 0\lx$1: Integer = <blk>$10: [Integer].[](<blk>$11: Integer(0))\l<returnTemp>$15: Integer = x$1\l<block-break-assign>$16: Integer = x$1\l<magic>$17: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$18: T.untyped = <magic>$17: T.class_of(<Magic>).<block-break>(<returnTemp>$15: Integer)\ltarget: Integer = <block-break-assign>$16\l<unconditional>\l"
     ];
 
     "bb::Object#foo_5" -> "bb::Object#foo_4" [style="bold"];
@@ -145,7 +145,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_10" [
         shape = rectangle;
         color = black;
-        label = "block[id=10, rubyBlockId=2](<selfRestore>$55: T.class_of(<root>))\louterLoops: 1\l<returnTemp>$63: Integer(10) = 10\l<block-break-assign>$64: Integer(10) = <returnTemp>$63\la: Integer(10) = <block-break-assign>$64\l<magic>$65: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$66: T.untyped = <magic>$65: T.class_of(<Magic>).<block-break>(<returnTemp>$63: Integer(10))\l<unconditional>\l"
+        label = "block[id=10, rubyBlockId=2](<selfRestore>$55: T.class_of(<root>))\louterLoops: 1\l<returnTemp>$63: Integer(10) = 10\l<block-break-assign>$64: Integer(10) = <returnTemp>$63\l<magic>$65: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$66: T.untyped = <magic>$65: T.class_of(<Magic>).<block-break>(<returnTemp>$63: Integer(10))\la: Integer(10) = <block-break-assign>$64\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_10" -> "bb::<Class:<root>>#<static-init>_8" [style="bold"];
@@ -191,7 +191,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_16" [
         shape = rectangle;
         color = black;
-        label = "block[id=16, rubyBlockId=3](<selfRestore>$75: T.class_of(<root>))\louterLoops: 1\l<block-break-assign>$84: NilClass = <returnTemp>$83\lb: NilClass = <block-break-assign>$84\l<magic>$85: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$86: T.untyped = <magic>$85: T.class_of(<Magic>).<block-break>(<returnTemp>$83: NilClass)\l<unconditional>\l"
+        label = "block[id=16, rubyBlockId=3](<selfRestore>$75: T.class_of(<root>))\louterLoops: 1\l<block-break-assign>$84: NilClass = <returnTemp>$83\l<magic>$85: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$86: T.untyped = <magic>$85: T.class_of(<Magic>).<block-break>(<returnTemp>$83: NilClass)\lb: NilClass = <block-break-assign>$84\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_16" -> "bb::<Class:<root>>#<static-init>_14" [style="bold"];
@@ -237,7 +237,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_22" [
         shape = rectangle;
         color = black;
-        label = "block[id=22, rubyBlockId=0]()\louterLoops: 1\l<returnTemp>$102: Symbol(:abc) = :abc\l<block-break-assign>$103: Symbol(:abc) = <returnTemp>$102\lc: Symbol(:abc) = <block-break-assign>$103\l<magic>$104: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$105: T.untyped = <magic>$104: T.class_of(<Magic>).<block-break>(<returnTemp>$102: Symbol(:abc))\l<unconditional>\l"
+        label = "block[id=22, rubyBlockId=0]()\louterLoops: 1\l<returnTemp>$102: Symbol(:abc) = :abc\l<block-break-assign>$103: Symbol(:abc) = <returnTemp>$102\l<magic>$104: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$105: T.untyped = <magic>$104: T.class_of(<Magic>).<block-break>(<returnTemp>$102: Symbol(:abc))\lc: Symbol(:abc) = <block-break-assign>$103\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_22" -> "bb::<Class:<root>>#<static-init>_20" [style="bold"];

--- a/test/testdata/cfg/break_in_while.rb.cfg.exp
+++ b/test/testdata/cfg/break_in_while.rb.cfg.exp
@@ -43,7 +43,7 @@ subgraph "cluster_::Object#foo" {
     "bb::Object#foo_5" [
         shape = rectangle;
         color = black;
-        label = "block[id=5, rubyBlockId=0]()\louterLoops: 1\l<returnTemp>$7: Integer(2) = 2\l<block-break-assign>$8: Integer(2) = <returnTemp>$7\l<returnMethodTemp>$2: Integer(2) = <block-break-assign>$8\l<magic>$9: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$10: T.untyped = <magic>$9: T.class_of(<Magic>).<block-break>(<returnTemp>$7: Integer(2))\l<unconditional>\l"
+        label = "block[id=5, rubyBlockId=0]()\louterLoops: 1\l<returnTemp>$7: Integer(2) = 2\l<block-break-assign>$8: Integer(2) = <returnTemp>$7\l<magic>$9: T.class_of(<Magic>) = alias <C <Magic>>\l<block-break>$10: T.untyped = <magic>$9: T.class_of(<Magic>).<block-break>(<returnTemp>$7: Integer(2))\l<returnMethodTemp>$2: Integer(2) = <block-break-assign>$8\l<unconditional>\l"
     ];
 
     "bb::Object#foo_5" -> "bb::Object#foo_4" [style="bold"];


### PR DESCRIPTION
### Motivation

For a Ruby snippet like:

```ruby
  v = wrap do |value|
    if value == :in_raise
      p "inside block #{$!}"
      break :early_return
    end
    :late_return
  end
```

we'll generate CFG IR for the `if` block that looks roughly like:

```
    <cfgAlias>$27: T.class_of(<Magic>) = alias <C <Magic>>
    <statTemp>$28: String("inside block ") = "inside block "
    <statTemp>$25: String = <cfgAlias>$27: T.class_of(<Magic>).<string-interpolate>(<statTemp>$28: String("inside block "), $!$30: T.untyped)
    <statTemp>$23: NilClass = <self>: T.class_of(<root>).p(<statTemp>$25: String)
    <returnTemp>$31: Symbol(:early_return) = :early_return
    <block-break-assign>$32: Symbol(:early_return) = <returnTemp>$31
    v: Symbol(:early_return) = <block-break-assign>$32
    <magic>$33: T.class_of(<Magic>) = alias <C <Magic>>
    <block-break>$34: T.untyped = <magic>$33: T.class_of(<Magic>).<block-break>(<returnTemp>$31: Symbol(:early_return))
 ```

This IR is a bit gross, as `builder_walk.cc` documents:

https://github.com/sorbet/sorbet/blob/86b4a602488825444682836e4afaddc095963362/cfg/builder/builder_walk.cc#L563-L574

That is, what the above IR says is that we assign to the outermost variable `v` before calling `<Magic>.<block-break>`.  This is fine for static analysis purposes (mostly), but is not OK in the compiler.  If we widen the above example to:

```ruby
def wrap(&blk)
  begin
    p "starting begin"
    raise 'exception'
  rescue
    p "running raise #{$!}"
    yield :in_raise
  ensure
    p "running ensure #{$!}"
    raise 'from ensure'
  end
end

v = :unmodified

begin
  v = wrap do |value|
    if value == :in_raise
      p "inside block #{$!}"
      break :early_return
    end
    :late_return
  end
  p "got after v"
rescue Exception => e
...
```

`v` is not changed as the result of executing `wrap`, because `wrap` never actually returns a value.  But the above IR says that we should assign to `v` *before* breaking...except that the results of the break are not guaranteed to actually be returned, because something could preempt them -- a `raise` from an `ensure`, for instance, or a `return` from the same.

This PR continues the spirit of hacks around `break` by reordering the statements generated for a break: we generate the same statements, but `<Magic>.<block-break>` now comes before the assignment to the outermost variable.  We will still generate some dead code for the assignment that never happens (and, sadly, the variable still escapes because it's referenced in multiple blocks), but at least the runtime non-local exit `break` happens before the assignment.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I do not have compiler tests for this because such tests would depend on features -- `ensure` working in the presence of non-`Exception` non-local control flow -- that are currently broken in the compiler (and I am working on fixing, cf #4493, #4502 ).  I will add those tests when one of those PRs lands.
