### PR TITLE
don't set up an inliner for running cheap optimizations

### DIFF
--- a/compiler/Core/CompilerState.cc
+++ b/compiler/Core/CompilerState.cc
@@ -94,7 +94,7 @@ void CompilerState::runCheapOptimizations(llvm::Function *func) {
     int sizeLevel = 0;
     pmbuilder.OptLevel = optLevel;
     pmbuilder.SizeLevel = sizeLevel;
-    pmbuilder.Inliner = llvm::createFunctionInliningPass(optLevel, sizeLevel, false);
+    pmbuilder.Inliner = nullptr;
     pmbuilder.DisableUnrollLoops = false;
     pmbuilder.LoopVectorize = true;
     pmbuilder.SLPVectorize = true;


### PR DESCRIPTION
### Motivation

We're only running function-level passes here.  Since the inliner needs module-level passes (i.e. needs to see other functions) to work, allocating an inliner here is just useless work and we can skip it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
