### PR TITLE
use proper constants for exception handler offsets in IREmitterContext

### DIFF
--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -739,9 +739,9 @@ IREmitterContext IREmitterContext::getSorbetBlocks2LLVMBlockMapping(CompilerStat
 
             // the relative block ids of blocks that are involved in the translation of an exception handling block.
             auto bodyBlockId = bodyBlock->rubyBlockId;
-            auto handlersBlockId = bodyBlockId + 1;
-            auto ensureBlockId = bodyBlockId + 2;
-            auto elseBlockId = bodyBlockId + 3;
+            auto handlersBlockId = bodyBlockId + cfg::CFG::HANDLERS_BLOCK_OFFSET;
+            auto ensureBlockId = bodyBlockId + cfg::CFG::ENSURE_BLOCK_OFFSET;
+            auto elseBlockId = bodyBlockId + cfg::CFG::ELSE_BLOCK_OFFSET;
 
             userEntryBlockByFunction[bodyBlockId] = llvmBlocks[bodyBlock->id];
             userEntryBlockByFunction[handlersBlockId] = llvmBlocks[handlersBlock->id];


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have real named constants we should be using in this context.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
