### PR TITLE
Try fixing absl INFO loggin in a different way

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -250,13 +250,6 @@ build:webasm --copt=--llvm-lto --copt=3 --linkopt=--llvm-lto --linkopt=3
 # Specify a "sane" C++ toolchain for the host platform.
 build:webasm --host_crosstool_top=@llvm_toolchain_12_0_0//:toolchain
 
-# Our version of emscripten doesn't provide the offset converter that the
-# debugging library from absl is looking for. As a result, it will log an INFO
-# message to stdout when it starts up suggesting how to work around this. As we
-# can't fix that with emscripten-1.38.25, we'll need to upgrade to support it.
-# TODO(trevor) remove this when we upgrade emscripten
-build:webasm --copt=-DABSL_MIN_LOG_LEVEL=1
-
 ##
 ## Stripe's ci passes --config=ci, we need it to exist
 ##

--- a/common/os/emscripten.cc
+++ b/common/os/emscripten.cc
@@ -1,4 +1,5 @@
 #ifdef EMSCRIPTEN
+
 #include <string>
 
 using namespace std;
@@ -13,6 +14,15 @@ string getProgramName() {
 
 bool setCurrentThreadName(string_view name) {
     return false;
+}
+
+void initializeSymbolizer(char *argv0) {
+    // Our version of emscripten doesn't provide the offset converter that the debugging library
+    // from absl is looking for, so we can't call absl::InitializeSymbolizer here, otherwise it will
+    // log an INFO message to stdout when it starts up suggesting how to work around this.
+    //
+    // TODO(trevor) We can uncomment this by upgrading emscripten at some point in the future
+    // absl::InitializeSymbolizer(argv0);
 }
 
 #endif

--- a/common/os/linux.cc
+++ b/common/os/linux.cc
@@ -109,4 +109,8 @@ bool bindThreadToCore(pthread_t handle, int coreId) {
     int rc = pthread_setaffinity_np(handle, sizeof(cpu_set_t), &cpuset);
     return rc == 0;
 }
+
+void initializeSymbolizer(char *argv0) {
+    absl::InitializeSymbolizer(argv0);
+}
 #endif

--- a/common/os/mac.cc
+++ b/common/os/mac.cc
@@ -1,4 +1,5 @@
 #ifdef __APPLE__
+#include "absl/debugging/symbolize.h"
 #include "common/common.h"
 #include <cassert>
 #include <cstdio>
@@ -86,5 +87,9 @@ bool bindThreadToCore(pthread_t handle, int coreId) {
     thread_port_t mach_thread = pthread_mach_thread_np(handle);
     auto ret = thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY, (thread_policy_t)&policy, 1);
     return ret == 0;
+}
+
+void initializeSymbolizer(char *argv0) {
+    absl::InitializeSymbolizer(argv0);
 }
 #endif

--- a/common/os/os.h
+++ b/common/os/os.h
@@ -47,4 +47,6 @@ bool stopInDebugger();
 bool amIBeingDebugged();
 
 void intentionallyLeakMemory(void *ptr);
+
+void initializeSymbolizer(char *argv0);
 #endif // SORBET_OS_H

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -4,7 +4,6 @@
 #define FULL_BUILD_ONLY(X) X;
 #include "core/proto/proto.h" // has to be included first as it violates our poisons
 // intentional comment to stop from reformatting
-#include "absl/debugging/symbolize.h"
 #include "common/statsd/statsd.h"
 #include "common/web_tracer_framework/tracing.h"
 #include "main/autogen/autogen.h"
@@ -358,7 +357,7 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
 
 int realmain(int argc, char *argv[]) {
 #ifndef SORBET_REALMAIN_MIN
-    absl::InitializeSymbolizer(argv[0]);
+    initializeSymbolizer(argv[0]);
 #endif
     returnCode = 0;
     logger = make_shared<spd::logger>("console", stderrColorSink);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Tries fixing https://github.com/sorbet/sorbet/pull/4511 in a way that doesn't involve turning off all INFO logging.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I copied the `tar` file out of Buildkite and tested it in sorbet.run locally.
Steps looked like:

- Verify that sorbet.run master shows no error
- Verify that sorbet.run master^ shows the error that #4511 fixed
- Verify that untar'ing this PR's Buildkite artifact over master^ fixes the
  error again

I also tested that this builds on macOS by temporarily commenting out the `master` filter in the pipeline:

https://buildkite.com/sorbet/sorbet/builds/16994#85ca57cf-b08b-4a6e-b9e0-bce63f6e7235