### PR TITLE
Add support for multiple directory paths for a package

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -848,7 +848,8 @@ void readOptions(Options &opts,
             }
             for (string dirName : raw["extra-package-files-directory-prefix"].as<vector<string>>()) {
                 if (dirName.back() != '/') {
-                    logger->error("--extra-package-files-directory-prefix directory path must have slash (/) at the end");
+                    logger->error(
+                        "--extra-package-files-directory-prefix directory path must have slash (/) at the end");
                     throw EarlyReturnWithCode(1);
                 }
                 opts.extraPackageFilesDirectoryPrefixes.emplace_back(dirName);

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -846,7 +846,7 @@ void readOptions(Options &opts,
                 logger->error("--extra-package-files-directory-prefix can only be specified in --stripe-packages mode");
                 throw EarlyReturnWithCode(1);
             }
-            for (string dirName : raw["extra-package-files-directory-prefix"].as<vector<string>>()) {
+            for (const string &dirName : raw["extra-package-files-directory-prefix"].as<vector<string>>()) {
                 if (dirName.back() != '/') {
                     logger->error(
                         "--extra-package-files-directory-prefix directory path must have slash (/) at the end");

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -342,7 +342,7 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("stripe-packages", "Enable support for Stripe's internal Ruby package system",
                                     cxxopts::value<bool>());
     options.add_options("dev")("extra-package-files-directory-prefix",
-                               "Extra parent directories which contain package files"
+                               "Extra parent directories which contain package files. "
                                "This option must be used in conjunction with --stripe-packages",
                                cxxopts::value<vector<string>>(), "string");
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -341,6 +341,10 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("stripe-mode", "Enable Stripe specific error enforcement", cxxopts::value<bool>());
     options.add_options("advanced")("stripe-packages", "Enable support for Stripe's internal Ruby package system",
                                     cxxopts::value<bool>());
+    options.add_options("dev")("extra-package-files-directory-prefix",
+                               "Extra parent directories which contain package files"
+                               "This option must be used in conjunction with --stripe-packages",
+                               cxxopts::value<vector<string>>(), "string");
 
     options.add_options("advanced")(
         "autogen-autoloader-exclude-require",
@@ -837,6 +841,20 @@ void readOptions(Options &opts,
         }
         opts.stripeMode = raw["stripe-mode"].as<bool>();
         opts.stripePackages = raw["stripe-packages"].as<bool>();
+        if (raw.count("extra-package-files-directory-prefix")) {
+            if (!opts.stripePackages) {
+                logger->error("--extra-package-files-directory-prefix can only be specified in --stripe-packages mode");
+                throw EarlyReturnWithCode(1);
+            }
+            for (string dirName : raw["extra-package-files-directory-prefix"].as<vector<string>>()) {
+                if (dirName.back() != '/') {
+                    logger->error("--extra-package-files-directory-prefix directory path must have slash (/) at the end");
+                    throw EarlyReturnWithCode(1);
+                }
+                opts.extraPackageFilesDirectoryPrefixes.emplace_back(dirName);
+            }
+        }
+
         extractAutoloaderConfig(raw, opts, logger);
         opts.errorUrlBase = raw["error-url-base"].as<string>();
         opts.noErrorSections = raw["no-error-sections"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -151,6 +151,7 @@ struct Options {
     int autogenVersion = 0;
     bool stripeMode = false;
     bool stripePackages = false;
+    std::vector<std::string> extraPackageFilesDirectoryPrefixes;
     std::string typedSource = "";
     std::string cacheDir = "";
     UnorderedMap<std::string, core::StrictLevel> strictnessOverrides;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -223,7 +223,7 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
 #ifndef SORBET_REALMAIN_MIN
         if (opts.stripePackages) {
             Timer timeit(gs.tracer(), "incremental_packager");
-            what = packager::Packager::runIncremental(gs, move(what));
+            what = packager::Packager::runIncremental(gs, move(what), opts.extraPackageFilesDirectoryPrefixes);
         }
 #endif
         {
@@ -595,7 +595,7 @@ vector<ast::ParsedFile> package(core::GlobalState &gs, vector<ast::ParsedFile> w
 #ifndef SORBET_REALMAIN_MIN
     if (opts.stripePackages) {
         Timer timeit(gs.tracer(), "package");
-        what = packager::Packager::run(gs, workers, move(what));
+        what = packager::Packager::run(gs, workers, move(what), opts.extraPackageFilesDirectoryPrefixes);
         if (opts.print.Packager.enabled) {
             for (auto &f : what) {
                 opts.print.Packager.fmt("{}\n", f.tree.toStringWithTabs(gs, 0));

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -592,7 +592,7 @@ struct PackageInfoFinder {
 };
 
 // TODO (aadi-stripe) we can avoid syscalls if we invent an efficient way of looking up
-// directories in the source tree. Might be tied to https://github.com/sorbet/sorbet/issues/4509
+// directories in the source tree via GlobalState. Might be tied to https://github.com/sorbet/sorbet/issues/4509
 bool pathExists(const std::string &path) {
     struct stat buffer;
     return (stat(path.c_str(), &buffer) == 0);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -195,10 +195,8 @@ PackageName getPackageName(core::MutableContext ctx, ast::UnresolvedConstantLit 
 
     // Foo::Bar => Foo_Bar_Package
     auto mangledName = absl::StrCat(absl::StrJoin(pName.fullName.parts, "_", NameFormatter(ctx)), "_Package");
-
     auto utf8Name = ctx.state.enterNameUTF8(mangledName);
     auto packagerName = ctx.state.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
-
     pName.mangledName = ctx.state.enterNameConstant(packagerName);
 
     return pName;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -592,7 +592,8 @@ struct PackageInfoFinder {
 
 // Sanity checks package files, mutates arguments to export / export_methods to point to item in namespace,
 // builds up the expression injected into packages that import the package, and codegens the <PackagedMethods>  module.
-unique_ptr<PackageInfo> getPackageInfo(core::MutableContext ctx, ast::ParsedFile &package, vector<std::string> extraPackageFilesDirectoryPrefixes) {
+unique_ptr<PackageInfo> getPackageInfo(core::MutableContext ctx, ast::ParsedFile &package,
+                                       vector<std::string> extraPackageFilesDirectoryPrefixes) {
     ENFORCE(package.file.exists());
     ENFORCE(package.file.data(ctx).sourceType == core::File::Type::Package);
     // Assumption: Root of AST is <root> class.
@@ -843,7 +844,8 @@ bool checkContainsAllPackages(const core::GlobalState &gs, const vector<ast::Par
 
 } // namespace
 
-vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> files, vector<std::string> extraPackageFilesDirectoryPrefixes) {
+vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> files,
+                                      vector<std::string> extraPackageFilesDirectoryPrefixes) {
     Timer timeit(gs.tracer(), "packager");
     // Ensure files are in canonical order.
     fast_sort(files, [](const auto &a, const auto &b) -> bool { return a.file < b.file; });
@@ -936,7 +938,8 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
     return files;
 }
 
-vector<ast::ParsedFile> Packager::runIncremental(core::GlobalState &gs, vector<ast::ParsedFile> files, vector<std::string> extraPackageFilesDirectoryPrefixes) {
+vector<ast::ParsedFile> Packager::runIncremental(core::GlobalState &gs, vector<ast::ParsedFile> files,
+                                                 vector<std::string> extraPackageFilesDirectoryPrefixes) {
     // Just run all packages w/ the changed files through Packager again. It should not define any new names.
     // TODO(jvilk): This incremental pass reprocesses every package file in the project. It should instead only process
     // the packages needed to understand file changes.

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -878,7 +878,6 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
         packageDB.finalizePackages();
     }
 
-
     {
         Timer timeit(gs.tracer(), "packager.rewritePackages");
         // Step 2: Rewrite packages. Can be done in parallel (and w/ step 3) if this becomes a bottleneck.

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -80,8 +80,9 @@ public:
                                             const std::vector<std::string> &extraPackageFilesDirectoryPrefixes);
 
     // Run packager incrementally. Note: `files` must contain all packages files. Does not support package changes.
-    static std::vector<ast::ParsedFile> runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> files,
-                                                       const std::vector<std::string> &extraPackageFilesDirectoryPrefixes);
+    static std::vector<ast::ParsedFile>
+    runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> files,
+                   const std::vector<std::string> &extraPackageFilesDirectoryPrefixes);
 
     Packager() = delete;
 };

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -76,10 +76,13 @@ namespace sorbet::packager {
 class Packager final {
 public:
     static std::vector<ast::ParsedFile> run(core::GlobalState &gs, WorkerPool &workers,
-                                            std::vector<ast::ParsedFile> files);
+                                            std::vector<ast::ParsedFile> files,
+                                            std::vector<std::string> extraPackageFilesDirectoryPrefixes);
 
     // Run packager incrementally. Note: `files` must contain all packages files. Does not support package changes.
-    static std::vector<ast::ParsedFile> runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> files);
+    static std::vector<ast::ParsedFile> runIncremental(core::GlobalState &gs,
+                                                       std::vector<ast::ParsedFile> files,
+                                                       std::vector<std::string> extraPackageFilesDirectoryPrefixes);
 
     Packager() = delete;
 };

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -80,8 +80,7 @@ public:
                                             std::vector<std::string> extraPackageFilesDirectoryPrefixes);
 
     // Run packager incrementally. Note: `files` must contain all packages files. Does not support package changes.
-    static std::vector<ast::ParsedFile> runIncremental(core::GlobalState &gs,
-                                                       std::vector<ast::ParsedFile> files,
+    static std::vector<ast::ParsedFile> runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> files,
                                                        std::vector<std::string> extraPackageFilesDirectoryPrefixes);
 
     Packager() = delete;

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -77,11 +77,11 @@ class Packager final {
 public:
     static std::vector<ast::ParsedFile> run(core::GlobalState &gs, WorkerPool &workers,
                                             std::vector<ast::ParsedFile> files,
-                                            std::vector<std::string> extraPackageFilesDirectoryPrefixes);
+                                            const std::vector<std::string> &extraPackageFilesDirectoryPrefixes);
 
     // Run packager incrementally. Note: `files` must contain all packages files. Does not support package changes.
     static std::vector<ast::ParsedFile> runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> files,
-                                                       std::vector<std::string> extraPackageFilesDirectoryPrefixes);
+                                                       const std::vector<std::string> &extraPackageFilesDirectoryPrefixes);
 
     Packager() = delete;
 };

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -177,6 +177,10 @@ Usage:
                                 arguments
 
  dev options:
+      --extra-package-files-directory-prefix string
+                                Extra parent directories which contain
+                                package files. This option must be used in
+                                conjunction with --stripe-packages
   -p, --print type              Print: [parse-tree, parse-tree-json,
                                 parse-tree-json-with-locs, parse-tree-whitequark,
                                 desugar-tree, desugar-tree-raw, rewrite-tree,

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -960,14 +960,14 @@ string BooleanPropertyAssertion::toString() const {
 }
 
 shared_ptr<StringPropertyAssertion> StringPropertyAssertion::make(string_view filename, unique_ptr<Range> &range,
-                                                                    int assertionLine, string_view assertionContents,
-                                                                    string_view assertionType) {
+                                                                  int assertionLine, string_view assertionContents,
+                                                                  string_view assertionType) {
     return make_shared<StringPropertyAssertion>(filename, range, assertionLine, assertionContents.data(),
-                                                 assertionType);
+                                                assertionType);
 }
 
 optional<std::string> StringPropertyAssertion::getValue(string_view type,
-                                                  const vector<shared_ptr<RangeAssertion>> &assertions) {
+                                                        const vector<shared_ptr<RangeAssertion>> &assertions) {
     {
         INFO("Unrecognized string property assertion: " << type);
         CHECK_NE(assertionConstructors.find(string(type)), assertionConstructors.end());

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -140,6 +140,25 @@ public:
     std::string toString() const override;
 };
 
+// # some-property: foo
+class StringPropertyAssertion final : public RangeAssertion {
+public:
+    static std::shared_ptr<StringPropertyAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
+                                                          int assertionLine, std::string_view assertionContents,
+                                                          std::string_view assertionType);
+
+    static std::optional<std::string> getValue(std::string_view type,
+                    const std::vector<std::shared_ptr<RangeAssertion>> &assertions);
+
+    const std::string assertionType;
+    const std::string value;
+
+    StringPropertyAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine, std::string value,
+                             std::string_view assertionType);
+
+    std::string toString() const override;
+};
+
 // # ^^^ type-def: symbol
 class TypeDefAssertion final : public RangeAssertion {
 public:

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -144,17 +144,17 @@ public:
 class StringPropertyAssertion final : public RangeAssertion {
 public:
     static std::shared_ptr<StringPropertyAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
-                                                          int assertionLine, std::string_view assertionContents,
-                                                          std::string_view assertionType);
+                                                         int assertionLine, std::string_view assertionContents,
+                                                         std::string_view assertionType);
 
     static std::optional<std::string> getValue(std::string_view type,
-                    const std::vector<std::shared_ptr<RangeAssertion>> &assertions);
+                                               const std::vector<std::shared_ptr<RangeAssertion>> &assertions);
 
     const std::string assertionType;
     const std::string value;
 
-    StringPropertyAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine, std::string value,
-                             std::string_view assertionType);
+    StringPropertyAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
+                            std::string value, std::string_view assertionType);
 
     std::string toString() const override;
 };

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -278,9 +278,15 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     auto enablePackager = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
+    vector<std::string> extraPackageFilesDirectoryPrefixes;
     if (enablePackager) {
+        auto extraDir = StringPropertyAssertion::getValue("extra-package-files-directory-prefix", assertions);
+        if (extraDir.has_value()) {
+            extraPackageFilesDirectoryPrefixes.emplace_back(extraDir.value());
+        }
+
         // Packager runs over all trees.
-        trees = packager::Packager::run(*gs, *workers, move(trees));
+        trees = packager::Packager::run(*gs, *workers, move(trees), extraPackageFilesDirectoryPrefixes);
         for (auto &tree : trees) {
             handler.addObserved(*gs, "package-tree", [&]() { return tree.tree.toString(*gs); });
         }
@@ -558,7 +564,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     trees = move(newTrees);
     if (enablePackager) {
-        trees = packager::Packager::runIncremental(*gs, move(trees));
+        trees = packager::Packager::runIncremental(*gs, move(trees), extraPackageFilesDirectoryPrefixes);
         for (auto &tree : trees) {
             handler.addObserved(*gs, "package-tree", [&]() { return tree.tree.toString(*gs); });
         }

--- a/test/testdata/packager/extra_package_paths/bar/__package.rb
+++ b/test/testdata/packager/extra_package_paths/bar/__package.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# typed: strict
+# enable-packager: true
+# extra-package-files-directory-prefix: test/testdata/packager/extra_package_paths/extra/
+
+class Project::Bar < PackageSpec
+  import Project::Foo
+  import Project::Baz
+end

--- a/test/testdata/packager/extra_package_paths/bar/bar.rb
+++ b/test/testdata/packager/extra_package_paths/bar/bar.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Project::Bar::Bar
+  extend T::Sig
+
+  sig { void }
+  def bar1
+    Project::Foo::B.b
+  end
+
+  sig { void }
+  def bar2
+    Project::Baz::C.c
+  end
+end

--- a/test/testdata/packager/extra_package_paths/baz/__package.rb
+++ b/test/testdata/packager/extra_package_paths/baz/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Project::Baz < PackageSpec
+  export Project::Baz::C
+end

--- a/test/testdata/packager/extra_package_paths/extra/Project_Baz/c.rb
+++ b/test/testdata/packager/extra_package_paths/extra/Project_Baz/c.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Project::Baz::C
+  extend T::Sig
+
+  sig { void }
+  def self.c; end
+end

--- a/test/testdata/packager/extra_package_paths/extra/Project_Foo/b.rb
+++ b/test/testdata/packager/extra_package_paths/extra/Project_Foo/b.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Project::Foo::B
+  extend T::Sig
+
+  sig { void }
+  def self.b; end
+end

--- a/test/testdata/packager/extra_package_paths/foo/__package.rb
+++ b/test/testdata/packager/extra_package_paths/foo/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Project::Foo < PackageSpec
+  export Project::Foo::B
+end

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -1,0 +1,94 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Project>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Project>::<C Foo>)
+
+    <self>.import(<emptyTree>::<C Project>::<C Baz>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Baz><<C <todo sym>>> < ()
+      <emptyTree>::<C C> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1>::<C Project>::<C Baz>::<C C>
+    end
+
+    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C B>
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Project>::<C Bar>::<C Bar><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
+      def bar1<<todo method>>(&<blk>)
+        <emptyTree>::<C Project>::<C Foo>::<C B>.b()
+      end
+
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
+      def bar2<<todo method>>(&<blk>)
+        <emptyTree>::<C Project>::<C Baz>::<C C>.c()
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_def(<self>, :bar1, :normal)
+
+      ::Sorbet::Private::Static.keep_def(<self>, :bar2, :normal)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Project>::<C Baz><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1>::<C Project>::<C Baz>::<C C>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Project>::<C Baz>::<C C><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
+      def self.c<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_self_def(<self>, :c, :normal)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Project>::<C Foo>::<C B><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
+      def self.b<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_self_def(<self>, :b, :normal)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C B>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Adds a command line flag called `--extra-package-files-directory-prefix` which can have multiple instances and does the following.

Say we have packages `Project::Foo` and `Project::Bar`. For every `--extra-package-files-directory-prefix=extra_dir/` value, the packager will look for package files associated with `Project::Foo` in `extra_dir/Project_Foo/` and those associated with `Project::Bar` in `extra_dir/Project_Bar/`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In Stripe's codebase, package source files aren't just located in the default source tree, but also in other directories (where they get name-spaced by the package name munged together with underscores).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Tested on a sandbox repository similar to Stripe's codebase. Also see included automated tests.