### PR TITLE
Add T::Private::Compiler.running_compiled?

### DIFF
--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -708,6 +708,39 @@ public:
     };
 } TEnum_abstract;
 
+class TPrivateCompiler_runningCompiled_p : public SymbolBasedIntrinsicMethod {
+public:
+    TPrivateCompiler_runningCompiled_p() : SymbolBasedIntrinsicMethod(Intrinsics::HandleBlock::Unhandled) {}
+    virtual llvm::Value *makeCall(MethodCallContext &mcctx) const override {
+        auto &builder = builderCast(mcctx.build);
+        return Payload::rubyTrue(mcctx.cs, builder);
+    };
+
+    virtual InlinedVector<core::ClassOrModuleRef, 2> applicableClasses(const core::GlobalState &gs) const override {
+        return {core::Symbols::T_Private_CompilerSingleton()};
+    };
+    virtual InlinedVector<core::NameRef, 2> applicableMethods(const core::GlobalState &gs) const override {
+        return {core::Names::runningCompiled_p()};
+    };
+} TPrivateCompiler_runningCompiled_p;
+
+class TPrivateCompiler_compilerVersion : public SymbolBasedIntrinsicMethod {
+public:
+    TPrivateCompiler_compilerVersion() : SymbolBasedIntrinsicMethod(Intrinsics::HandleBlock::Unhandled) {}
+    virtual llvm::Value *makeCall(MethodCallContext &mcctx) const override {
+        auto &builder = builderCast(mcctx.build);
+        auto frozen = true;
+        return Payload::cPtrToRubyString(mcctx.cs, builder, sorbet_full_version_string, frozen);
+    };
+
+    virtual InlinedVector<core::ClassOrModuleRef, 2> applicableClasses(const core::GlobalState &gs) const override {
+        return {core::Symbols::T_Private_CompilerSingleton()};
+    };
+    virtual InlinedVector<core::NameRef, 2> applicableMethods(const core::GlobalState &gs) const override {
+        return {core::Names::compilerVersion()};
+    };
+} TPrivateCompiler_compilerVersion;
+
 class CallCMethodSingleton : public CallCMethod {
 public:
     CallCMethodSingleton(core::ClassOrModuleRef rubyClass, string_view rubyMethod, string cMethod)
@@ -805,6 +838,8 @@ vector<const SymbolBasedIntrinsicMethod *> getKnownCMethodPtrs(const core::Globa
         &Regexp_new,
         &TEnum_new,
         &TEnum_abstract,
+        &TPrivateCompiler_runningCompiled_p,
+        &TPrivateCompiler_compilerVersion,
     };
     for (auto &method : knownCMethodsInstance) {
         if (debug_mode) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -469,6 +469,11 @@ void GlobalState::initEmpty() {
     id = Symbols::Sorbet_Private_Static_ResolvedSig().data(*this)->singletonClass(*this);
     ENFORCE(id == Symbols::Sorbet_Private_Static_ResolvedSigSingleton());
 
+    id = enterClassSymbol(Loc::none(), Symbols::T_Private(), core::Names::Constants::Compiler());
+    ENFORCE(id == Symbols::T_Private_Compiler());
+    id = Symbols::T_Private_Compiler().data(*this)->singletonClass(*this);
+    ENFORCE(id == Symbols::T_Private_CompilerSingleton());
+
     typeArgument =
         enterTypeArgument(Loc::none(), Symbols::noMethod(), Names::Constants::TodoTypeArgument(), Variance::CoVariant);
     ENFORCE(typeArgument == Symbols::todoTypeArgument());

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -853,6 +853,14 @@ public:
         return ClassOrModuleRef::fromRaw(84);
     }
 
+    static ClassOrModuleRef T_Private_Compiler() {
+        return ClassOrModuleRef::fromRaw(85);
+    }
+
+    static ClassOrModuleRef T_Private_CompilerSingleton() {
+        return ClassOrModuleRef::fromRaw(86);
+    }
+
     static constexpr int MAX_PROC_ARITY = 10;
     static ClassOrModuleRef Proc0() {
         return ClassOrModuleRef::fromRaw(MAX_SYNTHETIC_CLASS_SYMBOLS - MAX_PROC_ARITY * 2 - 2);
@@ -875,11 +883,11 @@ public:
         return ClassOrModuleRef::fromRaw(MAX_SYNTHETIC_CLASS_SYMBOLS - 1);
     }
 
-    static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 200;
+    static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 202;
     static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 39;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 3;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
-    static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 96;
+    static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 98;
 };
 
 template <typename H> H AbslHashValue(H h, const SymbolRef &m) {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -412,6 +412,10 @@ NameDef names[] = {
     {"PackageRegistry", "<PackageRegistry>", true},
     {"PackageMethods", "<PackageMethods>", true},
 
+    // Compiler
+    {"runningCompiled_p", "running_compiled?"},
+    {"compilerVersion", "compiler_version"},
+
     // GlobalState initEmpty()
     {"Top", "<top>", true},
     {"Bottom", "T.noreturn", true},
@@ -495,6 +499,7 @@ NameDef names[] = {
     {"VERSION", "VERSION", true},
     {"Thread", "Thread", true},
     {"Configuration", "Configuration", true},
+    {"Compiler", "Compiler", true},
 };
 
 void emit_name_header(ostream &out, NameDef &name) {

--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -112,3 +112,6 @@ require_relative 'types/struct'
 require_relative 'types/non_forcing_constants'
 
 require_relative 'types/compatibility_patches'
+
+# Sorbet Compiler support module
+require_relative 'types/private/compiler'

--- a/gems/sorbet-runtime/lib/types/private/compiler.rb
+++ b/gems/sorbet-runtime/lib/types/private/compiler.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# typed: true
+
+module T::Private
+  module Compiler
+    # If this code ever runs, the caller is running interpreted (or the
+    # compiler didn't see the call to `running_compiled?` statically.)
+    #
+    # The Sorbet Compiler replaces calls to this method unconditionally (no
+    # runtime guards) to return `true` when compiling a file.
+    def self.running_compiled?
+      false
+    end
+
+    # Returns `nil` because the compiler isn't running.
+    #
+    # The Sorbet Compiler replaces calls to this method unconditionally (no
+    # runtime guards) to return a String showing the Sorbet Compiler's version
+    # string.
+    def self.compiler_version
+      nil
+    end
+  end
+end

--- a/gems/sorbet-runtime/test/types/compiler.rb
+++ b/gems/sorbet-runtime/test/types/compiler.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+module Opus::Types::Test
+  class CompilerTest < Critic::Unit::UnitTest
+    describe 'T::Private::Compiler.running_compiled?' do
+      it 'returns false always, because this is the interpreter' do
+        refute(T::Private::Compiler.running_compiled?)
+      end
+    end
+
+    describe 'T::Private::Compiler.compiler_version' do
+      it 'returns nil always, because this is the interpreter' do
+        assert_nil(T::Private::Compiler.compiler_version)
+      end
+    end
+  end
+end

--- a/rbi/sorbet/tprivate.rbi
+++ b/rbi/sorbet/tprivate.rbi
@@ -23,3 +23,11 @@ end
 module T::Private::Methods::CallValidation
   def self.disable_fast_path; end
 end
+
+module T::Private::Compiler
+  sig {returns(T::Boolean)}
+  def self.running_compiled?; end
+
+  sig {returns(T.nilable(String))}
+  def self.compiler_version; end
+end

--- a/test/testdata/compiler/t_private_compiler.rb
+++ b/test/testdata/compiler/t_private_compiler.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+running_compiled = T::Private::Compiler.running_compiled?
+case running_compiled
+when false, true
+  puts 'ok: T::Private::Compiler.running_compiled?'
+else
+  T.absurd(running_compiled)
+end
+
+compiler_version = T::Private::Compiler.compiler_version
+if running_compiled && compiler_version.is_a?(String)
+  puts 'ok: T::Private::Compiler.compiler_version'
+elsif !running_compiled && compiler_version.nil?
+  puts 'ok: T::Private::Compiler.compiler_version'
+else
+  raise "compiler_version does not match running_compiled?"
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Makes debugging certain things easier.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

I also made the test fail by printing the actual values to be sure it was
working:

```diff
--- test/testdata/compiler/t_private_compiler.ruby.stdout       2021-08-20 20:42:39.616719375 +0000
+++ /tmp/tmp.cYI4omxKq2 2021-08-20 20:51:44.869340567 +0000
@@ -1,4 +1,4 @@
 ok: T::Private::Compiler.running_compiled?
 ok: T::Private::Compiler.compiler_version
-false
-nil
+true
+"0.5.0 (non-release) debug_symbols=false clean=0"
```