### PR TITLE
Stop depending on system node for emscripten build

### DIFF
--- a/.buildkite/build-emscripten.sh
+++ b/.buildkite/build-emscripten.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 
 echo "--- Pre-setup"
 
-command -v node
 command -v realpath
 
 export JOB_NAME=build-emscripten

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -87,7 +87,6 @@ rust_repositories(
 )
 
 load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
-
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
 
 node_repositories()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -88,6 +88,10 @@ rust_repositories(
 
 load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
 
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
+
+node_repositories()
+
 bazel_version(name = "bazel_version")
 
 BAZEL_VERSION = "4.1.0"

--- a/third_party/emscripten_toolchain/emcc.py.patch
+++ b/third_party/emscripten_toolchain/emcc.py.patch
@@ -1,0 +1,20 @@
+--- emcc.py
++++ emcc.py
+@@ -789,7 +789,7 @@
+           newargs[i] = newargs[i + 1] = ''
+           if key == 'WASM_BACKEND=1':
+             exit_with_error('do not set -s WASM_BACKEND, instead set EMCC_WASM_BACKEND=1 in the environment')
+-    newargs = [arg for arg in newargs if arg is not '']
++    newargs = [arg for arg in newargs if arg != '']
+ 
+     settings_key_changes = set()
+     for s in settings_changes:
+@@ -900,7 +900,7 @@
+ 
+     original_input_files = input_files[:]
+ 
+-    newargs = [a for a in newargs if a is not '']
++    newargs = [a for a in newargs if a != '']
+ 
+     # -c means do not link in gcc, and for us, the parallel is to not go all the way to JS, but stop at bitcode
+     has_dash_c = '-c' in newargs

--- a/third_party/emscripten_toolchain/tools_shared.py.patch
+++ b/third_party/emscripten_toolchain/tools_shared.py.patch
@@ -1,0 +1,11 @@
+--- tools/shared.py
++++ tools/shared.py
+@@ -1658,7 +1658,7 @@
+       raise
+     if 'EMMAKEN_JUST_CONFIGURE' in env:
+       del env['EMMAKEN_JUST_CONFIGURE']
+-    if res.returncode is not 0:
++    if res.returncode != 0:
+       logger.error('Configure step failed with non-zero return code: %s.  Command line: %s at %s' % (res.returncode, ' '.join(args), os.getcwd()))
+       raise subprocess.CalledProcessError(cmd=args, returncode=res.returncode)
+ 

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -188,6 +188,12 @@ package(default_visibility = ["//visibility:public"])
     )
 
     http_archive(
+        name = "build_bazel_rules_nodejs",
+        sha256 = "e79c08a488cc5ac40981987d862c7320cee8741122a2649e9b08e850b6f20442",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/3.8.0/rules_nodejs-3.8.0.tar.gz"],
+    )
+
+    http_archive(
         name = "com_github_bazelbuild_buildtools",
         urls = _github_public_urls("bazelbuild/buildtools/archive/5bcc31df55ec1de770cb52887f2e989e7068301f.zip"),
         sha256 = "875d0c49953e221cfc35d2a3846e502f366dfa4024b271fa266b186ca4664b37",
@@ -234,6 +240,10 @@ package(default_visibility = ["//visibility:public"])
         build_file = "@com_stripe_ruby_typer//third_party:emscripten-toolchain.BUILD",
         sha256 = "4d6fa350895fabc25b89ce5f9dcb528e719e7c2bf7dacab2a3e3cc818ecd7019",
         strip_prefix = "emscripten-1.38.25",
+        patches = [
+            "@com_stripe_ruby_typer//third_party:emscripten_toolchain/emcc.py.patch",
+            "@com_stripe_ruby_typer//third_party:emscripten_toolchain/tools_shared.py.patch",
+        ],
     )
 
     http_archive(

--- a/tools/toolchain/webasm-darwin/BUILD
+++ b/tools/toolchain/webasm-darwin/BUILD
@@ -19,7 +19,7 @@ export PATH="$${PATH}:/usr/local/bin/"
 EM_CONFIG="LLVM_ROOT='$${PWD}/external/emscripten_clang_darwin/';"
 EM_CONFIG+="EMSCRIPTEN_NATIVE_OPTIMIZER='$${PWD}/external/external/emscripten_clang_darwin/optimizer';"
 EM_CONFIG+="BINARYEN_ROOT='$${PWD}/external/emscripten_clang_darwin/binaryen';"
-EM_CONFIG+="NODE_JS='node';"
+EM_CONFIG+="NODE_JS='$${PWD}/external/nodejs_darwin_amd64/bin/node';"
 EM_CONFIG+="EMSCRIPTEN_ROOT='$${PWD}/external/emscripten_toolchain';"
 EM_CONFIG+="SPIDERMONKEY_ENGINE='';"
 EM_CONFIG+="V8_ENGINE='';"
@@ -53,6 +53,7 @@ genrule(
     srcs = [
         "@emscripten_clang_darwin//:all",
         "@emscripten_toolchain//:all",
+        "@nodejs_darwin_amd64//:node",
     ],
     outs = ["em_cache.tar.gz"],
     cmd = GENERATE_EM_CACHE_COMMAND,
@@ -66,6 +67,7 @@ filegroup(
         "emcc.sh",
         "@emscripten_clang_darwin//:all",
         "@emscripten_toolchain//:all",
+        "@nodejs_darwin_amd64//:node",
     ],
     tags = ["manual"],
 )

--- a/tools/toolchain/webasm-darwin/ar.sh
+++ b/tools/toolchain/webasm-darwin/ar.sh
@@ -1,16 +1,37 @@
 #!/bin/bash
 set -euo pipefail
-EM_CONFIG="LLVM_ROOT='${PWD}/external/emscripten_clang_darwin/';"
-EM_CONFIG+="EMSCRIPTEN_NATIVE_OPTIMIZER='${PWD}/external/external/emscripten_clang_darwin/optimizer';"
-EM_CONFIG+="BINARYEN_ROOT='${PWD}/external/emscripten_clang_darwin/binaryen';"
-EM_CONFIG+="NODE_JS='node';"
-EM_CONFIG+="EMSCRIPTEN_ROOT='${PWD}/external/emscripten_toolchain';"
+
+command -v realpath > /dev/null 2>&1 || { echo 'You need to install the "realpath" command system-wide.' ; exit 1; }
+
+ABSOLUTE_PREFIX=$(realpath "${PWD}") # bazel replaces PWD with /proc/self/cwd which is unstable under "cd", meaning that reffering to a path under relative name fails
+
+EM_CONFIG="LLVM_ROOT='${ABSOLUTE_PREFIX}/external/emscripten_clang_darwin/';"
+EM_CONFIG+="EMSCRIPTEN_NATIVE_OPTIMIZER='${ABSOLUTE_PREFIX}/external/external/emscripten_clang_darwin/optimizer';"
+EM_CONFIG+="BINARYEN_ROOT='${ABSOLUTE_PREFIX}/external/emscripten_clang_darwin/binaryen';"
+EM_CONFIG+="NODE_JS='${ABSOLUTE_PREFIX}/external/nodejs_darwin_amd64/bin/node';"
+EM_CONFIG+="EMSCRIPTEN_ROOT='${ABSOLUTE_PREFIX}/external/emscripten_toolchain';"
 EM_CONFIG+="SPIDERMONKEY_ENGINE='';"
 EM_CONFIG+="V8_ENGINE='';"
-EM_CONFIG+="TEMP_DIR='${PWD}/tmp/emscripten_tmp';"
+EM_CONFIG+="TEMP_DIR='${ABSOLUTE_PREFIX}/tmp/emscripten_tmp';"
 EM_CONFIG+="COMPILER_ENGINE=NODE_JS;"
 EM_CONFIG+="JS_ENGINES=[NODE_JS];"
 export EM_CONFIG
+
+# Try to find Python on the system.
+# Our version of emscripten uses Python 2, but upstream has already switched to
+# Python 3. For now we prefer finding python2 if available, and fall back to
+# trying Python 3 in case no Python 2 was found (which will chunder warnings
+# but still work).
+if command -v python &> /dev/null; then
+  PYTHON="python"
+elif command -v python2 &> /dev/null; then
+  PYTHON="python2"
+elif command -v python3 &> /dev/null; then
+  PYTHON="python3"
+else
+  export PATH="${PATH}:/usr/local/bin/"
+  PYTHON="python"
+fi
 
 export EM_EXCLUSIVE_CACHE_ACCESS=1
 export EMCC_SKIP_SANITY_CHECK=1
@@ -18,4 +39,4 @@ export EMCC_SKIP_SANITY_CHECK=1
 export EMCC_WASM_BACKEND=0
 mkdir -p "tmp/emscripten_tmp"
 
-python external/emscripten_toolchain/emar.py "$@"
+"$PYTHON" external/emscripten_toolchain/emar.py "$@"

--- a/tools/toolchain/webasm-linux/BUILD
+++ b/tools/toolchain/webasm-linux/BUILD
@@ -19,7 +19,7 @@ export PATH="$${PATH}:/usr/local/bin/"
 EM_CONFIG="LLVM_ROOT='$${PWD}/external/emscripten_clang_linux/';"
 EM_CONFIG+="EMSCRIPTEN_NATIVE_OPTIMIZER='$${PWD}/external/external/emscripten_clang_linux/optimizer';"
 EM_CONFIG+="BINARYEN_ROOT='$${PWD}/external/emscripten_clang_linux/binaryen';"
-EM_CONFIG+="NODE_JS='node';"
+EM_CONFIG+="NODE_JS='$${PWD}/external/nodejs_linux_amd64/bin/node';"
 EM_CONFIG+="EMSCRIPTEN_ROOT='$${PWD}/external/emscripten_toolchain';"
 EM_CONFIG+="SPIDERMONKEY_ENGINE='';"
 EM_CONFIG+="V8_ENGINE='';"
@@ -53,6 +53,7 @@ genrule(
     srcs = [
         "@emscripten_clang_linux//:all",
         "@emscripten_toolchain//:all",
+        "@nodejs_linux_amd64//:node",
     ],
     outs = ["em_cache.tar.gz"],
     cmd = GENERATE_EM_CACHE_COMMAND,
@@ -66,6 +67,7 @@ filegroup(
         "emcc.sh",
         "@emscripten_clang_linux//:all",
         "@emscripten_toolchain//:all",
+        "@nodejs_linux_amd64//:node",
     ],
     tags = ["manual"],
 )

--- a/tools/toolchain/webasm-linux/ar.sh
+++ b/tools/toolchain/webasm-linux/ar.sh
@@ -1,16 +1,37 @@
 #!/bin/bash
 set -euo pipefail
-EM_CONFIG="LLVM_ROOT='${PWD}/external/emscripten_clang_linux/';"
-EM_CONFIG+="EMSCRIPTEN_NATIVE_OPTIMIZER='${PWD}/external/external/emscripten_clang_linux/optimizer';"
-EM_CONFIG+="BINARYEN_ROOT='${PWD}/external/emscripten_clang_linux/binaryen';"
-EM_CONFIG+="NODE_JS='node';"
-EM_CONFIG+="EMSCRIPTEN_ROOT='${PWD}/external/emscripten_toolchain';"
+
+command -v realpath > /dev/null 2>&1 || { echo 'You need to install the "realpath" command system-wide.' ; exit 1; }
+
+ABSOLUTE_PREFIX=$(realpath "${PWD}") # bazel replaces PWD with /proc/self/cwd which is unstable under "cd", meaning that reffering to a path under relative name fails
+
+EM_CONFIG="LLVM_ROOT='${ABSOLUTE_PREFIX}/external/emscripten_clang_linux/';"
+EM_CONFIG+="EMSCRIPTEN_NATIVE_OPTIMIZER='${ABSOLUTE_PREFIX}/external/external/emscripten_clang_linux/optimizer';"
+EM_CONFIG+="BINARYEN_ROOT='${ABSOLUTE_PREFIX}/external/emscripten_clang_linux/binaryen';"
+EM_CONFIG+="NODE_JS='${ABSOLUTE_PREFIX}/external/nodejs_linux_amd64/bin/node';"
+EM_CONFIG+="EMSCRIPTEN_ROOT='${ABSOLUTE_PREFIX}/external/emscripten_toolchain';"
 EM_CONFIG+="SPIDERMONKEY_ENGINE='';"
 EM_CONFIG+="V8_ENGINE='';"
-EM_CONFIG+="TEMP_DIR='${PWD}/tmp/emscripten_tmp';"
+EM_CONFIG+="TEMP_DIR='${ABSOLUTE_PREFIX}/tmp/emscripten_tmp';"
 EM_CONFIG+="COMPILER_ENGINE=NODE_JS;"
 EM_CONFIG+="JS_ENGINES=[NODE_JS];"
 export EM_CONFIG
+
+# Try to find Python on the system.
+# Our version of emscripten uses Python 2, but upstream has already switched to
+# Python 3. For now we prefer finding python2 if available, and fall back to
+# trying Python 3 in case no Python 2 was found (which will chunder warnings
+# but still work).
+if command -v python &> /dev/null; then
+  PYTHON="python"
+elif command -v python2 &> /dev/null; then
+  PYTHON="python2"
+elif command -v python3 &> /dev/null; then
+  PYTHON="python3"
+else
+  export PATH="${PATH}:/usr/local/bin/"
+  PYTHON="python"
+fi
 
 export EM_EXCLUSIVE_CACHE_ACCESS=1
 export EMCC_SKIP_SANITY_CHECK=1
@@ -18,4 +39,4 @@ export EMCC_SKIP_SANITY_CHECK=1
 export EMCC_WASM_BACKEND=0
 mkdir -p "tmp/emscripten_tmp"
 
-python external/emscripten_toolchain/emar.py "$@"
+"$PYTHON" external/emscripten_toolchain/emar.py "$@"

--- a/tools/toolchain/webasm-linux/emcc.sh
+++ b/tools/toolchain/webasm-linux/emcc.sh
@@ -1,23 +1,37 @@
 #!/bin/bash
 set -eo pipefail
 
-export PATH="${PATH}:/usr/local/bin/" # this is where we find node
 EM_CACHE_ARCHIVE="tools/toolchain/webasm-linux/em_cache_existing.tar.gz"
 
 if [ ! -f "$EM_CACHE_ARCHIVE" ]; then
   echo "can't find stdlib compilation cache";
 fi
 
-command -v node >/dev/null 2>&1 || { echo 'will need node' ; exit 1; }
-command -v realpath > /dev/null 2>&1 || { echo 'will need realpath' ; exit 1; }
+command -v realpath > /dev/null 2>&1 || { echo 'You need to install the "realpath" command system-wide.' ; exit 1; }
+
+# Try to find Python on the system.
+# Our version of emscripten uses Python 2, but upstream has already switched to
+# Python 3. For now we prefer finding python2 if available, and fall back to
+# trying Python 3 in case no Python 2 was found (which will chunder warnings
+# but still work).
+if command -v python &> /dev/null; then
+  PYTHON="python"
+elif command -v python2 &> /dev/null; then
+  PYTHON="python2"
+elif command -v python3 &> /dev/null; then
+  PYTHON="python3"
+else
+  export PATH="${PATH}:/usr/local/bin/"
+  PYTHON="python"
+fi
 
 ABSOLUTE_PREFIX=$(realpath "${PWD}") # bazel replaces PWD with /proc/self/cwd which is unstable under "cd", meaning that reffering to a path under relative name fails
 
 EM_CONFIG="LLVM_ROOT='${ABSOLUTE_PREFIX}/external/emscripten_clang_linux/';"
-EM_CONFIG+="EMSCRIPTEN_NATIVE_OPTIMIZER='${PWD}/external/emscripten_clang_linux/optimizer';"
-EM_CONFIG+="BINARYEN_ROOT='${PWD}/external/emscripten_clang_linux/binaryen';"
-EM_CONFIG+="NODE_JS='node';"
-EM_CONFIG+="EMSCRIPTEN_ROOT='${PWD}/external/emscripten_toolchain';"
+EM_CONFIG+="EMSCRIPTEN_NATIVE_OPTIMIZER='${ABSOLUTE_PREFIX}/external/emscripten_clang_linux/optimizer';"
+EM_CONFIG+="BINARYEN_ROOT='${ABSOLUTE_PREFIX}/external/emscripten_clang_linux/binaryen';"
+EM_CONFIG+="NODE_JS='${ABSOLUTE_PREFIX}/external/nodejs_linux_amd64/bin/node';"
+EM_CONFIG+="EMSCRIPTEN_ROOT='${ABSOLUTE_PREFIX}/external/emscripten_toolchain';"
 EM_CONFIG+="SPIDERMONKEY_ENGINE='';"
 EM_CONFIG+="V8_ENGINE='';"
 EM_CONFIG+="COMPILER_ENGINE=NODE_JS;"
@@ -87,7 +101,7 @@ fi
 # Run emscripten to compile and link
 #echo "original_args" "$@"
 #echo "transformed_args" "${args[@]}"
-python external/emscripten_toolchain/emcc.py "${args[@]}"
+"$PYTHON" external/emscripten_toolchain/emcc.py "${args[@]}"
 
 if [ -n "${tar_name}" ]; then
     full_tar_path=$(realpath "${tar_name}.tar")


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I don't have `node` installed system-wide, so I wasn't able to build the WASM
build of Sorbet with emscripten.

(I also don't have `python` system-wide, I only have `python3`, but that's a
battle for another day, because it seems harder to get a hermetic python
executable than to get a hermetic node executable.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Ran this command on my personal desktop, which is what we also invoke in
Buildkite:

```
bazel build //emscripten:sorbet-wasm.tar --config=webasm-linux --strip=always
```