### PR TITLE
Remove the single argument restriction from test_each

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -244,11 +244,11 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
     }
 
     if ((send->fun == core::Names::testEach() || send->fun == core::Names::testEachHash()) && send->args.size() == 1) {
-        if ((send->fun == core::Names::testEach() && block->args.size() != 1) ||
+        if ((send->fun == core::Names::testEach() && block->args.size() < 1) ||
             (send->fun == core::Names::testEachHash() && block->args.size() != 2)) {
             if (auto e = ctx.beginError(send->block.loc(), core::errors::Rewriter::BadTestEach)) {
                 e.setHeader("Wrong number of parameters for `{}` block: expected `{}`, got `{}`", send->fun.show(ctx),
-                            1, block->args.size());
+                            send->fun == core::Names::testEach() ? "at least 1" : "2", block->args.size());
             }
             return nullptr;
         }

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -86,13 +86,48 @@ class MyTest
   end
 
 
-  test_each [1, 2, 3] do |k, v| # error: Wrong number of parameters for `test_each` block
-    it "does not handle more than one argument" do
+  test_each [1, 2, 3] do |k, v|
+    it "blocks get padded with NilClass arguments" do
+      T.reveal_type(k) # error: Revealed type: `Integer`
+      T.reveal_type(v) # error: Revealed type: `NilClass`
+    end
+
+    it "multiple it blocks are ok with multiple arguments" do
+      T.reveal_type(k) # error: Revealed type: `Integer`
+      T.reveal_type(v) # error: Revealed type: `NilClass`
+    end
+  end
+
+  test_each [1, 2, 3] do |(k, v)|
+    it "destructured blocks get padded with NilClass arguments" do
+      T.reveal_type(k) # error: Revealed type: `Integer`
+      T.reveal_type(v) # error: Revealed type: `NilClass`
+    end
+
+    it "multiple it blocks are ok with multiple destructured arguments" do
+      T.reveal_type(k) # error: Revealed type: `Integer`
+      T.reveal_type(v) # error: Revealed type: `NilClass`
+    end
+  end
+
+  test_each [[1, ['hi', false]], [2, ['bye', true]]] do |i, (s,b), (x, y)|
+    it "handles mixed destructuring and positional arguments" do
+      T.reveal_type(i) # error: Revealed type: `Integer`
+      T.reveal_type(s) # error: Revealed type: `String`
+      T.reveal_type(b) # error: Revealed type: `T::Boolean`
+      T.reveal_type(x) # error: Revealed type: `NilClass`
+      T.reveal_type(y) # error: Revealed type: `NilClass`
+    end
+
+    it "multiple it blocks are ok with mixed argument styles" do
+      T.reveal_type(i) # error: Revealed type: `Integer`
+      T.reveal_type(s) # error: Revealed type: `String`
+      T.reveal_type(b) # error: Revealed type: `T::Boolean`
     end
   end
 
   test_each [1, 2, 3] do # error: Wrong number of parameters for `test_each` block
-    it "does not handle more than one argument" do
+    it "does not handle zero argument blocks" do
     end
   end
 

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -126,6 +126,51 @@ class MyTest
     end
   end
 
+  CONST_LIST_TUPLE = [[1,'a'], [2,'b']]
+  test_each CONST_LIST_TUPLE do |i, s|
+    it "succeeds with a constant list of tuples" do
+      T.reveal_type(i) # error: type: `T.untyped`
+      T.reveal_type(s) # error: type: `T.untyped`
+    end
+  end
+
+  test_each CONST_LIST_TUPLE do |(i, s)|
+    it "succeeds with a constant list of tuples and destructuring" do
+      T.reveal_type(i) # error: type: `T.untyped`
+      T.reveal_type(s) # error: type: `T.untyped`
+    end
+  end
+
+  ANOTHER_CONST_LIST_TUPLE = T.let([[1,'a'], [2,'b']], T::Array[[Integer, String]])
+  test_each ANOTHER_CONST_LIST_TUPLE do |i, s|
+    it "succeeds with a typed constant tuple list" do
+      T.reveal_type(i) # error: type: `Integer`
+      T.reveal_type(s) # error: type: `String`
+    end
+  end
+
+  test_each ANOTHER_CONST_LIST_TUPLE do |(i, s)|
+    it "succeeds with a typed constant tuple list with destructuring" do
+      T.reveal_type(i) # error: type: `Integer`
+      T.reveal_type(s) # error: type: `String`
+    end
+  end
+
+  local_tuple = [[1,'a'], [2,'b']]
+  test_each local_tuple do |i,s|
+    it "succeed with local variables but cannot type them" do
+      T.reveal_type(i) # error: type: `T.untyped`
+      T.reveal_type(s) # error: type: `T.untyped`
+    end
+  end
+
+  test_each local_tuple do |(i,s)|
+    it "succeed with destructured local variables but cannot type them" do
+      T.reveal_type(i) # error: type: `T.untyped`
+      T.reveal_type(s) # error: type: `T.untyped`
+    end
+  end
+
   test_each [1, 2, 3] do # error: Wrong number of parameters for `test_each` block
     it "does not handle zero argument blocks" do
     end

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -116,6 +116,138 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
+    def <it 'blocks get padded with NilClass arguments'><<todo method>>(&<blk>)
+      [1, 2, 3].each() do |k, v|
+        begin
+          <emptyTree>::<C T>.reveal_type(k)
+          <emptyTree>::<C T>.reveal_type(v)
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'multiple it blocks are ok with multiple arguments'><<todo method>>(&<blk>)
+      [1, 2, 3].each() do |k, v|
+        begin
+          <emptyTree>::<C T>.reveal_type(k)
+          <emptyTree>::<C T>.reveal_type(v)
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'destructured blocks get padded with NilClass arguments'><<todo method>>(&<blk>)
+      [1, 2, 3].each() do |<destructure>$4|
+        begin
+          begin
+            <assignTemp>$5 = <destructure>$4
+            <assignTemp>$6 = ::<Magic>.<expand-splat>(<assignTemp>$5, 2, 0)
+            k = <assignTemp>$6.[](0)
+            v = <assignTemp>$6.[](1)
+            <assignTemp>$5
+          end
+          begin
+            <emptyTree>::<C T>.reveal_type(k)
+            <emptyTree>::<C T>.reveal_type(v)
+          end
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'multiple it blocks are ok with multiple destructured arguments'><<todo method>>(&<blk>)
+      [1, 2, 3].each() do |<destructure>$4|
+        begin
+          begin
+            <assignTemp>$5 = <destructure>$4
+            <assignTemp>$6 = ::<Magic>.<expand-splat>(<assignTemp>$5, 2, 0)
+            k = <assignTemp>$6.[](0)
+            v = <assignTemp>$6.[](1)
+            <assignTemp>$5
+          end
+          begin
+            <emptyTree>::<C T>.reveal_type(k)
+            <emptyTree>::<C T>.reveal_type(v)
+          end
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'handles mixed destructuring and positional arguments'><<todo method>>(&<blk>)
+      [[1, ["hi", false]], [2, ["bye", true]]].each() do |i, <destructure>$7, <destructure>$10|
+        begin
+          begin
+            <assignTemp>$8 = <destructure>$7
+            <assignTemp>$9 = ::<Magic>.<expand-splat>(<assignTemp>$8, 2, 0)
+            s = <assignTemp>$9.[](0)
+            b = <assignTemp>$9.[](1)
+            <assignTemp>$8
+          end
+          begin
+            <assignTemp>$11 = <destructure>$10
+            <assignTemp>$12 = ::<Magic>.<expand-splat>(<assignTemp>$11, 2, 0)
+            x = <assignTemp>$12.[](0)
+            y = <assignTemp>$12.[](1)
+            <assignTemp>$11
+          end
+          begin
+            <emptyTree>::<C T>.reveal_type(i)
+            <emptyTree>::<C T>.reveal_type(s)
+            <emptyTree>::<C T>.reveal_type(b)
+            <emptyTree>::<C T>.reveal_type(x)
+            <emptyTree>::<C T>.reveal_type(y)
+          end
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'multiple it blocks are ok with mixed argument styles'><<todo method>>(&<blk>)
+      [[1, ["hi", false]], [2, ["bye", true]]].each() do |i, <destructure>$7, <destructure>$10|
+        begin
+          begin
+            <assignTemp>$8 = <destructure>$7
+            <assignTemp>$9 = ::<Magic>.<expand-splat>(<assignTemp>$8, 2, 0)
+            s = <assignTemp>$9.[](0)
+            b = <assignTemp>$9.[](1)
+            <assignTemp>$8
+          end
+          begin
+            <assignTemp>$11 = <destructure>$10
+            <assignTemp>$12 = ::<Magic>.<expand-splat>(<assignTemp>$11, 2, 0)
+            x = <assignTemp>$12.[](0)
+            y = <assignTemp>$12.[](1)
+            <assignTemp>$11
+          end
+          begin
+            <emptyTree>::<C T>.reveal_type(i)
+            <emptyTree>::<C T>.reveal_type(s)
+            <emptyTree>::<C T>.reveal_type(b)
+          end
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
     def <it 'handles lists with several types'><<todo method>>(&<blk>)
       {:foo => 1, :bar => 2, :baz => 3}.each() do |k, v|
         begin
@@ -187,13 +319,28 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     <self>.test_each([1, 2, 3]) do |k, v|
-      <self>.it("does not handle more than one argument") do ||
-        <emptyTree>
+      begin
+        ::Sorbet::Private::Static.keep_def(<self>, :"<it \'blocks get padded with NilClass arguments\'>", :normal)
+        ::Sorbet::Private::Static.keep_def(<self>, :"<it \'multiple it blocks are ok with multiple arguments\'>", :normal)
+      end
+    end
+
+    <self>.test_each([1, 2, 3]) do |<destructure>$4|
+      begin
+        ::Sorbet::Private::Static.keep_def(<self>, :"<it \'destructured blocks get padded with NilClass arguments\'>", :normal)
+        ::Sorbet::Private::Static.keep_def(<self>, :"<it \'multiple it blocks are ok with multiple destructured arguments\'>", :normal)
+      end
+    end
+
+    <self>.test_each([[1, ["hi", false]], [2, ["bye", true]]]) do |i, <destructure>$7, <destructure>$10|
+      begin
+        ::Sorbet::Private::Static.keep_def(<self>, :"<it \'handles mixed destructuring and positional arguments\'>", :normal)
+        ::Sorbet::Private::Static.keep_def(<self>, :"<it \'multiple it blocks are ok with mixed argument styles\'>", :normal)
       end
     end
 
     <self>.test_each([1, 2, 3]) do ||
-      <self>.it("does not handle more than one argument") do ||
+      <self>.it("does not handle zero argument blocks") do ||
         <emptyTree>
       end
     end

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -248,6 +248,111 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
+    def <it 'succeeds with a constant list of tuples'><<todo method>>(&<blk>)
+      <emptyTree>::<C CONST_LIST_TUPLE>.each() do |i, s|
+        begin
+          <emptyTree>::<C T>.reveal_type(i)
+          <emptyTree>::<C T>.reveal_type(s)
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'succeeds with a constant list of tuples and destructuring'><<todo method>>(&<blk>)
+      <emptyTree>::<C CONST_LIST_TUPLE>.each() do |<destructure>$13|
+        begin
+          begin
+            <assignTemp>$14 = <destructure>$13
+            <assignTemp>$15 = ::<Magic>.<expand-splat>(<assignTemp>$14, 2, 0)
+            i = <assignTemp>$15.[](0)
+            s = <assignTemp>$15.[](1)
+            <assignTemp>$14
+          end
+          begin
+            <emptyTree>::<C T>.reveal_type(i)
+            <emptyTree>::<C T>.reveal_type(s)
+          end
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'succeeds with a typed constant tuple list'><<todo method>>(&<blk>)
+      <emptyTree>::<C ANOTHER_CONST_LIST_TUPLE>.each() do |i, s|
+        begin
+          <emptyTree>::<C T>.reveal_type(i)
+          <emptyTree>::<C T>.reveal_type(s)
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'succeeds with a typed constant tuple list with destructuring'><<todo method>>(&<blk>)
+      <emptyTree>::<C ANOTHER_CONST_LIST_TUPLE>.each() do |<destructure>$16|
+        begin
+          begin
+            <assignTemp>$17 = <destructure>$16
+            <assignTemp>$18 = ::<Magic>.<expand-splat>(<assignTemp>$17, 2, 0)
+            i = <assignTemp>$18.[](0)
+            s = <assignTemp>$18.[](1)
+            <assignTemp>$17
+          end
+          begin
+            <emptyTree>::<C T>.reveal_type(i)
+            <emptyTree>::<C T>.reveal_type(s)
+          end
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'succeed with local variables but cannot type them'><<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented").each() do |i, s|
+        begin
+          <emptyTree>::<C T>.reveal_type(i)
+          <emptyTree>::<C T>.reveal_type(s)
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'succeed with destructured local variables but cannot type them'><<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented").each() do |<destructure>$19|
+        begin
+          begin
+            <assignTemp>$20 = <destructure>$19
+            <assignTemp>$21 = ::<Magic>.<expand-splat>(<assignTemp>$20, 2, 0)
+            i = <assignTemp>$21.[](0)
+            s = <assignTemp>$21.[](1)
+            <assignTemp>$20
+          end
+          begin
+            <emptyTree>::<C T>.reveal_type(i)
+            <emptyTree>::<C T>.reveal_type(s)
+          end
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
     def <it 'handles lists with several types'><<todo method>>(&<blk>)
       {:foo => 1, :bar => 2, :baz => 3}.each() do |k, v|
         begin
@@ -337,6 +442,36 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         ::Sorbet::Private::Static.keep_def(<self>, :"<it \'handles mixed destructuring and positional arguments\'>", :normal)
         ::Sorbet::Private::Static.keep_def(<self>, :"<it \'multiple it blocks are ok with mixed argument styles\'>", :normal)
       end
+    end
+
+    <emptyTree>::<C CONST_LIST_TUPLE> = [[1, "a"], [2, "b"]]
+
+    <self>.test_each(<emptyTree>::<C CONST_LIST_TUPLE>) do |i, s|
+      ::Sorbet::Private::Static.keep_def(<self>, :"<it \'succeeds with a constant list of tuples\'>", :normal)
+    end
+
+    <self>.test_each(<emptyTree>::<C CONST_LIST_TUPLE>) do |<destructure>$13|
+      ::Sorbet::Private::Static.keep_def(<self>, :"<it \'succeeds with a constant list of tuples and destructuring\'>", :normal)
+    end
+
+    <emptyTree>::<C ANOTHER_CONST_LIST_TUPLE> = <emptyTree>::<C T>.let([[1, "a"], [2, "b"]], <emptyTree>::<C T>::<C Array>.[]([<emptyTree>::<C Integer>, <emptyTree>::<C String>]))
+
+    <self>.test_each(<emptyTree>::<C ANOTHER_CONST_LIST_TUPLE>) do |i, s|
+      ::Sorbet::Private::Static.keep_def(<self>, :"<it \'succeeds with a typed constant tuple list\'>", :normal)
+    end
+
+    <self>.test_each(<emptyTree>::<C ANOTHER_CONST_LIST_TUPLE>) do |<destructure>$16|
+      ::Sorbet::Private::Static.keep_def(<self>, :"<it \'succeeds with a typed constant tuple list with destructuring\'>", :normal)
+    end
+
+    local_tuple = [[1, "a"], [2, "b"]]
+
+    <self>.test_each(local_tuple) do |i, s|
+      ::Sorbet::Private::Static.keep_def(<self>, :"<it \'succeed with local variables but cannot type them\'>", :normal)
+    end
+
+    <self>.test_each(local_tuple) do |<destructure>$19|
+      ::Sorbet::Private::Static.keep_def(<self>, :"<it \'succeed with destructured local variables but cannot type them\'>", :normal)
     end
 
     <self>.test_each([1, 2, 3]) do ||

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -10,6 +10,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)
   end
 
+  class <emptyTree>::<C NoShow><<C <todo sym>>> < (<emptyTree>::<C BasicObject>)
+  end
+
   class <emptyTree>::<C MyTest><<C <todo sym>>> < (::<todo sym>)
     def outside_method<<todo method>>(&<blk>)
       <emptyTree>
@@ -353,6 +356,41 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
+    def <it 'rejects manual destructuring of the list argument'><<todo method>>(&<blk>)
+      [[1, "a"], [2, "b"]].each() do |value|
+        begin
+          <emptyTree>::<C T>.reveal_type(i)
+          <emptyTree>::<C T>.reveal_type(s)
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it '::<Magic>.<string-interpolate>("color ", color, " which is not purple is not number 1 ", ns)'><<todo method>>(&<blk>)
+      [["red", <emptyTree>::<C NoShow>.new()], ["blue", <emptyTree>::<C NoShow>.new()]].each() do |<destructure>$24|
+        begin
+          begin
+            <assignTemp>$25 = <destructure>$24
+            <assignTemp>$26 = ::<Magic>.<expand-splat>(<assignTemp>$25, 2, 0)
+            color = <assignTemp>$26.[](0)
+            ns = <assignTemp>$26.[](1)
+            <assignTemp>$25
+          end
+          begin
+            <emptyTree>::<C T>.reveal_type(color)
+            <emptyTree>::<C T>.reveal_type(ns)
+          end
+        end
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
     def <it 'handles lists with several types'><<todo method>>(&<blk>)
       {:foo => 1, :bar => 2, :baz => 3}.each() do |k, v|
         begin
@@ -478,6 +516,23 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.it("does not handle zero argument blocks") do ||
         <emptyTree>
       end
+    end
+
+    <self>.test_each([[1, "a"], [2, "b"]]) do |value|
+      begin
+        begin
+          <assignTemp>$22 = value
+          <assignTemp>$23 = ::<Magic>.<expand-splat>(<assignTemp>$22, 2, 0)
+          i = <assignTemp>$23.[](0)
+          s = <assignTemp>$23.[](1)
+          <assignTemp>$22
+        end
+        ::Sorbet::Private::Static.keep_def(<self>, :"<it \'rejects manual destructuring of the list argument\'>", :normal)
+      end
+    end
+
+    <self>.test_each([["red", <emptyTree>::<C NoShow>.new()], ["blue", <emptyTree>::<C NoShow>.new()]]) do |<destructure>$24|
+      ::Sorbet::Private::Static.keep_def(<self>, :"<it \'::<Magic>.<string-interpolate>(\"color \", color, \" which is not purple is not number 1 \", ns)\'>", :normal)
     end
 
     <self>.test_each_hash({:foo => 1, :bar => 2, :baz => 3}) do |k, v|


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Extend the behavior of `test_each` allowing destructuring in the block argument list.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
