### PR TITLE
Support additional per-package directory source paths in packager

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -847,6 +847,10 @@ void readOptions(Options &opts,
                 throw EarlyReturnWithCode(1);
             }
             for (string dirName : raw["extra-package-files-directory-prefix"].as<vector<string>>()) {
+                if (dirName.back() != '/') {
+                    logger->error("--extra-package-files-directory-prefix directory path must have slash (/) at the end");
+                    throw EarlyReturnWithCode(1);
+                }
                 opts.extraPackageFilesDirectoryPrefixes.emplace_back(dirName);
             }
         }

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -341,6 +341,10 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("stripe-mode", "Enable Stripe specific error enforcement", cxxopts::value<bool>());
     options.add_options("advanced")("stripe-packages", "Enable support for Stripe's internal Ruby package system",
                                     cxxopts::value<bool>());
+    options.add_options("dev")("extra-package-files-directory-prefix",
+                               "Extra parent directories which contain package files"
+                               "This option must be used in conjunction with --stripe-packages",
+                               cxxopts::value<vector<string>>(), "string");
 
     options.add_options("advanced")(
         "autogen-autoloader-exclude-require",
@@ -837,6 +841,16 @@ void readOptions(Options &opts,
         }
         opts.stripeMode = raw["stripe-mode"].as<bool>();
         opts.stripePackages = raw["stripe-packages"].as<bool>();
+        if (raw.count("extra-package-files-directory-prefix")) {
+            if (!opts.stripePackages) {
+                logger->error("--extra-package-files-directory-prefix can only be specified in --stripe-packages mode");
+                throw EarlyReturnWithCode(1);
+            }
+            for (string dirName : raw["extra-package-files-directory-prefix"].as<vector<string>>()) {
+                opts.extraPackageFilesDirectoryPrefixes.emplace_back(dirName);
+            }
+        }
+
         extractAutoloaderConfig(raw, opts, logger);
         opts.errorUrlBase = raw["error-url-base"].as<string>();
         opts.noErrorSections = raw["no-error-sections"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -151,6 +151,7 @@ struct Options {
     int autogenVersion = 0;
     bool stripeMode = false;
     bool stripePackages = false;
+    std::vector<std::string> extraPackageFilesDirectoryPrefixes;
     std::string typedSource = "";
     std::string cacheDir = "";
     UnorderedMap<std::string, core::StrictLevel> strictnessOverrides;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -223,7 +223,7 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
 #ifndef SORBET_REALMAIN_MIN
         if (opts.stripePackages) {
             Timer timeit(gs.tracer(), "incremental_packager");
-            what = packager::Packager::runIncremental(gs, move(what));
+            what = packager::Packager::runIncremental(gs, move(what), opts.extraPackageFilesDirectoryPrefixes);
         }
 #endif
         {
@@ -595,7 +595,7 @@ vector<ast::ParsedFile> package(core::GlobalState &gs, vector<ast::ParsedFile> w
 #ifndef SORBET_REALMAIN_MIN
     if (opts.stripePackages) {
         Timer timeit(gs.tracer(), "package");
-        what = packager::Packager::run(gs, workers, move(what));
+        what = packager::Packager::run(gs, workers, move(what), opts.extraPackageFilesDirectoryPrefixes);
         if (opts.print.Packager.enabled) {
             for (auto &f : what) {
                 opts.print.Packager.fmt("{}\n", f.tree.toStringWithTabs(gs, 0));

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -139,8 +139,7 @@ public:
         auto curPrefixPos = path.find_last_of('/');
 
         while (curPrefixPos != std::string::npos) {
-            path = path.substr(0, curPrefixPos + 1);
-            const auto &it = packageInfoByPathPrefix.find(path);
+            const auto &it = packageInfoByPathPrefix.find(path.substr(0, curPrefixPos + 1));
 
             if (it != packageInfoByPathPrefix.end()) {
                 return it->second.get();

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -107,7 +107,7 @@ public:
      * Given a file of type PACKAGE, return its PackageInfo or nullptr if one does not exist.
      */
     const PackageInfo *getPackageByFile(core::Context ctx, core::FileRef packageFile) const {
-        const auto path = packageFile.data(ctx).path();
+        const std::string_view path = packageFile.data(ctx).path();
         const auto &it = packageInfoByPathPrefix.find(path.substr(0, path.find_last_of('/') + 1));
         if (it == packageInfoByPathPrefix.end()) {
             return nullptr;
@@ -135,8 +135,8 @@ public:
             Exception::raise("Cannot map files to packages until all packages are added and PackageDB is finalized");
         }
 
-        auto path = ctx.file.data(ctx).path();
-        auto curPrefixPos = path.find_last_of('/');
+        std::string_view path = ctx.file.data(ctx).path();
+        int curPrefixPos = path.find_last_of('/');
 
         while (curPrefixPos != std::string::npos) {
             const auto &it = packageInfoByPathPrefix.find(path.substr(0, curPrefixPos + 1));

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -48,8 +48,8 @@ struct PackageName {
 };
 
 struct PackageInfo {
-    // The path prefix before every file in the package, including path separator at end.
-    std::string packagePathPrefix;
+    // The possible path prefixes associated with files in the package, including path separator at end.
+    vector<std::string> packagePathPrefixes;
     PackageName name;
     // loc for the package definition. Used for error messages.
     core::Loc loc;
@@ -95,7 +95,9 @@ public:
             packageInfoByMangledName[pkg->name.mangledName] = pkg;
         }
 
-        packageInfoByPathPrefix[pkg->packagePathPrefix] = pkg;
+        for (std::string packagePathPrefix : pkg->packagePathPrefixes) {
+            packageInfoByPathPrefix[packagePathPrefix] = pkg;
+        }
     }
 
     void finalizePackages() {
@@ -603,7 +605,7 @@ unique_ptr<PackageInfo> getPackageInfo(core::MutableContext ctx, ast::ParsedFile
     package.tree = ast::TreeMap::apply(ctx, finder, move(package.tree));
     finder.finalize(ctx);
     if (finder.info) {
-        finder.info->packagePathPrefix = packageFilePath.substr(0, packageFilePath.find_last_of('/') + 1);
+        finder.info->packagePathPrefixes.emplace_back(packageFilePath.substr(0, packageFilePath.find_last_of('/') + 1));
     }
     return move(finder.info);
 }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -137,18 +137,15 @@ public:
         }
 
         auto path = ctx.file.data(ctx).path();
-        string pathStr = path.data();
-        auto curPrefixPos = pathStr.find_last_of('/');
+        auto curPrefixPos = path.find_last_of('/');
 
         while (curPrefixPos != std::string::npos) {
-            pathStr.resize(curPrefixPos + 1);
-
-            const auto &it = packageInfoByPathPrefix.find(pathStr);
+            const auto &it = packageInfoByPathPrefix.find(path.substr(0, curPrefixPos + 1));
             if (it != packageInfoByPathPrefix.end()) {
                 return it->second.get();
             }
 
-            curPrefixPos = pathStr.find_last_of('/', curPrefixPos - 1);
+            curPrefixPos = path.find_last_of('/', curPrefixPos - 1);
         }
 
         return nullptr;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -839,7 +839,7 @@ bool checkContainsAllPackages(const core::GlobalState &gs, const vector<ast::Par
 
 } // namespace
 
-vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> files) {
+vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> files, vector<std::string> extraPackageFilesDirectoryPrefixes) {
     Timer timeit(gs.tracer(), "packager");
     // Ensure files are in canonical order.
     fast_sort(files, [](const auto &a, const auto &b) -> bool { return a.file < b.file; });
@@ -932,14 +932,14 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
     return files;
 }
 
-vector<ast::ParsedFile> Packager::runIncremental(core::GlobalState &gs, vector<ast::ParsedFile> files) {
+vector<ast::ParsedFile> Packager::runIncremental(core::GlobalState &gs, vector<ast::ParsedFile> files, vector<std::string> extraPackageFilesDirectoryPrefixes) {
     // Just run all packages w/ the changed files through Packager again. It should not define any new names.
     // TODO(jvilk): This incremental pass reprocesses every package file in the project. It should instead only process
     // the packages needed to understand file changes.
     ENFORCE(checkContainsAllPackages(gs, files));
     auto namesUsed = gs.namesUsedTotal();
     auto emptyWorkers = WorkerPool::create(0, gs.tracer());
-    files = Packager::run(gs, *emptyWorkers, move(files));
+    files = Packager::run(gs, *emptyWorkers, move(files), extraPackageFilesDirectoryPrefixes);
     ENFORCE(gs.namesUsedTotal() == namesUsed);
     return files;
 }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -135,17 +135,20 @@ public:
         if (!finalized) {
             Exception::raise("Cannot map files to packages until all packages are added and PackageDB is finalized");
         }
+
         auto path = ctx.file.data(ctx).path();
-        auto curPrefixPos = path.find_last_of('/');
+        string pathStr = path.data();
+        auto curPrefixPos = pathStr.find_last_of('/');
 
         while (curPrefixPos != std::string::npos) {
-            const auto &it = packageInfoByPathPrefix.find(path.substr(0, curPrefixPos + 1));
+            pathStr.resize(curPrefixPos + 1);
 
+            const auto &it = packageInfoByPathPrefix.find(pathStr);
             if (it != packageInfoByPathPrefix.end()) {
                 return it->second.get();
             }
 
-            curPrefixPos = path.find_last_of('/', curPrefixPos - 1);
+            curPrefixPos = pathStr.find_last_of('/', curPrefixPos - 1);
         }
 
         return nullptr;

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -76,10 +76,13 @@ namespace sorbet::packager {
 class Packager final {
 public:
     static std::vector<ast::ParsedFile> run(core::GlobalState &gs, WorkerPool &workers,
-                                            std::vector<ast::ParsedFile> files);
+                                            std::vector<ast::ParsedFile> files,
+                                            std::vector<std::string> extraPackageFilesDirectoryPrefixes);
 
     // Run packager incrementally. Note: `files` must contain all packages files. Does not support package changes.
-    static std::vector<ast::ParsedFile> runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> files);
+    static std::vector<ast::ParsedFile> runIncremental(core::GlobalState &gs,
+                                                       std::vector<ast::ParsedFile> files,
+                                                       std::vector<std::string> extraPackageFilesDirectoryPrefixes);
 
     Packager() = delete;
 };

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -140,6 +140,25 @@ public:
     std::string toString() const override;
 };
 
+// # some-property: foo
+class StringPropertyAssertion final : public RangeAssertion {
+public:
+    static std::shared_ptr<StringPropertyAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
+                                                          int assertionLine, std::string_view assertionContents,
+                                                          std::string_view assertionType);
+
+    static std::optional<std::string> getValue(std::string_view type,
+                    const std::vector<std::shared_ptr<RangeAssertion>> &assertions);
+
+    const std::string assertionType;
+    const std::string value;
+
+    StringPropertyAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine, std::string value,
+                             std::string_view assertionType);
+
+    std::string toString() const override;
+};
+
 // # ^^^ type-def: symbol
 class TypeDefAssertion final : public RangeAssertion {
 public:

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -278,8 +278,13 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     auto enablePackager = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
+    vector<std::string> extraPackageFilesDirectoryPrefixes;
     if (enablePackager) {
-        vector<std::string> extraPackageFilesDirectoryPrefixes;
+        auto extraDir = StringPropertyAssertion::getValue("extra-package-files-directory-prefix", assertions);
+        if (extraDir.has_value()) {
+            extraPackageFilesDirectoryPrefixes.emplace_back(extraDir.value());
+        }
+
         // Packager runs over all trees.
         trees = packager::Packager::run(*gs, *workers, move(trees), extraPackageFilesDirectoryPrefixes);
         for (auto &tree : trees) {
@@ -559,7 +564,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     trees = move(newTrees);
     if (enablePackager) {
-        vector<std::string> extraPackageFilesDirectoryPrefixes;
         trees = packager::Packager::runIncremental(*gs, move(trees), extraPackageFilesDirectoryPrefixes);
         for (auto &tree : trees) {
             handler.addObserved(*gs, "package-tree", [&]() { return tree.tree.toString(*gs); });

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -279,8 +279,9 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     auto enablePackager = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
     if (enablePackager) {
+        vector<std::string> extraPackageFilesDirectoryPrefixes;
         // Packager runs over all trees.
-        trees = packager::Packager::run(*gs, *workers, move(trees));
+        trees = packager::Packager::run(*gs, *workers, move(trees), extraPackageFilesDirectoryPrefixes);
         for (auto &tree : trees) {
             handler.addObserved(*gs, "package-tree", [&]() { return tree.tree.toString(*gs); });
         }
@@ -558,7 +559,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     trees = move(newTrees);
     if (enablePackager) {
-        trees = packager::Packager::runIncremental(*gs, move(trees));
+        vector<std::string> extraPackageFilesDirectoryPrefixes;
+        trees = packager::Packager::runIncremental(*gs, move(trees), extraPackageFilesDirectoryPrefixes);
         for (auto &tree : trees) {
             handler.addObserved(*gs, "package-tree", [&]() { return tree.tree.toString(*gs); });
         }

--- a/test/testdata/packager/deeply_nested_packages/__package.rb
+++ b/test/testdata/packager/deeply_nested_packages/__package.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# typed: strict
+# enable-packager: true
+
+class Package < PackageSpec
+  import Package::Subpackage
+  export Package::PackageClass
+  export Package::InnerClass
+end

--- a/test/testdata/packager/deeply_nested_packages/mainpackage.rb
+++ b/test/testdata/packager/deeply_nested_packages/mainpackage.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Package::PackageClass
+    extend T::Sig
+
+    sig {returns(Package::Subpackage::SubpackageClass)}
+    def self.subpkg_class
+        Package::Subpackage::SubpackageClass.new()
+    end
+end

--- a/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
@@ -1,0 +1,72 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Package>::<C Subpackage>)
+
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>)
+
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C InnerClass>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
+      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Package>::<C PackageClass><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.returns(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
+      end
+
+      def self.subpkg_class<<todo method>>(&<blk>)
+        <emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>.new()
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_self_def(<self>, :subpkg_class, :normal)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Package>::<C InnerClass><<C <todo sym>>> < (::<todo sym>)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Package>::<C Subpackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Package>)
+
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C InnerClass>
+    end
+
+    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.returns(<emptyTree>::<C Package>::<C PackageClass>)
+      end
+
+      def self.package_class<<todo method>>(&<blk>)
+        return <emptyTree>::<C Package>::<C PackageClass>.new()
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_self_def(<self>, :package_class, :normal)
+    end
+  end
+end

--- a/test/testdata/packager/deeply_nested_packages/subdirectory/inner_class.rb
+++ b/test/testdata/packager/deeply_nested_packages/subdirectory/inner_class.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Package::InnerClass
+end

--- a/test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/__package.rb
+++ b/test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Package::Subpackage < PackageSpec
+  import Package
+  export Package::Subpackage::SubpackageClass
+end

--- a/test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/subpackage.rb
+++ b/test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/subpackage.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Package::Subpackage::SubpackageClass
+  extend T::Sig
+
+  sig {returns(Package::PackageClass)}
+  def self.package_class
+    return Package::PackageClass.new()
+  end
+end

--- a/test/testdata/packager/extra_package_paths/bar/__package.rb
+++ b/test/testdata/packager/extra_package_paths/bar/__package.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# typed: strict
+# enable-packager: true
+# extra-package-files-directory-prefix: test/testdata/packager/extra_package_paths/extra/
+
+class Project::Bar < PackageSpec
+  import Project::Foo
+  import Project::Baz
+end

--- a/test/testdata/packager/extra_package_paths/bar/bar.rb
+++ b/test/testdata/packager/extra_package_paths/bar/bar.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Project::Bar::Bar
+  extend T::Sig
+
+  sig { void }
+  def bar1
+    Project::Foo::B.b
+  end
+
+  sig { void }
+  def bar2
+    Project::Baz::C.c
+  end
+end

--- a/test/testdata/packager/extra_package_paths/baz/__package.rb
+++ b/test/testdata/packager/extra_package_paths/baz/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Project::Baz < PackageSpec
+  export Project::Baz::C
+end

--- a/test/testdata/packager/extra_package_paths/extra/Project_Baz/c.rb
+++ b/test/testdata/packager/extra_package_paths/extra/Project_Baz/c.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Project::Baz::C
+  extend T::Sig
+
+  sig { void }
+  def self.c; end
+end

--- a/test/testdata/packager/extra_package_paths/extra/Project_Foo/b.rb
+++ b/test/testdata/packager/extra_package_paths/extra/Project_Foo/b.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Project::Foo::B
+  extend T::Sig
+
+  sig { void }
+  def self.b; end
+end

--- a/test/testdata/packager/extra_package_paths/foo/__package.rb
+++ b/test/testdata/packager/extra_package_paths/foo/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Project::Foo < PackageSpec
+  export Project::Foo::B
+end

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -1,0 +1,94 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Project>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Project>::<C Foo>)
+
+    <self>.import(<emptyTree>::<C Project>::<C Baz>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Baz><<C <todo sym>>> < ()
+      <emptyTree>::<C C> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1>::<C Project>::<C Baz>::<C C>
+    end
+
+    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C B>
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Project>::<C Bar>::<C Bar><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
+      def bar1<<todo method>>(&<blk>)
+        <emptyTree>::<C Project>::<C Foo>::<C B>.b()
+      end
+
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
+      def bar2<<todo method>>(&<blk>)
+        <emptyTree>::<C Project>::<C Baz>::<C C>.c()
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_def(<self>, :bar1, :normal)
+
+      ::Sorbet::Private::Static.keep_def(<self>, :bar2, :normal)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Project>::<C Baz><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1>::<C Project>::<C Baz>::<C C>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Project>::<C Baz>::<C C><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
+      def self.c<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_self_def(<self>, :c, :normal)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Project>::<C Foo>::<C B><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
+      def self.b<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_self_def(<self>, :b, :normal)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C B>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Adds a command line flag called `--extra-package-files-directory-prefix` which can have multiple instances and does the following.

Say we have packages `Project::Foo` and `Project::Bar`. For every `--extra-package-files-directory-prefix=extra_dir/` value, the packager will look for package files associated with `Project::Foo` in `extra_dir/Project_Foo/` and those associated with `Project::Bar` in `extra_dir/Project_Bar/`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In Stripe's codebase, package source files aren't just located in the default source tree, but also in other directories (where they get name-spaced by the package name munged together with underscores).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Tested on a sandbox repository similar to Stripe's codebase. Also see included automated tests.