### PR TITLE
move the implementation of sorbet_throwReturn into the VM

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -152,6 +152,8 @@ SORBET_ALIVE(void, sorbet_vm_register_sig,
 SORBET_ALIVE(void, sorbet_vm_define_method,
              (VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp, rb_iseq_t *iseq, bool isSelf));
 
+SORBET_ALIVE(void, sorbet_throwReturn, (rb_execution_context_t *ec, VALUE retval));
+
 // The next several functions exist to convert Ruby definitions into LLVM IR, and
 // are always inlined as a consequence.
 
@@ -2299,18 +2301,6 @@ void sorbet_ensureSorbetRuby(int compile_time_is_release_build, char *compile_ti
                  "SorbetLLVM runtime version mismatch: sorbet_ruby compiled with %s but shared object compiled with %s",
                  runtime_build_scm_revision, compile_time_build_scm_revision);
     }
-}
-
-extern VALUE sorbet_vm_throw(const rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t throw_state,
-                             VALUE throwobj);
-extern void sorbet_ec_jump_tag(rb_execution_context_t *ec, enum ruby_tag_type tt);
-
-SORBET_INLINE
-void sorbet_throwReturn(rb_execution_context_t *ec, VALUE retval) {
-    VALUE v = sorbet_vm_throw(ec, ec->cfp, TAG_RETURN, retval);
-
-    ec->errinfo = v;
-    sorbet_ec_jump_tag(ec, ec->tag->state);
 }
 
 // This is invoked at the beginning of a method's body, and is analogous to EC_PUSH_TAG + EC_EXEC_TAG

--- a/compiler/IREmitter/Payload/patches/vm_insnhelper.c
+++ b/compiler/IREmitter/Payload/patches/vm_insnhelper.c
@@ -475,11 +475,9 @@ void sorbet_vm_setivar(VALUE obj, ID id, VALUE val, IVC ic) {
     vm_setivar(obj, id, val, ic, cc, is_attr);
 }
 
-VALUE sorbet_vm_throw(const rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t throw_state,
-                      VALUE throwobj) {
-    return vm_throw(ec, reg_cfp, throw_state, throwobj);
-}
+void sorbet_throwReturn(rb_execution_context_t *ec, VALUE retval) {
+    VALUE v = vm_throw(ec, ec->cfp, TAG_RETURN, retval);
 
-void sorbet_ec_jump_tag(rb_execution_context_t *ec, enum ruby_tag_type tt) {
-    EC_JUMP_TAG(ec, tt);
+    ec->errinfo = v;
+    EC_JUMP_TAG(ec, ec->tag->state);
 }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The current implementation of `sorbet_throwReturn` will transition into `libruby.so` twice.  Instead, why don't we just transition once and make the code smaller in the process?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
