### PR TITLE
enable control-flow protection unconditionally for compiled modules

### DIFF
--- a/plugin_injector/plugin_injector.cc
+++ b/plugin_injector/plugin_injector.cc
@@ -224,6 +224,8 @@ public:
             module = llvm::CloneModule(*threadState->codegenPayload);
 
             module->addModuleFlag(llvm::Module::Warning, "Debug Info Version", llvm::DEBUG_METADATA_VERSION);
+            module->addModuleFlag(llvm::Module::Override, "cf-protection-return", 1);
+            module->addModuleFlag(llvm::Module::Override, "cf-protection-branch", 1);
 
             if (llvm::Triple(llvm::sys::getProcessTriple()).isOSDarwin()) {
                 // osx only supports dwarf2

--- a/test/testdata/compiler/all_arguments.llo.exp
+++ b/test/testdata/compiler/all_arguments.llo.exp
@@ -198,206 +198,206 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #8
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #8
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#take_arguments"(i32 %argc, i64* %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !8 {
+define i64 @"func_Object#take_arguments"(i32 %argc, i64* %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !10 {
 functionEntryInitializers:
   %callArgs = alloca [8 x i64], align 8
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %0, align 8, !tbaa !12
-  %hashAttemptReadGuard = icmp ult i32 1, %argc, !dbg !14
-  br i1 %hashAttemptReadGuard, label %argCountSecondCheckBlock.thread, label %argCountSecondCheckBlock, !dbg !14
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %0, align 8, !tbaa !14
+  %hashAttemptReadGuard = icmp ult i32 1, %argc, !dbg !16
+  br i1 %hashAttemptReadGuard, label %argCountSecondCheckBlock.thread, label %argCountSecondCheckBlock, !dbg !16
 
 argCountSecondCheckBlock.thread:                  ; preds = %functionEntryInitializers
-  %argsWithoutHashCount = sub nuw i32 %argc, 1, !dbg !14
-  %1 = getelementptr i64, i64* %argArray, i32 %argsWithoutHashCount, !dbg !14
-  %KWArgHash = load i64, i64* %1, align 8, !dbg !14
-  %2 = and i64 %KWArgHash, 7, !dbg !14
-  %3 = icmp ne i64 %2, 0, !dbg !14
-  %4 = and i64 %KWArgHash, -9, !dbg !14
-  %5 = icmp eq i64 %4, 0, !dbg !14
-  %6 = or i1 %3, %5, !dbg !14
-  br i1 %6, label %.thread, label %sorbet_isa_Hash.exit, !dbg !14
+  %argsWithoutHashCount = sub nuw i32 %argc, 1, !dbg !16
+  %1 = getelementptr i64, i64* %argArray, i32 %argsWithoutHashCount, !dbg !16
+  %KWArgHash = load i64, i64* %1, align 8, !dbg !16
+  %2 = and i64 %KWArgHash, 7, !dbg !16
+  %3 = icmp ne i64 %2, 0, !dbg !16
+  %4 = and i64 %KWArgHash, -9, !dbg !16
+  %5 = icmp eq i64 %4, 0, !dbg !16
+  %6 = or i1 %3, %5, !dbg !16
+  br i1 %6, label %.thread, label %sorbet_isa_Hash.exit, !dbg !16
 
 sorbet_isa_Hash.exit:                             ; preds = %argCountSecondCheckBlock.thread
-  %7 = inttoptr i64 %KWArgHash to %struct.iseq_inline_iv_cache_entry*, !dbg !14
-  %8 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %7, i64 0, i32 0, !dbg !14
-  %9 = load i64, i64* %8, align 8, !dbg !14, !tbaa !15
-  %10 = and i64 %9, 31, !dbg !14
-  %11 = icmp eq i64 %10, 8, !dbg !14
-  br i1 %11, label %fillRequiredArgs, label %.thread, !dbg !14
+  %7 = inttoptr i64 %KWArgHash to %struct.iseq_inline_iv_cache_entry*, !dbg !16
+  %8 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %7, i64 0, i32 0, !dbg !16
+  %9 = load i64, i64* %8, align 8, !dbg !16, !tbaa !17
+  %10 = and i64 %9, 31, !dbg !16
+  %11 = icmp eq i64 %10, 8, !dbg !16
+  br i1 %11, label %fillRequiredArgs, label %.thread, !dbg !16
 
 .thread:                                          ; preds = %sorbet_isa_Hash.exit, %argCountSecondCheckBlock.thread
-  br label %fillRequiredArgs, !dbg !14
+  br label %fillRequiredArgs, !dbg !16
 
 argCountFailBlock:                                ; preds = %argCountSecondCheckBlock
-  tail call void @sorbet_raiseArity(i32 noundef 0, i32 noundef 1, i32 noundef -1) #9, !dbg !14
-  unreachable, !dbg !14
+  tail call void @sorbet_raiseArity(i32 noundef 0, i32 noundef 1, i32 noundef -1) #9, !dbg !16
+  unreachable, !dbg !16
 
 argCountSecondCheckBlock:                         ; preds = %functionEntryInitializers
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !14
-  br i1 %tooFewArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !14, !prof !17
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !16
+  br i1 %tooFewArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !16, !prof !19
 
 fillFromDefaultBlockDone1:                        ; preds = %sorbet_getMethodBlockAsProc.exit
-  %12 = getelementptr i64, i64* %argArray, i32 1, !dbg !14
-  %rawArg_b = load i64, i64* %12, align 8, !dbg !14
-  %13 = icmp sgt i32 %argcPhi84, 2, !dbg !14
-  br i1 %13, label %15, label %fillFromDefaultBlockDone1.thread, !dbg !14
+  %12 = getelementptr i64, i64* %argArray, i32 1, !dbg !16
+  %rawArg_b = load i64, i64* %12, align 8, !dbg !16
+  %13 = icmp sgt i32 %argcPhi84, 2, !dbg !16
+  br i1 %13, label %15, label %fillFromDefaultBlockDone1.thread, !dbg !16
 
 fillFromDefaultBlockDone1.thread:                 ; preds = %sorbet_getMethodBlockAsProc.exit, %fillFromDefaultBlockDone1
   %"<argPresent>.sroa.0.090" = phi i64 [ 20, %fillFromDefaultBlockDone1 ], [ 0, %sorbet_getMethodBlockAsProc.exit ]
   %b.sroa.0.188 = phi i64 [ %rawArg_b, %fillFromDefaultBlockDone1 ], [ 8, %sorbet_getMethodBlockAsProc.exit ]
-  %14 = tail call i64 @rb_ary_new() #10, !dbg !14
-  br label %sorbet_readRestArgs.exit, !dbg !14
+  %14 = tail call i64 @rb_ary_new() #10, !dbg !16
+  br label %sorbet_readRestArgs.exit, !dbg !16
 
 15:                                               ; preds = %fillFromDefaultBlockDone1
-  %16 = sub nuw nsw i32 %argcPhi84, 2, !dbg !14
+  %16 = sub nuw nsw i32 %argcPhi84, 2, !dbg !16
   %17 = zext i32 %16 to i64
-  %18 = getelementptr inbounds i64, i64* %argArray, i64 2, !dbg !14
-  %19 = tail call i64 @rb_ary_new_from_values(i64 %17, i64* nonnull %18) #10, !dbg !14
-  br label %sorbet_readRestArgs.exit, !dbg !14
+  %18 = getelementptr inbounds i64, i64* %argArray, i64 2, !dbg !16
+  %19 = tail call i64 @rb_ary_new_from_values(i64 %17, i64* nonnull %18) #10, !dbg !16
+  br label %sorbet_readRestArgs.exit, !dbg !16
 
 sorbet_readRestArgs.exit:                         ; preds = %fillFromDefaultBlockDone1.thread, %15
   %"<argPresent>.sroa.0.089" = phi i64 [ %"<argPresent>.sroa.0.090", %fillFromDefaultBlockDone1.thread ], [ 20, %15 ]
   %b.sroa.0.187 = phi i64 [ %b.sroa.0.188, %fillFromDefaultBlockDone1.thread ], [ %rawArg_b, %15 ]
-  %20 = phi i64 [ %14, %fillFromDefaultBlockDone1.thread ], [ %19, %15 ], !dbg !14
-  %rubyId_d = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !14
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_d), !dbg !14
-  %21 = icmp eq i64 %hashArgsPhi81, 52, !dbg !14
-  br i1 %21, label %33, label %sorbet_getKWArg.exit77, !dbg !14
+  %20 = phi i64 [ %14, %fillFromDefaultBlockDone1.thread ], [ %19, %15 ], !dbg !16
+  %rubyId_d = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !16
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_d), !dbg !16
+  %21 = icmp eq i64 %hashArgsPhi81, 52, !dbg !16
+  br i1 %21, label %33, label %sorbet_getKWArg.exit77, !dbg !16
 
 sorbet_getKWArg.exit77:                           ; preds = %sorbet_readRestArgs.exit
-  %22 = tail call i64 @rb_hash_delete_entry(i64 %hashArgsPhi81, i64 %rawSym) #10, !dbg !14
-  %23 = icmp eq i64 %22, 52, !dbg !14
-  %24 = select i1 %23, i64 8, i64 %22, !dbg !14
-  %rubyId_e = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !14
-  %rawSym20 = tail call i64 @rb_id2sym(i64 %rubyId_e), !dbg !14
-  %25 = tail call i64 @rb_hash_delete_entry(i64 %hashArgsPhi81, i64 %rawSym20) #10, !dbg !14
-  %26 = icmp eq i64 %25, 52, !dbg !14
-  %e.sroa.0.1 = select i1 %26, i64 8, i64 %25, !dbg !14
-  %27 = tail call i64 @rb_hash_dup(i64 %hashArgsPhi81) #10, !dbg !14
+  %22 = tail call i64 @rb_hash_delete_entry(i64 %hashArgsPhi81, i64 %rawSym) #10, !dbg !16
+  %23 = icmp eq i64 %22, 52, !dbg !16
+  %24 = select i1 %23, i64 8, i64 %22, !dbg !16
+  %rubyId_e = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !16
+  %rawSym20 = tail call i64 @rb_id2sym(i64 %rubyId_e), !dbg !16
+  %25 = tail call i64 @rb_hash_delete_entry(i64 %hashArgsPhi81, i64 %rawSym20) #10, !dbg !16
+  %26 = icmp eq i64 %25, 52, !dbg !16
+  %e.sroa.0.1 = select i1 %26, i64 8, i64 %25, !dbg !16
+  %27 = tail call i64 @rb_hash_dup(i64 %hashArgsPhi81) #10, !dbg !16
   br i1 %26, label %sorbet_readKWRestArgs.exit.thread, label %37
 
 fillRequiredArgs:                                 ; preds = %.thread, %sorbet_isa_Hash.exit, %argCountSecondCheckBlock
   %argcPhi84 = phi i32 [ 1, %argCountSecondCheckBlock ], [ %argc, %.thread ], [ %argsWithoutHashCount, %sorbet_isa_Hash.exit ]
   %hashArgsPhi81 = phi i64 [ 52, %argCountSecondCheckBlock ], [ 52, %.thread ], [ %KWArgHash, %sorbet_isa_Hash.exit ]
-  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !14
-  %28 = tail call i32 @rb_block_given_p() #10, !dbg !14
-  %29 = icmp eq i32 %28, 0, !dbg !14
-  br i1 %29, label %sorbet_getMethodBlockAsProc.exit, label %30, !dbg !14
+  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !16
+  %28 = tail call i32 @rb_block_given_p() #10, !dbg !16
+  %29 = icmp eq i32 %28, 0, !dbg !16
+  br i1 %29, label %sorbet_getMethodBlockAsProc.exit, label %30, !dbg !16
 
 30:                                               ; preds = %fillRequiredArgs
-  %31 = tail call i64 @rb_block_proc() #10, !dbg !14
-  br label %sorbet_getMethodBlockAsProc.exit, !dbg !14
+  %31 = tail call i64 @rb_block_proc() #10, !dbg !16
+  br label %sorbet_getMethodBlockAsProc.exit, !dbg !16
 
 sorbet_getMethodBlockAsProc.exit:                 ; preds = %fillRequiredArgs, %30
-  %32 = phi i64 [ %31, %30 ], [ 8, %fillRequiredArgs ], !dbg !14
-  %default0 = icmp eq i32 %argcPhi84, 1, !dbg !14
-  br i1 %default0, label %fillFromDefaultBlockDone1.thread, label %fillFromDefaultBlockDone1, !dbg !14, !prof !17
+  %32 = phi i64 [ %31, %30 ], [ 8, %fillRequiredArgs ], !dbg !16
+  %default0 = icmp eq i32 %argcPhi84, 1, !dbg !16
+  br i1 %default0, label %fillFromDefaultBlockDone1.thread, label %fillFromDefaultBlockDone1, !dbg !16, !prof !19
 
 33:                                               ; preds = %sorbet_readRestArgs.exit
-  %rubyId_e101 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !14
-  %rawSym20102 = tail call i64 @rb_id2sym(i64 %rubyId_e101), !dbg !14
-  %34 = tail call i64 @rb_hash_new() #10, !dbg !14
-  br label %sorbet_readKWRestArgs.exit.thread, !dbg !14
+  %rubyId_e101 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !16
+  %rawSym20102 = tail call i64 @rb_id2sym(i64 %rubyId_e101), !dbg !16
+  %34 = tail call i64 @rb_hash_new() #10, !dbg !16
+  br label %sorbet_readKWRestArgs.exit.thread, !dbg !16
 
 sorbet_readKWRestArgs.exit.thread:                ; preds = %33, %sorbet_getKWArg.exit77
   %.ph = phi i64 [ 8, %33 ], [ %24, %sorbet_getKWArg.exit77 ]
   %.ph113 = phi i64 [ %34, %33 ], [ %27, %sorbet_getKWArg.exit77 ]
-  %35 = and i64 %"<argPresent>.sroa.0.089", -9, !dbg !18
-  %36 = icmp ne i64 %35, 0, !dbg !18
-  %b.sroa.0.0116 = select i1 %36, i64 %b.sroa.0.187, i64 3, !dbg !18
-  br label %42, !dbg !19
+  %35 = and i64 %"<argPresent>.sroa.0.089", -9, !dbg !20
+  %36 = icmp ne i64 %35, 0, !dbg !20
+  %b.sroa.0.0116 = select i1 %36, i64 %b.sroa.0.187, i64 3, !dbg !20
+  br label %42, !dbg !21
 
 37:                                               ; preds = %sorbet_getKWArg.exit77
   %"<argPresent>9.sroa.0.0108" = phi i64 [ 20, %sorbet_getKWArg.exit77 ]
   %e.sroa.0.1106 = phi i64 [ %e.sroa.0.1, %sorbet_getKWArg.exit77 ]
   %38 = phi i64 [ %24, %sorbet_getKWArg.exit77 ]
-  %39 = phi i64 [ %27, %sorbet_getKWArg.exit77 ], !dbg !14
-  %40 = and i64 %"<argPresent>.sroa.0.089", -9, !dbg !18
-  %41 = icmp ne i64 %40, 0, !dbg !18
-  %b.sroa.0.0 = select i1 %41, i64 %b.sroa.0.187, i64 3, !dbg !18
-  br label %42, !dbg !19
+  %39 = phi i64 [ %27, %sorbet_getKWArg.exit77 ], !dbg !16
+  %40 = and i64 %"<argPresent>.sroa.0.089", -9, !dbg !20
+  %41 = icmp ne i64 %40, 0, !dbg !20
+  %b.sroa.0.0 = select i1 %41, i64 %b.sroa.0.187, i64 3, !dbg !20
+  br label %42, !dbg !21
 
 42:                                               ; preds = %sorbet_readKWRestArgs.exit.thread, %37
   %b.sroa.0.0117 = phi i64 [ %b.sroa.0.0, %37 ], [ %b.sroa.0.0116, %sorbet_readKWRestArgs.exit.thread ]
   %43 = phi i64 [ %39, %37 ], [ %.ph113, %sorbet_readKWRestArgs.exit.thread ]
   %44 = phi i64 [ %38, %37 ], [ %.ph, %sorbet_readKWRestArgs.exit.thread ]
   %45 = phi i64 [ %e.sroa.0.1106, %37 ], [ 5, %sorbet_readKWRestArgs.exit.thread ]
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !20, !tbaa !12
-  %callArgs0Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 0, !dbg !21
-  store i64 %rawArg_a, i64* %callArgs0Addr, align 8, !dbg !21
-  %callArgs1Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 1, !dbg !21
-  store i64 %b.sroa.0.0117, i64* %callArgs1Addr, align 8, !dbg !21
-  %callArgs2Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 2, !dbg !21
-  store i64 %20, i64* %callArgs2Addr, align 8, !dbg !21
-  %callArgs3Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 3, !dbg !21
-  store i64 %44, i64* %callArgs3Addr, align 8, !dbg !21
-  %callArgs4Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 4, !dbg !21
-  store i64 %45, i64* %callArgs4Addr, align 8, !dbg !21
-  %callArgs5Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 5, !dbg !21
-  store i64 %43, i64* %callArgs5Addr, align 8, !dbg !21
-  %callArgs6Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 6, !dbg !21
-  store i64 %32, i64* %callArgs6Addr, align 8, !dbg !21
-  %46 = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 0, !dbg !21
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !22) #11, !dbg !21
-  %47 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull %46) #10, !dbg !21
-  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !21
-  %49 = load i64*, i64** %48, align 8, !dbg !21
-  store i64 %47, i64* %49, align 8, !dbg !21, !tbaa !4
-  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !21
-  store i64* %50, i64** %48, align 8, !dbg !21
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_inspect, i64 0), !dbg !21
-  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !25
-  %52 = load i64*, i64** %51, align 8, !dbg !25
-  store i64 %selfRaw, i64* %52, align 8, !dbg !25, !tbaa !4
-  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !25
-  store i64 %send, i64* %53, align 8, !dbg !25, !tbaa !4
-  %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !25
-  store i64* %54, i64** %51, align 8, !dbg !25
-  %send112 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !25
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !22, !tbaa !14
+  %callArgs0Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 0, !dbg !23
+  store i64 %rawArg_a, i64* %callArgs0Addr, align 8, !dbg !23
+  %callArgs1Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 1, !dbg !23
+  store i64 %b.sroa.0.0117, i64* %callArgs1Addr, align 8, !dbg !23
+  %callArgs2Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 2, !dbg !23
+  store i64 %20, i64* %callArgs2Addr, align 8, !dbg !23
+  %callArgs3Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 3, !dbg !23
+  store i64 %44, i64* %callArgs3Addr, align 8, !dbg !23
+  %callArgs4Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 4, !dbg !23
+  store i64 %45, i64* %callArgs4Addr, align 8, !dbg !23
+  %callArgs5Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 5, !dbg !23
+  store i64 %43, i64* %callArgs5Addr, align 8, !dbg !23
+  %callArgs6Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 6, !dbg !23
+  store i64 %32, i64* %callArgs6Addr, align 8, !dbg !23
+  %46 = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 0, !dbg !23
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !24) #11, !dbg !23
+  %47 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull %46) #10, !dbg !23
+  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !23
+  %49 = load i64*, i64** %48, align 8, !dbg !23
+  store i64 %47, i64* %49, align 8, !dbg !23, !tbaa !6
+  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !23
+  store i64* %50, i64** %48, align 8, !dbg !23
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_inspect, i64 0), !dbg !23
+  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !27
+  %52 = load i64*, i64** %51, align 8, !dbg !27
+  store i64 %selfRaw, i64* %52, align 8, !dbg !27, !tbaa !6
+  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !27
+  store i64 %send, i64* %53, align 8, !dbg !27, !tbaa !6
+  %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !27
+  store i64* %54, i64** %51, align 8, !dbg !27
+  %send112 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !27
   ret i64 %send112
 }
 
 ; Function Attrs: sspreq
 define void @Init_all_arguments() local_unnamed_addr #6 {
 entry:
-  %positional_table.i = alloca i64, i32 4, align 8, !dbg !26
-  %keyword_table.i = alloca i64, i32 3, align 8, !dbg !26
+  %positional_table.i = alloca i64, i32 4, align 8, !dbg !28
+  %keyword_table.i = alloca i64, i32 3, align 8, !dbg !28
   %locals.i165.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, align 8, !dbg !28
-  %keywords5.i = alloca i64, align 8, !dbg !29
-  %keywords11.i = alloca i64, align 8, !dbg !30
-  %keywords17.i = alloca i64, align 8, !dbg !31
-  %keywords23.i = alloca i64, align 8, !dbg !32
-  %keywords29.i = alloca i64, align 8, !dbg !33
-  %keywords35.i = alloca i64, align 8, !dbg !34
-  %keywords41.i = alloca i64, i32 2, align 8, !dbg !35
-  %keywords48.i = alloca i64, i32 2, align 8, !dbg !36
-  %keywords56.i = alloca i64, i32 2, align 8, !dbg !37
-  %keywords64.i = alloca i64, i32 2, align 8, !dbg !38
-  %keywords72.i = alloca i64, i32 2, align 8, !dbg !39
-  %keywords80.i = alloca i64, i32 2, align 8, !dbg !40
-  %keywords88.i = alloca i64, i32 2, align 8, !dbg !41
-  %keywords96.i = alloca i64, i32 3, align 8, !dbg !42
-  %keywords105.i = alloca i64, i32 3, align 8, !dbg !43
-  %keywords115.i = alloca i64, i32 3, align 8, !dbg !44
-  %keywords125.i = alloca i64, i32 3, align 8, !dbg !45
-  %keywords135.i = alloca i64, i32 3, align 8, !dbg !46
-  %keywords145.i = alloca i64, i32 3, align 8, !dbg !47
-  %keywords155.i = alloca i64, i32 3, align 8, !dbg !48
+  %keywords.i = alloca i64, align 8, !dbg !30
+  %keywords5.i = alloca i64, align 8, !dbg !31
+  %keywords11.i = alloca i64, align 8, !dbg !32
+  %keywords17.i = alloca i64, align 8, !dbg !33
+  %keywords23.i = alloca i64, align 8, !dbg !34
+  %keywords29.i = alloca i64, align 8, !dbg !35
+  %keywords35.i = alloca i64, align 8, !dbg !36
+  %keywords41.i = alloca i64, i32 2, align 8, !dbg !37
+  %keywords48.i = alloca i64, i32 2, align 8, !dbg !38
+  %keywords56.i = alloca i64, i32 2, align 8, !dbg !39
+  %keywords64.i = alloca i64, i32 2, align 8, !dbg !40
+  %keywords72.i = alloca i64, i32 2, align 8, !dbg !41
+  %keywords80.i = alloca i64, i32 2, align 8, !dbg !42
+  %keywords88.i = alloca i64, i32 2, align 8, !dbg !43
+  %keywords96.i = alloca i64, i32 3, align 8, !dbg !44
+  %keywords105.i = alloca i64, i32 3, align 8, !dbg !45
+  %keywords115.i = alloca i64, i32 3, align 8, !dbg !46
+  %keywords125.i = alloca i64, i32 3, align 8, !dbg !47
+  %keywords135.i = alloca i64, i32 3, align 8, !dbg !48
+  %keywords145.i = alloca i64, i32 3, align 8, !dbg !49
+  %keywords155.i = alloca i64, i32 3, align 8, !dbg !50
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
@@ -482,207 +482,207 @@ entry:
   %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
   %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_take_arguments.i.i, i64 %rubyId_take_arguments.i.i, i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 8)
   store %struct.rb_iseq_struct* %38, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#take_arguments", align 8
-  %rubyId_inspect.i = load i64, i64* @rubyIdPrecomputed_inspect, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_inspect, i64 %rubyId_inspect.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !21
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
+  %rubyId_inspect.i = load i64, i64* @rubyIdPrecomputed_inspect, align 8, !dbg !23
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_inspect, i64 %rubyId_inspect.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !23
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !27
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !27
   %39 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
   call void @rb_gc_register_mark_object(i64 %39) #10
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/all_arguments.rb.i164.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
   %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %39, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i164.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i165.i, i32 noundef 0, i32 noundef 11)
   store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !26
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !26
-  %rubyId_take_arguments.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !28
-  %rubyId_d.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !28
-  %41 = call i64 @rb_id2sym(i64 %rubyId_d.i) #10, !dbg !28
-  store i64 %41, i64* %keywords.i, align 8, !dbg !28
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments.i, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !28
-  %rubyId_take_arguments4.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !29
-  %rubyId_d6.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !29
-  %42 = call i64 @rb_id2sym(i64 %rubyId_d6.i) #10, !dbg !29
-  store i64 %42, i64* %keywords5.i, align 8, !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments4.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull %keywords5.i), !dbg !29
-  %rubyId_take_arguments10.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !30
-  %rubyId_d12.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !30
-  %43 = call i64 @rb_id2sym(i64 %rubyId_d12.i) #10, !dbg !30
-  store i64 %43, i64* %keywords11.i, align 8, !dbg !30
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments10.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull %keywords11.i), !dbg !30
-  %rubyId_take_arguments16.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !31
-  %rubyId_d18.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !31
-  %44 = call i64 @rb_id2sym(i64 %rubyId_d18.i) #10, !dbg !31
-  store i64 %44, i64* %keywords17.i, align 8, !dbg !31
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments16.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull %keywords17.i), !dbg !31
-  %rubyId_take_arguments22.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !32
-  %rubyId_d24.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !32
-  %45 = call i64 @rb_id2sym(i64 %rubyId_d24.i) #10, !dbg !32
-  store i64 %45, i64* %keywords23.i, align 8, !dbg !32
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments22.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull %keywords23.i), !dbg !32
-  %rubyId_take_arguments28.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !33
-  %rubyId_d30.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !33
-  %46 = call i64 @rb_id2sym(i64 %rubyId_d30.i) #10, !dbg !33
-  store i64 %46, i64* %keywords29.i, align 8, !dbg !33
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments28.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull %keywords29.i), !dbg !33
-  %rubyId_take_arguments34.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !34
-  %rubyId_d36.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !34
-  %47 = call i64 @rb_id2sym(i64 %rubyId_d36.i) #10, !dbg !34
-  store i64 %47, i64* %keywords35.i, align 8, !dbg !34
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments34.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull %keywords35.i), !dbg !34
-  %rubyId_take_arguments40.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !35
-  %rubyId_d42.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !35
-  %48 = call i64 @rb_id2sym(i64 %rubyId_d42.i) #10, !dbg !35
-  store i64 %48, i64* %keywords41.i, align 8, !dbg !35
-  %rubyId_e.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !35
-  %49 = call i64 @rb_id2sym(i64 %rubyId_e.i) #10, !dbg !35
-  %50 = getelementptr i64, i64* %keywords41.i, i32 1, !dbg !35
-  store i64 %49, i64* %50, align 8, !dbg !35
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments40.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull %keywords41.i), !dbg !35
-  %rubyId_take_arguments47.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !36
-  %rubyId_d49.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !36
-  %51 = call i64 @rb_id2sym(i64 %rubyId_d49.i) #10, !dbg !36
-  store i64 %51, i64* %keywords48.i, align 8, !dbg !36
-  %rubyId_e51.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !36
-  %52 = call i64 @rb_id2sym(i64 %rubyId_e51.i) #10, !dbg !36
-  %53 = getelementptr i64, i64* %keywords48.i, i32 1, !dbg !36
-  store i64 %52, i64* %53, align 8, !dbg !36
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments47.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull %keywords48.i), !dbg !36
-  %rubyId_take_arguments55.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !37
-  %rubyId_d57.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !37
-  %54 = call i64 @rb_id2sym(i64 %rubyId_d57.i) #10, !dbg !37
-  store i64 %54, i64* %keywords56.i, align 8, !dbg !37
-  %rubyId_e59.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !37
-  %55 = call i64 @rb_id2sym(i64 %rubyId_e59.i) #10, !dbg !37
-  %56 = getelementptr i64, i64* %keywords56.i, i32 1, !dbg !37
-  store i64 %55, i64* %56, align 8, !dbg !37
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments55.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull %keywords56.i), !dbg !37
-  %rubyId_take_arguments63.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !38
-  %rubyId_d65.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !38
-  %57 = call i64 @rb_id2sym(i64 %rubyId_d65.i) #10, !dbg !38
-  store i64 %57, i64* %keywords64.i, align 8, !dbg !38
-  %rubyId_e67.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !38
-  %58 = call i64 @rb_id2sym(i64 %rubyId_e67.i) #10, !dbg !38
-  %59 = getelementptr i64, i64* %keywords64.i, i32 1, !dbg !38
-  store i64 %58, i64* %59, align 8, !dbg !38
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments63.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull %keywords64.i), !dbg !38
-  %rubyId_take_arguments71.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !39
-  %rubyId_d73.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !39
-  %60 = call i64 @rb_id2sym(i64 %rubyId_d73.i) #10, !dbg !39
-  store i64 %60, i64* %keywords72.i, align 8, !dbg !39
-  %rubyId_e75.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !39
-  %61 = call i64 @rb_id2sym(i64 %rubyId_e75.i) #10, !dbg !39
-  %62 = getelementptr i64, i64* %keywords72.i, i32 1, !dbg !39
-  store i64 %61, i64* %62, align 8, !dbg !39
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments71.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull %keywords72.i), !dbg !39
-  %rubyId_take_arguments79.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !40
-  %rubyId_d81.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !40
-  %63 = call i64 @rb_id2sym(i64 %rubyId_d81.i) #10, !dbg !40
-  store i64 %63, i64* %keywords80.i, align 8, !dbg !40
-  %rubyId_e83.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !40
-  %64 = call i64 @rb_id2sym(i64 %rubyId_e83.i) #10, !dbg !40
-  %65 = getelementptr i64, i64* %keywords80.i, i32 1, !dbg !40
-  store i64 %64, i64* %65, align 8, !dbg !40
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments79.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull %keywords80.i), !dbg !40
-  %rubyId_take_arguments87.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !41
-  %rubyId_d89.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !41
-  %66 = call i64 @rb_id2sym(i64 %rubyId_d89.i) #10, !dbg !41
-  store i64 %66, i64* %keywords88.i, align 8, !dbg !41
-  %rubyId_e91.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !41
-  %67 = call i64 @rb_id2sym(i64 %rubyId_e91.i) #10, !dbg !41
-  %68 = getelementptr i64, i64* %keywords88.i, i32 1, !dbg !41
-  store i64 %67, i64* %68, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments87.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull %keywords88.i), !dbg !41
-  %rubyId_take_arguments95.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !42
-  %rubyId_d97.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !42
-  %69 = call i64 @rb_id2sym(i64 %rubyId_d97.i) #10, !dbg !42
-  store i64 %69, i64* %keywords96.i, align 8, !dbg !42
-  %rubyId_e99.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !42
-  %70 = call i64 @rb_id2sym(i64 %rubyId_e99.i) #10, !dbg !42
-  %71 = getelementptr i64, i64* %keywords96.i, i32 1, !dbg !42
-  store i64 %70, i64* %71, align 8, !dbg !42
-  %rubyId_baz.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !42
-  %72 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #10, !dbg !42
-  %73 = getelementptr i64, i64* %keywords96.i, i32 2, !dbg !42
-  store i64 %72, i64* %73, align 8, !dbg !42
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments95.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull %keywords96.i), !dbg !42
-  %rubyId_take_arguments104.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !43
-  %rubyId_d106.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !43
-  %74 = call i64 @rb_id2sym(i64 %rubyId_d106.i) #10, !dbg !43
-  store i64 %74, i64* %keywords105.i, align 8, !dbg !43
-  %rubyId_e108.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !43
-  %75 = call i64 @rb_id2sym(i64 %rubyId_e108.i) #10, !dbg !43
-  %76 = getelementptr i64, i64* %keywords105.i, i32 1, !dbg !43
-  store i64 %75, i64* %76, align 8, !dbg !43
-  %rubyId_baz110.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !43
-  %77 = call i64 @rb_id2sym(i64 %rubyId_baz110.i) #10, !dbg !43
-  %78 = getelementptr i64, i64* %keywords105.i, i32 2, !dbg !43
-  store i64 %77, i64* %78, align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments104.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull %keywords105.i), !dbg !43
-  %rubyId_take_arguments114.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !44
-  %rubyId_d116.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !44
-  %79 = call i64 @rb_id2sym(i64 %rubyId_d116.i) #10, !dbg !44
-  store i64 %79, i64* %keywords115.i, align 8, !dbg !44
-  %rubyId_e118.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !44
-  %80 = call i64 @rb_id2sym(i64 %rubyId_e118.i) #10, !dbg !44
-  %81 = getelementptr i64, i64* %keywords115.i, i32 1, !dbg !44
-  store i64 %80, i64* %81, align 8, !dbg !44
-  %rubyId_baz120.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !44
-  %82 = call i64 @rb_id2sym(i64 %rubyId_baz120.i) #10, !dbg !44
-  %83 = getelementptr i64, i64* %keywords115.i, i32 2, !dbg !44
-  store i64 %82, i64* %83, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments114.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull %keywords115.i), !dbg !44
-  %rubyId_take_arguments124.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !45
-  %rubyId_d126.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !45
-  %84 = call i64 @rb_id2sym(i64 %rubyId_d126.i) #10, !dbg !45
-  store i64 %84, i64* %keywords125.i, align 8, !dbg !45
-  %rubyId_e128.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !45
-  %85 = call i64 @rb_id2sym(i64 %rubyId_e128.i) #10, !dbg !45
-  %86 = getelementptr i64, i64* %keywords125.i, i32 1, !dbg !45
-  store i64 %85, i64* %86, align 8, !dbg !45
-  %rubyId_baz130.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !45
-  %87 = call i64 @rb_id2sym(i64 %rubyId_baz130.i) #10, !dbg !45
-  %88 = getelementptr i64, i64* %keywords125.i, i32 2, !dbg !45
-  store i64 %87, i64* %88, align 8, !dbg !45
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments124.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull %keywords125.i), !dbg !45
-  %rubyId_take_arguments134.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !46
-  %rubyId_d136.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !46
-  %89 = call i64 @rb_id2sym(i64 %rubyId_d136.i) #10, !dbg !46
-  store i64 %89, i64* %keywords135.i, align 8, !dbg !46
-  %rubyId_e138.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !46
-  %90 = call i64 @rb_id2sym(i64 %rubyId_e138.i) #10, !dbg !46
-  %91 = getelementptr i64, i64* %keywords135.i, i32 1, !dbg !46
-  store i64 %90, i64* %91, align 8, !dbg !46
-  %rubyId_baz140.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !46
-  %92 = call i64 @rb_id2sym(i64 %rubyId_baz140.i) #10, !dbg !46
-  %93 = getelementptr i64, i64* %keywords135.i, i32 2, !dbg !46
-  store i64 %92, i64* %93, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments134.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull %keywords135.i), !dbg !46
-  %rubyId_take_arguments144.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !47
-  %rubyId_d146.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !47
-  %94 = call i64 @rb_id2sym(i64 %rubyId_d146.i) #10, !dbg !47
-  store i64 %94, i64* %keywords145.i, align 8, !dbg !47
-  %rubyId_e148.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !47
-  %95 = call i64 @rb_id2sym(i64 %rubyId_e148.i) #10, !dbg !47
-  %96 = getelementptr i64, i64* %keywords145.i, i32 1, !dbg !47
-  store i64 %95, i64* %96, align 8, !dbg !47
-  %rubyId_baz150.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !47
-  %97 = call i64 @rb_id2sym(i64 %rubyId_baz150.i) #10, !dbg !47
-  %98 = getelementptr i64, i64* %keywords145.i, i32 2, !dbg !47
-  store i64 %97, i64* %98, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments144.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull %keywords145.i), !dbg !47
-  %rubyId_take_arguments154.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !48
-  %rubyId_d156.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !48
-  %99 = call i64 @rb_id2sym(i64 %rubyId_d156.i) #10, !dbg !48
-  store i64 %99, i64* %keywords155.i, align 8, !dbg !48
-  %rubyId_e158.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !48
-  %100 = call i64 @rb_id2sym(i64 %rubyId_e158.i) #10, !dbg !48
-  %101 = getelementptr i64, i64* %keywords155.i, i32 1, !dbg !48
-  store i64 %100, i64* %101, align 8, !dbg !48
-  %rubyId_baz160.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !48
-  %102 = call i64 @rb_id2sym(i64 %rubyId_baz160.i) #10, !dbg !48
-  %103 = getelementptr i64, i64* %keywords155.i, i32 2, !dbg !48
-  store i64 %102, i64* %103, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments154.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull %keywords155.i), !dbg !48
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !28
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !28
+  %rubyId_take_arguments.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !30
+  %rubyId_d.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !30
+  %41 = call i64 @rb_id2sym(i64 %rubyId_d.i) #10, !dbg !30
+  store i64 %41, i64* %keywords.i, align 8, !dbg !30
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments.i, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !30
+  %rubyId_take_arguments4.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !31
+  %rubyId_d6.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !31
+  %42 = call i64 @rb_id2sym(i64 %rubyId_d6.i) #10, !dbg !31
+  store i64 %42, i64* %keywords5.i, align 8, !dbg !31
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments4.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull %keywords5.i), !dbg !31
+  %rubyId_take_arguments10.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !32
+  %rubyId_d12.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !32
+  %43 = call i64 @rb_id2sym(i64 %rubyId_d12.i) #10, !dbg !32
+  store i64 %43, i64* %keywords11.i, align 8, !dbg !32
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments10.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull %keywords11.i), !dbg !32
+  %rubyId_take_arguments16.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !33
+  %rubyId_d18.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !33
+  %44 = call i64 @rb_id2sym(i64 %rubyId_d18.i) #10, !dbg !33
+  store i64 %44, i64* %keywords17.i, align 8, !dbg !33
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments16.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull %keywords17.i), !dbg !33
+  %rubyId_take_arguments22.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !34
+  %rubyId_d24.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !34
+  %45 = call i64 @rb_id2sym(i64 %rubyId_d24.i) #10, !dbg !34
+  store i64 %45, i64* %keywords23.i, align 8, !dbg !34
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments22.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull %keywords23.i), !dbg !34
+  %rubyId_take_arguments28.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !35
+  %rubyId_d30.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !35
+  %46 = call i64 @rb_id2sym(i64 %rubyId_d30.i) #10, !dbg !35
+  store i64 %46, i64* %keywords29.i, align 8, !dbg !35
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments28.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull %keywords29.i), !dbg !35
+  %rubyId_take_arguments34.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !36
+  %rubyId_d36.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !36
+  %47 = call i64 @rb_id2sym(i64 %rubyId_d36.i) #10, !dbg !36
+  store i64 %47, i64* %keywords35.i, align 8, !dbg !36
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments34.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull %keywords35.i), !dbg !36
+  %rubyId_take_arguments40.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !37
+  %rubyId_d42.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !37
+  %48 = call i64 @rb_id2sym(i64 %rubyId_d42.i) #10, !dbg !37
+  store i64 %48, i64* %keywords41.i, align 8, !dbg !37
+  %rubyId_e.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !37
+  %49 = call i64 @rb_id2sym(i64 %rubyId_e.i) #10, !dbg !37
+  %50 = getelementptr i64, i64* %keywords41.i, i32 1, !dbg !37
+  store i64 %49, i64* %50, align 8, !dbg !37
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments40.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull %keywords41.i), !dbg !37
+  %rubyId_take_arguments47.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !38
+  %rubyId_d49.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !38
+  %51 = call i64 @rb_id2sym(i64 %rubyId_d49.i) #10, !dbg !38
+  store i64 %51, i64* %keywords48.i, align 8, !dbg !38
+  %rubyId_e51.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !38
+  %52 = call i64 @rb_id2sym(i64 %rubyId_e51.i) #10, !dbg !38
+  %53 = getelementptr i64, i64* %keywords48.i, i32 1, !dbg !38
+  store i64 %52, i64* %53, align 8, !dbg !38
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments47.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull %keywords48.i), !dbg !38
+  %rubyId_take_arguments55.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !39
+  %rubyId_d57.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !39
+  %54 = call i64 @rb_id2sym(i64 %rubyId_d57.i) #10, !dbg !39
+  store i64 %54, i64* %keywords56.i, align 8, !dbg !39
+  %rubyId_e59.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !39
+  %55 = call i64 @rb_id2sym(i64 %rubyId_e59.i) #10, !dbg !39
+  %56 = getelementptr i64, i64* %keywords56.i, i32 1, !dbg !39
+  store i64 %55, i64* %56, align 8, !dbg !39
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments55.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull %keywords56.i), !dbg !39
+  %rubyId_take_arguments63.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !40
+  %rubyId_d65.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !40
+  %57 = call i64 @rb_id2sym(i64 %rubyId_d65.i) #10, !dbg !40
+  store i64 %57, i64* %keywords64.i, align 8, !dbg !40
+  %rubyId_e67.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !40
+  %58 = call i64 @rb_id2sym(i64 %rubyId_e67.i) #10, !dbg !40
+  %59 = getelementptr i64, i64* %keywords64.i, i32 1, !dbg !40
+  store i64 %58, i64* %59, align 8, !dbg !40
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments63.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull %keywords64.i), !dbg !40
+  %rubyId_take_arguments71.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !41
+  %rubyId_d73.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !41
+  %60 = call i64 @rb_id2sym(i64 %rubyId_d73.i) #10, !dbg !41
+  store i64 %60, i64* %keywords72.i, align 8, !dbg !41
+  %rubyId_e75.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !41
+  %61 = call i64 @rb_id2sym(i64 %rubyId_e75.i) #10, !dbg !41
+  %62 = getelementptr i64, i64* %keywords72.i, i32 1, !dbg !41
+  store i64 %61, i64* %62, align 8, !dbg !41
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments71.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull %keywords72.i), !dbg !41
+  %rubyId_take_arguments79.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !42
+  %rubyId_d81.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !42
+  %63 = call i64 @rb_id2sym(i64 %rubyId_d81.i) #10, !dbg !42
+  store i64 %63, i64* %keywords80.i, align 8, !dbg !42
+  %rubyId_e83.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !42
+  %64 = call i64 @rb_id2sym(i64 %rubyId_e83.i) #10, !dbg !42
+  %65 = getelementptr i64, i64* %keywords80.i, i32 1, !dbg !42
+  store i64 %64, i64* %65, align 8, !dbg !42
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments79.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull %keywords80.i), !dbg !42
+  %rubyId_take_arguments87.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !43
+  %rubyId_d89.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !43
+  %66 = call i64 @rb_id2sym(i64 %rubyId_d89.i) #10, !dbg !43
+  store i64 %66, i64* %keywords88.i, align 8, !dbg !43
+  %rubyId_e91.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !43
+  %67 = call i64 @rb_id2sym(i64 %rubyId_e91.i) #10, !dbg !43
+  %68 = getelementptr i64, i64* %keywords88.i, i32 1, !dbg !43
+  store i64 %67, i64* %68, align 8, !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments87.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull %keywords88.i), !dbg !43
+  %rubyId_take_arguments95.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !44
+  %rubyId_d97.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !44
+  %69 = call i64 @rb_id2sym(i64 %rubyId_d97.i) #10, !dbg !44
+  store i64 %69, i64* %keywords96.i, align 8, !dbg !44
+  %rubyId_e99.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !44
+  %70 = call i64 @rb_id2sym(i64 %rubyId_e99.i) #10, !dbg !44
+  %71 = getelementptr i64, i64* %keywords96.i, i32 1, !dbg !44
+  store i64 %70, i64* %71, align 8, !dbg !44
+  %rubyId_baz.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !44
+  %72 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #10, !dbg !44
+  %73 = getelementptr i64, i64* %keywords96.i, i32 2, !dbg !44
+  store i64 %72, i64* %73, align 8, !dbg !44
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments95.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull %keywords96.i), !dbg !44
+  %rubyId_take_arguments104.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !45
+  %rubyId_d106.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !45
+  %74 = call i64 @rb_id2sym(i64 %rubyId_d106.i) #10, !dbg !45
+  store i64 %74, i64* %keywords105.i, align 8, !dbg !45
+  %rubyId_e108.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !45
+  %75 = call i64 @rb_id2sym(i64 %rubyId_e108.i) #10, !dbg !45
+  %76 = getelementptr i64, i64* %keywords105.i, i32 1, !dbg !45
+  store i64 %75, i64* %76, align 8, !dbg !45
+  %rubyId_baz110.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !45
+  %77 = call i64 @rb_id2sym(i64 %rubyId_baz110.i) #10, !dbg !45
+  %78 = getelementptr i64, i64* %keywords105.i, i32 2, !dbg !45
+  store i64 %77, i64* %78, align 8, !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments104.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull %keywords105.i), !dbg !45
+  %rubyId_take_arguments114.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !46
+  %rubyId_d116.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !46
+  %79 = call i64 @rb_id2sym(i64 %rubyId_d116.i) #10, !dbg !46
+  store i64 %79, i64* %keywords115.i, align 8, !dbg !46
+  %rubyId_e118.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !46
+  %80 = call i64 @rb_id2sym(i64 %rubyId_e118.i) #10, !dbg !46
+  %81 = getelementptr i64, i64* %keywords115.i, i32 1, !dbg !46
+  store i64 %80, i64* %81, align 8, !dbg !46
+  %rubyId_baz120.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !46
+  %82 = call i64 @rb_id2sym(i64 %rubyId_baz120.i) #10, !dbg !46
+  %83 = getelementptr i64, i64* %keywords115.i, i32 2, !dbg !46
+  store i64 %82, i64* %83, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments114.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull %keywords115.i), !dbg !46
+  %rubyId_take_arguments124.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !47
+  %rubyId_d126.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !47
+  %84 = call i64 @rb_id2sym(i64 %rubyId_d126.i) #10, !dbg !47
+  store i64 %84, i64* %keywords125.i, align 8, !dbg !47
+  %rubyId_e128.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !47
+  %85 = call i64 @rb_id2sym(i64 %rubyId_e128.i) #10, !dbg !47
+  %86 = getelementptr i64, i64* %keywords125.i, i32 1, !dbg !47
+  store i64 %85, i64* %86, align 8, !dbg !47
+  %rubyId_baz130.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !47
+  %87 = call i64 @rb_id2sym(i64 %rubyId_baz130.i) #10, !dbg !47
+  %88 = getelementptr i64, i64* %keywords125.i, i32 2, !dbg !47
+  store i64 %87, i64* %88, align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments124.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull %keywords125.i), !dbg !47
+  %rubyId_take_arguments134.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !48
+  %rubyId_d136.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !48
+  %89 = call i64 @rb_id2sym(i64 %rubyId_d136.i) #10, !dbg !48
+  store i64 %89, i64* %keywords135.i, align 8, !dbg !48
+  %rubyId_e138.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !48
+  %90 = call i64 @rb_id2sym(i64 %rubyId_e138.i) #10, !dbg !48
+  %91 = getelementptr i64, i64* %keywords135.i, i32 1, !dbg !48
+  store i64 %90, i64* %91, align 8, !dbg !48
+  %rubyId_baz140.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !48
+  %92 = call i64 @rb_id2sym(i64 %rubyId_baz140.i) #10, !dbg !48
+  %93 = getelementptr i64, i64* %keywords135.i, i32 2, !dbg !48
+  store i64 %92, i64* %93, align 8, !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments134.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull %keywords135.i), !dbg !48
+  %rubyId_take_arguments144.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !49
+  %rubyId_d146.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !49
+  %94 = call i64 @rb_id2sym(i64 %rubyId_d146.i) #10, !dbg !49
+  store i64 %94, i64* %keywords145.i, align 8, !dbg !49
+  %rubyId_e148.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !49
+  %95 = call i64 @rb_id2sym(i64 %rubyId_e148.i) #10, !dbg !49
+  %96 = getelementptr i64, i64* %keywords145.i, i32 1, !dbg !49
+  store i64 %95, i64* %96, align 8, !dbg !49
+  %rubyId_baz150.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !49
+  %97 = call i64 @rb_id2sym(i64 %rubyId_baz150.i) #10, !dbg !49
+  %98 = getelementptr i64, i64* %keywords145.i, i32 2, !dbg !49
+  store i64 %97, i64* %98, align 8, !dbg !49
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments144.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull %keywords145.i), !dbg !49
+  %rubyId_take_arguments154.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !50
+  %rubyId_d156.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !50
+  %99 = call i64 @rb_id2sym(i64 %rubyId_d156.i) #10, !dbg !50
+  store i64 %99, i64* %keywords155.i, align 8, !dbg !50
+  %rubyId_e158.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !50
+  %100 = call i64 @rb_id2sym(i64 %rubyId_e158.i) #10, !dbg !50
+  %101 = getelementptr i64, i64* %keywords155.i, i32 1, !dbg !50
+  store i64 %100, i64* %101, align 8, !dbg !50
+  %rubyId_baz160.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !50
+  %102 = call i64 @rb_id2sym(i64 %rubyId_baz160.i) #10, !dbg !50
+  %103 = getelementptr i64, i64* %keywords155.i, i32 2, !dbg !50
+  store i64 %102, i64* %103, align 8, !dbg !50
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments154.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull %keywords155.i), !dbg !50
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %2)
@@ -704,577 +704,577 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %18)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %19)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %20)
-  %104 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !12
+  %104 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %105 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %104, i64 0, i32 18
-  %106 = load i64, i64* %105, align 8, !tbaa !49
-  %107 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %106 = load i64, i64* %105, align 8, !tbaa !51
+  %107 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %108 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %107, i64 0, i32 2
-  %109 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %108, align 8, !tbaa !59
+  %109 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %108, align 8, !tbaa !61
   %110 = bitcast i64* %positional_table.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %110)
   %111 = bitcast i64* %keyword_table.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %111)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %112 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %112, align 8, !tbaa !62
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %112, align 8, !tbaa !64
   %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 4
-  %114 = load i64*, i64** %113, align 8, !tbaa !64
-  %115 = load i64, i64* %114, align 8, !tbaa !4
+  %114 = load i64*, i64** %113, align 8, !tbaa !66
+  %115 = load i64, i64* %114, align 8, !tbaa !6
   %116 = and i64 %115, -33
-  store i64 %116, i64* %114, align 8, !tbaa !4
+  store i64 %116, i64* %114, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %107, %struct.rb_control_frame_struct* %109, %struct.rb_iseq_struct* %stackFrame.i) #10
   %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %117, align 8, !dbg !65, !tbaa !12
-  %rubyId_take_arguments.i1 = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !26
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_take_arguments.i1) #10, !dbg !26
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !26
-  %rawSym386.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #10, !dbg !26
-  %118 = load i64, i64* @rb_cObject, align 8, !dbg !26
-  %stackFrame387.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#take_arguments", align 8, !dbg !26
-  %119 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !26
-  %120 = bitcast i8* %119 to i16*, !dbg !26
-  %121 = load i16, i16* %120, align 8, !dbg !26
-  %122 = and i16 %121, -384, !dbg !26
-  %123 = or i16 %122, 119, !dbg !26
-  store i16 %123, i16* %120, align 8, !dbg !26
-  %124 = getelementptr inbounds i8, i8* %119, i64 8, !dbg !26
-  %125 = bitcast i8* %124 to i32*, !dbg !26
-  %126 = getelementptr inbounds i8, i8* %119, i64 12, !dbg !26
-  %127 = bitcast i8* %126 to i32*, !dbg !26
-  %128 = getelementptr inbounds i8, i8* %119, i64 16, !dbg !26
-  %129 = getelementptr inbounds i8, i8* %119, i64 20, !dbg !26
-  %130 = bitcast i8* %129 to i32*, !dbg !26
-  store i32 0, i32* %130, align 4, !dbg !26, !tbaa !66
-  %131 = getelementptr inbounds i8, i8* %119, i64 24, !dbg !26
-  %132 = bitcast i8* %131 to i32*, !dbg !26
-  store i32 0, i32* %132, align 8, !dbg !26, !tbaa !69
-  %133 = getelementptr inbounds i8, i8* %119, i64 28, !dbg !26
-  %134 = bitcast i8* %133 to i32*, !dbg !26
-  store i32 3, i32* %134, align 4, !dbg !26, !tbaa !70
-  %135 = getelementptr inbounds i8, i8* %119, i64 4, !dbg !26
-  %136 = bitcast i8* %135 to i32*, !dbg !26
-  %137 = bitcast i32* %136 to <4 x i32>*, !dbg !26
-  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %137, align 4, !dbg !26, !tbaa !71
-  %rubyId_a.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !26
-  store i64 %rubyId_a.i, i64* %positional_table.i, align 8, !dbg !26
-  %rubyId_b.i = load i64, i64* @rubyIdPrecomputed_b, align 8, !dbg !26
-  %138 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !26
-  store i64 %rubyId_b.i, i64* %138, align 8, !dbg !26
-  %rubyId_c.i = load i64, i64* @rubyIdPrecomputed_c, align 8, !dbg !26
-  %139 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !26
-  store i64 %rubyId_c.i, i64* %139, align 8, !dbg !26
-  %rubyId_g.i = load i64, i64* @rubyIdPrecomputed_g, align 8, !dbg !26
-  %140 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !26
-  store i64 %rubyId_g.i, i64* %140, align 8, !dbg !26
-  %141 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #12, !dbg !26
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %141, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %110, i64 noundef 32, i1 noundef false) #10, !dbg !26
-  %142 = getelementptr inbounds i8, i8* %119, i64 32, !dbg !26
-  %143 = bitcast i8* %142 to i8**, !dbg !26
-  store i8* %141, i8** %143, align 8, !dbg !26, !tbaa !72
-  %rubyId_d.i2 = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !26
-  store i64 %rubyId_d.i2, i64* %keyword_table.i, align 8, !dbg !26
-  %rubyId_e.i3 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !26
-  %144 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !26
-  store i64 %rubyId_e.i3, i64* %144, align 8, !dbg !26
-  %rubyId_f.i = load i64, i64* @rubyIdPrecomputed_f, align 8, !dbg !26
-  %145 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !26
-  store i64 %rubyId_f.i, i64* %145, align 8, !dbg !26
-  %146 = getelementptr inbounds i8, i8* %119, i64 40, !dbg !26
-  %147 = bitcast i8* %146 to i32*, !dbg !26
-  store i32 2, i32* %147, align 8, !dbg !26, !tbaa !73
-  %148 = getelementptr inbounds i8, i8* %119, i64 44, !dbg !26
-  %149 = bitcast i8* %148 to i32*, !dbg !26
-  store i32 1, i32* %149, align 4, !dbg !26, !tbaa !74
-  %150 = load i32, i32* %125, align 8, !dbg !26, !tbaa !75
-  %151 = load i32, i32* %127, align 4, !dbg !26, !tbaa !76
-  %152 = add i32 %150, 2, !dbg !26
-  %153 = add i32 %152, %151, !dbg !26
-  %154 = getelementptr inbounds i8, i8* %119, i64 48, !dbg !26
-  %155 = bitcast i8* %154 to i32*, !dbg !26
-  store i32 %153, i32* %155, align 8, !dbg !26, !tbaa !77
-  %156 = load i16, i16* %120, align 8, !dbg !26
-  %157 = and i16 %156, 32, !dbg !26
-  %158 = icmp eq i16 %157, 0, !dbg !26
-  br i1 %158, label %sorbet_setupParamKeywords.exit.i, label %159, !dbg !26
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %117, align 8, !dbg !67, !tbaa !14
+  %rubyId_take_arguments.i1 = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !28
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_take_arguments.i1) #10, !dbg !28
+  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !28
+  %rawSym386.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #10, !dbg !28
+  %118 = load i64, i64* @rb_cObject, align 8, !dbg !28
+  %stackFrame387.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#take_arguments", align 8, !dbg !28
+  %119 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !28
+  %120 = bitcast i8* %119 to i16*, !dbg !28
+  %121 = load i16, i16* %120, align 8, !dbg !28
+  %122 = and i16 %121, -384, !dbg !28
+  %123 = or i16 %122, 119, !dbg !28
+  store i16 %123, i16* %120, align 8, !dbg !28
+  %124 = getelementptr inbounds i8, i8* %119, i64 8, !dbg !28
+  %125 = bitcast i8* %124 to i32*, !dbg !28
+  %126 = getelementptr inbounds i8, i8* %119, i64 12, !dbg !28
+  %127 = bitcast i8* %126 to i32*, !dbg !28
+  %128 = getelementptr inbounds i8, i8* %119, i64 16, !dbg !28
+  %129 = getelementptr inbounds i8, i8* %119, i64 20, !dbg !28
+  %130 = bitcast i8* %129 to i32*, !dbg !28
+  store i32 0, i32* %130, align 4, !dbg !28, !tbaa !68
+  %131 = getelementptr inbounds i8, i8* %119, i64 24, !dbg !28
+  %132 = bitcast i8* %131 to i32*, !dbg !28
+  store i32 0, i32* %132, align 8, !dbg !28, !tbaa !71
+  %133 = getelementptr inbounds i8, i8* %119, i64 28, !dbg !28
+  %134 = bitcast i8* %133 to i32*, !dbg !28
+  store i32 3, i32* %134, align 4, !dbg !28, !tbaa !72
+  %135 = getelementptr inbounds i8, i8* %119, i64 4, !dbg !28
+  %136 = bitcast i8* %135 to i32*, !dbg !28
+  %137 = bitcast i32* %136 to <4 x i32>*, !dbg !28
+  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %137, align 4, !dbg !28, !tbaa !73
+  %rubyId_a.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !28
+  store i64 %rubyId_a.i, i64* %positional_table.i, align 8, !dbg !28
+  %rubyId_b.i = load i64, i64* @rubyIdPrecomputed_b, align 8, !dbg !28
+  %138 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !28
+  store i64 %rubyId_b.i, i64* %138, align 8, !dbg !28
+  %rubyId_c.i = load i64, i64* @rubyIdPrecomputed_c, align 8, !dbg !28
+  %139 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !28
+  store i64 %rubyId_c.i, i64* %139, align 8, !dbg !28
+  %rubyId_g.i = load i64, i64* @rubyIdPrecomputed_g, align 8, !dbg !28
+  %140 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !28
+  store i64 %rubyId_g.i, i64* %140, align 8, !dbg !28
+  %141 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #12, !dbg !28
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %141, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %110, i64 noundef 32, i1 noundef false) #10, !dbg !28
+  %142 = getelementptr inbounds i8, i8* %119, i64 32, !dbg !28
+  %143 = bitcast i8* %142 to i8**, !dbg !28
+  store i8* %141, i8** %143, align 8, !dbg !28, !tbaa !74
+  %rubyId_d.i2 = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !28
+  store i64 %rubyId_d.i2, i64* %keyword_table.i, align 8, !dbg !28
+  %rubyId_e.i3 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !28
+  %144 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !28
+  store i64 %rubyId_e.i3, i64* %144, align 8, !dbg !28
+  %rubyId_f.i = load i64, i64* @rubyIdPrecomputed_f, align 8, !dbg !28
+  %145 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !28
+  store i64 %rubyId_f.i, i64* %145, align 8, !dbg !28
+  %146 = getelementptr inbounds i8, i8* %119, i64 40, !dbg !28
+  %147 = bitcast i8* %146 to i32*, !dbg !28
+  store i32 2, i32* %147, align 8, !dbg !28, !tbaa !75
+  %148 = getelementptr inbounds i8, i8* %119, i64 44, !dbg !28
+  %149 = bitcast i8* %148 to i32*, !dbg !28
+  store i32 1, i32* %149, align 4, !dbg !28, !tbaa !76
+  %150 = load i32, i32* %125, align 8, !dbg !28, !tbaa !77
+  %151 = load i32, i32* %127, align 4, !dbg !28, !tbaa !78
+  %152 = add i32 %150, 2, !dbg !28
+  %153 = add i32 %152, %151, !dbg !28
+  %154 = getelementptr inbounds i8, i8* %119, i64 48, !dbg !28
+  %155 = bitcast i8* %154 to i32*, !dbg !28
+  store i32 %153, i32* %155, align 8, !dbg !28, !tbaa !79
+  %156 = load i16, i16* %120, align 8, !dbg !28
+  %157 = and i16 %156, 32, !dbg !28
+  %158 = icmp eq i16 %157, 0, !dbg !28
+  br i1 %158, label %sorbet_setupParamKeywords.exit.i, label %159, !dbg !28
 
 159:                                              ; preds = %entry
-  %160 = add nsw i32 %153, 1, !dbg !26
-  %161 = getelementptr inbounds i8, i8* %119, i64 52, !dbg !26
-  %162 = bitcast i8* %161 to i32*, !dbg !26
-  store i32 %160, i32* %162, align 4, !dbg !26, !tbaa !78
-  br label %sorbet_setupParamKeywords.exit.i, !dbg !26
+  %160 = add nsw i32 %153, 1, !dbg !28
+  %161 = getelementptr inbounds i8, i8* %119, i64 52, !dbg !28
+  %162 = bitcast i8* %161 to i32*, !dbg !28
+  store i32 %160, i32* %162, align 4, !dbg !28, !tbaa !80
+  br label %sorbet_setupParamKeywords.exit.i, !dbg !28
 
 sorbet_setupParamKeywords.exit.i:                 ; preds = %159, %entry
-  %163 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #12, !dbg !26
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %163, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %111, i64 noundef 24, i1 noundef false) #10, !dbg !26
-  %164 = getelementptr inbounds i8, i8* %119, i64 56, !dbg !26
-  %165 = bitcast i8* %164 to i8**, !dbg !26
-  store i8* %163, i8** %165, align 8, !dbg !26, !tbaa !79
-  call void @sorbet_vm_define_method(i64 %118, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#take_arguments", i8* nonnull %119, %struct.rb_iseq_struct* %stackFrame387.i, i1 noundef zeroext false) #10, !dbg !26
-  %166 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !12
-  %167 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 5, !dbg !26
-  %168 = load i32, i32* %167, align 8, !dbg !26, !tbaa !80
-  %169 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 6, !dbg !26
-  %170 = load i32, i32* %169, align 4, !dbg !26, !tbaa !81
-  %171 = xor i32 %170, -1, !dbg !26
-  %172 = and i32 %171, %168, !dbg !26
-  %173 = icmp eq i32 %172, 0, !dbg !26
-  br i1 %173, label %"func_<root>.<static-init>$151.exit", label %174, !dbg !26, !prof !82
+  %163 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #12, !dbg !28
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %163, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %111, i64 noundef 24, i1 noundef false) #10, !dbg !28
+  %164 = getelementptr inbounds i8, i8* %119, i64 56, !dbg !28
+  %165 = bitcast i8* %164 to i8**, !dbg !28
+  store i8* %163, i8** %165, align 8, !dbg !28, !tbaa !81
+  call void @sorbet_vm_define_method(i64 %118, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#take_arguments", i8* nonnull %119, %struct.rb_iseq_struct* %stackFrame387.i, i1 noundef zeroext false) #10, !dbg !28
+  %166 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !14
+  %167 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 5, !dbg !28
+  %168 = load i32, i32* %167, align 8, !dbg !28, !tbaa !82
+  %169 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 6, !dbg !28
+  %170 = load i32, i32* %169, align 4, !dbg !28, !tbaa !83
+  %171 = xor i32 %170, -1, !dbg !28
+  %172 = and i32 %171, %168, !dbg !28
+  %173 = icmp eq i32 %172, 0, !dbg !28
+  br i1 %173, label %"func_<root>.<static-init>$151.exit", label %174, !dbg !28, !prof !84
 
 174:                                              ; preds = %sorbet_setupParamKeywords.exit.i
-  %175 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 8, !dbg !26
-  %176 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %175, align 8, !dbg !26, !tbaa !83
-  %177 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %176, i32 noundef 0) #10, !dbg !26
-  br label %"func_<root>.<static-init>$151.exit", !dbg !26
+  %175 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 8, !dbg !28
+  %176 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %175, align 8, !dbg !28, !tbaa !85
+  %177 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %176, i32 noundef 0) #10, !dbg !28
+  br label %"func_<root>.<static-init>$151.exit", !dbg !28
 
 "func_<root>.<static-init>$151.exit":             ; preds = %sorbet_setupParamKeywords.exit.i, %174
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %117, align 8, !dbg !26, !tbaa !12
-  %rubyId_d398.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !84
-  %rawSym399.i = call i64 @rb_id2sym(i64 %rubyId_d398.i) #10, !dbg !84
-  %178 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !28
-  %179 = load i64*, i64** %178, align 8, !dbg !28
-  store i64 %106, i64* %179, align 8, !dbg !28, !tbaa !4
-  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !28
-  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !28
-  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !28
-  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !28
-  %184 = bitcast i64* %180 to <4 x i64>*, !dbg !28
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %184, align 8, !dbg !28, !tbaa !4
-  %185 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !28
-  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !28
-  %187 = bitcast i64* %185 to <2 x i64>*, !dbg !28
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %187, align 8, !dbg !28, !tbaa !4
-  %188 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !28
-  store i64 -13, i64* %188, align 8, !dbg !28, !tbaa !4
-  %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !28
-  store i64 -15, i64* %189, align 8, !dbg !28, !tbaa !4
-  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !28
-  store i64* %190, i64** %178, align 8, !dbg !28
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments, i64 0), !dbg !28
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %117, align 8, !dbg !28, !tbaa !12
-  %rubyId_d419.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !85
-  %rawSym420.i = call i64 @rb_id2sym(i64 %rubyId_d419.i) #10, !dbg !85
-  %191 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !29
-  %192 = load i64*, i64** %191, align 8, !dbg !29
-  store i64 %106, i64* %192, align 8, !dbg !29, !tbaa !4
-  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !29
-  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !29
-  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !29
-  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !29
-  %197 = bitcast i64* %193 to <4 x i64>*, !dbg !29
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %197, align 8, !dbg !29, !tbaa !4
-  %198 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !29
-  %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !29
-  %200 = bitcast i64* %198 to <2 x i64>*, !dbg !29
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %200, align 8, !dbg !29, !tbaa !4
-  %201 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !29
-  store i64 -15, i64* %201, align 8, !dbg !29, !tbaa !4
-  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !29
-  store i64* %202, i64** %191, align 8, !dbg !29
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !29
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %117, align 8, !dbg !29, !tbaa !12
-  %rubyId_d439.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !86
-  %rawSym440.i = call i64 @rb_id2sym(i64 %rubyId_d439.i) #10, !dbg !86
-  %203 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !30
-  %204 = load i64*, i64** %203, align 8, !dbg !30
-  store i64 %106, i64* %204, align 8, !dbg !30, !tbaa !4
-  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !30
-  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !30
-  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !30
-  %208 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !30
-  %209 = bitcast i64* %205 to <4 x i64>*, !dbg !30
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %209, align 8, !dbg !30, !tbaa !4
-  %210 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !30
-  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !30
-  %212 = bitcast i64* %210 to <2 x i64>*, !dbg !30
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %212, align 8, !dbg !30, !tbaa !4
-  %213 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !30
-  store i64* %213, i64** %203, align 8, !dbg !30
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !30
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %117, align 8, !dbg !30, !tbaa !12
-  %rubyId_d457.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !87
-  %rawSym458.i = call i64 @rb_id2sym(i64 %rubyId_d457.i) #10, !dbg !87
-  %214 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !31
-  %215 = load i64*, i64** %214, align 8, !dbg !31
-  store i64 %106, i64* %215, align 8, !dbg !31, !tbaa !4
-  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !31
-  %217 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !31
-  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !31
-  %219 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !31
-  %220 = bitcast i64* %216 to <4 x i64>*, !dbg !31
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %220, align 8, !dbg !31, !tbaa !4
-  %221 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !31
-  store i64 -15, i64* %221, align 8, !dbg !31, !tbaa !4
-  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !31
-  store i64* %222, i64** %214, align 8, !dbg !31
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !31
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %117, align 8, !dbg !31, !tbaa !12
-  %rubyId_d473.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !88
-  %rawSym474.i = call i64 @rb_id2sym(i64 %rubyId_d473.i) #10, !dbg !88
-  %223 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !32
-  %224 = load i64*, i64** %223, align 8, !dbg !32
-  store i64 %106, i64* %224, align 8, !dbg !32, !tbaa !4
-  %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !32
-  %226 = getelementptr inbounds i64, i64* %225, i64 1, !dbg !32
-  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !32
-  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !32
-  %229 = bitcast i64* %225 to <4 x i64>*, !dbg !32
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %229, align 8, !dbg !32, !tbaa !4
-  %230 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !32
-  store i64* %230, i64** %223, align 8, !dbg !32
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !32
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %117, align 8, !dbg !32, !tbaa !12
-  %rubyId_d487.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !89
-  %rawSym488.i = call i64 @rb_id2sym(i64 %rubyId_d487.i) #10, !dbg !89
-  %231 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !33
-  %232 = load i64*, i64** %231, align 8, !dbg !33
-  store i64 %106, i64* %232, align 8, !dbg !33, !tbaa !4
-  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !33
-  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !33
-  %235 = bitcast i64* %233 to <2 x i64>*, !dbg !33
-  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %235, align 8, !dbg !33, !tbaa !4
-  %236 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !33
-  store i64 -15, i64* %236, align 8, !dbg !33, !tbaa !4
-  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !33
-  store i64* %237, i64** %231, align 8, !dbg !33
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !33
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %117, align 8, !dbg !33, !tbaa !12
-  %rubyId_d499.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !90
-  %rawSym500.i = call i64 @rb_id2sym(i64 %rubyId_d499.i) #10, !dbg !90
-  %238 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !34
-  %239 = load i64*, i64** %238, align 8, !dbg !34
-  store i64 %106, i64* %239, align 8, !dbg !34, !tbaa !4
-  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !34
-  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !34
-  %242 = bitcast i64* %240 to <2 x i64>*, !dbg !34
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %242, align 8, !dbg !34, !tbaa !4
-  %243 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !34
-  store i64* %243, i64** %238, align 8, !dbg !34
-  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !34
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %117, align 8, !dbg !34, !tbaa !12
-  %rubyId_d516.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !91
-  %rawSym517.i = call i64 @rb_id2sym(i64 %rubyId_d516.i) #10, !dbg !91
-  %rubyId_e519.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !92
-  %rawSym520.i = call i64 @rb_id2sym(i64 %rubyId_e519.i) #10, !dbg !92
-  %244 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !35
-  %245 = load i64*, i64** %244, align 8, !dbg !35
-  store i64 %106, i64* %245, align 8, !dbg !35, !tbaa !4
-  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !35
-  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !35
-  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !35
-  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !35
-  %250 = bitcast i64* %246 to <4 x i64>*, !dbg !35
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %250, align 8, !dbg !35, !tbaa !4
-  %251 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !35
-  %252 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !35
-  %253 = bitcast i64* %251 to <2 x i64>*, !dbg !35
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %253, align 8, !dbg !35, !tbaa !4
-  %254 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !35
-  store i64 -13, i64* %254, align 8, !dbg !35, !tbaa !4
-  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !35
-  store i64 -15, i64* %255, align 8, !dbg !35, !tbaa !4
-  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !35
-  store i64 -17, i64* %256, align 8, !dbg !35, !tbaa !4
-  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !35
-  store i64* %257, i64** %244, align 8, !dbg !35
-  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !35
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %117, align 8, !dbg !35, !tbaa !12
-  %rubyId_d542.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !93
-  %rawSym543.i = call i64 @rb_id2sym(i64 %rubyId_d542.i) #10, !dbg !93
-  %rubyId_e545.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !94
-  %rawSym546.i = call i64 @rb_id2sym(i64 %rubyId_e545.i) #10, !dbg !94
-  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !36
-  %259 = load i64*, i64** %258, align 8, !dbg !36
-  store i64 %106, i64* %259, align 8, !dbg !36, !tbaa !4
-  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !36
-  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !36
-  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !36
-  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !36
-  %264 = bitcast i64* %260 to <4 x i64>*, !dbg !36
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %264, align 8, !dbg !36, !tbaa !4
-  %265 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !36
-  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !36
-  %267 = bitcast i64* %265 to <2 x i64>*, !dbg !36
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %267, align 8, !dbg !36, !tbaa !4
-  %268 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !36
-  store i64 -15, i64* %268, align 8, !dbg !36, !tbaa !4
-  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !36
-  store i64 -17, i64* %269, align 8, !dbg !36, !tbaa !4
-  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !36
-  store i64* %270, i64** %258, align 8, !dbg !36
-  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !36
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %117, align 8, !dbg !36, !tbaa !12
-  %rubyId_d566.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !95
-  %rawSym567.i = call i64 @rb_id2sym(i64 %rubyId_d566.i) #10, !dbg !95
-  %rubyId_e569.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !96
-  %rawSym570.i = call i64 @rb_id2sym(i64 %rubyId_e569.i) #10, !dbg !96
-  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !37
-  %272 = load i64*, i64** %271, align 8, !dbg !37
-  store i64 %106, i64* %272, align 8, !dbg !37, !tbaa !4
-  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !37
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !37
-  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !37
-  %276 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !37
-  %277 = bitcast i64* %273 to <4 x i64>*, !dbg !37
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %277, align 8, !dbg !37, !tbaa !4
-  %278 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !37
-  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !37
-  %280 = bitcast i64* %278 to <2 x i64>*, !dbg !37
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %280, align 8, !dbg !37, !tbaa !4
-  %281 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !37
-  store i64 -17, i64* %281, align 8, !dbg !37, !tbaa !4
-  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !37
-  store i64* %282, i64** %271, align 8, !dbg !37
-  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !37
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %117, align 8, !dbg !37, !tbaa !12
-  %rubyId_d588.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !97
-  %rawSym589.i = call i64 @rb_id2sym(i64 %rubyId_d588.i) #10, !dbg !97
-  %rubyId_e591.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !98
-  %rawSym592.i = call i64 @rb_id2sym(i64 %rubyId_e591.i) #10, !dbg !98
-  %283 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !38
-  %284 = load i64*, i64** %283, align 8, !dbg !38
-  store i64 %106, i64* %284, align 8, !dbg !38, !tbaa !4
-  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !38
-  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !38
-  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !38
-  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !38
-  %289 = bitcast i64* %285 to <4 x i64>*, !dbg !38
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %289, align 8, !dbg !38, !tbaa !4
-  %290 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !38
-  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !38
-  %292 = bitcast i64* %290 to <2 x i64>*, !dbg !38
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %292, align 8, !dbg !38, !tbaa !4
-  %293 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !38
-  store i64* %293, i64** %283, align 8, !dbg !38
-  %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !38
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %117, align 8, !dbg !38, !tbaa !12
-  %rubyId_d608.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !99
-  %rawSym609.i = call i64 @rb_id2sym(i64 %rubyId_d608.i) #10, !dbg !99
-  %rubyId_e611.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !100
-  %rawSym612.i = call i64 @rb_id2sym(i64 %rubyId_e611.i) #10, !dbg !100
-  %294 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !39
-  %295 = load i64*, i64** %294, align 8, !dbg !39
-  store i64 %106, i64* %295, align 8, !dbg !39, !tbaa !4
-  %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !39
-  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !39
-  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !39
-  %299 = getelementptr inbounds i64, i64* %298, i64 1, !dbg !39
-  %300 = bitcast i64* %296 to <4 x i64>*, !dbg !39
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %300, align 8, !dbg !39, !tbaa !4
-  %301 = getelementptr inbounds i64, i64* %299, i64 1, !dbg !39
-  store i64 -17, i64* %301, align 8, !dbg !39, !tbaa !4
-  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !39
-  store i64* %302, i64** %294, align 8, !dbg !39
-  %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !39
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %117, align 8, !dbg !39, !tbaa !12
-  %rubyId_d626.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !101
-  %rawSym627.i = call i64 @rb_id2sym(i64 %rubyId_d626.i) #10, !dbg !101
-  %rubyId_e629.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !102
-  %rawSym630.i = call i64 @rb_id2sym(i64 %rubyId_e629.i) #10, !dbg !102
-  %303 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !40
-  %304 = load i64*, i64** %303, align 8, !dbg !40
-  store i64 %106, i64* %304, align 8, !dbg !40, !tbaa !4
-  %305 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !40
-  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !40
-  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !40
-  %308 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !40
-  %309 = bitcast i64* %305 to <4 x i64>*, !dbg !40
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %309, align 8, !dbg !40, !tbaa !4
-  %310 = getelementptr inbounds i64, i64* %308, i64 1, !dbg !40
-  store i64* %310, i64** %303, align 8, !dbg !40
-  %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !40
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %117, align 8, !dbg !40, !tbaa !12
-  %rubyId_d642.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !103
-  %rawSym643.i = call i64 @rb_id2sym(i64 %rubyId_d642.i) #10, !dbg !103
-  %rubyId_e645.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !104
-  %rawSym646.i = call i64 @rb_id2sym(i64 %rubyId_e645.i) #10, !dbg !104
-  %311 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !41
-  %312 = load i64*, i64** %311, align 8, !dbg !41
-  store i64 %106, i64* %312, align 8, !dbg !41, !tbaa !4
-  %313 = getelementptr inbounds i64, i64* %312, i64 1, !dbg !41
-  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !41
-  %315 = bitcast i64* %313 to <2 x i64>*, !dbg !41
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %315, align 8, !dbg !41, !tbaa !4
-  %316 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !41
-  store i64 -17, i64* %316, align 8, !dbg !41, !tbaa !4
-  %317 = getelementptr inbounds i64, i64* %316, i64 1, !dbg !41
-  store i64* %317, i64** %311, align 8, !dbg !41
-  %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !41
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %117, align 8, !dbg !41, !tbaa !12
-  %rubyId_d663.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !105
-  %rawSym664.i = call i64 @rb_id2sym(i64 %rubyId_d663.i) #10, !dbg !105
-  %rubyId_e666.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !106
-  %rawSym667.i = call i64 @rb_id2sym(i64 %rubyId_e666.i) #10, !dbg !106
-  %rubyId_baz.i4 = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !107
-  %rawSym669.i = call i64 @rb_id2sym(i64 %rubyId_baz.i4) #10, !dbg !107
-  %318 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !42
-  %319 = load i64*, i64** %318, align 8, !dbg !42
-  store i64 %106, i64* %319, align 8, !dbg !42, !tbaa !4
-  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !42
-  %321 = getelementptr inbounds i64, i64* %320, i64 1, !dbg !42
-  %322 = getelementptr inbounds i64, i64* %321, i64 1, !dbg !42
-  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !42
-  %324 = bitcast i64* %320 to <4 x i64>*, !dbg !42
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %324, align 8, !dbg !42, !tbaa !4
-  %325 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !42
-  %326 = getelementptr inbounds i64, i64* %325, i64 1, !dbg !42
-  %327 = bitcast i64* %325 to <2 x i64>*, !dbg !42
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %327, align 8, !dbg !42, !tbaa !4
-  %328 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !42
-  store i64 -13, i64* %328, align 8, !dbg !42, !tbaa !4
-  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !42
-  store i64 -15, i64* %329, align 8, !dbg !42, !tbaa !4
-  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !42
-  store i64 -17, i64* %330, align 8, !dbg !42, !tbaa !4
-  %331 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !42
-  store i64 -19, i64* %331, align 8, !dbg !42, !tbaa !4
-  %332 = getelementptr inbounds i64, i64* %331, i64 1, !dbg !42
-  store i64* %332, i64** %318, align 8, !dbg !42
-  %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !42
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %117, align 8, !dbg !42, !tbaa !12
-  %rubyId_d692.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !108
-  %rawSym693.i = call i64 @rb_id2sym(i64 %rubyId_d692.i) #10, !dbg !108
-  %rubyId_e695.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !109
-  %rawSym696.i = call i64 @rb_id2sym(i64 %rubyId_e695.i) #10, !dbg !109
-  %rubyId_baz698.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !110
-  %rawSym699.i = call i64 @rb_id2sym(i64 %rubyId_baz698.i) #10, !dbg !110
-  %333 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !43
-  %334 = load i64*, i64** %333, align 8, !dbg !43
-  store i64 %106, i64* %334, align 8, !dbg !43, !tbaa !4
-  %335 = getelementptr inbounds i64, i64* %334, i64 1, !dbg !43
-  %336 = getelementptr inbounds i64, i64* %335, i64 1, !dbg !43
-  %337 = getelementptr inbounds i64, i64* %336, i64 1, !dbg !43
-  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !43
-  %339 = bitcast i64* %335 to <4 x i64>*, !dbg !43
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %339, align 8, !dbg !43, !tbaa !4
-  %340 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !43
-  %341 = getelementptr inbounds i64, i64* %340, i64 1, !dbg !43
-  %342 = bitcast i64* %340 to <2 x i64>*, !dbg !43
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %342, align 8, !dbg !43, !tbaa !4
-  %343 = getelementptr inbounds i64, i64* %341, i64 1, !dbg !43
-  store i64 -15, i64* %343, align 8, !dbg !43, !tbaa !4
-  %344 = getelementptr inbounds i64, i64* %343, i64 1, !dbg !43
-  store i64 -17, i64* %344, align 8, !dbg !43, !tbaa !4
-  %345 = getelementptr inbounds i64, i64* %344, i64 1, !dbg !43
-  store i64 -19, i64* %345, align 8, !dbg !43, !tbaa !4
-  %346 = getelementptr inbounds i64, i64* %345, i64 1, !dbg !43
-  store i64* %346, i64** %333, align 8, !dbg !43
-  %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %117, align 8, !dbg !43, !tbaa !12
-  %rubyId_d720.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !111
-  %rawSym721.i = call i64 @rb_id2sym(i64 %rubyId_d720.i) #10, !dbg !111
-  %rubyId_e723.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !112
-  %rawSym724.i = call i64 @rb_id2sym(i64 %rubyId_e723.i) #10, !dbg !112
-  %rubyId_baz726.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !113
-  %rawSym727.i = call i64 @rb_id2sym(i64 %rubyId_baz726.i) #10, !dbg !113
-  %347 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !44
-  %348 = load i64*, i64** %347, align 8, !dbg !44
-  store i64 %106, i64* %348, align 8, !dbg !44, !tbaa !4
-  %349 = getelementptr inbounds i64, i64* %348, i64 1, !dbg !44
-  %350 = getelementptr inbounds i64, i64* %349, i64 1, !dbg !44
-  %351 = getelementptr inbounds i64, i64* %350, i64 1, !dbg !44
-  %352 = getelementptr inbounds i64, i64* %351, i64 1, !dbg !44
-  %353 = bitcast i64* %349 to <4 x i64>*, !dbg !44
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %353, align 8, !dbg !44, !tbaa !4
-  %354 = getelementptr inbounds i64, i64* %352, i64 1, !dbg !44
-  %355 = getelementptr inbounds i64, i64* %354, i64 1, !dbg !44
-  %356 = bitcast i64* %354 to <2 x i64>*, !dbg !44
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %356, align 8, !dbg !44, !tbaa !4
-  %357 = getelementptr inbounds i64, i64* %355, i64 1, !dbg !44
-  store i64 -17, i64* %357, align 8, !dbg !44, !tbaa !4
-  %358 = getelementptr inbounds i64, i64* %357, i64 1, !dbg !44
-  store i64 -19, i64* %358, align 8, !dbg !44, !tbaa !4
-  %359 = getelementptr inbounds i64, i64* %358, i64 1, !dbg !44
-  store i64* %359, i64** %347, align 8, !dbg !44
-  %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !44
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %117, align 8, !dbg !44, !tbaa !12
-  %rubyId_d746.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !114
-  %rawSym747.i = call i64 @rb_id2sym(i64 %rubyId_d746.i) #10, !dbg !114
-  %rubyId_e749.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !115
-  %rawSym750.i = call i64 @rb_id2sym(i64 %rubyId_e749.i) #10, !dbg !115
-  %rubyId_baz752.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !116
-  %rawSym753.i = call i64 @rb_id2sym(i64 %rubyId_baz752.i) #10, !dbg !116
-  %360 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !45
-  %361 = load i64*, i64** %360, align 8, !dbg !45
-  store i64 %106, i64* %361, align 8, !dbg !45, !tbaa !4
-  %362 = getelementptr inbounds i64, i64* %361, i64 1, !dbg !45
-  %363 = getelementptr inbounds i64, i64* %362, i64 1, !dbg !45
-  %364 = getelementptr inbounds i64, i64* %363, i64 1, !dbg !45
-  %365 = getelementptr inbounds i64, i64* %364, i64 1, !dbg !45
-  %366 = bitcast i64* %362 to <4 x i64>*, !dbg !45
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %366, align 8, !dbg !45, !tbaa !4
-  %367 = getelementptr inbounds i64, i64* %365, i64 1, !dbg !45
-  %368 = getelementptr inbounds i64, i64* %367, i64 1, !dbg !45
-  %369 = bitcast i64* %367 to <2 x i64>*, !dbg !45
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %369, align 8, !dbg !45, !tbaa !4
-  %370 = getelementptr inbounds i64, i64* %368, i64 1, !dbg !45
-  store i64 -19, i64* %370, align 8, !dbg !45, !tbaa !4
-  %371 = getelementptr inbounds i64, i64* %370, i64 1, !dbg !45
-  store i64* %371, i64** %360, align 8, !dbg !45
-  %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !45
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %117, align 8, !dbg !45, !tbaa !12
-  %rubyId_d770.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !117
-  %rawSym771.i = call i64 @rb_id2sym(i64 %rubyId_d770.i) #10, !dbg !117
-  %rubyId_e773.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !118
-  %rawSym774.i = call i64 @rb_id2sym(i64 %rubyId_e773.i) #10, !dbg !118
-  %rubyId_baz776.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !119
-  %rawSym777.i = call i64 @rb_id2sym(i64 %rubyId_baz776.i) #10, !dbg !119
-  %372 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !46
-  %373 = load i64*, i64** %372, align 8, !dbg !46
-  store i64 %106, i64* %373, align 8, !dbg !46, !tbaa !4
-  %374 = getelementptr inbounds i64, i64* %373, i64 1, !dbg !46
-  %375 = getelementptr inbounds i64, i64* %374, i64 1, !dbg !46
-  %376 = getelementptr inbounds i64, i64* %375, i64 1, !dbg !46
-  %377 = getelementptr inbounds i64, i64* %376, i64 1, !dbg !46
-  %378 = bitcast i64* %374 to <4 x i64>*, !dbg !46
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %378, align 8, !dbg !46, !tbaa !4
-  %379 = getelementptr inbounds i64, i64* %377, i64 1, !dbg !46
-  %380 = getelementptr inbounds i64, i64* %379, i64 1, !dbg !46
-  %381 = bitcast i64* %379 to <2 x i64>*, !dbg !46
-  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %381, align 8, !dbg !46, !tbaa !4
-  %382 = getelementptr inbounds i64, i64* %380, i64 1, !dbg !46
-  store i64* %382, i64** %372, align 8, !dbg !46
-  %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !46
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %117, align 8, !dbg !46, !tbaa !12
-  %rubyId_d792.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !120
-  %rawSym793.i = call i64 @rb_id2sym(i64 %rubyId_d792.i) #10, !dbg !120
-  %rubyId_e795.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !121
-  %rawSym796.i = call i64 @rb_id2sym(i64 %rubyId_e795.i) #10, !dbg !121
-  %rubyId_baz798.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !122
-  %rawSym799.i = call i64 @rb_id2sym(i64 %rubyId_baz798.i) #10, !dbg !122
-  %383 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !47
-  %384 = load i64*, i64** %383, align 8, !dbg !47
-  store i64 %106, i64* %384, align 8, !dbg !47, !tbaa !4
-  %385 = getelementptr inbounds i64, i64* %384, i64 1, !dbg !47
-  %386 = getelementptr inbounds i64, i64* %385, i64 1, !dbg !47
-  %387 = getelementptr inbounds i64, i64* %386, i64 1, !dbg !47
-  %388 = getelementptr inbounds i64, i64* %387, i64 1, !dbg !47
-  %389 = bitcast i64* %385 to <4 x i64>*, !dbg !47
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %389, align 8, !dbg !47, !tbaa !4
-  %390 = getelementptr inbounds i64, i64* %388, i64 1, !dbg !47
-  store i64 -19, i64* %390, align 8, !dbg !47, !tbaa !4
-  %391 = getelementptr inbounds i64, i64* %390, i64 1, !dbg !47
-  store i64* %391, i64** %383, align 8, !dbg !47
-  %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !47
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %117, align 8, !dbg !47, !tbaa !12
-  %rubyId_d812.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !123
-  %rawSym813.i = call i64 @rb_id2sym(i64 %rubyId_d812.i) #10, !dbg !123
-  %rubyId_e815.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !124
-  %rawSym816.i = call i64 @rb_id2sym(i64 %rubyId_e815.i) #10, !dbg !124
-  %rubyId_baz818.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !125
-  %rawSym819.i = call i64 @rb_id2sym(i64 %rubyId_baz818.i) #10, !dbg !125
-  %392 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !48
-  %393 = load i64*, i64** %392, align 8, !dbg !48
-  store i64 %106, i64* %393, align 8, !dbg !48, !tbaa !4
-  %394 = getelementptr inbounds i64, i64* %393, i64 1, !dbg !48
-  %395 = getelementptr inbounds i64, i64* %394, i64 1, !dbg !48
-  %396 = getelementptr inbounds i64, i64* %395, i64 1, !dbg !48
-  %397 = getelementptr inbounds i64, i64* %396, i64 1, !dbg !48
-  %398 = bitcast i64* %394 to <4 x i64>*, !dbg !48
-  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %398, align 8, !dbg !48, !tbaa !4
-  %399 = getelementptr inbounds i64, i64* %397, i64 1, !dbg !48
-  store i64* %399, i64** %392, align 8, !dbg !48
-  %send44 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !48
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %117, align 8, !dbg !28, !tbaa !14
+  %rubyId_d398.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !86
+  %rawSym399.i = call i64 @rb_id2sym(i64 %rubyId_d398.i) #10, !dbg !86
+  %178 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !30
+  %179 = load i64*, i64** %178, align 8, !dbg !30
+  store i64 %106, i64* %179, align 8, !dbg !30, !tbaa !6
+  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !30
+  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !30
+  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !30
+  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !30
+  %184 = bitcast i64* %180 to <4 x i64>*, !dbg !30
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %184, align 8, !dbg !30, !tbaa !6
+  %185 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !30
+  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !30
+  %187 = bitcast i64* %185 to <2 x i64>*, !dbg !30
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %187, align 8, !dbg !30, !tbaa !6
+  %188 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !30
+  store i64 -13, i64* %188, align 8, !dbg !30, !tbaa !6
+  %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !30
+  store i64 -15, i64* %189, align 8, !dbg !30, !tbaa !6
+  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !30
+  store i64* %190, i64** %178, align 8, !dbg !30
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments, i64 0), !dbg !30
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %117, align 8, !dbg !30, !tbaa !14
+  %rubyId_d419.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !87
+  %rawSym420.i = call i64 @rb_id2sym(i64 %rubyId_d419.i) #10, !dbg !87
+  %191 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !31
+  %192 = load i64*, i64** %191, align 8, !dbg !31
+  store i64 %106, i64* %192, align 8, !dbg !31, !tbaa !6
+  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !31
+  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !31
+  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !31
+  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !31
+  %197 = bitcast i64* %193 to <4 x i64>*, !dbg !31
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %197, align 8, !dbg !31, !tbaa !6
+  %198 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !31
+  %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !31
+  %200 = bitcast i64* %198 to <2 x i64>*, !dbg !31
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %200, align 8, !dbg !31, !tbaa !6
+  %201 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !31
+  store i64 -15, i64* %201, align 8, !dbg !31, !tbaa !6
+  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !31
+  store i64* %202, i64** %191, align 8, !dbg !31
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !31
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %117, align 8, !dbg !31, !tbaa !14
+  %rubyId_d439.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !88
+  %rawSym440.i = call i64 @rb_id2sym(i64 %rubyId_d439.i) #10, !dbg !88
+  %203 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !32
+  %204 = load i64*, i64** %203, align 8, !dbg !32
+  store i64 %106, i64* %204, align 8, !dbg !32, !tbaa !6
+  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !32
+  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !32
+  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !32
+  %208 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !32
+  %209 = bitcast i64* %205 to <4 x i64>*, !dbg !32
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %209, align 8, !dbg !32, !tbaa !6
+  %210 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !32
+  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !32
+  %212 = bitcast i64* %210 to <2 x i64>*, !dbg !32
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %212, align 8, !dbg !32, !tbaa !6
+  %213 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !32
+  store i64* %213, i64** %203, align 8, !dbg !32
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !32
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %117, align 8, !dbg !32, !tbaa !14
+  %rubyId_d457.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !89
+  %rawSym458.i = call i64 @rb_id2sym(i64 %rubyId_d457.i) #10, !dbg !89
+  %214 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !33
+  %215 = load i64*, i64** %214, align 8, !dbg !33
+  store i64 %106, i64* %215, align 8, !dbg !33, !tbaa !6
+  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !33
+  %217 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !33
+  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !33
+  %219 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !33
+  %220 = bitcast i64* %216 to <4 x i64>*, !dbg !33
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %220, align 8, !dbg !33, !tbaa !6
+  %221 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !33
+  store i64 -15, i64* %221, align 8, !dbg !33, !tbaa !6
+  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !33
+  store i64* %222, i64** %214, align 8, !dbg !33
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !33
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %117, align 8, !dbg !33, !tbaa !14
+  %rubyId_d473.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !90
+  %rawSym474.i = call i64 @rb_id2sym(i64 %rubyId_d473.i) #10, !dbg !90
+  %223 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !34
+  %224 = load i64*, i64** %223, align 8, !dbg !34
+  store i64 %106, i64* %224, align 8, !dbg !34, !tbaa !6
+  %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !34
+  %226 = getelementptr inbounds i64, i64* %225, i64 1, !dbg !34
+  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !34
+  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !34
+  %229 = bitcast i64* %225 to <4 x i64>*, !dbg !34
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %229, align 8, !dbg !34, !tbaa !6
+  %230 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !34
+  store i64* %230, i64** %223, align 8, !dbg !34
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !34
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %117, align 8, !dbg !34, !tbaa !14
+  %rubyId_d487.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !91
+  %rawSym488.i = call i64 @rb_id2sym(i64 %rubyId_d487.i) #10, !dbg !91
+  %231 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !35
+  %232 = load i64*, i64** %231, align 8, !dbg !35
+  store i64 %106, i64* %232, align 8, !dbg !35, !tbaa !6
+  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !35
+  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !35
+  %235 = bitcast i64* %233 to <2 x i64>*, !dbg !35
+  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %235, align 8, !dbg !35, !tbaa !6
+  %236 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !35
+  store i64 -15, i64* %236, align 8, !dbg !35, !tbaa !6
+  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !35
+  store i64* %237, i64** %231, align 8, !dbg !35
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !35
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %117, align 8, !dbg !35, !tbaa !14
+  %rubyId_d499.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !92
+  %rawSym500.i = call i64 @rb_id2sym(i64 %rubyId_d499.i) #10, !dbg !92
+  %238 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !36
+  %239 = load i64*, i64** %238, align 8, !dbg !36
+  store i64 %106, i64* %239, align 8, !dbg !36, !tbaa !6
+  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !36
+  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !36
+  %242 = bitcast i64* %240 to <2 x i64>*, !dbg !36
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %242, align 8, !dbg !36, !tbaa !6
+  %243 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !36
+  store i64* %243, i64** %238, align 8, !dbg !36
+  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !36
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %117, align 8, !dbg !36, !tbaa !14
+  %rubyId_d516.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !93
+  %rawSym517.i = call i64 @rb_id2sym(i64 %rubyId_d516.i) #10, !dbg !93
+  %rubyId_e519.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !94
+  %rawSym520.i = call i64 @rb_id2sym(i64 %rubyId_e519.i) #10, !dbg !94
+  %244 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !37
+  %245 = load i64*, i64** %244, align 8, !dbg !37
+  store i64 %106, i64* %245, align 8, !dbg !37, !tbaa !6
+  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !37
+  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !37
+  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !37
+  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !37
+  %250 = bitcast i64* %246 to <4 x i64>*, !dbg !37
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %250, align 8, !dbg !37, !tbaa !6
+  %251 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !37
+  %252 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !37
+  %253 = bitcast i64* %251 to <2 x i64>*, !dbg !37
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %253, align 8, !dbg !37, !tbaa !6
+  %254 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !37
+  store i64 -13, i64* %254, align 8, !dbg !37, !tbaa !6
+  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !37
+  store i64 -15, i64* %255, align 8, !dbg !37, !tbaa !6
+  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !37
+  store i64 -17, i64* %256, align 8, !dbg !37, !tbaa !6
+  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !37
+  store i64* %257, i64** %244, align 8, !dbg !37
+  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !37
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %117, align 8, !dbg !37, !tbaa !14
+  %rubyId_d542.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !95
+  %rawSym543.i = call i64 @rb_id2sym(i64 %rubyId_d542.i) #10, !dbg !95
+  %rubyId_e545.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !96
+  %rawSym546.i = call i64 @rb_id2sym(i64 %rubyId_e545.i) #10, !dbg !96
+  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !38
+  %259 = load i64*, i64** %258, align 8, !dbg !38
+  store i64 %106, i64* %259, align 8, !dbg !38, !tbaa !6
+  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !38
+  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !38
+  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !38
+  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !38
+  %264 = bitcast i64* %260 to <4 x i64>*, !dbg !38
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %264, align 8, !dbg !38, !tbaa !6
+  %265 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !38
+  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !38
+  %267 = bitcast i64* %265 to <2 x i64>*, !dbg !38
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %267, align 8, !dbg !38, !tbaa !6
+  %268 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !38
+  store i64 -15, i64* %268, align 8, !dbg !38, !tbaa !6
+  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !38
+  store i64 -17, i64* %269, align 8, !dbg !38, !tbaa !6
+  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !38
+  store i64* %270, i64** %258, align 8, !dbg !38
+  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !38
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %117, align 8, !dbg !38, !tbaa !14
+  %rubyId_d566.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !97
+  %rawSym567.i = call i64 @rb_id2sym(i64 %rubyId_d566.i) #10, !dbg !97
+  %rubyId_e569.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !98
+  %rawSym570.i = call i64 @rb_id2sym(i64 %rubyId_e569.i) #10, !dbg !98
+  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !39
+  %272 = load i64*, i64** %271, align 8, !dbg !39
+  store i64 %106, i64* %272, align 8, !dbg !39, !tbaa !6
+  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !39
+  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !39
+  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !39
+  %276 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !39
+  %277 = bitcast i64* %273 to <4 x i64>*, !dbg !39
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %277, align 8, !dbg !39, !tbaa !6
+  %278 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !39
+  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !39
+  %280 = bitcast i64* %278 to <2 x i64>*, !dbg !39
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %280, align 8, !dbg !39, !tbaa !6
+  %281 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !39
+  store i64 -17, i64* %281, align 8, !dbg !39, !tbaa !6
+  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !39
+  store i64* %282, i64** %271, align 8, !dbg !39
+  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !39
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %117, align 8, !dbg !39, !tbaa !14
+  %rubyId_d588.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !99
+  %rawSym589.i = call i64 @rb_id2sym(i64 %rubyId_d588.i) #10, !dbg !99
+  %rubyId_e591.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !100
+  %rawSym592.i = call i64 @rb_id2sym(i64 %rubyId_e591.i) #10, !dbg !100
+  %283 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !40
+  %284 = load i64*, i64** %283, align 8, !dbg !40
+  store i64 %106, i64* %284, align 8, !dbg !40, !tbaa !6
+  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !40
+  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !40
+  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !40
+  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !40
+  %289 = bitcast i64* %285 to <4 x i64>*, !dbg !40
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %289, align 8, !dbg !40, !tbaa !6
+  %290 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !40
+  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !40
+  %292 = bitcast i64* %290 to <2 x i64>*, !dbg !40
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %292, align 8, !dbg !40, !tbaa !6
+  %293 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !40
+  store i64* %293, i64** %283, align 8, !dbg !40
+  %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !40
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %117, align 8, !dbg !40, !tbaa !14
+  %rubyId_d608.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !101
+  %rawSym609.i = call i64 @rb_id2sym(i64 %rubyId_d608.i) #10, !dbg !101
+  %rubyId_e611.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !102
+  %rawSym612.i = call i64 @rb_id2sym(i64 %rubyId_e611.i) #10, !dbg !102
+  %294 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !41
+  %295 = load i64*, i64** %294, align 8, !dbg !41
+  store i64 %106, i64* %295, align 8, !dbg !41, !tbaa !6
+  %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !41
+  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !41
+  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !41
+  %299 = getelementptr inbounds i64, i64* %298, i64 1, !dbg !41
+  %300 = bitcast i64* %296 to <4 x i64>*, !dbg !41
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %300, align 8, !dbg !41, !tbaa !6
+  %301 = getelementptr inbounds i64, i64* %299, i64 1, !dbg !41
+  store i64 -17, i64* %301, align 8, !dbg !41, !tbaa !6
+  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !41
+  store i64* %302, i64** %294, align 8, !dbg !41
+  %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !41
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %117, align 8, !dbg !41, !tbaa !14
+  %rubyId_d626.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !103
+  %rawSym627.i = call i64 @rb_id2sym(i64 %rubyId_d626.i) #10, !dbg !103
+  %rubyId_e629.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !104
+  %rawSym630.i = call i64 @rb_id2sym(i64 %rubyId_e629.i) #10, !dbg !104
+  %303 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !42
+  %304 = load i64*, i64** %303, align 8, !dbg !42
+  store i64 %106, i64* %304, align 8, !dbg !42, !tbaa !6
+  %305 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !42
+  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !42
+  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !42
+  %308 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !42
+  %309 = bitcast i64* %305 to <4 x i64>*, !dbg !42
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %309, align 8, !dbg !42, !tbaa !6
+  %310 = getelementptr inbounds i64, i64* %308, i64 1, !dbg !42
+  store i64* %310, i64** %303, align 8, !dbg !42
+  %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !42
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %117, align 8, !dbg !42, !tbaa !14
+  %rubyId_d642.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !105
+  %rawSym643.i = call i64 @rb_id2sym(i64 %rubyId_d642.i) #10, !dbg !105
+  %rubyId_e645.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !106
+  %rawSym646.i = call i64 @rb_id2sym(i64 %rubyId_e645.i) #10, !dbg !106
+  %311 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !43
+  %312 = load i64*, i64** %311, align 8, !dbg !43
+  store i64 %106, i64* %312, align 8, !dbg !43, !tbaa !6
+  %313 = getelementptr inbounds i64, i64* %312, i64 1, !dbg !43
+  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !43
+  %315 = bitcast i64* %313 to <2 x i64>*, !dbg !43
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %315, align 8, !dbg !43, !tbaa !6
+  %316 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !43
+  store i64 -17, i64* %316, align 8, !dbg !43, !tbaa !6
+  %317 = getelementptr inbounds i64, i64* %316, i64 1, !dbg !43
+  store i64* %317, i64** %311, align 8, !dbg !43
+  %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !43
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %117, align 8, !dbg !43, !tbaa !14
+  %rubyId_d663.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !107
+  %rawSym664.i = call i64 @rb_id2sym(i64 %rubyId_d663.i) #10, !dbg !107
+  %rubyId_e666.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !108
+  %rawSym667.i = call i64 @rb_id2sym(i64 %rubyId_e666.i) #10, !dbg !108
+  %rubyId_baz.i4 = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !109
+  %rawSym669.i = call i64 @rb_id2sym(i64 %rubyId_baz.i4) #10, !dbg !109
+  %318 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !44
+  %319 = load i64*, i64** %318, align 8, !dbg !44
+  store i64 %106, i64* %319, align 8, !dbg !44, !tbaa !6
+  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !44
+  %321 = getelementptr inbounds i64, i64* %320, i64 1, !dbg !44
+  %322 = getelementptr inbounds i64, i64* %321, i64 1, !dbg !44
+  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !44
+  %324 = bitcast i64* %320 to <4 x i64>*, !dbg !44
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %324, align 8, !dbg !44, !tbaa !6
+  %325 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !44
+  %326 = getelementptr inbounds i64, i64* %325, i64 1, !dbg !44
+  %327 = bitcast i64* %325 to <2 x i64>*, !dbg !44
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %327, align 8, !dbg !44, !tbaa !6
+  %328 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !44
+  store i64 -13, i64* %328, align 8, !dbg !44, !tbaa !6
+  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !44
+  store i64 -15, i64* %329, align 8, !dbg !44, !tbaa !6
+  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !44
+  store i64 -17, i64* %330, align 8, !dbg !44, !tbaa !6
+  %331 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !44
+  store i64 -19, i64* %331, align 8, !dbg !44, !tbaa !6
+  %332 = getelementptr inbounds i64, i64* %331, i64 1, !dbg !44
+  store i64* %332, i64** %318, align 8, !dbg !44
+  %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !44
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %117, align 8, !dbg !44, !tbaa !14
+  %rubyId_d692.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !110
+  %rawSym693.i = call i64 @rb_id2sym(i64 %rubyId_d692.i) #10, !dbg !110
+  %rubyId_e695.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !111
+  %rawSym696.i = call i64 @rb_id2sym(i64 %rubyId_e695.i) #10, !dbg !111
+  %rubyId_baz698.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !112
+  %rawSym699.i = call i64 @rb_id2sym(i64 %rubyId_baz698.i) #10, !dbg !112
+  %333 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !45
+  %334 = load i64*, i64** %333, align 8, !dbg !45
+  store i64 %106, i64* %334, align 8, !dbg !45, !tbaa !6
+  %335 = getelementptr inbounds i64, i64* %334, i64 1, !dbg !45
+  %336 = getelementptr inbounds i64, i64* %335, i64 1, !dbg !45
+  %337 = getelementptr inbounds i64, i64* %336, i64 1, !dbg !45
+  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !45
+  %339 = bitcast i64* %335 to <4 x i64>*, !dbg !45
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %339, align 8, !dbg !45, !tbaa !6
+  %340 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !45
+  %341 = getelementptr inbounds i64, i64* %340, i64 1, !dbg !45
+  %342 = bitcast i64* %340 to <2 x i64>*, !dbg !45
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %342, align 8, !dbg !45, !tbaa !6
+  %343 = getelementptr inbounds i64, i64* %341, i64 1, !dbg !45
+  store i64 -15, i64* %343, align 8, !dbg !45, !tbaa !6
+  %344 = getelementptr inbounds i64, i64* %343, i64 1, !dbg !45
+  store i64 -17, i64* %344, align 8, !dbg !45, !tbaa !6
+  %345 = getelementptr inbounds i64, i64* %344, i64 1, !dbg !45
+  store i64 -19, i64* %345, align 8, !dbg !45, !tbaa !6
+  %346 = getelementptr inbounds i64, i64* %345, i64 1, !dbg !45
+  store i64* %346, i64** %333, align 8, !dbg !45
+  %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !45
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %117, align 8, !dbg !45, !tbaa !14
+  %rubyId_d720.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !113
+  %rawSym721.i = call i64 @rb_id2sym(i64 %rubyId_d720.i) #10, !dbg !113
+  %rubyId_e723.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !114
+  %rawSym724.i = call i64 @rb_id2sym(i64 %rubyId_e723.i) #10, !dbg !114
+  %rubyId_baz726.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !115
+  %rawSym727.i = call i64 @rb_id2sym(i64 %rubyId_baz726.i) #10, !dbg !115
+  %347 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !46
+  %348 = load i64*, i64** %347, align 8, !dbg !46
+  store i64 %106, i64* %348, align 8, !dbg !46, !tbaa !6
+  %349 = getelementptr inbounds i64, i64* %348, i64 1, !dbg !46
+  %350 = getelementptr inbounds i64, i64* %349, i64 1, !dbg !46
+  %351 = getelementptr inbounds i64, i64* %350, i64 1, !dbg !46
+  %352 = getelementptr inbounds i64, i64* %351, i64 1, !dbg !46
+  %353 = bitcast i64* %349 to <4 x i64>*, !dbg !46
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %353, align 8, !dbg !46, !tbaa !6
+  %354 = getelementptr inbounds i64, i64* %352, i64 1, !dbg !46
+  %355 = getelementptr inbounds i64, i64* %354, i64 1, !dbg !46
+  %356 = bitcast i64* %354 to <2 x i64>*, !dbg !46
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %356, align 8, !dbg !46, !tbaa !6
+  %357 = getelementptr inbounds i64, i64* %355, i64 1, !dbg !46
+  store i64 -17, i64* %357, align 8, !dbg !46, !tbaa !6
+  %358 = getelementptr inbounds i64, i64* %357, i64 1, !dbg !46
+  store i64 -19, i64* %358, align 8, !dbg !46, !tbaa !6
+  %359 = getelementptr inbounds i64, i64* %358, i64 1, !dbg !46
+  store i64* %359, i64** %347, align 8, !dbg !46
+  %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !46
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %117, align 8, !dbg !46, !tbaa !14
+  %rubyId_d746.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !116
+  %rawSym747.i = call i64 @rb_id2sym(i64 %rubyId_d746.i) #10, !dbg !116
+  %rubyId_e749.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !117
+  %rawSym750.i = call i64 @rb_id2sym(i64 %rubyId_e749.i) #10, !dbg !117
+  %rubyId_baz752.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !118
+  %rawSym753.i = call i64 @rb_id2sym(i64 %rubyId_baz752.i) #10, !dbg !118
+  %360 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !47
+  %361 = load i64*, i64** %360, align 8, !dbg !47
+  store i64 %106, i64* %361, align 8, !dbg !47, !tbaa !6
+  %362 = getelementptr inbounds i64, i64* %361, i64 1, !dbg !47
+  %363 = getelementptr inbounds i64, i64* %362, i64 1, !dbg !47
+  %364 = getelementptr inbounds i64, i64* %363, i64 1, !dbg !47
+  %365 = getelementptr inbounds i64, i64* %364, i64 1, !dbg !47
+  %366 = bitcast i64* %362 to <4 x i64>*, !dbg !47
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %366, align 8, !dbg !47, !tbaa !6
+  %367 = getelementptr inbounds i64, i64* %365, i64 1, !dbg !47
+  %368 = getelementptr inbounds i64, i64* %367, i64 1, !dbg !47
+  %369 = bitcast i64* %367 to <2 x i64>*, !dbg !47
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %369, align 8, !dbg !47, !tbaa !6
+  %370 = getelementptr inbounds i64, i64* %368, i64 1, !dbg !47
+  store i64 -19, i64* %370, align 8, !dbg !47, !tbaa !6
+  %371 = getelementptr inbounds i64, i64* %370, i64 1, !dbg !47
+  store i64* %371, i64** %360, align 8, !dbg !47
+  %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !47
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %117, align 8, !dbg !47, !tbaa !14
+  %rubyId_d770.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !119
+  %rawSym771.i = call i64 @rb_id2sym(i64 %rubyId_d770.i) #10, !dbg !119
+  %rubyId_e773.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !120
+  %rawSym774.i = call i64 @rb_id2sym(i64 %rubyId_e773.i) #10, !dbg !120
+  %rubyId_baz776.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !121
+  %rawSym777.i = call i64 @rb_id2sym(i64 %rubyId_baz776.i) #10, !dbg !121
+  %372 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !48
+  %373 = load i64*, i64** %372, align 8, !dbg !48
+  store i64 %106, i64* %373, align 8, !dbg !48, !tbaa !6
+  %374 = getelementptr inbounds i64, i64* %373, i64 1, !dbg !48
+  %375 = getelementptr inbounds i64, i64* %374, i64 1, !dbg !48
+  %376 = getelementptr inbounds i64, i64* %375, i64 1, !dbg !48
+  %377 = getelementptr inbounds i64, i64* %376, i64 1, !dbg !48
+  %378 = bitcast i64* %374 to <4 x i64>*, !dbg !48
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %378, align 8, !dbg !48, !tbaa !6
+  %379 = getelementptr inbounds i64, i64* %377, i64 1, !dbg !48
+  %380 = getelementptr inbounds i64, i64* %379, i64 1, !dbg !48
+  %381 = bitcast i64* %379 to <2 x i64>*, !dbg !48
+  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %381, align 8, !dbg !48, !tbaa !6
+  %382 = getelementptr inbounds i64, i64* %380, i64 1, !dbg !48
+  store i64* %382, i64** %372, align 8, !dbg !48
+  %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !48
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %117, align 8, !dbg !48, !tbaa !14
+  %rubyId_d792.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !122
+  %rawSym793.i = call i64 @rb_id2sym(i64 %rubyId_d792.i) #10, !dbg !122
+  %rubyId_e795.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !123
+  %rawSym796.i = call i64 @rb_id2sym(i64 %rubyId_e795.i) #10, !dbg !123
+  %rubyId_baz798.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !124
+  %rawSym799.i = call i64 @rb_id2sym(i64 %rubyId_baz798.i) #10, !dbg !124
+  %383 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !49
+  %384 = load i64*, i64** %383, align 8, !dbg !49
+  store i64 %106, i64* %384, align 8, !dbg !49, !tbaa !6
+  %385 = getelementptr inbounds i64, i64* %384, i64 1, !dbg !49
+  %386 = getelementptr inbounds i64, i64* %385, i64 1, !dbg !49
+  %387 = getelementptr inbounds i64, i64* %386, i64 1, !dbg !49
+  %388 = getelementptr inbounds i64, i64* %387, i64 1, !dbg !49
+  %389 = bitcast i64* %385 to <4 x i64>*, !dbg !49
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %389, align 8, !dbg !49, !tbaa !6
+  %390 = getelementptr inbounds i64, i64* %388, i64 1, !dbg !49
+  store i64 -19, i64* %390, align 8, !dbg !49, !tbaa !6
+  %391 = getelementptr inbounds i64, i64* %390, i64 1, !dbg !49
+  store i64* %391, i64** %383, align 8, !dbg !49
+  %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !49
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %117, align 8, !dbg !49, !tbaa !14
+  %rubyId_d812.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !125
+  %rawSym813.i = call i64 @rb_id2sym(i64 %rubyId_d812.i) #10, !dbg !125
+  %rubyId_e815.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !126
+  %rawSym816.i = call i64 @rb_id2sym(i64 %rubyId_e815.i) #10, !dbg !126
+  %rubyId_baz818.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !127
+  %rawSym819.i = call i64 @rb_id2sym(i64 %rubyId_baz818.i) #10, !dbg !127
+  %392 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !50
+  %393 = load i64*, i64** %392, align 8, !dbg !50
+  store i64 %106, i64* %393, align 8, !dbg !50, !tbaa !6
+  %394 = getelementptr inbounds i64, i64* %393, i64 1, !dbg !50
+  %395 = getelementptr inbounds i64, i64* %394, i64 1, !dbg !50
+  %396 = getelementptr inbounds i64, i64* %395, i64 1, !dbg !50
+  %397 = getelementptr inbounds i64, i64* %396, i64 1, !dbg !50
+  %398 = bitcast i64* %394 to <4 x i64>*, !dbg !50
+  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %398, align 8, !dbg !50, !tbaa !6
+  %399 = getelementptr inbounds i64, i64* %397, i64 1, !dbg !50
+  store i64* %399, i64** %392, align 8, !dbg !50
+  %send44 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !50
   call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %110)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %111)
   ret void
@@ -1303,132 +1303,134 @@ attributes #10 = { nounwind }
 attributes #11 = { willreturn }
 attributes #12 = { nounwind allocsize(0,1) }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/all_arguments.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "Object#take_arguments", linkageName: "func_Object#take_arguments", scope: null, file: !2, line: 4, type: !9, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = !DISubroutineType(types: !10)
-!10 = !{!11}
-!11 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!12 = !{!13, !13, i64 0}
-!13 = !{!"any pointer", !6, i64 0}
-!14 = !DILocation(line: 4, column: 1, scope: !8)
-!15 = !{!16, !5, i64 0}
-!16 = !{!"RBasic", !5, i64 0, !5, i64 8}
-!17 = !{!"branch_weights", i32 1, i32 2000}
-!18 = !DILocation(line: 4, column: 23, scope: !8)
-!19 = !DILocation(line: 4, column: 36, scope: !8)
-!20 = !DILocation(line: 0, scope: !8)
-!21 = !DILocation(line: 5, column: 10, scope: !8)
-!22 = !{!23}
-!23 = distinct !{!23, !24, !"sorbet_buildArrayIntrinsic: argument 0"}
-!24 = distinct !{!24, !"sorbet_buildArrayIntrinsic"}
-!25 = !DILocation(line: 5, column: 5, scope: !8)
-!26 = !DILocation(line: 4, column: 1, scope: !27)
-!27 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !9, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!28 = !DILocation(line: 8, column: 1, scope: !27)
-!29 = !DILocation(line: 9, column: 1, scope: !27)
-!30 = !DILocation(line: 10, column: 1, scope: !27)
-!31 = !DILocation(line: 11, column: 1, scope: !27)
-!32 = !DILocation(line: 12, column: 1, scope: !27)
-!33 = !DILocation(line: 13, column: 1, scope: !27)
-!34 = !DILocation(line: 14, column: 1, scope: !27)
-!35 = !DILocation(line: 16, column: 1, scope: !27)
-!36 = !DILocation(line: 17, column: 1, scope: !27)
-!37 = !DILocation(line: 18, column: 1, scope: !27)
-!38 = !DILocation(line: 19, column: 1, scope: !27)
-!39 = !DILocation(line: 20, column: 1, scope: !27)
-!40 = !DILocation(line: 21, column: 1, scope: !27)
-!41 = !DILocation(line: 22, column: 1, scope: !27)
-!42 = !DILocation(line: 24, column: 1, scope: !27)
-!43 = !DILocation(line: 25, column: 1, scope: !27)
-!44 = !DILocation(line: 26, column: 1, scope: !27)
-!45 = !DILocation(line: 27, column: 1, scope: !27)
-!46 = !DILocation(line: 28, column: 1, scope: !27)
-!47 = !DILocation(line: 29, column: 1, scope: !27)
-!48 = !DILocation(line: 30, column: 1, scope: !27)
-!49 = !{!50, !5, i64 400}
-!50 = !{!"rb_vm_struct", !5, i64 0, !51, i64 8, !13, i64 192, !13, i64 200, !13, i64 208, !55, i64 216, !6, i64 224, !52, i64 264, !52, i64 280, !52, i64 296, !52, i64 312, !5, i64 328, !54, i64 336, !54, i64 340, !54, i64 344, !54, i64 344, !54, i64 344, !54, i64 344, !54, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !13, i64 456, !13, i64 464, !56, i64 472, !57, i64 992, !13, i64 1016, !13, i64 1024, !54, i64 1032, !54, i64 1036, !52, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !54, i64 1136, !13, i64 1144, !13, i64 1152, !13, i64 1160, !13, i64 1168, !13, i64 1176, !13, i64 1184, !54, i64 1192, !58, i64 1200, !6, i64 1232}
-!51 = !{!"rb_global_vm_lock_struct", !13, i64 0, !6, i64 8, !52, i64 48, !13, i64 64, !54, i64 72, !6, i64 80, !6, i64 128, !54, i64 176, !54, i64 180}
-!52 = !{!"list_head", !53, i64 0}
-!53 = !{!"list_node", !13, i64 0, !13, i64 8}
-!54 = !{!"int", !6, i64 0}
-!55 = !{!"long long", !6, i64 0}
-!56 = !{!"", !6, i64 0}
-!57 = !{!"rb_hook_list_struct", !13, i64 0, !54, i64 8, !54, i64 12, !54, i64 16}
-!58 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!59 = !{!60, !13, i64 16}
-!60 = !{!"rb_execution_context_struct", !13, i64 0, !5, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !54, i64 40, !54, i64 44, !13, i64 48, !13, i64 56, !13, i64 64, !5, i64 72, !5, i64 80, !13, i64 88, !5, i64 96, !13, i64 104, !13, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !61, i64 152}
-!61 = !{!"", !13, i64 0, !13, i64 8, !5, i64 16, !6, i64 24}
-!62 = !{!63, !13, i64 16}
-!63 = !{!"rb_control_frame_struct", !13, i64 0, !13, i64 8, !13, i64 16, !5, i64 24, !13, i64 32, !13, i64 40, !13, i64 48}
-!64 = !{!63, !13, i64 32}
-!65 = !DILocation(line: 0, scope: !27)
-!66 = !{!67, !54, i64 20}
-!67 = !{!"rb_sorbet_param_struct", !68, i64 0, !54, i64 4, !54, i64 8, !54, i64 12, !54, i64 16, !54, i64 20, !54, i64 24, !54, i64 28, !13, i64 32, !54, i64 40, !54, i64 44, !54, i64 48, !54, i64 52, !13, i64 56}
-!68 = !{!"", !54, i64 0, !54, i64 0, !54, i64 0, !54, i64 0, !54, i64 0, !54, i64 0, !54, i64 0, !54, i64 0, !54, i64 1, !54, i64 1}
-!69 = !{!67, !54, i64 24}
-!70 = !{!67, !54, i64 28}
-!71 = !{!54, !54, i64 0}
-!72 = !{!67, !13, i64 32}
-!73 = !{!67, !54, i64 40}
-!74 = !{!67, !54, i64 44}
-!75 = !{!67, !54, i64 8}
-!76 = !{!67, !54, i64 12}
-!77 = !{!67, !54, i64 48}
-!78 = !{!67, !54, i64 52}
-!79 = !{!67, !13, i64 56}
-!80 = !{!60, !54, i64 40}
-!81 = !{!60, !54, i64 44}
-!82 = !{!"branch_weights", i32 2000, i32 1}
-!83 = !{!60, !13, i64 56}
-!84 = !DILocation(line: 8, column: 44, scope: !27)
-!85 = !DILocation(line: 9, column: 40, scope: !27)
-!86 = !DILocation(line: 10, column: 36, scope: !27)
-!87 = !DILocation(line: 11, column: 32, scope: !27)
-!88 = !DILocation(line: 12, column: 28, scope: !27)
-!89 = !DILocation(line: 13, column: 24, scope: !27)
-!90 = !DILocation(line: 14, column: 20, scope: !27)
-!91 = !DILocation(line: 16, column: 44, scope: !27)
-!92 = !DILocation(line: 16, column: 51, scope: !27)
-!93 = !DILocation(line: 17, column: 40, scope: !27)
-!94 = !DILocation(line: 17, column: 47, scope: !27)
-!95 = !DILocation(line: 18, column: 36, scope: !27)
-!96 = !DILocation(line: 18, column: 43, scope: !27)
-!97 = !DILocation(line: 19, column: 32, scope: !27)
-!98 = !DILocation(line: 19, column: 39, scope: !27)
-!99 = !DILocation(line: 20, column: 28, scope: !27)
-!100 = !DILocation(line: 20, column: 35, scope: !27)
-!101 = !DILocation(line: 21, column: 24, scope: !27)
-!102 = !DILocation(line: 21, column: 31, scope: !27)
-!103 = !DILocation(line: 22, column: 20, scope: !27)
-!104 = !DILocation(line: 22, column: 27, scope: !27)
-!105 = !DILocation(line: 24, column: 44, scope: !27)
-!106 = !DILocation(line: 24, column: 51, scope: !27)
-!107 = !DILocation(line: 24, column: 58, scope: !27)
-!108 = !DILocation(line: 25, column: 40, scope: !27)
-!109 = !DILocation(line: 25, column: 47, scope: !27)
-!110 = !DILocation(line: 25, column: 54, scope: !27)
-!111 = !DILocation(line: 26, column: 36, scope: !27)
-!112 = !DILocation(line: 26, column: 43, scope: !27)
-!113 = !DILocation(line: 26, column: 50, scope: !27)
-!114 = !DILocation(line: 27, column: 32, scope: !27)
-!115 = !DILocation(line: 27, column: 39, scope: !27)
-!116 = !DILocation(line: 27, column: 46, scope: !27)
-!117 = !DILocation(line: 28, column: 28, scope: !27)
-!118 = !DILocation(line: 28, column: 35, scope: !27)
-!119 = !DILocation(line: 28, column: 42, scope: !27)
-!120 = !DILocation(line: 29, column: 24, scope: !27)
-!121 = !DILocation(line: 29, column: 31, scope: !27)
-!122 = !DILocation(line: 29, column: 38, scope: !27)
-!123 = !DILocation(line: 30, column: 20, scope: !27)
-!124 = !DILocation(line: 30, column: 27, scope: !27)
-!125 = !DILocation(line: 30, column: 34, scope: !27)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/all_arguments.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "Object#take_arguments", linkageName: "func_Object#take_arguments", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!14 = !{!15, !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !DILocation(line: 4, column: 1, scope: !10)
+!17 = !{!18, !7, i64 0}
+!18 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!19 = !{!"branch_weights", i32 1, i32 2000}
+!20 = !DILocation(line: 4, column: 23, scope: !10)
+!21 = !DILocation(line: 4, column: 36, scope: !10)
+!22 = !DILocation(line: 0, scope: !10)
+!23 = !DILocation(line: 5, column: 10, scope: !10)
+!24 = !{!25}
+!25 = distinct !{!25, !26, !"sorbet_buildArrayIntrinsic: argument 0"}
+!26 = distinct !{!26, !"sorbet_buildArrayIntrinsic"}
+!27 = !DILocation(line: 5, column: 5, scope: !10)
+!28 = !DILocation(line: 4, column: 1, scope: !29)
+!29 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!30 = !DILocation(line: 8, column: 1, scope: !29)
+!31 = !DILocation(line: 9, column: 1, scope: !29)
+!32 = !DILocation(line: 10, column: 1, scope: !29)
+!33 = !DILocation(line: 11, column: 1, scope: !29)
+!34 = !DILocation(line: 12, column: 1, scope: !29)
+!35 = !DILocation(line: 13, column: 1, scope: !29)
+!36 = !DILocation(line: 14, column: 1, scope: !29)
+!37 = !DILocation(line: 16, column: 1, scope: !29)
+!38 = !DILocation(line: 17, column: 1, scope: !29)
+!39 = !DILocation(line: 18, column: 1, scope: !29)
+!40 = !DILocation(line: 19, column: 1, scope: !29)
+!41 = !DILocation(line: 20, column: 1, scope: !29)
+!42 = !DILocation(line: 21, column: 1, scope: !29)
+!43 = !DILocation(line: 22, column: 1, scope: !29)
+!44 = !DILocation(line: 24, column: 1, scope: !29)
+!45 = !DILocation(line: 25, column: 1, scope: !29)
+!46 = !DILocation(line: 26, column: 1, scope: !29)
+!47 = !DILocation(line: 27, column: 1, scope: !29)
+!48 = !DILocation(line: 28, column: 1, scope: !29)
+!49 = !DILocation(line: 29, column: 1, scope: !29)
+!50 = !DILocation(line: 30, column: 1, scope: !29)
+!51 = !{!52, !7, i64 400}
+!52 = !{!"rb_vm_struct", !7, i64 0, !53, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !57, i64 216, !8, i64 224, !54, i64 264, !54, i64 280, !54, i64 296, !54, i64 312, !7, i64 328, !56, i64 336, !56, i64 340, !56, i64 344, !56, i64 344, !56, i64 344, !56, i64 344, !56, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !58, i64 472, !59, i64 992, !15, i64 1016, !15, i64 1024, !56, i64 1032, !56, i64 1036, !54, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !56, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !56, i64 1192, !60, i64 1200, !8, i64 1232}
+!53 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !54, i64 48, !15, i64 64, !56, i64 72, !8, i64 80, !8, i64 128, !56, i64 176, !56, i64 180}
+!54 = !{!"list_head", !55, i64 0}
+!55 = !{!"list_node", !15, i64 0, !15, i64 8}
+!56 = !{!"int", !8, i64 0}
+!57 = !{!"long long", !8, i64 0}
+!58 = !{!"", !8, i64 0}
+!59 = !{!"rb_hook_list_struct", !15, i64 0, !56, i64 8, !56, i64 12, !56, i64 16}
+!60 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!61 = !{!62, !15, i64 16}
+!62 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !56, i64 40, !56, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !63, i64 152}
+!63 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!64 = !{!65, !15, i64 16}
+!65 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!66 = !{!65, !15, i64 32}
+!67 = !DILocation(line: 0, scope: !29)
+!68 = !{!69, !56, i64 20}
+!69 = !{!"rb_sorbet_param_struct", !70, i64 0, !56, i64 4, !56, i64 8, !56, i64 12, !56, i64 16, !56, i64 20, !56, i64 24, !56, i64 28, !15, i64 32, !56, i64 40, !56, i64 44, !56, i64 48, !56, i64 52, !15, i64 56}
+!70 = !{!"", !56, i64 0, !56, i64 0, !56, i64 0, !56, i64 0, !56, i64 0, !56, i64 0, !56, i64 0, !56, i64 0, !56, i64 1, !56, i64 1}
+!71 = !{!69, !56, i64 24}
+!72 = !{!69, !56, i64 28}
+!73 = !{!56, !56, i64 0}
+!74 = !{!69, !15, i64 32}
+!75 = !{!69, !56, i64 40}
+!76 = !{!69, !56, i64 44}
+!77 = !{!69, !56, i64 8}
+!78 = !{!69, !56, i64 12}
+!79 = !{!69, !56, i64 48}
+!80 = !{!69, !56, i64 52}
+!81 = !{!69, !15, i64 56}
+!82 = !{!62, !56, i64 40}
+!83 = !{!62, !56, i64 44}
+!84 = !{!"branch_weights", i32 2000, i32 1}
+!85 = !{!62, !15, i64 56}
+!86 = !DILocation(line: 8, column: 44, scope: !29)
+!87 = !DILocation(line: 9, column: 40, scope: !29)
+!88 = !DILocation(line: 10, column: 36, scope: !29)
+!89 = !DILocation(line: 11, column: 32, scope: !29)
+!90 = !DILocation(line: 12, column: 28, scope: !29)
+!91 = !DILocation(line: 13, column: 24, scope: !29)
+!92 = !DILocation(line: 14, column: 20, scope: !29)
+!93 = !DILocation(line: 16, column: 44, scope: !29)
+!94 = !DILocation(line: 16, column: 51, scope: !29)
+!95 = !DILocation(line: 17, column: 40, scope: !29)
+!96 = !DILocation(line: 17, column: 47, scope: !29)
+!97 = !DILocation(line: 18, column: 36, scope: !29)
+!98 = !DILocation(line: 18, column: 43, scope: !29)
+!99 = !DILocation(line: 19, column: 32, scope: !29)
+!100 = !DILocation(line: 19, column: 39, scope: !29)
+!101 = !DILocation(line: 20, column: 28, scope: !29)
+!102 = !DILocation(line: 20, column: 35, scope: !29)
+!103 = !DILocation(line: 21, column: 24, scope: !29)
+!104 = !DILocation(line: 21, column: 31, scope: !29)
+!105 = !DILocation(line: 22, column: 20, scope: !29)
+!106 = !DILocation(line: 22, column: 27, scope: !29)
+!107 = !DILocation(line: 24, column: 44, scope: !29)
+!108 = !DILocation(line: 24, column: 51, scope: !29)
+!109 = !DILocation(line: 24, column: 58, scope: !29)
+!110 = !DILocation(line: 25, column: 40, scope: !29)
+!111 = !DILocation(line: 25, column: 47, scope: !29)
+!112 = !DILocation(line: 25, column: 54, scope: !29)
+!113 = !DILocation(line: 26, column: 36, scope: !29)
+!114 = !DILocation(line: 26, column: 43, scope: !29)
+!115 = !DILocation(line: 26, column: 50, scope: !29)
+!116 = !DILocation(line: 27, column: 32, scope: !29)
+!117 = !DILocation(line: 27, column: 39, scope: !29)
+!118 = !DILocation(line: 27, column: 46, scope: !29)
+!119 = !DILocation(line: 28, column: 28, scope: !29)
+!120 = !DILocation(line: 28, column: 35, scope: !29)
+!121 = !DILocation(line: 28, column: 42, scope: !29)
+!122 = !DILocation(line: 29, column: 24, scope: !29)
+!123 = !DILocation(line: 29, column: 31, scope: !29)
+!124 = !DILocation(line: 29, column: 38, scope: !29)
+!125 = !DILocation(line: 30, column: 20, scope: !29)
+!126 = !DILocation(line: 30, column: 27, scope: !29)
+!127 = !DILocation(line: 30, column: 34, scope: !29)

--- a/test/testdata/compiler/block_arg_expand.llo.exp
+++ b/test/testdata/compiler/block_arg_expand.llo.exp
@@ -174,530 +174,530 @@ declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*,
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #5 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #11
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #5 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #11
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !8 {
+define internal i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !10 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !15
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !21
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !21
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !23
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -129
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !tbaa !13
-  %arrayExpansionSizeGuard = icmp eq i32 %argc, 1, !dbg !22
-  br i1 %arrayExpansionSizeGuard, label %argArrayExpandArrayTest, label %fillRequiredArgs, !dbg !22
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !tbaa !15
+  %arrayExpansionSizeGuard = icmp eq i32 %argc, 1, !dbg !24
+  br i1 %arrayExpansionSizeGuard, label %argArrayExpandArrayTest, label %fillRequiredArgs, !dbg !24
 
 argArrayExpandArrayTest:                          ; preds = %functionEntryInitializers
-  %arg1_maybeExpandToFullArgs = load i64, i64* %argArray, align 8, !dbg !22
-  %9 = and i64 %arg1_maybeExpandToFullArgs, 7, !dbg !22
-  %10 = icmp ne i64 %9, 0, !dbg !22
-  %11 = and i64 %arg1_maybeExpandToFullArgs, -9, !dbg !22
-  %12 = icmp eq i64 %11, 0, !dbg !22
-  %13 = or i1 %10, %12, !dbg !22
-  br i1 %13, label %fillFromDefaultBlockDone2, label %sorbet_isa_Array.exit, !dbg !22
+  %arg1_maybeExpandToFullArgs = load i64, i64* %argArray, align 8, !dbg !24
+  %9 = and i64 %arg1_maybeExpandToFullArgs, 7, !dbg !24
+  %10 = icmp ne i64 %9, 0, !dbg !24
+  %11 = and i64 %arg1_maybeExpandToFullArgs, -9, !dbg !24
+  %12 = icmp eq i64 %11, 0, !dbg !24
+  %13 = or i1 %10, %12, !dbg !24
+  br i1 %13, label %fillFromDefaultBlockDone2, label %sorbet_isa_Array.exit, !dbg !24
 
 sorbet_isa_Array.exit:                            ; preds = %argArrayExpandArrayTest
-  %14 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !22
-  %15 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %14, i64 0, i32 0, !dbg !22
-  %16 = load i64, i64* %15, align 8, !dbg !22, !tbaa !23
-  %17 = and i64 %16, 31, !dbg !22
-  %18 = icmp eq i64 %17, 7, !dbg !22
-  br i1 %18, label %argArrayExpand, label %fillFromDefaultBlockDone2, !dbg !22
+  %14 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !24
+  %15 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %14, i64 0, i32 0, !dbg !24
+  %16 = load i64, i64* %15, align 8, !dbg !24, !tbaa !25
+  %17 = and i64 %16, 31, !dbg !24
+  %18 = icmp eq i64 %17, 7, !dbg !24
+  br i1 %18, label %argArrayExpand, label %fillFromDefaultBlockDone2, !dbg !24
 
 argArrayExpand:                                   ; preds = %sorbet_isa_Array.exit
-  %19 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !22
-  %20 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %19, i64 0, i32 0, !dbg !22
-  %21 = load i64, i64* %20, align 8, !dbg !22, !tbaa !23
-  %22 = and i64 %21, 33554432, !dbg !22
-  %23 = icmp eq i64 %22, 0, !dbg !22
-  br i1 %23, label %25, label %24, !dbg !22
+  %19 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !24
+  %20 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %19, i64 0, i32 0, !dbg !24
+  %21 = load i64, i64* %20, align 8, !dbg !24, !tbaa !25
+  %22 = and i64 %21, 33554432, !dbg !24
+  %23 = icmp eq i64 %22, 0, !dbg !24
+  br i1 %23, label %25, label %24, !dbg !24
 
 24:                                               ; preds = %argArrayExpand
-  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #12, !dbg !22
-  br label %25, !dbg !22
+  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #12, !dbg !24
+  br label %25, !dbg !24
 
 25:                                               ; preds = %24, %argArrayExpand
-  %26 = load i64, i64* %20, align 8, !dbg !22, !tbaa !23
-  %27 = and i64 %26, 8192, !dbg !22
-  %28 = icmp eq i64 %27, 0, !dbg !22
-  %29 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.RArray*, !dbg !22
-  br i1 %28, label %34, label %30, !dbg !22
+  %26 = load i64, i64* %20, align 8, !dbg !24, !tbaa !25
+  %27 = and i64 %26, 8192, !dbg !24
+  %28 = icmp eq i64 %27, 0, !dbg !24
+  %29 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.RArray*, !dbg !24
+  br i1 %28, label %34, label %30, !dbg !24
 
 30:                                               ; preds = %25
-  %31 = getelementptr inbounds %struct.RArray, %struct.RArray* %29, i64 0, i32 1, i32 0, i32 0, !dbg !22
-  %32 = lshr i64 %26, 15, !dbg !22
-  %33 = and i64 %32, 3, !dbg !22
-  br label %rb_array_len.exit, !dbg !22
+  %31 = getelementptr inbounds %struct.RArray, %struct.RArray* %29, i64 0, i32 1, i32 0, i32 0, !dbg !24
+  %32 = lshr i64 %26, 15, !dbg !24
+  %33 = and i64 %32, 3, !dbg !24
+  br label %rb_array_len.exit, !dbg !24
 
 34:                                               ; preds = %25
-  %35 = getelementptr inbounds %struct.RArray, %struct.RArray* %29, i64 0, i32 1, i32 0, i32 2, !dbg !22
-  %36 = load i64*, i64** %35, align 8, !dbg !22, !tbaa !25
-  %37 = getelementptr inbounds %struct.RArray, %struct.RArray* %29, i64 0, i32 1, i32 0, i32 0, !dbg !22
-  %38 = load i64, i64* %37, align 8, !dbg !22, !tbaa !25
-  br label %rb_array_len.exit, !dbg !22
+  %35 = getelementptr inbounds %struct.RArray, %struct.RArray* %29, i64 0, i32 1, i32 0, i32 2, !dbg !24
+  %36 = load i64*, i64** %35, align 8, !dbg !24, !tbaa !27
+  %37 = getelementptr inbounds %struct.RArray, %struct.RArray* %29, i64 0, i32 1, i32 0, i32 0, !dbg !24
+  %38 = load i64, i64* %37, align 8, !dbg !24, !tbaa !27
+  br label %rb_array_len.exit, !dbg !24
 
 rb_array_len.exit:                                ; preds = %30, %34
   %39 = phi i64* [ %31, %30 ], [ %36, %34 ]
-  %40 = phi i64 [ %33, %30 ], [ %38, %34 ], !dbg !22
-  %41 = trunc i64 %40 to i32, !dbg !22
-  br label %fillRequiredArgs, !dbg !22
+  %40 = phi i64 [ %33, %30 ], [ %38, %34 ], !dbg !24
+  %41 = trunc i64 %40 to i32, !dbg !24
+  br label %fillRequiredArgs, !dbg !24
 
 fillFromArgBlock0:                                ; preds = %fillRequiredArgs
-  %rawArg_el1 = load i64, i64* %argArrayPhi, align 8, !dbg !22
-  %default1 = icmp eq i32 %argcPhi, 1, !dbg !22
-  br i1 %default1, label %fillFromDefaultBlockDone2, label %fillFromArgBlock1, !dbg !22, !prof !26
+  %rawArg_el1 = load i64, i64* %argArrayPhi, align 8, !dbg !24
+  %default1 = icmp eq i32 %argcPhi, 1, !dbg !24
+  br i1 %default1, label %fillFromDefaultBlockDone2, label %fillFromArgBlock1, !dbg !24, !prof !28
 
 fillFromArgBlock1:                                ; preds = %fillFromArgBlock0
-  %42 = getelementptr i64, i64* %argArrayPhi, i32 1, !dbg !22
-  %rawArg_el2 = load i64, i64* %42, align 8, !dbg !22
-  br label %fillFromDefaultBlockDone2, !dbg !22
+  %42 = getelementptr i64, i64* %argArrayPhi, i32 1, !dbg !24
+  %rawArg_el2 = load i64, i64* %42, align 8, !dbg !24
+  br label %fillFromDefaultBlockDone2, !dbg !24
 
 fillFromDefaultBlockDone2:                        ; preds = %argArrayExpandArrayTest, %sorbet_isa_Array.exit, %fillFromArgBlock0, %fillFromArgBlock1
-  %el2.sroa.0.0 = phi i64 [ %rawArg_el2, %fillFromArgBlock1 ], [ 8, %fillFromArgBlock0 ], [ 8, %sorbet_isa_Array.exit ], [ 8, %argArrayExpandArrayTest ], !dbg !22
-  %el1.sroa.0.1 = phi i64 [ %rawArg_el1, %fillFromArgBlock1 ], [ %rawArg_el1, %fillFromArgBlock0 ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ], !dbg !22
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !27, !tbaa !13
-  %43 = and i64 %el1.sroa.0.1, 1, !dbg !28
-  %44 = icmp eq i64 %43, 0, !dbg !28
-  br i1 %44, label %45, label %typeTestSuccess, !dbg !28, !prof !26
+  %el2.sroa.0.0 = phi i64 [ %rawArg_el2, %fillFromArgBlock1 ], [ 8, %fillFromArgBlock0 ], [ 8, %sorbet_isa_Array.exit ], [ 8, %argArrayExpandArrayTest ], !dbg !24
+  %el1.sroa.0.1 = phi i64 [ %rawArg_el1, %fillFromArgBlock1 ], [ %rawArg_el1, %fillFromArgBlock0 ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ], !dbg !24
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !29, !tbaa !15
+  %43 = and i64 %el1.sroa.0.1, 1, !dbg !30
+  %44 = icmp eq i64 %43, 0, !dbg !30
+  br i1 %44, label %45, label %typeTestSuccess, !dbg !30, !prof !28
 
 45:                                               ; preds = %fillFromDefaultBlockDone2.thread, %fillFromDefaultBlockDone2
   %el1.sroa.0.149 = phi i64 [ 8, %fillFromDefaultBlockDone2.thread ], [ %el1.sroa.0.1, %fillFromDefaultBlockDone2 ]
   %el2.sroa.0.046 = phi i64 [ 8, %fillFromDefaultBlockDone2.thread ], [ %el2.sroa.0.0, %fillFromDefaultBlockDone2 ]
-  %46 = and i64 %el1.sroa.0.149, 7, !dbg !28
-  %47 = icmp ne i64 %46, 0, !dbg !28
-  %48 = and i64 %el1.sroa.0.149, -9, !dbg !28
-  %49 = icmp eq i64 %48, 0, !dbg !28
-  %50 = or i1 %47, %49, !dbg !28
-  br i1 %50, label %codeRepl41, label %sorbet_isa_Integer.exit, !dbg !28
+  %46 = and i64 %el1.sroa.0.149, 7, !dbg !30
+  %47 = icmp ne i64 %46, 0, !dbg !30
+  %48 = and i64 %el1.sroa.0.149, -9, !dbg !30
+  %49 = icmp eq i64 %48, 0, !dbg !30
+  %50 = or i1 %47, %49, !dbg !30
+  br i1 %50, label %codeRepl41, label %sorbet_isa_Integer.exit, !dbg !30
 
 sorbet_isa_Integer.exit:                          ; preds = %45
-  %51 = inttoptr i64 %el1.sroa.0.149 to %struct.iseq_inline_iv_cache_entry*, !dbg !28
-  %52 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %51, i64 0, i32 0, !dbg !28
-  %53 = load i64, i64* %52, align 8, !dbg !28, !tbaa !23
-  %54 = and i64 %53, 31, !dbg !28
-  %55 = icmp eq i64 %54, 10, !dbg !28
-  br i1 %55, label %typeTestSuccess, label %codeRepl41, !dbg !28, !prof !29
+  %51 = inttoptr i64 %el1.sroa.0.149 to %struct.iseq_inline_iv_cache_entry*, !dbg !30
+  %52 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %51, i64 0, i32 0, !dbg !30
+  %53 = load i64, i64* %52, align 8, !dbg !30, !tbaa !25
+  %54 = and i64 %53, 31, !dbg !30
+  %55 = icmp eq i64 %54, 10, !dbg !30
+  br i1 %55, label %typeTestSuccess, label %codeRepl41, !dbg !30, !prof !31
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers, %rb_array_len.exit
-  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %41, %rb_array_len.exit ], !dbg !22
-  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %39, %rb_array_len.exit ], !dbg !22
-  %default0 = icmp eq i32 %argcPhi, 0, !dbg !22
-  br i1 %default0, label %fillFromDefaultBlockDone2.thread, label %fillFromArgBlock0, !dbg !22, !prof !26
+  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %41, %rb_array_len.exit ], !dbg !24
+  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %39, %rb_array_len.exit ], !dbg !24
+  %default0 = icmp eq i32 %argcPhi, 0, !dbg !24
+  br i1 %default0, label %fillFromDefaultBlockDone2.thread, label %fillFromArgBlock0, !dbg !24, !prof !28
 
 fillFromDefaultBlockDone2.thread:                 ; preds = %fillRequiredArgs
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !27, !tbaa !13
-  br label %45, !dbg !28
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !29, !tbaa !15
+  br label %45, !dbg !30
 
 typeTestSuccess:                                  ; preds = %fillFromDefaultBlockDone2, %sorbet_isa_Integer.exit
   %el1.sroa.0.148 = phi i64 [ %el1.sroa.0.1, %fillFromDefaultBlockDone2 ], [ %el1.sroa.0.149, %sorbet_isa_Integer.exit ]
   %el2.sroa.0.045 = phi i64 [ %el2.sroa.0.0, %fillFromDefaultBlockDone2 ], [ %el2.sroa.0.046, %sorbet_isa_Integer.exit ]
-  %56 = and i64 %el2.sroa.0.045, 1, !dbg !30
-  %57 = icmp eq i64 %56, 0, !dbg !30
-  br i1 %57, label %58, label %"fastSymCallIntrinsic_Integer_+", !dbg !30, !prof !26
+  %56 = and i64 %el2.sroa.0.045, 1, !dbg !32
+  %57 = icmp eq i64 %56, 0, !dbg !32
+  br i1 %57, label %58, label %"fastSymCallIntrinsic_Integer_+", !dbg !32, !prof !28
 
 58:                                               ; preds = %typeTestSuccess
-  %59 = and i64 %el2.sroa.0.045, 7, !dbg !30
-  %60 = icmp ne i64 %59, 0, !dbg !30
-  %61 = and i64 %el2.sroa.0.045, -9, !dbg !30
-  %62 = icmp eq i64 %61, 0, !dbg !30
-  %63 = or i1 %60, %62, !dbg !30
-  br i1 %63, label %codeRepl, label %sorbet_isa_Integer.exit42, !dbg !30
+  %59 = and i64 %el2.sroa.0.045, 7, !dbg !32
+  %60 = icmp ne i64 %59, 0, !dbg !32
+  %61 = and i64 %el2.sroa.0.045, -9, !dbg !32
+  %62 = icmp eq i64 %61, 0, !dbg !32
+  %63 = or i1 %60, %62, !dbg !32
+  br i1 %63, label %codeRepl, label %sorbet_isa_Integer.exit42, !dbg !32
 
 sorbet_isa_Integer.exit42:                        ; preds = %58
-  %64 = inttoptr i64 %el2.sroa.0.045 to %struct.iseq_inline_iv_cache_entry*, !dbg !30
-  %65 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %64, i64 0, i32 0, !dbg !30
-  %66 = load i64, i64* %65, align 8, !dbg !30, !tbaa !23
-  %67 = and i64 %66, 31, !dbg !30
-  %68 = icmp eq i64 %67, 10, !dbg !30
-  br i1 %68, label %"fastSymCallIntrinsic_Integer_+", label %codeRepl, !dbg !30, !prof !29
+  %64 = inttoptr i64 %el2.sroa.0.045 to %struct.iseq_inline_iv_cache_entry*, !dbg !32
+  %65 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %64, i64 0, i32 0, !dbg !32
+  %66 = load i64, i64* %65, align 8, !dbg !32, !tbaa !25
+  %67 = and i64 %66, 31, !dbg !32
+  %68 = icmp eq i64 %67, 10, !dbg !32
+  br i1 %68, label %"fastSymCallIntrinsic_Integer_+", label %codeRepl, !dbg !32, !prof !31
 
 codeRepl41:                                       ; preds = %45, %sorbet_isa_Integer.exit
   %el1.sroa.0.150 = phi i64 [ %el1.sroa.0.149, %45 ], [ %el1.sroa.0.149, %sorbet_isa_Integer.exit ]
-  tail call fastcc void @"func_<root>.<static-init>$151$block_1.cold.1"(i64 %el1.sroa.0.150) #13, !dbg !28
+  tail call fastcc void @"func_<root>.<static-init>$151$block_1.cold.1"(i64 %el1.sroa.0.150) #13, !dbg !30
   unreachable
 
 codeRepl:                                         ; preds = %58, %sorbet_isa_Integer.exit42
   %el2.sroa.0.047 = phi i64 [ %el2.sroa.0.045, %58 ], [ %el2.sroa.0.045, %sorbet_isa_Integer.exit42 ]
-  tail call fastcc void @"func_<root>.<static-init>$151$block_1.cold.1"(i64 %el2.sroa.0.047) #13, !dbg !30
+  tail call fastcc void @"func_<root>.<static-init>$151$block_1.cold.1"(i64 %el2.sroa.0.047) #13, !dbg !32
   unreachable
 
 "fastSymCallIntrinsic_Integer_+":                 ; preds = %typeTestSuccess, %sorbet_isa_Integer.exit42
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !31), !dbg !28
-  %69 = and i64 %el2.sroa.0.045, 1, !dbg !28
-  %70 = and i64 %69, %el1.sroa.0.148, !dbg !28
-  %71 = icmp eq i64 %70, 0, !dbg !28
-  br i1 %71, label %81, label %72, !dbg !28, !prof !34
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !33), !dbg !30
+  %69 = and i64 %el2.sroa.0.045, 1, !dbg !30
+  %70 = and i64 %69, %el1.sroa.0.148, !dbg !30
+  %71 = icmp eq i64 %70, 0, !dbg !30
+  br i1 %71, label %81, label %72, !dbg !30, !prof !36
 
 72:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %73 = add nsw i64 %el2.sroa.0.045, -1, !dbg !28
-  %74 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %el1.sroa.0.148, i64 %73) #14, !dbg !28
-  %75 = extractvalue { i64, i1 } %74, 1, !dbg !28
-  %76 = extractvalue { i64, i1 } %74, 0, !dbg !28
-  br i1 %75, label %77, label %sorbet_rb_int_plus.exit, !dbg !28
+  %73 = add nsw i64 %el2.sroa.0.045, -1, !dbg !30
+  %74 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %el1.sroa.0.148, i64 %73) #14, !dbg !30
+  %75 = extractvalue { i64, i1 } %74, 1, !dbg !30
+  %76 = extractvalue { i64, i1 } %74, 0, !dbg !30
+  br i1 %75, label %77, label %sorbet_rb_int_plus.exit, !dbg !30
 
 77:                                               ; preds = %72
-  %78 = ashr i64 %76, 1, !dbg !28
-  %79 = xor i64 %78, -9223372036854775808, !dbg !28
-  %80 = tail call i64 @rb_int2big(i64 %79) #12, !dbg !28, !noalias !31
-  br label %sorbet_rb_int_plus.exit, !dbg !28
+  %78 = ashr i64 %76, 1, !dbg !30
+  %79 = xor i64 %78, -9223372036854775808, !dbg !30
+  %80 = tail call i64 @rb_int2big(i64 %79) #12, !dbg !30, !noalias !33
+  br label %sorbet_rb_int_plus.exit, !dbg !30
 
 81:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %82 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %el1.sroa.0.148, i64 %el2.sroa.0.045) #12, !dbg !28, !noalias !31
-  br label %sorbet_rb_int_plus.exit, !dbg !28
+  %82 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %el1.sroa.0.148, i64 %el2.sroa.0.045) #12, !dbg !30, !noalias !33
+  br label %sorbet_rb_int_plus.exit, !dbg !30
 
 sorbet_rb_int_plus.exit:                          ; preds = %77, %72, %81
-  %83 = phi i64 [ %82, %81 ], [ %80, %77 ], [ %76, %72 ], !dbg !28
-  %84 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !13
-  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 5, !dbg !28
-  %86 = load i32, i32* %85, align 8, !dbg !28, !tbaa !35
-  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 6, !dbg !28
-  %88 = load i32, i32* %87, align 4, !dbg !28, !tbaa !36
-  %89 = xor i32 %88, -1, !dbg !28
-  %90 = and i32 %89, %86, !dbg !28
-  %91 = icmp eq i32 %90, 0, !dbg !28
-  br i1 %91, label %rb_vm_check_ints.exit, label %92, !dbg !28, !prof !29
+  %83 = phi i64 [ %82, %81 ], [ %80, %77 ], [ %76, %72 ], !dbg !30
+  %84 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !15
+  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 5, !dbg !30
+  %86 = load i32, i32* %85, align 8, !dbg !30, !tbaa !37
+  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 6, !dbg !30
+  %88 = load i32, i32* %87, align 4, !dbg !30, !tbaa !38
+  %89 = xor i32 %88, -1, !dbg !30
+  %90 = and i32 %89, %86, !dbg !30
+  %91 = icmp eq i32 %90, 0, !dbg !30
+  br i1 %91, label %rb_vm_check_ints.exit, label %92, !dbg !30, !prof !31
 
 92:                                               ; preds = %sorbet_rb_int_plus.exit
-  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 8, !dbg !28
-  %94 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %93, align 8, !dbg !28, !tbaa !37
-  %95 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #12, !dbg !28
-  br label %rb_vm_check_ints.exit, !dbg !28
+  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 8, !dbg !30
+  %94 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %93, align 8, !dbg !30, !tbaa !39
+  %95 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #12, !dbg !30
+  br label %rb_vm_check_ints.exit, !dbg !30
 
 rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.exit, %92
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !28, !tbaa !13
-  ret i64 %83, !dbg !38
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !30, !tbaa !15
+  ret i64 %83, !dbg !40
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$151$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !39 {
+define internal i64 @"func_<root>.<static-init>$151$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !41 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !15
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !40
+  %4 = load i64, i64* %3, align 8, !tbaa !42
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_2", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !21
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !21
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !23
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %10, align 8, !tbaa !13
-  %default0 = icmp eq i32 %argc, 0, !dbg !41
-  br i1 %default0, label %fillFromDefaultBlockDone1, label %fillFromArgBlock0, !dbg !41, !prof !26
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %10, align 8, !tbaa !15
+  %default0 = icmp eq i32 %argc, 0, !dbg !43
+  br i1 %default0, label %fillFromDefaultBlockDone1, label %fillFromArgBlock0, !dbg !43, !prof !28
 
 fillFromArgBlock0:                                ; preds = %functionEntryInitializers
-  %rawArg_array = load i64, i64* %argArray, align 8, !dbg !41
-  br label %fillFromDefaultBlockDone1, !dbg !41
+  %rawArg_array = load i64, i64* %argArray, align 8, !dbg !43
+  br label %fillFromDefaultBlockDone1, !dbg !43
 
 fillFromDefaultBlockDone1:                        ; preds = %functionEntryInitializers, %fillFromArgBlock0
-  %array.sroa.0.0 = phi i64 [ %rawArg_array, %fillFromArgBlock0 ], [ 8, %functionEntryInitializers ], !dbg !41
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %10, align 8, !dbg !42, !tbaa !13
-  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !43
-  %12 = load i64*, i64** %11, align 8, !dbg !43
-  store i64 %4, i64* %12, align 8, !dbg !43, !tbaa !4
-  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !43
-  store i64 %array.sroa.0.0, i64* %13, align 8, !dbg !43, !tbaa !4
-  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !43
-  store i64* %14, i64** %11, align 8, !dbg !43
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %10, align 8, !dbg !43, !tbaa !13
-  ret i64 %send, !dbg !44
+  %array.sroa.0.0 = phi i64 [ %rawArg_array, %fillFromArgBlock0 ], [ 8, %functionEntryInitializers ], !dbg !43
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %10, align 8, !dbg !44, !tbaa !15
+  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !45
+  %12 = load i64*, i64** %11, align 8, !dbg !45
+  store i64 %4, i64* %12, align 8, !dbg !45, !tbaa !6
+  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !45
+  store i64 %array.sroa.0.0, i64* %13, align 8, !dbg !45, !tbaa !6
+  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !45
+  store i64* %14, i64** %11, align 8, !dbg !45
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !45
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %10, align 8, !dbg !45, !tbaa !15
+  ret i64 %send, !dbg !46
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$151$block_3"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !45 {
+define internal i64 @"func_<root>.<static-init>$151$block_3"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !47 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !15
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !40
+  %4 = load i64, i64* %3, align 8, !tbaa !42
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_3", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !21
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !21
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !23
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %10, align 8, !tbaa !13
-  %default0 = icmp eq i32 %argc, 0, !dbg !46
-  br i1 %default0, label %fillFromDefaultBlockDone1, label %fillFromArgBlock0, !dbg !46, !prof !26
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %10, align 8, !tbaa !15
+  %default0 = icmp eq i32 %argc, 0, !dbg !48
+  br i1 %default0, label %fillFromDefaultBlockDone1, label %fillFromArgBlock0, !dbg !48, !prof !28
 
 fillFromArgBlock0:                                ; preds = %functionEntryInitializers
-  %rawArg_array = load i64, i64* %argArray, align 8, !dbg !46
-  br label %fillFromDefaultBlockDone1, !dbg !46
+  %rawArg_array = load i64, i64* %argArray, align 8, !dbg !48
+  br label %fillFromDefaultBlockDone1, !dbg !48
 
 fillFromDefaultBlockDone1:                        ; preds = %functionEntryInitializers, %fillFromArgBlock0
-  %array.sroa.0.0 = phi i64 [ %rawArg_array, %fillFromArgBlock0 ], [ 8, %functionEntryInitializers ], !dbg !46
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %10, align 8, !dbg !47, !tbaa !13
-  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !48
-  %12 = load i64*, i64** %11, align 8, !dbg !48
-  store i64 %4, i64* %12, align 8, !dbg !48, !tbaa !4
-  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !48
-  store i64 %array.sroa.0.0, i64* %13, align 8, !dbg !48, !tbaa !4
-  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !48
-  store i64* %14, i64** %11, align 8, !dbg !48
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.5, i64 0), !dbg !48
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %10, align 8, !dbg !48, !tbaa !13
-  ret i64 %send, !dbg !49
+  %array.sroa.0.0 = phi i64 [ %rawArg_array, %fillFromArgBlock0 ], [ 8, %functionEntryInitializers ], !dbg !48
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %10, align 8, !dbg !49, !tbaa !15
+  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !50
+  %12 = load i64*, i64** %11, align 8, !dbg !50
+  store i64 %4, i64* %12, align 8, !dbg !50, !tbaa !6
+  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !50
+  store i64 %array.sroa.0.0, i64* %13, align 8, !dbg !50, !tbaa !6
+  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !50
+  store i64* %14, i64** %11, align 8, !dbg !50
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.5, i64 0), !dbg !50
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %10, align 8, !dbg !50, !tbaa !15
+  ret i64 %send, !dbg !51
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$151$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !50 {
+define internal i64 @"func_<root>.<static-init>$151$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !52 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !15
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !40
+  %4 = load i64, i64* %3, align 8, !tbaa !42
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_4", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !21
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !21
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !23
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %10, align 8, !tbaa !13
-  %arrayExpansionSizeGuard = icmp eq i32 %argc, 1, !dbg !51
-  br i1 %arrayExpansionSizeGuard, label %argArrayExpandArrayTest, label %fillRequiredArgs, !dbg !51
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %10, align 8, !tbaa !15
+  %arrayExpansionSizeGuard = icmp eq i32 %argc, 1, !dbg !53
+  br i1 %arrayExpansionSizeGuard, label %argArrayExpandArrayTest, label %fillRequiredArgs, !dbg !53
 
 argArrayExpandArrayTest:                          ; preds = %functionEntryInitializers
-  %arg1_maybeExpandToFullArgs = load i64, i64* %argArray, align 8, !dbg !51
-  %11 = and i64 %arg1_maybeExpandToFullArgs, 7, !dbg !51
-  %12 = icmp ne i64 %11, 0, !dbg !51
-  %13 = and i64 %arg1_maybeExpandToFullArgs, -9, !dbg !51
-  %14 = icmp eq i64 %13, 0, !dbg !51
-  %15 = or i1 %12, %14, !dbg !51
-  br i1 %15, label %fillFromDefaultBlockDone2, label %sorbet_isa_Array.exit, !dbg !51
+  %arg1_maybeExpandToFullArgs = load i64, i64* %argArray, align 8, !dbg !53
+  %11 = and i64 %arg1_maybeExpandToFullArgs, 7, !dbg !53
+  %12 = icmp ne i64 %11, 0, !dbg !53
+  %13 = and i64 %arg1_maybeExpandToFullArgs, -9, !dbg !53
+  %14 = icmp eq i64 %13, 0, !dbg !53
+  %15 = or i1 %12, %14, !dbg !53
+  br i1 %15, label %fillFromDefaultBlockDone2, label %sorbet_isa_Array.exit, !dbg !53
 
 sorbet_isa_Array.exit:                            ; preds = %argArrayExpandArrayTest
-  %16 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !51
-  %17 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %16, i64 0, i32 0, !dbg !51
-  %18 = load i64, i64* %17, align 8, !dbg !51, !tbaa !23
-  %19 = and i64 %18, 31, !dbg !51
-  %20 = icmp eq i64 %19, 7, !dbg !51
-  br i1 %20, label %argArrayExpand, label %fillFromDefaultBlockDone2, !dbg !51
+  %16 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !53
+  %17 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %16, i64 0, i32 0, !dbg !53
+  %18 = load i64, i64* %17, align 8, !dbg !53, !tbaa !25
+  %19 = and i64 %18, 31, !dbg !53
+  %20 = icmp eq i64 %19, 7, !dbg !53
+  br i1 %20, label %argArrayExpand, label %fillFromDefaultBlockDone2, !dbg !53
 
 argArrayExpand:                                   ; preds = %sorbet_isa_Array.exit
-  %21 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !51
-  %22 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %21, i64 0, i32 0, !dbg !51
-  %23 = load i64, i64* %22, align 8, !dbg !51, !tbaa !23
-  %24 = and i64 %23, 33554432, !dbg !51
-  %25 = icmp eq i64 %24, 0, !dbg !51
-  br i1 %25, label %27, label %26, !dbg !51
+  %21 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !53
+  %22 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %21, i64 0, i32 0, !dbg !53
+  %23 = load i64, i64* %22, align 8, !dbg !53, !tbaa !25
+  %24 = and i64 %23, 33554432, !dbg !53
+  %25 = icmp eq i64 %24, 0, !dbg !53
+  br i1 %25, label %27, label %26, !dbg !53
 
 26:                                               ; preds = %argArrayExpand
-  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #12, !dbg !51
-  br label %27, !dbg !51
+  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #12, !dbg !53
+  br label %27, !dbg !53
 
 27:                                               ; preds = %26, %argArrayExpand
-  %28 = load i64, i64* %22, align 8, !dbg !51, !tbaa !23
-  %29 = and i64 %28, 8192, !dbg !51
-  %30 = icmp eq i64 %29, 0, !dbg !51
-  %31 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.RArray*, !dbg !51
-  br i1 %30, label %36, label %32, !dbg !51
+  %28 = load i64, i64* %22, align 8, !dbg !53, !tbaa !25
+  %29 = and i64 %28, 8192, !dbg !53
+  %30 = icmp eq i64 %29, 0, !dbg !53
+  %31 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.RArray*, !dbg !53
+  br i1 %30, label %36, label %32, !dbg !53
 
 32:                                               ; preds = %27
-  %33 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !51
-  %34 = lshr i64 %28, 15, !dbg !51
-  %35 = and i64 %34, 3, !dbg !51
-  br label %rb_array_len.exit, !dbg !51
+  %33 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !53
+  %34 = lshr i64 %28, 15, !dbg !53
+  %35 = and i64 %34, 3, !dbg !53
+  br label %rb_array_len.exit, !dbg !53
 
 36:                                               ; preds = %27
-  %37 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 2, !dbg !51
-  %38 = load i64*, i64** %37, align 8, !dbg !51, !tbaa !25
-  %39 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !51
-  %40 = load i64, i64* %39, align 8, !dbg !51, !tbaa !25
-  br label %rb_array_len.exit, !dbg !51
+  %37 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 2, !dbg !53
+  %38 = load i64*, i64** %37, align 8, !dbg !53, !tbaa !27
+  %39 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !53
+  %40 = load i64, i64* %39, align 8, !dbg !53, !tbaa !27
+  br label %rb_array_len.exit, !dbg !53
 
 rb_array_len.exit:                                ; preds = %32, %36
   %41 = phi i64* [ %33, %32 ], [ %38, %36 ]
-  %42 = phi i64 [ %35, %32 ], [ %40, %36 ], !dbg !51
-  %43 = trunc i64 %42 to i32, !dbg !51
-  br label %fillRequiredArgs, !dbg !51
+  %42 = phi i64 [ %35, %32 ], [ %40, %36 ], !dbg !53
+  %43 = trunc i64 %42 to i32, !dbg !53
+  br label %fillRequiredArgs, !dbg !53
 
 fillFromArgBlock0:                                ; preds = %fillRequiredArgs
-  %rawArg_x = load i64, i64* %argArrayPhi, align 8, !dbg !51
-  %default1 = icmp eq i32 %argcPhi, 1, !dbg !51
-  br i1 %default1, label %fillFromDefaultBlockDone2, label %fillFromArgBlock1, !dbg !51, !prof !26
+  %rawArg_x = load i64, i64* %argArrayPhi, align 8, !dbg !53
+  %default1 = icmp eq i32 %argcPhi, 1, !dbg !53
+  br i1 %default1, label %fillFromDefaultBlockDone2, label %fillFromArgBlock1, !dbg !53, !prof !28
 
 fillFromArgBlock1:                                ; preds = %fillFromArgBlock0
-  %44 = getelementptr i64, i64* %argArrayPhi, i32 1, !dbg !51
-  %rawArg_y = load i64, i64* %44, align 8, !dbg !51
-  br label %fillFromDefaultBlockDone2, !dbg !51
+  %44 = getelementptr i64, i64* %argArrayPhi, i32 1, !dbg !53
+  %rawArg_y = load i64, i64* %44, align 8, !dbg !53
+  br label %fillFromDefaultBlockDone2, !dbg !53
 
 fillFromDefaultBlockDone2:                        ; preds = %argArrayExpandArrayTest, %sorbet_isa_Array.exit, %fillFromArgBlock0, %fillRequiredArgs, %fillFromArgBlock1
-  %y.sroa.0.0 = phi i64 [ %rawArg_y, %fillFromArgBlock1 ], [ 8, %fillRequiredArgs ], [ 8, %fillFromArgBlock0 ], [ 8, %sorbet_isa_Array.exit ], [ 8, %argArrayExpandArrayTest ], !dbg !51
-  %x.sroa.0.1 = phi i64 [ %rawArg_x, %fillFromArgBlock1 ], [ %rawArg_x, %fillFromArgBlock0 ], [ 8, %fillRequiredArgs ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ], !dbg !51
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %10, align 8, !dbg !52, !tbaa !13
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !53
-  %46 = load i64*, i64** %45, align 8, !dbg !53
-  store i64 %4, i64* %46, align 8, !dbg !53, !tbaa !4
-  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !53
-  store i64 %x.sroa.0.1, i64* %47, align 8, !dbg !53, !tbaa !4
-  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !53
-  store i64* %48, i64** %45, align 8, !dbg !53
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.8, i64 0), !dbg !53
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %10, align 8, !dbg !53, !tbaa !13
-  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !54
-  %50 = load i64*, i64** %49, align 8, !dbg !54
-  store i64 %4, i64* %50, align 8, !dbg !54, !tbaa !4
-  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !54
-  store i64 %y.sroa.0.0, i64* %51, align 8, !dbg !54, !tbaa !4
-  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !54
-  store i64* %52, i64** %49, align 8, !dbg !54
-  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.9, i64 0), !dbg !54
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %10, align 8, !dbg !54, !tbaa !13
-  ret i64 %send38, !dbg !55
+  %y.sroa.0.0 = phi i64 [ %rawArg_y, %fillFromArgBlock1 ], [ 8, %fillRequiredArgs ], [ 8, %fillFromArgBlock0 ], [ 8, %sorbet_isa_Array.exit ], [ 8, %argArrayExpandArrayTest ], !dbg !53
+  %x.sroa.0.1 = phi i64 [ %rawArg_x, %fillFromArgBlock1 ], [ %rawArg_x, %fillFromArgBlock0 ], [ 8, %fillRequiredArgs ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ], !dbg !53
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %10, align 8, !dbg !54, !tbaa !15
+  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !55
+  %46 = load i64*, i64** %45, align 8, !dbg !55
+  store i64 %4, i64* %46, align 8, !dbg !55, !tbaa !6
+  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !55
+  store i64 %x.sroa.0.1, i64* %47, align 8, !dbg !55, !tbaa !6
+  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !55
+  store i64* %48, i64** %45, align 8, !dbg !55
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.8, i64 0), !dbg !55
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %10, align 8, !dbg !55, !tbaa !15
+  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !56
+  %50 = load i64*, i64** %49, align 8, !dbg !56
+  store i64 %4, i64* %50, align 8, !dbg !56, !tbaa !6
+  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !56
+  store i64 %y.sroa.0.0, i64* %51, align 8, !dbg !56, !tbaa !6
+  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !56
+  store i64* %52, i64** %49, align 8, !dbg !56
+  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.9, i64 0), !dbg !56
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %10, align 8, !dbg !56, !tbaa !15
+  ret i64 %send38, !dbg !57
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers, %rb_array_len.exit
-  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %43, %rb_array_len.exit ], !dbg !51
-  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %41, %rb_array_len.exit ], !dbg !51
-  %default0 = icmp eq i32 %argcPhi, 0, !dbg !51
-  br i1 %default0, label %fillFromDefaultBlockDone2, label %fillFromArgBlock0, !dbg !51, !prof !26
+  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %43, %rb_array_len.exit ], !dbg !53
+  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %41, %rb_array_len.exit ], !dbg !53
+  %default0 = icmp eq i32 %argcPhi, 0, !dbg !53
+  br i1 %default0, label %fillFromDefaultBlockDone2, label %fillFromArgBlock0, !dbg !53, !prof !28
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$151$block_5"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !56 {
+define internal i64 @"func_<root>.<static-init>$151$block_5"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !58 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !15
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !40
+  %4 = load i64, i64* %3, align 8, !tbaa !42
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_5", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !21
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !21
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !23
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %10, align 8, !tbaa !13
-  %arrayExpansionSizeGuard = icmp eq i32 %argc, 1, !dbg !57
-  br i1 %arrayExpansionSizeGuard, label %argArrayExpandArrayTest, label %fillRequiredArgs, !dbg !57
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %10, align 8, !tbaa !15
+  %arrayExpansionSizeGuard = icmp eq i32 %argc, 1, !dbg !59
+  br i1 %arrayExpansionSizeGuard, label %argArrayExpandArrayTest, label %fillRequiredArgs, !dbg !59
 
 argArrayExpandArrayTest:                          ; preds = %functionEntryInitializers
-  %arg1_maybeExpandToFullArgs = load i64, i64* %argArray, align 8, !dbg !57
-  %11 = and i64 %arg1_maybeExpandToFullArgs, 7, !dbg !57
-  %12 = icmp ne i64 %11, 0, !dbg !57
-  %13 = and i64 %arg1_maybeExpandToFullArgs, -9, !dbg !57
-  %14 = icmp eq i64 %13, 0, !dbg !57
-  %15 = or i1 %12, %14, !dbg !57
-  br i1 %15, label %fillFromDefaultBlockDone2, label %sorbet_isa_Array.exit, !dbg !57
+  %arg1_maybeExpandToFullArgs = load i64, i64* %argArray, align 8, !dbg !59
+  %11 = and i64 %arg1_maybeExpandToFullArgs, 7, !dbg !59
+  %12 = icmp ne i64 %11, 0, !dbg !59
+  %13 = and i64 %arg1_maybeExpandToFullArgs, -9, !dbg !59
+  %14 = icmp eq i64 %13, 0, !dbg !59
+  %15 = or i1 %12, %14, !dbg !59
+  br i1 %15, label %fillFromDefaultBlockDone2, label %sorbet_isa_Array.exit, !dbg !59
 
 sorbet_isa_Array.exit:                            ; preds = %argArrayExpandArrayTest
-  %16 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !57
-  %17 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %16, i64 0, i32 0, !dbg !57
-  %18 = load i64, i64* %17, align 8, !dbg !57, !tbaa !23
-  %19 = and i64 %18, 31, !dbg !57
-  %20 = icmp eq i64 %19, 7, !dbg !57
-  br i1 %20, label %argArrayExpand, label %fillFromDefaultBlockDone2, !dbg !57
+  %16 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !59
+  %17 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %16, i64 0, i32 0, !dbg !59
+  %18 = load i64, i64* %17, align 8, !dbg !59, !tbaa !25
+  %19 = and i64 %18, 31, !dbg !59
+  %20 = icmp eq i64 %19, 7, !dbg !59
+  br i1 %20, label %argArrayExpand, label %fillFromDefaultBlockDone2, !dbg !59
 
 argArrayExpand:                                   ; preds = %sorbet_isa_Array.exit
-  %21 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !57
-  %22 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %21, i64 0, i32 0, !dbg !57
-  %23 = load i64, i64* %22, align 8, !dbg !57, !tbaa !23
-  %24 = and i64 %23, 33554432, !dbg !57
-  %25 = icmp eq i64 %24, 0, !dbg !57
-  br i1 %25, label %27, label %26, !dbg !57
+  %21 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !59
+  %22 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %21, i64 0, i32 0, !dbg !59
+  %23 = load i64, i64* %22, align 8, !dbg !59, !tbaa !25
+  %24 = and i64 %23, 33554432, !dbg !59
+  %25 = icmp eq i64 %24, 0, !dbg !59
+  br i1 %25, label %27, label %26, !dbg !59
 
 26:                                               ; preds = %argArrayExpand
-  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #12, !dbg !57
-  br label %27, !dbg !57
+  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #12, !dbg !59
+  br label %27, !dbg !59
 
 27:                                               ; preds = %26, %argArrayExpand
-  %28 = load i64, i64* %22, align 8, !dbg !57, !tbaa !23
-  %29 = and i64 %28, 8192, !dbg !57
-  %30 = icmp eq i64 %29, 0, !dbg !57
-  %31 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.RArray*, !dbg !57
-  br i1 %30, label %36, label %32, !dbg !57
+  %28 = load i64, i64* %22, align 8, !dbg !59, !tbaa !25
+  %29 = and i64 %28, 8192, !dbg !59
+  %30 = icmp eq i64 %29, 0, !dbg !59
+  %31 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.RArray*, !dbg !59
+  br i1 %30, label %36, label %32, !dbg !59
 
 32:                                               ; preds = %27
-  %33 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !57
-  %34 = lshr i64 %28, 15, !dbg !57
-  %35 = and i64 %34, 3, !dbg !57
-  br label %rb_array_len.exit, !dbg !57
+  %33 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !59
+  %34 = lshr i64 %28, 15, !dbg !59
+  %35 = and i64 %34, 3, !dbg !59
+  br label %rb_array_len.exit, !dbg !59
 
 36:                                               ; preds = %27
-  %37 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 2, !dbg !57
-  %38 = load i64*, i64** %37, align 8, !dbg !57, !tbaa !25
-  %39 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !57
-  %40 = load i64, i64* %39, align 8, !dbg !57, !tbaa !25
-  br label %rb_array_len.exit, !dbg !57
+  %37 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 2, !dbg !59
+  %38 = load i64*, i64** %37, align 8, !dbg !59, !tbaa !27
+  %39 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !59
+  %40 = load i64, i64* %39, align 8, !dbg !59, !tbaa !27
+  br label %rb_array_len.exit, !dbg !59
 
 rb_array_len.exit:                                ; preds = %32, %36
   %41 = phi i64* [ %33, %32 ], [ %38, %36 ]
-  %42 = phi i64 [ %35, %32 ], [ %40, %36 ], !dbg !57
-  %43 = trunc i64 %42 to i32, !dbg !57
-  br label %fillRequiredArgs, !dbg !57
+  %42 = phi i64 [ %35, %32 ], [ %40, %36 ], !dbg !59
+  %43 = trunc i64 %42 to i32, !dbg !59
+  br label %fillRequiredArgs, !dbg !59
 
 fillFromArgBlock0:                                ; preds = %fillRequiredArgs
-  %rawArg_x = load i64, i64* %argArrayPhi, align 8, !dbg !57
-  %default1 = icmp eq i32 %argcPhi, 1, !dbg !57
-  br i1 %default1, label %fillFromDefaultBlockDone2, label %fillFromArgBlock1, !dbg !57, !prof !26
+  %rawArg_x = load i64, i64* %argArrayPhi, align 8, !dbg !59
+  %default1 = icmp eq i32 %argcPhi, 1, !dbg !59
+  br i1 %default1, label %fillFromDefaultBlockDone2, label %fillFromArgBlock1, !dbg !59, !prof !28
 
 fillFromArgBlock1:                                ; preds = %fillFromArgBlock0
-  %44 = getelementptr i64, i64* %argArrayPhi, i32 1, !dbg !57
-  %rawArg_y = load i64, i64* %44, align 8, !dbg !57
-  br label %fillFromDefaultBlockDone2, !dbg !57
+  %44 = getelementptr i64, i64* %argArrayPhi, i32 1, !dbg !59
+  %rawArg_y = load i64, i64* %44, align 8, !dbg !59
+  br label %fillFromDefaultBlockDone2, !dbg !59
 
 fillFromDefaultBlockDone2:                        ; preds = %argArrayExpandArrayTest, %sorbet_isa_Array.exit, %fillFromArgBlock0, %fillRequiredArgs, %fillFromArgBlock1
-  %y.sroa.0.0 = phi i64 [ %rawArg_y, %fillFromArgBlock1 ], [ 8, %fillRequiredArgs ], [ 8, %fillFromArgBlock0 ], [ 8, %sorbet_isa_Array.exit ], [ 8, %argArrayExpandArrayTest ], !dbg !57
-  %x.sroa.0.1 = phi i64 [ %rawArg_x, %fillFromArgBlock1 ], [ %rawArg_x, %fillFromArgBlock0 ], [ 8, %fillRequiredArgs ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ], !dbg !57
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %10, align 8, !dbg !58, !tbaa !13
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !59
-  %46 = load i64*, i64** %45, align 8, !dbg !59
-  store i64 %4, i64* %46, align 8, !dbg !59, !tbaa !4
-  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !59
-  store i64 %x.sroa.0.1, i64* %47, align 8, !dbg !59, !tbaa !4
-  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !59
-  store i64* %48, i64** %45, align 8, !dbg !59
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.12, i64 0), !dbg !59
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %10, align 8, !dbg !59, !tbaa !13
-  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !60
-  %50 = load i64*, i64** %49, align 8, !dbg !60
-  store i64 %4, i64* %50, align 8, !dbg !60, !tbaa !4
-  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !60
-  store i64 %y.sroa.0.0, i64* %51, align 8, !dbg !60, !tbaa !4
-  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !60
-  store i64* %52, i64** %49, align 8, !dbg !60
-  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.13, i64 0), !dbg !60
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %10, align 8, !dbg !60, !tbaa !13
-  ret i64 %send38, !dbg !61
+  %y.sroa.0.0 = phi i64 [ %rawArg_y, %fillFromArgBlock1 ], [ 8, %fillRequiredArgs ], [ 8, %fillFromArgBlock0 ], [ 8, %sorbet_isa_Array.exit ], [ 8, %argArrayExpandArrayTest ], !dbg !59
+  %x.sroa.0.1 = phi i64 [ %rawArg_x, %fillFromArgBlock1 ], [ %rawArg_x, %fillFromArgBlock0 ], [ 8, %fillRequiredArgs ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ], !dbg !59
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %10, align 8, !dbg !60, !tbaa !15
+  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !61
+  %46 = load i64*, i64** %45, align 8, !dbg !61
+  store i64 %4, i64* %46, align 8, !dbg !61, !tbaa !6
+  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !61
+  store i64 %x.sroa.0.1, i64* %47, align 8, !dbg !61, !tbaa !6
+  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !61
+  store i64* %48, i64** %45, align 8, !dbg !61
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.12, i64 0), !dbg !61
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %10, align 8, !dbg !61, !tbaa !15
+  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !62
+  %50 = load i64*, i64** %49, align 8, !dbg !62
+  store i64 %4, i64* %50, align 8, !dbg !62, !tbaa !6
+  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !62
+  store i64 %y.sroa.0.0, i64* %51, align 8, !dbg !62, !tbaa !6
+  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !62
+  store i64* %52, i64** %49, align 8, !dbg !62
+  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.13, i64 0), !dbg !62
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %10, align 8, !dbg !62, !tbaa !15
+  ret i64 %send38, !dbg !63
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers, %rb_array_len.exit
-  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %43, %rb_array_len.exit ], !dbg !57
-  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %41, %rb_array_len.exit ], !dbg !57
-  %default0 = icmp eq i32 %argcPhi, 0, !dbg !57
-  br i1 %default0, label %fillFromDefaultBlockDone2, label %fillFromArgBlock0, !dbg !57, !prof !26
+  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %43, %rb_array_len.exit ], !dbg !59
+  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %41, %rb_array_len.exit ], !dbg !59
+  %default0 = icmp eq i32 %argcPhi, 0, !dbg !59
+  br i1 %default0, label %fillFromDefaultBlockDone2, label %fillFromArgBlock0, !dbg !59, !prof !28
 }
 
 ; Function Attrs: sspreq
@@ -776,699 +776,699 @@ entry:
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i42.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
   %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block for.i41.i", i64 %"rubyId_block for.i40.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i42.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i39.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
   store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_5", align 8
-  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !28
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !43
-  %rubyId_p7.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.5, i64 %rubyId_p7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
-  %rubyId_p12.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !53
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.8, i64 %rubyId_p12.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !53
-  %rubyId_p15.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !54
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.9, i64 %rubyId_p15.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !54
-  %rubyId_p20.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !59
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p20.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !59
-  %rubyId_p23.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !60
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p23.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !60
-  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !30
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
+  %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
+  %rubyId_p7.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !50
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.5, i64 %rubyId_p7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
+  %rubyId_p12.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !55
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.8, i64 %rubyId_p12.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !55
+  %rubyId_p15.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !56
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.9, i64 %rubyId_p15.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !56
+  %rubyId_p20.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !61
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p20.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !61
+  %rubyId_p23.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !62
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p23.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !62
+  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 2
-  %27 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !15
+  %27 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !17
   %28 = bitcast [3 x i64]* %callArgs.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %28)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !15
+  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !17
   %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %30, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %30, align 8, !tbaa !21
   %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4
-  %32 = load i64*, i64** %31, align 8, !tbaa !21
-  %33 = load i64, i64* %32, align 8, !tbaa !4
+  %32 = load i64*, i64** %31, align 8, !tbaa !23
+  %33 = load i64, i64* %32, align 8, !tbaa !6
   %34 = and i64 %33, -33
-  store i64 %34, i64* %32, align 8, !tbaa !4
+  store i64 %34, i64* %32, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %25, %struct.rb_control_frame_struct* %29, %struct.rb_iseq_struct* %stackFrame.i) #12
   %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %35, align 8, !dbg !62, !tbaa !13
-  %callArgs0Addr.i = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i32 0, i64 0, !dbg !63
-  %36 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !63
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %36, align 8, !dbg !63
-  %37 = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i64 0, i64 0, !dbg !63
-  call void @llvm.experimental.noalias.scope.decl(metadata !64) #12, !dbg !63
-  %38 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %37) #12, !dbg !63
-  store i64 %38, i64* %callArgs0Addr.i, align 8, !dbg !67
-  call void @llvm.experimental.noalias.scope.decl(metadata !68) #12, !dbg !67
-  %39 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %37) #12, !dbg !67
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %35, align 8, !dbg !67, !tbaa !13
-  %rubyId_each.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !71
-  %40 = bitcast %struct.sorbet_inlineIntrinsicEnv* %6 to i8*, !dbg !71
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %40) #12, !dbg !71
-  %41 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 0, !dbg !71
-  store i64 %39, i64* %41, align 8, !dbg !71, !tbaa !72
-  %42 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 1, !dbg !71
-  store i64 %rubyId_each.i, i64* %42, align 8, !dbg !71, !tbaa !74
-  %43 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 2, !dbg !71
-  store i32 0, i32* %43, align 8, !dbg !71, !tbaa !75
-  %44 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 3, !dbg !71
-  %45 = bitcast i64** %44 to i8*, !dbg !71
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %45, i8 0, i64 16, i1 false) #12, !dbg !71
-  %46 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !71, !tbaa !13
-  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2, !dbg !71
-  %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !dbg !71, !tbaa !15
-  call void @llvm.experimental.noalias.scope.decl(metadata !76) #12, !dbg !71
-  %49 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_1", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !71
-  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 3, !dbg !71
-  %51 = bitcast i64* %50 to %struct.rb_captured_block*, !dbg !71
-  %52 = getelementptr inbounds i64, i64* %50, i64 2, !dbg !71
-  %53 = bitcast i64* %52 to %struct.vm_ifunc**, !dbg !71
-  store %struct.vm_ifunc* %49, %struct.vm_ifunc** %53, align 8, !dbg !71, !tbaa !25
-  call void @llvm.experimental.noalias.scope.decl(metadata !79) #12, !dbg !71
-  %54 = ptrtoint %struct.rb_captured_block* %51 to i64, !dbg !71
-  %55 = or i64 %54, 3, !dbg !71
-  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 17, !dbg !71
-  store i64 %55, i64* %56, align 8, !dbg !71, !tbaa !82
-  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !83, !tbaa !13
-  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 17, !dbg !83
-  %59 = load i64, i64* %58, align 8, !dbg !83, !tbaa !82
-  %60 = and i64 %59, -4, !dbg !83
-  %61 = inttoptr i64 %60 to %struct.rb_captured_block*, !dbg !83
-  store i64 0, i64* %58, align 8, !dbg !83, !tbaa !82
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %61) #12, !dbg !83
-  %62 = inttoptr i64 %39 to %struct.iseq_inline_iv_cache_entry*, !dbg !83
-  %63 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %62, i64 0, i32 0, !dbg !83
-  %64 = load i64, i64* %63, align 8, !dbg !83, !tbaa !23
-  %65 = and i64 %64, 8192, !dbg !83
-  %66 = icmp eq i64 %65, 0, !dbg !83
-  br i1 %66, label %70, label %67, !dbg !83
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %35, align 8, !dbg !64, !tbaa !15
+  %callArgs0Addr.i = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i32 0, i64 0, !dbg !65
+  %36 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !65
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %36, align 8, !dbg !65
+  %37 = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i64 0, i64 0, !dbg !65
+  call void @llvm.experimental.noalias.scope.decl(metadata !66) #12, !dbg !65
+  %38 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %37) #12, !dbg !65
+  store i64 %38, i64* %callArgs0Addr.i, align 8, !dbg !69
+  call void @llvm.experimental.noalias.scope.decl(metadata !70) #12, !dbg !69
+  %39 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %37) #12, !dbg !69
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %35, align 8, !dbg !69, !tbaa !15
+  %rubyId_each.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !73
+  %40 = bitcast %struct.sorbet_inlineIntrinsicEnv* %6 to i8*, !dbg !73
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %40) #12, !dbg !73
+  %41 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 0, !dbg !73
+  store i64 %39, i64* %41, align 8, !dbg !73, !tbaa !74
+  %42 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 1, !dbg !73
+  store i64 %rubyId_each.i, i64* %42, align 8, !dbg !73, !tbaa !76
+  %43 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 2, !dbg !73
+  store i32 0, i32* %43, align 8, !dbg !73, !tbaa !77
+  %44 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 3, !dbg !73
+  %45 = bitcast i64** %44 to i8*, !dbg !73
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %45, i8 0, i64 16, i1 false) #12, !dbg !73
+  %46 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !73, !tbaa !15
+  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2, !dbg !73
+  %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !dbg !73, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !78) #12, !dbg !73
+  %49 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_1", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !73
+  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 3, !dbg !73
+  %51 = bitcast i64* %50 to %struct.rb_captured_block*, !dbg !73
+  %52 = getelementptr inbounds i64, i64* %50, i64 2, !dbg !73
+  %53 = bitcast i64* %52 to %struct.vm_ifunc**, !dbg !73
+  store %struct.vm_ifunc* %49, %struct.vm_ifunc** %53, align 8, !dbg !73, !tbaa !27
+  call void @llvm.experimental.noalias.scope.decl(metadata !81) #12, !dbg !73
+  %54 = ptrtoint %struct.rb_captured_block* %51 to i64, !dbg !73
+  %55 = or i64 %54, 3, !dbg !73
+  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 17, !dbg !73
+  store i64 %55, i64* %56, align 8, !dbg !73, !tbaa !84
+  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !85, !tbaa !15
+  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 17, !dbg !85
+  %59 = load i64, i64* %58, align 8, !dbg !85, !tbaa !84
+  %60 = and i64 %59, -4, !dbg !85
+  %61 = inttoptr i64 %60 to %struct.rb_captured_block*, !dbg !85
+  store i64 0, i64* %58, align 8, !dbg !85, !tbaa !84
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %61) #12, !dbg !85
+  %62 = inttoptr i64 %39 to %struct.iseq_inline_iv_cache_entry*, !dbg !85
+  %63 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %62, i64 0, i32 0, !dbg !85
+  %64 = load i64, i64* %63, align 8, !dbg !85, !tbaa !25
+  %65 = and i64 %64, 8192, !dbg !85
+  %66 = icmp eq i64 %65, 0, !dbg !85
+  br i1 %66, label %70, label %67, !dbg !85
 
 67:                                               ; preds = %entry
-  %68 = lshr i64 %64, 15, !dbg !83
-  %69 = and i64 %68, 3, !dbg !83
-  br label %rb_array_len.exit1.i3.i, !dbg !83
+  %68 = lshr i64 %64, 15, !dbg !85
+  %69 = and i64 %68, 3, !dbg !85
+  br label %rb_array_len.exit1.i3.i, !dbg !85
 
 70:                                               ; preds = %entry
-  %71 = inttoptr i64 %39 to %struct.RArray*, !dbg !83
-  %72 = getelementptr inbounds %struct.RArray, %struct.RArray* %71, i64 0, i32 1, i32 0, i32 0, !dbg !83
-  %73 = load i64, i64* %72, align 8, !dbg !83, !tbaa !25
-  br label %rb_array_len.exit1.i3.i, !dbg !83
+  %71 = inttoptr i64 %39 to %struct.RArray*, !dbg !85
+  %72 = getelementptr inbounds %struct.RArray, %struct.RArray* %71, i64 0, i32 1, i32 0, i32 0, !dbg !85
+  %73 = load i64, i64* %72, align 8, !dbg !85, !tbaa !27
+  br label %rb_array_len.exit1.i3.i, !dbg !85
 
 rb_array_len.exit1.i3.i:                          ; preds = %70, %67
-  %74 = phi i64 [ %69, %67 ], [ %73, %70 ], !dbg !83
-  %75 = icmp sgt i64 %74, 0, !dbg !83
-  br i1 %75, label %76, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !83
+  %74 = phi i64 [ %69, %67 ], [ %73, %70 ], !dbg !85
+  %75 = icmp sgt i64 %74, 0, !dbg !85
+  br i1 %75, label %76, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !85
 
 76:                                               ; preds = %rb_array_len.exit1.i3.i
-  %77 = bitcast i64* %1 to i8*, !dbg !83
-  %78 = inttoptr i64 %39 to %struct.RArray*, !dbg !71
-  %79 = getelementptr inbounds %struct.RArray, %struct.RArray* %78, i64 0, i32 1, i32 0, i32 0, !dbg !71
-  %80 = getelementptr inbounds %struct.RArray, %struct.RArray* %78, i64 0, i32 1, i32 0, i32 2, !dbg !71
-  br label %81, !dbg !83
+  %77 = bitcast i64* %1 to i8*, !dbg !85
+  %78 = inttoptr i64 %39 to %struct.RArray*, !dbg !73
+  %79 = getelementptr inbounds %struct.RArray, %struct.RArray* %78, i64 0, i32 1, i32 0, i32 0, !dbg !73
+  %80 = getelementptr inbounds %struct.RArray, %struct.RArray* %78, i64 0, i32 1, i32 0, i32 2, !dbg !73
+  br label %81, !dbg !85
 
 81:                                               ; preds = %rb_array_len.exit.i5.i, %76
-  %82 = phi i64 [ 0, %76 ], [ %92, %rb_array_len.exit.i5.i ], !dbg !83
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %77) #12, !dbg !83
-  %83 = load i64, i64* %63, align 8, !dbg !83, !tbaa !23
-  %84 = and i64 %83, 8192, !dbg !83
-  %85 = icmp eq i64 %84, 0, !dbg !83
-  br i1 %85, label %86, label %rb_array_const_ptr_transient.exit.i4.i, !dbg !83
+  %82 = phi i64 [ 0, %76 ], [ %92, %rb_array_len.exit.i5.i ], !dbg !85
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %77) #12, !dbg !85
+  %83 = load i64, i64* %63, align 8, !dbg !85, !tbaa !25
+  %84 = and i64 %83, 8192, !dbg !85
+  %85 = icmp eq i64 %84, 0, !dbg !85
+  br i1 %85, label %86, label %rb_array_const_ptr_transient.exit.i4.i, !dbg !85
 
 86:                                               ; preds = %81
-  %87 = load i64*, i64** %80, align 8, !dbg !83, !tbaa !25
-  br label %rb_array_const_ptr_transient.exit.i4.i, !dbg !83
+  %87 = load i64*, i64** %80, align 8, !dbg !85, !tbaa !27
+  br label %rb_array_const_ptr_transient.exit.i4.i, !dbg !85
 
 rb_array_const_ptr_transient.exit.i4.i:           ; preds = %86, %81
-  %88 = phi i64* [ %87, %86 ], [ %79, %81 ], !dbg !83
-  %89 = getelementptr inbounds i64, i64* %88, i64 %82, !dbg !83
-  %90 = load i64, i64* %89, align 8, !dbg !83, !tbaa !4
-  store i64 %90, i64* %1, align 8, !dbg !83, !tbaa !4
-  %91 = call i64 @"func_<root>.<static-init>$151$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %1, i64 undef) #12, !dbg !83
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %77) #12, !dbg !83
-  %92 = add nuw nsw i64 %82, 1, !dbg !83
-  %93 = load i64, i64* %63, align 8, !dbg !83, !tbaa !23
-  %94 = and i64 %93, 8192, !dbg !83
-  %95 = icmp eq i64 %94, 0, !dbg !83
-  br i1 %95, label %99, label %96, !dbg !83
+  %88 = phi i64* [ %87, %86 ], [ %79, %81 ], !dbg !85
+  %89 = getelementptr inbounds i64, i64* %88, i64 %82, !dbg !85
+  %90 = load i64, i64* %89, align 8, !dbg !85, !tbaa !6
+  store i64 %90, i64* %1, align 8, !dbg !85, !tbaa !6
+  %91 = call i64 @"func_<root>.<static-init>$151$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %1, i64 undef) #12, !dbg !85
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %77) #12, !dbg !85
+  %92 = add nuw nsw i64 %82, 1, !dbg !85
+  %93 = load i64, i64* %63, align 8, !dbg !85, !tbaa !25
+  %94 = and i64 %93, 8192, !dbg !85
+  %95 = icmp eq i64 %94, 0, !dbg !85
+  br i1 %95, label %99, label %96, !dbg !85
 
 96:                                               ; preds = %rb_array_const_ptr_transient.exit.i4.i
-  %97 = lshr i64 %93, 15, !dbg !83
-  %98 = and i64 %97, 3, !dbg !83
-  br label %rb_array_len.exit.i5.i, !dbg !83
+  %97 = lshr i64 %93, 15, !dbg !85
+  %98 = and i64 %97, 3, !dbg !85
+  br label %rb_array_len.exit.i5.i, !dbg !85
 
 99:                                               ; preds = %rb_array_const_ptr_transient.exit.i4.i
-  %100 = load i64, i64* %79, align 8, !dbg !83, !tbaa !25
-  br label %rb_array_len.exit.i5.i, !dbg !83
+  %100 = load i64, i64* %79, align 8, !dbg !85, !tbaa !27
+  br label %rb_array_len.exit.i5.i, !dbg !85
 
 rb_array_len.exit.i5.i:                           ; preds = %99, %96
-  %101 = phi i64 [ %98, %96 ], [ %100, %99 ], !dbg !83
-  %102 = icmp sgt i64 %101, %92, !dbg !83
-  br i1 %102, label %81, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !83, !llvm.loop !85
+  %101 = phi i64 [ %98, %96 ], [ %100, %99 ], !dbg !85
+  %102 = icmp sgt i64 %101, %92, !dbg !85
+  br i1 %102, label %81, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !85, !llvm.loop !87
 
 forward_sorbet_rb_array_each_withBlock.exit.i:    ; preds = %rb_array_len.exit.i5.i, %rb_array_len.exit1.i3.i
-  call void @sorbet_popFrame() #12, !dbg !83
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %40) #12, !dbg !71
-  %103 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !71, !tbaa !13
-  %104 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 5, !dbg !71
-  %105 = load i32, i32* %104, align 8, !dbg !71, !tbaa !35
-  %106 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 6, !dbg !71
-  %107 = load i32, i32* %106, align 4, !dbg !71, !tbaa !36
-  %108 = xor i32 %107, -1, !dbg !71
-  %109 = and i32 %108, %105, !dbg !71
-  %110 = icmp eq i32 %109, 0, !dbg !71
-  br i1 %110, label %rb_check_arity.1.exit.i8.i, label %111, !dbg !71, !prof !29
+  call void @sorbet_popFrame() #12, !dbg !85
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %40) #12, !dbg !73
+  %103 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !73, !tbaa !15
+  %104 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 5, !dbg !73
+  %105 = load i32, i32* %104, align 8, !dbg !73, !tbaa !37
+  %106 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 6, !dbg !73
+  %107 = load i32, i32* %106, align 4, !dbg !73, !tbaa !38
+  %108 = xor i32 %107, -1, !dbg !73
+  %109 = and i32 %108, %105, !dbg !73
+  %110 = icmp eq i32 %109, 0, !dbg !73
+  br i1 %110, label %rb_check_arity.1.exit.i8.i, label %111, !dbg !73, !prof !31
 
 111:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.exit.i
-  %112 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 8, !dbg !71
-  %113 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %112, align 8, !dbg !71, !tbaa !37
-  %114 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %113, i32 noundef 0) #12, !dbg !71
-  br label %rb_check_arity.1.exit.i8.i, !dbg !71
+  %112 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 8, !dbg !73
+  %113 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %112, align 8, !dbg !73, !tbaa !39
+  %114 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %113, i32 noundef 0) #12, !dbg !73
+  br label %rb_check_arity.1.exit.i8.i, !dbg !73
 
 rb_check_arity.1.exit.i8.i:                       ; preds = %111, %forward_sorbet_rb_array_each_withBlock.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %35, align 8, !dbg !71, !tbaa !13
-  %rubyId_each66.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !87
-  %115 = bitcast %struct.sorbet_inlineIntrinsicEnv* %5 to i8*, !dbg !87
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %115) #12, !dbg !87
-  %116 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 0, !dbg !87
-  store i64 %39, i64* %116, align 8, !dbg !87, !tbaa !72
-  %117 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 1, !dbg !87
-  store i64 %rubyId_each66.i, i64* %117, align 8, !dbg !87, !tbaa !74
-  %118 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 2, !dbg !87
-  store i32 0, i32* %118, align 8, !dbg !87, !tbaa !75
-  %119 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 3, !dbg !87
-  %120 = bitcast i64** %119 to i8*, !dbg !87
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %120, i8 0, i64 16, i1 false) #12, !dbg !87
-  %121 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !87, !tbaa !13
-  %122 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %121, i64 0, i32 2, !dbg !87
-  %123 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %122, align 8, !dbg !87, !tbaa !15
-  call void @llvm.experimental.noalias.scope.decl(metadata !88) #12, !dbg !87
-  %124 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_2", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !87
-  %125 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %123, i64 0, i32 3, !dbg !87
-  %126 = bitcast i64* %125 to %struct.rb_captured_block*, !dbg !87
-  %127 = getelementptr inbounds i64, i64* %125, i64 2, !dbg !87
-  %128 = bitcast i64* %127 to %struct.vm_ifunc**, !dbg !87
-  store %struct.vm_ifunc* %124, %struct.vm_ifunc** %128, align 8, !dbg !87, !tbaa !25
-  call void @llvm.experimental.noalias.scope.decl(metadata !91) #12, !dbg !87
-  %129 = ptrtoint %struct.rb_captured_block* %126 to i64, !dbg !87
-  %130 = or i64 %129, 3, !dbg !87
-  %131 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %121, i64 0, i32 17, !dbg !87
-  store i64 %130, i64* %131, align 8, !dbg !87, !tbaa !82
-  %132 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !94, !tbaa !13
-  %133 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %132, i64 0, i32 17, !dbg !94
-  %134 = load i64, i64* %133, align 8, !dbg !94, !tbaa !82
-  %135 = and i64 %134, -4, !dbg !94
-  %136 = inttoptr i64 %135 to %struct.rb_captured_block*, !dbg !94
-  store i64 0, i64* %133, align 8, !dbg !94, !tbaa !82
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %136) #12, !dbg !94
-  %137 = load i64, i64* %63, align 8, !dbg !94, !tbaa !23
-  %138 = and i64 %137, 8192, !dbg !94
-  %139 = icmp eq i64 %138, 0, !dbg !94
-  br i1 %139, label %143, label %140, !dbg !94
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %35, align 8, !dbg !73, !tbaa !15
+  %rubyId_each66.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !89
+  %115 = bitcast %struct.sorbet_inlineIntrinsicEnv* %5 to i8*, !dbg !89
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %115) #12, !dbg !89
+  %116 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 0, !dbg !89
+  store i64 %39, i64* %116, align 8, !dbg !89, !tbaa !74
+  %117 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 1, !dbg !89
+  store i64 %rubyId_each66.i, i64* %117, align 8, !dbg !89, !tbaa !76
+  %118 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 2, !dbg !89
+  store i32 0, i32* %118, align 8, !dbg !89, !tbaa !77
+  %119 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 3, !dbg !89
+  %120 = bitcast i64** %119 to i8*, !dbg !89
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %120, i8 0, i64 16, i1 false) #12, !dbg !89
+  %121 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !89, !tbaa !15
+  %122 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %121, i64 0, i32 2, !dbg !89
+  %123 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %122, align 8, !dbg !89, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !90) #12, !dbg !89
+  %124 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_2", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !89
+  %125 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %123, i64 0, i32 3, !dbg !89
+  %126 = bitcast i64* %125 to %struct.rb_captured_block*, !dbg !89
+  %127 = getelementptr inbounds i64, i64* %125, i64 2, !dbg !89
+  %128 = bitcast i64* %127 to %struct.vm_ifunc**, !dbg !89
+  store %struct.vm_ifunc* %124, %struct.vm_ifunc** %128, align 8, !dbg !89, !tbaa !27
+  call void @llvm.experimental.noalias.scope.decl(metadata !93) #12, !dbg !89
+  %129 = ptrtoint %struct.rb_captured_block* %126 to i64, !dbg !89
+  %130 = or i64 %129, 3, !dbg !89
+  %131 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %121, i64 0, i32 17, !dbg !89
+  store i64 %130, i64* %131, align 8, !dbg !89, !tbaa !84
+  %132 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !96, !tbaa !15
+  %133 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %132, i64 0, i32 17, !dbg !96
+  %134 = load i64, i64* %133, align 8, !dbg !96, !tbaa !84
+  %135 = and i64 %134, -4, !dbg !96
+  %136 = inttoptr i64 %135 to %struct.rb_captured_block*, !dbg !96
+  store i64 0, i64* %133, align 8, !dbg !96, !tbaa !84
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %136) #12, !dbg !96
+  %137 = load i64, i64* %63, align 8, !dbg !96, !tbaa !25
+  %138 = and i64 %137, 8192, !dbg !96
+  %139 = icmp eq i64 %138, 0, !dbg !96
+  br i1 %139, label %143, label %140, !dbg !96
 
 140:                                              ; preds = %rb_check_arity.1.exit.i8.i
-  %141 = lshr i64 %137, 15, !dbg !94
-  %142 = and i64 %141, 3, !dbg !94
-  br label %rb_array_len.exit1.i9.i, !dbg !94
+  %141 = lshr i64 %137, 15, !dbg !96
+  %142 = and i64 %141, 3, !dbg !96
+  br label %rb_array_len.exit1.i9.i, !dbg !96
 
 143:                                              ; preds = %rb_check_arity.1.exit.i8.i
-  %144 = inttoptr i64 %39 to %struct.RArray*, !dbg !94
-  %145 = getelementptr inbounds %struct.RArray, %struct.RArray* %144, i64 0, i32 1, i32 0, i32 0, !dbg !94
-  %146 = load i64, i64* %145, align 8, !dbg !94, !tbaa !25
-  br label %rb_array_len.exit1.i9.i, !dbg !94
+  %144 = inttoptr i64 %39 to %struct.RArray*, !dbg !96
+  %145 = getelementptr inbounds %struct.RArray, %struct.RArray* %144, i64 0, i32 1, i32 0, i32 0, !dbg !96
+  %146 = load i64, i64* %145, align 8, !dbg !96, !tbaa !27
+  br label %rb_array_len.exit1.i9.i, !dbg !96
 
 rb_array_len.exit1.i9.i:                          ; preds = %143, %140
-  %147 = phi i64 [ %142, %140 ], [ %146, %143 ], !dbg !94
-  %148 = icmp sgt i64 %147, 0, !dbg !94
-  br i1 %148, label %149, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !94
+  %147 = phi i64 [ %142, %140 ], [ %146, %143 ], !dbg !96
+  %148 = icmp sgt i64 %147, 0, !dbg !96
+  br i1 %148, label %149, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !96
 
 149:                                              ; preds = %rb_array_len.exit1.i9.i
-  %150 = inttoptr i64 %39 to %struct.RArray*, !dbg !87
-  %151 = getelementptr inbounds %struct.RArray, %struct.RArray* %150, i64 0, i32 1, i32 0, i32 0, !dbg !87
-  %152 = getelementptr inbounds %struct.RArray, %struct.RArray* %150, i64 0, i32 1, i32 0, i32 2, !dbg !87
-  br label %153, !dbg !94
+  %150 = inttoptr i64 %39 to %struct.RArray*, !dbg !89
+  %151 = getelementptr inbounds %struct.RArray, %struct.RArray* %150, i64 0, i32 1, i32 0, i32 0, !dbg !89
+  %152 = getelementptr inbounds %struct.RArray, %struct.RArray* %150, i64 0, i32 1, i32 0, i32 2, !dbg !89
+  br label %153, !dbg !96
 
 153:                                              ; preds = %rb_array_len.exit.i11.i, %149
-  %154 = phi i64 [ 0, %149 ], [ %178, %rb_array_len.exit.i11.i ], !dbg !94
-  %155 = load i64, i64* %63, align 8, !dbg !94, !tbaa !23
-  %156 = and i64 %155, 8192, !dbg !94
-  %157 = icmp eq i64 %156, 0, !dbg !94
-  br i1 %157, label %158, label %rb_array_const_ptr_transient.exit.i10.i, !dbg !94
+  %154 = phi i64 [ 0, %149 ], [ %178, %rb_array_len.exit.i11.i ], !dbg !96
+  %155 = load i64, i64* %63, align 8, !dbg !96, !tbaa !25
+  %156 = and i64 %155, 8192, !dbg !96
+  %157 = icmp eq i64 %156, 0, !dbg !96
+  br i1 %157, label %158, label %rb_array_const_ptr_transient.exit.i10.i, !dbg !96
 
 158:                                              ; preds = %153
-  %159 = load i64*, i64** %152, align 8, !dbg !94, !tbaa !25
-  br label %rb_array_const_ptr_transient.exit.i10.i, !dbg !94
+  %159 = load i64*, i64** %152, align 8, !dbg !96, !tbaa !27
+  br label %rb_array_const_ptr_transient.exit.i10.i, !dbg !96
 
 rb_array_const_ptr_transient.exit.i10.i:          ; preds = %158, %153
-  %160 = phi i64* [ %159, %158 ], [ %151, %153 ], !dbg !94
-  %161 = getelementptr inbounds i64, i64* %160, i64 %154, !dbg !94
-  %162 = load i64, i64* %161, align 8, !dbg !94, !tbaa !4
-  call void @llvm.experimental.noalias.scope.decl(metadata !96) #12, !dbg !94
-  %163 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !87, !tbaa !13, !noalias !96
-  %164 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %163, i64 0, i32 2, !dbg !87
-  %165 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %164, align 8, !dbg !87, !tbaa !15, !noalias !96
-  %166 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 3, !dbg !87
-  %167 = load i64, i64* %166, align 8, !dbg !87, !tbaa !40, !noalias !96
-  %stackFrame.i.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_2", align 8, !dbg !87, !noalias !96
-  %168 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 2, !dbg !87
-  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %168, align 8, !dbg !87, !tbaa !19, !noalias !96
-  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 4, !dbg !87
-  %170 = load i64*, i64** %169, align 8, !dbg !87, !tbaa !21, !noalias !96
-  %171 = load i64, i64* %170, align 8, !dbg !87, !tbaa !4, !noalias !96
-  %172 = and i64 %171, -129, !dbg !87
-  store i64 %172, i64* %170, align 8, !dbg !87, !tbaa !4, !noalias !96
-  %173 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 0, !dbg !87
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %173, align 8, !dbg !99, !tbaa !13, !noalias !96
-  %174 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 1, !dbg !101
-  %175 = load i64*, i64** %174, align 8, !dbg !101
-  store i64 %167, i64* %175, align 8, !dbg !101, !tbaa !4
-  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !101
-  store i64 %162, i64* %176, align 8, !dbg !101, !tbaa !4
-  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !101
-  store i64* %177, i64** %174, align 8, !dbg !101
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !101
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %173, align 8, !dbg !101, !tbaa !13, !noalias !96
-  %178 = add nuw nsw i64 %154, 1, !dbg !94
-  %179 = load i64, i64* %63, align 8, !dbg !94, !tbaa !23
-  %180 = and i64 %179, 8192, !dbg !94
-  %181 = icmp eq i64 %180, 0, !dbg !94
-  br i1 %181, label %185, label %182, !dbg !94
+  %160 = phi i64* [ %159, %158 ], [ %151, %153 ], !dbg !96
+  %161 = getelementptr inbounds i64, i64* %160, i64 %154, !dbg !96
+  %162 = load i64, i64* %161, align 8, !dbg !96, !tbaa !6
+  call void @llvm.experimental.noalias.scope.decl(metadata !98) #12, !dbg !96
+  %163 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !89, !tbaa !15, !noalias !98
+  %164 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %163, i64 0, i32 2, !dbg !89
+  %165 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %164, align 8, !dbg !89, !tbaa !17, !noalias !98
+  %166 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 3, !dbg !89
+  %167 = load i64, i64* %166, align 8, !dbg !89, !tbaa !42, !noalias !98
+  %stackFrame.i.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_2", align 8, !dbg !89, !noalias !98
+  %168 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 2, !dbg !89
+  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %168, align 8, !dbg !89, !tbaa !21, !noalias !98
+  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 4, !dbg !89
+  %170 = load i64*, i64** %169, align 8, !dbg !89, !tbaa !23, !noalias !98
+  %171 = load i64, i64* %170, align 8, !dbg !89, !tbaa !6, !noalias !98
+  %172 = and i64 %171, -129, !dbg !89
+  store i64 %172, i64* %170, align 8, !dbg !89, !tbaa !6, !noalias !98
+  %173 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 0, !dbg !89
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %173, align 8, !dbg !101, !tbaa !15, !noalias !98
+  %174 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 1, !dbg !103
+  %175 = load i64*, i64** %174, align 8, !dbg !103
+  store i64 %167, i64* %175, align 8, !dbg !103, !tbaa !6
+  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !103
+  store i64 %162, i64* %176, align 8, !dbg !103, !tbaa !6
+  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !103
+  store i64* %177, i64** %174, align 8, !dbg !103
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !103
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %173, align 8, !dbg !103, !tbaa !15, !noalias !98
+  %178 = add nuw nsw i64 %154, 1, !dbg !96
+  %179 = load i64, i64* %63, align 8, !dbg !96, !tbaa !25
+  %180 = and i64 %179, 8192, !dbg !96
+  %181 = icmp eq i64 %180, 0, !dbg !96
+  br i1 %181, label %185, label %182, !dbg !96
 
 182:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
-  %183 = lshr i64 %179, 15, !dbg !94
-  %184 = and i64 %183, 3, !dbg !94
-  br label %rb_array_len.exit.i11.i, !dbg !94
+  %183 = lshr i64 %179, 15, !dbg !96
+  %184 = and i64 %183, 3, !dbg !96
+  br label %rb_array_len.exit.i11.i, !dbg !96
 
 185:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
-  %186 = load i64, i64* %151, align 8, !dbg !94, !tbaa !25
-  br label %rb_array_len.exit.i11.i, !dbg !94
+  %186 = load i64, i64* %151, align 8, !dbg !96, !tbaa !27
+  br label %rb_array_len.exit.i11.i, !dbg !96
 
 rb_array_len.exit.i11.i:                          ; preds = %185, %182
-  %187 = phi i64 [ %184, %182 ], [ %186, %185 ], !dbg !94
-  %188 = icmp sgt i64 %187, %178, !dbg !94
-  br i1 %188, label %153, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !94, !llvm.loop !102
+  %187 = phi i64 [ %184, %182 ], [ %186, %185 ], !dbg !96
+  %188 = icmp sgt i64 %187, %178, !dbg !96
+  br i1 %188, label %153, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !96, !llvm.loop !104
 
 forward_sorbet_rb_array_each_withBlock.1.exit.i:  ; preds = %rb_array_len.exit.i11.i, %rb_array_len.exit1.i9.i
-  call void @sorbet_popFrame() #12, !dbg !94
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %115) #12, !dbg !87
-  %189 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !87, !tbaa !13
-  %190 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %189, i64 0, i32 5, !dbg !87
-  %191 = load i32, i32* %190, align 8, !dbg !87, !tbaa !35
-  %192 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %189, i64 0, i32 6, !dbg !87
-  %193 = load i32, i32* %192, align 4, !dbg !87, !tbaa !36
-  %194 = xor i32 %193, -1, !dbg !87
-  %195 = and i32 %194, %191, !dbg !87
-  %196 = icmp eq i32 %195, 0, !dbg !87
-  br i1 %196, label %rb_check_arity.1.exit.i14.i, label %197, !dbg !87, !prof !29
+  call void @sorbet_popFrame() #12, !dbg !96
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %115) #12, !dbg !89
+  %189 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !89, !tbaa !15
+  %190 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %189, i64 0, i32 5, !dbg !89
+  %191 = load i32, i32* %190, align 8, !dbg !89, !tbaa !37
+  %192 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %189, i64 0, i32 6, !dbg !89
+  %193 = load i32, i32* %192, align 4, !dbg !89, !tbaa !38
+  %194 = xor i32 %193, -1, !dbg !89
+  %195 = and i32 %194, %191, !dbg !89
+  %196 = icmp eq i32 %195, 0, !dbg !89
+  br i1 %196, label %rb_check_arity.1.exit.i14.i, label %197, !dbg !89, !prof !31
 
 197:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.1.exit.i
-  %198 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %189, i64 0, i32 8, !dbg !87
-  %199 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %198, align 8, !dbg !87, !tbaa !37
-  %200 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %199, i32 noundef 0) #12, !dbg !87
-  br label %rb_check_arity.1.exit.i14.i, !dbg !87
+  %198 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %189, i64 0, i32 8, !dbg !89
+  %199 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %198, align 8, !dbg !89, !tbaa !39
+  %200 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %199, i32 noundef 0) #12, !dbg !89
+  br label %rb_check_arity.1.exit.i14.i, !dbg !89
 
 rb_check_arity.1.exit.i14.i:                      ; preds = %197, %forward_sorbet_rb_array_each_withBlock.1.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %35, align 8, !dbg !87, !tbaa !13
-  %rubyId_each78.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !103
-  %201 = bitcast %struct.sorbet_inlineIntrinsicEnv* %4 to i8*, !dbg !103
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %201) #12, !dbg !103
-  %202 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 0, !dbg !103
-  store i64 %39, i64* %202, align 8, !dbg !103, !tbaa !72
-  %203 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 1, !dbg !103
-  store i64 %rubyId_each78.i, i64* %203, align 8, !dbg !103, !tbaa !74
-  %204 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 2, !dbg !103
-  store i32 0, i32* %204, align 8, !dbg !103, !tbaa !75
-  %205 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 3, !dbg !103
-  %206 = bitcast i64** %205 to i8*, !dbg !103
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %206, i8 0, i64 16, i1 false) #12, !dbg !103
-  %207 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !103, !tbaa !13
-  %208 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %207, i64 0, i32 2, !dbg !103
-  %209 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %208, align 8, !dbg !103, !tbaa !15
-  call void @llvm.experimental.noalias.scope.decl(metadata !104) #12, !dbg !103
-  %210 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_3", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !103
-  %211 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %209, i64 0, i32 3, !dbg !103
-  %212 = bitcast i64* %211 to %struct.rb_captured_block*, !dbg !103
-  %213 = getelementptr inbounds i64, i64* %211, i64 2, !dbg !103
-  %214 = bitcast i64* %213 to %struct.vm_ifunc**, !dbg !103
-  store %struct.vm_ifunc* %210, %struct.vm_ifunc** %214, align 8, !dbg !103, !tbaa !25
-  call void @llvm.experimental.noalias.scope.decl(metadata !107) #12, !dbg !103
-  %215 = ptrtoint %struct.rb_captured_block* %212 to i64, !dbg !103
-  %216 = or i64 %215, 3, !dbg !103
-  %217 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %207, i64 0, i32 17, !dbg !103
-  store i64 %216, i64* %217, align 8, !dbg !103, !tbaa !82
-  %218 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !110, !tbaa !13
-  %219 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %218, i64 0, i32 17, !dbg !110
-  %220 = load i64, i64* %219, align 8, !dbg !110, !tbaa !82
-  %221 = and i64 %220, -4, !dbg !110
-  %222 = inttoptr i64 %221 to %struct.rb_captured_block*, !dbg !110
-  store i64 0, i64* %219, align 8, !dbg !110, !tbaa !82
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %222) #12, !dbg !110
-  %223 = load i64, i64* %63, align 8, !dbg !110, !tbaa !23
-  %224 = and i64 %223, 8192, !dbg !110
-  %225 = icmp eq i64 %224, 0, !dbg !110
-  br i1 %225, label %229, label %226, !dbg !110
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %35, align 8, !dbg !89, !tbaa !15
+  %rubyId_each78.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !105
+  %201 = bitcast %struct.sorbet_inlineIntrinsicEnv* %4 to i8*, !dbg !105
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %201) #12, !dbg !105
+  %202 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 0, !dbg !105
+  store i64 %39, i64* %202, align 8, !dbg !105, !tbaa !74
+  %203 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 1, !dbg !105
+  store i64 %rubyId_each78.i, i64* %203, align 8, !dbg !105, !tbaa !76
+  %204 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 2, !dbg !105
+  store i32 0, i32* %204, align 8, !dbg !105, !tbaa !77
+  %205 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 3, !dbg !105
+  %206 = bitcast i64** %205 to i8*, !dbg !105
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %206, i8 0, i64 16, i1 false) #12, !dbg !105
+  %207 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !105, !tbaa !15
+  %208 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %207, i64 0, i32 2, !dbg !105
+  %209 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %208, align 8, !dbg !105, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !106) #12, !dbg !105
+  %210 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_3", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !105
+  %211 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %209, i64 0, i32 3, !dbg !105
+  %212 = bitcast i64* %211 to %struct.rb_captured_block*, !dbg !105
+  %213 = getelementptr inbounds i64, i64* %211, i64 2, !dbg !105
+  %214 = bitcast i64* %213 to %struct.vm_ifunc**, !dbg !105
+  store %struct.vm_ifunc* %210, %struct.vm_ifunc** %214, align 8, !dbg !105, !tbaa !27
+  call void @llvm.experimental.noalias.scope.decl(metadata !109) #12, !dbg !105
+  %215 = ptrtoint %struct.rb_captured_block* %212 to i64, !dbg !105
+  %216 = or i64 %215, 3, !dbg !105
+  %217 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %207, i64 0, i32 17, !dbg !105
+  store i64 %216, i64* %217, align 8, !dbg !105, !tbaa !84
+  %218 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !112, !tbaa !15
+  %219 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %218, i64 0, i32 17, !dbg !112
+  %220 = load i64, i64* %219, align 8, !dbg !112, !tbaa !84
+  %221 = and i64 %220, -4, !dbg !112
+  %222 = inttoptr i64 %221 to %struct.rb_captured_block*, !dbg !112
+  store i64 0, i64* %219, align 8, !dbg !112, !tbaa !84
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %222) #12, !dbg !112
+  %223 = load i64, i64* %63, align 8, !dbg !112, !tbaa !25
+  %224 = and i64 %223, 8192, !dbg !112
+  %225 = icmp eq i64 %224, 0, !dbg !112
+  br i1 %225, label %229, label %226, !dbg !112
 
 226:                                              ; preds = %rb_check_arity.1.exit.i14.i
-  %227 = lshr i64 %223, 15, !dbg !110
-  %228 = and i64 %227, 3, !dbg !110
-  br label %rb_array_len.exit1.i15.i, !dbg !110
+  %227 = lshr i64 %223, 15, !dbg !112
+  %228 = and i64 %227, 3, !dbg !112
+  br label %rb_array_len.exit1.i15.i, !dbg !112
 
 229:                                              ; preds = %rb_check_arity.1.exit.i14.i
-  %230 = inttoptr i64 %39 to %struct.RArray*, !dbg !110
-  %231 = getelementptr inbounds %struct.RArray, %struct.RArray* %230, i64 0, i32 1, i32 0, i32 0, !dbg !110
-  %232 = load i64, i64* %231, align 8, !dbg !110, !tbaa !25
-  br label %rb_array_len.exit1.i15.i, !dbg !110
+  %230 = inttoptr i64 %39 to %struct.RArray*, !dbg !112
+  %231 = getelementptr inbounds %struct.RArray, %struct.RArray* %230, i64 0, i32 1, i32 0, i32 0, !dbg !112
+  %232 = load i64, i64* %231, align 8, !dbg !112, !tbaa !27
+  br label %rb_array_len.exit1.i15.i, !dbg !112
 
 rb_array_len.exit1.i15.i:                         ; preds = %229, %226
-  %233 = phi i64 [ %228, %226 ], [ %232, %229 ], !dbg !110
-  %234 = icmp sgt i64 %233, 0, !dbg !110
-  br i1 %234, label %235, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !110
+  %233 = phi i64 [ %228, %226 ], [ %232, %229 ], !dbg !112
+  %234 = icmp sgt i64 %233, 0, !dbg !112
+  br i1 %234, label %235, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !112
 
 235:                                              ; preds = %rb_array_len.exit1.i15.i
-  %236 = inttoptr i64 %39 to %struct.RArray*, !dbg !103
-  %237 = getelementptr inbounds %struct.RArray, %struct.RArray* %236, i64 0, i32 1, i32 0, i32 0, !dbg !103
-  %238 = getelementptr inbounds %struct.RArray, %struct.RArray* %236, i64 0, i32 1, i32 0, i32 2, !dbg !103
-  br label %239, !dbg !110
+  %236 = inttoptr i64 %39 to %struct.RArray*, !dbg !105
+  %237 = getelementptr inbounds %struct.RArray, %struct.RArray* %236, i64 0, i32 1, i32 0, i32 0, !dbg !105
+  %238 = getelementptr inbounds %struct.RArray, %struct.RArray* %236, i64 0, i32 1, i32 0, i32 2, !dbg !105
+  br label %239, !dbg !112
 
 239:                                              ; preds = %rb_array_len.exit.i18.i, %235
-  %240 = phi i64 [ 0, %235 ], [ %264, %rb_array_len.exit.i18.i ], !dbg !110
-  %241 = load i64, i64* %63, align 8, !dbg !110, !tbaa !23
-  %242 = and i64 %241, 8192, !dbg !110
-  %243 = icmp eq i64 %242, 0, !dbg !110
-  br i1 %243, label %244, label %rb_array_const_ptr_transient.exit.i17.i, !dbg !110
+  %240 = phi i64 [ 0, %235 ], [ %264, %rb_array_len.exit.i18.i ], !dbg !112
+  %241 = load i64, i64* %63, align 8, !dbg !112, !tbaa !25
+  %242 = and i64 %241, 8192, !dbg !112
+  %243 = icmp eq i64 %242, 0, !dbg !112
+  br i1 %243, label %244, label %rb_array_const_ptr_transient.exit.i17.i, !dbg !112
 
 244:                                              ; preds = %239
-  %245 = load i64*, i64** %238, align 8, !dbg !110, !tbaa !25
-  br label %rb_array_const_ptr_transient.exit.i17.i, !dbg !110
+  %245 = load i64*, i64** %238, align 8, !dbg !112, !tbaa !27
+  br label %rb_array_const_ptr_transient.exit.i17.i, !dbg !112
 
 rb_array_const_ptr_transient.exit.i17.i:          ; preds = %244, %239
-  %246 = phi i64* [ %245, %244 ], [ %237, %239 ], !dbg !110
-  %247 = getelementptr inbounds i64, i64* %246, i64 %240, !dbg !110
-  %248 = load i64, i64* %247, align 8, !dbg !110, !tbaa !4
-  call void @llvm.experimental.noalias.scope.decl(metadata !112) #12, !dbg !110
-  %249 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !103, !tbaa !13, !noalias !112
-  %250 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %249, i64 0, i32 2, !dbg !103
-  %251 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %250, align 8, !dbg !103, !tbaa !15, !noalias !112
-  %252 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 3, !dbg !103
-  %253 = load i64, i64* %252, align 8, !dbg !103, !tbaa !40, !noalias !112
-  %stackFrame.i.i16.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_3", align 8, !dbg !103, !noalias !112
-  %254 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 2, !dbg !103
-  store %struct.rb_iseq_struct* %stackFrame.i.i16.i, %struct.rb_iseq_struct** %254, align 8, !dbg !103, !tbaa !19, !noalias !112
-  %255 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 4, !dbg !103
-  %256 = load i64*, i64** %255, align 8, !dbg !103, !tbaa !21, !noalias !112
-  %257 = load i64, i64* %256, align 8, !dbg !103, !tbaa !4, !noalias !112
-  %258 = and i64 %257, -129, !dbg !103
-  store i64 %258, i64* %256, align 8, !dbg !103, !tbaa !4, !noalias !112
-  %259 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 0, !dbg !103
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %259, align 8, !dbg !115, !tbaa !13, !noalias !112
-  %260 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 1, !dbg !117
-  %261 = load i64*, i64** %260, align 8, !dbg !117
-  store i64 %253, i64* %261, align 8, !dbg !117, !tbaa !4
-  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !117
-  store i64 %248, i64* %262, align 8, !dbg !117, !tbaa !4
-  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !117
-  store i64* %263, i64** %260, align 8, !dbg !117
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.5, i64 0), !dbg !117
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %259, align 8, !dbg !117, !tbaa !13, !noalias !112
-  %264 = add nuw nsw i64 %240, 1, !dbg !110
-  %265 = load i64, i64* %63, align 8, !dbg !110, !tbaa !23
-  %266 = and i64 %265, 8192, !dbg !110
-  %267 = icmp eq i64 %266, 0, !dbg !110
-  br i1 %267, label %271, label %268, !dbg !110
+  %246 = phi i64* [ %245, %244 ], [ %237, %239 ], !dbg !112
+  %247 = getelementptr inbounds i64, i64* %246, i64 %240, !dbg !112
+  %248 = load i64, i64* %247, align 8, !dbg !112, !tbaa !6
+  call void @llvm.experimental.noalias.scope.decl(metadata !114) #12, !dbg !112
+  %249 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !105, !tbaa !15, !noalias !114
+  %250 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %249, i64 0, i32 2, !dbg !105
+  %251 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %250, align 8, !dbg !105, !tbaa !17, !noalias !114
+  %252 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 3, !dbg !105
+  %253 = load i64, i64* %252, align 8, !dbg !105, !tbaa !42, !noalias !114
+  %stackFrame.i.i16.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_3", align 8, !dbg !105, !noalias !114
+  %254 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 2, !dbg !105
+  store %struct.rb_iseq_struct* %stackFrame.i.i16.i, %struct.rb_iseq_struct** %254, align 8, !dbg !105, !tbaa !21, !noalias !114
+  %255 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 4, !dbg !105
+  %256 = load i64*, i64** %255, align 8, !dbg !105, !tbaa !23, !noalias !114
+  %257 = load i64, i64* %256, align 8, !dbg !105, !tbaa !6, !noalias !114
+  %258 = and i64 %257, -129, !dbg !105
+  store i64 %258, i64* %256, align 8, !dbg !105, !tbaa !6, !noalias !114
+  %259 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 0, !dbg !105
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %259, align 8, !dbg !117, !tbaa !15, !noalias !114
+  %260 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 1, !dbg !119
+  %261 = load i64*, i64** %260, align 8, !dbg !119
+  store i64 %253, i64* %261, align 8, !dbg !119, !tbaa !6
+  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !119
+  store i64 %248, i64* %262, align 8, !dbg !119, !tbaa !6
+  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !119
+  store i64* %263, i64** %260, align 8, !dbg !119
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.5, i64 0), !dbg !119
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %259, align 8, !dbg !119, !tbaa !15, !noalias !114
+  %264 = add nuw nsw i64 %240, 1, !dbg !112
+  %265 = load i64, i64* %63, align 8, !dbg !112, !tbaa !25
+  %266 = and i64 %265, 8192, !dbg !112
+  %267 = icmp eq i64 %266, 0, !dbg !112
+  br i1 %267, label %271, label %268, !dbg !112
 
 268:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
-  %269 = lshr i64 %265, 15, !dbg !110
-  %270 = and i64 %269, 3, !dbg !110
-  br label %rb_array_len.exit.i18.i, !dbg !110
+  %269 = lshr i64 %265, 15, !dbg !112
+  %270 = and i64 %269, 3, !dbg !112
+  br label %rb_array_len.exit.i18.i, !dbg !112
 
 271:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
-  %272 = load i64, i64* %237, align 8, !dbg !110, !tbaa !25
-  br label %rb_array_len.exit.i18.i, !dbg !110
+  %272 = load i64, i64* %237, align 8, !dbg !112, !tbaa !27
+  br label %rb_array_len.exit.i18.i, !dbg !112
 
 rb_array_len.exit.i18.i:                          ; preds = %271, %268
-  %273 = phi i64 [ %270, %268 ], [ %272, %271 ], !dbg !110
-  %274 = icmp sgt i64 %273, %264, !dbg !110
-  br i1 %274, label %239, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !110, !llvm.loop !118
+  %273 = phi i64 [ %270, %268 ], [ %272, %271 ], !dbg !112
+  %274 = icmp sgt i64 %273, %264, !dbg !112
+  br i1 %274, label %239, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !112, !llvm.loop !120
 
 forward_sorbet_rb_array_each_withBlock.3.exit.i:  ; preds = %rb_array_len.exit.i18.i, %rb_array_len.exit1.i15.i
-  call void @sorbet_popFrame() #12, !dbg !110
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %201) #12, !dbg !103
-  %275 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !103, !tbaa !13
-  %276 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %275, i64 0, i32 5, !dbg !103
-  %277 = load i32, i32* %276, align 8, !dbg !103, !tbaa !35
-  %278 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %275, i64 0, i32 6, !dbg !103
-  %279 = load i32, i32* %278, align 4, !dbg !103, !tbaa !36
-  %280 = xor i32 %279, -1, !dbg !103
-  %281 = and i32 %280, %277, !dbg !103
-  %282 = icmp eq i32 %281, 0, !dbg !103
-  br i1 %282, label %rb_check_arity.1.exit.i21.i, label %283, !dbg !103, !prof !29
+  call void @sorbet_popFrame() #12, !dbg !112
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %201) #12, !dbg !105
+  %275 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !105, !tbaa !15
+  %276 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %275, i64 0, i32 5, !dbg !105
+  %277 = load i32, i32* %276, align 8, !dbg !105, !tbaa !37
+  %278 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %275, i64 0, i32 6, !dbg !105
+  %279 = load i32, i32* %278, align 4, !dbg !105, !tbaa !38
+  %280 = xor i32 %279, -1, !dbg !105
+  %281 = and i32 %280, %277, !dbg !105
+  %282 = icmp eq i32 %281, 0, !dbg !105
+  br i1 %282, label %rb_check_arity.1.exit.i21.i, label %283, !dbg !105, !prof !31
 
 283:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.3.exit.i
-  %284 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %275, i64 0, i32 8, !dbg !103
-  %285 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %284, align 8, !dbg !103, !tbaa !37
-  %286 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %285, i32 noundef 0) #12, !dbg !103
-  br label %rb_check_arity.1.exit.i21.i, !dbg !103
+  %284 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %275, i64 0, i32 8, !dbg !105
+  %285 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %284, align 8, !dbg !105, !tbaa !39
+  %286 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %285, i32 noundef 0) #12, !dbg !105
+  br label %rb_check_arity.1.exit.i21.i, !dbg !105
 
 rb_check_arity.1.exit.i21.i:                      ; preds = %283, %forward_sorbet_rb_array_each_withBlock.3.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %35, align 8, !dbg !103, !tbaa !13
-  %rubyId_each90.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !119
-  %287 = bitcast %struct.sorbet_inlineIntrinsicEnv* %3 to i8*, !dbg !119
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %287) #12, !dbg !119
-  %288 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 0, !dbg !119
-  store i64 %39, i64* %288, align 8, !dbg !119, !tbaa !72
-  %289 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 1, !dbg !119
-  store i64 %rubyId_each90.i, i64* %289, align 8, !dbg !119, !tbaa !74
-  %290 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 2, !dbg !119
-  store i32 0, i32* %290, align 8, !dbg !119, !tbaa !75
-  %291 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 3, !dbg !119
-  %292 = bitcast i64** %291 to i8*, !dbg !119
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %292, i8 0, i64 16, i1 false) #12, !dbg !119
-  %293 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !119, !tbaa !13
-  %294 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %293, i64 0, i32 2, !dbg !119
-  %295 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %294, align 8, !dbg !119, !tbaa !15
-  call void @llvm.experimental.noalias.scope.decl(metadata !120) #12, !dbg !119
-  %296 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_4", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !119
-  %297 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %295, i64 0, i32 3, !dbg !119
-  %298 = bitcast i64* %297 to %struct.rb_captured_block*, !dbg !119
-  %299 = getelementptr inbounds i64, i64* %297, i64 2, !dbg !119
-  %300 = bitcast i64* %299 to %struct.vm_ifunc**, !dbg !119
-  store %struct.vm_ifunc* %296, %struct.vm_ifunc** %300, align 8, !dbg !119, !tbaa !25
-  call void @llvm.experimental.noalias.scope.decl(metadata !123) #12, !dbg !119
-  %301 = ptrtoint %struct.rb_captured_block* %298 to i64, !dbg !119
-  %302 = or i64 %301, 3, !dbg !119
-  %303 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %293, i64 0, i32 17, !dbg !119
-  store i64 %302, i64* %303, align 8, !dbg !119, !tbaa !82
-  %304 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !126, !tbaa !13
-  %305 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %304, i64 0, i32 17, !dbg !126
-  %306 = load i64, i64* %305, align 8, !dbg !126, !tbaa !82
-  %307 = and i64 %306, -4, !dbg !126
-  %308 = inttoptr i64 %307 to %struct.rb_captured_block*, !dbg !126
-  store i64 0, i64* %305, align 8, !dbg !126, !tbaa !82
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %308) #12, !dbg !126
-  %309 = load i64, i64* %63, align 8, !dbg !126, !tbaa !23
-  %310 = and i64 %309, 8192, !dbg !126
-  %311 = icmp eq i64 %310, 0, !dbg !126
-  br i1 %311, label %315, label %312, !dbg !126
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %35, align 8, !dbg !105, !tbaa !15
+  %rubyId_each90.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !121
+  %287 = bitcast %struct.sorbet_inlineIntrinsicEnv* %3 to i8*, !dbg !121
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %287) #12, !dbg !121
+  %288 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 0, !dbg !121
+  store i64 %39, i64* %288, align 8, !dbg !121, !tbaa !74
+  %289 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 1, !dbg !121
+  store i64 %rubyId_each90.i, i64* %289, align 8, !dbg !121, !tbaa !76
+  %290 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 2, !dbg !121
+  store i32 0, i32* %290, align 8, !dbg !121, !tbaa !77
+  %291 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 3, !dbg !121
+  %292 = bitcast i64** %291 to i8*, !dbg !121
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %292, i8 0, i64 16, i1 false) #12, !dbg !121
+  %293 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !121, !tbaa !15
+  %294 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %293, i64 0, i32 2, !dbg !121
+  %295 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %294, align 8, !dbg !121, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !122) #12, !dbg !121
+  %296 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_4", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !121
+  %297 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %295, i64 0, i32 3, !dbg !121
+  %298 = bitcast i64* %297 to %struct.rb_captured_block*, !dbg !121
+  %299 = getelementptr inbounds i64, i64* %297, i64 2, !dbg !121
+  %300 = bitcast i64* %299 to %struct.vm_ifunc**, !dbg !121
+  store %struct.vm_ifunc* %296, %struct.vm_ifunc** %300, align 8, !dbg !121, !tbaa !27
+  call void @llvm.experimental.noalias.scope.decl(metadata !125) #12, !dbg !121
+  %301 = ptrtoint %struct.rb_captured_block* %298 to i64, !dbg !121
+  %302 = or i64 %301, 3, !dbg !121
+  %303 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %293, i64 0, i32 17, !dbg !121
+  store i64 %302, i64* %303, align 8, !dbg !121, !tbaa !84
+  %304 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !128, !tbaa !15
+  %305 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %304, i64 0, i32 17, !dbg !128
+  %306 = load i64, i64* %305, align 8, !dbg !128, !tbaa !84
+  %307 = and i64 %306, -4, !dbg !128
+  %308 = inttoptr i64 %307 to %struct.rb_captured_block*, !dbg !128
+  store i64 0, i64* %305, align 8, !dbg !128, !tbaa !84
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %308) #12, !dbg !128
+  %309 = load i64, i64* %63, align 8, !dbg !128, !tbaa !25
+  %310 = and i64 %309, 8192, !dbg !128
+  %311 = icmp eq i64 %310, 0, !dbg !128
+  br i1 %311, label %315, label %312, !dbg !128
 
 312:                                              ; preds = %rb_check_arity.1.exit.i21.i
-  %313 = lshr i64 %309, 15, !dbg !126
-  %314 = and i64 %313, 3, !dbg !126
-  br label %rb_array_len.exit1.i22.i, !dbg !126
+  %313 = lshr i64 %309, 15, !dbg !128
+  %314 = and i64 %313, 3, !dbg !128
+  br label %rb_array_len.exit1.i22.i, !dbg !128
 
 315:                                              ; preds = %rb_check_arity.1.exit.i21.i
-  %316 = inttoptr i64 %39 to %struct.RArray*, !dbg !126
-  %317 = getelementptr inbounds %struct.RArray, %struct.RArray* %316, i64 0, i32 1, i32 0, i32 0, !dbg !126
-  %318 = load i64, i64* %317, align 8, !dbg !126, !tbaa !25
-  br label %rb_array_len.exit1.i22.i, !dbg !126
+  %316 = inttoptr i64 %39 to %struct.RArray*, !dbg !128
+  %317 = getelementptr inbounds %struct.RArray, %struct.RArray* %316, i64 0, i32 1, i32 0, i32 0, !dbg !128
+  %318 = load i64, i64* %317, align 8, !dbg !128, !tbaa !27
+  br label %rb_array_len.exit1.i22.i, !dbg !128
 
 rb_array_len.exit1.i22.i:                         ; preds = %315, %312
-  %319 = phi i64 [ %314, %312 ], [ %318, %315 ], !dbg !126
-  %320 = icmp sgt i64 %319, 0, !dbg !126
-  br i1 %320, label %321, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !126
+  %319 = phi i64 [ %314, %312 ], [ %318, %315 ], !dbg !128
+  %320 = icmp sgt i64 %319, 0, !dbg !128
+  br i1 %320, label %321, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !128
 
 321:                                              ; preds = %rb_array_len.exit1.i22.i
-  %322 = bitcast i64* %0 to i8*, !dbg !126
-  %323 = inttoptr i64 %39 to %struct.RArray*, !dbg !119
-  %324 = getelementptr inbounds %struct.RArray, %struct.RArray* %323, i64 0, i32 1, i32 0, i32 0, !dbg !119
-  %325 = getelementptr inbounds %struct.RArray, %struct.RArray* %323, i64 0, i32 1, i32 0, i32 2, !dbg !119
-  br label %326, !dbg !126
+  %322 = bitcast i64* %0 to i8*, !dbg !128
+  %323 = inttoptr i64 %39 to %struct.RArray*, !dbg !121
+  %324 = getelementptr inbounds %struct.RArray, %struct.RArray* %323, i64 0, i32 1, i32 0, i32 0, !dbg !121
+  %325 = getelementptr inbounds %struct.RArray, %struct.RArray* %323, i64 0, i32 1, i32 0, i32 2, !dbg !121
+  br label %326, !dbg !128
 
 326:                                              ; preds = %rb_array_len.exit.i24.i, %321
-  %327 = phi i64 [ 0, %321 ], [ %337, %rb_array_len.exit.i24.i ], !dbg !126
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %322) #12, !dbg !126
-  %328 = load i64, i64* %63, align 8, !dbg !126, !tbaa !23
-  %329 = and i64 %328, 8192, !dbg !126
-  %330 = icmp eq i64 %329, 0, !dbg !126
-  br i1 %330, label %331, label %rb_array_const_ptr_transient.exit.i23.i, !dbg !126
+  %327 = phi i64 [ 0, %321 ], [ %337, %rb_array_len.exit.i24.i ], !dbg !128
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %322) #12, !dbg !128
+  %328 = load i64, i64* %63, align 8, !dbg !128, !tbaa !25
+  %329 = and i64 %328, 8192, !dbg !128
+  %330 = icmp eq i64 %329, 0, !dbg !128
+  br i1 %330, label %331, label %rb_array_const_ptr_transient.exit.i23.i, !dbg !128
 
 331:                                              ; preds = %326
-  %332 = load i64*, i64** %325, align 8, !dbg !126, !tbaa !25
-  br label %rb_array_const_ptr_transient.exit.i23.i, !dbg !126
+  %332 = load i64*, i64** %325, align 8, !dbg !128, !tbaa !27
+  br label %rb_array_const_ptr_transient.exit.i23.i, !dbg !128
 
 rb_array_const_ptr_transient.exit.i23.i:          ; preds = %331, %326
-  %333 = phi i64* [ %332, %331 ], [ %324, %326 ], !dbg !126
-  %334 = getelementptr inbounds i64, i64* %333, i64 %327, !dbg !126
-  %335 = load i64, i64* %334, align 8, !dbg !126, !tbaa !4
-  store i64 %335, i64* %0, align 8, !dbg !126, !tbaa !4
-  %336 = call i64 @"func_<root>.<static-init>$151$block_4"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #12, !dbg !126
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %322) #12, !dbg !126
-  %337 = add nuw nsw i64 %327, 1, !dbg !126
-  %338 = load i64, i64* %63, align 8, !dbg !126, !tbaa !23
-  %339 = and i64 %338, 8192, !dbg !126
-  %340 = icmp eq i64 %339, 0, !dbg !126
-  br i1 %340, label %344, label %341, !dbg !126
+  %333 = phi i64* [ %332, %331 ], [ %324, %326 ], !dbg !128
+  %334 = getelementptr inbounds i64, i64* %333, i64 %327, !dbg !128
+  %335 = load i64, i64* %334, align 8, !dbg !128, !tbaa !6
+  store i64 %335, i64* %0, align 8, !dbg !128, !tbaa !6
+  %336 = call i64 @"func_<root>.<static-init>$151$block_4"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #12, !dbg !128
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %322) #12, !dbg !128
+  %337 = add nuw nsw i64 %327, 1, !dbg !128
+  %338 = load i64, i64* %63, align 8, !dbg !128, !tbaa !25
+  %339 = and i64 %338, 8192, !dbg !128
+  %340 = icmp eq i64 %339, 0, !dbg !128
+  br i1 %340, label %344, label %341, !dbg !128
 
 341:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
-  %342 = lshr i64 %338, 15, !dbg !126
-  %343 = and i64 %342, 3, !dbg !126
-  br label %rb_array_len.exit.i24.i, !dbg !126
+  %342 = lshr i64 %338, 15, !dbg !128
+  %343 = and i64 %342, 3, !dbg !128
+  br label %rb_array_len.exit.i24.i, !dbg !128
 
 344:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
-  %345 = load i64, i64* %324, align 8, !dbg !126, !tbaa !25
-  br label %rb_array_len.exit.i24.i, !dbg !126
+  %345 = load i64, i64* %324, align 8, !dbg !128, !tbaa !27
+  br label %rb_array_len.exit.i24.i, !dbg !128
 
 rb_array_len.exit.i24.i:                          ; preds = %344, %341
-  %346 = phi i64 [ %343, %341 ], [ %345, %344 ], !dbg !126
-  %347 = icmp sgt i64 %346, %337, !dbg !126
-  br i1 %347, label %326, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !126, !llvm.loop !128
+  %346 = phi i64 [ %343, %341 ], [ %345, %344 ], !dbg !128
+  %347 = icmp sgt i64 %346, %337, !dbg !128
+  br i1 %347, label %326, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !128, !llvm.loop !130
 
 forward_sorbet_rb_array_each_withBlock.6.exit.i:  ; preds = %rb_array_len.exit.i24.i, %rb_array_len.exit1.i22.i
-  call void @sorbet_popFrame() #12, !dbg !126
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %287) #12, !dbg !119
-  %348 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !119, !tbaa !13
-  %349 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %348, i64 0, i32 5, !dbg !119
-  %350 = load i32, i32* %349, align 8, !dbg !119, !tbaa !35
-  %351 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %348, i64 0, i32 6, !dbg !119
-  %352 = load i32, i32* %351, align 4, !dbg !119, !tbaa !36
-  %353 = xor i32 %352, -1, !dbg !119
-  %354 = and i32 %353, %350, !dbg !119
-  %355 = icmp eq i32 %354, 0, !dbg !119
-  br i1 %355, label %rb_check_arity.1.exit.i.i, label %356, !dbg !119, !prof !29
+  call void @sorbet_popFrame() #12, !dbg !128
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %287) #12, !dbg !121
+  %348 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !121, !tbaa !15
+  %349 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %348, i64 0, i32 5, !dbg !121
+  %350 = load i32, i32* %349, align 8, !dbg !121, !tbaa !37
+  %351 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %348, i64 0, i32 6, !dbg !121
+  %352 = load i32, i32* %351, align 4, !dbg !121, !tbaa !38
+  %353 = xor i32 %352, -1, !dbg !121
+  %354 = and i32 %353, %350, !dbg !121
+  %355 = icmp eq i32 %354, 0, !dbg !121
+  br i1 %355, label %rb_check_arity.1.exit.i.i, label %356, !dbg !121, !prof !31
 
 356:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.6.exit.i
-  %357 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %348, i64 0, i32 8, !dbg !119
-  %358 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %357, align 8, !dbg !119, !tbaa !37
-  %359 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %358, i32 noundef 0) #12, !dbg !119
-  br label %rb_check_arity.1.exit.i.i, !dbg !119
+  %357 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %348, i64 0, i32 8, !dbg !121
+  %358 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %357, align 8, !dbg !121, !tbaa !39
+  %359 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %358, i32 noundef 0) #12, !dbg !121
+  br label %rb_check_arity.1.exit.i.i, !dbg !121
 
 rb_check_arity.1.exit.i.i:                        ; preds = %356, %forward_sorbet_rb_array_each_withBlock.6.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %35, align 8, !dbg !119, !tbaa !13
-  %rubyId_each102.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !129
-  %360 = bitcast %struct.sorbet_inlineIntrinsicEnv* %7 to i8*, !dbg !129
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %360) #12, !dbg !129
-  %361 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 0, !dbg !129
-  store i64 %39, i64* %361, align 8, !dbg !129, !tbaa !72
-  %362 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 1, !dbg !129
-  store i64 %rubyId_each102.i, i64* %362, align 8, !dbg !129, !tbaa !74
-  %363 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 2, !dbg !129
-  store i32 0, i32* %363, align 8, !dbg !129, !tbaa !75
-  %364 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 3, !dbg !129
-  %365 = bitcast i64** %364 to i8*, !dbg !129
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %365, i8 0, i64 16, i1 false) #12, !dbg !129
-  %366 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !129, !tbaa !13
-  %367 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %366, i64 0, i32 2, !dbg !129
-  %368 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %367, align 8, !dbg !129, !tbaa !15
-  call void @llvm.experimental.noalias.scope.decl(metadata !130) #12, !dbg !129
-  %369 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_5", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !129
-  %370 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %368, i64 0, i32 3, !dbg !129
-  %371 = bitcast i64* %370 to %struct.rb_captured_block*, !dbg !129
-  %372 = getelementptr inbounds i64, i64* %370, i64 2, !dbg !129
-  %373 = bitcast i64* %372 to %struct.vm_ifunc**, !dbg !129
-  store %struct.vm_ifunc* %369, %struct.vm_ifunc** %373, align 8, !dbg !129, !tbaa !25
-  call void @llvm.experimental.noalias.scope.decl(metadata !133) #12, !dbg !129
-  %374 = ptrtoint %struct.rb_captured_block* %371 to i64, !dbg !129
-  %375 = or i64 %374, 3, !dbg !129
-  %376 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %366, i64 0, i32 17, !dbg !129
-  store i64 %375, i64* %376, align 8, !dbg !129, !tbaa !82
-  %377 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !136, !tbaa !13
-  %378 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %377, i64 0, i32 17, !dbg !136
-  %379 = load i64, i64* %378, align 8, !dbg !136, !tbaa !82
-  %380 = and i64 %379, -4, !dbg !136
-  %381 = inttoptr i64 %380 to %struct.rb_captured_block*, !dbg !136
-  store i64 0, i64* %378, align 8, !dbg !136, !tbaa !82
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %381) #12, !dbg !136
-  %382 = load i64, i64* %63, align 8, !dbg !136, !tbaa !23
-  %383 = and i64 %382, 8192, !dbg !136
-  %384 = icmp eq i64 %383, 0, !dbg !136
-  br i1 %384, label %388, label %385, !dbg !136
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %35, align 8, !dbg !121, !tbaa !15
+  %rubyId_each102.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !131
+  %360 = bitcast %struct.sorbet_inlineIntrinsicEnv* %7 to i8*, !dbg !131
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %360) #12, !dbg !131
+  %361 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 0, !dbg !131
+  store i64 %39, i64* %361, align 8, !dbg !131, !tbaa !74
+  %362 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 1, !dbg !131
+  store i64 %rubyId_each102.i, i64* %362, align 8, !dbg !131, !tbaa !76
+  %363 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 2, !dbg !131
+  store i32 0, i32* %363, align 8, !dbg !131, !tbaa !77
+  %364 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 3, !dbg !131
+  %365 = bitcast i64** %364 to i8*, !dbg !131
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %365, i8 0, i64 16, i1 false) #12, !dbg !131
+  %366 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !131, !tbaa !15
+  %367 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %366, i64 0, i32 2, !dbg !131
+  %368 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %367, align 8, !dbg !131, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !132) #12, !dbg !131
+  %369 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_5", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !131
+  %370 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %368, i64 0, i32 3, !dbg !131
+  %371 = bitcast i64* %370 to %struct.rb_captured_block*, !dbg !131
+  %372 = getelementptr inbounds i64, i64* %370, i64 2, !dbg !131
+  %373 = bitcast i64* %372 to %struct.vm_ifunc**, !dbg !131
+  store %struct.vm_ifunc* %369, %struct.vm_ifunc** %373, align 8, !dbg !131, !tbaa !27
+  call void @llvm.experimental.noalias.scope.decl(metadata !135) #12, !dbg !131
+  %374 = ptrtoint %struct.rb_captured_block* %371 to i64, !dbg !131
+  %375 = or i64 %374, 3, !dbg !131
+  %376 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %366, i64 0, i32 17, !dbg !131
+  store i64 %375, i64* %376, align 8, !dbg !131, !tbaa !84
+  %377 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !138, !tbaa !15
+  %378 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %377, i64 0, i32 17, !dbg !138
+  %379 = load i64, i64* %378, align 8, !dbg !138, !tbaa !84
+  %380 = and i64 %379, -4, !dbg !138
+  %381 = inttoptr i64 %380 to %struct.rb_captured_block*, !dbg !138
+  store i64 0, i64* %378, align 8, !dbg !138, !tbaa !84
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %381) #12, !dbg !138
+  %382 = load i64, i64* %63, align 8, !dbg !138, !tbaa !25
+  %383 = and i64 %382, 8192, !dbg !138
+  %384 = icmp eq i64 %383, 0, !dbg !138
+  br i1 %384, label %388, label %385, !dbg !138
 
 385:                                              ; preds = %rb_check_arity.1.exit.i.i
-  %386 = lshr i64 %382, 15, !dbg !136
-  %387 = and i64 %386, 3, !dbg !136
-  br label %rb_array_len.exit1.i.i, !dbg !136
+  %386 = lshr i64 %382, 15, !dbg !138
+  %387 = and i64 %386, 3, !dbg !138
+  br label %rb_array_len.exit1.i.i, !dbg !138
 
 388:                                              ; preds = %rb_check_arity.1.exit.i.i
-  %389 = inttoptr i64 %39 to %struct.RArray*, !dbg !136
-  %390 = getelementptr inbounds %struct.RArray, %struct.RArray* %389, i64 0, i32 1, i32 0, i32 0, !dbg !136
-  %391 = load i64, i64* %390, align 8, !dbg !136, !tbaa !25
-  br label %rb_array_len.exit1.i.i, !dbg !136
+  %389 = inttoptr i64 %39 to %struct.RArray*, !dbg !138
+  %390 = getelementptr inbounds %struct.RArray, %struct.RArray* %389, i64 0, i32 1, i32 0, i32 0, !dbg !138
+  %391 = load i64, i64* %390, align 8, !dbg !138, !tbaa !27
+  br label %rb_array_len.exit1.i.i, !dbg !138
 
 rb_array_len.exit1.i.i:                           ; preds = %388, %385
-  %392 = phi i64 [ %387, %385 ], [ %391, %388 ], !dbg !136
-  %393 = icmp sgt i64 %392, 0, !dbg !136
-  br i1 %393, label %394, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !136
+  %392 = phi i64 [ %387, %385 ], [ %391, %388 ], !dbg !138
+  %393 = icmp sgt i64 %392, 0, !dbg !138
+  br i1 %393, label %394, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !138
 
 394:                                              ; preds = %rb_array_len.exit1.i.i
-  %395 = bitcast i64* %2 to i8*, !dbg !136
-  %396 = inttoptr i64 %39 to %struct.RArray*, !dbg !129
-  %397 = getelementptr inbounds %struct.RArray, %struct.RArray* %396, i64 0, i32 1, i32 0, i32 0, !dbg !129
-  %398 = getelementptr inbounds %struct.RArray, %struct.RArray* %396, i64 0, i32 1, i32 0, i32 2, !dbg !129
-  br label %399, !dbg !136
+  %395 = bitcast i64* %2 to i8*, !dbg !138
+  %396 = inttoptr i64 %39 to %struct.RArray*, !dbg !131
+  %397 = getelementptr inbounds %struct.RArray, %struct.RArray* %396, i64 0, i32 1, i32 0, i32 0, !dbg !131
+  %398 = getelementptr inbounds %struct.RArray, %struct.RArray* %396, i64 0, i32 1, i32 0, i32 2, !dbg !131
+  br label %399, !dbg !138
 
 399:                                              ; preds = %rb_array_len.exit.i.i, %394
-  %400 = phi i64 [ 0, %394 ], [ %410, %rb_array_len.exit.i.i ], !dbg !136
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %395) #12, !dbg !136
-  %401 = load i64, i64* %63, align 8, !dbg !136, !tbaa !23
-  %402 = and i64 %401, 8192, !dbg !136
-  %403 = icmp eq i64 %402, 0, !dbg !136
-  br i1 %403, label %404, label %rb_array_const_ptr_transient.exit.i.i, !dbg !136
+  %400 = phi i64 [ 0, %394 ], [ %410, %rb_array_len.exit.i.i ], !dbg !138
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %395) #12, !dbg !138
+  %401 = load i64, i64* %63, align 8, !dbg !138, !tbaa !25
+  %402 = and i64 %401, 8192, !dbg !138
+  %403 = icmp eq i64 %402, 0, !dbg !138
+  br i1 %403, label %404, label %rb_array_const_ptr_transient.exit.i.i, !dbg !138
 
 404:                                              ; preds = %399
-  %405 = load i64*, i64** %398, align 8, !dbg !136, !tbaa !25
-  br label %rb_array_const_ptr_transient.exit.i.i, !dbg !136
+  %405 = load i64*, i64** %398, align 8, !dbg !138, !tbaa !27
+  br label %rb_array_const_ptr_transient.exit.i.i, !dbg !138
 
 rb_array_const_ptr_transient.exit.i.i:            ; preds = %404, %399
-  %406 = phi i64* [ %405, %404 ], [ %397, %399 ], !dbg !136
-  %407 = getelementptr inbounds i64, i64* %406, i64 %400, !dbg !136
-  %408 = load i64, i64* %407, align 8, !dbg !136, !tbaa !4
-  store i64 %408, i64* %2, align 8, !dbg !136, !tbaa !4
-  %409 = call i64 @"func_<root>.<static-init>$151$block_5"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %2, i64 undef) #12, !dbg !136
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %395) #12, !dbg !136
-  %410 = add nuw nsw i64 %400, 1, !dbg !136
-  %411 = load i64, i64* %63, align 8, !dbg !136, !tbaa !23
-  %412 = and i64 %411, 8192, !dbg !136
-  %413 = icmp eq i64 %412, 0, !dbg !136
-  br i1 %413, label %417, label %414, !dbg !136
+  %406 = phi i64* [ %405, %404 ], [ %397, %399 ], !dbg !138
+  %407 = getelementptr inbounds i64, i64* %406, i64 %400, !dbg !138
+  %408 = load i64, i64* %407, align 8, !dbg !138, !tbaa !6
+  store i64 %408, i64* %2, align 8, !dbg !138, !tbaa !6
+  %409 = call i64 @"func_<root>.<static-init>$151$block_5"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %2, i64 undef) #12, !dbg !138
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %395) #12, !dbg !138
+  %410 = add nuw nsw i64 %400, 1, !dbg !138
+  %411 = load i64, i64* %63, align 8, !dbg !138, !tbaa !25
+  %412 = and i64 %411, 8192, !dbg !138
+  %413 = icmp eq i64 %412, 0, !dbg !138
+  br i1 %413, label %417, label %414, !dbg !138
 
 414:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %415 = lshr i64 %411, 15, !dbg !136
-  %416 = and i64 %415, 3, !dbg !136
-  br label %rb_array_len.exit.i.i, !dbg !136
+  %415 = lshr i64 %411, 15, !dbg !138
+  %416 = and i64 %415, 3, !dbg !138
+  br label %rb_array_len.exit.i.i, !dbg !138
 
 417:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %418 = load i64, i64* %397, align 8, !dbg !136, !tbaa !25
-  br label %rb_array_len.exit.i.i, !dbg !136
+  %418 = load i64, i64* %397, align 8, !dbg !138, !tbaa !27
+  br label %rb_array_len.exit.i.i, !dbg !138
 
 rb_array_len.exit.i.i:                            ; preds = %417, %414
-  %419 = phi i64 [ %416, %414 ], [ %418, %417 ], !dbg !136
-  %420 = icmp sgt i64 %419, %410, !dbg !136
-  br i1 %420, label %399, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !136, !llvm.loop !138
+  %419 = phi i64 [ %416, %414 ], [ %418, %417 ], !dbg !138
+  %420 = icmp sgt i64 %419, %410, !dbg !138
+  br i1 %420, label %399, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !138, !llvm.loop !140
 
 forward_sorbet_rb_array_each_withBlock.10.exit.i: ; preds = %rb_array_len.exit.i.i, %rb_array_len.exit1.i.i
-  call void @sorbet_popFrame() #12, !dbg !136
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %360) #12, !dbg !129
-  %421 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !129, !tbaa !13
-  %422 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %421, i64 0, i32 5, !dbg !129
-  %423 = load i32, i32* %422, align 8, !dbg !129, !tbaa !35
-  %424 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %421, i64 0, i32 6, !dbg !129
-  %425 = load i32, i32* %424, align 4, !dbg !129, !tbaa !36
-  %426 = xor i32 %425, -1, !dbg !129
-  %427 = and i32 %426, %423, !dbg !129
-  %428 = icmp eq i32 %427, 0, !dbg !129
-  br i1 %428, label %"func_<root>.<static-init>$151.exit", label %429, !dbg !129, !prof !29
+  call void @sorbet_popFrame() #12, !dbg !138
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %360) #12, !dbg !131
+  %421 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !131, !tbaa !15
+  %422 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %421, i64 0, i32 5, !dbg !131
+  %423 = load i32, i32* %422, align 8, !dbg !131, !tbaa !37
+  %424 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %421, i64 0, i32 6, !dbg !131
+  %425 = load i32, i32* %424, align 4, !dbg !131, !tbaa !38
+  %426 = xor i32 %425, -1, !dbg !131
+  %427 = and i32 %426, %423, !dbg !131
+  %428 = icmp eq i32 %427, 0, !dbg !131
+  br i1 %428, label %"func_<root>.<static-init>$151.exit", label %429, !dbg !131, !prof !31
 
 429:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i
-  %430 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %421, i64 0, i32 8, !dbg !129
-  %431 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %430, align 8, !dbg !129, !tbaa !37
-  %432 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %431, i32 noundef 0) #12, !dbg !129
-  br label %"func_<root>.<static-init>$151.exit", !dbg !129
+  %430 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %421, i64 0, i32 8, !dbg !131
+  %431 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %430, align 8, !dbg !131, !tbaa !39
+  %432 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %431, i32 noundef 0) #12, !dbg !131
+  br label %"func_<root>.<static-init>$151.exit", !dbg !131
 
 "func_<root>.<static-init>$151.exit":             ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i, %429
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %35, align 8, !tbaa !13
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %35, align 8, !tbaa !15
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %28)
   ret void
 }
@@ -1480,10 +1480,10 @@ declare void @llvm.experimental.noalias.scope.decl(metadata) #8
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #9
 
 ; Function Attrs: cold minsize noreturn ssp
-define internal fastcc void @"func_<root>.<static-init>$151$block_1.cold.1"(i64 %el2.sroa.0.0) unnamed_addr #10 !dbg !139 {
+define internal fastcc void @"func_<root>.<static-init>$151$block_1.cold.1"(i64 %el2.sroa.0.0) unnamed_addr #10 !dbg !141 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %el2.sroa.0.0, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_T.let, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #15, !dbg !141
-  unreachable, !dbg !141
+  tail call void @sorbet_cast_failure(i64 %el2.sroa.0.0, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_T.let, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #15, !dbg !143
+  unreachable, !dbg !143
 }
 
 attributes #0 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
@@ -1503,148 +1503,150 @@ attributes #13 = { noinline }
 attributes #14 = { nounwind willreturn }
 attributes #15 = { noreturn }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/block_arg_expand.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !9, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !{!14, !14, i64 0}
-!14 = !{!"any pointer", !6, i64 0}
-!15 = !{!16, !14, i64 16}
-!16 = !{!"rb_execution_context_struct", !14, i64 0, !5, i64 8, !14, i64 16, !14, i64 24, !14, i64 32, !17, i64 40, !17, i64 44, !14, i64 48, !14, i64 56, !14, i64 64, !5, i64 72, !5, i64 80, !14, i64 88, !5, i64 96, !14, i64 104, !14, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !18, i64 152}
-!17 = !{!"int", !6, i64 0}
-!18 = !{!"", !14, i64 0, !14, i64 8, !5, i64 16, !6, i64 24}
-!19 = !{!20, !14, i64 16}
-!20 = !{!"rb_control_frame_struct", !14, i64 0, !14, i64 8, !14, i64 16, !5, i64 24, !14, i64 32, !14, i64 40, !14, i64 48}
-!21 = !{!20, !14, i64 32}
-!22 = !DILocation(line: 5, column: 1, scope: !8)
-!23 = !{!24, !5, i64 0}
-!24 = !{!"RBasic", !5, i64 0, !5, i64 8}
-!25 = !{!6, !6, i64 0}
-!26 = !{!"branch_weights", i32 1, i32 2000}
-!27 = !DILocation(line: 8, column: 17, scope: !8)
-!28 = !DILocation(line: 9, column: 3, scope: !8)
-!29 = !{!"branch_weights", i32 2000, i32 1}
-!30 = !DILocation(line: 9, column: 25, scope: !8)
-!31 = !{!32}
-!32 = distinct !{!32, !33, !"sorbet_rb_int_plus: argument 0"}
-!33 = distinct !{!33, !"sorbet_rb_int_plus"}
-!34 = !{!"branch_weights", i32 4001, i32 4000000}
-!35 = !{!16, !17, i64 40}
-!36 = !{!16, !17, i64 44}
-!37 = !{!16, !14, i64 56}
-!38 = !DILocation(line: 8, column: 1, scope: !8)
-!39 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_2", scope: !9, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!40 = !{!20, !5, i64 24}
-!41 = !DILocation(line: 5, column: 1, scope: !39)
-!42 = !DILocation(line: 13, column: 12, scope: !39)
-!43 = !DILocation(line: 14, column: 3, scope: !39)
-!44 = !DILocation(line: 13, column: 1, scope: !39)
-!45 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_3", scope: !9, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!46 = !DILocation(line: 5, column: 1, scope: !45)
-!47 = !DILocation(line: 18, column: 12, scope: !45)
-!48 = !DILocation(line: 19, column: 3, scope: !45)
-!49 = !DILocation(line: 18, column: 1, scope: !45)
-!50 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_4", scope: !9, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!51 = !DILocation(line: 5, column: 1, scope: !50)
-!52 = !DILocation(line: 23, column: 24, scope: !50)
-!53 = !DILocation(line: 24, column: 3, scope: !50)
-!54 = !DILocation(line: 25, column: 3, scope: !50)
-!55 = !DILocation(line: 23, column: 1, scope: !50)
-!56 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_5", scope: !9, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!57 = !DILocation(line: 5, column: 1, scope: !56)
-!58 = !DILocation(line: 28, column: 15, scope: !56)
-!59 = !DILocation(line: 29, column: 3, scope: !56)
-!60 = !DILocation(line: 30, column: 3, scope: !56)
-!61 = !DILocation(line: 28, column: 1, scope: !56)
-!62 = !DILocation(line: 0, scope: !9)
-!63 = !DILocation(line: 5, column: 6, scope: !9)
-!64 = !{!65}
-!65 = distinct !{!65, !66, !"sorbet_buildArrayIntrinsic: argument 0"}
-!66 = distinct !{!66, !"sorbet_buildArrayIntrinsic"}
-!67 = !DILocation(line: 5, column: 5, scope: !9)
-!68 = !{!69}
-!69 = distinct !{!69, !70, !"sorbet_buildArrayIntrinsic: argument 0"}
-!70 = distinct !{!70, !"sorbet_buildArrayIntrinsic"}
-!71 = !DILocation(line: 8, column: 1, scope: !9)
-!72 = !{!73, !5, i64 0}
-!73 = !{!"sorbet_inlineIntrinsicEnv", !5, i64 0, !5, i64 8, !17, i64 16, !14, i64 24, !5, i64 32}
-!74 = !{!73, !5, i64 8}
-!75 = !{!73, !17, i64 16}
-!76 = !{!77}
-!77 = distinct !{!77, !78, !"rb_vm_ifunc_proc_new: argument 0"}
-!78 = distinct !{!78, !"rb_vm_ifunc_proc_new"}
-!79 = !{!80}
-!80 = distinct !{!80, !81, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!81 = distinct !{!81, !"VM_BH_FROM_IFUNC_BLOCK"}
-!82 = !{!16, !5, i64 128}
-!83 = !DILocation(line: 8, column: 1, scope: !9, inlinedAt: !84)
-!84 = distinct !DILocation(line: 8, column: 1, scope: !9)
-!85 = distinct !{!85, !86}
-!86 = !{!"llvm.loop.unroll.disable"}
-!87 = !DILocation(line: 13, column: 1, scope: !9)
-!88 = !{!89}
-!89 = distinct !{!89, !90, !"rb_vm_ifunc_proc_new: argument 0"}
-!90 = distinct !{!90, !"rb_vm_ifunc_proc_new"}
-!91 = !{!92}
-!92 = distinct !{!92, !93, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!93 = distinct !{!93, !"VM_BH_FROM_IFUNC_BLOCK"}
-!94 = !DILocation(line: 13, column: 1, scope: !9, inlinedAt: !95)
-!95 = distinct !DILocation(line: 13, column: 1, scope: !9)
-!96 = !{!97}
-!97 = distinct !{!97, !98, !"func_<root>.<static-init>$151$block_2: %argArray"}
-!98 = distinct !{!98, !"func_<root>.<static-init>$151$block_2"}
-!99 = !DILocation(line: 13, column: 12, scope: !39, inlinedAt: !100)
-!100 = distinct !DILocation(line: 13, column: 1, scope: !9, inlinedAt: !95)
-!101 = !DILocation(line: 14, column: 3, scope: !39, inlinedAt: !100)
-!102 = distinct !{!102, !86}
-!103 = !DILocation(line: 18, column: 1, scope: !9)
-!104 = !{!105}
-!105 = distinct !{!105, !106, !"rb_vm_ifunc_proc_new: argument 0"}
-!106 = distinct !{!106, !"rb_vm_ifunc_proc_new"}
-!107 = !{!108}
-!108 = distinct !{!108, !109, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!109 = distinct !{!109, !"VM_BH_FROM_IFUNC_BLOCK"}
-!110 = !DILocation(line: 18, column: 1, scope: !9, inlinedAt: !111)
-!111 = distinct !DILocation(line: 18, column: 1, scope: !9)
-!112 = !{!113}
-!113 = distinct !{!113, !114, !"func_<root>.<static-init>$151$block_3: %argArray"}
-!114 = distinct !{!114, !"func_<root>.<static-init>$151$block_3"}
-!115 = !DILocation(line: 18, column: 12, scope: !45, inlinedAt: !116)
-!116 = distinct !DILocation(line: 18, column: 1, scope: !9, inlinedAt: !111)
-!117 = !DILocation(line: 19, column: 3, scope: !45, inlinedAt: !116)
-!118 = distinct !{!118, !86}
-!119 = !DILocation(line: 23, column: 1, scope: !9)
-!120 = !{!121}
-!121 = distinct !{!121, !122, !"rb_vm_ifunc_proc_new: argument 0"}
-!122 = distinct !{!122, !"rb_vm_ifunc_proc_new"}
-!123 = !{!124}
-!124 = distinct !{!124, !125, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!125 = distinct !{!125, !"VM_BH_FROM_IFUNC_BLOCK"}
-!126 = !DILocation(line: 23, column: 1, scope: !9, inlinedAt: !127)
-!127 = distinct !DILocation(line: 23, column: 1, scope: !9)
-!128 = distinct !{!128, !86}
-!129 = !DILocation(line: 28, column: 1, scope: !9)
-!130 = !{!131}
-!131 = distinct !{!131, !132, !"rb_vm_ifunc_proc_new: argument 0"}
-!132 = distinct !{!132, !"rb_vm_ifunc_proc_new"}
-!133 = !{!134}
-!134 = distinct !{!134, !135, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!135 = distinct !{!135, !"VM_BH_FROM_IFUNC_BLOCK"}
-!136 = !DILocation(line: 28, column: 1, scope: !9, inlinedAt: !137)
-!137 = distinct !DILocation(line: 28, column: 1, scope: !9)
-!138 = distinct !{!138, !86}
-!139 = distinct !DISubprogram(name: "func_<root>.<static-init>$151$block_1.cold.1", linkageName: "func_<root>.<static-init>$151$block_1.cold.1", scope: null, file: !2, type: !140, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!140 = !DISubroutineType(types: !3)
-!141 = !DILocation(line: 9, column: 25, scope: !139)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/block_arg_expand.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !11, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !{!16, !16, i64 0}
+!16 = !{!"any pointer", !8, i64 0}
+!17 = !{!18, !16, i64 16}
+!18 = !{!"rb_execution_context_struct", !16, i64 0, !7, i64 8, !16, i64 16, !16, i64 24, !16, i64 32, !19, i64 40, !19, i64 44, !16, i64 48, !16, i64 56, !16, i64 64, !7, i64 72, !7, i64 80, !16, i64 88, !7, i64 96, !16, i64 104, !16, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !20, i64 152}
+!19 = !{!"int", !8, i64 0}
+!20 = !{!"", !16, i64 0, !16, i64 8, !7, i64 16, !8, i64 24}
+!21 = !{!22, !16, i64 16}
+!22 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !7, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
+!23 = !{!22, !16, i64 32}
+!24 = !DILocation(line: 5, column: 1, scope: !10)
+!25 = !{!26, !7, i64 0}
+!26 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!27 = !{!8, !8, i64 0}
+!28 = !{!"branch_weights", i32 1, i32 2000}
+!29 = !DILocation(line: 8, column: 17, scope: !10)
+!30 = !DILocation(line: 9, column: 3, scope: !10)
+!31 = !{!"branch_weights", i32 2000, i32 1}
+!32 = !DILocation(line: 9, column: 25, scope: !10)
+!33 = !{!34}
+!34 = distinct !{!34, !35, !"sorbet_rb_int_plus: argument 0"}
+!35 = distinct !{!35, !"sorbet_rb_int_plus"}
+!36 = !{!"branch_weights", i32 4001, i32 4000000}
+!37 = !{!18, !19, i64 40}
+!38 = !{!18, !19, i64 44}
+!39 = !{!18, !16, i64 56}
+!40 = !DILocation(line: 8, column: 1, scope: !10)
+!41 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_2", scope: !11, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!42 = !{!22, !7, i64 24}
+!43 = !DILocation(line: 5, column: 1, scope: !41)
+!44 = !DILocation(line: 13, column: 12, scope: !41)
+!45 = !DILocation(line: 14, column: 3, scope: !41)
+!46 = !DILocation(line: 13, column: 1, scope: !41)
+!47 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_3", scope: !11, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!48 = !DILocation(line: 5, column: 1, scope: !47)
+!49 = !DILocation(line: 18, column: 12, scope: !47)
+!50 = !DILocation(line: 19, column: 3, scope: !47)
+!51 = !DILocation(line: 18, column: 1, scope: !47)
+!52 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_4", scope: !11, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!53 = !DILocation(line: 5, column: 1, scope: !52)
+!54 = !DILocation(line: 23, column: 24, scope: !52)
+!55 = !DILocation(line: 24, column: 3, scope: !52)
+!56 = !DILocation(line: 25, column: 3, scope: !52)
+!57 = !DILocation(line: 23, column: 1, scope: !52)
+!58 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_5", scope: !11, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!59 = !DILocation(line: 5, column: 1, scope: !58)
+!60 = !DILocation(line: 28, column: 15, scope: !58)
+!61 = !DILocation(line: 29, column: 3, scope: !58)
+!62 = !DILocation(line: 30, column: 3, scope: !58)
+!63 = !DILocation(line: 28, column: 1, scope: !58)
+!64 = !DILocation(line: 0, scope: !11)
+!65 = !DILocation(line: 5, column: 6, scope: !11)
+!66 = !{!67}
+!67 = distinct !{!67, !68, !"sorbet_buildArrayIntrinsic: argument 0"}
+!68 = distinct !{!68, !"sorbet_buildArrayIntrinsic"}
+!69 = !DILocation(line: 5, column: 5, scope: !11)
+!70 = !{!71}
+!71 = distinct !{!71, !72, !"sorbet_buildArrayIntrinsic: argument 0"}
+!72 = distinct !{!72, !"sorbet_buildArrayIntrinsic"}
+!73 = !DILocation(line: 8, column: 1, scope: !11)
+!74 = !{!75, !7, i64 0}
+!75 = !{!"sorbet_inlineIntrinsicEnv", !7, i64 0, !7, i64 8, !19, i64 16, !16, i64 24, !7, i64 32}
+!76 = !{!75, !7, i64 8}
+!77 = !{!75, !19, i64 16}
+!78 = !{!79}
+!79 = distinct !{!79, !80, !"rb_vm_ifunc_proc_new: argument 0"}
+!80 = distinct !{!80, !"rb_vm_ifunc_proc_new"}
+!81 = !{!82}
+!82 = distinct !{!82, !83, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!83 = distinct !{!83, !"VM_BH_FROM_IFUNC_BLOCK"}
+!84 = !{!18, !7, i64 128}
+!85 = !DILocation(line: 8, column: 1, scope: !11, inlinedAt: !86)
+!86 = distinct !DILocation(line: 8, column: 1, scope: !11)
+!87 = distinct !{!87, !88}
+!88 = !{!"llvm.loop.unroll.disable"}
+!89 = !DILocation(line: 13, column: 1, scope: !11)
+!90 = !{!91}
+!91 = distinct !{!91, !92, !"rb_vm_ifunc_proc_new: argument 0"}
+!92 = distinct !{!92, !"rb_vm_ifunc_proc_new"}
+!93 = !{!94}
+!94 = distinct !{!94, !95, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!95 = distinct !{!95, !"VM_BH_FROM_IFUNC_BLOCK"}
+!96 = !DILocation(line: 13, column: 1, scope: !11, inlinedAt: !97)
+!97 = distinct !DILocation(line: 13, column: 1, scope: !11)
+!98 = !{!99}
+!99 = distinct !{!99, !100, !"func_<root>.<static-init>$151$block_2: %argArray"}
+!100 = distinct !{!100, !"func_<root>.<static-init>$151$block_2"}
+!101 = !DILocation(line: 13, column: 12, scope: !41, inlinedAt: !102)
+!102 = distinct !DILocation(line: 13, column: 1, scope: !11, inlinedAt: !97)
+!103 = !DILocation(line: 14, column: 3, scope: !41, inlinedAt: !102)
+!104 = distinct !{!104, !88}
+!105 = !DILocation(line: 18, column: 1, scope: !11)
+!106 = !{!107}
+!107 = distinct !{!107, !108, !"rb_vm_ifunc_proc_new: argument 0"}
+!108 = distinct !{!108, !"rb_vm_ifunc_proc_new"}
+!109 = !{!110}
+!110 = distinct !{!110, !111, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!111 = distinct !{!111, !"VM_BH_FROM_IFUNC_BLOCK"}
+!112 = !DILocation(line: 18, column: 1, scope: !11, inlinedAt: !113)
+!113 = distinct !DILocation(line: 18, column: 1, scope: !11)
+!114 = !{!115}
+!115 = distinct !{!115, !116, !"func_<root>.<static-init>$151$block_3: %argArray"}
+!116 = distinct !{!116, !"func_<root>.<static-init>$151$block_3"}
+!117 = !DILocation(line: 18, column: 12, scope: !47, inlinedAt: !118)
+!118 = distinct !DILocation(line: 18, column: 1, scope: !11, inlinedAt: !113)
+!119 = !DILocation(line: 19, column: 3, scope: !47, inlinedAt: !118)
+!120 = distinct !{!120, !88}
+!121 = !DILocation(line: 23, column: 1, scope: !11)
+!122 = !{!123}
+!123 = distinct !{!123, !124, !"rb_vm_ifunc_proc_new: argument 0"}
+!124 = distinct !{!124, !"rb_vm_ifunc_proc_new"}
+!125 = !{!126}
+!126 = distinct !{!126, !127, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!127 = distinct !{!127, !"VM_BH_FROM_IFUNC_BLOCK"}
+!128 = !DILocation(line: 23, column: 1, scope: !11, inlinedAt: !129)
+!129 = distinct !DILocation(line: 23, column: 1, scope: !11)
+!130 = distinct !{!130, !88}
+!131 = !DILocation(line: 28, column: 1, scope: !11)
+!132 = !{!133}
+!133 = distinct !{!133, !134, !"rb_vm_ifunc_proc_new: argument 0"}
+!134 = distinct !{!134, !"rb_vm_ifunc_proc_new"}
+!135 = !{!136}
+!136 = distinct !{!136, !137, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!137 = distinct !{!137, !"VM_BH_FROM_IFUNC_BLOCK"}
+!138 = !DILocation(line: 28, column: 1, scope: !11, inlinedAt: !139)
+!139 = distinct !DILocation(line: 28, column: 1, scope: !11)
+!140 = distinct !{!140, !88}
+!141 = distinct !DISubprogram(name: "func_<root>.<static-init>$151$block_1.cold.1", linkageName: "func_<root>.<static-init>$151$block_1.cold.1", scope: null, file: !4, type: !142, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!142 = !DISubroutineType(types: !5)
+!143 = !DILocation(line: 9, column: 25, scope: !141)

--- a/test/testdata/compiler/block_args.llo.exp
+++ b/test/testdata/compiler/block_args.llo.exp
@@ -160,116 +160,116 @@ declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*,
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #5 !dbg !8 {
+define internal i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #5 !dbg !10 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !15
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !21
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !21
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !23
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -129
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %8, align 8, !tbaa !13
-  %default0 = icmp eq i32 %argc, 0, !dbg !22
-  br i1 %default0, label %fillFromDefaultBlockDone1.thread, label %fillFromDefaultBlockDone1, !dbg !22, !prof !23
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %8, align 8, !tbaa !15
+  %default0 = icmp eq i32 %argc, 0, !dbg !24
+  br i1 %default0, label %fillFromDefaultBlockDone1.thread, label %fillFromDefaultBlockDone1, !dbg !24, !prof !25
 
 fillFromDefaultBlockDone1:                        ; preds = %functionEntryInitializers
-  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !22
-  %9 = and i64 %rawArg_x, 1, !dbg !24
-  %10 = icmp eq i64 %9, 0, !dbg !24
-  br i1 %10, label %fillFromDefaultBlockDone1.thread, label %"fastSymCallIntrinsic_Integer_+", !dbg !24, !prof !23
+  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !24
+  %9 = and i64 %rawArg_x, 1, !dbg !26
+  %10 = icmp eq i64 %9, 0, !dbg !26
+  br i1 %10, label %fillFromDefaultBlockDone1.thread, label %"fastSymCallIntrinsic_Integer_+", !dbg !26, !prof !25
 
 fillFromDefaultBlockDone1.thread:                 ; preds = %functionEntryInitializers, %fillFromDefaultBlockDone1
   %x.sroa.0.020 = phi i64 [ %rawArg_x, %fillFromDefaultBlockDone1 ], [ 8, %functionEntryInitializers ]
-  %11 = and i64 %x.sroa.0.020, 7, !dbg !24
-  %12 = icmp ne i64 %11, 0, !dbg !24
-  %13 = and i64 %x.sroa.0.020, -9, !dbg !24
-  %14 = icmp eq i64 %13, 0, !dbg !24
-  %15 = or i1 %12, %14, !dbg !24
-  br i1 %15, label %"alternativeCallIntrinsic_Integer_+", label %sorbet_isa_Integer.exit, !dbg !24
+  %11 = and i64 %x.sroa.0.020, 7, !dbg !26
+  %12 = icmp ne i64 %11, 0, !dbg !26
+  %13 = and i64 %x.sroa.0.020, -9, !dbg !26
+  %14 = icmp eq i64 %13, 0, !dbg !26
+  %15 = or i1 %12, %14, !dbg !26
+  br i1 %15, label %"alternativeCallIntrinsic_Integer_+", label %sorbet_isa_Integer.exit, !dbg !26
 
 sorbet_isa_Integer.exit:                          ; preds = %fillFromDefaultBlockDone1.thread
-  %16 = inttoptr i64 %x.sroa.0.020 to %struct.iseq_inline_iv_cache_entry*, !dbg !24
-  %17 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %16, i64 0, i32 0, !dbg !24
-  %18 = load i64, i64* %17, align 8, !dbg !24, !tbaa !25
-  %19 = and i64 %18, 31, !dbg !24
-  %20 = icmp eq i64 %19, 10, !dbg !24
-  br i1 %20, label %"fastSymCallIntrinsic_Integer_+", label %"alternativeCallIntrinsic_Integer_+", !dbg !24, !prof !27
+  %16 = inttoptr i64 %x.sroa.0.020 to %struct.iseq_inline_iv_cache_entry*, !dbg !26
+  %17 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %16, i64 0, i32 0, !dbg !26
+  %18 = load i64, i64* %17, align 8, !dbg !26, !tbaa !27
+  %19 = and i64 %18, 31, !dbg !26
+  %20 = icmp eq i64 %19, 10, !dbg !26
+  br i1 %20, label %"fastSymCallIntrinsic_Integer_+", label %"alternativeCallIntrinsic_Integer_+", !dbg !26, !prof !29
 
 afterSend:                                        ; preds = %46, %sorbet_rb_int_plus.exit, %"alternativeCallIntrinsic_Integer_+"
-  %"symIntrinsicRawPhi_+" = phi i64 [ %send, %"alternativeCallIntrinsic_Integer_+" ], [ %37, %sorbet_rb_int_plus.exit ], [ %37, %46 ], !dbg !24
-  ret i64 %"symIntrinsicRawPhi_+", !dbg !28
+  %"symIntrinsicRawPhi_+" = phi i64 [ %send, %"alternativeCallIntrinsic_Integer_+" ], [ %37, %sorbet_rb_int_plus.exit ], [ %37, %46 ], !dbg !26
+  ret i64 %"symIntrinsicRawPhi_+", !dbg !30
 
 "alternativeCallIntrinsic_Integer_+":             ; preds = %fillFromDefaultBlockDone1.thread, %sorbet_isa_Integer.exit
   %x.sroa.0.021 = phi i64 [ %x.sroa.0.020, %fillFromDefaultBlockDone1.thread ], [ %x.sroa.0.020, %sorbet_isa_Integer.exit ]
-  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !24
-  %22 = load i64*, i64** %21, align 8, !dbg !24
-  store i64 %x.sroa.0.021, i64* %22, align 8, !dbg !24, !tbaa !4
-  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !24
-  store i64 3, i64* %23, align 8, !dbg !24, !tbaa !4
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !24
-  store i64* %24, i64** %21, align 8, !dbg !24
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !24
-  br label %afterSend, !dbg !24
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !26
+  %22 = load i64*, i64** %21, align 8, !dbg !26
+  store i64 %x.sroa.0.021, i64* %22, align 8, !dbg !26, !tbaa !6
+  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !26
+  store i64 3, i64* %23, align 8, !dbg !26, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !26
+  store i64* %24, i64** %21, align 8, !dbg !26
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !26
+  br label %afterSend, !dbg !26
 
 "fastSymCallIntrinsic_Integer_+":                 ; preds = %fillFromDefaultBlockDone1, %sorbet_isa_Integer.exit
   %x.sroa.0.019 = phi i64 [ %rawArg_x, %fillFromDefaultBlockDone1 ], [ %x.sroa.0.020, %sorbet_isa_Integer.exit ]
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !29), !dbg !24
-  %25 = and i64 %x.sroa.0.019, 1, !dbg !24
-  %26 = icmp eq i64 %25, 0, !dbg !24
-  br i1 %26, label %35, label %27, !dbg !24, !prof !32
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !31), !dbg !26
+  %25 = and i64 %x.sroa.0.019, 1, !dbg !26
+  %26 = icmp eq i64 %25, 0, !dbg !26
+  br i1 %26, label %35, label %27, !dbg !26, !prof !34
 
 27:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %28 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %x.sroa.0.019, i64 noundef 2) #10, !dbg !24
-  %29 = extractvalue { i64, i1 } %28, 1, !dbg !24
-  %30 = extractvalue { i64, i1 } %28, 0, !dbg !24
-  br i1 %29, label %31, label %sorbet_rb_int_plus.exit, !dbg !24
+  %28 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %x.sroa.0.019, i64 noundef 2) #10, !dbg !26
+  %29 = extractvalue { i64, i1 } %28, 1, !dbg !26
+  %30 = extractvalue { i64, i1 } %28, 0, !dbg !26
+  br i1 %29, label %31, label %sorbet_rb_int_plus.exit, !dbg !26
 
 31:                                               ; preds = %27
-  %32 = ashr i64 %30, 1, !dbg !24
-  %33 = xor i64 %32, -9223372036854775808, !dbg !24
-  %34 = tail call i64 @rb_int2big(i64 %33) #11, !dbg !24
-  br label %sorbet_rb_int_plus.exit, !dbg !24
+  %32 = ashr i64 %30, 1, !dbg !26
+  %33 = xor i64 %32, -9223372036854775808, !dbg !26
+  %34 = tail call i64 @rb_int2big(i64 %33) #11, !dbg !26
+  br label %sorbet_rb_int_plus.exit, !dbg !26
 
 35:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %36 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %x.sroa.0.019, i64 noundef 3) #11, !dbg !24, !noalias !29
-  br label %sorbet_rb_int_plus.exit, !dbg !24
+  %36 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %x.sroa.0.019, i64 noundef 3) #11, !dbg !26, !noalias !31
+  br label %sorbet_rb_int_plus.exit, !dbg !26
 
 sorbet_rb_int_plus.exit:                          ; preds = %31, %27, %35
-  %37 = phi i64 [ %36, %35 ], [ %34, %31 ], [ %30, %27 ], !dbg !24
-  %38 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !13
-  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 5, !dbg !24
-  %40 = load i32, i32* %39, align 8, !dbg !24, !tbaa !33
-  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 6, !dbg !24
-  %42 = load i32, i32* %41, align 4, !dbg !24, !tbaa !34
-  %43 = xor i32 %42, -1, !dbg !24
-  %44 = and i32 %43, %40, !dbg !24
-  %45 = icmp eq i32 %44, 0, !dbg !24
-  br i1 %45, label %afterSend, label %46, !dbg !24, !prof !27
+  %37 = phi i64 [ %36, %35 ], [ %34, %31 ], [ %30, %27 ], !dbg !26
+  %38 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !15
+  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 5, !dbg !26
+  %40 = load i32, i32* %39, align 8, !dbg !26, !tbaa !35
+  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 6, !dbg !26
+  %42 = load i32, i32* %41, align 4, !dbg !26, !tbaa !36
+  %43 = xor i32 %42, -1, !dbg !26
+  %44 = and i32 %43, %40, !dbg !26
+  %45 = icmp eq i32 %44, 0, !dbg !26
+  br i1 %45, label %afterSend, label %46, !dbg !26, !prof !29
 
 46:                                               ; preds = %sorbet_rb_int_plus.exit
-  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 8, !dbg !24
-  %48 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %47, align 8, !dbg !24, !tbaa !35
-  %49 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %48, i32 noundef 0) #11, !dbg !24
-  br label %afterSend, !dbg !24
+  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 8, !dbg !26
+  %48 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %47, align 8, !dbg !26, !tbaa !37
+  %49 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %48, i32 noundef 0) #11, !dbg !26
+  br label %afterSend, !dbg !26
 }
 
 ; Function Attrs: sspreq
@@ -310,188 +310,188 @@ entry:
   %"rubyStr_test/testdata/compiler/block_args.rb.i3.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_args.rb", align 8
   %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_block for.i.i", i64 %"rubyStr_test/testdata/compiler/block_args.rb.i3.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
   store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8
-  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !36
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !36
-  %13 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !13
+  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !26
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !38
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !38
+  %13 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
   %14 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %13, i64 0, i32 18
-  %15 = load i64, i64* %14, align 8, !tbaa !37
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %15 = load i64, i64* %14, align 8, !tbaa !39
+  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2
-  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !15
+  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !17
   %19 = bitcast [3 x i64]* %callArgs.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %19)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %20 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !15
+  %20 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !17
   %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %21, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %21, align 8, !tbaa !21
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 4
-  %23 = load i64*, i64** %22, align 8, !tbaa !21
-  %24 = load i64, i64* %23, align 8, !tbaa !4
+  %23 = load i64*, i64** %22, align 8, !tbaa !23
+  %24 = load i64, i64* %23, align 8, !tbaa !6
   %25 = and i64 %24, -33
-  store i64 %25, i64* %23, align 8, !tbaa !4
+  store i64 %25, i64* %23, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %16, %struct.rb_control_frame_struct* %20, %struct.rb_iseq_struct* %stackFrame.i) #11
   %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 0
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %26, align 8, !dbg !46, !tbaa !13
-  %callArgs0Addr.i = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i32 0, i64 0, !dbg !47
-  %27 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !47
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %27, align 8, !dbg !47
-  %28 = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i64 0, i64 0, !dbg !47
-  call void @llvm.experimental.noalias.scope.decl(metadata !48) #11, !dbg !47
-  %29 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %28) #11, !dbg !47
-  %rubyId_map.i = load i64, i64* @rubyIdPrecomputed_map, align 8, !dbg !47
-  %30 = bitcast %struct.sorbet_inlineIntrinsicEnv* %1 to i8*, !dbg !47
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %30) #11, !dbg !47
-  %31 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 0, !dbg !47
-  store i64 %29, i64* %31, align 8, !dbg !47, !tbaa !51
-  %32 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 1, !dbg !47
-  store i64 %rubyId_map.i, i64* %32, align 8, !dbg !47, !tbaa !53
-  %33 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 2, !dbg !47
-  store i32 0, i32* %33, align 8, !dbg !47, !tbaa !54
-  %34 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 3, !dbg !47
-  %35 = bitcast i64** %34 to i8*, !dbg !47
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %35, i8 0, i64 16, i1 false) #11, !dbg !47
-  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !13
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2, !dbg !47
-  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !dbg !47, !tbaa !15
-  call void @llvm.experimental.noalias.scope.decl(metadata !55) #11, !dbg !47
-  %39 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_1", i8* null, i32 noundef 0, i32 noundef -1) #11, !dbg !47
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 3, !dbg !47
-  %41 = bitcast i64* %40 to %struct.rb_captured_block*, !dbg !47
-  %42 = getelementptr inbounds i64, i64* %40, i64 2, !dbg !47
-  %43 = bitcast i64* %42 to %struct.vm_ifunc**, !dbg !47
-  store %struct.vm_ifunc* %39, %struct.vm_ifunc** %43, align 8, !dbg !47, !tbaa !58
-  call void @llvm.experimental.noalias.scope.decl(metadata !59) #11, !dbg !47
-  %44 = ptrtoint %struct.rb_captured_block* %41 to i64, !dbg !47
-  %45 = or i64 %44, 3, !dbg !47
-  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 17, !dbg !47
-  store i64 %45, i64* %46, align 8, !dbg !47, !tbaa !62
-  %47 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !63, !tbaa !13
-  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 17, !dbg !63
-  %49 = load i64, i64* %48, align 8, !dbg !63, !tbaa !62
-  %50 = and i64 %49, -4, !dbg !63
-  %51 = inttoptr i64 %50 to %struct.rb_captured_block*, !dbg !63
-  store i64 0, i64* %48, align 8, !dbg !63, !tbaa !62
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %51) #11, !dbg !63
-  %52 = inttoptr i64 %29 to %struct.iseq_inline_iv_cache_entry*, !dbg !63
-  %53 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %52, i64 0, i32 0, !dbg !63
-  %54 = load i64, i64* %53, align 8, !dbg !63, !tbaa !25
-  %55 = and i64 %54, 8192, !dbg !63
-  %56 = icmp eq i64 %55, 0, !dbg !63
-  br i1 %56, label %60, label %57, !dbg !63
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %26, align 8, !dbg !48, !tbaa !15
+  %callArgs0Addr.i = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i32 0, i64 0, !dbg !49
+  %27 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !49
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %27, align 8, !dbg !49
+  %28 = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i64 0, i64 0, !dbg !49
+  call void @llvm.experimental.noalias.scope.decl(metadata !50) #11, !dbg !49
+  %29 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %28) #11, !dbg !49
+  %rubyId_map.i = load i64, i64* @rubyIdPrecomputed_map, align 8, !dbg !49
+  %30 = bitcast %struct.sorbet_inlineIntrinsicEnv* %1 to i8*, !dbg !49
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %30) #11, !dbg !49
+  %31 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 0, !dbg !49
+  store i64 %29, i64* %31, align 8, !dbg !49, !tbaa !53
+  %32 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 1, !dbg !49
+  store i64 %rubyId_map.i, i64* %32, align 8, !dbg !49, !tbaa !55
+  %33 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 2, !dbg !49
+  store i32 0, i32* %33, align 8, !dbg !49, !tbaa !56
+  %34 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 3, !dbg !49
+  %35 = bitcast i64** %34 to i8*, !dbg !49
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %35, i8 0, i64 16, i1 false) #11, !dbg !49
+  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !15
+  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2, !dbg !49
+  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !dbg !49, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !57) #11, !dbg !49
+  %39 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_1", i8* null, i32 noundef 0, i32 noundef -1) #11, !dbg !49
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 3, !dbg !49
+  %41 = bitcast i64* %40 to %struct.rb_captured_block*, !dbg !49
+  %42 = getelementptr inbounds i64, i64* %40, i64 2, !dbg !49
+  %43 = bitcast i64* %42 to %struct.vm_ifunc**, !dbg !49
+  store %struct.vm_ifunc* %39, %struct.vm_ifunc** %43, align 8, !dbg !49, !tbaa !60
+  call void @llvm.experimental.noalias.scope.decl(metadata !61) #11, !dbg !49
+  %44 = ptrtoint %struct.rb_captured_block* %41 to i64, !dbg !49
+  %45 = or i64 %44, 3, !dbg !49
+  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 17, !dbg !49
+  store i64 %45, i64* %46, align 8, !dbg !49, !tbaa !64
+  %47 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !15
+  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 17, !dbg !65
+  %49 = load i64, i64* %48, align 8, !dbg !65, !tbaa !64
+  %50 = and i64 %49, -4, !dbg !65
+  %51 = inttoptr i64 %50 to %struct.rb_captured_block*, !dbg !65
+  store i64 0, i64* %48, align 8, !dbg !65, !tbaa !64
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %51) #11, !dbg !65
+  %52 = inttoptr i64 %29 to %struct.iseq_inline_iv_cache_entry*, !dbg !65
+  %53 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %52, i64 0, i32 0, !dbg !65
+  %54 = load i64, i64* %53, align 8, !dbg !65, !tbaa !27
+  %55 = and i64 %54, 8192, !dbg !65
+  %56 = icmp eq i64 %55, 0, !dbg !65
+  br i1 %56, label %60, label %57, !dbg !65
 
 57:                                               ; preds = %entry
-  %58 = lshr i64 %54, 15, !dbg !63
-  %59 = and i64 %58, 3, !dbg !63
-  br label %rb_array_len.exit2.i.i, !dbg !63
+  %58 = lshr i64 %54, 15, !dbg !65
+  %59 = and i64 %58, 3, !dbg !65
+  br label %rb_array_len.exit2.i.i, !dbg !65
 
 60:                                               ; preds = %entry
-  %61 = inttoptr i64 %29 to %struct.RArray*, !dbg !63
-  %62 = getelementptr inbounds %struct.RArray, %struct.RArray* %61, i64 0, i32 1, i32 0, i32 0, !dbg !63
-  %63 = load i64, i64* %62, align 8, !dbg !63, !tbaa !58
-  br label %rb_array_len.exit2.i.i, !dbg !63
+  %61 = inttoptr i64 %29 to %struct.RArray*, !dbg !65
+  %62 = getelementptr inbounds %struct.RArray, %struct.RArray* %61, i64 0, i32 1, i32 0, i32 0, !dbg !65
+  %63 = load i64, i64* %62, align 8, !dbg !65, !tbaa !60
+  br label %rb_array_len.exit2.i.i, !dbg !65
 
 rb_array_len.exit2.i.i:                           ; preds = %60, %57
-  %64 = phi i64 [ %59, %57 ], [ %63, %60 ], !dbg !63
-  %65 = call i64 @rb_ary_new_capa(i64 %64) #11, !dbg !63
-  %66 = load i64, i64* %53, align 8, !dbg !63, !tbaa !25
-  %67 = and i64 %66, 8192, !dbg !63
-  %68 = icmp eq i64 %67, 0, !dbg !63
-  br i1 %68, label %72, label %69, !dbg !63
+  %64 = phi i64 [ %59, %57 ], [ %63, %60 ], !dbg !65
+  %65 = call i64 @rb_ary_new_capa(i64 %64) #11, !dbg !65
+  %66 = load i64, i64* %53, align 8, !dbg !65, !tbaa !27
+  %67 = and i64 %66, 8192, !dbg !65
+  %68 = icmp eq i64 %67, 0, !dbg !65
+  br i1 %68, label %72, label %69, !dbg !65
 
 69:                                               ; preds = %rb_array_len.exit2.i.i
-  %70 = lshr i64 %66, 15, !dbg !63
-  %71 = and i64 %70, 3, !dbg !63
-  br label %rb_array_len.exit1.i.i, !dbg !63
+  %70 = lshr i64 %66, 15, !dbg !65
+  %71 = and i64 %70, 3, !dbg !65
+  br label %rb_array_len.exit1.i.i, !dbg !65
 
 72:                                               ; preds = %rb_array_len.exit2.i.i
-  %73 = inttoptr i64 %29 to %struct.RArray*, !dbg !63
-  %74 = getelementptr inbounds %struct.RArray, %struct.RArray* %73, i64 0, i32 1, i32 0, i32 0, !dbg !63
-  %75 = load i64, i64* %74, align 8, !dbg !63, !tbaa !58
-  br label %rb_array_len.exit1.i.i, !dbg !63
+  %73 = inttoptr i64 %29 to %struct.RArray*, !dbg !65
+  %74 = getelementptr inbounds %struct.RArray, %struct.RArray* %73, i64 0, i32 1, i32 0, i32 0, !dbg !65
+  %75 = load i64, i64* %74, align 8, !dbg !65, !tbaa !60
+  br label %rb_array_len.exit1.i.i, !dbg !65
 
 rb_array_len.exit1.i.i:                           ; preds = %72, %69
-  %76 = phi i64 [ %71, %69 ], [ %75, %72 ], !dbg !63
-  %77 = icmp sgt i64 %76, 0, !dbg !63
-  br i1 %77, label %78, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !63
+  %76 = phi i64 [ %71, %69 ], [ %75, %72 ], !dbg !65
+  %77 = icmp sgt i64 %76, 0, !dbg !65
+  br i1 %77, label %78, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !65
 
 78:                                               ; preds = %rb_array_len.exit1.i.i
-  %79 = bitcast i64* %0 to i8*, !dbg !63
-  %80 = inttoptr i64 %29 to %struct.RArray*, !dbg !47
-  %81 = getelementptr inbounds %struct.RArray, %struct.RArray* %80, i64 0, i32 1, i32 0, i32 0, !dbg !47
-  %82 = getelementptr inbounds %struct.RArray, %struct.RArray* %80, i64 0, i32 1, i32 0, i32 2, !dbg !47
-  br label %83, !dbg !63
+  %79 = bitcast i64* %0 to i8*, !dbg !65
+  %80 = inttoptr i64 %29 to %struct.RArray*, !dbg !49
+  %81 = getelementptr inbounds %struct.RArray, %struct.RArray* %80, i64 0, i32 1, i32 0, i32 0, !dbg !49
+  %82 = getelementptr inbounds %struct.RArray, %struct.RArray* %80, i64 0, i32 1, i32 0, i32 2, !dbg !49
+  br label %83, !dbg !65
 
 83:                                               ; preds = %rb_array_len.exit.i.i, %78
-  %84 = phi i64 [ 0, %78 ], [ %95, %rb_array_len.exit.i.i ], !dbg !63
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %79) #11, !dbg !63
-  %85 = load i64, i64* %53, align 8, !dbg !63, !tbaa !25
-  %86 = and i64 %85, 8192, !dbg !63
-  %87 = icmp eq i64 %86, 0, !dbg !63
-  br i1 %87, label %88, label %rb_array_const_ptr_transient.exit.i.i, !dbg !63
+  %84 = phi i64 [ 0, %78 ], [ %95, %rb_array_len.exit.i.i ], !dbg !65
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %79) #11, !dbg !65
+  %85 = load i64, i64* %53, align 8, !dbg !65, !tbaa !27
+  %86 = and i64 %85, 8192, !dbg !65
+  %87 = icmp eq i64 %86, 0, !dbg !65
+  br i1 %87, label %88, label %rb_array_const_ptr_transient.exit.i.i, !dbg !65
 
 88:                                               ; preds = %83
-  %89 = load i64*, i64** %82, align 8, !dbg !63, !tbaa !58
-  br label %rb_array_const_ptr_transient.exit.i.i, !dbg !63
+  %89 = load i64*, i64** %82, align 8, !dbg !65, !tbaa !60
+  br label %rb_array_const_ptr_transient.exit.i.i, !dbg !65
 
 rb_array_const_ptr_transient.exit.i.i:            ; preds = %88, %83
-  %90 = phi i64* [ %89, %88 ], [ %81, %83 ], !dbg !63
-  %91 = getelementptr inbounds i64, i64* %90, i64 %84, !dbg !63
-  %92 = load i64, i64* %91, align 8, !dbg !63, !tbaa !4
-  store i64 %92, i64* %0, align 8, !dbg !63, !tbaa !4
-  %93 = call i64 @"func_<root>.<static-init>$151$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #11, !dbg !63
-  %94 = call i64 @rb_ary_push(i64 %65, i64 %93) #11, !dbg !63
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %79) #11, !dbg !63
-  %95 = add nuw nsw i64 %84, 1, !dbg !63
-  %96 = load i64, i64* %53, align 8, !dbg !63, !tbaa !25
-  %97 = and i64 %96, 8192, !dbg !63
-  %98 = icmp eq i64 %97, 0, !dbg !63
-  br i1 %98, label %102, label %99, !dbg !63
+  %90 = phi i64* [ %89, %88 ], [ %81, %83 ], !dbg !65
+  %91 = getelementptr inbounds i64, i64* %90, i64 %84, !dbg !65
+  %92 = load i64, i64* %91, align 8, !dbg !65, !tbaa !6
+  store i64 %92, i64* %0, align 8, !dbg !65, !tbaa !6
+  %93 = call i64 @"func_<root>.<static-init>$151$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #11, !dbg !65
+  %94 = call i64 @rb_ary_push(i64 %65, i64 %93) #11, !dbg !65
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %79) #11, !dbg !65
+  %95 = add nuw nsw i64 %84, 1, !dbg !65
+  %96 = load i64, i64* %53, align 8, !dbg !65, !tbaa !27
+  %97 = and i64 %96, 8192, !dbg !65
+  %98 = icmp eq i64 %97, 0, !dbg !65
+  br i1 %98, label %102, label %99, !dbg !65
 
 99:                                               ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %100 = lshr i64 %96, 15, !dbg !63
-  %101 = and i64 %100, 3, !dbg !63
-  br label %rb_array_len.exit.i.i, !dbg !63
+  %100 = lshr i64 %96, 15, !dbg !65
+  %101 = and i64 %100, 3, !dbg !65
+  br label %rb_array_len.exit.i.i, !dbg !65
 
 102:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %103 = load i64, i64* %81, align 8, !dbg !63, !tbaa !58
-  br label %rb_array_len.exit.i.i, !dbg !63
+  %103 = load i64, i64* %81, align 8, !dbg !65, !tbaa !60
+  br label %rb_array_len.exit.i.i, !dbg !65
 
 rb_array_len.exit.i.i:                            ; preds = %102, %99
-  %104 = phi i64 [ %101, %99 ], [ %103, %102 ], !dbg !63
-  %105 = icmp slt i64 %95, %104, !dbg !63
-  br i1 %105, label %83, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !63, !llvm.loop !65
+  %104 = phi i64 [ %101, %99 ], [ %103, %102 ], !dbg !65
+  %105 = icmp slt i64 %95, %104, !dbg !65
+  br i1 %105, label %83, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !65, !llvm.loop !67
 
 forward_sorbet_rb_array_collect_withBlock.exit.i: ; preds = %rb_array_len.exit.i.i, %rb_array_len.exit1.i.i
-  call void @sorbet_popFrame() #11, !dbg !63
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %30) #11, !dbg !47
-  %106 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !13
-  %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 5, !dbg !47
-  %108 = load i32, i32* %107, align 8, !dbg !47, !tbaa !33
-  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 6, !dbg !47
-  %110 = load i32, i32* %109, align 4, !dbg !47, !tbaa !34
-  %111 = xor i32 %110, -1, !dbg !47
-  %112 = and i32 %111, %108, !dbg !47
-  %113 = icmp eq i32 %112, 0, !dbg !47
-  br i1 %113, label %"func_<root>.<static-init>$151.exit", label %114, !dbg !47, !prof !27
+  call void @sorbet_popFrame() #11, !dbg !65
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %30) #11, !dbg !49
+  %106 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !15
+  %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 5, !dbg !49
+  %108 = load i32, i32* %107, align 8, !dbg !49, !tbaa !35
+  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 6, !dbg !49
+  %110 = load i32, i32* %109, align 4, !dbg !49, !tbaa !36
+  %111 = xor i32 %110, -1, !dbg !49
+  %112 = and i32 %111, %108, !dbg !49
+  %113 = icmp eq i32 %112, 0, !dbg !49
+  br i1 %113, label %"func_<root>.<static-init>$151.exit", label %114, !dbg !49, !prof !29
 
 114:                                              ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i
-  %115 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 8, !dbg !47
-  %116 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %115, align 8, !dbg !47, !tbaa !35
-  %117 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %116, i32 noundef 0) #11, !dbg !47
-  br label %"func_<root>.<static-init>$151.exit", !dbg !47
+  %115 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 8, !dbg !49
+  %116 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %115, align 8, !dbg !49, !tbaa !37
+  %117 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %116, i32 noundef 0) #11, !dbg !49
+  br label %"func_<root>.<static-init>$151.exit", !dbg !49
 
 "func_<root>.<static-init>$151.exit":             ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i, %114
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %26, align 8, !tbaa !13
-  %118 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !36
-  %119 = load i64*, i64** %118, align 8, !dbg !36
-  store i64 %15, i64* %119, align 8, !dbg !36, !tbaa !4
-  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !36
-  store i64 %65, i64* %120, align 8, !dbg !36, !tbaa !4
-  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !36
-  store i64* %121, i64** %118, align 8, !dbg !36
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !36
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %26, align 8, !tbaa !15
+  %118 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !38
+  %119 = load i64*, i64** %118, align 8, !dbg !38
+  store i64 %15, i64* %119, align 8, !dbg !38, !tbaa !6
+  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !38
+  store i64 %65, i64* %120, align 8, !dbg !38, !tbaa !6
+  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !38
+  store i64* %121, i64** %118, align 8, !dbg !38
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !38
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %19)
   ret void
 }
@@ -515,73 +515,75 @@ attributes #9 = { noreturn nounwind }
 attributes #10 = { nounwind willreturn }
 attributes #11 = { nounwind }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/block_args.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !9, file: !2, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !{!14, !14, i64 0}
-!14 = !{!"any pointer", !6, i64 0}
-!15 = !{!16, !14, i64 16}
-!16 = !{!"rb_execution_context_struct", !14, i64 0, !5, i64 8, !14, i64 16, !14, i64 24, !14, i64 32, !17, i64 40, !17, i64 44, !14, i64 48, !14, i64 56, !14, i64 64, !5, i64 72, !5, i64 80, !14, i64 88, !5, i64 96, !14, i64 104, !14, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !18, i64 152}
-!17 = !{!"int", !6, i64 0}
-!18 = !{!"", !14, i64 0, !14, i64 8, !5, i64 16, !6, i64 24}
-!19 = !{!20, !14, i64 16}
-!20 = !{!"rb_control_frame_struct", !14, i64 0, !14, i64 8, !14, i64 16, !5, i64 24, !14, i64 32, !14, i64 40, !14, i64 48}
-!21 = !{!20, !14, i64 32}
-!22 = !DILocation(line: 4, column: 1, scope: !8)
-!23 = !{!"branch_weights", i32 1, i32 2000}
-!24 = !DILocation(line: 4, column: 21, scope: !8)
-!25 = !{!26, !5, i64 0}
-!26 = !{!"RBasic", !5, i64 0, !5, i64 8}
-!27 = !{!"branch_weights", i32 2000, i32 1}
-!28 = !DILocation(line: 4, column: 6, scope: !8)
-!29 = !{!30}
-!30 = distinct !{!30, !31, !"sorbet_rb_int_plus: argument 0"}
-!31 = distinct !{!31, !"sorbet_rb_int_plus"}
-!32 = !{!"branch_weights", i32 4001, i32 4000000}
-!33 = !{!16, !17, i64 40}
-!34 = !{!16, !17, i64 44}
-!35 = !{!16, !14, i64 56}
-!36 = !DILocation(line: 4, column: 1, scope: !9)
-!37 = !{!38, !5, i64 400}
-!38 = !{!"rb_vm_struct", !5, i64 0, !39, i64 8, !14, i64 192, !14, i64 200, !14, i64 208, !42, i64 216, !6, i64 224, !40, i64 264, !40, i64 280, !40, i64 296, !40, i64 312, !5, i64 328, !17, i64 336, !17, i64 340, !17, i64 344, !17, i64 344, !17, i64 344, !17, i64 344, !17, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !14, i64 456, !14, i64 464, !43, i64 472, !44, i64 992, !14, i64 1016, !14, i64 1024, !17, i64 1032, !17, i64 1036, !40, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !17, i64 1136, !14, i64 1144, !14, i64 1152, !14, i64 1160, !14, i64 1168, !14, i64 1176, !14, i64 1184, !17, i64 1192, !45, i64 1200, !6, i64 1232}
-!39 = !{!"rb_global_vm_lock_struct", !14, i64 0, !6, i64 8, !40, i64 48, !14, i64 64, !17, i64 72, !6, i64 80, !6, i64 128, !17, i64 176, !17, i64 180}
-!40 = !{!"list_head", !41, i64 0}
-!41 = !{!"list_node", !14, i64 0, !14, i64 8}
-!42 = !{!"long long", !6, i64 0}
-!43 = !{!"", !6, i64 0}
-!44 = !{!"rb_hook_list_struct", !14, i64 0, !17, i64 8, !17, i64 12, !17, i64 16}
-!45 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!46 = !DILocation(line: 0, scope: !9)
-!47 = !DILocation(line: 4, column: 6, scope: !9)
-!48 = !{!49}
-!49 = distinct !{!49, !50, !"sorbet_buildArrayIntrinsic: argument 0"}
-!50 = distinct !{!50, !"sorbet_buildArrayIntrinsic"}
-!51 = !{!52, !5, i64 0}
-!52 = !{!"sorbet_inlineIntrinsicEnv", !5, i64 0, !5, i64 8, !17, i64 16, !14, i64 24, !5, i64 32}
-!53 = !{!52, !5, i64 8}
-!54 = !{!52, !17, i64 16}
-!55 = !{!56}
-!56 = distinct !{!56, !57, !"rb_vm_ifunc_proc_new: argument 0"}
-!57 = distinct !{!57, !"rb_vm_ifunc_proc_new"}
-!58 = !{!6, !6, i64 0}
-!59 = !{!60}
-!60 = distinct !{!60, !61, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!61 = distinct !{!61, !"VM_BH_FROM_IFUNC_BLOCK"}
-!62 = !{!16, !5, i64 128}
-!63 = !DILocation(line: 4, column: 6, scope: !9, inlinedAt: !64)
-!64 = distinct !DILocation(line: 4, column: 6, scope: !9)
-!65 = distinct !{!65, !66}
-!66 = !{!"llvm.loop.unroll.disable"}
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/block_args.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !11, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !{!16, !16, i64 0}
+!16 = !{!"any pointer", !8, i64 0}
+!17 = !{!18, !16, i64 16}
+!18 = !{!"rb_execution_context_struct", !16, i64 0, !7, i64 8, !16, i64 16, !16, i64 24, !16, i64 32, !19, i64 40, !19, i64 44, !16, i64 48, !16, i64 56, !16, i64 64, !7, i64 72, !7, i64 80, !16, i64 88, !7, i64 96, !16, i64 104, !16, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !20, i64 152}
+!19 = !{!"int", !8, i64 0}
+!20 = !{!"", !16, i64 0, !16, i64 8, !7, i64 16, !8, i64 24}
+!21 = !{!22, !16, i64 16}
+!22 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !7, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
+!23 = !{!22, !16, i64 32}
+!24 = !DILocation(line: 4, column: 1, scope: !10)
+!25 = !{!"branch_weights", i32 1, i32 2000}
+!26 = !DILocation(line: 4, column: 21, scope: !10)
+!27 = !{!28, !7, i64 0}
+!28 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!29 = !{!"branch_weights", i32 2000, i32 1}
+!30 = !DILocation(line: 4, column: 6, scope: !10)
+!31 = !{!32}
+!32 = distinct !{!32, !33, !"sorbet_rb_int_plus: argument 0"}
+!33 = distinct !{!33, !"sorbet_rb_int_plus"}
+!34 = !{!"branch_weights", i32 4001, i32 4000000}
+!35 = !{!18, !19, i64 40}
+!36 = !{!18, !19, i64 44}
+!37 = !{!18, !16, i64 56}
+!38 = !DILocation(line: 4, column: 1, scope: !11)
+!39 = !{!40, !7, i64 400}
+!40 = !{!"rb_vm_struct", !7, i64 0, !41, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !44, i64 216, !8, i64 224, !42, i64 264, !42, i64 280, !42, i64 296, !42, i64 312, !7, i64 328, !19, i64 336, !19, i64 340, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !45, i64 472, !46, i64 992, !16, i64 1016, !16, i64 1024, !19, i64 1032, !19, i64 1036, !42, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !19, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !19, i64 1192, !47, i64 1200, !8, i64 1232}
+!41 = !{!"rb_global_vm_lock_struct", !16, i64 0, !8, i64 8, !42, i64 48, !16, i64 64, !19, i64 72, !8, i64 80, !8, i64 128, !19, i64 176, !19, i64 180}
+!42 = !{!"list_head", !43, i64 0}
+!43 = !{!"list_node", !16, i64 0, !16, i64 8}
+!44 = !{!"long long", !8, i64 0}
+!45 = !{!"", !8, i64 0}
+!46 = !{!"rb_hook_list_struct", !16, i64 0, !19, i64 8, !19, i64 12, !19, i64 16}
+!47 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!48 = !DILocation(line: 0, scope: !11)
+!49 = !DILocation(line: 4, column: 6, scope: !11)
+!50 = !{!51}
+!51 = distinct !{!51, !52, !"sorbet_buildArrayIntrinsic: argument 0"}
+!52 = distinct !{!52, !"sorbet_buildArrayIntrinsic"}
+!53 = !{!54, !7, i64 0}
+!54 = !{!"sorbet_inlineIntrinsicEnv", !7, i64 0, !7, i64 8, !19, i64 16, !16, i64 24, !7, i64 32}
+!55 = !{!54, !7, i64 8}
+!56 = !{!54, !19, i64 16}
+!57 = !{!58}
+!58 = distinct !{!58, !59, !"rb_vm_ifunc_proc_new: argument 0"}
+!59 = distinct !{!59, !"rb_vm_ifunc_proc_new"}
+!60 = !{!8, !8, i64 0}
+!61 = !{!62}
+!62 = distinct !{!62, !63, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!63 = distinct !{!63, !"VM_BH_FROM_IFUNC_BLOCK"}
+!64 = !{!18, !7, i64 128}
+!65 = !DILocation(line: 4, column: 6, scope: !11, inlinedAt: !66)
+!66 = distinct !DILocation(line: 4, column: 6, scope: !11)
+!67 = distinct !{!67, !68}
+!68 = !{!"llvm.loop.unroll.disable"}

--- a/test/testdata/compiler/block_no_args.llo.exp
+++ b/test/testdata/compiler/block_no_args.llo.exp
@@ -132,46 +132,46 @@ declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*,
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #6
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #6
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #3 !dbg !8 {
+define internal i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #3 !dbg !10 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !15
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !21
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !21
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !23
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -129
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !22, !tbaa !13
-  %rubyStr_hi = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !23
-  %9 = load i64, i64* @rb_mKernel, align 8, !dbg !24
-  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !24
-  %11 = load i64*, i64** %10, align 8, !dbg !24
-  store i64 %9, i64* %11, align 8, !dbg !24, !tbaa !4
-  %12 = getelementptr inbounds i64, i64* %11, i64 1, !dbg !24
-  store i64 %rubyStr_hi, i64* %12, align 8, !dbg !24, !tbaa !4
-  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !24
-  store i64* %13, i64** %10, align 8, !dbg !24
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !24
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %8, align 8, !dbg !24, !tbaa !13
-  ret i64 %send, !dbg !22
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !24, !tbaa !15
+  %rubyStr_hi = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !25
+  %9 = load i64, i64* @rb_mKernel, align 8, !dbg !26
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !26
+  %11 = load i64*, i64** %10, align 8, !dbg !26
+  store i64 %9, i64* %11, align 8, !dbg !26, !tbaa !6
+  %12 = getelementptr inbounds i64, i64* %11, i64 1, !dbg !26
+  store i64 %rubyStr_hi, i64* %12, align 8, !dbg !26, !tbaa !6
+  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !26
+  store i64* %13, i64** %10, align 8, !dbg !26
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !26
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %8, align 8, !dbg !26, !tbaa !15
+  ret i64 %send, !dbg !24
 }
 
 ; Function Attrs: sspreq
@@ -208,96 +208,96 @@ entry:
   %9 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #7
   call void @rb_gc_register_mark_object(i64 %9) #7
   store i64 %9, i64* @rubyStrFrozen_hi, align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !26
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
+  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %11 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %10, i64 0, i32 2
-  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !15
+  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !17
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !21
   %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 4
-  %15 = load i64*, i64** %14, align 8, !tbaa !21
-  %16 = load i64, i64* %15, align 8, !tbaa !4
+  %15 = load i64*, i64** %14, align 8, !tbaa !23
+  %16 = load i64, i64* %15, align 8, !tbaa !6
   %17 = and i64 %16, -33
-  store i64 %17, i64* %15, align 8, !tbaa !4
+  store i64 %17, i64* %15, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #7
   %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !25, !tbaa !13
-  %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !13
-  %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 2, !dbg !26
-  %21 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %20, align 8, !dbg !26, !tbaa !15
-  call void @llvm.experimental.noalias.scope.decl(metadata !27) #7, !dbg !26
-  %22 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_1", i8* null, i32 noundef 0, i32 noundef -1) #7, !dbg !26
-  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 3, !dbg !26
-  %24 = bitcast i64* %23 to %struct.rb_captured_block*, !dbg !26
-  %25 = getelementptr inbounds i64, i64* %23, i64 2, !dbg !26
-  %26 = bitcast i64* %25 to %struct.vm_ifunc**, !dbg !26
-  store %struct.vm_ifunc* %22, %struct.vm_ifunc** %26, align 8, !dbg !26, !tbaa !30
-  call void @llvm.experimental.noalias.scope.decl(metadata !31) #7, !dbg !26
-  %27 = ptrtoint %struct.rb_captured_block* %24 to i64, !dbg !26
-  %28 = or i64 %27, 3, !dbg !26
-  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 17, !dbg !26
-  store i64 %28, i64* %29, align 8, !dbg !26, !tbaa !34
-  %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !35, !tbaa !13
-  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 17, !dbg !35
-  %32 = load i64, i64* %31, align 8, !dbg !35, !tbaa !34
-  %33 = and i64 %32, -4, !dbg !35
-  %34 = inttoptr i64 %33 to %struct.rb_captured_block*, !dbg !35
-  store i64 0, i64* %31, align 8, !dbg !35, !tbaa !34
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %34) #7, !dbg !35
-  %35 = load i64, i64* @rb_mKernel, align 8, !dbg !26
-  br label %36, !dbg !35
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !27, !tbaa !15
+  %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
+  %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 2, !dbg !28
+  %21 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %20, align 8, !dbg !28, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !29) #7, !dbg !28
+  %22 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_1", i8* null, i32 noundef 0, i32 noundef -1) #7, !dbg !28
+  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 3, !dbg !28
+  %24 = bitcast i64* %23 to %struct.rb_captured_block*, !dbg !28
+  %25 = getelementptr inbounds i64, i64* %23, i64 2, !dbg !28
+  %26 = bitcast i64* %25 to %struct.vm_ifunc**, !dbg !28
+  store %struct.vm_ifunc* %22, %struct.vm_ifunc** %26, align 8, !dbg !28, !tbaa !32
+  call void @llvm.experimental.noalias.scope.decl(metadata !33) #7, !dbg !28
+  %27 = ptrtoint %struct.rb_captured_block* %24 to i64, !dbg !28
+  %28 = or i64 %27, 3, !dbg !28
+  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 17, !dbg !28
+  store i64 %28, i64* %29, align 8, !dbg !28, !tbaa !36
+  %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !15
+  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 17, !dbg !37
+  %32 = load i64, i64* %31, align 8, !dbg !37, !tbaa !36
+  %33 = and i64 %32, -4, !dbg !37
+  %34 = inttoptr i64 %33 to %struct.rb_captured_block*, !dbg !37
+  store i64 0, i64* %31, align 8, !dbg !37, !tbaa !36
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %34) #7, !dbg !37
+  %35 = load i64, i64* @rb_mKernel, align 8, !dbg !28
+  br label %36, !dbg !37
 
 36:                                               ; preds = %36, %entry
-  %37 = phi i64 [ 0, %entry ], [ %51, %36 ], !dbg !35
-  %38 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !13
-  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 2, !dbg !26
-  %40 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %39, align 8, !dbg !26, !tbaa !15
-  %stackFrame.i1.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8, !dbg !26
-  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 2, !dbg !26
-  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %41, align 8, !dbg !26, !tbaa !19
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 4, !dbg !26
-  %43 = load i64*, i64** %42, align 8, !dbg !26, !tbaa !21
-  %44 = load i64, i64* %43, align 8, !dbg !26, !tbaa !4
-  %45 = and i64 %44, -129, !dbg !26
-  store i64 %45, i64* %43, align 8, !dbg !26, !tbaa !4
-  %46 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 0, !dbg !26
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %46, align 8, !dbg !37, !tbaa !13
-  %rubyStr_hi.i2.i.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !39
-  %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 1, !dbg !40
-  %48 = load i64*, i64** %47, align 8, !dbg !40
-  store i64 %35, i64* %48, align 8, !dbg !40, !tbaa !4
-  %49 = getelementptr inbounds i64, i64* %48, i64 1, !dbg !40
-  store i64 %rubyStr_hi.i2.i.i, i64* %49, align 8, !dbg !40, !tbaa !4
-  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !40
-  store i64* %50, i64** %47, align 8, !dbg !40
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !40
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %46, align 8, !dbg !40, !tbaa !13
-  %51 = add nuw nsw i64 %37, 1, !dbg !35
-  %52 = icmp eq i64 %51, 10, !dbg !35
-  br i1 %52, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %36, !dbg !35, !llvm.loop !41
+  %37 = phi i64 [ 0, %entry ], [ %51, %36 ], !dbg !37
+  %38 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
+  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 2, !dbg !28
+  %40 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %39, align 8, !dbg !28, !tbaa !17
+  %stackFrame.i1.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8, !dbg !28
+  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 2, !dbg !28
+  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %41, align 8, !dbg !28, !tbaa !21
+  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 4, !dbg !28
+  %43 = load i64*, i64** %42, align 8, !dbg !28, !tbaa !23
+  %44 = load i64, i64* %43, align 8, !dbg !28, !tbaa !6
+  %45 = and i64 %44, -129, !dbg !28
+  store i64 %45, i64* %43, align 8, !dbg !28, !tbaa !6
+  %46 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 0, !dbg !28
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %46, align 8, !dbg !39, !tbaa !15
+  %rubyStr_hi.i2.i.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !41
+  %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 1, !dbg !42
+  %48 = load i64*, i64** %47, align 8, !dbg !42
+  store i64 %35, i64* %48, align 8, !dbg !42, !tbaa !6
+  %49 = getelementptr inbounds i64, i64* %48, i64 1, !dbg !42
+  store i64 %rubyStr_hi.i2.i.i, i64* %49, align 8, !dbg !42, !tbaa !6
+  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !42
+  store i64* %50, i64** %47, align 8, !dbg !42
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !42
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %46, align 8, !dbg !42, !tbaa !15
+  %51 = add nuw nsw i64 %37, 1, !dbg !37
+  %52 = icmp eq i64 %51, 10, !dbg !37
+  br i1 %52, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %36, !dbg !37, !llvm.loop !43
 
 forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %36
-  call void @sorbet_popFrame() #7, !dbg !35
-  %53 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !13
-  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 5, !dbg !26
-  %55 = load i32, i32* %54, align 8, !dbg !26, !tbaa !43
-  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 6, !dbg !26
-  %57 = load i32, i32* %56, align 4, !dbg !26, !tbaa !44
-  %58 = xor i32 %57, -1, !dbg !26
-  %59 = and i32 %58, %55, !dbg !26
-  %60 = icmp eq i32 %59, 0, !dbg !26
-  br i1 %60, label %"func_<root>.<static-init>$151.exit", label %61, !dbg !26, !prof !45
+  call void @sorbet_popFrame() #7, !dbg !37
+  %53 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
+  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 5, !dbg !28
+  %55 = load i32, i32* %54, align 8, !dbg !28, !tbaa !45
+  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 6, !dbg !28
+  %57 = load i32, i32* %56, align 4, !dbg !28, !tbaa !46
+  %58 = xor i32 %57, -1, !dbg !28
+  %59 = and i32 %58, %55, !dbg !28
+  %60 = icmp eq i32 %59, 0, !dbg !28
+  br i1 %60, label %"func_<root>.<static-init>$151.exit", label %61, !dbg !28, !prof !47
 
 61:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
-  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 8, !dbg !26
-  %63 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %62, align 8, !dbg !26, !tbaa !46
-  %64 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %63, i32 noundef 0) #7, !dbg !26
-  br label %"func_<root>.<static-init>$151.exit", !dbg !26
+  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 8, !dbg !28
+  %63 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %62, align 8, !dbg !28, !tbaa !48
+  %64 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %63, i32 noundef 0) #7, !dbg !28
+  br label %"func_<root>.<static-init>$151.exit", !dbg !28
 
 "func_<root>.<static-init>$151.exit":             ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %61
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !tbaa !13
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !tbaa !15
   ret void
 }
 
@@ -313,53 +313,55 @@ attributes #5 = { inaccessiblememonly nofree nosync nounwind willreturn }
 attributes #6 = { noreturn nounwind }
 attributes #7 = { nounwind }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/block_no_args.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !9, file: !2, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !{!14, !14, i64 0}
-!14 = !{!"any pointer", !6, i64 0}
-!15 = !{!16, !14, i64 16}
-!16 = !{!"rb_execution_context_struct", !14, i64 0, !5, i64 8, !14, i64 16, !14, i64 24, !14, i64 32, !17, i64 40, !17, i64 44, !14, i64 48, !14, i64 56, !14, i64 64, !5, i64 72, !5, i64 80, !14, i64 88, !5, i64 96, !14, i64 104, !14, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !18, i64 152}
-!17 = !{!"int", !6, i64 0}
-!18 = !{!"", !14, i64 0, !14, i64 8, !5, i64 16, !6, i64 24}
-!19 = !{!20, !14, i64 16}
-!20 = !{!"rb_control_frame_struct", !14, i64 0, !14, i64 8, !14, i64 16, !5, i64 24, !14, i64 32, !14, i64 40, !14, i64 48}
-!21 = !{!20, !14, i64 32}
-!22 = !DILocation(line: 4, column: 1, scope: !8)
-!23 = !DILocation(line: 5, column: 15, scope: !8)
-!24 = !DILocation(line: 5, column: 3, scope: !8)
-!25 = !DILocation(line: 0, scope: !9)
-!26 = !DILocation(line: 4, column: 1, scope: !9)
-!27 = !{!28}
-!28 = distinct !{!28, !29, !"rb_vm_ifunc_proc_new: argument 0"}
-!29 = distinct !{!29, !"rb_vm_ifunc_proc_new"}
-!30 = !{!6, !6, i64 0}
-!31 = !{!32}
-!32 = distinct !{!32, !33, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!33 = distinct !{!33, !"VM_BH_FROM_IFUNC_BLOCK"}
-!34 = !{!16, !5, i64 128}
-!35 = !DILocation(line: 4, column: 1, scope: !9, inlinedAt: !36)
-!36 = distinct !DILocation(line: 4, column: 1, scope: !9)
-!37 = !DILocation(line: 4, column: 1, scope: !8, inlinedAt: !38)
-!38 = distinct !DILocation(line: 4, column: 1, scope: !9, inlinedAt: !36)
-!39 = !DILocation(line: 5, column: 15, scope: !8, inlinedAt: !38)
-!40 = !DILocation(line: 5, column: 3, scope: !8, inlinedAt: !38)
-!41 = distinct !{!41, !42}
-!42 = !{!"llvm.loop.unroll.disable"}
-!43 = !{!16, !17, i64 40}
-!44 = !{!16, !17, i64 44}
-!45 = !{!"branch_weights", i32 2000, i32 1}
-!46 = !{!16, !14, i64 56}
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/block_no_args.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !11, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !{!16, !16, i64 0}
+!16 = !{!"any pointer", !8, i64 0}
+!17 = !{!18, !16, i64 16}
+!18 = !{!"rb_execution_context_struct", !16, i64 0, !7, i64 8, !16, i64 16, !16, i64 24, !16, i64 32, !19, i64 40, !19, i64 44, !16, i64 48, !16, i64 56, !16, i64 64, !7, i64 72, !7, i64 80, !16, i64 88, !7, i64 96, !16, i64 104, !16, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !20, i64 152}
+!19 = !{!"int", !8, i64 0}
+!20 = !{!"", !16, i64 0, !16, i64 8, !7, i64 16, !8, i64 24}
+!21 = !{!22, !16, i64 16}
+!22 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !7, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
+!23 = !{!22, !16, i64 32}
+!24 = !DILocation(line: 4, column: 1, scope: !10)
+!25 = !DILocation(line: 5, column: 15, scope: !10)
+!26 = !DILocation(line: 5, column: 3, scope: !10)
+!27 = !DILocation(line: 0, scope: !11)
+!28 = !DILocation(line: 4, column: 1, scope: !11)
+!29 = !{!30}
+!30 = distinct !{!30, !31, !"rb_vm_ifunc_proc_new: argument 0"}
+!31 = distinct !{!31, !"rb_vm_ifunc_proc_new"}
+!32 = !{!8, !8, i64 0}
+!33 = !{!34}
+!34 = distinct !{!34, !35, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!35 = distinct !{!35, !"VM_BH_FROM_IFUNC_BLOCK"}
+!36 = !{!18, !7, i64 128}
+!37 = !DILocation(line: 4, column: 1, scope: !11, inlinedAt: !38)
+!38 = distinct !DILocation(line: 4, column: 1, scope: !11)
+!39 = !DILocation(line: 4, column: 1, scope: !10, inlinedAt: !40)
+!40 = distinct !DILocation(line: 4, column: 1, scope: !11, inlinedAt: !38)
+!41 = !DILocation(line: 5, column: 15, scope: !10, inlinedAt: !40)
+!42 = !DILocation(line: 5, column: 3, scope: !10, inlinedAt: !40)
+!43 = distinct !{!43, !44}
+!44 = !{!"llvm.loop.unroll.disable"}
+!45 = !{!18, !19, i64 40}
+!46 = !{!18, !19, i64 44}
+!47 = !{!"branch_weights", i32 2000, i32 1}
+!48 = !{!18, !16, i64 56}

--- a/test/testdata/compiler/block_no_args_capture.llo.exp
+++ b/test/testdata/compiler/block_no_args_capture.llo.exp
@@ -144,51 +144,51 @@ declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*,
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #8
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #8
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #4 !dbg !8 {
+define internal i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #4 !dbg !10 {
 vm_get_ep.exit:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !15
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !21
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
   %5 = load i64*, i64** %4, align 8
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -129
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !21, !tbaa !13
-  %9 = getelementptr inbounds i64, i64* %5, i64 -1, !dbg !22
-  %10 = load i64, i64* %9, align 8, !dbg !22, !tbaa !4
-  %11 = and i64 %10, -4, !dbg !22
-  %12 = inttoptr i64 %11 to i64*, !dbg !22
-  %13 = getelementptr inbounds i64, i64* %12, i64 -3, !dbg !22
-  %14 = load i64, i64* %13, align 8, !dbg !22, !tbaa !4
-  %15 = load i64, i64* @rb_mKernel, align 8, !dbg !22
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !22
-  %17 = load i64*, i64** %16, align 8, !dbg !22
-  store i64 %15, i64* %17, align 8, !dbg !22, !tbaa !4
-  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !22
-  store i64 %14, i64* %18, align 8, !dbg !22, !tbaa !4
-  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !22
-  store i64* %19, i64** %16, align 8, !dbg !22
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !22
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !22, !tbaa !13
-  ret i64 %send, !dbg !21
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !23, !tbaa !15
+  %9 = getelementptr inbounds i64, i64* %5, i64 -1, !dbg !24
+  %10 = load i64, i64* %9, align 8, !dbg !24, !tbaa !6
+  %11 = and i64 %10, -4, !dbg !24
+  %12 = inttoptr i64 %11 to i64*, !dbg !24
+  %13 = getelementptr inbounds i64, i64* %12, i64 -3, !dbg !24
+  %14 = load i64, i64* %13, align 8, !dbg !24, !tbaa !6
+  %15 = load i64, i64* @rb_mKernel, align 8, !dbg !24
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !24
+  %17 = load i64*, i64** %16, align 8, !dbg !24
+  store i64 %15, i64* %17, align 8, !dbg !24, !tbaa !6
+  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !24
+  store i64 %14, i64* %18, align 8, !dbg !24, !tbaa !6
+  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !24
+  store i64* %19, i64** %16, align 8, !dbg !24
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !24
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !24, !tbaa !15
+  ret i64 %send, !dbg !23
 }
 
 ; Function Attrs: sspreq
@@ -234,132 +234,132 @@ entry:
   %12 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #9
   call void @rb_gc_register_mark_object(i64 %12) #9
   store i64 %12, i64* @rubyStrFrozen_hi, align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
-  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
+  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 2
-  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !15
+  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !17
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !21
   %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 4
-  %18 = load i64*, i64** %17, align 8, !tbaa !23
-  %19 = load i64, i64* %18, align 8, !tbaa !4
+  %18 = load i64*, i64** %17, align 8, !tbaa !25
+  %19 = load i64, i64* %18, align 8, !tbaa !6
   %20 = and i64 %19, -33
-  store i64 %20, i64* %18, align 8, !tbaa !4
+  store i64 %20, i64* %18, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #9
   %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 0
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %21, align 8, !dbg !24, !tbaa !13
-  %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !25
-  %22 = load i64*, i64** %17, align 8, !dbg !25, !tbaa !23
-  %23 = load i64, i64* %22, align 8, !dbg !25, !tbaa !4
-  %24 = and i64 %23, 8, !dbg !25
-  %25 = icmp eq i64 %24, 0, !dbg !25
-  br i1 %25, label %26, label %28, !dbg !25, !prof !26
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %21, align 8, !dbg !26, !tbaa !15
+  %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !27
+  %22 = load i64*, i64** %17, align 8, !dbg !27, !tbaa !25
+  %23 = load i64, i64* %22, align 8, !dbg !27, !tbaa !6
+  %24 = and i64 %23, 8, !dbg !27
+  %25 = icmp eq i64 %24, 0, !dbg !27
+  br i1 %25, label %26, label %28, !dbg !27, !prof !28
 
 26:                                               ; preds = %entry
-  %27 = getelementptr inbounds i64, i64* %22, i64 -3, !dbg !25
-  store i64 %rubyStr_hi.i, i64* %27, align 8, !dbg !25, !tbaa !4
-  br label %29, !dbg !25
+  %27 = getelementptr inbounds i64, i64* %22, i64 -3, !dbg !27
+  store i64 %rubyStr_hi.i, i64* %27, align 8, !dbg !27, !tbaa !6
+  br label %29, !dbg !27
 
 28:                                               ; preds = %entry
-  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %22, i32 noundef -3, i64 %rubyStr_hi.i) #9, !dbg !25
-  br label %29, !dbg !25
+  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %22, i32 noundef -3, i64 %rubyStr_hi.i) #9, !dbg !27
+  br label %29, !dbg !27
 
 29:                                               ; preds = %28, %26
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !dbg !25, !tbaa !13
-  %rubyId_times.i = load i64, i64* @rubyIdPrecomputed_times, align 8, !dbg !27
-  %30 = bitcast %struct.sorbet_inlineIntrinsicEnv* %0 to i8*, !dbg !27
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %30) #9, !dbg !27
-  %31 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 0, !dbg !27
-  store i64 21, i64* %31, align 8, !dbg !27, !tbaa !28
-  %32 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 1, !dbg !27
-  store i64 %rubyId_times.i, i64* %32, align 8, !dbg !27, !tbaa !30
-  %33 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 2, !dbg !27
-  store i32 0, i32* %33, align 8, !dbg !27, !tbaa !31
-  %34 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 3, !dbg !27
-  %35 = bitcast i64** %34 to i8*, !dbg !27
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %35, i8 0, i64 16, i1 false) #9, !dbg !27
-  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !27, !tbaa !13
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2, !dbg !27
-  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !dbg !27, !tbaa !15
-  call void @llvm.experimental.noalias.scope.decl(metadata !32) #9, !dbg !27
-  %39 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_1", i8* null, i32 noundef 0, i32 noundef -1) #9, !dbg !27
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 3, !dbg !27
-  %41 = bitcast i64* %40 to %struct.rb_captured_block*, !dbg !27
-  %42 = getelementptr inbounds i64, i64* %40, i64 2, !dbg !27
-  %43 = bitcast i64* %42 to %struct.vm_ifunc**, !dbg !27
-  store %struct.vm_ifunc* %39, %struct.vm_ifunc** %43, align 8, !dbg !27, !tbaa !35
-  call void @llvm.experimental.noalias.scope.decl(metadata !36) #9, !dbg !27
-  %44 = ptrtoint %struct.rb_captured_block* %41 to i64, !dbg !27
-  %45 = or i64 %44, 3, !dbg !27
-  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 17, !dbg !27
-  store i64 %45, i64* %46, align 8, !dbg !27, !tbaa !39
-  %47 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !13
-  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 17, !dbg !40
-  %49 = load i64, i64* %48, align 8, !dbg !40, !tbaa !39
-  %50 = and i64 %49, -4, !dbg !40
-  %51 = inttoptr i64 %50 to %struct.rb_captured_block*, !dbg !40
-  store i64 0, i64* %48, align 8, !dbg !40, !tbaa !39
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %51) #9, !dbg !40
-  %52 = load i64, i64* @rb_mKernel, align 8, !dbg !27
-  br label %53, !dbg !40
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !dbg !27, !tbaa !15
+  %rubyId_times.i = load i64, i64* @rubyIdPrecomputed_times, align 8, !dbg !29
+  %30 = bitcast %struct.sorbet_inlineIntrinsicEnv* %0 to i8*, !dbg !29
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %30) #9, !dbg !29
+  %31 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 0, !dbg !29
+  store i64 21, i64* %31, align 8, !dbg !29, !tbaa !30
+  %32 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 1, !dbg !29
+  store i64 %rubyId_times.i, i64* %32, align 8, !dbg !29, !tbaa !32
+  %33 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 2, !dbg !29
+  store i32 0, i32* %33, align 8, !dbg !29, !tbaa !33
+  %34 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 3, !dbg !29
+  %35 = bitcast i64** %34 to i8*, !dbg !29
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %35, i8 0, i64 16, i1 false) #9, !dbg !29
+  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
+  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2, !dbg !29
+  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !dbg !29, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !34) #9, !dbg !29
+  %39 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_1", i8* null, i32 noundef 0, i32 noundef -1) #9, !dbg !29
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 3, !dbg !29
+  %41 = bitcast i64* %40 to %struct.rb_captured_block*, !dbg !29
+  %42 = getelementptr inbounds i64, i64* %40, i64 2, !dbg !29
+  %43 = bitcast i64* %42 to %struct.vm_ifunc**, !dbg !29
+  store %struct.vm_ifunc* %39, %struct.vm_ifunc** %43, align 8, !dbg !29, !tbaa !37
+  call void @llvm.experimental.noalias.scope.decl(metadata !38) #9, !dbg !29
+  %44 = ptrtoint %struct.rb_captured_block* %41 to i64, !dbg !29
+  %45 = or i64 %44, 3, !dbg !29
+  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 17, !dbg !29
+  store i64 %45, i64* %46, align 8, !dbg !29, !tbaa !41
+  %47 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !42, !tbaa !15
+  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 17, !dbg !42
+  %49 = load i64, i64* %48, align 8, !dbg !42, !tbaa !41
+  %50 = and i64 %49, -4, !dbg !42
+  %51 = inttoptr i64 %50 to %struct.rb_captured_block*, !dbg !42
+  store i64 0, i64* %48, align 8, !dbg !42, !tbaa !41
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %51) #9, !dbg !42
+  %52 = load i64, i64* @rb_mKernel, align 8, !dbg !29
+  br label %53, !dbg !42
 
 53:                                               ; preds = %53, %29
-  %54 = phi i64 [ 0, %29 ], [ %74, %53 ], !dbg !40
-  %55 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !27, !tbaa !13
-  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %55, i64 0, i32 2, !dbg !27
-  %57 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %56, align 8, !dbg !27, !tbaa !15
-  %stackFrame.i1.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8, !dbg !27
-  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 2, !dbg !27
-  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %58, align 8, !dbg !27, !tbaa !19
-  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 4, !dbg !27
-  %60 = load i64*, i64** %59, align 8, !dbg !27
-  %61 = load i64, i64* %60, align 8, !dbg !27, !tbaa !4
-  %62 = and i64 %61, -129, !dbg !27
-  store i64 %62, i64* %60, align 8, !dbg !27, !tbaa !4
-  %63 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 0, !dbg !27
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %63, align 8, !dbg !42, !tbaa !13
-  %64 = getelementptr inbounds i64, i64* %60, i64 -1, !dbg !44
-  %65 = load i64, i64* %64, align 8, !dbg !44, !tbaa !4
-  %66 = and i64 %65, -4, !dbg !44
-  %67 = inttoptr i64 %66 to i64*, !dbg !44
-  %68 = getelementptr inbounds i64, i64* %67, i64 -3, !dbg !44
-  %69 = load i64, i64* %68, align 8, !dbg !44, !tbaa !4
-  %70 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 1, !dbg !44
-  %71 = load i64*, i64** %70, align 8, !dbg !44
-  store i64 %52, i64* %71, align 8, !dbg !44, !tbaa !4
-  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !44
-  store i64 %69, i64* %72, align 8, !dbg !44, !tbaa !4
-  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !44
-  store i64* %73, i64** %70, align 8, !dbg !44
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !44
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %63, align 8, !dbg !44, !tbaa !13
-  %74 = add nuw nsw i64 %54, 1, !dbg !40
-  %75 = icmp eq i64 %74, 10, !dbg !40
-  br i1 %75, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %53, !dbg !40, !llvm.loop !45
+  %54 = phi i64 [ 0, %29 ], [ %74, %53 ], !dbg !42
+  %55 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
+  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %55, i64 0, i32 2, !dbg !29
+  %57 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %56, align 8, !dbg !29, !tbaa !17
+  %stackFrame.i1.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8, !dbg !29
+  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 2, !dbg !29
+  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %58, align 8, !dbg !29, !tbaa !21
+  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 4, !dbg !29
+  %60 = load i64*, i64** %59, align 8, !dbg !29
+  %61 = load i64, i64* %60, align 8, !dbg !29, !tbaa !6
+  %62 = and i64 %61, -129, !dbg !29
+  store i64 %62, i64* %60, align 8, !dbg !29, !tbaa !6
+  %63 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 0, !dbg !29
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %63, align 8, !dbg !44, !tbaa !15
+  %64 = getelementptr inbounds i64, i64* %60, i64 -1, !dbg !46
+  %65 = load i64, i64* %64, align 8, !dbg !46, !tbaa !6
+  %66 = and i64 %65, -4, !dbg !46
+  %67 = inttoptr i64 %66 to i64*, !dbg !46
+  %68 = getelementptr inbounds i64, i64* %67, i64 -3, !dbg !46
+  %69 = load i64, i64* %68, align 8, !dbg !46, !tbaa !6
+  %70 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 1, !dbg !46
+  %71 = load i64*, i64** %70, align 8, !dbg !46
+  store i64 %52, i64* %71, align 8, !dbg !46, !tbaa !6
+  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !46
+  store i64 %69, i64* %72, align 8, !dbg !46, !tbaa !6
+  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !46
+  store i64* %73, i64** %70, align 8, !dbg !46
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !46
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %63, align 8, !dbg !46, !tbaa !15
+  %74 = add nuw nsw i64 %54, 1, !dbg !42
+  %75 = icmp eq i64 %74, 10, !dbg !42
+  br i1 %75, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %53, !dbg !42, !llvm.loop !47
 
 forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %53
-  call void @sorbet_popFrame() #9, !dbg !40
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %30) #9, !dbg !27
-  %76 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !27, !tbaa !13
-  %77 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 5, !dbg !27
-  %78 = load i32, i32* %77, align 8, !dbg !27, !tbaa !47
-  %79 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 6, !dbg !27
-  %80 = load i32, i32* %79, align 4, !dbg !27, !tbaa !48
-  %81 = xor i32 %80, -1, !dbg !27
-  %82 = and i32 %81, %78, !dbg !27
-  %83 = icmp eq i32 %82, 0, !dbg !27
-  br i1 %83, label %"func_<root>.<static-init>$151.exit", label %84, !dbg !27, !prof !26
+  call void @sorbet_popFrame() #9, !dbg !42
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %30) #9, !dbg !29
+  %76 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
+  %77 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 5, !dbg !29
+  %78 = load i32, i32* %77, align 8, !dbg !29, !tbaa !49
+  %79 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 6, !dbg !29
+  %80 = load i32, i32* %79, align 4, !dbg !29, !tbaa !50
+  %81 = xor i32 %80, -1, !dbg !29
+  %82 = and i32 %81, %78, !dbg !29
+  %83 = icmp eq i32 %82, 0, !dbg !29
+  br i1 %83, label %"func_<root>.<static-init>$151.exit", label %84, !dbg !29, !prof !28
 
 84:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
-  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 8, !dbg !27
-  %86 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %85, align 8, !dbg !27, !tbaa !49
-  %87 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %86, i32 noundef 0) #9, !dbg !27
-  br label %"func_<root>.<static-init>$151.exit", !dbg !27
+  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 8, !dbg !29
+  %86 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %85, align 8, !dbg !29, !tbaa !51
+  %87 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %86, i32 noundef 0) #9, !dbg !29
+  br label %"func_<root>.<static-init>$151.exit", !dbg !29
 
 "func_<root>.<static-init>$151.exit":             ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %84
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !tbaa !13
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !tbaa !15
   ret void
 }
 
@@ -380,56 +380,58 @@ attributes #7 = { argmemonly nofree nosync nounwind willreturn writeonly }
 attributes #8 = { noreturn nounwind }
 attributes #9 = { nounwind }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/block_no_args_capture.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !9, file: !2, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !{!14, !14, i64 0}
-!14 = !{!"any pointer", !6, i64 0}
-!15 = !{!16, !14, i64 16}
-!16 = !{!"rb_execution_context_struct", !14, i64 0, !5, i64 8, !14, i64 16, !14, i64 24, !14, i64 32, !17, i64 40, !17, i64 44, !14, i64 48, !14, i64 56, !14, i64 64, !5, i64 72, !5, i64 80, !14, i64 88, !5, i64 96, !14, i64 104, !14, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !18, i64 152}
-!17 = !{!"int", !6, i64 0}
-!18 = !{!"", !14, i64 0, !14, i64 8, !5, i64 16, !6, i64 24}
-!19 = !{!20, !14, i64 16}
-!20 = !{!"rb_control_frame_struct", !14, i64 0, !14, i64 8, !14, i64 16, !5, i64 24, !14, i64 32, !14, i64 40, !14, i64 48}
-!21 = !DILocation(line: 5, column: 1, scope: !8)
-!22 = !DILocation(line: 6, column: 3, scope: !8)
-!23 = !{!20, !14, i64 32}
-!24 = !DILocation(line: 0, scope: !9)
-!25 = !DILocation(line: 4, column: 5, scope: !9)
-!26 = !{!"branch_weights", i32 2000, i32 1}
-!27 = !DILocation(line: 5, column: 1, scope: !9)
-!28 = !{!29, !5, i64 0}
-!29 = !{!"sorbet_inlineIntrinsicEnv", !5, i64 0, !5, i64 8, !17, i64 16, !14, i64 24, !5, i64 32}
-!30 = !{!29, !5, i64 8}
-!31 = !{!29, !17, i64 16}
-!32 = !{!33}
-!33 = distinct !{!33, !34, !"rb_vm_ifunc_proc_new: argument 0"}
-!34 = distinct !{!34, !"rb_vm_ifunc_proc_new"}
-!35 = !{!6, !6, i64 0}
-!36 = !{!37}
-!37 = distinct !{!37, !38, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!38 = distinct !{!38, !"VM_BH_FROM_IFUNC_BLOCK"}
-!39 = !{!16, !5, i64 128}
-!40 = !DILocation(line: 5, column: 1, scope: !9, inlinedAt: !41)
-!41 = distinct !DILocation(line: 5, column: 1, scope: !9)
-!42 = !DILocation(line: 5, column: 1, scope: !8, inlinedAt: !43)
-!43 = distinct !DILocation(line: 5, column: 1, scope: !9, inlinedAt: !41)
-!44 = !DILocation(line: 6, column: 3, scope: !8, inlinedAt: !43)
-!45 = distinct !{!45, !46}
-!46 = !{!"llvm.loop.unroll.disable"}
-!47 = !{!16, !17, i64 40}
-!48 = !{!16, !17, i64 44}
-!49 = !{!16, !14, i64 56}
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/block_no_args_capture.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !11, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !{!16, !16, i64 0}
+!16 = !{!"any pointer", !8, i64 0}
+!17 = !{!18, !16, i64 16}
+!18 = !{!"rb_execution_context_struct", !16, i64 0, !7, i64 8, !16, i64 16, !16, i64 24, !16, i64 32, !19, i64 40, !19, i64 44, !16, i64 48, !16, i64 56, !16, i64 64, !7, i64 72, !7, i64 80, !16, i64 88, !7, i64 96, !16, i64 104, !16, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !20, i64 152}
+!19 = !{!"int", !8, i64 0}
+!20 = !{!"", !16, i64 0, !16, i64 8, !7, i64 16, !8, i64 24}
+!21 = !{!22, !16, i64 16}
+!22 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !7, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
+!23 = !DILocation(line: 5, column: 1, scope: !10)
+!24 = !DILocation(line: 6, column: 3, scope: !10)
+!25 = !{!22, !16, i64 32}
+!26 = !DILocation(line: 0, scope: !11)
+!27 = !DILocation(line: 4, column: 5, scope: !11)
+!28 = !{!"branch_weights", i32 2000, i32 1}
+!29 = !DILocation(line: 5, column: 1, scope: !11)
+!30 = !{!31, !7, i64 0}
+!31 = !{!"sorbet_inlineIntrinsicEnv", !7, i64 0, !7, i64 8, !19, i64 16, !16, i64 24, !7, i64 32}
+!32 = !{!31, !7, i64 8}
+!33 = !{!31, !19, i64 16}
+!34 = !{!35}
+!35 = distinct !{!35, !36, !"rb_vm_ifunc_proc_new: argument 0"}
+!36 = distinct !{!36, !"rb_vm_ifunc_proc_new"}
+!37 = !{!8, !8, i64 0}
+!38 = !{!39}
+!39 = distinct !{!39, !40, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!40 = distinct !{!40, !"VM_BH_FROM_IFUNC_BLOCK"}
+!41 = !{!18, !7, i64 128}
+!42 = !DILocation(line: 5, column: 1, scope: !11, inlinedAt: !43)
+!43 = distinct !DILocation(line: 5, column: 1, scope: !11)
+!44 = !DILocation(line: 5, column: 1, scope: !10, inlinedAt: !45)
+!45 = distinct !DILocation(line: 5, column: 1, scope: !11, inlinedAt: !43)
+!46 = !DILocation(line: 6, column: 3, scope: !10, inlinedAt: !45)
+!47 = distinct !{!47, !48}
+!48 = !{!"llvm.loop.unroll.disable"}
+!49 = !{!18, !19, i64 40}
+!50 = !{!18, !19, i64 44}
+!51 = !{!18, !16, i64 56}

--- a/test/testdata/compiler/block_no_args_captures_constant.llo.exp
+++ b/test/testdata/compiler/block_no_args_captures_constant.llo.exp
@@ -162,174 +162,174 @@ declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #4 !dbg !8 {
+define i64 @"func_Object#foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #4 !dbg !10 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !14
-  br i1 %tooManyArgs, label %argCountFailBlock, label %1, !dbg !14, !prof !15
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !16
+  br i1 %tooManyArgs, label %argCountFailBlock, label %1, !dbg !16, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #11, !dbg !14
-  unreachable, !dbg !14
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #11, !dbg !16
+  unreachable, !dbg !16
 
 1:                                                ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !16, !tbaa !12
-  %2 = load i64, i64* @guard_epoch_A, align 8, !dbg !17
-  %3 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !17, !tbaa !18
-  %needTakeSlowPath = icmp ne i64 %2, %3, !dbg !17
-  br i1 %needTakeSlowPath, label %4, label %5, !dbg !17, !prof !20
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !18, !tbaa !14
+  %2 = load i64, i64* @guard_epoch_A, align 8, !dbg !19
+  %3 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !19, !tbaa !20
+  %needTakeSlowPath = icmp ne i64 %2, %3, !dbg !19
+  br i1 %needTakeSlowPath, label %4, label %5, !dbg !19, !prof !22
 
 4:                                                ; preds = %1
-  tail call void @const_recompute_A(), !dbg !17
-  br label %5, !dbg !17
+  tail call void @const_recompute_A(), !dbg !19
+  br label %5, !dbg !19
 
 5:                                                ; preds = %1, %4
-  %6 = load i64, i64* @guarded_const_A, align 8, !dbg !17
-  %7 = load i64, i64* @guard_epoch_A, align 8, !dbg !17
-  %8 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !17, !tbaa !18
-  %guardUpdated = icmp eq i64 %7, %8, !dbg !17
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !17
-  %9 = load i64, i64* @rb_mKernel, align 8, !dbg !17
-  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !17
-  %11 = load i64*, i64** %10, align 8, !dbg !17
-  store i64 %9, i64* %11, align 8, !dbg !17, !tbaa !4
-  %12 = getelementptr inbounds i64, i64* %11, i64 1, !dbg !17
-  store i64 %6, i64* %12, align 8, !dbg !17, !tbaa !4
-  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !17
-  store i64* %13, i64** %10, align 8, !dbg !17
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !17, !tbaa !12
-  %14 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !21, !tbaa !12
-  %15 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 2, !dbg !21
-  %16 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %15, align 8, !dbg !21, !tbaa !22
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !26), !dbg !21
-  %17 = tail call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_Object#foo$block_1", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !21
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 3, !dbg !21
-  %19 = bitcast i64* %18 to %struct.rb_captured_block*, !dbg !21
-  %20 = getelementptr inbounds i64, i64* %18, i64 2, !dbg !21
-  %21 = bitcast i64* %20 to %struct.vm_ifunc**, !dbg !21
-  store %struct.vm_ifunc* %17, %struct.vm_ifunc** %21, align 8, !dbg !21, !tbaa !29
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !30), !dbg !21
-  %22 = ptrtoint %struct.rb_captured_block* %19 to i64, !dbg !21
-  %23 = or i64 %22, 3, !dbg !21
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 17, !dbg !21
-  store i64 %23, i64* %24, align 8, !dbg !21, !tbaa !33
-  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !34, !tbaa !12
-  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 17, !dbg !34
-  %27 = load i64, i64* %26, align 8, !dbg !34, !tbaa !33
-  %28 = and i64 %27, -4, !dbg !34
-  %29 = inttoptr i64 %28 to %struct.rb_captured_block*, !dbg !34
-  store i64 0, i64* %26, align 8, !dbg !34, !tbaa !33
-  tail call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %29) #12, !dbg !34
-  br label %30, !dbg !34
+  %6 = load i64, i64* @guarded_const_A, align 8, !dbg !19
+  %7 = load i64, i64* @guard_epoch_A, align 8, !dbg !19
+  %8 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !19, !tbaa !20
+  %guardUpdated = icmp eq i64 %7, %8, !dbg !19
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !19
+  %9 = load i64, i64* @rb_mKernel, align 8, !dbg !19
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !19
+  %11 = load i64*, i64** %10, align 8, !dbg !19
+  store i64 %9, i64* %11, align 8, !dbg !19, !tbaa !6
+  %12 = getelementptr inbounds i64, i64* %11, i64 1, !dbg !19
+  store i64 %6, i64* %12, align 8, !dbg !19, !tbaa !6
+  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !19
+  store i64* %13, i64** %10, align 8, !dbg !19
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !19, !tbaa !14
+  %14 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !14
+  %15 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 2, !dbg !23
+  %16 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %15, align 8, !dbg !23, !tbaa !24
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !28), !dbg !23
+  %17 = tail call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_Object#foo$block_1", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !23
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 3, !dbg !23
+  %19 = bitcast i64* %18 to %struct.rb_captured_block*, !dbg !23
+  %20 = getelementptr inbounds i64, i64* %18, i64 2, !dbg !23
+  %21 = bitcast i64* %20 to %struct.vm_ifunc**, !dbg !23
+  store %struct.vm_ifunc* %17, %struct.vm_ifunc** %21, align 8, !dbg !23, !tbaa !31
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !32), !dbg !23
+  %22 = ptrtoint %struct.rb_captured_block* %19 to i64, !dbg !23
+  %23 = or i64 %22, 3, !dbg !23
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 17, !dbg !23
+  store i64 %23, i64* %24, align 8, !dbg !23, !tbaa !35
+  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !36, !tbaa !14
+  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 17, !dbg !36
+  %27 = load i64, i64* %26, align 8, !dbg !36, !tbaa !35
+  %28 = and i64 %27, -4, !dbg !36
+  %29 = inttoptr i64 %28 to %struct.rb_captured_block*, !dbg !36
+  store i64 0, i64* %26, align 8, !dbg !36, !tbaa !35
+  tail call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %29) #12, !dbg !36
+  br label %30, !dbg !36
 
 30:                                               ; preds = %30, %5
-  %31 = phi i64 [ 0, %5 ], [ %45, %30 ], !dbg !34
-  %32 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !21, !tbaa !12
-  %33 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %32, i64 0, i32 2, !dbg !21
-  %34 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %33, align 8, !dbg !21, !tbaa !22
-  %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#foo$block_1", align 8, !dbg !21
-  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 2, !dbg !21
-  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %35, align 8, !dbg !21, !tbaa !36
-  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 4, !dbg !21
-  %37 = load i64*, i64** %36, align 8, !dbg !21, !tbaa !38
-  %38 = load i64, i64* %37, align 8, !dbg !21, !tbaa !4
-  %39 = and i64 %38, -129, !dbg !21
-  store i64 %39, i64* %37, align 8, !dbg !21, !tbaa !4
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 0, !dbg !21
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %40, align 8, !dbg !39, !tbaa !12
-  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 1, !dbg !42
-  %42 = load i64*, i64** %41, align 8, !dbg !42
-  store i64 %9, i64* %42, align 8, !dbg !42, !tbaa !4
-  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !42
-  store i64 %6, i64* %43, align 8, !dbg !42, !tbaa !4
-  %44 = getelementptr inbounds i64, i64* %43, i64 1, !dbg !42
-  store i64* %44, i64** %41, align 8, !dbg !42
-  %send26 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !42
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %40, align 8, !dbg !42, !tbaa !12
-  %45 = add nuw nsw i64 %31, 1, !dbg !34
-  %46 = icmp eq i64 %45, 10, !dbg !34
-  br i1 %46, label %forward_sorbet_rb_int_dotimes_withBlock.exit, label %30, !dbg !34, !llvm.loop !43
+  %31 = phi i64 [ 0, %5 ], [ %45, %30 ], !dbg !36
+  %32 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !14
+  %33 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %32, i64 0, i32 2, !dbg !23
+  %34 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %33, align 8, !dbg !23, !tbaa !24
+  %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#foo$block_1", align 8, !dbg !23
+  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 2, !dbg !23
+  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %35, align 8, !dbg !23, !tbaa !38
+  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 4, !dbg !23
+  %37 = load i64*, i64** %36, align 8, !dbg !23, !tbaa !40
+  %38 = load i64, i64* %37, align 8, !dbg !23, !tbaa !6
+  %39 = and i64 %38, -129, !dbg !23
+  store i64 %39, i64* %37, align 8, !dbg !23, !tbaa !6
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 0, !dbg !23
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %40, align 8, !dbg !41, !tbaa !14
+  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 1, !dbg !44
+  %42 = load i64*, i64** %41, align 8, !dbg !44
+  store i64 %9, i64* %42, align 8, !dbg !44, !tbaa !6
+  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !44
+  store i64 %6, i64* %43, align 8, !dbg !44, !tbaa !6
+  %44 = getelementptr inbounds i64, i64* %43, i64 1, !dbg !44
+  store i64* %44, i64** %41, align 8, !dbg !44
+  %send26 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !44
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %40, align 8, !dbg !44, !tbaa !14
+  %45 = add nuw nsw i64 %31, 1, !dbg !36
+  %46 = icmp eq i64 %45, 10, !dbg !36
+  br i1 %46, label %forward_sorbet_rb_int_dotimes_withBlock.exit, label %30, !dbg !36, !llvm.loop !45
 
 forward_sorbet_rb_int_dotimes_withBlock.exit:     ; preds = %30
-  tail call void @sorbet_popFrame() #12, !dbg !34
-  %47 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !21, !tbaa !12
-  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 5, !dbg !21
-  %49 = load i32, i32* %48, align 8, !dbg !21, !tbaa !45
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 6, !dbg !21
-  %51 = load i32, i32* %50, align 4, !dbg !21, !tbaa !46
-  %52 = xor i32 %51, -1, !dbg !21
-  %53 = and i32 %52, %49, !dbg !21
-  %54 = icmp eq i32 %53, 0, !dbg !21
-  br i1 %54, label %rb_vm_check_ints.exit, label %55, !dbg !21, !prof !47
+  tail call void @sorbet_popFrame() #12, !dbg !36
+  %47 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !14
+  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 5, !dbg !23
+  %49 = load i32, i32* %48, align 8, !dbg !23, !tbaa !47
+  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 6, !dbg !23
+  %51 = load i32, i32* %50, align 4, !dbg !23, !tbaa !48
+  %52 = xor i32 %51, -1, !dbg !23
+  %53 = and i32 %52, %49, !dbg !23
+  %54 = icmp eq i32 %53, 0, !dbg !23
+  br i1 %54, label %rb_vm_check_ints.exit, label %55, !dbg !23, !prof !49
 
 55:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit
-  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 8, !dbg !21
-  %57 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %56, align 8, !dbg !21, !tbaa !48
-  %58 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %57, i32 noundef 0) #12, !dbg !21
-  br label %rb_vm_check_ints.exit, !dbg !21
+  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 8, !dbg !23
+  %57 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %56, align 8, !dbg !23, !tbaa !50
+  %58 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %57, i32 noundef 0) #12, !dbg !23
+  br label %rb_vm_check_ints.exit, !dbg !23
 
 rb_vm_check_ints.exit:                            ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit, %55
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !12
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !14
   ret i64 21
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_Object#foo$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #5 !dbg !40 {
+define internal i64 @"func_Object#foo$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #5 !dbg !42 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !22
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !24
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#foo$block_1", align 8
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !36
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !38
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !38
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !40
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -129
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !49, !tbaa !12
-  %9 = load i64, i64* @guard_epoch_A, align 8, !dbg !50
-  %10 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !18
-  %needTakeSlowPath = icmp ne i64 %9, %10, !dbg !50
-  br i1 %needTakeSlowPath, label %11, label %12, !dbg !50, !prof !20
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !51, !tbaa !14
+  %9 = load i64, i64* @guard_epoch_A, align 8, !dbg !52
+  %10 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !20
+  %needTakeSlowPath = icmp ne i64 %9, %10, !dbg !52
+  br i1 %needTakeSlowPath, label %11, label %12, !dbg !52, !prof !22
 
 11:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_A(), !dbg !50
-  br label %12, !dbg !50
+  tail call void @const_recompute_A(), !dbg !52
+  br label %12, !dbg !52
 
 12:                                               ; preds = %functionEntryInitializers, %11
-  %13 = load i64, i64* @guarded_const_A, align 8, !dbg !50
-  %14 = load i64, i64* @guard_epoch_A, align 8, !dbg !50
-  %15 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !18
-  %guardUpdated = icmp eq i64 %14, %15, !dbg !50
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !50
-  %16 = load i64, i64* @rb_mKernel, align 8, !dbg !50
-  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !50
-  %18 = load i64*, i64** %17, align 8, !dbg !50
-  store i64 %16, i64* %18, align 8, !dbg !50, !tbaa !4
-  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !50
-  store i64 %13, i64* %19, align 8, !dbg !50, !tbaa !4
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !50
-  store i64* %20, i64** %17, align 8, !dbg !50
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !50
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !50, !tbaa !12
-  ret i64 %send, !dbg !49
+  %13 = load i64, i64* @guarded_const_A, align 8, !dbg !52
+  %14 = load i64, i64* @guard_epoch_A, align 8, !dbg !52
+  %15 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !20
+  %guardUpdated = icmp eq i64 %14, %15, !dbg !52
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !52
+  %16 = load i64, i64* @rb_mKernel, align 8, !dbg !52
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !52
+  %18 = load i64*, i64** %17, align 8, !dbg !52
+  store i64 %16, i64* %18, align 8, !dbg !52, !tbaa !6
+  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !52
+  store i64 %13, i64* %19, align 8, !dbg !52, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !52
+  store i64* %20, i64** %17, align 8, !dbg !52
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !52
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !52, !tbaa !14
+  ret i64 %send, !dbg !51
 }
 
 ; Function Attrs: sspreq
@@ -370,10 +370,10 @@ entry:
   %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
   %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %10, i64 %"rubyId_block for.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#foo$block_1", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !50
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !52
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !52
   %12 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
   call void @rb_gc_register_mark_object(i64 %12) #12
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -383,68 +383,68 @@ entry:
   %14 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #12
   call void @rb_gc_register_mark_object(i64 %14) #12
   store i64 %14, i64* @rubyStrFrozen_hi, align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !51
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !51
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !53
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !53
-  %15 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !12
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !53
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !53
+  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !55
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !55
+  %15 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %16 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %15, i64 0, i32 18
-  %17 = load i64, i64* %16, align 8, !tbaa !54
-  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %17 = load i64, i64* %16, align 8, !tbaa !56
+  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 2
-  %20 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %19, align 8, !tbaa !22
+  %20 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %19, align 8, !tbaa !24
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %21, align 8, !tbaa !36
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %21, align 8, !tbaa !38
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 4
-  %23 = load i64*, i64** %22, align 8, !tbaa !38
-  %24 = load i64, i64* %23, align 8, !tbaa !4
+  %23 = load i64*, i64** %22, align 8, !tbaa !40
+  %24 = load i64, i64* %23, align 8, !tbaa !6
   %25 = and i64 %24, -33
-  store i64 %25, i64* %23, align 8, !tbaa !4
+  store i64 %25, i64* %23, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %18, %struct.rb_control_frame_struct* %20, %struct.rb_iseq_struct* %stackFrame.i) #12
   %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %26, align 8, !dbg !62, !tbaa !12
-  %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !63
-  %27 = load i64, i64* @rb_cObject, align 8, !dbg !63
-  %28 = call i64 @sorbet_setConstant(i64 %27, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 noundef 1, i64 %rubyStr_hi.i) #12, !dbg !63
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %26, align 8, !dbg !63, !tbaa !12
-  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !51
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #12, !dbg !51
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !51
-  %rawSym12.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #12, !dbg !51
-  %stackFrame13.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#foo", align 8, !dbg !51
-  %29 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !51
-  %30 = bitcast i8* %29 to i16*, !dbg !51
-  %31 = load i16, i16* %30, align 8, !dbg !51
-  %32 = and i16 %31, -384, !dbg !51
-  store i16 %32, i16* %30, align 8, !dbg !51
-  %33 = getelementptr inbounds i8, i8* %29, i64 4, !dbg !51
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %33, i8 0, i64 28, i1 false) #12, !dbg !51
-  call void @sorbet_vm_define_method(i64 %27, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#foo", i8* nonnull %29, %struct.rb_iseq_struct* %stackFrame13.i, i1 noundef zeroext false) #12, !dbg !51
-  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !51, !tbaa !12
-  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 5, !dbg !51
-  %36 = load i32, i32* %35, align 8, !dbg !51, !tbaa !45
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 6, !dbg !51
-  %38 = load i32, i32* %37, align 4, !dbg !51, !tbaa !46
-  %39 = xor i32 %38, -1, !dbg !51
-  %40 = and i32 %39, %36, !dbg !51
-  %41 = icmp eq i32 %40, 0, !dbg !51
-  br i1 %41, label %"func_<root>.<static-init>$151.exit", label %42, !dbg !51, !prof !47
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %26, align 8, !dbg !64, !tbaa !14
+  %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !65
+  %27 = load i64, i64* @rb_cObject, align 8, !dbg !65
+  %28 = call i64 @sorbet_setConstant(i64 %27, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 noundef 1, i64 %rubyStr_hi.i) #12, !dbg !65
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %26, align 8, !dbg !65, !tbaa !14
+  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !53
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #12, !dbg !53
+  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !53
+  %rawSym12.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #12, !dbg !53
+  %stackFrame13.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#foo", align 8, !dbg !53
+  %29 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !53
+  %30 = bitcast i8* %29 to i16*, !dbg !53
+  %31 = load i16, i16* %30, align 8, !dbg !53
+  %32 = and i16 %31, -384, !dbg !53
+  store i16 %32, i16* %30, align 8, !dbg !53
+  %33 = getelementptr inbounds i8, i8* %29, i64 4, !dbg !53
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %33, i8 0, i64 28, i1 false) #12, !dbg !53
+  call void @sorbet_vm_define_method(i64 %27, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#foo", i8* nonnull %29, %struct.rb_iseq_struct* %stackFrame13.i, i1 noundef zeroext false) #12, !dbg !53
+  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !53, !tbaa !14
+  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 5, !dbg !53
+  %36 = load i32, i32* %35, align 8, !dbg !53, !tbaa !47
+  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 6, !dbg !53
+  %38 = load i32, i32* %37, align 4, !dbg !53, !tbaa !48
+  %39 = xor i32 %38, -1, !dbg !53
+  %40 = and i32 %39, %36, !dbg !53
+  %41 = icmp eq i32 %40, 0, !dbg !53
+  br i1 %41, label %"func_<root>.<static-init>$151.exit", label %42, !dbg !53, !prof !49
 
 42:                                               ; preds = %entry
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 8, !dbg !51
-  %44 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %43, align 8, !dbg !51, !tbaa !48
-  %45 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %44, i32 noundef 0) #12, !dbg !51
-  br label %"func_<root>.<static-init>$151.exit", !dbg !51
+  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 8, !dbg !53
+  %44 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %43, align 8, !dbg !53, !tbaa !50
+  %45 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %44, i32 noundef 0) #12, !dbg !53
+  br label %"func_<root>.<static-init>$151.exit", !dbg !53
 
 "func_<root>.<static-init>$151.exit":             ; preds = %entry, %42
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %26, align 8, !dbg !51, !tbaa !12
-  %46 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 1, !dbg !53
-  %47 = load i64*, i64** %46, align 8, !dbg !53
-  store i64 %17, i64* %47, align 8, !dbg !53, !tbaa !4
-  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !53
-  store i64* %48, i64** %46, align 8, !dbg !53
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !53
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %26, align 8, !dbg !53, !tbaa !14
+  %46 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 1, !dbg !55
+  %47 = load i64*, i64** %46, align 8, !dbg !55
+  store i64 %17, i64* %47, align 8, !dbg !55, !tbaa !6
+  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !55
+  store i64* %48, i64** %46, align 8, !dbg !55
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !55
   ret void
 }
 
@@ -461,7 +461,7 @@ declare void @llvm.assume(i1 noundef) #9
 define linkonce void @const_recompute_A() local_unnamed_addr #5 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !18
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !20
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -481,70 +481,72 @@ attributes #11 = { noreturn }
 attributes #12 = { nounwind }
 attributes #13 = { nounwind allocsize(0,1) }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/block_no_args_captures_constant.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "Object#foo", linkageName: "func_Object#foo", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = !DISubroutineType(types: !10)
-!10 = !{!11}
-!11 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!12 = !{!13, !13, i64 0}
-!13 = !{!"any pointer", !6, i64 0}
-!14 = !DILocation(line: 5, column: 1, scope: !8)
-!15 = !{!"branch_weights", i32 1, i32 2000}
-!16 = !DILocation(line: 0, scope: !8)
-!17 = !DILocation(line: 6, column: 3, scope: !8)
-!18 = !{!19, !19, i64 0}
-!19 = !{!"long long", !6, i64 0}
-!20 = !{!"branch_weights", i32 1, i32 10000}
-!21 = !DILocation(line: 7, column: 3, scope: !8)
-!22 = !{!23, !13, i64 16}
-!23 = !{!"rb_execution_context_struct", !13, i64 0, !5, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !24, i64 40, !24, i64 44, !13, i64 48, !13, i64 56, !13, i64 64, !5, i64 72, !5, i64 80, !13, i64 88, !5, i64 96, !13, i64 104, !13, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !25, i64 152}
-!24 = !{!"int", !6, i64 0}
-!25 = !{!"", !13, i64 0, !13, i64 8, !5, i64 16, !6, i64 24}
-!26 = !{!27}
-!27 = distinct !{!27, !28, !"rb_vm_ifunc_proc_new: argument 0"}
-!28 = distinct !{!28, !"rb_vm_ifunc_proc_new"}
-!29 = !{!6, !6, i64 0}
-!30 = !{!31}
-!31 = distinct !{!31, !32, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!32 = distinct !{!32, !"VM_BH_FROM_IFUNC_BLOCK"}
-!33 = !{!23, !5, i64 128}
-!34 = !DILocation(line: 7, column: 3, scope: !8, inlinedAt: !35)
-!35 = distinct !DILocation(line: 7, column: 3, scope: !8)
-!36 = !{!37, !13, i64 16}
-!37 = !{!"rb_control_frame_struct", !13, i64 0, !13, i64 8, !13, i64 16, !5, i64 24, !13, i64 32, !13, i64 40, !13, i64 48}
-!38 = !{!37, !13, i64 32}
-!39 = !DILocation(line: 7, column: 3, scope: !40, inlinedAt: !41)
-!40 = distinct !DISubprogram(name: "Object#foo", linkageName: "func_Object#foo$block_1", scope: !8, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!41 = distinct !DILocation(line: 7, column: 3, scope: !8, inlinedAt: !35)
-!42 = !DILocation(line: 8, column: 5, scope: !40, inlinedAt: !41)
-!43 = distinct !{!43, !44}
-!44 = !{!"llvm.loop.unroll.disable"}
-!45 = !{!23, !24, i64 40}
-!46 = !{!23, !24, i64 44}
-!47 = !{!"branch_weights", i32 2000, i32 1}
-!48 = !{!23, !13, i64 56}
-!49 = !DILocation(line: 7, column: 3, scope: !40)
-!50 = !DILocation(line: 8, column: 5, scope: !40)
-!51 = !DILocation(line: 5, column: 1, scope: !52)
-!52 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !9, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!53 = !DILocation(line: 12, column: 1, scope: !52)
-!54 = !{!55, !5, i64 400}
-!55 = !{!"rb_vm_struct", !5, i64 0, !56, i64 8, !13, i64 192, !13, i64 200, !13, i64 208, !19, i64 216, !6, i64 224, !57, i64 264, !57, i64 280, !57, i64 296, !57, i64 312, !5, i64 328, !24, i64 336, !24, i64 340, !24, i64 344, !24, i64 344, !24, i64 344, !24, i64 344, !24, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !13, i64 456, !13, i64 464, !59, i64 472, !60, i64 992, !13, i64 1016, !13, i64 1024, !24, i64 1032, !24, i64 1036, !57, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !24, i64 1136, !13, i64 1144, !13, i64 1152, !13, i64 1160, !13, i64 1168, !13, i64 1176, !13, i64 1184, !24, i64 1192, !61, i64 1200, !6, i64 1232}
-!56 = !{!"rb_global_vm_lock_struct", !13, i64 0, !6, i64 8, !57, i64 48, !13, i64 64, !24, i64 72, !6, i64 80, !6, i64 128, !24, i64 176, !24, i64 180}
-!57 = !{!"list_head", !58, i64 0}
-!58 = !{!"list_node", !13, i64 0, !13, i64 8}
-!59 = !{!"", !6, i64 0}
-!60 = !{!"rb_hook_list_struct", !13, i64 0, !24, i64 8, !24, i64 12, !24, i64 16}
-!61 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!62 = !DILocation(line: 0, scope: !52)
-!63 = !DILocation(line: 4, column: 5, scope: !52)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/block_no_args_captures_constant.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "Object#foo", linkageName: "func_Object#foo", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!14 = !{!15, !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !DILocation(line: 5, column: 1, scope: !10)
+!17 = !{!"branch_weights", i32 1, i32 2000}
+!18 = !DILocation(line: 0, scope: !10)
+!19 = !DILocation(line: 6, column: 3, scope: !10)
+!20 = !{!21, !21, i64 0}
+!21 = !{!"long long", !8, i64 0}
+!22 = !{!"branch_weights", i32 1, i32 10000}
+!23 = !DILocation(line: 7, column: 3, scope: !10)
+!24 = !{!25, !15, i64 16}
+!25 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !26, i64 40, !26, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !27, i64 152}
+!26 = !{!"int", !8, i64 0}
+!27 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!28 = !{!29}
+!29 = distinct !{!29, !30, !"rb_vm_ifunc_proc_new: argument 0"}
+!30 = distinct !{!30, !"rb_vm_ifunc_proc_new"}
+!31 = !{!8, !8, i64 0}
+!32 = !{!33}
+!33 = distinct !{!33, !34, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!34 = distinct !{!34, !"VM_BH_FROM_IFUNC_BLOCK"}
+!35 = !{!25, !7, i64 128}
+!36 = !DILocation(line: 7, column: 3, scope: !10, inlinedAt: !37)
+!37 = distinct !DILocation(line: 7, column: 3, scope: !10)
+!38 = !{!39, !15, i64 16}
+!39 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!40 = !{!39, !15, i64 32}
+!41 = !DILocation(line: 7, column: 3, scope: !42, inlinedAt: !43)
+!42 = distinct !DISubprogram(name: "Object#foo", linkageName: "func_Object#foo$block_1", scope: !10, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!43 = distinct !DILocation(line: 7, column: 3, scope: !10, inlinedAt: !37)
+!44 = !DILocation(line: 8, column: 5, scope: !42, inlinedAt: !43)
+!45 = distinct !{!45, !46}
+!46 = !{!"llvm.loop.unroll.disable"}
+!47 = !{!25, !26, i64 40}
+!48 = !{!25, !26, i64 44}
+!49 = !{!"branch_weights", i32 2000, i32 1}
+!50 = !{!25, !15, i64 56}
+!51 = !DILocation(line: 7, column: 3, scope: !42)
+!52 = !DILocation(line: 8, column: 5, scope: !42)
+!53 = !DILocation(line: 5, column: 1, scope: !54)
+!54 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!55 = !DILocation(line: 12, column: 1, scope: !54)
+!56 = !{!57, !7, i64 400}
+!57 = !{!"rb_vm_struct", !7, i64 0, !58, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !21, i64 216, !8, i64 224, !59, i64 264, !59, i64 280, !59, i64 296, !59, i64 312, !7, i64 328, !26, i64 336, !26, i64 340, !26, i64 344, !26, i64 344, !26, i64 344, !26, i64 344, !26, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !61, i64 472, !62, i64 992, !15, i64 1016, !15, i64 1024, !26, i64 1032, !26, i64 1036, !59, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !26, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !26, i64 1192, !63, i64 1200, !8, i64 1232}
+!58 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !59, i64 48, !15, i64 64, !26, i64 72, !8, i64 80, !8, i64 128, !26, i64 176, !26, i64 180}
+!59 = !{!"list_head", !60, i64 0}
+!60 = !{!"list_node", !15, i64 0, !15, i64 8}
+!61 = !{!"", !8, i64 0}
+!62 = !{!"rb_hook_list_struct", !15, i64 0, !26, i64 8, !26, i64 12, !26, i64 16}
+!63 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!64 = !DILocation(line: 0, scope: !54)
+!65 = !DILocation(line: 4, column: 5, scope: !54)

--- a/test/testdata/compiler/block_type_checking.llo.exp
+++ b/test/testdata/compiler/block_type_checking.llo.exp
@@ -219,168 +219,168 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: nofree nosync nounwind ssp willreturn
-define internal noundef i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !8 {
+define internal noundef i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !10 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !15
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !21
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !21
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !23
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -129
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %8, align 8, !dbg !22, !tbaa !13
-  ret i64 13, !dbg !23
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %8, align 8, !dbg !24, !tbaa !15
+  ret i64 13, !dbg !25
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_Foo.<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !24 {
+define internal fastcc void @"func_Foo.<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !26 {
 fastSymCallIntrinsic_ResolvedSig_sig:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.<static-init>", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !15
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !21
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !21
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !23
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #16
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !25, !tbaa !13
-  %rubyId_bar = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !26
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_bar), !dbg !26
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_Foo.<static-init>L62$block_1"), !dbg !26
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !13
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !26
-  %11 = load i32, i32* %10, align 8, !dbg !26, !tbaa !27
-  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !26
-  %13 = load i32, i32* %12, align 4, !dbg !26, !tbaa !28
-  %14 = xor i32 %13, -1, !dbg !26
-  %15 = and i32 %14, %11, !dbg !26
-  %16 = icmp eq i32 %15, 0, !dbg !26
-  br i1 %16, label %fastSymCallIntrinsic_Static_keep_def, label %17, !dbg !26, !prof !29
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !27, !tbaa !15
+  %rubyId_bar = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !28
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_bar), !dbg !28
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_Foo.<static-init>L62$block_1"), !dbg !28
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !28
+  %11 = load i32, i32* %10, align 8, !dbg !28, !tbaa !29
+  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !28
+  %13 = load i32, i32* %12, align 4, !dbg !28, !tbaa !30
+  %14 = xor i32 %13, -1, !dbg !28
+  %15 = and i32 %14, %11, !dbg !28
+  %16 = icmp eq i32 %15, 0, !dbg !28
+  br i1 %16, label %fastSymCallIntrinsic_Static_keep_def, label %17, !dbg !28, !prof !31
 
 17:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig
-  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !26
-  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !26, !tbaa !30
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !26
-  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !26
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !28
+  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !28, !tbaa !32
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !28
+  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !28
 
 afterSend45:                                      ; preds = %65, %35
   ret void
 
 fastSymCallIntrinsic_Static_keep_def:             ; preds = %fastSymCallIntrinsic_ResolvedSig_sig, %17
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !26, !tbaa !13
-  %21 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !31
-  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !31, !tbaa !32
-  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !31
-  br i1 %needTakeSlowPath, label %23, label %24, !dbg !31, !prof !34
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !28, !tbaa !15
+  %21 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !33
+  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !34
+  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !33
+  br i1 %needTakeSlowPath, label %23, label %24, !dbg !33, !prof !36
 
 23:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
-  tail call void @"const_recompute_T::Sig"(), !dbg !31
-  br label %24, !dbg !31
+  tail call void @"const_recompute_T::Sig"(), !dbg !33
+  br label %24, !dbg !33
 
 24:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def, %23
-  %25 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !31
-  %26 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !31
-  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !31, !tbaa !32
-  %guardUpdated = icmp eq i64 %26, %27, !dbg !31
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !31
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !31
-  %29 = load i64*, i64** %28, align 8, !dbg !31
-  store i64 %selfRaw, i64* %29, align 8, !dbg !31, !tbaa !4
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !31
-  store i64 %25, i64* %30, align 8, !dbg !31, !tbaa !4
-  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !31
-  store i64* %31, i64** %28, align 8, !dbg !31
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !31
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !31, !tbaa !13
-  %rubyId_bar40 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !35
-  %rawSym41 = tail call i64 @rb_id2sym(i64 %rubyId_bar40), !dbg !35
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !35
-  %rawSym42 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !35
-  %32 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !35
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !35, !tbaa !32
-  %needTakeSlowPath2 = icmp ne i64 %32, %33, !dbg !35
-  br i1 %needTakeSlowPath2, label %34, label %35, !dbg !35, !prof !34
+  %25 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !33
+  %26 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !33
+  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !34
+  %guardUpdated = icmp eq i64 %26, %27, !dbg !33
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !33
+  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !33
+  %29 = load i64*, i64** %28, align 8, !dbg !33
+  store i64 %selfRaw, i64* %29, align 8, !dbg !33, !tbaa !6
+  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !33
+  store i64 %25, i64* %30, align 8, !dbg !33, !tbaa !6
+  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !33
+  store i64* %31, i64** %28, align 8, !dbg !33
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !33
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !33, !tbaa !15
+  %rubyId_bar40 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !37
+  %rawSym41 = tail call i64 @rb_id2sym(i64 %rubyId_bar40), !dbg !37
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !37
+  %rawSym42 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !37
+  %32 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !37
+  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !37, !tbaa !34
+  %needTakeSlowPath2 = icmp ne i64 %32, %33, !dbg !37
+  br i1 %needTakeSlowPath2, label %34, label %35, !dbg !37, !prof !36
 
 34:                                               ; preds = %24
-  tail call void @const_recompute_Foo(), !dbg !35
-  br label %35, !dbg !35
+  tail call void @const_recompute_Foo(), !dbg !37
+  br label %35, !dbg !37
 
 35:                                               ; preds = %24, %34
-  %36 = load i64, i64* @guarded_const_Foo, align 8, !dbg !35
-  %37 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !35
-  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !35, !tbaa !32
-  %guardUpdated3 = icmp eq i64 %37, %38, !dbg !35
-  tail call void @llvm.assume(i1 %guardUpdated3), !dbg !35
-  %stackFrame46 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#bar", align 8, !dbg !35
-  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !35
-  %40 = bitcast i8* %39 to i16*, !dbg !35
-  %41 = load i16, i16* %40, align 8, !dbg !35
-  %42 = and i16 %41, -384, !dbg !35
-  %43 = or i16 %42, 65, !dbg !35
-  store i16 %43, i16* %40, align 8, !dbg !35
-  %44 = getelementptr inbounds i8, i8* %39, i64 8, !dbg !35
-  %45 = bitcast i8* %44 to i32*, !dbg !35
-  store i32 1, i32* %45, align 8, !dbg !35, !tbaa !36
-  %46 = getelementptr inbounds i8, i8* %39, i64 12, !dbg !35
-  %47 = bitcast i8* %46 to i32*, !dbg !35
-  %48 = getelementptr inbounds i8, i8* %39, i64 28, !dbg !35
-  %49 = bitcast i8* %48 to i32*, !dbg !35
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 16, i1 false), !dbg !35
-  store i32 1, i32* %49, align 4, !dbg !35, !tbaa !39
-  %50 = getelementptr inbounds i8, i8* %39, i64 4, !dbg !35
-  %51 = bitcast i8* %50 to i32*, !dbg !35
-  store i32 2, i32* %51, align 4, !dbg !35, !tbaa !40
-  %positional_table = alloca i64, i32 2, align 8, !dbg !35
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !35
-  store i64 %rubyId_x, i64* %positional_table, align 8, !dbg !35
-  %rubyId_blk = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !35
-  %52 = getelementptr i64, i64* %positional_table, i32 1, !dbg !35
-  store i64 %rubyId_blk, i64* %52, align 8, !dbg !35
-  %53 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !35
-  %54 = bitcast i64* %positional_table to i8*, !dbg !35
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %53, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %54, i64 noundef 16, i1 noundef false) #16, !dbg !35
-  %55 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !35
-  %56 = bitcast i8* %55 to i8**, !dbg !35
-  store i8* %53, i8** %56, align 8, !dbg !35, !tbaa !41
-  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Foo#bar", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame46, i1 noundef zeroext false) #16, !dbg !35
-  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !35, !tbaa !13
-  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 5, !dbg !35
-  %59 = load i32, i32* %58, align 8, !dbg !35, !tbaa !27
-  %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 6, !dbg !35
-  %61 = load i32, i32* %60, align 4, !dbg !35, !tbaa !28
-  %62 = xor i32 %61, -1, !dbg !35
-  %63 = and i32 %62, %59, !dbg !35
-  %64 = icmp eq i32 %63, 0, !dbg !35
-  br i1 %64, label %afterSend45, label %65, !dbg !35, !prof !29
+  %36 = load i64, i64* @guarded_const_Foo, align 8, !dbg !37
+  %37 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !37
+  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !37, !tbaa !34
+  %guardUpdated3 = icmp eq i64 %37, %38, !dbg !37
+  tail call void @llvm.assume(i1 %guardUpdated3), !dbg !37
+  %stackFrame46 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#bar", align 8, !dbg !37
+  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !37
+  %40 = bitcast i8* %39 to i16*, !dbg !37
+  %41 = load i16, i16* %40, align 8, !dbg !37
+  %42 = and i16 %41, -384, !dbg !37
+  %43 = or i16 %42, 65, !dbg !37
+  store i16 %43, i16* %40, align 8, !dbg !37
+  %44 = getelementptr inbounds i8, i8* %39, i64 8, !dbg !37
+  %45 = bitcast i8* %44 to i32*, !dbg !37
+  store i32 1, i32* %45, align 8, !dbg !37, !tbaa !38
+  %46 = getelementptr inbounds i8, i8* %39, i64 12, !dbg !37
+  %47 = bitcast i8* %46 to i32*, !dbg !37
+  %48 = getelementptr inbounds i8, i8* %39, i64 28, !dbg !37
+  %49 = bitcast i8* %48 to i32*, !dbg !37
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 16, i1 false), !dbg !37
+  store i32 1, i32* %49, align 4, !dbg !37, !tbaa !41
+  %50 = getelementptr inbounds i8, i8* %39, i64 4, !dbg !37
+  %51 = bitcast i8* %50 to i32*, !dbg !37
+  store i32 2, i32* %51, align 4, !dbg !37, !tbaa !42
+  %positional_table = alloca i64, i32 2, align 8, !dbg !37
+  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !37
+  store i64 %rubyId_x, i64* %positional_table, align 8, !dbg !37
+  %rubyId_blk = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !37
+  %52 = getelementptr i64, i64* %positional_table, i32 1, !dbg !37
+  store i64 %rubyId_blk, i64* %52, align 8, !dbg !37
+  %53 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !37
+  %54 = bitcast i64* %positional_table to i8*, !dbg !37
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %53, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %54, i64 noundef 16, i1 noundef false) #16, !dbg !37
+  %55 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !37
+  %56 = bitcast i8* %55 to i8**, !dbg !37
+  store i8* %53, i8** %56, align 8, !dbg !37, !tbaa !43
+  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Foo#bar", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame46, i1 noundef zeroext false) #16, !dbg !37
+  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !15
+  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 5, !dbg !37
+  %59 = load i32, i32* %58, align 8, !dbg !37, !tbaa !29
+  %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 6, !dbg !37
+  %61 = load i32, i32* %60, align 4, !dbg !37, !tbaa !30
+  %62 = xor i32 %61, -1, !dbg !37
+  %63 = and i32 %62, %59, !dbg !37
+  %64 = icmp eq i32 %63, 0, !dbg !37
+  br i1 %64, label %afterSend45, label %65, !dbg !37, !prof !31
 
 65:                                               ; preds = %35
-  %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 8, !dbg !35
-  %67 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %66, align 8, !dbg !35, !tbaa !30
-  %68 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %67, i32 noundef 0) #16, !dbg !35
-  br label %afterSend45, !dbg !35
+  %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 8, !dbg !37
+  %67 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %66, align 8, !dbg !37, !tbaa !32
+  %68 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %67, i32 noundef 0) #16, !dbg !37
+  br label %afterSend45, !dbg !37
 }
 
 ; Function Attrs: sspreq
@@ -389,7 +389,7 @@ entry:
   %locals.i21.i = alloca i64, i32 0, align 8
   %locals.i17.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, i32 2, align 8, !dbg !42
+  %keywords.i = alloca i64, i32 2, align 8, !dbg !44
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %0)
@@ -442,12 +442,12 @@ entry:
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %"rubyId_block for.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !44
-  %rubyId_bar.i = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !44
-  %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !45
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !46
+  %rubyId_bar.i = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
+  %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
   %21 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #16
   call void @rb_gc_register_mark_object(i64 %21) #16
   %rubyId_bar.i.i = load i64, i64* @rubyIdPrecomputed_bar, align 8
@@ -464,212 +464,212 @@ entry:
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i25.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block for.i24.i", i64 %"rubyId_block for.i23.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i25.i", i64 %realpath, %struct.rb_iseq_struct* %23, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.<static-init>$block_1", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !26
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !26
-  %rubyId_proc.i = load i64, i64* @rubyIdPrecomputed_proc, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_proc, i64 %rubyId_proc.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !46
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
-  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !42
-  %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !42
-  %25 = call i64 @rb_id2sym(i64 %rubyId_x.i) #16, !dbg !42
-  store i64 %25, i64* %keywords.i, align 8, !dbg !42
-  %rubyId_blk.i = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !42
-  %26 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #16, !dbg !42
-  %27 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !42
-  store i64 %26, i64* %27, align 8, !dbg !42
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords.i), !dbg !42
-  %rubyId_returns10.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !42
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.1, i64 %rubyId_returns10.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !42
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !31
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !31
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !35
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !35
+  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !28
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !28
+  %rubyId_proc.i = load i64, i64* @rubyIdPrecomputed_proc, align 8, !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_proc, i64 %rubyId_proc.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !48
+  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
+  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !44
+  %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !44
+  %25 = call i64 @rb_id2sym(i64 %rubyId_x.i) #16, !dbg !44
+  store i64 %25, i64* %keywords.i, align 8, !dbg !44
+  %rubyId_blk.i = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !44
+  %26 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #16, !dbg !44
+  %27 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !44
+  store i64 %26, i64* %27, align 8, !dbg !44
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords.i), !dbg !44
+  %rubyId_returns10.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !44
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.1, i64 %rubyId_returns10.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !44
+  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !33
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !33
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !37
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !37
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %0)
-  %28 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !13
+  %28 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
   %29 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %28, i64 0, i32 18
-  %30 = load i64, i64* %29, align 8, !tbaa !47
-  %31 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %30 = load i64, i64* %29, align 8, !tbaa !49
+  %31 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 2
-  %33 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %32, align 8, !tbaa !15
+  %33 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %32, align 8, !tbaa !17
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %34, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %34, align 8, !tbaa !21
   %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 4
-  %36 = load i64*, i64** %35, align 8, !tbaa !21
-  %37 = load i64, i64* %36, align 8, !tbaa !4
+  %36 = load i64*, i64** %35, align 8, !tbaa !23
+  %37 = load i64, i64* %36, align 8, !tbaa !6
   %38 = and i64 %37, -33
-  store i64 %38, i64* %36, align 8, !tbaa !4
+  store i64 %38, i64* %36, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %31, %struct.rb_control_frame_struct* %33, %struct.rb_iseq_struct* %stackFrame.i) #16
   %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %39, align 8, !dbg !55, !tbaa !13
-  %40 = load i64, i64* @rb_cObject, align 8, !dbg !56
-  %41 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 %40) #16, !dbg !56
-  %42 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %41) #16, !dbg !56
-  call fastcc void @"func_Foo.<static-init>L62"(i64 %41, %struct.rb_control_frame_struct* %42) #16, !dbg !56
-  call void @sorbet_popFrame() #16, !dbg !56
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %39, align 8, !dbg !56, !tbaa !13
-  %43 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !44
-  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !44, !tbaa !32
-  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !44
-  br i1 %needTakeSlowPath, label %45, label %46, !dbg !44, !prof !34
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %39, align 8, !dbg !57, !tbaa !15
+  %40 = load i64, i64* @rb_cObject, align 8, !dbg !58
+  %41 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 %40) #16, !dbg !58
+  %42 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %41) #16, !dbg !58
+  call fastcc void @"func_Foo.<static-init>L62"(i64 %41, %struct.rb_control_frame_struct* %42) #16, !dbg !58
+  call void @sorbet_popFrame() #16, !dbg !58
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %39, align 8, !dbg !58, !tbaa !15
+  %43 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !46
+  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !34
+  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !46
+  br i1 %needTakeSlowPath, label %45, label %46, !dbg !46, !prof !36
 
 45:                                               ; preds = %entry
-  call void @const_recompute_Foo(), !dbg !44
-  br label %46, !dbg !44
+  call void @const_recompute_Foo(), !dbg !46
+  br label %46, !dbg !46
 
 46:                                               ; preds = %entry, %45
-  %47 = load i64, i64* @guarded_const_Foo, align 8, !dbg !44
-  %48 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !44
-  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !44, !tbaa !32
-  %guardUpdated = icmp eq i64 %48, %49, !dbg !44
-  call void @llvm.assume(i1 %guardUpdated), !dbg !44
-  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !44
-  %51 = load i64*, i64** %50, align 8, !dbg !44
-  store i64 %47, i64* %51, align 8, !dbg !44, !tbaa !4
-  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !44
-  store i64* %52, i64** %50, align 8, !dbg !44
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !44
-  %53 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !44
-  %54 = load i64*, i64** %53, align 8, !dbg !44
-  store i64 %send, i64* %54, align 8, !dbg !44, !tbaa !4
-  %55 = getelementptr inbounds i64, i64* %54, i64 1, !dbg !44
-  store i64 11, i64* %55, align 8, !dbg !44, !tbaa !4
-  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !44
-  store i64* %56, i64** %53, align 8, !dbg !44
-  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !44, !tbaa !13
-  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 2, !dbg !44
-  %59 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %58, align 8, !dbg !44, !tbaa !15
-  %60 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_1", i8* null, i32 noundef 0, i32 noundef -1) #16, !dbg !44
-  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %59, i64 0, i32 3, !dbg !44
-  %62 = bitcast i64* %61 to %struct.rb_captured_block*, !dbg !44
-  %63 = getelementptr inbounds i64, i64* %61, i64 2, !dbg !44
-  %64 = bitcast i64* %63 to %struct.vm_ifunc**, !dbg !44
-  store %struct.vm_ifunc* %60, %struct.vm_ifunc** %64, align 8, !dbg !44, !tbaa !57
-  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 17, !dbg !44
-  store i64 0, i64* %65, align 8, !dbg !44, !tbaa !58
-  call void @llvm.experimental.noalias.scope.decl(metadata !59) #16, !dbg !44
-  %66 = ptrtoint %struct.rb_captured_block* %62 to i64, !dbg !44
-  %67 = or i64 %66, 3, !dbg !44
-  %68 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %67) #16, !dbg !44
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %39, align 8, !dbg !44, !tbaa !13
-  %69 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !45
-  %70 = load i64*, i64** %69, align 8, !dbg !45
-  store i64 %30, i64* %70, align 8, !dbg !45, !tbaa !4
-  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !45
-  store i64 %68, i64* %71, align 8, !dbg !45, !tbaa !4
-  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !45
-  store i64* %72, i64** %69, align 8, !dbg !45
-  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !45
+  %47 = load i64, i64* @guarded_const_Foo, align 8, !dbg !46
+  %48 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !46
+  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !34
+  %guardUpdated = icmp eq i64 %48, %49, !dbg !46
+  call void @llvm.assume(i1 %guardUpdated), !dbg !46
+  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !46
+  %51 = load i64*, i64** %50, align 8, !dbg !46
+  store i64 %47, i64* %51, align 8, !dbg !46, !tbaa !6
+  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !46
+  store i64* %52, i64** %50, align 8, !dbg !46
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !46
+  %53 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !46
+  %54 = load i64*, i64** %53, align 8, !dbg !46
+  store i64 %send, i64* %54, align 8, !dbg !46, !tbaa !6
+  %55 = getelementptr inbounds i64, i64* %54, i64 1, !dbg !46
+  store i64 11, i64* %55, align 8, !dbg !46, !tbaa !6
+  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !46
+  store i64* %56, i64** %53, align 8, !dbg !46
+  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !15
+  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 2, !dbg !46
+  %59 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %58, align 8, !dbg !46, !tbaa !17
+  %60 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_1", i8* null, i32 noundef 0, i32 noundef -1) #16, !dbg !46
+  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %59, i64 0, i32 3, !dbg !46
+  %62 = bitcast i64* %61 to %struct.rb_captured_block*, !dbg !46
+  %63 = getelementptr inbounds i64, i64* %61, i64 2, !dbg !46
+  %64 = bitcast i64* %63 to %struct.vm_ifunc**, !dbg !46
+  store %struct.vm_ifunc* %60, %struct.vm_ifunc** %64, align 8, !dbg !46, !tbaa !59
+  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 17, !dbg !46
+  store i64 0, i64* %65, align 8, !dbg !46, !tbaa !60
+  call void @llvm.experimental.noalias.scope.decl(metadata !61) #16, !dbg !46
+  %66 = ptrtoint %struct.rb_captured_block* %62 to i64, !dbg !46
+  %67 = or i64 %66, 3, !dbg !46
+  %68 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %67) #16, !dbg !46
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %39, align 8, !dbg !46, !tbaa !15
+  %69 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !47
+  %70 = load i64*, i64** %69, align 8, !dbg !47
+  store i64 %30, i64* %70, align 8, !dbg !47, !tbaa !6
+  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !47
+  store i64 %68, i64* %71, align 8, !dbg !47, !tbaa !6
+  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !47
+  store i64* %72, i64** %69, align 8, !dbg !47
+  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !47
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Foo#bar"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #8 !dbg !62 {
+define i64 @"func_Foo#bar"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #8 !dbg !64 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !tbaa !13
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !63
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !63
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !63
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !63, !prof !64
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !tbaa !15
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !65
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !65
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !65
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !65, !prof !66
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #18, !dbg !63
-  unreachable, !dbg !63
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #18, !dbg !65
+  unreachable, !dbg !65
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !63
-  %1 = tail call i32 @rb_block_given_p() #16, !dbg !63
-  %2 = icmp eq i32 %1, 0, !dbg !63
-  br i1 %2, label %sorbet_getMethodBlockAsProc.exit, label %3, !dbg !63
+  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !65
+  %1 = tail call i32 @rb_block_given_p() #16, !dbg !65
+  %2 = icmp eq i32 %1, 0, !dbg !65
+  br i1 %2, label %sorbet_getMethodBlockAsProc.exit, label %3, !dbg !65
 
 3:                                                ; preds = %fillRequiredArgs
-  %4 = tail call i64 @rb_block_proc() #16, !dbg !63
-  br label %sorbet_getMethodBlockAsProc.exit, !dbg !63
+  %4 = tail call i64 @rb_block_proc() #16, !dbg !65
+  br label %sorbet_getMethodBlockAsProc.exit, !dbg !65
 
 sorbet_getMethodBlockAsProc.exit:                 ; preds = %fillRequiredArgs, %3
-  %5 = phi i64 [ %4, %3 ], [ 8, %fillRequiredArgs ], !dbg !63
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !65, !tbaa !13
-  %6 = and i64 %rawArg_x, 1, !dbg !66
-  %7 = icmp eq i64 %6, 0, !dbg !66
-  br i1 %7, label %8, label %typeTestSuccess, !dbg !66, !prof !67
+  %5 = phi i64 [ %4, %3 ], [ 8, %fillRequiredArgs ], !dbg !65
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !67, !tbaa !15
+  %6 = and i64 %rawArg_x, 1, !dbg !68
+  %7 = icmp eq i64 %6, 0, !dbg !68
+  br i1 %7, label %8, label %typeTestSuccess, !dbg !68, !prof !69
 
 8:                                                ; preds = %sorbet_getMethodBlockAsProc.exit
-  %9 = and i64 %rawArg_x, 7, !dbg !66
-  %10 = icmp ne i64 %9, 0, !dbg !66
-  %11 = and i64 %rawArg_x, -9, !dbg !66
-  %12 = icmp eq i64 %11, 0, !dbg !66
-  %13 = or i1 %10, %12, !dbg !66
-  br i1 %13, label %codeRepl25, label %sorbet_isa_Integer.exit, !dbg !66
+  %9 = and i64 %rawArg_x, 7, !dbg !68
+  %10 = icmp ne i64 %9, 0, !dbg !68
+  %11 = and i64 %rawArg_x, -9, !dbg !68
+  %12 = icmp eq i64 %11, 0, !dbg !68
+  %13 = or i1 %10, %12, !dbg !68
+  br i1 %13, label %codeRepl25, label %sorbet_isa_Integer.exit, !dbg !68
 
 sorbet_isa_Integer.exit:                          ; preds = %8
-  %14 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !66
-  %15 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %14, i64 0, i32 0, !dbg !66
-  %16 = load i64, i64* %15, align 8, !dbg !66, !tbaa !68
-  %17 = and i64 %16, 31, !dbg !66
-  %18 = icmp eq i64 %17, 10, !dbg !66
-  br i1 %18, label %typeTestSuccess, label %codeRepl25, !dbg !66, !prof !29
+  %14 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !68
+  %15 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %14, i64 0, i32 0, !dbg !68
+  %16 = load i64, i64* %15, align 8, !dbg !68, !tbaa !70
+  %17 = and i64 %16, 31, !dbg !68
+  %18 = icmp eq i64 %17, 10, !dbg !68
+  br i1 %18, label %typeTestSuccess, label %codeRepl25, !dbg !68, !prof !31
 
 typeTestSuccess:                                  ; preds = %sorbet_getMethodBlockAsProc.exit, %sorbet_isa_Integer.exit
-  %19 = tail call i32 @rb_block_given_p() #16, !dbg !70
-  %20 = icmp ne i32 %19, 0, !dbg !70
-  br i1 %20, label %typeTestSuccess7, label %codeRepl24, !dbg !70, !prof !29
+  %19 = tail call i32 @rb_block_given_p() #16, !dbg !72
+  %20 = icmp ne i32 %19, 0, !dbg !72
+  br i1 %20, label %typeTestSuccess7, label %codeRepl24, !dbg !72, !prof !31
 
 codeRepl25:                                       ; preds = %8, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_Foo#bar.cold.3"(i64 %rawArg_x) #19, !dbg !66
+  tail call fastcc void @"func_Foo#bar.cold.3"(i64 %rawArg_x) #19, !dbg !68
   unreachable
 
 typeTestSuccess7:                                 ; preds = %typeTestSuccess
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !70, !tbaa !13
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !71), !dbg !74
-  %21 = tail call i64 @rb_yield_values_kw(i32 noundef 0, i64* noundef null, i32 noundef 0) #16, !dbg !74
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %0, align 8, !dbg !74, !tbaa !13
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !75), !dbg !78
-  %22 = and i64 %rawArg_x, 1, !dbg !78
-  %23 = and i64 %22, %21, !dbg !78
-  %24 = icmp eq i64 %23, 0, !dbg !78
-  br i1 %24, label %34, label %25, !dbg !78, !prof !64
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !72, !tbaa !15
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !73), !dbg !76
+  %21 = tail call i64 @rb_yield_values_kw(i32 noundef 0, i64* noundef null, i32 noundef 0) #16, !dbg !76
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %0, align 8, !dbg !76, !tbaa !15
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !77), !dbg !80
+  %22 = and i64 %rawArg_x, 1, !dbg !80
+  %23 = and i64 %22, %21, !dbg !80
+  %24 = icmp eq i64 %23, 0, !dbg !80
+  br i1 %24, label %34, label %25, !dbg !80, !prof !66
 
 25:                                               ; preds = %typeTestSuccess7
-  %26 = add nsw i64 %21, -1, !dbg !78
-  %27 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_x, i64 %26) #20, !dbg !78
-  %28 = extractvalue { i64, i1 } %27, 1, !dbg !78
-  %29 = extractvalue { i64, i1 } %27, 0, !dbg !78
-  br i1 %28, label %30, label %sorbet_rb_int_plus.exit, !dbg !78
+  %26 = add nsw i64 %21, -1, !dbg !80
+  %27 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_x, i64 %26) #20, !dbg !80
+  %28 = extractvalue { i64, i1 } %27, 1, !dbg !80
+  %29 = extractvalue { i64, i1 } %27, 0, !dbg !80
+  br i1 %28, label %30, label %sorbet_rb_int_plus.exit, !dbg !80
 
 30:                                               ; preds = %25
-  %31 = ashr i64 %29, 1, !dbg !78
-  %32 = xor i64 %31, -9223372036854775808, !dbg !78
-  %33 = tail call i64 @rb_int2big(i64 %32) #16, !dbg !78, !noalias !75
-  br label %sorbet_rb_int_plus.exit, !dbg !78
+  %31 = ashr i64 %29, 1, !dbg !80
+  %32 = xor i64 %31, -9223372036854775808, !dbg !80
+  %33 = tail call i64 @rb_int2big(i64 %32) #16, !dbg !80, !noalias !77
+  br label %sorbet_rb_int_plus.exit, !dbg !80
 
 34:                                               ; preds = %typeTestSuccess7
-  %35 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_x, i64 %21) #16, !dbg !78, !noalias !75
-  br label %sorbet_rb_int_plus.exit, !dbg !78
+  %35 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_x, i64 %21) #16, !dbg !80, !noalias !77
+  br label %sorbet_rb_int_plus.exit, !dbg !80
 
 sorbet_rb_int_plus.exit:                          ; preds = %30, %25, %34
-  %36 = phi i64 [ %35, %34 ], [ %33, %30 ], [ %29, %25 ], !dbg !78
-  %37 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !13
-  %38 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %37, i64 0, i32 5, !dbg !78
-  %39 = load i32, i32* %38, align 8, !dbg !78, !tbaa !27
-  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %37, i64 0, i32 6, !dbg !78
-  %41 = load i32, i32* %40, align 4, !dbg !78, !tbaa !28
-  %42 = xor i32 %41, -1, !dbg !78
-  %43 = and i32 %42, %39, !dbg !78
-  %44 = icmp eq i32 %43, 0, !dbg !78
-  br i1 %44, label %rb_vm_check_ints.exit, label %45, !dbg !78, !prof !29
+  %36 = phi i64 [ %35, %34 ], [ %33, %30 ], [ %29, %25 ], !dbg !80
+  %37 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
+  %38 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %37, i64 0, i32 5, !dbg !80
+  %39 = load i32, i32* %38, align 8, !dbg !80, !tbaa !29
+  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %37, i64 0, i32 6, !dbg !80
+  %41 = load i32, i32* %40, align 4, !dbg !80, !tbaa !30
+  %42 = xor i32 %41, -1, !dbg !80
+  %43 = and i32 %42, %39, !dbg !80
+  %44 = icmp eq i32 %43, 0, !dbg !80
+  br i1 %44, label %rb_vm_check_ints.exit, label %45, !dbg !80, !prof !31
 
 45:                                               ; preds = %sorbet_rb_int_plus.exit
-  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %37, i64 0, i32 8, !dbg !78
-  %47 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %46, align 8, !dbg !78, !tbaa !30
-  %48 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %47, i32 noundef 0) #16, !dbg !78
-  br label %rb_vm_check_ints.exit, !dbg !78
+  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %37, i64 0, i32 8, !dbg !80
+  %47 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %46, align 8, !dbg !80, !tbaa !32
+  %48 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %47, i32 noundef 0) #16, !dbg !80
+  br label %rb_vm_check_ints.exit, !dbg !80
 
 rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.exit, %45
   %49 = and i64 %36, 1
   %50 = icmp eq i64 %49, 0
-  br i1 %50, label %51, label %typeTestSuccess17, !prof !67
+  br i1 %50, label %51, label %typeTestSuccess17, !prof !69
 
 51:                                               ; preds = %rb_vm_check_ints.exit
   %52 = and i64 %36, 7
@@ -682,94 +682,94 @@ rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.
 sorbet_isa_Integer.exit26:                        ; preds = %51
   %57 = inttoptr i64 %36 to %struct.iseq_inline_iv_cache_entry*
   %58 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %57, i64 0, i32 0
-  %59 = load i64, i64* %58, align 8, !tbaa !68
+  %59 = load i64, i64* %58, align 8, !tbaa !70
   %60 = and i64 %59, 31
   %61 = icmp eq i64 %60, 10
-  br i1 %61, label %typeTestSuccess17, label %codeRepl, !prof !29
+  br i1 %61, label %typeTestSuccess17, label %codeRepl, !prof !31
 
 codeRepl24:                                       ; preds = %typeTestSuccess
-  tail call fastcc void @"func_Foo#bar.cold.2"(i64 %5) #19, !dbg !70
+  tail call fastcc void @"func_Foo#bar.cold.2"(i64 %5) #19, !dbg !72
   unreachable
 
 typeTestSuccess17:                                ; preds = %rb_vm_check_ints.exit, %sorbet_isa_Integer.exit26
   ret i64 %36
 
 codeRepl:                                         ; preds = %51, %sorbet_isa_Integer.exit26
-  tail call fastcc void @"func_Foo#bar.cold.1"(i64 %36) #19, !dbg !65
+  tail call fastcc void @"func_Foo#bar.cold.1"(i64 %36) #19, !dbg !67
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_Foo.<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #10 !dbg !43 {
+define internal i64 @"func_Foo.<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #10 !dbg !45 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !15
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !79
+  %4 = load i64, i64* %3, align 8, !tbaa !81
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.<static-init>$block_1", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !21
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !21
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !23
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %10, align 8, !tbaa !13
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !80
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !80
-  %rubyId_blk = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !81
-  %rawSym19 = tail call i64 @rb_id2sym(i64 %rubyId_blk), !dbg !81
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !46
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !32
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !46
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !46, !prof !34
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %10, align 8, !tbaa !15
+  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !82
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !82
+  %rubyId_blk = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !83
+  %rawSym19 = tail call i64 @rb_id2sym(i64 %rubyId_blk), !dbg !83
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !48
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !34
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !48
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !48, !prof !36
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !46
-  br label %14, !dbg !46
+  tail call void @const_recompute_T(), !dbg !48
+  br label %14, !dbg !48
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !46
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !46
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !32
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !46
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !46
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !46
-  %19 = load i64*, i64** %18, align 8, !dbg !46
-  store i64 %15, i64* %19, align 8, !dbg !46, !tbaa !4
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !46
-  store i64* %20, i64** %18, align 8, !dbg !46
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_proc, i64 0), !dbg !46
-  %21 = load i64, i64* @rb_cInteger, align 8, !dbg !46
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !46
-  %23 = load i64*, i64** %22, align 8, !dbg !46
-  store i64 %send, i64* %23, align 8, !dbg !46, !tbaa !4
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !46
-  store i64 %21, i64* %24, align 8, !dbg !46, !tbaa !4
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !46
-  store i64* %25, i64** %22, align 8, !dbg !46
-  %send41 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !46
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !42
-  %27 = load i64*, i64** %26, align 8, !dbg !42
-  store i64 %4, i64* %27, align 8, !dbg !42, !tbaa !4
-  %28 = getelementptr inbounds i64, i64* %27, i64 1, !dbg !42
-  store i64 %21, i64* %28, align 8, !dbg !42, !tbaa !4
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !42
-  store i64 %send41, i64* %29, align 8, !dbg !42, !tbaa !4
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !42
-  store i64* %30, i64** %26, align 8, !dbg !42
-  %send43 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !42
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !42
-  %32 = load i64*, i64** %31, align 8, !dbg !42
-  store i64 %send43, i64* %32, align 8, !dbg !42, !tbaa !4
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !42
-  store i64 %21, i64* %33, align 8, !dbg !42, !tbaa !4
-  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !42
-  store i64* %34, i64** %31, align 8, !dbg !42
-  %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.1, i64 0), !dbg !42
-  ret i64 %send45, !dbg !82
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !48
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !48
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !34
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !48
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !48
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !48
+  %19 = load i64*, i64** %18, align 8, !dbg !48
+  store i64 %15, i64* %19, align 8, !dbg !48, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !48
+  store i64* %20, i64** %18, align 8, !dbg !48
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_proc, i64 0), !dbg !48
+  %21 = load i64, i64* @rb_cInteger, align 8, !dbg !48
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !48
+  %23 = load i64*, i64** %22, align 8, !dbg !48
+  store i64 %send, i64* %23, align 8, !dbg !48, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !48
+  store i64 %21, i64* %24, align 8, !dbg !48, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !48
+  store i64* %25, i64** %22, align 8, !dbg !48
+  %send41 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !48
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !44
+  %27 = load i64*, i64** %26, align 8, !dbg !44
+  store i64 %4, i64* %27, align 8, !dbg !44, !tbaa !6
+  %28 = getelementptr inbounds i64, i64* %27, i64 1, !dbg !44
+  store i64 %21, i64* %28, align 8, !dbg !44, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !44
+  store i64 %send41, i64* %29, align 8, !dbg !44, !tbaa !6
+  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !44
+  store i64* %30, i64** %26, align 8, !dbg !44
+  %send43 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !44
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !44
+  %32 = load i64*, i64** %31, align 8, !dbg !44
+  store i64 %send43, i64* %32, align 8, !dbg !44, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !44
+  store i64 %21, i64* %33, align 8, !dbg !44, !tbaa !6
+  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !44
+  store i64* %34, i64** %31, align 8, !dbg !44
+  %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.1, i64 0), !dbg !44
+  ret i64 %send45, !dbg !84
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
@@ -785,24 +785,24 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Foo#bar.cold.1"(i64 %0) unnamed_addr #13 !dbg !83 {
+define internal fastcc void @"func_Foo#bar.cold.1"(i64 %0) unnamed_addr #13 !dbg !85 {
 newFuncRoot:
   tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18
   unreachable
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Foo#bar.cold.2"(i64 %0) unnamed_addr #13 !dbg !85 {
+define internal fastcc void @"func_Foo#bar.cold.2"(i64 %0) unnamed_addr #13 !dbg !87 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_T.proc.returns(Integer)", i64 0, i64 0)) #18, !dbg !86
-  unreachable, !dbg !86
+  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_T.proc.returns(Integer)", i64 0, i64 0)) #18, !dbg !88
+  unreachable, !dbg !88
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Foo#bar.cold.3"(i64 %rawArg_x) unnamed_addr #13 !dbg !87 {
+define internal fastcc void @"func_Foo#bar.cold.3"(i64 %rawArg_x) unnamed_addr #13 !dbg !89 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !88
-  unreachable, !dbg !88
+  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !90
+  unreachable, !dbg !90
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
@@ -812,7 +812,7 @@ declare void @llvm.assume(i1 noundef) #14
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !32
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
@@ -821,7 +821,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #10 {
 define linkonce void @const_recompute_Foo() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 3)
   store i64 %1, i64* @guarded_const_Foo, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !32
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
   store i64 %2, i64* @guard_epoch_Foo, align 8
   ret void
 }
@@ -830,7 +830,7 @@ define linkonce void @const_recompute_Foo() local_unnamed_addr #10 {
 define linkonce void @const_recompute_T() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_T, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_T, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !32
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
   store i64 %2, i64* @guard_epoch_T, align 8
   ret void
 }
@@ -857,95 +857,97 @@ attributes #18 = { noreturn }
 attributes #19 = { noinline }
 attributes #20 = { nounwind willreturn }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/block_type_checking.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !9, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !{!14, !14, i64 0}
-!14 = !{!"any pointer", !6, i64 0}
-!15 = !{!16, !14, i64 16}
-!16 = !{!"rb_execution_context_struct", !14, i64 0, !5, i64 8, !14, i64 16, !14, i64 24, !14, i64 32, !17, i64 40, !17, i64 44, !14, i64 48, !14, i64 56, !14, i64 64, !5, i64 72, !5, i64 80, !14, i64 88, !5, i64 96, !14, i64 104, !14, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !18, i64 152}
-!17 = !{!"int", !6, i64 0}
-!18 = !{!"", !14, i64 0, !14, i64 8, !5, i64 16, !6, i64 24}
-!19 = !{!20, !14, i64 16}
-!20 = !{!"rb_control_frame_struct", !14, i64 0, !14, i64 8, !14, i64 16, !5, i64 24, !14, i64 32, !14, i64 40, !14, i64 48}
-!21 = !{!20, !14, i64 32}
-!22 = !DILocation(line: 16, column: 3, scope: !8)
-!23 = !DILocation(line: 15, column: 10, scope: !8)
-!24 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.<static-init>L62", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!25 = !DILocation(line: 0, scope: !24)
-!26 = !DILocation(line: 8, column: 3, scope: !24)
-!27 = !{!16, !17, i64 40}
-!28 = !{!16, !17, i64 44}
-!29 = !{!"branch_weights", i32 2000, i32 1}
-!30 = !{!16, !14, i64 56}
-!31 = !DILocation(line: 6, column: 3, scope: !24)
-!32 = !{!33, !33, i64 0}
-!33 = !{!"long long", !6, i64 0}
-!34 = !{!"branch_weights", i32 1, i32 10000}
-!35 = !DILocation(line: 9, column: 3, scope: !24)
-!36 = !{!37, !17, i64 8}
-!37 = !{!"rb_sorbet_param_struct", !38, i64 0, !17, i64 4, !17, i64 8, !17, i64 12, !17, i64 16, !17, i64 20, !17, i64 24, !17, i64 28, !14, i64 32, !17, i64 40, !17, i64 44, !17, i64 48, !17, i64 52, !14, i64 56}
-!38 = !{!"", !17, i64 0, !17, i64 0, !17, i64 0, !17, i64 0, !17, i64 0, !17, i64 0, !17, i64 0, !17, i64 0, !17, i64 1, !17, i64 1}
-!39 = !{!37, !17, i64 28}
-!40 = !{!37, !17, i64 4}
-!41 = !{!37, !14, i64 32}
-!42 = !DILocation(line: 8, column: 8, scope: !43)
-!43 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.<static-init>L62$block_1", scope: !24, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!44 = !DILocation(line: 15, column: 10, scope: !9)
-!45 = !DILocation(line: 18, column: 1, scope: !9)
-!46 = !DILocation(line: 8, column: 32, scope: !43)
-!47 = !{!48, !5, i64 400}
-!48 = !{!"rb_vm_struct", !5, i64 0, !49, i64 8, !14, i64 192, !14, i64 200, !14, i64 208, !33, i64 216, !6, i64 224, !50, i64 264, !50, i64 280, !50, i64 296, !50, i64 312, !5, i64 328, !17, i64 336, !17, i64 340, !17, i64 344, !17, i64 344, !17, i64 344, !17, i64 344, !17, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !14, i64 456, !14, i64 464, !52, i64 472, !53, i64 992, !14, i64 1016, !14, i64 1024, !17, i64 1032, !17, i64 1036, !50, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !17, i64 1136, !14, i64 1144, !14, i64 1152, !14, i64 1160, !14, i64 1168, !14, i64 1176, !14, i64 1184, !17, i64 1192, !54, i64 1200, !6, i64 1232}
-!49 = !{!"rb_global_vm_lock_struct", !14, i64 0, !6, i64 8, !50, i64 48, !14, i64 64, !17, i64 72, !6, i64 80, !6, i64 128, !17, i64 176, !17, i64 180}
-!50 = !{!"list_head", !51, i64 0}
-!51 = !{!"list_node", !14, i64 0, !14, i64 8}
-!52 = !{!"", !6, i64 0}
-!53 = !{!"rb_hook_list_struct", !14, i64 0, !17, i64 8, !17, i64 12, !17, i64 16}
-!54 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!55 = !DILocation(line: 0, scope: !9)
-!56 = !DILocation(line: 5, column: 1, scope: !9)
-!57 = !{!6, !6, i64 0}
-!58 = !{!16, !5, i64 128}
-!59 = !{!60}
-!60 = distinct !{!60, !61, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!61 = distinct !{!61, !"VM_BH_FROM_IFUNC_BLOCK"}
-!62 = distinct !DISubprogram(name: "Foo#bar", linkageName: "func_Foo#bar", scope: null, file: !2, line: 9, type: !10, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!63 = !DILocation(line: 9, column: 3, scope: !62)
-!64 = !{!"branch_weights", i32 4001, i32 4000000}
-!65 = !DILocation(line: 0, scope: !62)
-!66 = !DILocation(line: 9, column: 11, scope: !62)
-!67 = !{!"branch_weights", i32 1, i32 2000}
-!68 = !{!69, !5, i64 0}
-!69 = !{!"RBasic", !5, i64 0, !5, i64 8}
-!70 = !DILocation(line: 9, column: 15, scope: !62)
-!71 = !{!72}
-!72 = distinct !{!72, !73, !"sorbet_callBlock: argument 0"}
-!73 = distinct !{!73, !"sorbet_callBlock"}
-!74 = !DILocation(line: 10, column: 9, scope: !62)
-!75 = !{!76}
-!76 = distinct !{!76, !77, !"sorbet_rb_int_plus: argument 0"}
-!77 = distinct !{!77, !"sorbet_rb_int_plus"}
-!78 = !DILocation(line: 11, column: 5, scope: !62)
-!79 = !{!20, !5, i64 24}
-!80 = !DILocation(line: 8, column: 15, scope: !43)
-!81 = !DILocation(line: 8, column: 27, scope: !43)
-!82 = !DILocation(line: 8, column: 3, scope: !43)
-!83 = distinct !DISubprogram(name: "func_Foo#bar.cold.1", linkageName: "func_Foo#bar.cold.1", scope: null, file: !2, type: !84, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!84 = !DISubroutineType(types: !3)
-!85 = distinct !DISubprogram(name: "func_Foo#bar.cold.2", linkageName: "func_Foo#bar.cold.2", scope: null, file: !2, type: !84, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!86 = !DILocation(line: 9, column: 15, scope: !85)
-!87 = distinct !DISubprogram(name: "func_Foo#bar.cold.3", linkageName: "func_Foo#bar.cold.3", scope: null, file: !2, type: !84, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!88 = !DILocation(line: 9, column: 11, scope: !87)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/block_type_checking.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !11, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !{!16, !16, i64 0}
+!16 = !{!"any pointer", !8, i64 0}
+!17 = !{!18, !16, i64 16}
+!18 = !{!"rb_execution_context_struct", !16, i64 0, !7, i64 8, !16, i64 16, !16, i64 24, !16, i64 32, !19, i64 40, !19, i64 44, !16, i64 48, !16, i64 56, !16, i64 64, !7, i64 72, !7, i64 80, !16, i64 88, !7, i64 96, !16, i64 104, !16, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !20, i64 152}
+!19 = !{!"int", !8, i64 0}
+!20 = !{!"", !16, i64 0, !16, i64 8, !7, i64 16, !8, i64 24}
+!21 = !{!22, !16, i64 16}
+!22 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !7, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
+!23 = !{!22, !16, i64 32}
+!24 = !DILocation(line: 16, column: 3, scope: !10)
+!25 = !DILocation(line: 15, column: 10, scope: !10)
+!26 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!27 = !DILocation(line: 0, scope: !26)
+!28 = !DILocation(line: 8, column: 3, scope: !26)
+!29 = !{!18, !19, i64 40}
+!30 = !{!18, !19, i64 44}
+!31 = !{!"branch_weights", i32 2000, i32 1}
+!32 = !{!18, !16, i64 56}
+!33 = !DILocation(line: 6, column: 3, scope: !26)
+!34 = !{!35, !35, i64 0}
+!35 = !{!"long long", !8, i64 0}
+!36 = !{!"branch_weights", i32 1, i32 10000}
+!37 = !DILocation(line: 9, column: 3, scope: !26)
+!38 = !{!39, !19, i64 8}
+!39 = !{!"rb_sorbet_param_struct", !40, i64 0, !19, i64 4, !19, i64 8, !19, i64 12, !19, i64 16, !19, i64 20, !19, i64 24, !19, i64 28, !16, i64 32, !19, i64 40, !19, i64 44, !19, i64 48, !19, i64 52, !16, i64 56}
+!40 = !{!"", !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 1, !19, i64 1}
+!41 = !{!39, !19, i64 28}
+!42 = !{!39, !19, i64 4}
+!43 = !{!39, !16, i64 32}
+!44 = !DILocation(line: 8, column: 8, scope: !45)
+!45 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.<static-init>L62$block_1", scope: !26, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!46 = !DILocation(line: 15, column: 10, scope: !11)
+!47 = !DILocation(line: 18, column: 1, scope: !11)
+!48 = !DILocation(line: 8, column: 32, scope: !45)
+!49 = !{!50, !7, i64 400}
+!50 = !{!"rb_vm_struct", !7, i64 0, !51, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !35, i64 216, !8, i64 224, !52, i64 264, !52, i64 280, !52, i64 296, !52, i64 312, !7, i64 328, !19, i64 336, !19, i64 340, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !54, i64 472, !55, i64 992, !16, i64 1016, !16, i64 1024, !19, i64 1032, !19, i64 1036, !52, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !19, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !19, i64 1192, !56, i64 1200, !8, i64 1232}
+!51 = !{!"rb_global_vm_lock_struct", !16, i64 0, !8, i64 8, !52, i64 48, !16, i64 64, !19, i64 72, !8, i64 80, !8, i64 128, !19, i64 176, !19, i64 180}
+!52 = !{!"list_head", !53, i64 0}
+!53 = !{!"list_node", !16, i64 0, !16, i64 8}
+!54 = !{!"", !8, i64 0}
+!55 = !{!"rb_hook_list_struct", !16, i64 0, !19, i64 8, !19, i64 12, !19, i64 16}
+!56 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!57 = !DILocation(line: 0, scope: !11)
+!58 = !DILocation(line: 5, column: 1, scope: !11)
+!59 = !{!8, !8, i64 0}
+!60 = !{!18, !7, i64 128}
+!61 = !{!62}
+!62 = distinct !{!62, !63, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!63 = distinct !{!63, !"VM_BH_FROM_IFUNC_BLOCK"}
+!64 = distinct !DISubprogram(name: "Foo#bar", linkageName: "func_Foo#bar", scope: null, file: !4, line: 9, type: !12, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!65 = !DILocation(line: 9, column: 3, scope: !64)
+!66 = !{!"branch_weights", i32 4001, i32 4000000}
+!67 = !DILocation(line: 0, scope: !64)
+!68 = !DILocation(line: 9, column: 11, scope: !64)
+!69 = !{!"branch_weights", i32 1, i32 2000}
+!70 = !{!71, !7, i64 0}
+!71 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!72 = !DILocation(line: 9, column: 15, scope: !64)
+!73 = !{!74}
+!74 = distinct !{!74, !75, !"sorbet_callBlock: argument 0"}
+!75 = distinct !{!75, !"sorbet_callBlock"}
+!76 = !DILocation(line: 10, column: 9, scope: !64)
+!77 = !{!78}
+!78 = distinct !{!78, !79, !"sorbet_rb_int_plus: argument 0"}
+!79 = distinct !{!79, !"sorbet_rb_int_plus"}
+!80 = !DILocation(line: 11, column: 5, scope: !64)
+!81 = !{!22, !7, i64 24}
+!82 = !DILocation(line: 8, column: 15, scope: !45)
+!83 = !DILocation(line: 8, column: 27, scope: !45)
+!84 = !DILocation(line: 8, column: 3, scope: !45)
+!85 = distinct !DISubprogram(name: "func_Foo#bar.cold.1", linkageName: "func_Foo#bar.cold.1", scope: null, file: !4, type: !86, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!86 = !DISubroutineType(types: !5)
+!87 = distinct !DISubprogram(name: "func_Foo#bar.cold.2", linkageName: "func_Foo#bar.cold.2", scope: null, file: !4, type: !86, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!88 = !DILocation(line: 9, column: 15, scope: !87)
+!89 = distinct !DISubprogram(name: "func_Foo#bar.cold.3", linkageName: "func_Foo#bar.cold.3", scope: null, file: !4, type: !86, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!90 = !DILocation(line: 9, column: 11, scope: !89)

--- a/test/testdata/compiler/boolean_ops.llo.exp
+++ b/test/testdata/compiler/boolean_ops.llo.exp
@@ -119,14 +119,14 @@ declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) loc
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #5
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #5
   unreachable
 }
@@ -154,52 +154,52 @@ entry:
   %"rubyStr_test/testdata/compiler/boolean_ops.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/boolean_ops.rb", align 8
   %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/boolean_ops.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !8
-  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !13
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
+  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
   %8 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %7, i64 0, i32 18
-  %9 = load i64, i64* %8, align 8, !tbaa !15
-  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %9 = load i64, i64* %8, align 8, !tbaa !17
+  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %11 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %10, i64 0, i32 2
-  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !25
+  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !27
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !28
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !30
   %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 4
-  %15 = load i64*, i64** %14, align 8, !tbaa !30
-  %16 = load i64, i64* %15, align 8, !tbaa !4
+  %15 = load i64*, i64** %14, align 8, !tbaa !32
+  %16 = load i64, i64* %15, align 8, !tbaa !6
   %17 = and i64 %16, -33
-  store i64 %17, i64* %15, align 8, !tbaa !4
+  store i64 %17, i64* %15, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #6
   %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
-  store i64* getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %18, align 8, !dbg !31, !tbaa !13
-  call void @llvm.experimental.noalias.scope.decl(metadata !32) #6, !dbg !35
-  %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !35, !tbaa !13
-  %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 5, !dbg !35
-  %21 = load i32, i32* %20, align 8, !dbg !35, !tbaa !36
-  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 6, !dbg !35
-  %23 = load i32, i32* %22, align 4, !dbg !35, !tbaa !37
-  %24 = xor i32 %23, -1, !dbg !35
-  %25 = and i32 %24, %21, !dbg !35
-  %26 = icmp eq i32 %25, 0, !dbg !35
-  br i1 %26, label %"func_<root>.<static-init>$151.exit", label %27, !dbg !35, !prof !38
+  store i64* getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %18, align 8, !dbg !33, !tbaa !15
+  call void @llvm.experimental.noalias.scope.decl(metadata !34) #6, !dbg !37
+  %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !15
+  %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 5, !dbg !37
+  %21 = load i32, i32* %20, align 8, !dbg !37, !tbaa !38
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 6, !dbg !37
+  %23 = load i32, i32* %22, align 4, !dbg !37, !tbaa !39
+  %24 = xor i32 %23, -1, !dbg !37
+  %25 = and i32 %24, %21, !dbg !37
+  %26 = icmp eq i32 %25, 0, !dbg !37
+  br i1 %26, label %"func_<root>.<static-init>$151.exit", label %27, !dbg !37, !prof !40
 
 27:                                               ; preds = %entry
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 8, !dbg !35
-  %29 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %28, align 8, !dbg !35, !tbaa !39
-  %30 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %29, i32 noundef 0) #6, !dbg !35
-  br label %"func_<root>.<static-init>$151.exit", !dbg !35
+  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 8, !dbg !37
+  %29 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %28, align 8, !dbg !37, !tbaa !41
+  %30 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %29, i32 noundef 0) #6, !dbg !37
+  br label %"func_<root>.<static-init>$151.exit", !dbg !37
 
 "func_<root>.<static-init>$151.exit":             ; preds = %entry, %27
-  call void @llvm.experimental.noalias.scope.decl(metadata !40) #6, !dbg !43
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !8
-  %32 = load i64*, i64** %31, align 8, !dbg !8
-  store i64 %9, i64* %32, align 8, !dbg !8, !tbaa !4
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !8
-  store i64 20, i64* %33, align 8, !dbg !8, !tbaa !4
-  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !8
-  store i64* %34, i64** %31, align 8, !dbg !8
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !8
+  call void @llvm.experimental.noalias.scope.decl(metadata !42) #6, !dbg !45
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !10
+  %32 = load i64*, i64** %31, align 8, !dbg !10
+  store i64 %9, i64* %32, align 8, !dbg !10, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !10
+  store i64 20, i64* %33, align 8, !dbg !10, !tbaa !6
+  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !10
+  store i64* %34, i64** %31, align 8, !dbg !10
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
   ret void
 }
 
@@ -214,50 +214,52 @@ attributes #4 = { inaccessiblememonly nofree nosync nounwind willreturn }
 attributes #5 = { noreturn nounwind }
 attributes #6 = { nounwind }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/boolean_ops.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 5, column: 1, scope: !9)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !{!14, !14, i64 0}
-!14 = !{!"any pointer", !6, i64 0}
-!15 = !{!16, !5, i64 400}
-!16 = !{!"rb_vm_struct", !5, i64 0, !17, i64 8, !14, i64 192, !14, i64 200, !14, i64 208, !21, i64 216, !6, i64 224, !18, i64 264, !18, i64 280, !18, i64 296, !18, i64 312, !5, i64 328, !20, i64 336, !20, i64 340, !20, i64 344, !20, i64 344, !20, i64 344, !20, i64 344, !20, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !14, i64 456, !14, i64 464, !22, i64 472, !23, i64 992, !14, i64 1016, !14, i64 1024, !20, i64 1032, !20, i64 1036, !18, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !20, i64 1136, !14, i64 1144, !14, i64 1152, !14, i64 1160, !14, i64 1168, !14, i64 1176, !14, i64 1184, !20, i64 1192, !24, i64 1200, !6, i64 1232}
-!17 = !{!"rb_global_vm_lock_struct", !14, i64 0, !6, i64 8, !18, i64 48, !14, i64 64, !20, i64 72, !6, i64 80, !6, i64 128, !20, i64 176, !20, i64 180}
-!18 = !{!"list_head", !19, i64 0}
-!19 = !{!"list_node", !14, i64 0, !14, i64 8}
-!20 = !{!"int", !6, i64 0}
-!21 = !{!"long long", !6, i64 0}
-!22 = !{!"", !6, i64 0}
-!23 = !{!"rb_hook_list_struct", !14, i64 0, !20, i64 8, !20, i64 12, !20, i64 16}
-!24 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!25 = !{!26, !14, i64 16}
-!26 = !{!"rb_execution_context_struct", !14, i64 0, !5, i64 8, !14, i64 16, !14, i64 24, !14, i64 32, !20, i64 40, !20, i64 44, !14, i64 48, !14, i64 56, !14, i64 64, !5, i64 72, !5, i64 80, !14, i64 88, !5, i64 96, !14, i64 104, !14, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !27, i64 152}
-!27 = !{!"", !14, i64 0, !14, i64 8, !5, i64 16, !6, i64 24}
-!28 = !{!29, !14, i64 16}
-!29 = !{!"rb_control_frame_struct", !14, i64 0, !14, i64 8, !14, i64 16, !5, i64 24, !14, i64 32, !14, i64 40, !14, i64 48}
-!30 = !{!29, !14, i64 32}
-!31 = !DILocation(line: 0, scope: !9)
-!32 = !{!33}
-!33 = distinct !{!33, !34, !"sorbet_rb_int_gt: argument 0"}
-!34 = distinct !{!34, !"sorbet_rb_int_gt"}
-!35 = !DILocation(line: 5, column: 8, scope: !9)
-!36 = !{!26, !20, i64 40}
-!37 = !{!26, !20, i64 44}
-!38 = !{!"branch_weights", i32 2000, i32 1}
-!39 = !{!26, !14, i64 56}
-!40 = !{!41}
-!41 = distinct !{!41, !42, !"sorbet_bang: argument 0"}
-!42 = distinct !{!42, !"sorbet_bang"}
-!43 = !DILocation(line: 5, column: 6, scope: !9)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/boolean_ops.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 5, column: 1, scope: !11)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !{!16, !16, i64 0}
+!16 = !{!"any pointer", !8, i64 0}
+!17 = !{!18, !7, i64 400}
+!18 = !{!"rb_vm_struct", !7, i64 0, !19, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !23, i64 216, !8, i64 224, !20, i64 264, !20, i64 280, !20, i64 296, !20, i64 312, !7, i64 328, !22, i64 336, !22, i64 340, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !24, i64 472, !25, i64 992, !16, i64 1016, !16, i64 1024, !22, i64 1032, !22, i64 1036, !20, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !22, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !22, i64 1192, !26, i64 1200, !8, i64 1232}
+!19 = !{!"rb_global_vm_lock_struct", !16, i64 0, !8, i64 8, !20, i64 48, !16, i64 64, !22, i64 72, !8, i64 80, !8, i64 128, !22, i64 176, !22, i64 180}
+!20 = !{!"list_head", !21, i64 0}
+!21 = !{!"list_node", !16, i64 0, !16, i64 8}
+!22 = !{!"int", !8, i64 0}
+!23 = !{!"long long", !8, i64 0}
+!24 = !{!"", !8, i64 0}
+!25 = !{!"rb_hook_list_struct", !16, i64 0, !22, i64 8, !22, i64 12, !22, i64 16}
+!26 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!27 = !{!28, !16, i64 16}
+!28 = !{!"rb_execution_context_struct", !16, i64 0, !7, i64 8, !16, i64 16, !16, i64 24, !16, i64 32, !22, i64 40, !22, i64 44, !16, i64 48, !16, i64 56, !16, i64 64, !7, i64 72, !7, i64 80, !16, i64 88, !7, i64 96, !16, i64 104, !16, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !29, i64 152}
+!29 = !{!"", !16, i64 0, !16, i64 8, !7, i64 16, !8, i64 24}
+!30 = !{!31, !16, i64 16}
+!31 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !7, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
+!32 = !{!31, !16, i64 32}
+!33 = !DILocation(line: 0, scope: !11)
+!34 = !{!35}
+!35 = distinct !{!35, !36, !"sorbet_rb_int_gt: argument 0"}
+!36 = distinct !{!36, !"sorbet_rb_int_gt"}
+!37 = !DILocation(line: 5, column: 8, scope: !11)
+!38 = !{!28, !22, i64 40}
+!39 = !{!28, !22, i64 44}
+!40 = !{!"branch_weights", i32 2000, i32 1}
+!41 = !{!28, !16, i64 56}
+!42 = !{!43}
+!43 = distinct !{!43, !44, !"sorbet_bang: argument 0"}
+!44 = distinct !{!44, !"sorbet_bang"}
+!45 = !DILocation(line: 5, column: 6, scope: !11)

--- a/test/testdata/compiler/casts.llo.exp
+++ b/test/testdata/compiler/casts.llo.exp
@@ -194,655 +194,655 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #7 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #13
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #7 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #13
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#fooAll"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #8 !dbg !8 {
+define i64 @"func_Object#fooAll"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #8 !dbg !10 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !14
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !14
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !14
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !14, !prof !15
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !16
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !16
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !16
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !16, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #14, !dbg !14
-  unreachable, !dbg !14
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #14, !dbg !16
+  unreachable, !dbg !16
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !14
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !16, !tbaa !12
-  %1 = load i64, i64* @rb_mKernel, align 8, !dbg !17
-  %2 = tail call i64 @rb_obj_is_kind_of(i64 %rawArg_arg, i64 %1), !dbg !17
-  %3 = icmp eq i64 %2, 20, !dbg !17
-  br i1 %3, label %typeTestSuccess, label %codeRepl, !dbg !17, !prof !18
+  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !16
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !18, !tbaa !14
+  %1 = load i64, i64* @rb_mKernel, align 8, !dbg !19
+  %2 = tail call i64 @rb_obj_is_kind_of(i64 %rawArg_arg, i64 %1), !dbg !19
+  %3 = icmp eq i64 %2, 20, !dbg !19
+  br i1 %3, label %typeTestSuccess, label %codeRepl, !dbg !19, !prof !20
 
 typeTestSuccess:                                  ; preds = %fillRequiredArgs
   ret i64 %rawArg_arg
 
 codeRepl:                                         ; preds = %fillRequiredArgs
-  tail call fastcc void @"func_Object#fooAll.cold.1"(i64 %rawArg_arg) #15, !dbg !17
+  tail call fastcc void @"func_Object#fooAll.cold.1"(i64 %rawArg_arg) #15, !dbg !19
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#fooAny1"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #8 !dbg !19 {
+define i64 @"func_Object#fooAny1"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #8 !dbg !21 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !20
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !20
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !20
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !20, !prof !15
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !22
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !22
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !22
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !22, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #14, !dbg !20
-  unreachable, !dbg !20
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #14, !dbg !22
+  unreachable, !dbg !22
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !20
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !21, !tbaa !12
-  %1 = and i64 %rawArg_arg, 1, !dbg !22
-  %2 = icmp eq i64 %1, 0, !dbg !22
-  br i1 %2, label %3, label %typeTestSuccess, !dbg !22, !prof !23
+  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !22
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !23, !tbaa !14
+  %1 = and i64 %rawArg_arg, 1, !dbg !24
+  %2 = icmp eq i64 %1, 0, !dbg !24
+  br i1 %2, label %3, label %typeTestSuccess, !dbg !24, !prof !25
 
 3:                                                ; preds = %fillRequiredArgs
-  %4 = and i64 %rawArg_arg, 7, !dbg !22
-  %5 = icmp ne i64 %4, 0, !dbg !22
-  %6 = and i64 %rawArg_arg, -9, !dbg !22
-  %7 = icmp eq i64 %6, 0, !dbg !22
-  %8 = or i1 %5, %7, !dbg !22
-  br i1 %8, label %orCase, label %sorbet_isa_Integer.exit, !dbg !22
+  %4 = and i64 %rawArg_arg, 7, !dbg !24
+  %5 = icmp ne i64 %4, 0, !dbg !24
+  %6 = and i64 %rawArg_arg, -9, !dbg !24
+  %7 = icmp eq i64 %6, 0, !dbg !24
+  %8 = or i1 %5, %7, !dbg !24
+  br i1 %8, label %orCase, label %sorbet_isa_Integer.exit, !dbg !24
 
 sorbet_isa_Integer.exit:                          ; preds = %3
-  %9 = inttoptr i64 %rawArg_arg to %struct.iseq_inline_iv_cache_entry*, !dbg !22
-  %10 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %9, i64 0, i32 0, !dbg !22
-  %11 = load i64, i64* %10, align 8, !dbg !22, !tbaa !24
-  %12 = and i64 %11, 31, !dbg !22
-  %13 = icmp eq i64 %12, 10, !dbg !22
-  br i1 %13, label %typeTestSuccess, label %orCase, !dbg !22
+  %9 = inttoptr i64 %rawArg_arg to %struct.iseq_inline_iv_cache_entry*, !dbg !24
+  %10 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %9, i64 0, i32 0, !dbg !24
+  %11 = load i64, i64* %10, align 8, !dbg !24, !tbaa !26
+  %12 = and i64 %11, 31, !dbg !24
+  %13 = icmp eq i64 %12, 10, !dbg !24
+  br i1 %13, label %typeTestSuccess, label %orCase, !dbg !24
 
 orCase:                                           ; preds = %3, %sorbet_isa_Integer.exit
-  %14 = and i64 %rawArg_arg, 3, !dbg !22
-  %15 = icmp eq i64 %14, 2, !dbg !22
-  br i1 %15, label %typeTestSuccess, label %16, !dbg !22
+  %14 = and i64 %rawArg_arg, 3, !dbg !24
+  %15 = icmp eq i64 %14, 2, !dbg !24
+  br i1 %15, label %typeTestSuccess, label %16, !dbg !24
 
 16:                                               ; preds = %orCase
-  %17 = and i64 %rawArg_arg, 7, !dbg !22
-  %18 = icmp ne i64 %17, 0, !dbg !22
-  %19 = and i64 %rawArg_arg, -9, !dbg !22
-  %20 = icmp eq i64 %19, 0, !dbg !22
-  %21 = or i1 %18, %20, !dbg !22
-  br i1 %21, label %codeRepl, label %sorbet_isa_Float.exit, !dbg !22
+  %17 = and i64 %rawArg_arg, 7, !dbg !24
+  %18 = icmp ne i64 %17, 0, !dbg !24
+  %19 = and i64 %rawArg_arg, -9, !dbg !24
+  %20 = icmp eq i64 %19, 0, !dbg !24
+  %21 = or i1 %18, %20, !dbg !24
+  br i1 %21, label %codeRepl, label %sorbet_isa_Float.exit, !dbg !24
 
 sorbet_isa_Float.exit:                            ; preds = %16
-  %22 = inttoptr i64 %rawArg_arg to %struct.iseq_inline_iv_cache_entry*, !dbg !22
-  %23 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %22, i64 0, i32 0, !dbg !22
-  %24 = load i64, i64* %23, align 8, !dbg !22, !tbaa !24
-  %25 = and i64 %24, 31, !dbg !22
-  %26 = icmp eq i64 %25, 4, !dbg !22
-  br i1 %26, label %typeTestSuccess, label %codeRepl, !dbg !22, !prof !18
+  %22 = inttoptr i64 %rawArg_arg to %struct.iseq_inline_iv_cache_entry*, !dbg !24
+  %23 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %22, i64 0, i32 0, !dbg !24
+  %24 = load i64, i64* %23, align 8, !dbg !24, !tbaa !26
+  %25 = and i64 %24, 31, !dbg !24
+  %26 = icmp eq i64 %25, 4, !dbg !24
+  br i1 %26, label %typeTestSuccess, label %codeRepl, !dbg !24, !prof !20
 
 typeTestSuccess:                                  ; preds = %orCase, %fillRequiredArgs, %sorbet_isa_Integer.exit, %sorbet_isa_Float.exit
   ret i64 %rawArg_arg
 
 codeRepl:                                         ; preds = %16, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#fooAny1.cold.1"(i64 %rawArg_arg) #15, !dbg !22
+  tail call fastcc void @"func_Object#fooAny1.cold.1"(i64 %rawArg_arg) #15, !dbg !24
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#fooAny2"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #8 !dbg !26 {
+define i64 @"func_Object#fooAny2"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #8 !dbg !28 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !27
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !27
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !27
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !27, !prof !15
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !29
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !29
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !29
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !29, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #14, !dbg !27
-  unreachable, !dbg !27
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #14, !dbg !29
+  unreachable, !dbg !29
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !27
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !28, !tbaa !12
-  %1 = and i64 %rawArg_arg, 3, !dbg !29
-  %2 = icmp eq i64 %1, 2, !dbg !29
-  br i1 %2, label %typeTestSuccess, label %3, !dbg !29
+  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !29
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !30, !tbaa !14
+  %1 = and i64 %rawArg_arg, 3, !dbg !31
+  %2 = icmp eq i64 %1, 2, !dbg !31
+  br i1 %2, label %typeTestSuccess, label %3, !dbg !31
 
 3:                                                ; preds = %fillRequiredArgs
-  %4 = and i64 %rawArg_arg, 7, !dbg !29
-  %5 = icmp ne i64 %4, 0, !dbg !29
-  %6 = and i64 %rawArg_arg, -9, !dbg !29
-  %7 = icmp eq i64 %6, 0, !dbg !29
-  %8 = or i1 %5, %7, !dbg !29
-  br i1 %8, label %orCase, label %sorbet_isa_Float.exit, !dbg !29
+  %4 = and i64 %rawArg_arg, 7, !dbg !31
+  %5 = icmp ne i64 %4, 0, !dbg !31
+  %6 = and i64 %rawArg_arg, -9, !dbg !31
+  %7 = icmp eq i64 %6, 0, !dbg !31
+  %8 = or i1 %5, %7, !dbg !31
+  br i1 %8, label %orCase, label %sorbet_isa_Float.exit, !dbg !31
 
 sorbet_isa_Float.exit:                            ; preds = %3
-  %9 = inttoptr i64 %rawArg_arg to %struct.iseq_inline_iv_cache_entry*, !dbg !29
-  %10 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %9, i64 0, i32 0, !dbg !29
-  %11 = load i64, i64* %10, align 8, !dbg !29, !tbaa !24
-  %12 = and i64 %11, 31, !dbg !29
-  %13 = icmp eq i64 %12, 4, !dbg !29
-  br i1 %13, label %typeTestSuccess, label %orCase, !dbg !29
+  %9 = inttoptr i64 %rawArg_arg to %struct.iseq_inline_iv_cache_entry*, !dbg !31
+  %10 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %9, i64 0, i32 0, !dbg !31
+  %11 = load i64, i64* %10, align 8, !dbg !31, !tbaa !26
+  %12 = and i64 %11, 31, !dbg !31
+  %13 = icmp eq i64 %12, 4, !dbg !31
+  br i1 %13, label %typeTestSuccess, label %orCase, !dbg !31
 
 orCase:                                           ; preds = %3, %sorbet_isa_Float.exit
-  %14 = and i64 %rawArg_arg, 1, !dbg !29
-  %15 = icmp eq i64 %14, 0, !dbg !29
-  br i1 %15, label %16, label %typeTestSuccess, !dbg !29, !prof !23
+  %14 = and i64 %rawArg_arg, 1, !dbg !31
+  %15 = icmp eq i64 %14, 0, !dbg !31
+  br i1 %15, label %16, label %typeTestSuccess, !dbg !31, !prof !25
 
 16:                                               ; preds = %orCase
-  %17 = and i64 %rawArg_arg, 7, !dbg !29
-  %18 = icmp ne i64 %17, 0, !dbg !29
-  %19 = and i64 %rawArg_arg, -9, !dbg !29
-  %20 = icmp eq i64 %19, 0, !dbg !29
-  %21 = or i1 %18, %20, !dbg !29
-  br i1 %21, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !29
+  %17 = and i64 %rawArg_arg, 7, !dbg !31
+  %18 = icmp ne i64 %17, 0, !dbg !31
+  %19 = and i64 %rawArg_arg, -9, !dbg !31
+  %20 = icmp eq i64 %19, 0, !dbg !31
+  %21 = or i1 %18, %20, !dbg !31
+  br i1 %21, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !31
 
 sorbet_isa_Integer.exit:                          ; preds = %16
-  %22 = inttoptr i64 %rawArg_arg to %struct.iseq_inline_iv_cache_entry*, !dbg !29
-  %23 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %22, i64 0, i32 0, !dbg !29
-  %24 = load i64, i64* %23, align 8, !dbg !29, !tbaa !24
-  %25 = and i64 %24, 31, !dbg !29
-  %26 = icmp eq i64 %25, 10, !dbg !29
-  br i1 %26, label %typeTestSuccess, label %codeRepl, !dbg !29, !prof !18
+  %22 = inttoptr i64 %rawArg_arg to %struct.iseq_inline_iv_cache_entry*, !dbg !31
+  %23 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %22, i64 0, i32 0, !dbg !31
+  %24 = load i64, i64* %23, align 8, !dbg !31, !tbaa !26
+  %25 = and i64 %24, 31, !dbg !31
+  %26 = icmp eq i64 %25, 10, !dbg !31
+  br i1 %26, label %typeTestSuccess, label %codeRepl, !dbg !31, !prof !20
 
 typeTestSuccess:                                  ; preds = %orCase, %fillRequiredArgs, %sorbet_isa_Float.exit, %sorbet_isa_Integer.exit
   ret i64 %rawArg_arg
 
 codeRepl:                                         ; preds = %16, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_Object#fooAny2.cold.1"(i64 %rawArg_arg) #15, !dbg !29
+  tail call fastcc void @"func_Object#fooAny2.cold.1"(i64 %rawArg_arg) #15, !dbg !31
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#fooInt"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #8 !dbg !30 {
+define i64 @"func_Object#fooInt"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #8 !dbg !32 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !31
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !31
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !31
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !31, !prof !15
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !33
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !33
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !33
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !33, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #14, !dbg !31
-  unreachable, !dbg !31
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #14, !dbg !33
+  unreachable, !dbg !33
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !31
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %0, align 8, !dbg !32, !tbaa !12
-  %1 = and i64 %rawArg_arg, 1, !dbg !33
-  %2 = icmp eq i64 %1, 0, !dbg !33
-  br i1 %2, label %3, label %"fastSymCallIntrinsic_Integer_+", !dbg !33, !prof !23
+  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !33
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %0, align 8, !dbg !34, !tbaa !14
+  %1 = and i64 %rawArg_arg, 1, !dbg !35
+  %2 = icmp eq i64 %1, 0, !dbg !35
+  br i1 %2, label %3, label %"fastSymCallIntrinsic_Integer_+", !dbg !35, !prof !25
 
 3:                                                ; preds = %fillRequiredArgs
-  %4 = and i64 %rawArg_arg, 7, !dbg !33
-  %5 = icmp ne i64 %4, 0, !dbg !33
-  %6 = and i64 %rawArg_arg, -9, !dbg !33
-  %7 = icmp eq i64 %6, 0, !dbg !33
-  %8 = or i1 %5, %7, !dbg !33
-  br i1 %8, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !33
+  %4 = and i64 %rawArg_arg, 7, !dbg !35
+  %5 = icmp ne i64 %4, 0, !dbg !35
+  %6 = and i64 %rawArg_arg, -9, !dbg !35
+  %7 = icmp eq i64 %6, 0, !dbg !35
+  %8 = or i1 %5, %7, !dbg !35
+  br i1 %8, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !35
 
 sorbet_isa_Integer.exit:                          ; preds = %3
-  %9 = inttoptr i64 %rawArg_arg to %struct.iseq_inline_iv_cache_entry*, !dbg !33
-  %10 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %9, i64 0, i32 0, !dbg !33
-  %11 = load i64, i64* %10, align 8, !dbg !33, !tbaa !24
-  %12 = and i64 %11, 31, !dbg !33
-  %13 = icmp eq i64 %12, 10, !dbg !33
-  br i1 %13, label %"fastSymCallIntrinsic_Integer_+", label %codeRepl, !dbg !33, !prof !18
+  %9 = inttoptr i64 %rawArg_arg to %struct.iseq_inline_iv_cache_entry*, !dbg !35
+  %10 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %9, i64 0, i32 0, !dbg !35
+  %11 = load i64, i64* %10, align 8, !dbg !35, !tbaa !26
+  %12 = and i64 %11, 31, !dbg !35
+  %13 = icmp eq i64 %12, 10, !dbg !35
+  br i1 %13, label %"fastSymCallIntrinsic_Integer_+", label %codeRepl, !dbg !35, !prof !20
 
 codeRepl:                                         ; preds = %3, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_Object#fooInt.cold.1"(i64 %rawArg_arg) #15, !dbg !33
+  tail call fastcc void @"func_Object#fooInt.cold.1"(i64 %rawArg_arg) #15, !dbg !35
   unreachable
 
 "fastSymCallIntrinsic_Integer_+":                 ; preds = %fillRequiredArgs, %sorbet_isa_Integer.exit
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !34), !dbg !33
-  %14 = and i64 %rawArg_arg, 1, !dbg !33
-  %15 = icmp eq i64 %14, 0, !dbg !33
-  br i1 %15, label %25, label %16, !dbg !33, !prof !15
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !36), !dbg !35
+  %14 = and i64 %rawArg_arg, 1, !dbg !35
+  %15 = icmp eq i64 %14, 0, !dbg !35
+  br i1 %15, label %25, label %16, !dbg !35, !prof !17
 
 16:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %17 = add nsw i64 %rawArg_arg, -1, !dbg !33
-  %18 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_arg, i64 %17) #16, !dbg !33
-  %19 = extractvalue { i64, i1 } %18, 1, !dbg !33
-  %20 = extractvalue { i64, i1 } %18, 0, !dbg !33
-  br i1 %19, label %21, label %sorbet_rb_int_plus.exit, !dbg !33
+  %17 = add nsw i64 %rawArg_arg, -1, !dbg !35
+  %18 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_arg, i64 %17) #16, !dbg !35
+  %19 = extractvalue { i64, i1 } %18, 1, !dbg !35
+  %20 = extractvalue { i64, i1 } %18, 0, !dbg !35
+  br i1 %19, label %21, label %sorbet_rb_int_plus.exit, !dbg !35
 
 21:                                               ; preds = %16
-  %22 = ashr i64 %20, 1, !dbg !33
-  %23 = xor i64 %22, -9223372036854775808, !dbg !33
-  %24 = tail call i64 @rb_int2big(i64 %23) #17, !dbg !33, !noalias !34
-  br label %sorbet_rb_int_plus.exit, !dbg !33
+  %22 = ashr i64 %20, 1, !dbg !35
+  %23 = xor i64 %22, -9223372036854775808, !dbg !35
+  %24 = tail call i64 @rb_int2big(i64 %23) #17, !dbg !35, !noalias !36
+  br label %sorbet_rb_int_plus.exit, !dbg !35
 
 25:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %26 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_arg, i64 %rawArg_arg) #17, !dbg !33, !noalias !34
-  br label %sorbet_rb_int_plus.exit, !dbg !33
+  %26 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_arg, i64 %rawArg_arg) #17, !dbg !35, !noalias !36
+  br label %sorbet_rb_int_plus.exit, !dbg !35
 
 sorbet_rb_int_plus.exit:                          ; preds = %21, %16, %25
-  %27 = phi i64 [ %26, %25 ], [ %24, %21 ], [ %20, %16 ], !dbg !33
-  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !33, !tbaa !12
-  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 5, !dbg !33
-  %30 = load i32, i32* %29, align 8, !dbg !33, !tbaa !37
-  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 6, !dbg !33
-  %32 = load i32, i32* %31, align 4, !dbg !33, !tbaa !41
-  %33 = xor i32 %32, -1, !dbg !33
-  %34 = and i32 %33, %30, !dbg !33
-  %35 = icmp eq i32 %34, 0, !dbg !33
-  br i1 %35, label %rb_vm_check_ints.exit, label %36, !dbg !33, !prof !18
+  %27 = phi i64 [ %26, %25 ], [ %24, %21 ], [ %20, %16 ], !dbg !35
+  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !35, !tbaa !14
+  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 5, !dbg !35
+  %30 = load i32, i32* %29, align 8, !dbg !35, !tbaa !39
+  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 6, !dbg !35
+  %32 = load i32, i32* %31, align 4, !dbg !35, !tbaa !43
+  %33 = xor i32 %32, -1, !dbg !35
+  %34 = and i32 %33, %30, !dbg !35
+  %35 = icmp eq i32 %34, 0, !dbg !35
+  br i1 %35, label %rb_vm_check_ints.exit, label %36, !dbg !35, !prof !20
 
 36:                                               ; preds = %sorbet_rb_int_plus.exit
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 8, !dbg !33
-  %38 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %37, align 8, !dbg !33, !tbaa !42
-  %39 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %38, i32 noundef 0) #17, !dbg !33
-  br label %rb_vm_check_ints.exit, !dbg !33
+  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 8, !dbg !35
+  %38 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %37, align 8, !dbg !35, !tbaa !44
+  %39 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %38, i32 noundef 0) #17, !dbg !35
+  br label %rb_vm_check_ints.exit, !dbg !35
 
 rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.exit, %36
   ret i64 %27
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#fooArray"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #8 !dbg !43 {
+define i64 @"func_Object#fooArray"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #8 !dbg !45 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !44
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !44
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !44
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !44, !prof !15
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !46
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !46
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !46
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !46, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #14, !dbg !44
-  unreachable, !dbg !44
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #14, !dbg !46
+  unreachable, !dbg !46
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !44
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %0, align 8, !dbg !45, !tbaa !12
-  %1 = and i64 %rawArg_arg, 7, !dbg !46
-  %2 = icmp ne i64 %1, 0, !dbg !46
-  %3 = and i64 %rawArg_arg, -9, !dbg !46
-  %4 = icmp eq i64 %3, 0, !dbg !46
-  %5 = or i1 %2, %4, !dbg !46
-  br i1 %5, label %codeRepl, label %sorbet_isa_Array.exit, !dbg !46
+  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !46
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %0, align 8, !dbg !47, !tbaa !14
+  %1 = and i64 %rawArg_arg, 7, !dbg !48
+  %2 = icmp ne i64 %1, 0, !dbg !48
+  %3 = and i64 %rawArg_arg, -9, !dbg !48
+  %4 = icmp eq i64 %3, 0, !dbg !48
+  %5 = or i1 %2, %4, !dbg !48
+  br i1 %5, label %codeRepl, label %sorbet_isa_Array.exit, !dbg !48
 
 sorbet_isa_Array.exit:                            ; preds = %fillRequiredArgs
-  %6 = inttoptr i64 %rawArg_arg to %struct.iseq_inline_iv_cache_entry*, !dbg !46
-  %7 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %6, i64 0, i32 0, !dbg !46
-  %8 = load i64, i64* %7, align 8, !dbg !46, !tbaa !24
-  %9 = and i64 %8, 31, !dbg !46
-  %10 = icmp eq i64 %9, 7, !dbg !46
-  br i1 %10, label %typeTestSuccess, label %codeRepl, !dbg !46, !prof !18
+  %6 = inttoptr i64 %rawArg_arg to %struct.iseq_inline_iv_cache_entry*, !dbg !48
+  %7 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %6, i64 0, i32 0, !dbg !48
+  %8 = load i64, i64* %7, align 8, !dbg !48, !tbaa !26
+  %9 = and i64 %8, 31, !dbg !48
+  %10 = icmp eq i64 %9, 7, !dbg !48
+  br i1 %10, label %typeTestSuccess, label %codeRepl, !dbg !48, !prof !20
 
 typeTestSuccess:                                  ; preds = %sorbet_isa_Array.exit
   ret i64 %rawArg_arg
 
 codeRepl:                                         ; preds = %fillRequiredArgs, %sorbet_isa_Array.exit
-  tail call fastcc void @"func_Object#fooArray.cold.1"(i64 %rawArg_arg) #15, !dbg !46
+  tail call fastcc void @"func_Object#fooArray.cold.1"(i64 %rawArg_arg) #15, !dbg !48
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_<root>.<static-init>$151"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !47 {
+define internal fastcc void @"func_<root>.<static-init>$151"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !49 {
 fastSymCallIntrinsic_Static_keep_def:
   %callArgs = alloca [4 x i64], align 8
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !48
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !50
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !49
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !51
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !51
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !53
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #17
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !52, !tbaa !12
-  %rubyId_fooAll = load i64, i64* @rubyIdPrecomputed_fooAll, align 8, !dbg !53
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_fooAll), !dbg !53
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !53
-  %rawSym73 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !53
-  %9 = load i64, i64* @rb_cObject, align 8, !dbg !53
-  %stackFrame74 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#fooAll", align 8, !dbg !53
-  %10 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !53
-  %11 = bitcast i8* %10 to i16*, !dbg !53
-  %12 = load i16, i16* %11, align 8, !dbg !53
-  %13 = and i16 %12, -384, !dbg !53
-  %14 = or i16 %13, 1, !dbg !53
-  store i16 %14, i16* %11, align 8, !dbg !53
-  %15 = getelementptr inbounds i8, i8* %10, i64 8, !dbg !53
-  %16 = bitcast i8* %15 to i32*, !dbg !53
-  store i32 1, i32* %16, align 8, !dbg !53, !tbaa !54
-  %17 = getelementptr inbounds i8, i8* %10, i64 12, !dbg !53
-  %18 = bitcast i8* %17 to i32*, !dbg !53
-  %19 = getelementptr inbounds i8, i8* %10, i64 4, !dbg !53
-  %20 = bitcast i8* %19 to i32*, !dbg !53
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %17, i8 0, i64 20, i1 false), !dbg !53
-  store i32 1, i32* %20, align 4, !dbg !53, !tbaa !57
-  %positional_table = alloca i64, align 8, !dbg !53
-  %rubyId_arg = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !53
-  store i64 %rubyId_arg, i64* %positional_table, align 8, !dbg !53
-  %21 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !53
-  %22 = bitcast i64* %positional_table to i8*, !dbg !53
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %21, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %22, i64 noundef 8, i1 noundef false) #17, !dbg !53
-  %23 = getelementptr inbounds i8, i8* %10, i64 32, !dbg !53
-  %24 = bitcast i8* %23 to i8**, !dbg !53
-  store i8* %21, i8** %24, align 8, !dbg !53, !tbaa !58
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#fooAll", i8* nonnull %10, %struct.rb_iseq_struct* %stackFrame74, i1 noundef zeroext false) #17, !dbg !53
-  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !53, !tbaa !12
-  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 5, !dbg !53
-  %27 = load i32, i32* %26, align 8, !dbg !53, !tbaa !37
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 6, !dbg !53
-  %29 = load i32, i32* %28, align 4, !dbg !53, !tbaa !41
-  %30 = xor i32 %29, -1, !dbg !53
-  %31 = and i32 %30, %27, !dbg !53
-  %32 = icmp eq i32 %31, 0, !dbg !53
-  br i1 %32, label %fastSymCallIntrinsic_Static_keep_def87, label %33, !dbg !53, !prof !18
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !54, !tbaa !14
+  %rubyId_fooAll = load i64, i64* @rubyIdPrecomputed_fooAll, align 8, !dbg !55
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_fooAll), !dbg !55
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !55
+  %rawSym73 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !55
+  %9 = load i64, i64* @rb_cObject, align 8, !dbg !55
+  %stackFrame74 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#fooAll", align 8, !dbg !55
+  %10 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !55
+  %11 = bitcast i8* %10 to i16*, !dbg !55
+  %12 = load i16, i16* %11, align 8, !dbg !55
+  %13 = and i16 %12, -384, !dbg !55
+  %14 = or i16 %13, 1, !dbg !55
+  store i16 %14, i16* %11, align 8, !dbg !55
+  %15 = getelementptr inbounds i8, i8* %10, i64 8, !dbg !55
+  %16 = bitcast i8* %15 to i32*, !dbg !55
+  store i32 1, i32* %16, align 8, !dbg !55, !tbaa !56
+  %17 = getelementptr inbounds i8, i8* %10, i64 12, !dbg !55
+  %18 = bitcast i8* %17 to i32*, !dbg !55
+  %19 = getelementptr inbounds i8, i8* %10, i64 4, !dbg !55
+  %20 = bitcast i8* %19 to i32*, !dbg !55
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %17, i8 0, i64 20, i1 false), !dbg !55
+  store i32 1, i32* %20, align 4, !dbg !55, !tbaa !59
+  %positional_table = alloca i64, align 8, !dbg !55
+  %rubyId_arg = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !55
+  store i64 %rubyId_arg, i64* %positional_table, align 8, !dbg !55
+  %21 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !55
+  %22 = bitcast i64* %positional_table to i8*, !dbg !55
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %21, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %22, i64 noundef 8, i1 noundef false) #17, !dbg !55
+  %23 = getelementptr inbounds i8, i8* %10, i64 32, !dbg !55
+  %24 = bitcast i8* %23 to i8**, !dbg !55
+  store i8* %21, i8** %24, align 8, !dbg !55, !tbaa !60
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#fooAll", i8* nonnull %10, %struct.rb_iseq_struct* %stackFrame74, i1 noundef zeroext false) #17, !dbg !55
+  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !55, !tbaa !14
+  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 5, !dbg !55
+  %27 = load i32, i32* %26, align 8, !dbg !55, !tbaa !39
+  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 6, !dbg !55
+  %29 = load i32, i32* %28, align 4, !dbg !55, !tbaa !43
+  %30 = xor i32 %29, -1, !dbg !55
+  %31 = and i32 %30, %27, !dbg !55
+  %32 = icmp eq i32 %31, 0, !dbg !55
+  br i1 %32, label %fastSymCallIntrinsic_Static_keep_def87, label %33, !dbg !55, !prof !20
 
 33:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
-  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 8, !dbg !53
-  %35 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %34, align 8, !dbg !53, !tbaa !42
-  %36 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %35, i32 noundef 0) #17, !dbg !53
-  br label %fastSymCallIntrinsic_Static_keep_def87, !dbg !53
+  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 8, !dbg !55
+  %35 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %34, align 8, !dbg !55, !tbaa !44
+  %36 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %35, i32 noundef 0) #17, !dbg !55
+  br label %fastSymCallIntrinsic_Static_keep_def87, !dbg !55
 
 fastSymCallIntrinsic_Static_keep_def87:           ; preds = %fastSymCallIntrinsic_Static_keep_def, %33
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !53, !tbaa !12
-  %rubyId_fooAny1 = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8, !dbg !59
-  %rawSym79 = tail call i64 @rb_id2sym(i64 %rubyId_fooAny1), !dbg !59
-  %rubyId_normal80 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !59
-  %rawSym81 = tail call i64 @rb_id2sym(i64 %rubyId_normal80), !dbg !59
-  %stackFrame88 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#fooAny1", align 8, !dbg !59
-  %37 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !59
-  %38 = bitcast i8* %37 to i16*, !dbg !59
-  %39 = load i16, i16* %38, align 8, !dbg !59
-  %40 = and i16 %39, -384, !dbg !59
-  %41 = or i16 %40, 1, !dbg !59
-  store i16 %41, i16* %38, align 8, !dbg !59
-  %42 = getelementptr inbounds i8, i8* %37, i64 8, !dbg !59
-  %43 = bitcast i8* %42 to i32*, !dbg !59
-  store i32 1, i32* %43, align 8, !dbg !59, !tbaa !54
-  %44 = getelementptr inbounds i8, i8* %37, i64 12, !dbg !59
-  %45 = bitcast i8* %44 to i32*, !dbg !59
-  %46 = getelementptr inbounds i8, i8* %37, i64 4, !dbg !59
-  %47 = bitcast i8* %46 to i32*, !dbg !59
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %44, i8 0, i64 20, i1 false), !dbg !59
-  store i32 1, i32* %47, align 4, !dbg !59, !tbaa !57
-  %positional_table90 = alloca i64, align 8, !dbg !59
-  %rubyId_arg91 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !59
-  store i64 %rubyId_arg91, i64* %positional_table90, align 8, !dbg !59
-  %48 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !59
-  %49 = bitcast i64* %positional_table90 to i8*, !dbg !59
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %48, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %49, i64 noundef 8, i1 noundef false) #17, !dbg !59
-  %50 = getelementptr inbounds i8, i8* %37, i64 32, !dbg !59
-  %51 = bitcast i8* %50 to i8**, !dbg !59
-  store i8* %48, i8** %51, align 8, !dbg !59, !tbaa !58
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#fooAny1", i8* nonnull %37, %struct.rb_iseq_struct* %stackFrame88, i1 noundef zeroext false) #17, !dbg !59
-  %52 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !59, !tbaa !12
-  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 5, !dbg !59
-  %54 = load i32, i32* %53, align 8, !dbg !59, !tbaa !37
-  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 6, !dbg !59
-  %56 = load i32, i32* %55, align 4, !dbg !59, !tbaa !41
-  %57 = xor i32 %56, -1, !dbg !59
-  %58 = and i32 %57, %54, !dbg !59
-  %59 = icmp eq i32 %58, 0, !dbg !59
-  br i1 %59, label %fastSymCallIntrinsic_Static_keep_def104, label %60, !dbg !59, !prof !18
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !55, !tbaa !14
+  %rubyId_fooAny1 = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8, !dbg !61
+  %rawSym79 = tail call i64 @rb_id2sym(i64 %rubyId_fooAny1), !dbg !61
+  %rubyId_normal80 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !61
+  %rawSym81 = tail call i64 @rb_id2sym(i64 %rubyId_normal80), !dbg !61
+  %stackFrame88 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#fooAny1", align 8, !dbg !61
+  %37 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !61
+  %38 = bitcast i8* %37 to i16*, !dbg !61
+  %39 = load i16, i16* %38, align 8, !dbg !61
+  %40 = and i16 %39, -384, !dbg !61
+  %41 = or i16 %40, 1, !dbg !61
+  store i16 %41, i16* %38, align 8, !dbg !61
+  %42 = getelementptr inbounds i8, i8* %37, i64 8, !dbg !61
+  %43 = bitcast i8* %42 to i32*, !dbg !61
+  store i32 1, i32* %43, align 8, !dbg !61, !tbaa !56
+  %44 = getelementptr inbounds i8, i8* %37, i64 12, !dbg !61
+  %45 = bitcast i8* %44 to i32*, !dbg !61
+  %46 = getelementptr inbounds i8, i8* %37, i64 4, !dbg !61
+  %47 = bitcast i8* %46 to i32*, !dbg !61
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %44, i8 0, i64 20, i1 false), !dbg !61
+  store i32 1, i32* %47, align 4, !dbg !61, !tbaa !59
+  %positional_table90 = alloca i64, align 8, !dbg !61
+  %rubyId_arg91 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !61
+  store i64 %rubyId_arg91, i64* %positional_table90, align 8, !dbg !61
+  %48 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !61
+  %49 = bitcast i64* %positional_table90 to i8*, !dbg !61
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %48, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %49, i64 noundef 8, i1 noundef false) #17, !dbg !61
+  %50 = getelementptr inbounds i8, i8* %37, i64 32, !dbg !61
+  %51 = bitcast i8* %50 to i8**, !dbg !61
+  store i8* %48, i8** %51, align 8, !dbg !61, !tbaa !60
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#fooAny1", i8* nonnull %37, %struct.rb_iseq_struct* %stackFrame88, i1 noundef zeroext false) #17, !dbg !61
+  %52 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !61, !tbaa !14
+  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 5, !dbg !61
+  %54 = load i32, i32* %53, align 8, !dbg !61, !tbaa !39
+  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 6, !dbg !61
+  %56 = load i32, i32* %55, align 4, !dbg !61, !tbaa !43
+  %57 = xor i32 %56, -1, !dbg !61
+  %58 = and i32 %57, %54, !dbg !61
+  %59 = icmp eq i32 %58, 0, !dbg !61
+  br i1 %59, label %fastSymCallIntrinsic_Static_keep_def104, label %60, !dbg !61, !prof !20
 
 60:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def87
-  %61 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 8, !dbg !59
-  %62 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %61, align 8, !dbg !59, !tbaa !42
-  %63 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %62, i32 noundef 0) #17, !dbg !59
-  br label %fastSymCallIntrinsic_Static_keep_def104, !dbg !59
+  %61 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 8, !dbg !61
+  %62 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %61, align 8, !dbg !61, !tbaa !44
+  %63 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %62, i32 noundef 0) #17, !dbg !61
+  br label %fastSymCallIntrinsic_Static_keep_def104, !dbg !61
 
 fastSymCallIntrinsic_Static_keep_def104:          ; preds = %fastSymCallIntrinsic_Static_keep_def87, %60
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !59, !tbaa !12
-  %rubyId_fooAny2 = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8, !dbg !60
-  %rawSym96 = tail call i64 @rb_id2sym(i64 %rubyId_fooAny2), !dbg !60
-  %rubyId_normal97 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !60
-  %rawSym98 = tail call i64 @rb_id2sym(i64 %rubyId_normal97), !dbg !60
-  %stackFrame105 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#fooAny2", align 8, !dbg !60
-  %64 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !60
-  %65 = bitcast i8* %64 to i16*, !dbg !60
-  %66 = load i16, i16* %65, align 8, !dbg !60
-  %67 = and i16 %66, -384, !dbg !60
-  %68 = or i16 %67, 1, !dbg !60
-  store i16 %68, i16* %65, align 8, !dbg !60
-  %69 = getelementptr inbounds i8, i8* %64, i64 8, !dbg !60
-  %70 = bitcast i8* %69 to i32*, !dbg !60
-  store i32 1, i32* %70, align 8, !dbg !60, !tbaa !54
-  %71 = getelementptr inbounds i8, i8* %64, i64 12, !dbg !60
-  %72 = bitcast i8* %71 to i32*, !dbg !60
-  %73 = getelementptr inbounds i8, i8* %64, i64 4, !dbg !60
-  %74 = bitcast i8* %73 to i32*, !dbg !60
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %71, i8 0, i64 20, i1 false), !dbg !60
-  store i32 1, i32* %74, align 4, !dbg !60, !tbaa !57
-  %positional_table107 = alloca i64, align 8, !dbg !60
-  %rubyId_arg108 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !60
-  store i64 %rubyId_arg108, i64* %positional_table107, align 8, !dbg !60
-  %75 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !60
-  %76 = bitcast i64* %positional_table107 to i8*, !dbg !60
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %75, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %76, i64 noundef 8, i1 noundef false) #17, !dbg !60
-  %77 = getelementptr inbounds i8, i8* %64, i64 32, !dbg !60
-  %78 = bitcast i8* %77 to i8**, !dbg !60
-  store i8* %75, i8** %78, align 8, !dbg !60, !tbaa !58
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#fooAny2", i8* nonnull %64, %struct.rb_iseq_struct* %stackFrame105, i1 noundef zeroext false) #17, !dbg !60
-  %79 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !60, !tbaa !12
-  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 5, !dbg !60
-  %81 = load i32, i32* %80, align 8, !dbg !60, !tbaa !37
-  %82 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 6, !dbg !60
-  %83 = load i32, i32* %82, align 4, !dbg !60, !tbaa !41
-  %84 = xor i32 %83, -1, !dbg !60
-  %85 = and i32 %84, %81, !dbg !60
-  %86 = icmp eq i32 %85, 0, !dbg !60
-  br i1 %86, label %fastSymCallIntrinsic_Static_keep_def121, label %87, !dbg !60, !prof !18
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !61, !tbaa !14
+  %rubyId_fooAny2 = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8, !dbg !62
+  %rawSym96 = tail call i64 @rb_id2sym(i64 %rubyId_fooAny2), !dbg !62
+  %rubyId_normal97 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !62
+  %rawSym98 = tail call i64 @rb_id2sym(i64 %rubyId_normal97), !dbg !62
+  %stackFrame105 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#fooAny2", align 8, !dbg !62
+  %64 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !62
+  %65 = bitcast i8* %64 to i16*, !dbg !62
+  %66 = load i16, i16* %65, align 8, !dbg !62
+  %67 = and i16 %66, -384, !dbg !62
+  %68 = or i16 %67, 1, !dbg !62
+  store i16 %68, i16* %65, align 8, !dbg !62
+  %69 = getelementptr inbounds i8, i8* %64, i64 8, !dbg !62
+  %70 = bitcast i8* %69 to i32*, !dbg !62
+  store i32 1, i32* %70, align 8, !dbg !62, !tbaa !56
+  %71 = getelementptr inbounds i8, i8* %64, i64 12, !dbg !62
+  %72 = bitcast i8* %71 to i32*, !dbg !62
+  %73 = getelementptr inbounds i8, i8* %64, i64 4, !dbg !62
+  %74 = bitcast i8* %73 to i32*, !dbg !62
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %71, i8 0, i64 20, i1 false), !dbg !62
+  store i32 1, i32* %74, align 4, !dbg !62, !tbaa !59
+  %positional_table107 = alloca i64, align 8, !dbg !62
+  %rubyId_arg108 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !62
+  store i64 %rubyId_arg108, i64* %positional_table107, align 8, !dbg !62
+  %75 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !62
+  %76 = bitcast i64* %positional_table107 to i8*, !dbg !62
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %75, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %76, i64 noundef 8, i1 noundef false) #17, !dbg !62
+  %77 = getelementptr inbounds i8, i8* %64, i64 32, !dbg !62
+  %78 = bitcast i8* %77 to i8**, !dbg !62
+  store i8* %75, i8** %78, align 8, !dbg !62, !tbaa !60
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#fooAny2", i8* nonnull %64, %struct.rb_iseq_struct* %stackFrame105, i1 noundef zeroext false) #17, !dbg !62
+  %79 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !62, !tbaa !14
+  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 5, !dbg !62
+  %81 = load i32, i32* %80, align 8, !dbg !62, !tbaa !39
+  %82 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 6, !dbg !62
+  %83 = load i32, i32* %82, align 4, !dbg !62, !tbaa !43
+  %84 = xor i32 %83, -1, !dbg !62
+  %85 = and i32 %84, %81, !dbg !62
+  %86 = icmp eq i32 %85, 0, !dbg !62
+  br i1 %86, label %fastSymCallIntrinsic_Static_keep_def121, label %87, !dbg !62, !prof !20
 
 87:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def104
-  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 8, !dbg !60
-  %89 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %88, align 8, !dbg !60, !tbaa !42
-  %90 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %89, i32 noundef 0) #17, !dbg !60
-  br label %fastSymCallIntrinsic_Static_keep_def121, !dbg !60
+  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 8, !dbg !62
+  %89 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %88, align 8, !dbg !62, !tbaa !44
+  %90 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %89, i32 noundef 0) #17, !dbg !62
+  br label %fastSymCallIntrinsic_Static_keep_def121, !dbg !62
 
 fastSymCallIntrinsic_Static_keep_def121:          ; preds = %fastSymCallIntrinsic_Static_keep_def104, %87
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %8, align 8, !dbg !60, !tbaa !12
-  %rubyId_fooInt = load i64, i64* @rubyIdPrecomputed_fooInt, align 8, !dbg !61
-  %rawSym113 = tail call i64 @rb_id2sym(i64 %rubyId_fooInt), !dbg !61
-  %rubyId_normal114 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !61
-  %rawSym115 = tail call i64 @rb_id2sym(i64 %rubyId_normal114), !dbg !61
-  %stackFrame122 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#fooInt", align 8, !dbg !61
-  %91 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !61
-  %92 = bitcast i8* %91 to i16*, !dbg !61
-  %93 = load i16, i16* %92, align 8, !dbg !61
-  %94 = and i16 %93, -384, !dbg !61
-  %95 = or i16 %94, 1, !dbg !61
-  store i16 %95, i16* %92, align 8, !dbg !61
-  %96 = getelementptr inbounds i8, i8* %91, i64 8, !dbg !61
-  %97 = bitcast i8* %96 to i32*, !dbg !61
-  store i32 1, i32* %97, align 8, !dbg !61, !tbaa !54
-  %98 = getelementptr inbounds i8, i8* %91, i64 12, !dbg !61
-  %99 = bitcast i8* %98 to i32*, !dbg !61
-  %100 = getelementptr inbounds i8, i8* %91, i64 4, !dbg !61
-  %101 = bitcast i8* %100 to i32*, !dbg !61
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %98, i8 0, i64 20, i1 false), !dbg !61
-  store i32 1, i32* %101, align 4, !dbg !61, !tbaa !57
-  %positional_table124 = alloca i64, align 8, !dbg !61
-  %rubyId_arg125 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !61
-  store i64 %rubyId_arg125, i64* %positional_table124, align 8, !dbg !61
-  %102 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !61
-  %103 = bitcast i64* %positional_table124 to i8*, !dbg !61
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %102, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %103, i64 noundef 8, i1 noundef false) #17, !dbg !61
-  %104 = getelementptr inbounds i8, i8* %91, i64 32, !dbg !61
-  %105 = bitcast i8* %104 to i8**, !dbg !61
-  store i8* %102, i8** %105, align 8, !dbg !61, !tbaa !58
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#fooInt", i8* nonnull %91, %struct.rb_iseq_struct* %stackFrame122, i1 noundef zeroext false) #17, !dbg !61
-  %106 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !61, !tbaa !12
-  %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 5, !dbg !61
-  %108 = load i32, i32* %107, align 8, !dbg !61, !tbaa !37
-  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 6, !dbg !61
-  %110 = load i32, i32* %109, align 4, !dbg !61, !tbaa !41
-  %111 = xor i32 %110, -1, !dbg !61
-  %112 = and i32 %111, %108, !dbg !61
-  %113 = icmp eq i32 %112, 0, !dbg !61
-  br i1 %113, label %fastSymCallIntrinsic_Static_keep_def138, label %114, !dbg !61, !prof !18
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %8, align 8, !dbg !62, !tbaa !14
+  %rubyId_fooInt = load i64, i64* @rubyIdPrecomputed_fooInt, align 8, !dbg !63
+  %rawSym113 = tail call i64 @rb_id2sym(i64 %rubyId_fooInt), !dbg !63
+  %rubyId_normal114 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !63
+  %rawSym115 = tail call i64 @rb_id2sym(i64 %rubyId_normal114), !dbg !63
+  %stackFrame122 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#fooInt", align 8, !dbg !63
+  %91 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !63
+  %92 = bitcast i8* %91 to i16*, !dbg !63
+  %93 = load i16, i16* %92, align 8, !dbg !63
+  %94 = and i16 %93, -384, !dbg !63
+  %95 = or i16 %94, 1, !dbg !63
+  store i16 %95, i16* %92, align 8, !dbg !63
+  %96 = getelementptr inbounds i8, i8* %91, i64 8, !dbg !63
+  %97 = bitcast i8* %96 to i32*, !dbg !63
+  store i32 1, i32* %97, align 8, !dbg !63, !tbaa !56
+  %98 = getelementptr inbounds i8, i8* %91, i64 12, !dbg !63
+  %99 = bitcast i8* %98 to i32*, !dbg !63
+  %100 = getelementptr inbounds i8, i8* %91, i64 4, !dbg !63
+  %101 = bitcast i8* %100 to i32*, !dbg !63
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %98, i8 0, i64 20, i1 false), !dbg !63
+  store i32 1, i32* %101, align 4, !dbg !63, !tbaa !59
+  %positional_table124 = alloca i64, align 8, !dbg !63
+  %rubyId_arg125 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !63
+  store i64 %rubyId_arg125, i64* %positional_table124, align 8, !dbg !63
+  %102 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !63
+  %103 = bitcast i64* %positional_table124 to i8*, !dbg !63
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %102, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %103, i64 noundef 8, i1 noundef false) #17, !dbg !63
+  %104 = getelementptr inbounds i8, i8* %91, i64 32, !dbg !63
+  %105 = bitcast i8* %104 to i8**, !dbg !63
+  store i8* %102, i8** %105, align 8, !dbg !63, !tbaa !60
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#fooInt", i8* nonnull %91, %struct.rb_iseq_struct* %stackFrame122, i1 noundef zeroext false) #17, !dbg !63
+  %106 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !63, !tbaa !14
+  %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 5, !dbg !63
+  %108 = load i32, i32* %107, align 8, !dbg !63, !tbaa !39
+  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 6, !dbg !63
+  %110 = load i32, i32* %109, align 4, !dbg !63, !tbaa !43
+  %111 = xor i32 %110, -1, !dbg !63
+  %112 = and i32 %111, %108, !dbg !63
+  %113 = icmp eq i32 %112, 0, !dbg !63
+  br i1 %113, label %fastSymCallIntrinsic_Static_keep_def138, label %114, !dbg !63, !prof !20
 
 114:                                              ; preds = %fastSymCallIntrinsic_Static_keep_def121
-  %115 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 8, !dbg !61
-  %116 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %115, align 8, !dbg !61, !tbaa !42
-  %117 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %116, i32 noundef 0) #17, !dbg !61
-  br label %fastSymCallIntrinsic_Static_keep_def138, !dbg !61
+  %115 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 8, !dbg !63
+  %116 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %115, align 8, !dbg !63, !tbaa !44
+  %117 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %116, i32 noundef 0) #17, !dbg !63
+  br label %fastSymCallIntrinsic_Static_keep_def138, !dbg !63
 
 afterSend135:                                     ; preds = %183, %fastSymCallIntrinsic_Static_keep_def138
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %8, align 8, !dbg !62, !tbaa !12
-  %118 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !63
-  %119 = load i64*, i64** %118, align 8, !dbg !63
-  store i64 %selfRaw, i64* %119, align 8, !dbg !63, !tbaa !4
-  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !63
-  store i64 5, i64* %120, align 8, !dbg !63, !tbaa !4
-  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !63
-  store i64* %121, i64** %118, align 8, !dbg !63
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooInt, i64 0), !dbg !63
-  %122 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !64
-  %123 = load i64*, i64** %122, align 8, !dbg !64
-  store i64 %selfRaw, i64* %123, align 8, !dbg !64, !tbaa !4
-  %124 = getelementptr inbounds i64, i64* %123, i64 1, !dbg !64
-  store i64 %send, i64* %124, align 8, !dbg !64, !tbaa !4
-  %125 = getelementptr inbounds i64, i64* %124, i64 1, !dbg !64
-  store i64* %125, i64** %122, align 8, !dbg !64
-  %send6 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !64
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %8, align 8, !dbg !64, !tbaa !12
-  %126 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !65
-  %127 = load i64*, i64** %126, align 8, !dbg !65
-  store i64 %selfRaw, i64* %127, align 8, !dbg !65, !tbaa !4
-  %128 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !65
-  store i64 5, i64* %128, align 8, !dbg !65, !tbaa !4
-  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !65
-  store i64* %129, i64** %126, align 8, !dbg !65
-  %send8 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny1, i64 0), !dbg !65
-  %130 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !66
-  %131 = load i64*, i64** %130, align 8, !dbg !66
-  store i64 %selfRaw, i64* %131, align 8, !dbg !66, !tbaa !4
-  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !66
-  store i64 %send8, i64* %132, align 8, !dbg !66, !tbaa !4
-  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !66
-  store i64* %133, i64** %130, align 8, !dbg !66
-  %send10 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !66
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %8, align 8, !dbg !66, !tbaa !12
-  %134 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !67
-  %135 = load i64*, i64** %134, align 8, !dbg !67
-  store i64 %selfRaw, i64* %135, align 8, !dbg !67, !tbaa !4
-  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !67
-  store i64 5, i64* %136, align 8, !dbg !67, !tbaa !4
-  %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !67
-  store i64* %137, i64** %134, align 8, !dbg !67
-  %send12 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny2, i64 0), !dbg !67
-  %138 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !68
-  %139 = load i64*, i64** %138, align 8, !dbg !68
-  store i64 %selfRaw, i64* %139, align 8, !dbg !68, !tbaa !4
-  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !68
-  store i64 %send12, i64* %140, align 8, !dbg !68, !tbaa !4
-  %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !68
-  store i64* %141, i64** %138, align 8, !dbg !68
-  %send14 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !68
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %8, align 8, !dbg !68, !tbaa !12
-  %142 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !69
-  %143 = load i64*, i64** %142, align 8, !dbg !69
-  store i64 %selfRaw, i64* %143, align 8, !dbg !69, !tbaa !4
-  %144 = getelementptr inbounds i64, i64* %143, i64 1, !dbg !69
-  store i64 5, i64* %144, align 8, !dbg !69, !tbaa !4
-  %145 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !69
-  store i64* %145, i64** %142, align 8, !dbg !69
-  %send16 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAll, i64 0), !dbg !69
-  %146 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !70
-  %147 = load i64*, i64** %146, align 8, !dbg !70
-  store i64 %selfRaw, i64* %147, align 8, !dbg !70, !tbaa !4
-  %148 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !70
-  store i64 %send16, i64* %148, align 8, !dbg !70, !tbaa !4
-  %149 = getelementptr inbounds i64, i64* %148, i64 1, !dbg !70
-  store i64* %149, i64** %146, align 8, !dbg !70
-  %send18 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.7, i64 0), !dbg !70
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %8, align 8, !dbg !70, !tbaa !12
-  %callArgs0Addr = getelementptr [4 x i64], [4 x i64]* %callArgs, i32 0, i64 0, !dbg !71
-  store i64 5, i64* %callArgs0Addr, align 8, !dbg !71
-  %150 = getelementptr [4 x i64], [4 x i64]* %callArgs, i64 0, i64 0, !dbg !71
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !72), !dbg !71
-  %151 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %150) #17, !dbg !71
-  %152 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !75
-  %153 = load i64*, i64** %152, align 8, !dbg !75
-  store i64 %selfRaw, i64* %153, align 8, !dbg !75, !tbaa !4
-  %154 = getelementptr inbounds i64, i64* %153, i64 1, !dbg !75
-  store i64 %151, i64* %154, align 8, !dbg !75, !tbaa !4
-  %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !75
-  store i64* %155, i64** %152, align 8, !dbg !75
-  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooArray, i64 0), !dbg !75
-  %156 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !76
-  %157 = load i64*, i64** %156, align 8, !dbg !76
-  store i64 %selfRaw, i64* %157, align 8, !dbg !76, !tbaa !4
-  %158 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !76
-  store i64 %send20, i64* %158, align 8, !dbg !76, !tbaa !4
-  %159 = getelementptr inbounds i64, i64* %158, i64 1, !dbg !76
-  store i64* %159, i64** %156, align 8, !dbg !76
-  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.8, i64 0), !dbg !76
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %8, align 8, !dbg !64, !tbaa !14
+  %118 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !65
+  %119 = load i64*, i64** %118, align 8, !dbg !65
+  store i64 %selfRaw, i64* %119, align 8, !dbg !65, !tbaa !6
+  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !65
+  store i64 5, i64* %120, align 8, !dbg !65, !tbaa !6
+  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !65
+  store i64* %121, i64** %118, align 8, !dbg !65
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooInt, i64 0), !dbg !65
+  %122 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !66
+  %123 = load i64*, i64** %122, align 8, !dbg !66
+  store i64 %selfRaw, i64* %123, align 8, !dbg !66, !tbaa !6
+  %124 = getelementptr inbounds i64, i64* %123, i64 1, !dbg !66
+  store i64 %send, i64* %124, align 8, !dbg !66, !tbaa !6
+  %125 = getelementptr inbounds i64, i64* %124, i64 1, !dbg !66
+  store i64* %125, i64** %122, align 8, !dbg !66
+  %send6 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !66
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %8, align 8, !dbg !66, !tbaa !14
+  %126 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !67
+  %127 = load i64*, i64** %126, align 8, !dbg !67
+  store i64 %selfRaw, i64* %127, align 8, !dbg !67, !tbaa !6
+  %128 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !67
+  store i64 5, i64* %128, align 8, !dbg !67, !tbaa !6
+  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !67
+  store i64* %129, i64** %126, align 8, !dbg !67
+  %send8 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny1, i64 0), !dbg !67
+  %130 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !68
+  %131 = load i64*, i64** %130, align 8, !dbg !68
+  store i64 %selfRaw, i64* %131, align 8, !dbg !68, !tbaa !6
+  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !68
+  store i64 %send8, i64* %132, align 8, !dbg !68, !tbaa !6
+  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !68
+  store i64* %133, i64** %130, align 8, !dbg !68
+  %send10 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !68
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %8, align 8, !dbg !68, !tbaa !14
+  %134 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !69
+  %135 = load i64*, i64** %134, align 8, !dbg !69
+  store i64 %selfRaw, i64* %135, align 8, !dbg !69, !tbaa !6
+  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !69
+  store i64 5, i64* %136, align 8, !dbg !69, !tbaa !6
+  %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !69
+  store i64* %137, i64** %134, align 8, !dbg !69
+  %send12 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny2, i64 0), !dbg !69
+  %138 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !70
+  %139 = load i64*, i64** %138, align 8, !dbg !70
+  store i64 %selfRaw, i64* %139, align 8, !dbg !70, !tbaa !6
+  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !70
+  store i64 %send12, i64* %140, align 8, !dbg !70, !tbaa !6
+  %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !70
+  store i64* %141, i64** %138, align 8, !dbg !70
+  %send14 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !70
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %8, align 8, !dbg !70, !tbaa !14
+  %142 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !71
+  %143 = load i64*, i64** %142, align 8, !dbg !71
+  store i64 %selfRaw, i64* %143, align 8, !dbg !71, !tbaa !6
+  %144 = getelementptr inbounds i64, i64* %143, i64 1, !dbg !71
+  store i64 5, i64* %144, align 8, !dbg !71, !tbaa !6
+  %145 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !71
+  store i64* %145, i64** %142, align 8, !dbg !71
+  %send16 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAll, i64 0), !dbg !71
+  %146 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !72
+  %147 = load i64*, i64** %146, align 8, !dbg !72
+  store i64 %selfRaw, i64* %147, align 8, !dbg !72, !tbaa !6
+  %148 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !72
+  store i64 %send16, i64* %148, align 8, !dbg !72, !tbaa !6
+  %149 = getelementptr inbounds i64, i64* %148, i64 1, !dbg !72
+  store i64* %149, i64** %146, align 8, !dbg !72
+  %send18 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.7, i64 0), !dbg !72
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %8, align 8, !dbg !72, !tbaa !14
+  %callArgs0Addr = getelementptr [4 x i64], [4 x i64]* %callArgs, i32 0, i64 0, !dbg !73
+  store i64 5, i64* %callArgs0Addr, align 8, !dbg !73
+  %150 = getelementptr [4 x i64], [4 x i64]* %callArgs, i64 0, i64 0, !dbg !73
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !74), !dbg !73
+  %151 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %150) #17, !dbg !73
+  %152 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !77
+  %153 = load i64*, i64** %152, align 8, !dbg !77
+  store i64 %selfRaw, i64* %153, align 8, !dbg !77, !tbaa !6
+  %154 = getelementptr inbounds i64, i64* %153, i64 1, !dbg !77
+  store i64 %151, i64* %154, align 8, !dbg !77, !tbaa !6
+  %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !77
+  store i64* %155, i64** %152, align 8, !dbg !77
+  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooArray, i64 0), !dbg !77
+  %156 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !78
+  %157 = load i64*, i64** %156, align 8, !dbg !78
+  store i64 %selfRaw, i64* %157, align 8, !dbg !78, !tbaa !6
+  %158 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !78
+  store i64 %send20, i64* %158, align 8, !dbg !78, !tbaa !6
+  %159 = getelementptr inbounds i64, i64* %158, i64 1, !dbg !78
+  store i64* %159, i64** %156, align 8, !dbg !78
+  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.8, i64 0), !dbg !78
   ret void
 
 fastSymCallIntrinsic_Static_keep_def138:          ; preds = %fastSymCallIntrinsic_Static_keep_def121, %114
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %8, align 8, !dbg !61, !tbaa !12
-  %rubyId_fooArray = load i64, i64* @rubyIdPrecomputed_fooArray, align 8, !dbg !62
-  %rawSym130 = tail call i64 @rb_id2sym(i64 %rubyId_fooArray), !dbg !62
-  %rubyId_normal131 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !62
-  %rawSym132 = tail call i64 @rb_id2sym(i64 %rubyId_normal131), !dbg !62
-  %stackFrame139 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#fooArray", align 8, !dbg !62
-  %160 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !62
-  %161 = bitcast i8* %160 to i16*, !dbg !62
-  %162 = load i16, i16* %161, align 8, !dbg !62
-  %163 = and i16 %162, -384, !dbg !62
-  %164 = or i16 %163, 1, !dbg !62
-  store i16 %164, i16* %161, align 8, !dbg !62
-  %165 = getelementptr inbounds i8, i8* %160, i64 8, !dbg !62
-  %166 = bitcast i8* %165 to i32*, !dbg !62
-  store i32 1, i32* %166, align 8, !dbg !62, !tbaa !54
-  %167 = getelementptr inbounds i8, i8* %160, i64 12, !dbg !62
-  %168 = bitcast i8* %167 to i32*, !dbg !62
-  %169 = getelementptr inbounds i8, i8* %160, i64 4, !dbg !62
-  %170 = bitcast i8* %169 to i32*, !dbg !62
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %167, i8 0, i64 20, i1 false), !dbg !62
-  store i32 1, i32* %170, align 4, !dbg !62, !tbaa !57
-  %positional_table141 = alloca i64, align 8, !dbg !62
-  %rubyId_arg142 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !62
-  store i64 %rubyId_arg142, i64* %positional_table141, align 8, !dbg !62
-  %171 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !62
-  %172 = bitcast i64* %positional_table141 to i8*, !dbg !62
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %171, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %172, i64 noundef 8, i1 noundef false) #17, !dbg !62
-  %173 = getelementptr inbounds i8, i8* %160, i64 32, !dbg !62
-  %174 = bitcast i8* %173 to i8**, !dbg !62
-  store i8* %171, i8** %174, align 8, !dbg !62, !tbaa !58
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#fooArray", i8* nonnull %160, %struct.rb_iseq_struct* %stackFrame139, i1 noundef zeroext false) #17, !dbg !62
-  %175 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !62, !tbaa !12
-  %176 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 5, !dbg !62
-  %177 = load i32, i32* %176, align 8, !dbg !62, !tbaa !37
-  %178 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 6, !dbg !62
-  %179 = load i32, i32* %178, align 4, !dbg !62, !tbaa !41
-  %180 = xor i32 %179, -1, !dbg !62
-  %181 = and i32 %180, %177, !dbg !62
-  %182 = icmp eq i32 %181, 0, !dbg !62
-  br i1 %182, label %afterSend135, label %183, !dbg !62, !prof !18
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %8, align 8, !dbg !63, !tbaa !14
+  %rubyId_fooArray = load i64, i64* @rubyIdPrecomputed_fooArray, align 8, !dbg !64
+  %rawSym130 = tail call i64 @rb_id2sym(i64 %rubyId_fooArray), !dbg !64
+  %rubyId_normal131 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !64
+  %rawSym132 = tail call i64 @rb_id2sym(i64 %rubyId_normal131), !dbg !64
+  %stackFrame139 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#fooArray", align 8, !dbg !64
+  %160 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !64
+  %161 = bitcast i8* %160 to i16*, !dbg !64
+  %162 = load i16, i16* %161, align 8, !dbg !64
+  %163 = and i16 %162, -384, !dbg !64
+  %164 = or i16 %163, 1, !dbg !64
+  store i16 %164, i16* %161, align 8, !dbg !64
+  %165 = getelementptr inbounds i8, i8* %160, i64 8, !dbg !64
+  %166 = bitcast i8* %165 to i32*, !dbg !64
+  store i32 1, i32* %166, align 8, !dbg !64, !tbaa !56
+  %167 = getelementptr inbounds i8, i8* %160, i64 12, !dbg !64
+  %168 = bitcast i8* %167 to i32*, !dbg !64
+  %169 = getelementptr inbounds i8, i8* %160, i64 4, !dbg !64
+  %170 = bitcast i8* %169 to i32*, !dbg !64
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %167, i8 0, i64 20, i1 false), !dbg !64
+  store i32 1, i32* %170, align 4, !dbg !64, !tbaa !59
+  %positional_table141 = alloca i64, align 8, !dbg !64
+  %rubyId_arg142 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !64
+  store i64 %rubyId_arg142, i64* %positional_table141, align 8, !dbg !64
+  %171 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !64
+  %172 = bitcast i64* %positional_table141 to i8*, !dbg !64
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %171, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %172, i64 noundef 8, i1 noundef false) #17, !dbg !64
+  %173 = getelementptr inbounds i8, i8* %160, i64 32, !dbg !64
+  %174 = bitcast i8* %173 to i8**, !dbg !64
+  store i8* %171, i8** %174, align 8, !dbg !64, !tbaa !60
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#fooArray", i8* nonnull %160, %struct.rb_iseq_struct* %stackFrame139, i1 noundef zeroext false) #17, !dbg !64
+  %175 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !64, !tbaa !14
+  %176 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 5, !dbg !64
+  %177 = load i32, i32* %176, align 8, !dbg !64, !tbaa !39
+  %178 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 6, !dbg !64
+  %179 = load i32, i32* %178, align 4, !dbg !64, !tbaa !43
+  %180 = xor i32 %179, -1, !dbg !64
+  %181 = and i32 %180, %177, !dbg !64
+  %182 = icmp eq i32 %181, 0, !dbg !64
+  br i1 %182, label %afterSend135, label %183, !dbg !64, !prof !20
 
 183:                                              ; preds = %fastSymCallIntrinsic_Static_keep_def138
-  %184 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 8, !dbg !62
-  %185 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %184, align 8, !dbg !62, !tbaa !42
-  %186 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %185, i32 noundef 0) #17, !dbg !62
-  br label %afterSend135, !dbg !62
+  %184 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 8, !dbg !64
+  %185 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %184, align 8, !dbg !64, !tbaa !44
+  %186 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %185, i32 noundef 0) #17, !dbg !64
+  br label %afterSend135, !dbg !64
 }
 
 ; Function Attrs: ssp
@@ -919,42 +919,42 @@ entry:
   %"rubyStr_test/testdata/compiler/casts.rb.i41.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %23, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/casts.rb.i41.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i42.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !53
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !53
-  %rubyId_keep_def2.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !59
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.1, i64 %rubyId_keep_def2.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !59
-  %rubyId_keep_def4.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !60
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.2, i64 %rubyId_keep_def4.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !60
-  %rubyId_keep_def6.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !61
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.3, i64 %rubyId_keep_def6.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !61
-  %rubyId_keep_def8.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !62
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def8.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !62
-  %rubyId_fooInt.i = load i64, i64* @rubyIdPrecomputed_fooInt, align 8, !dbg !63
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooInt, i64 %rubyId_fooInt.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !63
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !64
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !64
-  %rubyId_fooAny1.i = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8, !dbg !65
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny1, i64 %rubyId_fooAny1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !65
-  %rubyId_puts15.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !66
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts15.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !66
-  %rubyId_fooAny2.i = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8, !dbg !67
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny2, i64 %rubyId_fooAny2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !67
-  %rubyId_puts20.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !68
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts20.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !68
-  %rubyId_fooAll.i = load i64, i64* @rubyIdPrecomputed_fooAll, align 8, !dbg !69
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAll, i64 %rubyId_fooAll.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !69
-  %rubyId_puts25.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !70
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts25.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !70
-  %rubyId_fooArray.i = load i64, i64* @rubyIdPrecomputed_fooArray, align 8, !dbg !75
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooArray, i64 %rubyId_fooArray.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !75
-  %rubyId_puts30.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !76
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.8, i64 %rubyId_puts30.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !76
-  %25 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !12
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !55
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !55
+  %rubyId_keep_def2.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !61
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.1, i64 %rubyId_keep_def2.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !61
+  %rubyId_keep_def4.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !62
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.2, i64 %rubyId_keep_def4.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !62
+  %rubyId_keep_def6.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !63
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.3, i64 %rubyId_keep_def6.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !63
+  %rubyId_keep_def8.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !64
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def8.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !64
+  %rubyId_fooInt.i = load i64, i64* @rubyIdPrecomputed_fooInt, align 8, !dbg !65
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooInt, i64 %rubyId_fooInt.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !65
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !66
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !66
+  %rubyId_fooAny1.i = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8, !dbg !67
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny1, i64 %rubyId_fooAny1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !67
+  %rubyId_puts15.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !68
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts15.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !68
+  %rubyId_fooAny2.i = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8, !dbg !69
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny2, i64 %rubyId_fooAny2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !69
+  %rubyId_puts20.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !70
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts20.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !70
+  %rubyId_fooAll.i = load i64, i64* @rubyIdPrecomputed_fooAll, align 8, !dbg !71
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAll, i64 %rubyId_fooAll.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !71
+  %rubyId_puts25.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !72
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts25.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !72
+  %rubyId_fooArray.i = load i64, i64* @rubyIdPrecomputed_fooArray, align 8, !dbg !77
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooArray, i64 %rubyId_fooArray.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !77
+  %rubyId_puts30.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !78
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.8, i64 %rubyId_puts30.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !78
+  %25 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %26 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %25, i64 0, i32 18
-  %27 = load i64, i64* %26, align 8, !tbaa !77
-  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %27 = load i64, i64* %26, align 8, !tbaa !79
+  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 2
-  %30 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %29, align 8, !tbaa !48
+  %30 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %29, align 8, !tbaa !50
   call fastcc void @"func_<root>.<static-init>$151"(i64 %27, %struct.rb_control_frame_struct* %30) #17
   ret void
 }
@@ -966,38 +966,38 @@ declare void @llvm.experimental.noalias.scope.decl(metadata) #10
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #11
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#fooAll.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !86 {
+define internal fastcc void @"func_Object#fooAll.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !88 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_Kernel, i64 0, i64 0)) #14, !dbg !88
-  unreachable, !dbg !88
-}
-
-; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#fooAny1.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !89 {
-newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([22 x i8], [22 x i8]* @"str_T.any(Integer, Float)", i64 0, i64 0)) #14, !dbg !90
+  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_Kernel, i64 0, i64 0)) #14, !dbg !90
   unreachable, !dbg !90
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#fooAny2.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !91 {
+define internal fastcc void @"func_Object#fooAny1.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !91 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([22 x i8], [22 x i8]* @"str_T.any(Float, Integer)", i64 0, i64 0)) #14, !dbg !92
+  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([22 x i8], [22 x i8]* @"str_T.any(Integer, Float)", i64 0, i64 0)) #14, !dbg !92
   unreachable, !dbg !92
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#fooInt.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !93 {
+define internal fastcc void @"func_Object#fooAny2.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !93 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #14, !dbg !94
+  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([22 x i8], [22 x i8]* @"str_T.any(Float, Integer)", i64 0, i64 0)) #14, !dbg !94
   unreachable, !dbg !94
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#fooArray.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !95 {
+define internal fastcc void @"func_Object#fooInt.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !95 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @"str_T::Array[Integer]", i64 0, i64 0)) #14, !dbg !96
+  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #14, !dbg !96
   unreachable, !dbg !96
+}
+
+; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
+define internal fastcc void @"func_Object#fooArray.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !97 {
+newFuncRoot:
+  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @"str_T::Array[Integer]", i64 0, i64 0)) #14, !dbg !98
+  unreachable, !dbg !98
 }
 
 attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
@@ -1020,103 +1020,105 @@ attributes #16 = { nounwind willreturn }
 attributes #17 = { nounwind }
 attributes #18 = { nounwind allocsize(0,1) }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/casts.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "Object#fooAll", linkageName: "func_Object#fooAll", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = !DISubroutineType(types: !10)
-!10 = !{!11}
-!11 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!12 = !{!13, !13, i64 0}
-!13 = !{!"any pointer", !6, i64 0}
-!14 = !DILocation(line: 5, column: 1, scope: !8)
-!15 = !{!"branch_weights", i32 4001, i32 4000000}
-!16 = !DILocation(line: 5, column: 12, scope: !8)
-!17 = !DILocation(line: 6, column: 3, scope: !8)
-!18 = !{!"branch_weights", i32 2000, i32 1}
-!19 = distinct !DISubprogram(name: "Object#fooAny1", linkageName: "func_Object#fooAny1", scope: null, file: !2, line: 9, type: !9, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!20 = !DILocation(line: 9, column: 1, scope: !19)
-!21 = !DILocation(line: 9, column: 13, scope: !19)
-!22 = !DILocation(line: 10, column: 3, scope: !19)
-!23 = !{!"branch_weights", i32 1, i32 2000}
-!24 = !{!25, !5, i64 0}
-!25 = !{!"RBasic", !5, i64 0, !5, i64 8}
-!26 = distinct !DISubprogram(name: "Object#fooAny2", linkageName: "func_Object#fooAny2", scope: null, file: !2, line: 13, type: !9, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!27 = !DILocation(line: 13, column: 1, scope: !26)
-!28 = !DILocation(line: 13, column: 13, scope: !26)
-!29 = !DILocation(line: 14, column: 3, scope: !26)
-!30 = distinct !DISubprogram(name: "Object#fooInt", linkageName: "func_Object#fooInt", scope: null, file: !2, line: 17, type: !9, scopeLine: 17, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!31 = !DILocation(line: 17, column: 1, scope: !30)
-!32 = !DILocation(line: 17, column: 12, scope: !30)
-!33 = !DILocation(line: 18, column: 3, scope: !30)
-!34 = !{!35}
-!35 = distinct !{!35, !36, !"sorbet_rb_int_plus: argument 0"}
-!36 = distinct !{!36, !"sorbet_rb_int_plus"}
-!37 = !{!38, !39, i64 40}
-!38 = !{!"rb_execution_context_struct", !13, i64 0, !5, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !39, i64 40, !39, i64 44, !13, i64 48, !13, i64 56, !13, i64 64, !5, i64 72, !5, i64 80, !13, i64 88, !5, i64 96, !13, i64 104, !13, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !40, i64 152}
-!39 = !{!"int", !6, i64 0}
-!40 = !{!"", !13, i64 0, !13, i64 8, !5, i64 16, !6, i64 24}
-!41 = !{!38, !39, i64 44}
-!42 = !{!38, !13, i64 56}
-!43 = distinct !DISubprogram(name: "Object#fooArray", linkageName: "func_Object#fooArray", scope: null, file: !2, line: 21, type: !9, scopeLine: 21, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!44 = !DILocation(line: 21, column: 1, scope: !43)
-!45 = !DILocation(line: 21, column: 14, scope: !43)
-!46 = !DILocation(line: 22, column: 3, scope: !43)
-!47 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!48 = !{!38, !13, i64 16}
-!49 = !{!50, !13, i64 16}
-!50 = !{!"rb_control_frame_struct", !13, i64 0, !13, i64 8, !13, i64 16, !5, i64 24, !13, i64 32, !13, i64 40, !13, i64 48}
-!51 = !{!50, !13, i64 32}
-!52 = !DILocation(line: 0, scope: !47)
-!53 = !DILocation(line: 5, column: 1, scope: !47)
-!54 = !{!55, !39, i64 8}
-!55 = !{!"rb_sorbet_param_struct", !56, i64 0, !39, i64 4, !39, i64 8, !39, i64 12, !39, i64 16, !39, i64 20, !39, i64 24, !39, i64 28, !13, i64 32, !39, i64 40, !39, i64 44, !39, i64 48, !39, i64 52, !13, i64 56}
-!56 = !{!"", !39, i64 0, !39, i64 0, !39, i64 0, !39, i64 0, !39, i64 0, !39, i64 0, !39, i64 0, !39, i64 0, !39, i64 1, !39, i64 1}
-!57 = !{!55, !39, i64 4}
-!58 = !{!55, !13, i64 32}
-!59 = !DILocation(line: 9, column: 1, scope: !47)
-!60 = !DILocation(line: 13, column: 1, scope: !47)
-!61 = !DILocation(line: 17, column: 1, scope: !47)
-!62 = !DILocation(line: 21, column: 1, scope: !47)
-!63 = !DILocation(line: 25, column: 6, scope: !47)
-!64 = !DILocation(line: 25, column: 1, scope: !47)
-!65 = !DILocation(line: 26, column: 6, scope: !47)
-!66 = !DILocation(line: 26, column: 1, scope: !47)
-!67 = !DILocation(line: 27, column: 6, scope: !47)
-!68 = !DILocation(line: 27, column: 1, scope: !47)
-!69 = !DILocation(line: 28, column: 6, scope: !47)
-!70 = !DILocation(line: 28, column: 1, scope: !47)
-!71 = !DILocation(line: 29, column: 15, scope: !47)
-!72 = !{!73}
-!73 = distinct !{!73, !74, !"sorbet_buildArrayIntrinsic: argument 0"}
-!74 = distinct !{!74, !"sorbet_buildArrayIntrinsic"}
-!75 = !DILocation(line: 29, column: 6, scope: !47)
-!76 = !DILocation(line: 29, column: 1, scope: !47)
-!77 = !{!78, !5, i64 400}
-!78 = !{!"rb_vm_struct", !5, i64 0, !79, i64 8, !13, i64 192, !13, i64 200, !13, i64 208, !82, i64 216, !6, i64 224, !80, i64 264, !80, i64 280, !80, i64 296, !80, i64 312, !5, i64 328, !39, i64 336, !39, i64 340, !39, i64 344, !39, i64 344, !39, i64 344, !39, i64 344, !39, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !13, i64 456, !13, i64 464, !83, i64 472, !84, i64 992, !13, i64 1016, !13, i64 1024, !39, i64 1032, !39, i64 1036, !80, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !39, i64 1136, !13, i64 1144, !13, i64 1152, !13, i64 1160, !13, i64 1168, !13, i64 1176, !13, i64 1184, !39, i64 1192, !85, i64 1200, !6, i64 1232}
-!79 = !{!"rb_global_vm_lock_struct", !13, i64 0, !6, i64 8, !80, i64 48, !13, i64 64, !39, i64 72, !6, i64 80, !6, i64 128, !39, i64 176, !39, i64 180}
-!80 = !{!"list_head", !81, i64 0}
-!81 = !{!"list_node", !13, i64 0, !13, i64 8}
-!82 = !{!"long long", !6, i64 0}
-!83 = !{!"", !6, i64 0}
-!84 = !{!"rb_hook_list_struct", !13, i64 0, !39, i64 8, !39, i64 12, !39, i64 16}
-!85 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!86 = distinct !DISubprogram(name: "func_Object#fooAll.cold.1", linkageName: "func_Object#fooAll.cold.1", scope: null, file: !2, type: !87, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!87 = !DISubroutineType(types: !3)
-!88 = !DILocation(line: 6, column: 3, scope: !86)
-!89 = distinct !DISubprogram(name: "func_Object#fooAny1.cold.1", linkageName: "func_Object#fooAny1.cold.1", scope: null, file: !2, type: !87, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!90 = !DILocation(line: 10, column: 3, scope: !89)
-!91 = distinct !DISubprogram(name: "func_Object#fooAny2.cold.1", linkageName: "func_Object#fooAny2.cold.1", scope: null, file: !2, type: !87, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!92 = !DILocation(line: 14, column: 3, scope: !91)
-!93 = distinct !DISubprogram(name: "func_Object#fooInt.cold.1", linkageName: "func_Object#fooInt.cold.1", scope: null, file: !2, type: !87, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!94 = !DILocation(line: 18, column: 3, scope: !93)
-!95 = distinct !DISubprogram(name: "func_Object#fooArray.cold.1", linkageName: "func_Object#fooArray.cold.1", scope: null, file: !2, type: !87, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!96 = !DILocation(line: 22, column: 3, scope: !95)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/casts.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "Object#fooAll", linkageName: "func_Object#fooAll", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!14 = !{!15, !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !DILocation(line: 5, column: 1, scope: !10)
+!17 = !{!"branch_weights", i32 4001, i32 4000000}
+!18 = !DILocation(line: 5, column: 12, scope: !10)
+!19 = !DILocation(line: 6, column: 3, scope: !10)
+!20 = !{!"branch_weights", i32 2000, i32 1}
+!21 = distinct !DISubprogram(name: "Object#fooAny1", linkageName: "func_Object#fooAny1", scope: null, file: !4, line: 9, type: !11, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!22 = !DILocation(line: 9, column: 1, scope: !21)
+!23 = !DILocation(line: 9, column: 13, scope: !21)
+!24 = !DILocation(line: 10, column: 3, scope: !21)
+!25 = !{!"branch_weights", i32 1, i32 2000}
+!26 = !{!27, !7, i64 0}
+!27 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!28 = distinct !DISubprogram(name: "Object#fooAny2", linkageName: "func_Object#fooAny2", scope: null, file: !4, line: 13, type: !11, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!29 = !DILocation(line: 13, column: 1, scope: !28)
+!30 = !DILocation(line: 13, column: 13, scope: !28)
+!31 = !DILocation(line: 14, column: 3, scope: !28)
+!32 = distinct !DISubprogram(name: "Object#fooInt", linkageName: "func_Object#fooInt", scope: null, file: !4, line: 17, type: !11, scopeLine: 17, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!33 = !DILocation(line: 17, column: 1, scope: !32)
+!34 = !DILocation(line: 17, column: 12, scope: !32)
+!35 = !DILocation(line: 18, column: 3, scope: !32)
+!36 = !{!37}
+!37 = distinct !{!37, !38, !"sorbet_rb_int_plus: argument 0"}
+!38 = distinct !{!38, !"sorbet_rb_int_plus"}
+!39 = !{!40, !41, i64 40}
+!40 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !41, i64 40, !41, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !42, i64 152}
+!41 = !{!"int", !8, i64 0}
+!42 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!43 = !{!40, !41, i64 44}
+!44 = !{!40, !15, i64 56}
+!45 = distinct !DISubprogram(name: "Object#fooArray", linkageName: "func_Object#fooArray", scope: null, file: !4, line: 21, type: !11, scopeLine: 21, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!46 = !DILocation(line: 21, column: 1, scope: !45)
+!47 = !DILocation(line: 21, column: 14, scope: !45)
+!48 = !DILocation(line: 22, column: 3, scope: !45)
+!49 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!50 = !{!40, !15, i64 16}
+!51 = !{!52, !15, i64 16}
+!52 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!53 = !{!52, !15, i64 32}
+!54 = !DILocation(line: 0, scope: !49)
+!55 = !DILocation(line: 5, column: 1, scope: !49)
+!56 = !{!57, !41, i64 8}
+!57 = !{!"rb_sorbet_param_struct", !58, i64 0, !41, i64 4, !41, i64 8, !41, i64 12, !41, i64 16, !41, i64 20, !41, i64 24, !41, i64 28, !15, i64 32, !41, i64 40, !41, i64 44, !41, i64 48, !41, i64 52, !15, i64 56}
+!58 = !{!"", !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 1, !41, i64 1}
+!59 = !{!57, !41, i64 4}
+!60 = !{!57, !15, i64 32}
+!61 = !DILocation(line: 9, column: 1, scope: !49)
+!62 = !DILocation(line: 13, column: 1, scope: !49)
+!63 = !DILocation(line: 17, column: 1, scope: !49)
+!64 = !DILocation(line: 21, column: 1, scope: !49)
+!65 = !DILocation(line: 25, column: 6, scope: !49)
+!66 = !DILocation(line: 25, column: 1, scope: !49)
+!67 = !DILocation(line: 26, column: 6, scope: !49)
+!68 = !DILocation(line: 26, column: 1, scope: !49)
+!69 = !DILocation(line: 27, column: 6, scope: !49)
+!70 = !DILocation(line: 27, column: 1, scope: !49)
+!71 = !DILocation(line: 28, column: 6, scope: !49)
+!72 = !DILocation(line: 28, column: 1, scope: !49)
+!73 = !DILocation(line: 29, column: 15, scope: !49)
+!74 = !{!75}
+!75 = distinct !{!75, !76, !"sorbet_buildArrayIntrinsic: argument 0"}
+!76 = distinct !{!76, !"sorbet_buildArrayIntrinsic"}
+!77 = !DILocation(line: 29, column: 6, scope: !49)
+!78 = !DILocation(line: 29, column: 1, scope: !49)
+!79 = !{!80, !7, i64 400}
+!80 = !{!"rb_vm_struct", !7, i64 0, !81, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !84, i64 216, !8, i64 224, !82, i64 264, !82, i64 280, !82, i64 296, !82, i64 312, !7, i64 328, !41, i64 336, !41, i64 340, !41, i64 344, !41, i64 344, !41, i64 344, !41, i64 344, !41, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !85, i64 472, !86, i64 992, !15, i64 1016, !15, i64 1024, !41, i64 1032, !41, i64 1036, !82, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !41, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !41, i64 1192, !87, i64 1200, !8, i64 1232}
+!81 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !82, i64 48, !15, i64 64, !41, i64 72, !8, i64 80, !8, i64 128, !41, i64 176, !41, i64 180}
+!82 = !{!"list_head", !83, i64 0}
+!83 = !{!"list_node", !15, i64 0, !15, i64 8}
+!84 = !{!"long long", !8, i64 0}
+!85 = !{!"", !8, i64 0}
+!86 = !{!"rb_hook_list_struct", !15, i64 0, !41, i64 8, !41, i64 12, !41, i64 16}
+!87 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!88 = distinct !DISubprogram(name: "func_Object#fooAll.cold.1", linkageName: "func_Object#fooAll.cold.1", scope: null, file: !4, type: !89, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!89 = !DISubroutineType(types: !5)
+!90 = !DILocation(line: 6, column: 3, scope: !88)
+!91 = distinct !DISubprogram(name: "func_Object#fooAny1.cold.1", linkageName: "func_Object#fooAny1.cold.1", scope: null, file: !4, type: !89, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!92 = !DILocation(line: 10, column: 3, scope: !91)
+!93 = distinct !DISubprogram(name: "func_Object#fooAny2.cold.1", linkageName: "func_Object#fooAny2.cold.1", scope: null, file: !4, type: !89, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!94 = !DILocation(line: 14, column: 3, scope: !93)
+!95 = distinct !DISubprogram(name: "func_Object#fooInt.cold.1", linkageName: "func_Object#fooInt.cold.1", scope: null, file: !4, type: !89, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!96 = !DILocation(line: 18, column: 3, scope: !95)
+!97 = distinct !DISubprogram(name: "func_Object#fooArray.cold.1", linkageName: "func_Object#fooArray.cold.1", scope: null, file: !4, type: !89, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!98 = !DILocation(line: 22, column: 3, scope: !97)

--- a/test/testdata/compiler/class.llo.exp
+++ b/test/testdata/compiler/class.llo.exp
@@ -125,14 +125,14 @@ declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #7
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #7
   unreachable
 }
@@ -193,88 +193,88 @@ define void @Init_class() local_unnamed_addr #5 {
 entry:
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call fastcc void @sorbet_globalConstructors(i64 %realpath)
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !8
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !10
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !10
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !12
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %3, align 8, !tbaa !14
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %3, align 8, !tbaa !16
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !16
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !18
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame.i) #8
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %8, align 8, !dbg !17, !tbaa !8
-  %9 = tail call i64 @rb_define_module(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0)) #8, !dbg !22
-  %10 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %9) #8, !dbg !22
+  store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %8, align 8, !dbg !19, !tbaa !10
+  %9 = tail call i64 @rb_define_module(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0)) #8, !dbg !24
+  %10 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %9) #8, !dbg !24
   %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.<static-init>", align 8
-  %11 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !8
+  %11 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !10
   %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %11, i64 0, i32 2
-  %13 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %12, align 8, !tbaa !10
+  %13 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %12, align 8, !tbaa !12
   %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %14, align 8, !tbaa !14
+  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %14, align 8, !tbaa !16
   %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 4
-  %16 = load i64*, i64** %15, align 8, !tbaa !16
-  %17 = load i64, i64* %16, align 8, !tbaa !4
+  %16 = load i64*, i64** %15, align 8, !tbaa !18
+  %17 = load i64, i64* %16, align 8, !tbaa !6
   %18 = and i64 %17, -33
-  store i64 %18, i64* %16, align 8, !tbaa !4
+  store i64 %18, i64* %16, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %11, %struct.rb_control_frame_struct* %13, %struct.rb_iseq_struct* %stackFrame.i1.i) #8
   %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 0
-  store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %19, align 8, !dbg !23, !tbaa !8
-  %20 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
-  %21 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !27
-  %needTakeSlowPath = icmp ne i64 %20, %21, !dbg !26
-  br i1 %needTakeSlowPath, label %22, label %23, !dbg !26, !prof !29
+  store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %19, align 8, !dbg !25, !tbaa !10
+  %20 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !28
+  %21 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !28, !tbaa !29
+  %needTakeSlowPath = icmp ne i64 %20, %21, !dbg !28
+  br i1 %needTakeSlowPath, label %22, label %23, !dbg !28, !prof !31
 
 22:                                               ; preds = %entry
-  tail call void @const_recompute_Foo(), !dbg !26
-  br label %23, !dbg !26
+  tail call void @const_recompute_Foo(), !dbg !28
+  br label %23, !dbg !28
 
 23:                                               ; preds = %entry, %22
-  %24 = load i64, i64* @guarded_const_Foo, align 8, !dbg !26
-  %25 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
-  %26 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !27
-  %guardUpdated = icmp eq i64 %25, %26, !dbg !26
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !26
-  %27 = load i64, i64* @rb_cObject, align 8, !dbg !26
-  %28 = tail call i64 @rb_define_class_under(i64 %24, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bar, i64 0, i64 0), i64 %27) #8, !dbg !26
-  %29 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %28) #8, !dbg !26
+  %24 = load i64, i64* @guarded_const_Foo, align 8, !dbg !28
+  %25 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !28
+  %26 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !28, !tbaa !29
+  %guardUpdated = icmp eq i64 %25, %26, !dbg !28
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !28
+  %27 = load i64, i64* @rb_cObject, align 8, !dbg !28
+  %28 = tail call i64 @rb_define_class_under(i64 %24, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bar, i64 0, i64 0), i64 %27) #8, !dbg !28
+  %29 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %28) #8, !dbg !28
   %stackFrame.i.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo::Bar.<static-init>", align 8
-  %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !8
+  %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !10
   %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 2
-  %32 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %31, align 8, !tbaa !10
+  %32 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %31, align 8, !tbaa !12
   %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %33, align 8, !tbaa !14
+  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %33, align 8, !tbaa !16
   %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 4
-  %35 = load i64*, i64** %34, align 8, !tbaa !16
-  %36 = load i64, i64* %35, align 8, !tbaa !4
+  %35 = load i64*, i64** %34, align 8, !tbaa !18
+  %36 = load i64, i64* %35, align 8, !tbaa !6
   %37 = and i64 %36, -33
-  store i64 %37, i64* %35, align 8, !tbaa !4
+  store i64 %37, i64* %35, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %30, %struct.rb_control_frame_struct* %32, %struct.rb_iseq_struct* %stackFrame.i.i.i) #8
   %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 0
-  store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %38, align 8, !dbg !30, !tbaa !8
-  tail call void @sorbet_popFrame() #8, !dbg !26
-  tail call void @sorbet_popFrame() #8, !dbg !22
-  store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !22, !tbaa !8
-  %39 = tail call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Baz, i64 0, i64 0), i64 %27) #8, !dbg !33
-  %40 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %39) #8, !dbg !33
+  store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %38, align 8, !dbg !32, !tbaa !10
+  tail call void @sorbet_popFrame() #8, !dbg !28
+  tail call void @sorbet_popFrame() #8, !dbg !24
+  store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !24, !tbaa !10
+  %39 = tail call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Baz, i64 0, i64 0), i64 %27) #8, !dbg !35
+  %40 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %39) #8, !dbg !35
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Baz.<static-init>", align 8
-  %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !8
+  %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !10
   %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 2
-  %43 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %42, align 8, !tbaa !10
+  %43 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %42, align 8, !tbaa !12
   %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %44, align 8, !tbaa !14
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %44, align 8, !tbaa !16
   %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 4
-  %46 = load i64*, i64** %45, align 8, !tbaa !16
-  %47 = load i64, i64* %46, align 8, !tbaa !4
+  %46 = load i64*, i64** %45, align 8, !tbaa !18
+  %47 = load i64, i64* %46, align 8, !tbaa !6
   %48 = and i64 %47, -33
-  store i64 %48, i64* %46, align 8, !tbaa !4
+  store i64 %48, i64* %46, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %41, %struct.rb_control_frame_struct* %43, %struct.rb_iseq_struct* %stackFrame.i.i) #8
   %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 0
-  store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %49, align 8, !dbg !34, !tbaa !8
-  tail call void @sorbet_popFrame() #8, !dbg !33
+  store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %49, align 8, !dbg !36, !tbaa !10
+  tail call void @sorbet_popFrame() #8, !dbg !35
   ret void
 }
 
@@ -321,7 +321,7 @@ declare void @llvm.assume(i1 noundef) #6
 define linkonce void @const_recompute_Foo() local_unnamed_addr #3 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 3)
   store i64 %1, i64* @guarded_const_Foo, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !27
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !29
   store i64 %2, i64* @guard_epoch_Foo, align 8
   ret void
 }
@@ -336,43 +336,45 @@ attributes #6 = { nofree nosync nounwind willreturn }
 attributes #7 = { noreturn nounwind }
 attributes #8 = { nounwind }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/class.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !{!9, !9, i64 0}
-!9 = !{!"any pointer", !6, i64 0}
-!10 = !{!11, !9, i64 16}
-!11 = !{!"rb_execution_context_struct", !9, i64 0, !5, i64 8, !9, i64 16, !9, i64 24, !9, i64 32, !12, i64 40, !12, i64 44, !9, i64 48, !9, i64 56, !9, i64 64, !5, i64 72, !5, i64 80, !9, i64 88, !5, i64 96, !9, i64 104, !9, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !13, i64 152}
-!12 = !{!"int", !6, i64 0}
-!13 = !{!"", !9, i64 0, !9, i64 8, !5, i64 16, !6, i64 24}
-!14 = !{!15, !9, i64 16}
-!15 = !{!"rb_control_frame_struct", !9, i64 0, !9, i64 8, !9, i64 16, !5, i64 24, !9, i64 32, !9, i64 40, !9, i64 48}
-!16 = !{!15, !9, i64 32}
-!17 = !DILocation(line: 0, scope: !18)
-!18 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !19, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!19 = !DISubroutineType(types: !20)
-!20 = !{!21}
-!21 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!22 = !DILocation(line: 4, column: 1, scope: !18)
-!23 = !DILocation(line: 0, scope: !24, inlinedAt: !25)
-!24 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.<static-init>L61", scope: null, file: !2, line: 4, type: !19, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!25 = distinct !DILocation(line: 4, column: 1, scope: !18)
-!26 = !DILocation(line: 5, column: 3, scope: !24, inlinedAt: !25)
-!27 = !{!28, !28, i64 0}
-!28 = !{!"long long", !6, i64 0}
-!29 = !{!"branch_weights", i32 1, i32 10000}
-!30 = !DILocation(line: 0, scope: !31, inlinedAt: !32)
-!31 = distinct !DISubprogram(name: "Bar.<static-init>", linkageName: "func_Foo::Bar.<static-init>L74", scope: null, file: !2, line: 5, type: !19, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!32 = distinct !DILocation(line: 5, column: 3, scope: !24, inlinedAt: !25)
-!33 = !DILocation(line: 8, column: 1, scope: !18)
-!34 = !DILocation(line: 0, scope: !35, inlinedAt: !36)
-!35 = distinct !DISubprogram(name: "Baz.<static-init>", linkageName: "func_Baz.<static-init>L94", scope: null, file: !2, line: 8, type: !19, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!36 = distinct !DILocation(line: 8, column: 1, scope: !18)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/class.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !{!11, !11, i64 0}
+!11 = !{!"any pointer", !8, i64 0}
+!12 = !{!13, !11, i64 16}
+!13 = !{!"rb_execution_context_struct", !11, i64 0, !7, i64 8, !11, i64 16, !11, i64 24, !11, i64 32, !14, i64 40, !14, i64 44, !11, i64 48, !11, i64 56, !11, i64 64, !7, i64 72, !7, i64 80, !11, i64 88, !7, i64 96, !11, i64 104, !11, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !15, i64 152}
+!14 = !{!"int", !8, i64 0}
+!15 = !{!"", !11, i64 0, !11, i64 8, !7, i64 16, !8, i64 24}
+!16 = !{!17, !11, i64 16}
+!17 = !{!"rb_control_frame_struct", !11, i64 0, !11, i64 8, !11, i64 16, !7, i64 24, !11, i64 32, !11, i64 40, !11, i64 48}
+!18 = !{!17, !11, i64 32}
+!19 = !DILocation(line: 0, scope: !20)
+!20 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !21, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!21 = !DISubroutineType(types: !22)
+!22 = !{!23}
+!23 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!24 = !DILocation(line: 4, column: 1, scope: !20)
+!25 = !DILocation(line: 0, scope: !26, inlinedAt: !27)
+!26 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.<static-init>L61", scope: null, file: !4, line: 4, type: !21, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!27 = distinct !DILocation(line: 4, column: 1, scope: !20)
+!28 = !DILocation(line: 5, column: 3, scope: !26, inlinedAt: !27)
+!29 = !{!30, !30, i64 0}
+!30 = !{!"long long", !8, i64 0}
+!31 = !{!"branch_weights", i32 1, i32 10000}
+!32 = !DILocation(line: 0, scope: !33, inlinedAt: !34)
+!33 = distinct !DISubprogram(name: "Bar.<static-init>", linkageName: "func_Foo::Bar.<static-init>L74", scope: null, file: !4, line: 5, type: !21, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!34 = distinct !DILocation(line: 5, column: 3, scope: !26, inlinedAt: !27)
+!35 = !DILocation(line: 8, column: 1, scope: !20)
+!36 = !DILocation(line: 0, scope: !37, inlinedAt: !38)
+!37 = distinct !DISubprogram(name: "Baz.<static-init>", linkageName: "func_Baz.<static-init>L94", scope: null, file: !4, line: 8, type: !21, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!38 = distinct !DILocation(line: 8, column: 1, scope: !20)

--- a/test/testdata/compiler/classfields.llo.exp
+++ b/test/testdata/compiler/classfields.llo.exp
@@ -180,14 +180,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
   unreachable
 }
@@ -195,7 +195,7 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
 ; Function Attrs: sspreq
 define void @Init_classfields() local_unnamed_addr #5 {
 entry:
-  %positional_table.i.i = alloca i64, align 8, !dbg !8
+  %positional_table.i.i = alloca i64, align 8, !dbg !10
   %locals.i26.i = alloca i64, i32 0, align 8
   %locals.i22.i = alloca i64, i32 0, align 8
   %locals.i18.i = alloca i64, i32 0, align 8
@@ -234,20 +234,20 @@ entry:
   %"rubyStr_test/testdata/compiler/classfields.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
   %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !15
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !15
-  %rubyId_write.i = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !15
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_write, i64 %rubyId_write.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %rubyId_read.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !16
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !16
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_new4.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !18
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new.1, i64 %rubyId_new4.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !18
-  %rubyId_read6.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !18
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.2, i64 %rubyId_read6.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !18
-  %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !17
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
+  %rubyId_write.i = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !17
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_write, i64 %rubyId_write.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
+  %rubyId_read.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !18
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !18
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  %rubyId_new4.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !20
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new.1, i64 %rubyId_new4.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
+  %rubyId_read6.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !20
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.2, i64 %rubyId_read6.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
+  %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
   %13 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
   call void @rb_gc_register_mark_object(i64 %13) #11
   %rubyId_write.i.i = load i64, i64* @rubyIdPrecomputed_write, align 8
@@ -271,329 +271,329 @@ entry:
   %"rubyStr_test/testdata/compiler/classfields.rb.i25.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
   %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i24.i", i64 %"rubyId_<top (required)>.i23.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i25.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i26.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.<static-init>", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !20
-  %rubyId_keep_def12.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def12.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !21
-  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !22
-  %19 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !23
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !22
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !22
+  %rubyId_keep_def12.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !23
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def12.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !23
+  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
+  %19 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !25
   %20 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %19, i64 0, i32 18
-  %21 = load i64, i64* %20, align 8, !tbaa !25
-  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !23
+  %21 = load i64, i64* %20, align 8, !tbaa !27
+  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !25
   %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
-  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !35
+  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !37
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !38
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !40
   %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
-  %27 = load i64*, i64** %26, align 8, !tbaa !40
-  %28 = load i64, i64* %27, align 8, !tbaa !4
+  %27 = load i64*, i64** %26, align 8, !tbaa !42
+  %28 = load i64, i64* %27, align 8, !tbaa !6
   %29 = and i64 %28, -33
-  store i64 %29, i64* %27, align 8, !tbaa !4
+  store i64 %29, i64* %27, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i) #11
   %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !41, !tbaa !23
-  %31 = load i64, i64* @rb_cObject, align 8, !dbg !42
-  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_B, i64 0, i64 0), i64 %31) #11, !dbg !42
-  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #11, !dbg !42
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !43, !tbaa !25
+  %31 = load i64, i64* @rb_cObject, align 8, !dbg !44
+  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_B, i64 0, i64 0), i64 %31) #11, !dbg !44
+  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #11, !dbg !44
   %34 = bitcast i64* %positional_table.i.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %34) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.<static-init>", align 8
-  %35 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !23
+  %35 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !25
   %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %35, i64 0, i32 2
-  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %36, align 8, !tbaa !35
+  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %36, align 8, !tbaa !37
   %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %38, align 8, !tbaa !38
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %38, align 8, !tbaa !40
   %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 4
-  %40 = load i64*, i64** %39, align 8, !tbaa !40
-  %41 = load i64, i64* %40, align 8, !tbaa !4
+  %40 = load i64*, i64** %39, align 8, !tbaa !42
+  %41 = load i64, i64* %40, align 8, !tbaa !6
   %42 = and i64 %41, -33
-  store i64 %42, i64* %40, align 8, !tbaa !4
+  store i64 %42, i64* %40, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %35, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i.i) #11
   %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %43, align 8, !dbg !43, !tbaa !23
-  %rubyId_write.i.i1 = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !8
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_write.i.i1) #11, !dbg !8
-  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !8
-  %rawSym25.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !8
-  %44 = load i64, i64* @guard_epoch_B, align 8, !dbg !8
-  %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !8, !tbaa !44
-  %needTakeSlowPath = icmp ne i64 %44, %45, !dbg !8
-  br i1 %needTakeSlowPath, label %46, label %47, !dbg !8, !prof !45
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %43, align 8, !dbg !45, !tbaa !25
+  %rubyId_write.i.i1 = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !10
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_write.i.i1) #11, !dbg !10
+  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !10
+  %rawSym25.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !10
+  %44 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
+  %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !46
+  %needTakeSlowPath = icmp ne i64 %44, %45, !dbg !10
+  br i1 %needTakeSlowPath, label %46, label %47, !dbg !10, !prof !47
 
 46:                                               ; preds = %entry
-  call void @const_recompute_B(), !dbg !8
-  br label %47, !dbg !8
+  call void @const_recompute_B(), !dbg !10
+  br label %47, !dbg !10
 
 47:                                               ; preds = %entry, %46
-  %48 = load i64, i64* @guarded_const_B, align 8, !dbg !8
-  %49 = load i64, i64* @guard_epoch_B, align 8, !dbg !8
-  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !8, !tbaa !44
-  %guardUpdated = icmp eq i64 %49, %50, !dbg !8
-  call void @llvm.assume(i1 %guardUpdated), !dbg !8
-  %stackFrame26.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#write", align 8, !dbg !8
-  %51 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !8
-  %52 = bitcast i8* %51 to i16*, !dbg !8
-  %53 = load i16, i16* %52, align 8, !dbg !8
-  %54 = and i16 %53, -384, !dbg !8
-  %55 = or i16 %54, 1, !dbg !8
-  store i16 %55, i16* %52, align 8, !dbg !8
-  %56 = getelementptr inbounds i8, i8* %51, i64 8, !dbg !8
-  %57 = bitcast i8* %56 to i32*, !dbg !8
-  store i32 1, i32* %57, align 8, !dbg !8, !tbaa !46
-  %58 = getelementptr inbounds i8, i8* %51, i64 12, !dbg !8
-  %59 = getelementptr inbounds i8, i8* %51, i64 4, !dbg !8
-  %60 = bitcast i8* %59 to i32*, !dbg !8
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %58, i8 0, i64 20, i1 false) #11, !dbg !8
-  store i32 1, i32* %60, align 4, !dbg !8, !tbaa !49
-  %rubyId_a.i.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !8
-  store i64 %rubyId_a.i.i, i64* %positional_table.i.i, align 8, !dbg !8
-  %61 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !8
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %61, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %34, i64 noundef 8, i1 noundef false) #11, !dbg !8
-  %62 = getelementptr inbounds i8, i8* %51, i64 32, !dbg !8
-  %63 = bitcast i8* %62 to i8**, !dbg !8
-  store i8* %61, i8** %63, align 8, !dbg !8, !tbaa !50
-  call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_B#write", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext false) #11, !dbg !8
-  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !8, !tbaa !23
-  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 5, !dbg !8
-  %66 = load i32, i32* %65, align 8, !dbg !8, !tbaa !51
-  %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 6, !dbg !8
-  %68 = load i32, i32* %67, align 4, !dbg !8, !tbaa !52
-  %69 = xor i32 %68, -1, !dbg !8
-  %70 = and i32 %69, %66, !dbg !8
-  %71 = icmp eq i32 %70, 0, !dbg !8
-  br i1 %71, label %fastSymCallIntrinsic_Static_keep_def39.i.i, label %72, !dbg !8, !prof !53
+  %48 = load i64, i64* @guarded_const_B, align 8, !dbg !10
+  %49 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
+  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !46
+  %guardUpdated = icmp eq i64 %49, %50, !dbg !10
+  call void @llvm.assume(i1 %guardUpdated), !dbg !10
+  %stackFrame26.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#write", align 8, !dbg !10
+  %51 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %52 = bitcast i8* %51 to i16*, !dbg !10
+  %53 = load i16, i16* %52, align 8, !dbg !10
+  %54 = and i16 %53, -384, !dbg !10
+  %55 = or i16 %54, 1, !dbg !10
+  store i16 %55, i16* %52, align 8, !dbg !10
+  %56 = getelementptr inbounds i8, i8* %51, i64 8, !dbg !10
+  %57 = bitcast i8* %56 to i32*, !dbg !10
+  store i32 1, i32* %57, align 8, !dbg !10, !tbaa !48
+  %58 = getelementptr inbounds i8, i8* %51, i64 12, !dbg !10
+  %59 = getelementptr inbounds i8, i8* %51, i64 4, !dbg !10
+  %60 = bitcast i8* %59 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %58, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %60, align 4, !dbg !10, !tbaa !51
+  %rubyId_a.i.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !10
+  store i64 %rubyId_a.i.i, i64* %positional_table.i.i, align 8, !dbg !10
+  %61 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %61, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %34, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %62 = getelementptr inbounds i8, i8* %51, i64 32, !dbg !10
+  %63 = bitcast i8* %62 to i8**, !dbg !10
+  store i8* %61, i8** %63, align 8, !dbg !10, !tbaa !52
+  call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_B#write", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext false) #11, !dbg !10
+  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !25
+  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 5, !dbg !10
+  %66 = load i32, i32* %65, align 8, !dbg !10, !tbaa !53
+  %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 6, !dbg !10
+  %68 = load i32, i32* %67, align 4, !dbg !10, !tbaa !54
+  %69 = xor i32 %68, -1, !dbg !10
+  %70 = and i32 %69, %66, !dbg !10
+  %71 = icmp eq i32 %70, 0, !dbg !10
+  br i1 %71, label %fastSymCallIntrinsic_Static_keep_def39.i.i, label %72, !dbg !10, !prof !55
 
 72:                                               ; preds = %47
-  %73 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 8, !dbg !8
-  %74 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %73, align 8, !dbg !8, !tbaa !54
-  %75 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %74, i32 noundef 0) #11, !dbg !8
-  br label %fastSymCallIntrinsic_Static_keep_def39.i.i, !dbg !8
+  %73 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 8, !dbg !10
+  %74 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %73, align 8, !dbg !10, !tbaa !56
+  %75 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %74, i32 noundef 0) #11, !dbg !10
+  br label %fastSymCallIntrinsic_Static_keep_def39.i.i, !dbg !10
 
 fastSymCallIntrinsic_Static_keep_def39.i.i:       ; preds = %72, %47
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %43, align 8, !dbg !8, !tbaa !23
-  %rubyId_read.i.i2 = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !55
-  %rawSym31.i.i = call i64 @rb_id2sym(i64 %rubyId_read.i.i2) #11, !dbg !55
-  %rubyId_normal32.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !55
-  %rawSym33.i.i = call i64 @rb_id2sym(i64 %rubyId_normal32.i.i) #11, !dbg !55
-  %stackFrame40.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#read", align 8, !dbg !55
-  %76 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !55
-  %77 = bitcast i8* %76 to i16*, !dbg !55
-  %78 = load i16, i16* %77, align 8, !dbg !55
-  %79 = and i16 %78, -384, !dbg !55
-  store i16 %79, i16* %77, align 8, !dbg !55
-  %80 = getelementptr inbounds i8, i8* %76, i64 4, !dbg !55
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %80, i8 0, i64 28, i1 false) #11, !dbg !55
-  call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_B#read", i8* nonnull %76, %struct.rb_iseq_struct* %stackFrame40.i.i, i1 noundef zeroext false) #11, !dbg !55
-  %81 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !55, !tbaa !23
-  %82 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 5, !dbg !55
-  %83 = load i32, i32* %82, align 8, !dbg !55, !tbaa !51
-  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 6, !dbg !55
-  %85 = load i32, i32* %84, align 4, !dbg !55, !tbaa !52
-  %86 = xor i32 %85, -1, !dbg !55
-  %87 = and i32 %86, %83, !dbg !55
-  %88 = icmp eq i32 %87, 0, !dbg !55
-  br i1 %88, label %fastSymCallIntrinsic_Static_keep_self_def.i.i, label %89, !dbg !55, !prof !53
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %43, align 8, !dbg !10, !tbaa !25
+  %rubyId_read.i.i2 = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !57
+  %rawSym31.i.i = call i64 @rb_id2sym(i64 %rubyId_read.i.i2) #11, !dbg !57
+  %rubyId_normal32.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !57
+  %rawSym33.i.i = call i64 @rb_id2sym(i64 %rubyId_normal32.i.i) #11, !dbg !57
+  %stackFrame40.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#read", align 8, !dbg !57
+  %76 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !57
+  %77 = bitcast i8* %76 to i16*, !dbg !57
+  %78 = load i16, i16* %77, align 8, !dbg !57
+  %79 = and i16 %78, -384, !dbg !57
+  store i16 %79, i16* %77, align 8, !dbg !57
+  %80 = getelementptr inbounds i8, i8* %76, i64 4, !dbg !57
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %80, i8 0, i64 28, i1 false) #11, !dbg !57
+  call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_B#read", i8* nonnull %76, %struct.rb_iseq_struct* %stackFrame40.i.i, i1 noundef zeroext false) #11, !dbg !57
+  %81 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !57, !tbaa !25
+  %82 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 5, !dbg !57
+  %83 = load i32, i32* %82, align 8, !dbg !57, !tbaa !53
+  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 6, !dbg !57
+  %85 = load i32, i32* %84, align 4, !dbg !57, !tbaa !54
+  %86 = xor i32 %85, -1, !dbg !57
+  %87 = and i32 %86, %83, !dbg !57
+  %88 = icmp eq i32 %87, 0, !dbg !57
+  br i1 %88, label %fastSymCallIntrinsic_Static_keep_self_def.i.i, label %89, !dbg !57, !prof !55
 
 89:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def39.i.i
-  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 8, !dbg !55
-  %91 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %90, align 8, !dbg !55, !tbaa !54
-  %92 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %91, i32 noundef 0) #11, !dbg !55
-  br label %fastSymCallIntrinsic_Static_keep_self_def.i.i, !dbg !55
+  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 8, !dbg !57
+  %91 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %90, align 8, !dbg !57, !tbaa !56
+  %92 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %91, i32 noundef 0) #11, !dbg !57
+  br label %fastSymCallIntrinsic_Static_keep_self_def.i.i, !dbg !57
 
 fastSymCallIntrinsic_Static_keep_self_def.i.i:    ; preds = %89, %fastSymCallIntrinsic_Static_keep_def39.i.i
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %43, align 8, !dbg !55, !tbaa !23
-  %rubyId_read46.i.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !56
-  %rawSym47.i.i = call i64 @rb_id2sym(i64 %rubyId_read46.i.i) #11, !dbg !56
-  %rubyId_normal48.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !56
-  %rawSym49.i.i = call i64 @rb_id2sym(i64 %rubyId_normal48.i.i) #11, !dbg !56
-  %stackFrame53.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.read, align 8, !dbg !56
-  %93 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !56
-  %94 = bitcast i8* %93 to i16*, !dbg !56
-  %95 = load i16, i16* %94, align 8, !dbg !56
-  %96 = and i16 %95, -384, !dbg !56
-  store i16 %96, i16* %94, align 8, !dbg !56
-  %97 = getelementptr inbounds i8, i8* %93, i64 4, !dbg !56
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %97, i8 0, i64 28, i1 false) #11, !dbg !56
-  call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_B.read, i8* nonnull %93, %struct.rb_iseq_struct* %stackFrame53.i.i, i1 noundef zeroext true) #11, !dbg !56
-  %98 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !56, !tbaa !23
-  %99 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 5, !dbg !56
-  %100 = load i32, i32* %99, align 8, !dbg !56, !tbaa !51
-  %101 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 6, !dbg !56
-  %102 = load i32, i32* %101, align 4, !dbg !56, !tbaa !52
-  %103 = xor i32 %102, -1, !dbg !56
-  %104 = and i32 %103, %100, !dbg !56
-  %105 = icmp eq i32 %104, 0, !dbg !56
-  br i1 %105, label %"func_<root>.<static-init>$151.exit", label %106, !dbg !56, !prof !53
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %43, align 8, !dbg !57, !tbaa !25
+  %rubyId_read46.i.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !58
+  %rawSym47.i.i = call i64 @rb_id2sym(i64 %rubyId_read46.i.i) #11, !dbg !58
+  %rubyId_normal48.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !58
+  %rawSym49.i.i = call i64 @rb_id2sym(i64 %rubyId_normal48.i.i) #11, !dbg !58
+  %stackFrame53.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.read, align 8, !dbg !58
+  %93 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !58
+  %94 = bitcast i8* %93 to i16*, !dbg !58
+  %95 = load i16, i16* %94, align 8, !dbg !58
+  %96 = and i16 %95, -384, !dbg !58
+  store i16 %96, i16* %94, align 8, !dbg !58
+  %97 = getelementptr inbounds i8, i8* %93, i64 4, !dbg !58
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %97, i8 0, i64 28, i1 false) #11, !dbg !58
+  call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_B.read, i8* nonnull %93, %struct.rb_iseq_struct* %stackFrame53.i.i, i1 noundef zeroext true) #11, !dbg !58
+  %98 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !58, !tbaa !25
+  %99 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 5, !dbg !58
+  %100 = load i32, i32* %99, align 8, !dbg !58, !tbaa !53
+  %101 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 6, !dbg !58
+  %102 = load i32, i32* %101, align 4, !dbg !58, !tbaa !54
+  %103 = xor i32 %102, -1, !dbg !58
+  %104 = and i32 %103, %100, !dbg !58
+  %105 = icmp eq i32 %104, 0, !dbg !58
+  br i1 %105, label %"func_<root>.<static-init>$151.exit", label %106, !dbg !58, !prof !55
 
 106:                                              ; preds = %fastSymCallIntrinsic_Static_keep_self_def.i.i
-  %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 8, !dbg !56
-  %108 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %107, align 8, !dbg !56, !tbaa !54
-  %109 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %108, i32 noundef 0) #11, !dbg !56
-  br label %"func_<root>.<static-init>$151.exit", !dbg !56
+  %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 8, !dbg !58
+  %108 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %107, align 8, !dbg !58, !tbaa !56
+  %109 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %108, i32 noundef 0) #11, !dbg !58
+  br label %"func_<root>.<static-init>$151.exit", !dbg !58
 
 "func_<root>.<static-init>$151.exit":             ; preds = %fastSymCallIntrinsic_Static_keep_self_def.i.i, %106
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %34) #11
-  call void @sorbet_popFrame() #11, !dbg !42
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %30, align 8, !dbg !42, !tbaa !23
-  %110 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !15
-  %111 = load i64*, i64** %110, align 8, !dbg !15
-  store i64 %48, i64* %111, align 8, !dbg !15, !tbaa !4
-  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !15
-  store i64* %112, i64** %110, align 8, !dbg !15
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !15
-  %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !15
-  %114 = load i64*, i64** %113, align 8, !dbg !15
-  store i64 %send, i64* %114, align 8, !dbg !15, !tbaa !4
-  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !15
-  store i64 3, i64* %115, align 8, !dbg !15, !tbaa !4
-  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !15
-  store i64* %116, i64** %113, align 8, !dbg !15
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !15
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %30, align 8, !dbg !15, !tbaa !23
-  %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !16
-  %118 = load i64*, i64** %117, align 8, !dbg !16
-  store i64 %48, i64* %118, align 8, !dbg !16, !tbaa !4
-  %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !16
-  store i64* %119, i64** %117, align 8, !dbg !16
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !16
-  %120 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !17
-  %121 = load i64*, i64** %120, align 8, !dbg !17
-  store i64 %21, i64* %121, align 8, !dbg !17, !tbaa !4
-  %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !17
-  store i64 %send6, i64* %122, align 8, !dbg !17, !tbaa !4
-  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !17
-  store i64* %123, i64** %120, align 8, !dbg !17
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %30, align 8, !dbg !17, !tbaa !23
-  %124 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !18
-  %125 = load i64*, i64** %124, align 8, !dbg !18
-  store i64 %48, i64* %125, align 8, !dbg !18, !tbaa !4
-  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !18
-  store i64* %126, i64** %124, align 8, !dbg !18
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new.1, i64 0), !dbg !18
-  %127 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !18
-  %128 = load i64*, i64** %127, align 8, !dbg !18
-  store i64 %send10, i64* %128, align 8, !dbg !18, !tbaa !4
-  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !18
-  store i64* %129, i64** %127, align 8, !dbg !18
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.2, i64 0), !dbg !18
-  %130 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !19
-  %131 = load i64*, i64** %130, align 8, !dbg !19
-  store i64 %21, i64* %131, align 8, !dbg !19, !tbaa !4
-  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !19
-  store i64 %send12, i64* %132, align 8, !dbg !19, !tbaa !4
-  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !19
-  store i64* %133, i64** %130, align 8, !dbg !19
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !19
+  call void @sorbet_popFrame() #11, !dbg !44
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %30, align 8, !dbg !44, !tbaa !25
+  %110 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !17
+  %111 = load i64*, i64** %110, align 8, !dbg !17
+  store i64 %48, i64* %111, align 8, !dbg !17, !tbaa !6
+  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !17
+  store i64* %112, i64** %110, align 8, !dbg !17
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !17
+  %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !17
+  %114 = load i64*, i64** %113, align 8, !dbg !17
+  store i64 %send, i64* %114, align 8, !dbg !17, !tbaa !6
+  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !17
+  store i64 3, i64* %115, align 8, !dbg !17, !tbaa !6
+  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !17
+  store i64* %116, i64** %113, align 8, !dbg !17
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !17
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %30, align 8, !dbg !17, !tbaa !25
+  %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !18
+  %118 = load i64*, i64** %117, align 8, !dbg !18
+  store i64 %48, i64* %118, align 8, !dbg !18, !tbaa !6
+  %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !18
+  store i64* %119, i64** %117, align 8, !dbg !18
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
+  %120 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !19
+  %121 = load i64*, i64** %120, align 8, !dbg !19
+  store i64 %21, i64* %121, align 8, !dbg !19, !tbaa !6
+  %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !19
+  store i64 %send6, i64* %122, align 8, !dbg !19, !tbaa !6
+  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !19
+  store i64* %123, i64** %120, align 8, !dbg !19
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %30, align 8, !dbg !19, !tbaa !25
+  %124 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !20
+  %125 = load i64*, i64** %124, align 8, !dbg !20
+  store i64 %48, i64* %125, align 8, !dbg !20, !tbaa !6
+  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !20
+  store i64* %126, i64** %124, align 8, !dbg !20
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new.1, i64 0), !dbg !20
+  %127 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !20
+  %128 = load i64*, i64** %127, align 8, !dbg !20
+  store i64 %send10, i64* %128, align 8, !dbg !20, !tbaa !6
+  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !20
+  store i64* %129, i64** %127, align 8, !dbg !20
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.2, i64 0), !dbg !20
+  %130 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !21
+  %131 = load i64*, i64** %130, align 8, !dbg !21
+  store i64 %21, i64* %131, align 8, !dbg !21, !tbaa !6
+  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !21
+  store i64 %send12, i64* %132, align 8, !dbg !21, !tbaa !6
+  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !21
+  store i64* %133, i64** %130, align 8, !dbg !21
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !21
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_B#write"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !57 {
+define i64 @"func_B#write"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !59 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !23
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !58
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !58
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !58
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !58, !prof !59
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !25
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !60
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !60
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !60
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !60, !prof !61
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !58
-  unreachable, !dbg !58
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !60
+  unreachable, !dbg !60
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !58
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !60, !tbaa !23
-  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !61
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !61, !tbaa !44
-  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !61
-  br i1 %needTakeSlowPath, label %3, label %4, !dbg !61, !prof !45
+  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !60
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !62, !tbaa !25
+  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !63
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !63, !tbaa !46
+  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !63
+  br i1 %needTakeSlowPath, label %3, label %4, !dbg !63, !prof !47
 
 3:                                                ; preds = %fillRequiredArgs
-  tail call void @const_recompute_B(), !dbg !61
-  br label %4, !dbg !61
+  tail call void @const_recompute_B(), !dbg !63
+  br label %4, !dbg !63
 
 4:                                                ; preds = %fillRequiredArgs, %3
-  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !61
-  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !61
-  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !61, !tbaa !44
-  %guardUpdated = icmp eq i64 %6, %7, !dbg !61
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !61
-  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !61
-  tail call void @rb_cvar_set(i64 %5, i64 %"rubyId_@@f", i64 %rawArg_a) #11, !dbg !61
-  %"rubyId_@@f7" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !62
-  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f7") #11, !dbg !62
+  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !63
+  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !63
+  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !63, !tbaa !46
+  %guardUpdated = icmp eq i64 %6, %7, !dbg !63
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !63
+  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !63
+  tail call void @rb_cvar_set(i64 %5, i64 %"rubyId_@@f", i64 %rawArg_a) #11, !dbg !63
+  %"rubyId_@@f7" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !64
+  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f7") #11, !dbg !64
   ret i64 %8
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_B#read"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !63 {
+define i64 @"func_B#read"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !65 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !tbaa !23
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !64
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !64, !prof !65
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !tbaa !25
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !66
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !66, !prof !67
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !64
-  unreachable, !dbg !64
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !66
+  unreachable, !dbg !66
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !66, !tbaa !23
-  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !67
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !44
-  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !67
-  br i1 %needTakeSlowPath, label %3, label %4, !dbg !67, !prof !45
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !68, !tbaa !25
+  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !69
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !69, !tbaa !46
+  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !69
+  br i1 %needTakeSlowPath, label %3, label %4, !dbg !69, !prof !47
 
 3:                                                ; preds = %fillRequiredArgs
-  tail call void @const_recompute_B(), !dbg !67
-  br label %4, !dbg !67
+  tail call void @const_recompute_B(), !dbg !69
+  br label %4, !dbg !69
 
 4:                                                ; preds = %fillRequiredArgs, %3
-  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !67
-  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !67
-  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !44
-  %guardUpdated = icmp eq i64 %6, %7, !dbg !67
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !67
-  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !67
-  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !67
+  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !69
+  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !69
+  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !69, !tbaa !46
+  %guardUpdated = icmp eq i64 %6, %7, !dbg !69
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !69
+  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !69
+  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !69
   ret i64 %8
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @func_B.read(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !68 {
+define i64 @func_B.read(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !70 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %0, align 8, !tbaa !23
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !69
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !69, !prof !65
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %0, align 8, !tbaa !25
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !71
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !71, !prof !67
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !69
-  unreachable, !dbg !69
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !71
+  unreachable, !dbg !71
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %0, align 8, !dbg !70, !tbaa !23
-  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !71
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !71, !tbaa !44
-  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !71
-  br i1 %needTakeSlowPath, label %3, label %4, !dbg !71, !prof !45
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %0, align 8, !dbg !72, !tbaa !25
+  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !73
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !73, !tbaa !46
+  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !73
+  br i1 %needTakeSlowPath, label %3, label %4, !dbg !73, !prof !47
 
 3:                                                ; preds = %fillRequiredArgs
-  tail call void @const_recompute_B(), !dbg !71
-  br label %4, !dbg !71
+  tail call void @const_recompute_B(), !dbg !73
+  br label %4, !dbg !73
 
 4:                                                ; preds = %fillRequiredArgs, %3
-  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !71
-  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !71
-  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !71, !tbaa !44
-  %guardUpdated = icmp eq i64 %6, %7, !dbg !71
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !71
-  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !71
-  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !71
+  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !73
+  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !73
+  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !73, !tbaa !46
+  %guardUpdated = icmp eq i64 %6, %7, !dbg !73
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !73
+  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !73
+  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !73
   ret i64 %8
 }
 
@@ -613,7 +613,7 @@ declare void @llvm.assume(i1 noundef) #8
 define linkonce void @const_recompute_B() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_B, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_B, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !46
   store i64 %2, i64* @guard_epoch_B, align 8
   ret void
 }
@@ -633,78 +633,80 @@ attributes #11 = { nounwind }
 attributes #12 = { nounwind allocsize(0,1) }
 attributes #13 = { noreturn }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/classfields.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 7, column: 3, scope: !9, inlinedAt: !13)
-!9 = distinct !DISubprogram(name: "B.<static-init>", linkageName: "func_B.<static-init>L62", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = distinct !DILocation(line: 5, column: 1, scope: !14)
-!14 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!15 = !DILocation(line: 25, column: 1, scope: !14)
-!16 = !DILocation(line: 27, column: 6, scope: !14)
-!17 = !DILocation(line: 27, column: 1, scope: !14)
-!18 = !DILocation(line: 28, column: 6, scope: !14)
-!19 = !DILocation(line: 28, column: 1, scope: !14)
-!20 = !DILocation(line: 7, column: 3, scope: !9)
-!21 = !DILocation(line: 16, column: 3, scope: !9)
-!22 = !DILocation(line: 19, column: 3, scope: !9)
-!23 = !{!24, !24, i64 0}
-!24 = !{!"any pointer", !6, i64 0}
-!25 = !{!26, !5, i64 400}
-!26 = !{!"rb_vm_struct", !5, i64 0, !27, i64 8, !24, i64 192, !24, i64 200, !24, i64 208, !31, i64 216, !6, i64 224, !28, i64 264, !28, i64 280, !28, i64 296, !28, i64 312, !5, i64 328, !30, i64 336, !30, i64 340, !30, i64 344, !30, i64 344, !30, i64 344, !30, i64 344, !30, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !24, i64 456, !24, i64 464, !32, i64 472, !33, i64 992, !24, i64 1016, !24, i64 1024, !30, i64 1032, !30, i64 1036, !28, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !30, i64 1136, !24, i64 1144, !24, i64 1152, !24, i64 1160, !24, i64 1168, !24, i64 1176, !24, i64 1184, !30, i64 1192, !34, i64 1200, !6, i64 1232}
-!27 = !{!"rb_global_vm_lock_struct", !24, i64 0, !6, i64 8, !28, i64 48, !24, i64 64, !30, i64 72, !6, i64 80, !6, i64 128, !30, i64 176, !30, i64 180}
-!28 = !{!"list_head", !29, i64 0}
-!29 = !{!"list_node", !24, i64 0, !24, i64 8}
-!30 = !{!"int", !6, i64 0}
-!31 = !{!"long long", !6, i64 0}
-!32 = !{!"", !6, i64 0}
-!33 = !{!"rb_hook_list_struct", !24, i64 0, !30, i64 8, !30, i64 12, !30, i64 16}
-!34 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!35 = !{!36, !24, i64 16}
-!36 = !{!"rb_execution_context_struct", !24, i64 0, !5, i64 8, !24, i64 16, !24, i64 24, !24, i64 32, !30, i64 40, !30, i64 44, !24, i64 48, !24, i64 56, !24, i64 64, !5, i64 72, !5, i64 80, !24, i64 88, !5, i64 96, !24, i64 104, !24, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !37, i64 152}
-!37 = !{!"", !24, i64 0, !24, i64 8, !5, i64 16, !6, i64 24}
-!38 = !{!39, !24, i64 16}
-!39 = !{!"rb_control_frame_struct", !24, i64 0, !24, i64 8, !24, i64 16, !5, i64 24, !24, i64 32, !24, i64 40, !24, i64 48}
-!40 = !{!39, !24, i64 32}
-!41 = !DILocation(line: 0, scope: !14)
-!42 = !DILocation(line: 5, column: 1, scope: !14)
-!43 = !DILocation(line: 0, scope: !9, inlinedAt: !13)
-!44 = !{!31, !31, i64 0}
-!45 = !{!"branch_weights", i32 1, i32 10000}
-!46 = !{!47, !30, i64 8}
-!47 = !{!"rb_sorbet_param_struct", !48, i64 0, !30, i64 4, !30, i64 8, !30, i64 12, !30, i64 16, !30, i64 20, !30, i64 24, !30, i64 28, !24, i64 32, !30, i64 40, !30, i64 44, !30, i64 48, !30, i64 52, !24, i64 56}
-!48 = !{!"", !30, i64 0, !30, i64 0, !30, i64 0, !30, i64 0, !30, i64 0, !30, i64 0, !30, i64 0, !30, i64 0, !30, i64 1, !30, i64 1}
-!49 = !{!47, !30, i64 4}
-!50 = !{!47, !24, i64 32}
-!51 = !{!36, !30, i64 40}
-!52 = !{!36, !30, i64 44}
-!53 = !{!"branch_weights", i32 2000, i32 1}
-!54 = !{!36, !24, i64 56}
-!55 = !DILocation(line: 16, column: 3, scope: !9, inlinedAt: !13)
-!56 = !DILocation(line: 19, column: 3, scope: !9, inlinedAt: !13)
-!57 = distinct !DISubprogram(name: "B#write", linkageName: "func_B#write", scope: null, file: !2, line: 7, type: !10, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!58 = !DILocation(line: 7, column: 3, scope: !57)
-!59 = !{!"branch_weights", i32 4001, i32 4000000}
-!60 = !DILocation(line: 7, column: 13, scope: !57)
-!61 = !DILocation(line: 8, column: 11, scope: !57)
-!62 = !DILocation(line: 8, column: 5, scope: !57)
-!63 = distinct !DISubprogram(name: "B#read", linkageName: "func_B#read", scope: null, file: !2, line: 16, type: !10, scopeLine: 16, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!64 = !DILocation(line: 16, column: 3, scope: !63)
-!65 = !{!"branch_weights", i32 1, i32 2000}
-!66 = !DILocation(line: 0, scope: !63)
-!67 = !DILocation(line: 17, column: 5, scope: !63)
-!68 = distinct !DISubprogram(name: "B.read", linkageName: "func_B.read", scope: null, file: !2, line: 19, type: !10, scopeLine: 19, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!69 = !DILocation(line: 19, column: 3, scope: !68)
-!70 = !DILocation(line: 0, scope: !68)
-!71 = !DILocation(line: 20, column: 5, scope: !68)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/classfields.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 7, column: 3, scope: !11, inlinedAt: !15)
+!11 = distinct !DISubprogram(name: "B.<static-init>", linkageName: "func_B.<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = distinct !DILocation(line: 5, column: 1, scope: !16)
+!16 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!17 = !DILocation(line: 25, column: 1, scope: !16)
+!18 = !DILocation(line: 27, column: 6, scope: !16)
+!19 = !DILocation(line: 27, column: 1, scope: !16)
+!20 = !DILocation(line: 28, column: 6, scope: !16)
+!21 = !DILocation(line: 28, column: 1, scope: !16)
+!22 = !DILocation(line: 7, column: 3, scope: !11)
+!23 = !DILocation(line: 16, column: 3, scope: !11)
+!24 = !DILocation(line: 19, column: 3, scope: !11)
+!25 = !{!26, !26, i64 0}
+!26 = !{!"any pointer", !8, i64 0}
+!27 = !{!28, !7, i64 400}
+!28 = !{!"rb_vm_struct", !7, i64 0, !29, i64 8, !26, i64 192, !26, i64 200, !26, i64 208, !33, i64 216, !8, i64 224, !30, i64 264, !30, i64 280, !30, i64 296, !30, i64 312, !7, i64 328, !32, i64 336, !32, i64 340, !32, i64 344, !32, i64 344, !32, i64 344, !32, i64 344, !32, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !26, i64 456, !26, i64 464, !34, i64 472, !35, i64 992, !26, i64 1016, !26, i64 1024, !32, i64 1032, !32, i64 1036, !30, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !32, i64 1136, !26, i64 1144, !26, i64 1152, !26, i64 1160, !26, i64 1168, !26, i64 1176, !26, i64 1184, !32, i64 1192, !36, i64 1200, !8, i64 1232}
+!29 = !{!"rb_global_vm_lock_struct", !26, i64 0, !8, i64 8, !30, i64 48, !26, i64 64, !32, i64 72, !8, i64 80, !8, i64 128, !32, i64 176, !32, i64 180}
+!30 = !{!"list_head", !31, i64 0}
+!31 = !{!"list_node", !26, i64 0, !26, i64 8}
+!32 = !{!"int", !8, i64 0}
+!33 = !{!"long long", !8, i64 0}
+!34 = !{!"", !8, i64 0}
+!35 = !{!"rb_hook_list_struct", !26, i64 0, !32, i64 8, !32, i64 12, !32, i64 16}
+!36 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!37 = !{!38, !26, i64 16}
+!38 = !{!"rb_execution_context_struct", !26, i64 0, !7, i64 8, !26, i64 16, !26, i64 24, !26, i64 32, !32, i64 40, !32, i64 44, !26, i64 48, !26, i64 56, !26, i64 64, !7, i64 72, !7, i64 80, !26, i64 88, !7, i64 96, !26, i64 104, !26, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !39, i64 152}
+!39 = !{!"", !26, i64 0, !26, i64 8, !7, i64 16, !8, i64 24}
+!40 = !{!41, !26, i64 16}
+!41 = !{!"rb_control_frame_struct", !26, i64 0, !26, i64 8, !26, i64 16, !7, i64 24, !26, i64 32, !26, i64 40, !26, i64 48}
+!42 = !{!41, !26, i64 32}
+!43 = !DILocation(line: 0, scope: !16)
+!44 = !DILocation(line: 5, column: 1, scope: !16)
+!45 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
+!46 = !{!33, !33, i64 0}
+!47 = !{!"branch_weights", i32 1, i32 10000}
+!48 = !{!49, !32, i64 8}
+!49 = !{!"rb_sorbet_param_struct", !50, i64 0, !32, i64 4, !32, i64 8, !32, i64 12, !32, i64 16, !32, i64 20, !32, i64 24, !32, i64 28, !26, i64 32, !32, i64 40, !32, i64 44, !32, i64 48, !32, i64 52, !26, i64 56}
+!50 = !{!"", !32, i64 0, !32, i64 0, !32, i64 0, !32, i64 0, !32, i64 0, !32, i64 0, !32, i64 0, !32, i64 0, !32, i64 1, !32, i64 1}
+!51 = !{!49, !32, i64 4}
+!52 = !{!49, !26, i64 32}
+!53 = !{!38, !32, i64 40}
+!54 = !{!38, !32, i64 44}
+!55 = !{!"branch_weights", i32 2000, i32 1}
+!56 = !{!38, !26, i64 56}
+!57 = !DILocation(line: 16, column: 3, scope: !11, inlinedAt: !15)
+!58 = !DILocation(line: 19, column: 3, scope: !11, inlinedAt: !15)
+!59 = distinct !DISubprogram(name: "B#write", linkageName: "func_B#write", scope: null, file: !4, line: 7, type: !12, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!60 = !DILocation(line: 7, column: 3, scope: !59)
+!61 = !{!"branch_weights", i32 4001, i32 4000000}
+!62 = !DILocation(line: 7, column: 13, scope: !59)
+!63 = !DILocation(line: 8, column: 11, scope: !59)
+!64 = !DILocation(line: 8, column: 5, scope: !59)
+!65 = distinct !DISubprogram(name: "B#read", linkageName: "func_B#read", scope: null, file: !4, line: 16, type: !12, scopeLine: 16, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!66 = !DILocation(line: 16, column: 3, scope: !65)
+!67 = !{!"branch_weights", i32 1, i32 2000}
+!68 = !DILocation(line: 0, scope: !65)
+!69 = !DILocation(line: 17, column: 5, scope: !65)
+!70 = distinct !DISubprogram(name: "B.read", linkageName: "func_B.read", scope: null, file: !4, line: 19, type: !12, scopeLine: 19, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!71 = !DILocation(line: 19, column: 3, scope: !70)
+!72 = !DILocation(line: 0, scope: !70)
+!73 = !DILocation(line: 20, column: 5, scope: !70)

--- a/test/testdata/compiler/constant_cache.llo.exp
+++ b/test/testdata/compiler/constant_cache.llo.exp
@@ -154,82 +154,82 @@ declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #4 !dbg !8 {
+define i64 @"func_Object#foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #4 !dbg !10 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !14
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !14, !prof !15
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !16
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !16, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #10, !dbg !14
-  unreachable, !dbg !14
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #10, !dbg !16
+  unreachable, !dbg !16
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !16, !tbaa !12
-  %1 = load i64, i64* @guard_epoch_A, align 8, !dbg !17
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !17, !tbaa !18
-  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !17
-  br i1 %needTakeSlowPath, label %3, label %4, !dbg !17, !prof !20
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !18, !tbaa !14
+  %1 = load i64, i64* @guard_epoch_A, align 8, !dbg !19
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !19, !tbaa !20
+  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !19
+  br i1 %needTakeSlowPath, label %3, label %4, !dbg !19, !prof !22
 
 3:                                                ; preds = %fillRequiredArgs
-  tail call void @const_recompute_A(), !dbg !17
-  br label %4, !dbg !17
+  tail call void @const_recompute_A(), !dbg !19
+  br label %4, !dbg !19
 
 4:                                                ; preds = %fillRequiredArgs, %3
-  %5 = load i64, i64* @guarded_const_A, align 8, !dbg !17
-  %6 = load i64, i64* @guard_epoch_A, align 8, !dbg !17
-  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !17, !tbaa !18
-  %guardUpdated = icmp eq i64 %6, %7, !dbg !17
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !17
-  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !17
-  %9 = load i64*, i64** %8, align 8, !dbg !17
-  store i64 %selfRaw, i64* %9, align 8, !dbg !17, !tbaa !4
-  %10 = getelementptr inbounds i64, i64* %9, i64 1, !dbg !17
-  store i64 %5, i64* %10, align 8, !dbg !17, !tbaa !4
-  %11 = getelementptr inbounds i64, i64* %10, i64 1, !dbg !17
-  store i64* %11, i64** %8, align 8, !dbg !17
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !17, !tbaa !12
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !21
-  %13 = load i64*, i64** %12, align 8, !dbg !21
-  store i64 %selfRaw, i64* %13, align 8, !dbg !21, !tbaa !4
-  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !21
-  store i64 %5, i64* %14, align 8, !dbg !21, !tbaa !4
-  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !21
-  store i64* %15, i64** %12, align 8, !dbg !21
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !21
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !21, !tbaa !12
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !22
-  %17 = load i64*, i64** %16, align 8, !dbg !22
-  store i64 %selfRaw, i64* %17, align 8, !dbg !22, !tbaa !4
-  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !22
-  store i64 %5, i64* %18, align 8, !dbg !22, !tbaa !4
-  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !22
-  store i64* %19, i64** %16, align 8, !dbg !22
-  %send44 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !22
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !22, !tbaa !12
-  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !23
-  %21 = load i64*, i64** %20, align 8, !dbg !23
-  store i64 %selfRaw, i64* %21, align 8, !dbg !23, !tbaa !4
-  %22 = getelementptr inbounds i64, i64* %21, i64 1, !dbg !23
-  store i64 %5, i64* %22, align 8, !dbg !23, !tbaa !4
-  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !23
-  store i64* %23, i64** %20, align 8, !dbg !23
-  %send46 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !23
+  %5 = load i64, i64* @guarded_const_A, align 8, !dbg !19
+  %6 = load i64, i64* @guard_epoch_A, align 8, !dbg !19
+  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !19, !tbaa !20
+  %guardUpdated = icmp eq i64 %6, %7, !dbg !19
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !19
+  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !19
+  %9 = load i64*, i64** %8, align 8, !dbg !19
+  store i64 %selfRaw, i64* %9, align 8, !dbg !19, !tbaa !6
+  %10 = getelementptr inbounds i64, i64* %9, i64 1, !dbg !19
+  store i64 %5, i64* %10, align 8, !dbg !19, !tbaa !6
+  %11 = getelementptr inbounds i64, i64* %10, i64 1, !dbg !19
+  store i64* %11, i64** %8, align 8, !dbg !19
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !19, !tbaa !14
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !23
+  %13 = load i64*, i64** %12, align 8, !dbg !23
+  store i64 %selfRaw, i64* %13, align 8, !dbg !23, !tbaa !6
+  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !23
+  store i64 %5, i64* %14, align 8, !dbg !23, !tbaa !6
+  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !23
+  store i64* %15, i64** %12, align 8, !dbg !23
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !23
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !23, !tbaa !14
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !24
+  %17 = load i64*, i64** %16, align 8, !dbg !24
+  store i64 %selfRaw, i64* %17, align 8, !dbg !24, !tbaa !6
+  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !24
+  store i64 %5, i64* %18, align 8, !dbg !24, !tbaa !6
+  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !24
+  store i64* %19, i64** %16, align 8, !dbg !24
+  %send44 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !24
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !24, !tbaa !14
+  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !25
+  %21 = load i64*, i64** %20, align 8, !dbg !25
+  store i64 %selfRaw, i64* %21, align 8, !dbg !25, !tbaa !6
+  %22 = getelementptr inbounds i64, i64* %21, i64 1, !dbg !25
+  store i64 %5, i64* %22, align 8, !dbg !25, !tbaa !6
+  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !25
+  store i64* %23, i64** %20, align 8, !dbg !25
+  %send46 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !25
   ret i64 %send46
 }
 
@@ -262,14 +262,14 @@ entry:
   %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
   %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#foo", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_puts1.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  %rubyId_puts4.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts4.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
-  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  %rubyId_puts1.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
+  %rubyId_puts4.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts4.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
+  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
   %8 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
   call void @rb_gc_register_mark_object(i64 %8) #11
   store i64 %8, i64* @"rubyStrFrozen_<top (required)>", align 8
@@ -277,88 +277,88 @@ entry:
   %"rubyStr_test/testdata/compiler/constant_cache.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
   %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %8, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i14.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !26
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !26
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !26
+  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !28
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !28
   %"rubyId_<top (required)>.i15.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i16.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/constant_cache.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
   %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i16.i", i64 %"rubyId_<top (required)>.i15.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.<static-init>", align 8
-  %11 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !12
+  %11 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %12 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %11, i64 0, i32 18
-  %13 = load i64, i64* %12, align 8, !tbaa !27
-  %14 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %13 = load i64, i64* %12, align 8, !tbaa !29
+  %14 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %15 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 2
-  %16 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %15, align 8, !tbaa !36
+  %16 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %15, align 8, !tbaa !38
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %17, align 8, !tbaa !39
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %17, align 8, !tbaa !41
   %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 4
-  %19 = load i64*, i64** %18, align 8, !tbaa !41
-  %20 = load i64, i64* %19, align 8, !tbaa !4
+  %19 = load i64*, i64** %18, align 8, !tbaa !43
+  %20 = load i64, i64* %19, align 8, !tbaa !6
   %21 = and i64 %20, -33
-  store i64 %21, i64* %19, align 8, !tbaa !4
+  store i64 %21, i64* %19, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %14, %struct.rb_control_frame_struct* %16, %struct.rb_iseq_struct* %stackFrame.i) #11
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %22, align 8, !dbg !42, !tbaa !12
-  %23 = load i64, i64* @rb_cObject, align 8, !dbg !43
-  %24 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %23) #11, !dbg !43
-  %25 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %24) #11, !dbg !43
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %22, align 8, !dbg !44, !tbaa !14
+  %23 = load i64, i64* @rb_cObject, align 8, !dbg !45
+  %24 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %23) #11, !dbg !45
+  %25 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %24) #11, !dbg !45
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.<static-init>", align 8
-  %26 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %26 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %26, i64 0, i32 2
-  %28 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %27, align 8, !tbaa !36
+  %28 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %27, align 8, !tbaa !38
   %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %28, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %29, align 8, !tbaa !39
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %29, align 8, !tbaa !41
   %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %28, i64 0, i32 4
-  %31 = load i64*, i64** %30, align 8, !tbaa !41
-  %32 = load i64, i64* %31, align 8, !tbaa !4
+  %31 = load i64*, i64** %30, align 8, !tbaa !43
+  %32 = load i64, i64* %31, align 8, !tbaa !6
   %33 = and i64 %32, -33
-  store i64 %33, i64* %31, align 8, !tbaa !4
+  store i64 %33, i64* %31, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %26, %struct.rb_control_frame_struct* %28, %struct.rb_iseq_struct* %stackFrame.i.i) #11
   %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %34, align 8, !dbg !44, !tbaa !12
-  call void @sorbet_popFrame() #11, !dbg !43
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %22, align 8, !dbg !43, !tbaa !12
-  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !24
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #11, !dbg !24
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !24
-  %rawSym18.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #11, !dbg !24
-  %stackFrame22.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#foo", align 8, !dbg !24
-  %35 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !24
-  %36 = bitcast i8* %35 to i16*, !dbg !24
-  %37 = load i16, i16* %36, align 8, !dbg !24
-  %38 = and i16 %37, -384, !dbg !24
-  store i16 %38, i16* %36, align 8, !dbg !24
-  %39 = getelementptr inbounds i8, i8* %35, i64 4, !dbg !24
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %39, i8 0, i64 28, i1 false) #11, !dbg !24
-  call void @sorbet_vm_define_method(i64 %23, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#foo", i8* nonnull %35, %struct.rb_iseq_struct* %stackFrame22.i, i1 noundef zeroext false) #11, !dbg !24
-  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !12
-  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 5, !dbg !24
-  %42 = load i32, i32* %41, align 8, !dbg !24, !tbaa !47
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 6, !dbg !24
-  %44 = load i32, i32* %43, align 4, !dbg !24, !tbaa !48
-  %45 = xor i32 %44, -1, !dbg !24
-  %46 = and i32 %45, %42, !dbg !24
-  %47 = icmp eq i32 %46, 0, !dbg !24
-  br i1 %47, label %"func_<root>.<static-init>$151.exit", label %48, !dbg !24, !prof !49
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %34, align 8, !dbg !46, !tbaa !14
+  call void @sorbet_popFrame() #11, !dbg !45
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %22, align 8, !dbg !45, !tbaa !14
+  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !26
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #11, !dbg !26
+  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !26
+  %rawSym18.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #11, !dbg !26
+  %stackFrame22.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#foo", align 8, !dbg !26
+  %35 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !26
+  %36 = bitcast i8* %35 to i16*, !dbg !26
+  %37 = load i16, i16* %36, align 8, !dbg !26
+  %38 = and i16 %37, -384, !dbg !26
+  store i16 %38, i16* %36, align 8, !dbg !26
+  %39 = getelementptr inbounds i8, i8* %35, i64 4, !dbg !26
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %39, i8 0, i64 28, i1 false) #11, !dbg !26
+  call void @sorbet_vm_define_method(i64 %23, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#foo", i8* nonnull %35, %struct.rb_iseq_struct* %stackFrame22.i, i1 noundef zeroext false) #11, !dbg !26
+  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !14
+  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 5, !dbg !26
+  %42 = load i32, i32* %41, align 8, !dbg !26, !tbaa !49
+  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 6, !dbg !26
+  %44 = load i32, i32* %43, align 4, !dbg !26, !tbaa !50
+  %45 = xor i32 %44, -1, !dbg !26
+  %46 = and i32 %45, %42, !dbg !26
+  %47 = icmp eq i32 %46, 0, !dbg !26
+  br i1 %47, label %"func_<root>.<static-init>$151.exit", label %48, !dbg !26, !prof !51
 
 48:                                               ; preds = %entry
-  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 8, !dbg !24
-  %50 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %49, align 8, !dbg !24, !tbaa !50
-  %51 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %50, i32 noundef 0) #11, !dbg !24
-  br label %"func_<root>.<static-init>$151.exit", !dbg !24
+  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 8, !dbg !26
+  %50 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %49, align 8, !dbg !26, !tbaa !52
+  %51 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %50, i32 noundef 0) #11, !dbg !26
+  br label %"func_<root>.<static-init>$151.exit", !dbg !26
 
 "func_<root>.<static-init>$151.exit":             ; preds = %entry, %48
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %22, align 8, !dbg !24, !tbaa !12
-  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 1, !dbg !26
-  %53 = load i64*, i64** %52, align 8, !dbg !26
-  store i64 %13, i64* %53, align 8, !dbg !26, !tbaa !4
-  %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !26
-  store i64* %54, i64** %52, align 8, !dbg !26
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !26
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %22, align 8, !dbg !26, !tbaa !14
+  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 1, !dbg !28
+  %53 = load i64*, i64** %52, align 8, !dbg !28
+  store i64 %13, i64* %53, align 8, !dbg !28, !tbaa !6
+  %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !28
+  store i64* %54, i64** %52, align 8, !dbg !28
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !28
   ret void
 }
 
@@ -372,7 +372,7 @@ declare void @llvm.assume(i1 noundef) #7
 define linkonce void @const_recompute_A() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !18
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !20
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -391,57 +391,59 @@ attributes #10 = { noreturn }
 attributes #11 = { nounwind }
 attributes #12 = { nounwind allocsize(0,1) }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/constant_cache.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "Object#foo", linkageName: "func_Object#foo", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = !DISubroutineType(types: !10)
-!10 = !{!11}
-!11 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!12 = !{!13, !13, i64 0}
-!13 = !{!"any pointer", !6, i64 0}
-!14 = !DILocation(line: 5, column: 1, scope: !8)
-!15 = !{!"branch_weights", i32 1, i32 2000}
-!16 = !DILocation(line: 0, scope: !8)
-!17 = !DILocation(line: 6, column: 3, scope: !8)
-!18 = !{!19, !19, i64 0}
-!19 = !{!"long long", !6, i64 0}
-!20 = !{!"branch_weights", i32 1, i32 10000}
-!21 = !DILocation(line: 7, column: 3, scope: !8)
-!22 = !DILocation(line: 8, column: 3, scope: !8)
-!23 = !DILocation(line: 9, column: 3, scope: !8)
-!24 = !DILocation(line: 5, column: 1, scope: !25)
-!25 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !9, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!26 = !DILocation(line: 12, column: 1, scope: !25)
-!27 = !{!28, !5, i64 400}
-!28 = !{!"rb_vm_struct", !5, i64 0, !29, i64 8, !13, i64 192, !13, i64 200, !13, i64 208, !19, i64 216, !6, i64 224, !30, i64 264, !30, i64 280, !30, i64 296, !30, i64 312, !5, i64 328, !32, i64 336, !32, i64 340, !32, i64 344, !32, i64 344, !32, i64 344, !32, i64 344, !32, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !13, i64 456, !13, i64 464, !33, i64 472, !34, i64 992, !13, i64 1016, !13, i64 1024, !32, i64 1032, !32, i64 1036, !30, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !32, i64 1136, !13, i64 1144, !13, i64 1152, !13, i64 1160, !13, i64 1168, !13, i64 1176, !13, i64 1184, !32, i64 1192, !35, i64 1200, !6, i64 1232}
-!29 = !{!"rb_global_vm_lock_struct", !13, i64 0, !6, i64 8, !30, i64 48, !13, i64 64, !32, i64 72, !6, i64 80, !6, i64 128, !32, i64 176, !32, i64 180}
-!30 = !{!"list_head", !31, i64 0}
-!31 = !{!"list_node", !13, i64 0, !13, i64 8}
-!32 = !{!"int", !6, i64 0}
-!33 = !{!"", !6, i64 0}
-!34 = !{!"rb_hook_list_struct", !13, i64 0, !32, i64 8, !32, i64 12, !32, i64 16}
-!35 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!36 = !{!37, !13, i64 16}
-!37 = !{!"rb_execution_context_struct", !13, i64 0, !5, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !32, i64 40, !32, i64 44, !13, i64 48, !13, i64 56, !13, i64 64, !5, i64 72, !5, i64 80, !13, i64 88, !5, i64 96, !13, i64 104, !13, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !38, i64 152}
-!38 = !{!"", !13, i64 0, !13, i64 8, !5, i64 16, !6, i64 24}
-!39 = !{!40, !13, i64 16}
-!40 = !{!"rb_control_frame_struct", !13, i64 0, !13, i64 8, !13, i64 16, !5, i64 24, !13, i64 32, !13, i64 40, !13, i64 48}
-!41 = !{!40, !13, i64 32}
-!42 = !DILocation(line: 0, scope: !25)
-!43 = !DILocation(line: 4, column: 1, scope: !25)
-!44 = !DILocation(line: 0, scope: !45, inlinedAt: !46)
-!45 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L61", scope: null, file: !2, line: 4, type: !9, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!46 = distinct !DILocation(line: 4, column: 1, scope: !25)
-!47 = !{!37, !32, i64 40}
-!48 = !{!37, !32, i64 44}
-!49 = !{!"branch_weights", i32 2000, i32 1}
-!50 = !{!37, !13, i64 56}
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/constant_cache.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "Object#foo", linkageName: "func_Object#foo", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!14 = !{!15, !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !DILocation(line: 5, column: 1, scope: !10)
+!17 = !{!"branch_weights", i32 1, i32 2000}
+!18 = !DILocation(line: 0, scope: !10)
+!19 = !DILocation(line: 6, column: 3, scope: !10)
+!20 = !{!21, !21, i64 0}
+!21 = !{!"long long", !8, i64 0}
+!22 = !{!"branch_weights", i32 1, i32 10000}
+!23 = !DILocation(line: 7, column: 3, scope: !10)
+!24 = !DILocation(line: 8, column: 3, scope: !10)
+!25 = !DILocation(line: 9, column: 3, scope: !10)
+!26 = !DILocation(line: 5, column: 1, scope: !27)
+!27 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!28 = !DILocation(line: 12, column: 1, scope: !27)
+!29 = !{!30, !7, i64 400}
+!30 = !{!"rb_vm_struct", !7, i64 0, !31, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !21, i64 216, !8, i64 224, !32, i64 264, !32, i64 280, !32, i64 296, !32, i64 312, !7, i64 328, !34, i64 336, !34, i64 340, !34, i64 344, !34, i64 344, !34, i64 344, !34, i64 344, !34, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !35, i64 472, !36, i64 992, !15, i64 1016, !15, i64 1024, !34, i64 1032, !34, i64 1036, !32, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !34, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !34, i64 1192, !37, i64 1200, !8, i64 1232}
+!31 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !32, i64 48, !15, i64 64, !34, i64 72, !8, i64 80, !8, i64 128, !34, i64 176, !34, i64 180}
+!32 = !{!"list_head", !33, i64 0}
+!33 = !{!"list_node", !15, i64 0, !15, i64 8}
+!34 = !{!"int", !8, i64 0}
+!35 = !{!"", !8, i64 0}
+!36 = !{!"rb_hook_list_struct", !15, i64 0, !34, i64 8, !34, i64 12, !34, i64 16}
+!37 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!38 = !{!39, !15, i64 16}
+!39 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !34, i64 40, !34, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !40, i64 152}
+!40 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!41 = !{!42, !15, i64 16}
+!42 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!43 = !{!42, !15, i64 32}
+!44 = !DILocation(line: 0, scope: !27)
+!45 = !DILocation(line: 4, column: 1, scope: !27)
+!46 = !DILocation(line: 0, scope: !47, inlinedAt: !48)
+!47 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L61", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!48 = distinct !DILocation(line: 4, column: 1, scope: !27)
+!49 = !{!39, !34, i64 40}
+!50 = !{!39, !34, i64 44}
+!51 = !{!"branch_weights", i32 2000, i32 1}
+!52 = !{!39, !15, i64 56}

--- a/test/testdata/compiler/custom_plus.llo.exp
+++ b/test/testdata/compiler/custom_plus.llo.exp
@@ -177,233 +177,233 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#delegate"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !8 {
+define i64 @"func_Object#delegate"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !10 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !14
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !14
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !14
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !14, !prof !15
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !16
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !16
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !16
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !16, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #10, !dbg !14
-  unreachable, !dbg !14
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #10, !dbg !16
+  unreachable, !dbg !16
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !14
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %0, align 8, !dbg !16, !tbaa !12
-  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !17
-  %2 = load i64*, i64** %1, align 8, !dbg !17
-  store i64 %rawArg_a, i64* %2, align 8, !dbg !17, !tbaa !4
-  %3 = getelementptr inbounds i64, i64* %2, i64 1, !dbg !17
-  store i64 3, i64* %3, align 8, !dbg !17, !tbaa !4
-  %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !17
-  store i64* %4, i64** %1, align 8, !dbg !17
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !17
-  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !17
-  %6 = load i64*, i64** %5, align 8, !dbg !17
-  store i64 %send, i64* %6, align 8, !dbg !17, !tbaa !4
-  %7 = getelementptr inbounds i64, i64* %6, i64 1, !dbg !17
-  store i64 %rawArg_a, i64* %7, align 8, !dbg !17, !tbaa !4
-  %8 = getelementptr inbounds i64, i64* %7, i64 1, !dbg !17
-  store i64* %8, i64** %5, align 8, !dbg !17
-  %send44 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_==", i64 0), !dbg !17
-  %9 = and i64 %send44, -9, !dbg !17
-  %10 = icmp ne i64 %9, 0, !dbg !17
-  %.sink = select i1 %10, i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 16), i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 18), !dbg !17
-  %rubyStrFrozen_fail.sink = select i1 %10, i64* @rubyStrFrozen_ok, i64* @rubyStrFrozen_fail, !dbg !17
-  %ic_puts.1.sink = select i1 %10, %struct.FunctionInlineCache* @ic_puts, %struct.FunctionInlineCache* @ic_puts.1, !dbg !17
-  store i64* %.sink, i64** %0, align 8, !tbaa !12
-  %rubyStr_fail = load i64, i64* %rubyStrFrozen_fail.sink, align 8, !dbg !18
-  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !18
-  %12 = load i64*, i64** %11, align 8, !dbg !18
-  store i64 %selfRaw, i64* %12, align 8, !dbg !18, !tbaa !4
-  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !18
-  store i64 %rubyStr_fail, i64* %13, align 8, !dbg !18, !tbaa !4
-  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !18
-  store i64* %14, i64** %11, align 8, !dbg !18
-  %send46 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* %ic_puts.1.sink, i64 0), !dbg !18
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %0, align 8, !tbaa !12
+  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !16
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %0, align 8, !dbg !18, !tbaa !14
+  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !19
+  %2 = load i64*, i64** %1, align 8, !dbg !19
+  store i64 %rawArg_a, i64* %2, align 8, !dbg !19, !tbaa !6
+  %3 = getelementptr inbounds i64, i64* %2, i64 1, !dbg !19
+  store i64 3, i64* %3, align 8, !dbg !19, !tbaa !6
+  %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !19
+  store i64* %4, i64** %1, align 8, !dbg !19
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !19
+  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !19
+  %6 = load i64*, i64** %5, align 8, !dbg !19
+  store i64 %send, i64* %6, align 8, !dbg !19, !tbaa !6
+  %7 = getelementptr inbounds i64, i64* %6, i64 1, !dbg !19
+  store i64 %rawArg_a, i64* %7, align 8, !dbg !19, !tbaa !6
+  %8 = getelementptr inbounds i64, i64* %7, i64 1, !dbg !19
+  store i64* %8, i64** %5, align 8, !dbg !19
+  %send44 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_==", i64 0), !dbg !19
+  %9 = and i64 %send44, -9, !dbg !19
+  %10 = icmp ne i64 %9, 0, !dbg !19
+  %.sink = select i1 %10, i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 16), i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 18), !dbg !19
+  %rubyStrFrozen_fail.sink = select i1 %10, i64* @rubyStrFrozen_ok, i64* @rubyStrFrozen_fail, !dbg !19
+  %ic_puts.1.sink = select i1 %10, %struct.FunctionInlineCache* @ic_puts, %struct.FunctionInlineCache* @ic_puts.1, !dbg !19
+  store i64* %.sink, i64** %0, align 8, !tbaa !14
+  %rubyStr_fail = load i64, i64* %rubyStrFrozen_fail.sink, align 8, !dbg !20
+  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !20
+  %12 = load i64*, i64** %11, align 8, !dbg !20
+  store i64 %selfRaw, i64* %12, align 8, !dbg !20, !tbaa !6
+  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !20
+  store i64 %rubyStr_fail, i64* %13, align 8, !dbg !20, !tbaa !6
+  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !20
+  store i64* %14, i64** %11, align 8, !dbg !20
+  %send46 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* %ic_puts.1.sink, i64 0), !dbg !20
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %0, align 8, !tbaa !14
   ret i64 %send46
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_<root>.<static-init>$151"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #5 !dbg !19 {
+define internal fastcc void @"func_<root>.<static-init>$151"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #5 !dbg !21 {
 functionEntryInitializers:
-  %positional_table.i = alloca i64, align 8, !dbg !20
+  %positional_table.i = alloca i64, align 8, !dbg !22
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !23
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !25
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !27
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !29
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !29
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !31
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #11
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !30, !tbaa !12
-  %9 = load i64, i64* @rb_cObject, align 8, !dbg !31
-  %10 = tail call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %9) #11, !dbg !31
-  %11 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %10) #11, !dbg !31
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !32, !tbaa !14
+  %9 = load i64, i64* @rb_cObject, align 8, !dbg !33
+  %10 = tail call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %9) #11, !dbg !33
+  %11 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %10) #11, !dbg !33
   %12 = bitcast i64* %positional_table.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %12)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.<static-init>", align 8
-  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 2
-  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !23
+  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !25
   %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !27
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !29
   %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 4
-  %18 = load i64*, i64** %17, align 8, !tbaa !29
-  %19 = load i64, i64* %18, align 8, !tbaa !4
+  %18 = load i64*, i64** %17, align 8, !tbaa !31
+  %19 = load i64, i64* %18, align 8, !tbaa !6
   %20 = and i64 %19, -33
-  store i64 %20, i64* %18, align 8, !tbaa !4
+  store i64 %20, i64* %18, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #11
   %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %21, align 8, !dbg !32, !tbaa !12
-  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !20
-  %rawSym.i = tail call i64 @rb_id2sym(i64 %"rubyId_+.i") #11, !dbg !20
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !20
-  %rawSym7.i = tail call i64 @rb_id2sym(i64 %rubyId_normal.i) #11, !dbg !20
-  %22 = load i64, i64* @guard_epoch_A, align 8, !dbg !20
-  %23 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !20, !tbaa !33
-  %needTakeSlowPath = icmp ne i64 %22, %23, !dbg !20
-  br i1 %needTakeSlowPath, label %24, label %25, !dbg !20, !prof !35
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %21, align 8, !dbg !34, !tbaa !14
+  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !22
+  %rawSym.i = tail call i64 @rb_id2sym(i64 %"rubyId_+.i") #11, !dbg !22
+  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !22
+  %rawSym7.i = tail call i64 @rb_id2sym(i64 %rubyId_normal.i) #11, !dbg !22
+  %22 = load i64, i64* @guard_epoch_A, align 8, !dbg !22
+  %23 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !35
+  %needTakeSlowPath = icmp ne i64 %22, %23, !dbg !22
+  br i1 %needTakeSlowPath, label %24, label %25, !dbg !22, !prof !37
 
 24:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_A(), !dbg !20
-  br label %25, !dbg !20
+  tail call void @const_recompute_A(), !dbg !22
+  br label %25, !dbg !22
 
 25:                                               ; preds = %functionEntryInitializers, %24
-  %26 = load i64, i64* @guarded_const_A, align 8, !dbg !20
-  %27 = load i64, i64* @guard_epoch_A, align 8, !dbg !20
-  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !20, !tbaa !33
-  %guardUpdated = icmp eq i64 %27, %28, !dbg !20
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !20
-  %stackFrame8.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#+", align 8, !dbg !20
-  %29 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !20
-  %30 = bitcast i8* %29 to i16*, !dbg !20
-  %31 = load i16, i16* %30, align 8, !dbg !20
-  %32 = and i16 %31, -384, !dbg !20
-  %33 = or i16 %32, 1, !dbg !20
-  store i16 %33, i16* %30, align 8, !dbg !20
-  %34 = getelementptr inbounds i8, i8* %29, i64 8, !dbg !20
-  %35 = bitcast i8* %34 to i32*, !dbg !20
-  store i32 1, i32* %35, align 8, !dbg !20, !tbaa !36
-  %36 = getelementptr inbounds i8, i8* %29, i64 12, !dbg !20
-  %37 = getelementptr inbounds i8, i8* %29, i64 4, !dbg !20
-  %38 = bitcast i8* %37 to i32*, !dbg !20
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %36, i8 0, i64 20, i1 false) #11, !dbg !20
-  store i32 1, i32* %38, align 4, !dbg !20, !tbaa !39
-  %rubyId_b.i = load i64, i64* @rubyIdPrecomputed_b, align 8, !dbg !20
-  store i64 %rubyId_b.i, i64* %positional_table.i, align 8, !dbg !20
-  %39 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !20
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %39, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %12, i64 noundef 8, i1 noundef false) #11, !dbg !20
-  %40 = getelementptr inbounds i8, i8* %29, i64 32, !dbg !20
-  %41 = bitcast i8* %40 to i8**, !dbg !20
-  store i8* %39, i8** %41, align 8, !dbg !20, !tbaa !40
-  tail call void @sorbet_vm_define_method(i64 %26, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#+", i8* nonnull %29, %struct.rb_iseq_struct* %stackFrame8.i, i1 noundef zeroext false) #11, !dbg !20
-  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !20, !tbaa !12
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 5, !dbg !20
-  %44 = load i32, i32* %43, align 8, !dbg !20, !tbaa !41
-  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 6, !dbg !20
-  %46 = load i32, i32* %45, align 4, !dbg !20, !tbaa !42
-  %47 = xor i32 %46, -1, !dbg !20
-  %48 = and i32 %47, %44, !dbg !20
-  %49 = icmp eq i32 %48, 0, !dbg !20
-  br i1 %49, label %fastSymCallIntrinsic_Static_keep_def, label %50, !dbg !20, !prof !43
+  %26 = load i64, i64* @guarded_const_A, align 8, !dbg !22
+  %27 = load i64, i64* @guard_epoch_A, align 8, !dbg !22
+  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !35
+  %guardUpdated = icmp eq i64 %27, %28, !dbg !22
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !22
+  %stackFrame8.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#+", align 8, !dbg !22
+  %29 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !22
+  %30 = bitcast i8* %29 to i16*, !dbg !22
+  %31 = load i16, i16* %30, align 8, !dbg !22
+  %32 = and i16 %31, -384, !dbg !22
+  %33 = or i16 %32, 1, !dbg !22
+  store i16 %33, i16* %30, align 8, !dbg !22
+  %34 = getelementptr inbounds i8, i8* %29, i64 8, !dbg !22
+  %35 = bitcast i8* %34 to i32*, !dbg !22
+  store i32 1, i32* %35, align 8, !dbg !22, !tbaa !38
+  %36 = getelementptr inbounds i8, i8* %29, i64 12, !dbg !22
+  %37 = getelementptr inbounds i8, i8* %29, i64 4, !dbg !22
+  %38 = bitcast i8* %37 to i32*, !dbg !22
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %36, i8 0, i64 20, i1 false) #11, !dbg !22
+  store i32 1, i32* %38, align 4, !dbg !22, !tbaa !41
+  %rubyId_b.i = load i64, i64* @rubyIdPrecomputed_b, align 8, !dbg !22
+  store i64 %rubyId_b.i, i64* %positional_table.i, align 8, !dbg !22
+  %39 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !22
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %39, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %12, i64 noundef 8, i1 noundef false) #11, !dbg !22
+  %40 = getelementptr inbounds i8, i8* %29, i64 32, !dbg !22
+  %41 = bitcast i8* %40 to i8**, !dbg !22
+  store i8* %39, i8** %41, align 8, !dbg !22, !tbaa !42
+  tail call void @sorbet_vm_define_method(i64 %26, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#+", i8* nonnull %29, %struct.rb_iseq_struct* %stackFrame8.i, i1 noundef zeroext false) #11, !dbg !22
+  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !22, !tbaa !14
+  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 5, !dbg !22
+  %44 = load i32, i32* %43, align 8, !dbg !22, !tbaa !43
+  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 6, !dbg !22
+  %46 = load i32, i32* %45, align 4, !dbg !22, !tbaa !44
+  %47 = xor i32 %46, -1, !dbg !22
+  %48 = and i32 %47, %44, !dbg !22
+  %49 = icmp eq i32 %48, 0, !dbg !22
+  br i1 %49, label %fastSymCallIntrinsic_Static_keep_def, label %50, !dbg !22, !prof !45
 
 50:                                               ; preds = %25
-  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 8, !dbg !20
-  %52 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %51, align 8, !dbg !20, !tbaa !44
-  %53 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %52, i32 noundef 0) #11, !dbg !20
-  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !20
+  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 8, !dbg !22
+  %52 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %51, align 8, !dbg !22, !tbaa !46
+  %53 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %52, i32 noundef 0) #11, !dbg !22
+  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !22
 
 afterSend27:                                      ; preds = %84, %fastSymCallIntrinsic_Static_keep_def
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %8, align 8, !dbg !45, !tbaa !12
-  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !46
-  %55 = load i64*, i64** %54, align 8, !dbg !46
-  store i64 %selfRaw, i64* %55, align 8, !dbg !46, !tbaa !4
-  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !46
-  store i64 %send2, i64* %56, align 8, !dbg !46, !tbaa !4
-  %57 = getelementptr inbounds i64, i64* %56, i64 1, !dbg !46
-  store i64* %57, i64** %54, align 8, !dbg !46
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_delegate, i64 0), !dbg !46
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %8, align 8, !dbg !47, !tbaa !14
+  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !48
+  %55 = load i64*, i64** %54, align 8, !dbg !48
+  store i64 %selfRaw, i64* %55, align 8, !dbg !48, !tbaa !6
+  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !48
+  store i64 %send2, i64* %56, align 8, !dbg !48, !tbaa !6
+  %57 = getelementptr inbounds i64, i64* %56, i64 1, !dbg !48
+  store i64* %57, i64** %54, align 8, !dbg !48
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_delegate, i64 0), !dbg !48
   ret void
 
 fastSymCallIntrinsic_Static_keep_def:             ; preds = %50, %25
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %12)
-  tail call void @sorbet_popFrame() #11, !dbg !31
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !31, !tbaa !12
-  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !47
-  %59 = load i64*, i64** %58, align 8, !dbg !47
-  store i64 %26, i64* %59, align 8, !dbg !47, !tbaa !4
-  %60 = getelementptr inbounds i64, i64* %59, i64 1, !dbg !47
-  store i64* %60, i64** %58, align 8, !dbg !47
-  %send2 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !47
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !47, !tbaa !12
-  %rubyId_delegate = load i64, i64* @rubyIdPrecomputed_delegate, align 8, !dbg !45
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_delegate), !dbg !45
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !45
-  %rawSym24 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !45
-  %stackFrame28 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#delegate", align 8, !dbg !45
-  %61 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !45
-  %62 = bitcast i8* %61 to i16*, !dbg !45
-  %63 = load i16, i16* %62, align 8, !dbg !45
-  %64 = and i16 %63, -384, !dbg !45
-  %65 = or i16 %64, 1, !dbg !45
-  store i16 %65, i16* %62, align 8, !dbg !45
-  %66 = getelementptr inbounds i8, i8* %61, i64 8, !dbg !45
-  %67 = bitcast i8* %66 to i32*, !dbg !45
-  store i32 1, i32* %67, align 8, !dbg !45, !tbaa !36
-  %68 = getelementptr inbounds i8, i8* %61, i64 12, !dbg !45
-  %69 = bitcast i8* %68 to i32*, !dbg !45
-  %70 = getelementptr inbounds i8, i8* %61, i64 4, !dbg !45
-  %71 = bitcast i8* %70 to i32*, !dbg !45
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %68, i8 0, i64 20, i1 false), !dbg !45
-  store i32 1, i32* %71, align 4, !dbg !45, !tbaa !39
-  %positional_table = alloca i64, align 8, !dbg !45
-  %rubyId_a = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !45
-  store i64 %rubyId_a, i64* %positional_table, align 8, !dbg !45
-  %72 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !45
-  %73 = bitcast i64* %positional_table to i8*, !dbg !45
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %72, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %73, i64 noundef 8, i1 noundef false) #11, !dbg !45
-  %74 = getelementptr inbounds i8, i8* %61, i64 32, !dbg !45
-  %75 = bitcast i8* %74 to i8**, !dbg !45
-  store i8* %72, i8** %75, align 8, !dbg !45, !tbaa !40
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_delegate, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#delegate", i8* nonnull %61, %struct.rb_iseq_struct* %stackFrame28, i1 noundef zeroext false) #11, !dbg !45
-  %76 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !12
-  %77 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 5, !dbg !45
-  %78 = load i32, i32* %77, align 8, !dbg !45, !tbaa !41
-  %79 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 6, !dbg !45
-  %80 = load i32, i32* %79, align 4, !dbg !45, !tbaa !42
-  %81 = xor i32 %80, -1, !dbg !45
-  %82 = and i32 %81, %78, !dbg !45
-  %83 = icmp eq i32 %82, 0, !dbg !45
-  br i1 %83, label %afterSend27, label %84, !dbg !45, !prof !43
+  tail call void @sorbet_popFrame() #11, !dbg !33
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !33, !tbaa !14
+  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !49
+  %59 = load i64*, i64** %58, align 8, !dbg !49
+  store i64 %26, i64* %59, align 8, !dbg !49, !tbaa !6
+  %60 = getelementptr inbounds i64, i64* %59, i64 1, !dbg !49
+  store i64* %60, i64** %58, align 8, !dbg !49
+  %send2 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !49
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !49, !tbaa !14
+  %rubyId_delegate = load i64, i64* @rubyIdPrecomputed_delegate, align 8, !dbg !47
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_delegate), !dbg !47
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !47
+  %rawSym24 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !47
+  %stackFrame28 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#delegate", align 8, !dbg !47
+  %61 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !47
+  %62 = bitcast i8* %61 to i16*, !dbg !47
+  %63 = load i16, i16* %62, align 8, !dbg !47
+  %64 = and i16 %63, -384, !dbg !47
+  %65 = or i16 %64, 1, !dbg !47
+  store i16 %65, i16* %62, align 8, !dbg !47
+  %66 = getelementptr inbounds i8, i8* %61, i64 8, !dbg !47
+  %67 = bitcast i8* %66 to i32*, !dbg !47
+  store i32 1, i32* %67, align 8, !dbg !47, !tbaa !38
+  %68 = getelementptr inbounds i8, i8* %61, i64 12, !dbg !47
+  %69 = bitcast i8* %68 to i32*, !dbg !47
+  %70 = getelementptr inbounds i8, i8* %61, i64 4, !dbg !47
+  %71 = bitcast i8* %70 to i32*, !dbg !47
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %68, i8 0, i64 20, i1 false), !dbg !47
+  store i32 1, i32* %71, align 4, !dbg !47, !tbaa !41
+  %positional_table = alloca i64, align 8, !dbg !47
+  %rubyId_a = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !47
+  store i64 %rubyId_a, i64* %positional_table, align 8, !dbg !47
+  %72 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !47
+  %73 = bitcast i64* %positional_table to i8*, !dbg !47
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %72, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %73, i64 noundef 8, i1 noundef false) #11, !dbg !47
+  %74 = getelementptr inbounds i8, i8* %61, i64 32, !dbg !47
+  %75 = bitcast i8* %74 to i8**, !dbg !47
+  store i8* %72, i8** %75, align 8, !dbg !47, !tbaa !42
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_delegate, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#delegate", i8* nonnull %61, %struct.rb_iseq_struct* %stackFrame28, i1 noundef zeroext false) #11, !dbg !47
+  %76 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !14
+  %77 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 5, !dbg !47
+  %78 = load i32, i32* %77, align 8, !dbg !47, !tbaa !43
+  %79 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 6, !dbg !47
+  %80 = load i32, i32* %79, align 4, !dbg !47, !tbaa !44
+  %81 = xor i32 %80, -1, !dbg !47
+  %82 = and i32 %81, %78, !dbg !47
+  %83 = icmp eq i32 %82, 0, !dbg !47
+  br i1 %83, label %afterSend27, label %84, !dbg !47, !prof !45
 
 84:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
-  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 8, !dbg !45
-  %86 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %85, align 8, !dbg !45, !tbaa !44
-  %87 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %86, i32 noundef 0) #11, !dbg !45
-  br label %afterSend27, !dbg !45
+  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 8, !dbg !47
+  %86 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %85, align 8, !dbg !47, !tbaa !46
+  %87 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %86, i32 noundef 0) #11, !dbg !47
+  br label %afterSend27, !dbg !47
 }
 
 ; Function Attrs: ssp
@@ -446,20 +446,20 @@ entry:
   %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
   %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_delegate.i.i, i64 %rubyId_delegate.i.i, i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#delegate", align 8
-  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
-  %"rubyId_==.i" = load i64, i64* @"rubyIdPrecomputed_==", align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_==", i64 %"rubyId_==.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
+  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  %"rubyId_==.i" = load i64, i64* @"rubyIdPrecomputed_==", align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_==", i64 %"rubyId_==.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   %13 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_ok, i64 0, i64 0), i64 noundef 2) #11
   call void @rb_gc_register_mark_object(i64 %13) #11
   store i64 %13, i64* @rubyStrFrozen_ok, align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !50
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
   %14 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_fail, i64 0, i64 0), i64 noundef 4) #11
   call void @rb_gc_register_mark_object(i64 %14) #11
   store i64 %14, i64* @rubyStrFrozen_fail, align 8
-  %rubyId_puts3.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !49
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts3.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
+  %rubyId_puts3.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !51
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts3.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !51
   %15 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
   call void @rb_gc_register_mark_object(i64 %15) #11
   store i64 %15, i64* @"rubyStrFrozen_<top (required)>", align 8
@@ -467,12 +467,12 @@ entry:
   %"rubyStr_test/testdata/compiler/custom_plus.rb.i12.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
   %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i12.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i13.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !47
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !45
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !45
-  %rubyId_delegate.i = load i64, i64* @rubyIdPrecomputed_delegate, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_delegate, i64 %rubyId_delegate.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !49
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !49
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !47
+  %rubyId_delegate.i = load i64, i64* @rubyIdPrecomputed_delegate, align 8, !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_delegate, i64 %rubyId_delegate.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
   %17 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #11
   call void @rb_gc_register_mark_object(i64 %17) #11
   %"rubyId_+.i.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8
@@ -484,34 +484,34 @@ entry:
   %"rubyStr_test/testdata/compiler/custom_plus.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
   %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i17.i", i64 %"rubyId_<top (required)>.i16.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.<static-init>", align 8
-  %rubyId_keep_def10.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !50
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.2, i64 %rubyId_keep_def10.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !50
-  %20 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !12
+  %rubyId_keep_def10.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !52
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.2, i64 %rubyId_keep_def10.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !52
+  %20 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %21 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %20, i64 0, i32 18
-  %22 = load i64, i64* %21, align 8, !tbaa !51
-  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %22 = load i64, i64* %21, align 8, !tbaa !53
+  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
-  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !23
+  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !25
   call fastcc void @"func_<root>.<static-init>$151"(i64 %22, %struct.rb_control_frame_struct* %25) #11
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_A#+"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 returned %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #5 !dbg !59 {
+define i64 @"func_A#+"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 returned %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #5 !dbg !61 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !60
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !60
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !60
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !60, !prof !15
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !62
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !62
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !62
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !62, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #10, !dbg !60
-  unreachable, !dbg !60
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #10, !dbg !62
+  unreachable, !dbg !62
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !61, !tbaa !12
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !63, !tbaa !14
   ret i64 %selfRaw
 }
 
@@ -531,7 +531,7 @@ declare void @llvm.assume(i1 noundef) #8
 define linkonce void @const_recompute_A() local_unnamed_addr #6 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !33
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !35
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -550,68 +550,70 @@ attributes #10 = { noreturn }
 attributes #11 = { nounwind }
 attributes #12 = { nounwind allocsize(0,1) }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/custom_plus.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "Object#delegate", linkageName: "func_Object#delegate", scope: null, file: !2, line: 14, type: !9, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = !DISubroutineType(types: !10)
-!10 = !{!11}
-!11 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!12 = !{!13, !13, i64 0}
-!13 = !{!"any pointer", !6, i64 0}
-!14 = !DILocation(line: 14, column: 1, scope: !8)
-!15 = !{!"branch_weights", i32 4001, i32 4000000}
-!16 = !DILocation(line: 14, column: 14, scope: !8)
-!17 = !DILocation(line: 15, column: 6, scope: !8)
-!18 = !DILocation(line: 0, scope: !8)
-!19 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 6, type: !9, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!20 = !DILocation(line: 7, column: 3, scope: !21, inlinedAt: !22)
-!21 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L79", scope: null, file: !2, line: 6, type: !9, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!22 = distinct !DILocation(line: 6, column: 1, scope: !19)
-!23 = !{!24, !13, i64 16}
-!24 = !{!"rb_execution_context_struct", !13, i64 0, !5, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !25, i64 40, !25, i64 44, !13, i64 48, !13, i64 56, !13, i64 64, !5, i64 72, !5, i64 80, !13, i64 88, !5, i64 96, !13, i64 104, !13, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !26, i64 152}
-!25 = !{!"int", !6, i64 0}
-!26 = !{!"", !13, i64 0, !13, i64 8, !5, i64 16, !6, i64 24}
-!27 = !{!28, !13, i64 16}
-!28 = !{!"rb_control_frame_struct", !13, i64 0, !13, i64 8, !13, i64 16, !5, i64 24, !13, i64 32, !13, i64 40, !13, i64 48}
-!29 = !{!28, !13, i64 32}
-!30 = !DILocation(line: 0, scope: !19)
-!31 = !DILocation(line: 6, column: 1, scope: !19)
-!32 = !DILocation(line: 0, scope: !21, inlinedAt: !22)
-!33 = !{!34, !34, i64 0}
-!34 = !{!"long long", !6, i64 0}
-!35 = !{!"branch_weights", i32 1, i32 10000}
-!36 = !{!37, !25, i64 8}
-!37 = !{!"rb_sorbet_param_struct", !38, i64 0, !25, i64 4, !25, i64 8, !25, i64 12, !25, i64 16, !25, i64 20, !25, i64 24, !25, i64 28, !13, i64 32, !25, i64 40, !25, i64 44, !25, i64 48, !25, i64 52, !13, i64 56}
-!38 = !{!"", !25, i64 0, !25, i64 0, !25, i64 0, !25, i64 0, !25, i64 0, !25, i64 0, !25, i64 0, !25, i64 0, !25, i64 1, !25, i64 1}
-!39 = !{!37, !25, i64 4}
-!40 = !{!37, !13, i64 32}
-!41 = !{!24, !25, i64 40}
-!42 = !{!24, !25, i64 44}
-!43 = !{!"branch_weights", i32 2000, i32 1}
-!44 = !{!24, !13, i64 56}
-!45 = !DILocation(line: 14, column: 1, scope: !19)
-!46 = !DILocation(line: 22, column: 1, scope: !19)
-!47 = !DILocation(line: 12, column: 5, scope: !19)
-!48 = !DILocation(line: 16, column: 5, scope: !8)
-!49 = !DILocation(line: 18, column: 5, scope: !8)
-!50 = !DILocation(line: 7, column: 3, scope: !21)
-!51 = !{!52, !5, i64 400}
-!52 = !{!"rb_vm_struct", !5, i64 0, !53, i64 8, !13, i64 192, !13, i64 200, !13, i64 208, !34, i64 216, !6, i64 224, !54, i64 264, !54, i64 280, !54, i64 296, !54, i64 312, !5, i64 328, !25, i64 336, !25, i64 340, !25, i64 344, !25, i64 344, !25, i64 344, !25, i64 344, !25, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !13, i64 456, !13, i64 464, !56, i64 472, !57, i64 992, !13, i64 1016, !13, i64 1024, !25, i64 1032, !25, i64 1036, !54, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !25, i64 1136, !13, i64 1144, !13, i64 1152, !13, i64 1160, !13, i64 1168, !13, i64 1176, !13, i64 1184, !25, i64 1192, !58, i64 1200, !6, i64 1232}
-!53 = !{!"rb_global_vm_lock_struct", !13, i64 0, !6, i64 8, !54, i64 48, !13, i64 64, !25, i64 72, !6, i64 80, !6, i64 128, !25, i64 176, !25, i64 180}
-!54 = !{!"list_head", !55, i64 0}
-!55 = !{!"list_node", !13, i64 0, !13, i64 8}
-!56 = !{!"", !6, i64 0}
-!57 = !{!"rb_hook_list_struct", !13, i64 0, !25, i64 8, !25, i64 12, !25, i64 16}
-!58 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!59 = distinct !DISubprogram(name: "A#+", linkageName: "func_A#+", scope: null, file: !2, line: 7, type: !9, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!60 = !DILocation(line: 7, column: 3, scope: !59)
-!61 = !DILocation(line: 0, scope: !59)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/custom_plus.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "Object#delegate", linkageName: "func_Object#delegate", scope: null, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!14 = !{!15, !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !DILocation(line: 14, column: 1, scope: !10)
+!17 = !{!"branch_weights", i32 4001, i32 4000000}
+!18 = !DILocation(line: 14, column: 14, scope: !10)
+!19 = !DILocation(line: 15, column: 6, scope: !10)
+!20 = !DILocation(line: 0, scope: !10)
+!21 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!22 = !DILocation(line: 7, column: 3, scope: !23, inlinedAt: !24)
+!23 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L79", scope: null, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!24 = distinct !DILocation(line: 6, column: 1, scope: !21)
+!25 = !{!26, !15, i64 16}
+!26 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !27, i64 40, !27, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !28, i64 152}
+!27 = !{!"int", !8, i64 0}
+!28 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!29 = !{!30, !15, i64 16}
+!30 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!31 = !{!30, !15, i64 32}
+!32 = !DILocation(line: 0, scope: !21)
+!33 = !DILocation(line: 6, column: 1, scope: !21)
+!34 = !DILocation(line: 0, scope: !23, inlinedAt: !24)
+!35 = !{!36, !36, i64 0}
+!36 = !{!"long long", !8, i64 0}
+!37 = !{!"branch_weights", i32 1, i32 10000}
+!38 = !{!39, !27, i64 8}
+!39 = !{!"rb_sorbet_param_struct", !40, i64 0, !27, i64 4, !27, i64 8, !27, i64 12, !27, i64 16, !27, i64 20, !27, i64 24, !27, i64 28, !15, i64 32, !27, i64 40, !27, i64 44, !27, i64 48, !27, i64 52, !15, i64 56}
+!40 = !{!"", !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 1, !27, i64 1}
+!41 = !{!39, !27, i64 4}
+!42 = !{!39, !15, i64 32}
+!43 = !{!26, !27, i64 40}
+!44 = !{!26, !27, i64 44}
+!45 = !{!"branch_weights", i32 2000, i32 1}
+!46 = !{!26, !15, i64 56}
+!47 = !DILocation(line: 14, column: 1, scope: !21)
+!48 = !DILocation(line: 22, column: 1, scope: !21)
+!49 = !DILocation(line: 12, column: 5, scope: !21)
+!50 = !DILocation(line: 16, column: 5, scope: !10)
+!51 = !DILocation(line: 18, column: 5, scope: !10)
+!52 = !DILocation(line: 7, column: 3, scope: !23)
+!53 = !{!54, !7, i64 400}
+!54 = !{!"rb_vm_struct", !7, i64 0, !55, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !36, i64 216, !8, i64 224, !56, i64 264, !56, i64 280, !56, i64 296, !56, i64 312, !7, i64 328, !27, i64 336, !27, i64 340, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !58, i64 472, !59, i64 992, !15, i64 1016, !15, i64 1024, !27, i64 1032, !27, i64 1036, !56, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !27, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !27, i64 1192, !60, i64 1200, !8, i64 1232}
+!55 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !56, i64 48, !15, i64 64, !27, i64 72, !8, i64 80, !8, i64 128, !27, i64 176, !27, i64 180}
+!56 = !{!"list_head", !57, i64 0}
+!57 = !{!"list_node", !15, i64 0, !15, i64 8}
+!58 = !{!"", !8, i64 0}
+!59 = !{!"rb_hook_list_struct", !15, i64 0, !27, i64 8, !27, i64 12, !27, i64 16}
+!60 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!61 = distinct !DISubprogram(name: "A#+", linkageName: "func_A#+", scope: null, file: !4, line: 7, type: !11, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!62 = !DILocation(line: 7, column: 3, scope: !61)
+!63 = !DILocation(line: 0, scope: !61)

--- a/test/testdata/compiler/direct_call.llo.exp
+++ b/test/testdata/compiler/direct_call.llo.exp
@@ -142,55 +142,55 @@ declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #7
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #7
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define noundef i64 @"func_Object#foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #4 !dbg !8 {
+define noundef i64 @"func_Object#foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #4 !dbg !10 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !14
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !14, !prof !15
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !16
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !16, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #8, !dbg !14
-  unreachable, !dbg !14
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #8, !dbg !16
+  unreachable, !dbg !16
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !16, !tbaa !12
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !18, !tbaa !14
   ret i64 3
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#bar"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #4 !dbg !17 {
+define i64 @"func_Object#bar"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #4 !dbg !19 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !18
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !18, !prof !15
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !20
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !20, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #8, !dbg !18
-  unreachable, !dbg !18
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #8, !dbg !20
+  unreachable, !dbg !20
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !19, !tbaa !12
-  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !20
-  %2 = load i64*, i64** %1, align 8, !dbg !20
-  store i64 %selfRaw, i64* %2, align 8, !dbg !20, !tbaa !4
-  %3 = getelementptr inbounds i64, i64* %2, i64 1, !dbg !20
-  store i64* %3, i64** %1, align 8, !dbg !20
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !20
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !21, !tbaa !14
+  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !22
+  %2 = load i64*, i64** %1, align 8, !dbg !22
+  store i64 %selfRaw, i64* %2, align 8, !dbg !22, !tbaa !6
+  %3 = getelementptr inbounds i64, i64* %2, i64 1, !dbg !22
+  store i64* %3, i64** %1, align 8, !dbg !22
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !22
   ret i64 %send
 }
 
@@ -231,116 +231,116 @@ entry:
   %"rubyStr_test/testdata/compiler/direct_call.rb.i8.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
   %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i8.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i9.i, i32 noundef 0, i32 noundef 1)
   store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#bar", align 8
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
+  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !22
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
   %11 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #9
   call void @rb_gc_register_mark_object(i64 %11) #9
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/direct_call.rb.i10.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
   %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i10.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i11.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !21
-  %rubyId_keep_def2.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.1, i64 %rubyId_keep_def2.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !23
-  %rubyId_bar.i = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
-  %13 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !12
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !23
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !23
+  %rubyId_keep_def2.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !25
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.1, i64 %rubyId_keep_def2.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !25
+  %rubyId_bar.i = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !26
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !27
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !27
+  %13 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %14 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %13, i64 0, i32 18
-  %15 = load i64, i64* %14, align 8, !tbaa !26
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %15 = load i64, i64* %14, align 8, !tbaa !28
+  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2
-  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !36
+  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !38
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %19, align 8, !tbaa !39
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %19, align 8, !tbaa !41
   %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 4
-  %21 = load i64*, i64** %20, align 8, !tbaa !41
-  %22 = load i64, i64* %21, align 8, !tbaa !4
+  %21 = load i64*, i64** %20, align 8, !tbaa !43
+  %22 = load i64, i64* %21, align 8, !tbaa !6
   %23 = and i64 %22, -33
-  store i64 %23, i64* %21, align 8, !tbaa !4
+  store i64 %23, i64* %21, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %16, %struct.rb_control_frame_struct* %18, %struct.rb_iseq_struct* %stackFrame.i) #9
   %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %24, align 8, !dbg !42, !tbaa !12
-  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !21
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #9, !dbg !21
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !21
-  %rawSym21.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #9, !dbg !21
-  %25 = load i64, i64* @rb_cObject, align 8, !dbg !21
-  %stackFrame22.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#foo", align 8, !dbg !21
-  %26 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !21
-  %27 = bitcast i8* %26 to i16*, !dbg !21
-  %28 = load i16, i16* %27, align 8, !dbg !21
-  %29 = and i16 %28, -384, !dbg !21
-  store i16 %29, i16* %27, align 8, !dbg !21
-  %30 = getelementptr inbounds i8, i8* %26, i64 4, !dbg !21
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %30, i8 0, i64 28, i1 false) #9, !dbg !21
-  call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#foo", i8* nonnull %26, %struct.rb_iseq_struct* %stackFrame22.i, i1 noundef zeroext false) #9, !dbg !21
-  %31 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !21, !tbaa !12
-  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 5, !dbg !21
-  %33 = load i32, i32* %32, align 8, !dbg !21, !tbaa !43
-  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 6, !dbg !21
-  %35 = load i32, i32* %34, align 4, !dbg !21, !tbaa !44
-  %36 = xor i32 %35, -1, !dbg !21
-  %37 = and i32 %36, %33, !dbg !21
-  %38 = icmp eq i32 %37, 0, !dbg !21
-  br i1 %38, label %fastSymCallIntrinsic_Static_keep_def35.i, label %39, !dbg !21, !prof !45
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %24, align 8, !dbg !44, !tbaa !14
+  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !23
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #9, !dbg !23
+  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !23
+  %rawSym21.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #9, !dbg !23
+  %25 = load i64, i64* @rb_cObject, align 8, !dbg !23
+  %stackFrame22.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#foo", align 8, !dbg !23
+  %26 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !23
+  %27 = bitcast i8* %26 to i16*, !dbg !23
+  %28 = load i16, i16* %27, align 8, !dbg !23
+  %29 = and i16 %28, -384, !dbg !23
+  store i16 %29, i16* %27, align 8, !dbg !23
+  %30 = getelementptr inbounds i8, i8* %26, i64 4, !dbg !23
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %30, i8 0, i64 28, i1 false) #9, !dbg !23
+  call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#foo", i8* nonnull %26, %struct.rb_iseq_struct* %stackFrame22.i, i1 noundef zeroext false) #9, !dbg !23
+  %31 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !14
+  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 5, !dbg !23
+  %33 = load i32, i32* %32, align 8, !dbg !23, !tbaa !45
+  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 6, !dbg !23
+  %35 = load i32, i32* %34, align 4, !dbg !23, !tbaa !46
+  %36 = xor i32 %35, -1, !dbg !23
+  %37 = and i32 %36, %33, !dbg !23
+  %38 = icmp eq i32 %37, 0, !dbg !23
+  br i1 %38, label %fastSymCallIntrinsic_Static_keep_def35.i, label %39, !dbg !23, !prof !47
 
 39:                                               ; preds = %entry
-  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 8, !dbg !21
-  %41 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %40, align 8, !dbg !21, !tbaa !46
-  %42 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %41, i32 noundef 0) #9, !dbg !21
-  br label %fastSymCallIntrinsic_Static_keep_def35.i, !dbg !21
+  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 8, !dbg !23
+  %41 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %40, align 8, !dbg !23, !tbaa !48
+  %42 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %41, i32 noundef 0) #9, !dbg !23
+  br label %fastSymCallIntrinsic_Static_keep_def35.i, !dbg !23
 
 fastSymCallIntrinsic_Static_keep_def35.i:         ; preds = %39, %entry
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %24, align 8, !dbg !21, !tbaa !12
-  %rubyId_bar.i2 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !23
-  %rawSym27.i = call i64 @rb_id2sym(i64 %rubyId_bar.i2) #9, !dbg !23
-  %rubyId_normal28.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !23
-  %rawSym29.i = call i64 @rb_id2sym(i64 %rubyId_normal28.i) #9, !dbg !23
-  %stackFrame36.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#bar", align 8, !dbg !23
-  %43 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !23
-  %44 = bitcast i8* %43 to i16*, !dbg !23
-  %45 = load i16, i16* %44, align 8, !dbg !23
-  %46 = and i16 %45, -384, !dbg !23
-  store i16 %46, i16* %44, align 8, !dbg !23
-  %47 = getelementptr inbounds i8, i8* %43, i64 4, !dbg !23
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %47, i8 0, i64 28, i1 false) #9, !dbg !23
-  call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#bar", i8* nonnull %43, %struct.rb_iseq_struct* %stackFrame36.i, i1 noundef zeroext false) #9, !dbg !23
-  %48 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !12
-  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 5, !dbg !23
-  %50 = load i32, i32* %49, align 8, !dbg !23, !tbaa !43
-  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 6, !dbg !23
-  %52 = load i32, i32* %51, align 4, !dbg !23, !tbaa !44
-  %53 = xor i32 %52, -1, !dbg !23
-  %54 = and i32 %53, %50, !dbg !23
-  %55 = icmp eq i32 %54, 0, !dbg !23
-  br i1 %55, label %"func_<root>.<static-init>$151.exit", label %56, !dbg !23, !prof !45
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %24, align 8, !dbg !23, !tbaa !14
+  %rubyId_bar.i2 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !25
+  %rawSym27.i = call i64 @rb_id2sym(i64 %rubyId_bar.i2) #9, !dbg !25
+  %rubyId_normal28.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !25
+  %rawSym29.i = call i64 @rb_id2sym(i64 %rubyId_normal28.i) #9, !dbg !25
+  %stackFrame36.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#bar", align 8, !dbg !25
+  %43 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !25
+  %44 = bitcast i8* %43 to i16*, !dbg !25
+  %45 = load i16, i16* %44, align 8, !dbg !25
+  %46 = and i16 %45, -384, !dbg !25
+  store i16 %46, i16* %44, align 8, !dbg !25
+  %47 = getelementptr inbounds i8, i8* %43, i64 4, !dbg !25
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %47, i8 0, i64 28, i1 false) #9, !dbg !25
+  call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#bar", i8* nonnull %43, %struct.rb_iseq_struct* %stackFrame36.i, i1 noundef zeroext false) #9, !dbg !25
+  %48 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !25, !tbaa !14
+  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 5, !dbg !25
+  %50 = load i32, i32* %49, align 8, !dbg !25, !tbaa !45
+  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 6, !dbg !25
+  %52 = load i32, i32* %51, align 4, !dbg !25, !tbaa !46
+  %53 = xor i32 %52, -1, !dbg !25
+  %54 = and i32 %53, %50, !dbg !25
+  %55 = icmp eq i32 %54, 0, !dbg !25
+  br i1 %55, label %"func_<root>.<static-init>$151.exit", label %56, !dbg !25, !prof !47
 
 56:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def35.i
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 8, !dbg !23
-  %58 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %57, align 8, !dbg !23, !tbaa !46
-  %59 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %58, i32 noundef 0) #9, !dbg !23
-  br label %"func_<root>.<static-init>$151.exit", !dbg !23
+  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 8, !dbg !25
+  %58 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %57, align 8, !dbg !25, !tbaa !48
+  %59 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %58, i32 noundef 0) #9, !dbg !25
+  br label %"func_<root>.<static-init>$151.exit", !dbg !25
 
 "func_<root>.<static-init>$151.exit":             ; preds = %fastSymCallIntrinsic_Static_keep_def35.i, %56
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %24, align 8, !dbg !23, !tbaa !12
-  %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !24
-  %61 = load i64*, i64** %60, align 8, !dbg !24
-  store i64 %15, i64* %61, align 8, !dbg !24, !tbaa !4
-  %62 = getelementptr inbounds i64, i64* %61, i64 1, !dbg !24
-  store i64* %62, i64** %60, align 8, !dbg !24
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 0), !dbg !24
-  %63 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !25
-  %64 = load i64*, i64** %63, align 8, !dbg !25
-  store i64 %15, i64* %64, align 8, !dbg !25, !tbaa !4
-  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !25
-  store i64 %send, i64* %65, align 8, !dbg !25, !tbaa !4
-  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !25
-  store i64* %66, i64** %63, align 8, !dbg !25
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !25
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %24, align 8, !dbg !25, !tbaa !14
+  %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !26
+  %61 = load i64*, i64** %60, align 8, !dbg !26
+  store i64 %15, i64* %61, align 8, !dbg !26, !tbaa !6
+  %62 = getelementptr inbounds i64, i64* %61, i64 1, !dbg !26
+  store i64* %62, i64** %60, align 8, !dbg !26
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 0), !dbg !26
+  %63 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !27
+  %64 = load i64*, i64** %63, align 8, !dbg !27
+  store i64 %15, i64* %64, align 8, !dbg !27, !tbaa !6
+  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !27
+  store i64 %send, i64* %65, align 8, !dbg !27, !tbaa !6
+  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !27
+  store i64* %66, i64** %63, align 8, !dbg !27
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !27
   ret void
 }
 
@@ -359,53 +359,55 @@ attributes #8 = { noreturn }
 attributes #9 = { nounwind }
 attributes #10 = { nounwind allocsize(0,1) }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/direct_call.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "Object#foo", linkageName: "func_Object#foo", scope: null, file: !2, line: 4, type: !9, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = !DISubroutineType(types: !10)
-!10 = !{!11}
-!11 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!12 = !{!13, !13, i64 0}
-!13 = !{!"any pointer", !6, i64 0}
-!14 = !DILocation(line: 4, column: 1, scope: !8)
-!15 = !{!"branch_weights", i32 1, i32 2000}
-!16 = !DILocation(line: 0, scope: !8)
-!17 = distinct !DISubprogram(name: "Object#bar", linkageName: "func_Object#bar", scope: null, file: !2, line: 8, type: !9, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!18 = !DILocation(line: 8, column: 1, scope: !17)
-!19 = !DILocation(line: 0, scope: !17)
-!20 = !DILocation(line: 9, column: 3, scope: !17)
-!21 = !DILocation(line: 4, column: 1, scope: !22)
-!22 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !9, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!23 = !DILocation(line: 8, column: 1, scope: !22)
-!24 = !DILocation(line: 12, column: 6, scope: !22)
-!25 = !DILocation(line: 12, column: 1, scope: !22)
-!26 = !{!27, !5, i64 400}
-!27 = !{!"rb_vm_struct", !5, i64 0, !28, i64 8, !13, i64 192, !13, i64 200, !13, i64 208, !32, i64 216, !6, i64 224, !29, i64 264, !29, i64 280, !29, i64 296, !29, i64 312, !5, i64 328, !31, i64 336, !31, i64 340, !31, i64 344, !31, i64 344, !31, i64 344, !31, i64 344, !31, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !13, i64 456, !13, i64 464, !33, i64 472, !34, i64 992, !13, i64 1016, !13, i64 1024, !31, i64 1032, !31, i64 1036, !29, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !31, i64 1136, !13, i64 1144, !13, i64 1152, !13, i64 1160, !13, i64 1168, !13, i64 1176, !13, i64 1184, !31, i64 1192, !35, i64 1200, !6, i64 1232}
-!28 = !{!"rb_global_vm_lock_struct", !13, i64 0, !6, i64 8, !29, i64 48, !13, i64 64, !31, i64 72, !6, i64 80, !6, i64 128, !31, i64 176, !31, i64 180}
-!29 = !{!"list_head", !30, i64 0}
-!30 = !{!"list_node", !13, i64 0, !13, i64 8}
-!31 = !{!"int", !6, i64 0}
-!32 = !{!"long long", !6, i64 0}
-!33 = !{!"", !6, i64 0}
-!34 = !{!"rb_hook_list_struct", !13, i64 0, !31, i64 8, !31, i64 12, !31, i64 16}
-!35 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!36 = !{!37, !13, i64 16}
-!37 = !{!"rb_execution_context_struct", !13, i64 0, !5, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !31, i64 40, !31, i64 44, !13, i64 48, !13, i64 56, !13, i64 64, !5, i64 72, !5, i64 80, !13, i64 88, !5, i64 96, !13, i64 104, !13, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !38, i64 152}
-!38 = !{!"", !13, i64 0, !13, i64 8, !5, i64 16, !6, i64 24}
-!39 = !{!40, !13, i64 16}
-!40 = !{!"rb_control_frame_struct", !13, i64 0, !13, i64 8, !13, i64 16, !5, i64 24, !13, i64 32, !13, i64 40, !13, i64 48}
-!41 = !{!40, !13, i64 32}
-!42 = !DILocation(line: 0, scope: !22)
-!43 = !{!37, !31, i64 40}
-!44 = !{!37, !31, i64 44}
-!45 = !{!"branch_weights", i32 2000, i32 1}
-!46 = !{!37, !13, i64 56}
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/direct_call.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "Object#foo", linkageName: "func_Object#foo", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!14 = !{!15, !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !DILocation(line: 4, column: 1, scope: !10)
+!17 = !{!"branch_weights", i32 1, i32 2000}
+!18 = !DILocation(line: 0, scope: !10)
+!19 = distinct !DISubprogram(name: "Object#bar", linkageName: "func_Object#bar", scope: null, file: !4, line: 8, type: !11, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!20 = !DILocation(line: 8, column: 1, scope: !19)
+!21 = !DILocation(line: 0, scope: !19)
+!22 = !DILocation(line: 9, column: 3, scope: !19)
+!23 = !DILocation(line: 4, column: 1, scope: !24)
+!24 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!25 = !DILocation(line: 8, column: 1, scope: !24)
+!26 = !DILocation(line: 12, column: 6, scope: !24)
+!27 = !DILocation(line: 12, column: 1, scope: !24)
+!28 = !{!29, !7, i64 400}
+!29 = !{!"rb_vm_struct", !7, i64 0, !30, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !34, i64 216, !8, i64 224, !31, i64 264, !31, i64 280, !31, i64 296, !31, i64 312, !7, i64 328, !33, i64 336, !33, i64 340, !33, i64 344, !33, i64 344, !33, i64 344, !33, i64 344, !33, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !35, i64 472, !36, i64 992, !15, i64 1016, !15, i64 1024, !33, i64 1032, !33, i64 1036, !31, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !33, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !33, i64 1192, !37, i64 1200, !8, i64 1232}
+!30 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !31, i64 48, !15, i64 64, !33, i64 72, !8, i64 80, !8, i64 128, !33, i64 176, !33, i64 180}
+!31 = !{!"list_head", !32, i64 0}
+!32 = !{!"list_node", !15, i64 0, !15, i64 8}
+!33 = !{!"int", !8, i64 0}
+!34 = !{!"long long", !8, i64 0}
+!35 = !{!"", !8, i64 0}
+!36 = !{!"rb_hook_list_struct", !15, i64 0, !33, i64 8, !33, i64 12, !33, i64 16}
+!37 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!38 = !{!39, !15, i64 16}
+!39 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !33, i64 40, !33, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !40, i64 152}
+!40 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!41 = !{!42, !15, i64 16}
+!42 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!43 = !{!42, !15, i64 32}
+!44 = !DILocation(line: 0, scope: !24)
+!45 = !{!39, !33, i64 40}
+!46 = !{!39, !33, i64 44}
+!47 = !{!"branch_weights", i32 2000, i32 1}
+!48 = !{!39, !15, i64 56}

--- a/test/testdata/compiler/exceptions/basic.llo.exp
+++ b/test/testdata/compiler/exceptions/basic.llo.exp
@@ -206,14 +206,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
   unreachable
 }
@@ -221,7 +221,7 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
 ; Function Attrs: sspreq
 define void @Init_basic() local_unnamed_addr #5 {
 entry:
-  %positional_table.i.i = alloca i64, align 8, !dbg !8
+  %positional_table.i.i = alloca i64, align 8, !dbg !10
   %locals.i34.i = alloca i64, i32 0, align 8
   %locals.i27.i = alloca i64, i32 5, align 8
   %locals.i.i = alloca i64, i32 0, align 8
@@ -269,17 +269,17 @@ entry:
   %17 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_=== no-raise ===", i64 0, i64 0), i64 noundef 16) #11
   call void @rb_gc_register_mark_object(i64 %17) #11
   store i64 %17, i64* @"rubyStrFrozen_=== no-raise ===", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %rubyId_test.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !16
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
+  %rubyId_test.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !18
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
   %18 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_=== raise ===", i64 0, i64 0), i64 noundef 13) #11
   call void @rb_gc_register_mark_object(i64 %18) #11
   store i64 %18, i64* @"rubyStrFrozen_=== raise ===", align 8
-  %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_test5.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !18
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test.2, i64 %rubyId_test5.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
+  %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  %rubyId_test5.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !20
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test.2, i64 %rubyId_test5.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
   %19 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
   call void @rb_gc_register_mark_object(i64 %19) #11
   %20 = bitcast i64* %locals.i27.i to i8*
@@ -322,488 +322,488 @@ entry:
   %31 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_begin, i64 0, i64 0), i64 noundef 5) #11
   call void @rb_gc_register_mark_object(i64 %31) #11
   store i64 %31, i64* @rubyStrFrozen_begin, align 8
-  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %rubyId_puts10.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts10.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
+  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
+  %rubyId_puts10.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts10.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
   %32 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
   call void @rb_gc_register_mark_object(i64 %32) #11
   store i64 %32, i64* @rubyStrFrozen_foo, align 8
-  %rubyId_raise.i = load i64, i64* @rubyIdPrecomputed_raise, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_raise, i64 %rubyId_raise.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  %"rubyId_is_a?.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !26
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
+  %rubyId_raise.i = load i64, i64* @rubyIdPrecomputed_raise, align 8, !dbg !25
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_raise, i64 %rubyId_raise.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
+  %"rubyId_is_a?.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !26
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
+  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !28
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
   %33 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_else, i64 0, i64 0), i64 noundef 4) #11
   call void @rb_gc_register_mark_object(i64 %33) #11
   store i64 %33, i64* @rubyStrFrozen_else, align 8
-  %rubyId_puts19.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !27
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts19.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !27
+  %rubyId_puts19.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !29
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts19.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
   %34 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_ensure, i64 0, i64 0), i64 noundef 6) #11
   call void @rb_gc_register_mark_object(i64 %34) #11
   store i64 %34, i64* @rubyStrFrozen_ensure, align 8
-  %rubyId_puts22.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts22.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
+  %rubyId_puts22.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !31
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts22.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !31
   %"rubyId_<top (required)>.i31.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i32.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i33.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
   %35 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i32.i", i64 %"rubyId_<top (required)>.i31.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i33.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i34.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %35, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.<static-init>", align 8
-  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !31
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !31
-  %36 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !32
+  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !33
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !33
+  %36 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !34
   %37 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %36, i64 0, i32 18
-  %38 = load i64, i64* %37, align 8, !tbaa !34
-  %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !32
+  %38 = load i64, i64* %37, align 8, !tbaa !36
+  %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
   %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %39, i64 0, i32 2
-  %41 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %40, align 8, !tbaa !44
+  %41 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %40, align 8, !tbaa !46
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %42, align 8, !tbaa !47
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %42, align 8, !tbaa !49
   %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 4
-  %44 = load i64*, i64** %43, align 8, !tbaa !49
-  %45 = load i64, i64* %44, align 8, !tbaa !4
+  %44 = load i64*, i64** %43, align 8, !tbaa !51
+  %45 = load i64, i64* %44, align 8, !tbaa !6
   %46 = and i64 %45, -33
-  store i64 %46, i64* %44, align 8, !tbaa !4
+  store i64 %46, i64* %44, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %39, %struct.rb_control_frame_struct* %41, %struct.rb_iseq_struct* %stackFrame.i) #11
   %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %47, align 8, !dbg !50, !tbaa !32
-  %48 = load i64, i64* @rb_cObject, align 8, !dbg !51
-  %49 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %48) #11, !dbg !51
-  %50 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %49) #11, !dbg !51
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %47, align 8, !dbg !52, !tbaa !34
+  %48 = load i64, i64* @rb_cObject, align 8, !dbg !53
+  %49 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %48) #11, !dbg !53
+  %50 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %49) #11, !dbg !53
   %51 = bitcast i64* %positional_table.i.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %51) #11
   %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.<static-init>", align 8
-  %52 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !32
+  %52 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
   %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 2
-  %54 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %53, align 8, !tbaa !44
+  %54 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %53, align 8, !tbaa !46
   %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %54, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %55, align 8, !tbaa !47
+  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %55, align 8, !tbaa !49
   %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %54, i64 0, i32 4
-  %57 = load i64*, i64** %56, align 8, !tbaa !49
-  %58 = load i64, i64* %57, align 8, !tbaa !4
+  %57 = load i64*, i64** %56, align 8, !tbaa !51
+  %58 = load i64, i64* %57, align 8, !tbaa !6
   %59 = and i64 %58, -33
-  store i64 %59, i64* %57, align 8, !tbaa !4
+  store i64 %59, i64* %57, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %52, %struct.rb_control_frame_struct* %54, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
   %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %50, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %60, align 8, !dbg !52, !tbaa !32
-  %rubyId_test.i.i2 = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !8
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_test.i.i2) #11, !dbg !8
-  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !8
-  %rawSym7.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !8
-  %61 = load i64, i64* @guard_epoch_A, align 8, !dbg !8
-  %62 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !8, !tbaa !53
-  %needTakeSlowPath = icmp ne i64 %61, %62, !dbg !8
-  br i1 %needTakeSlowPath, label %63, label %64, !dbg !8, !prof !54
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %60, align 8, !dbg !54, !tbaa !34
+  %rubyId_test.i.i2 = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !10
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_test.i.i2) #11, !dbg !10
+  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !10
+  %rawSym7.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !10
+  %61 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %62 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !55
+  %needTakeSlowPath = icmp ne i64 %61, %62, !dbg !10
+  br i1 %needTakeSlowPath, label %63, label %64, !dbg !10, !prof !56
 
 63:                                               ; preds = %entry
-  call void @const_recompute_A(), !dbg !8
-  br label %64, !dbg !8
+  call void @const_recompute_A(), !dbg !10
+  br label %64, !dbg !10
 
 64:                                               ; preds = %entry, %63
-  %65 = load i64, i64* @guarded_const_A, align 8, !dbg !8
-  %66 = load i64, i64* @guard_epoch_A, align 8, !dbg !8
-  %67 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !8, !tbaa !53
-  %guardUpdated = icmp eq i64 %66, %67, !dbg !8
-  call void @llvm.assume(i1 %guardUpdated), !dbg !8
-  %stackFrame8.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.test, align 8, !dbg !8
-  %68 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !8
-  %69 = bitcast i8* %68 to i16*, !dbg !8
-  %70 = load i16, i16* %69, align 8, !dbg !8
-  %71 = and i16 %70, -384, !dbg !8
-  %72 = or i16 %71, 1, !dbg !8
-  store i16 %72, i16* %69, align 8, !dbg !8
-  %73 = getelementptr inbounds i8, i8* %68, i64 8, !dbg !8
-  %74 = bitcast i8* %73 to i32*, !dbg !8
-  store i32 1, i32* %74, align 8, !dbg !8, !tbaa !55
-  %75 = getelementptr inbounds i8, i8* %68, i64 12, !dbg !8
-  %76 = getelementptr inbounds i8, i8* %68, i64 4, !dbg !8
-  %77 = bitcast i8* %76 to i32*, !dbg !8
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %75, i8 0, i64 20, i1 false) #11, !dbg !8
-  store i32 1, i32* %77, align 4, !dbg !8, !tbaa !58
-  %rubyId_x.i.i3 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !8
-  store i64 %rubyId_x.i.i3, i64* %positional_table.i.i, align 8, !dbg !8
-  %78 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !8
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %78, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %51, i64 noundef 8, i1 noundef false) #11, !dbg !8
-  %79 = getelementptr inbounds i8, i8* %68, i64 32, !dbg !8
-  %80 = bitcast i8* %79 to i8**, !dbg !8
-  store i8* %78, i8** %80, align 8, !dbg !8, !tbaa !59
-  call void @sorbet_vm_define_method(i64 %65, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_A.test, i8* nonnull %68, %struct.rb_iseq_struct* %stackFrame8.i.i, i1 noundef zeroext true) #11, !dbg !8
-  %81 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !8, !tbaa !32
-  %82 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 5, !dbg !8
-  %83 = load i32, i32* %82, align 8, !dbg !8, !tbaa !60
-  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 6, !dbg !8
-  %85 = load i32, i32* %84, align 4, !dbg !8, !tbaa !61
-  %86 = xor i32 %85, -1, !dbg !8
-  %87 = and i32 %86, %83, !dbg !8
-  %88 = icmp eq i32 %87, 0, !dbg !8
-  br i1 %88, label %"func_<root>.<static-init>$151.exit", label %89, !dbg !8, !prof !62
+  %65 = load i64, i64* @guarded_const_A, align 8, !dbg !10
+  %66 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %67 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !55
+  %guardUpdated = icmp eq i64 %66, %67, !dbg !10
+  call void @llvm.assume(i1 %guardUpdated), !dbg !10
+  %stackFrame8.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.test, align 8, !dbg !10
+  %68 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %69 = bitcast i8* %68 to i16*, !dbg !10
+  %70 = load i16, i16* %69, align 8, !dbg !10
+  %71 = and i16 %70, -384, !dbg !10
+  %72 = or i16 %71, 1, !dbg !10
+  store i16 %72, i16* %69, align 8, !dbg !10
+  %73 = getelementptr inbounds i8, i8* %68, i64 8, !dbg !10
+  %74 = bitcast i8* %73 to i32*, !dbg !10
+  store i32 1, i32* %74, align 8, !dbg !10, !tbaa !57
+  %75 = getelementptr inbounds i8, i8* %68, i64 12, !dbg !10
+  %76 = getelementptr inbounds i8, i8* %68, i64 4, !dbg !10
+  %77 = bitcast i8* %76 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %75, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %77, align 4, !dbg !10, !tbaa !60
+  %rubyId_x.i.i3 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !10
+  store i64 %rubyId_x.i.i3, i64* %positional_table.i.i, align 8, !dbg !10
+  %78 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %78, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %51, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %79 = getelementptr inbounds i8, i8* %68, i64 32, !dbg !10
+  %80 = bitcast i8* %79 to i8**, !dbg !10
+  store i8* %78, i8** %80, align 8, !dbg !10, !tbaa !61
+  call void @sorbet_vm_define_method(i64 %65, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_A.test, i8* nonnull %68, %struct.rb_iseq_struct* %stackFrame8.i.i, i1 noundef zeroext true) #11, !dbg !10
+  %81 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !34
+  %82 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 5, !dbg !10
+  %83 = load i32, i32* %82, align 8, !dbg !10, !tbaa !62
+  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 6, !dbg !10
+  %85 = load i32, i32* %84, align 4, !dbg !10, !tbaa !63
+  %86 = xor i32 %85, -1, !dbg !10
+  %87 = and i32 %86, %83, !dbg !10
+  %88 = icmp eq i32 %87, 0, !dbg !10
+  br i1 %88, label %"func_<root>.<static-init>$151.exit", label %89, !dbg !10, !prof !64
 
 89:                                               ; preds = %64
-  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 8, !dbg !8
-  %91 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %90, align 8, !dbg !8, !tbaa !63
-  %92 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %91, i32 noundef 0) #11, !dbg !8
-  br label %"func_<root>.<static-init>$151.exit", !dbg !8
+  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 8, !dbg !10
+  %91 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %90, align 8, !dbg !10, !tbaa !65
+  %92 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %91, i32 noundef 0) #11, !dbg !10
+  br label %"func_<root>.<static-init>$151.exit", !dbg !10
 
 "func_<root>.<static-init>$151.exit":             ; preds = %64, %89
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %51) #11
-  call void @sorbet_popFrame() #11, !dbg !51
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %47, align 8, !dbg !51, !tbaa !32
-  %"rubyStr_=== no-raise ===.i" = load i64, i64* @"rubyStrFrozen_=== no-raise ===", align 8, !dbg !64
-  %93 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !15
-  %94 = load i64*, i64** %93, align 8, !dbg !15
-  store i64 %38, i64* %94, align 8, !dbg !15, !tbaa !4
-  %95 = getelementptr inbounds i64, i64* %94, i64 1, !dbg !15
-  store i64 %"rubyStr_=== no-raise ===.i", i64* %95, align 8, !dbg !15, !tbaa !4
-  %96 = getelementptr inbounds i64, i64* %95, i64 1, !dbg !15
-  store i64* %96, i64** %93, align 8, !dbg !15
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %47, align 8, !dbg !15, !tbaa !32
-  %97 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !16
-  %98 = load i64*, i64** %97, align 8, !dbg !16
-  store i64 %65, i64* %98, align 8, !dbg !16, !tbaa !4
-  %99 = getelementptr inbounds i64, i64* %98, i64 1, !dbg !16
-  store i64 0, i64* %99, align 8, !dbg !16, !tbaa !4
-  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !16
-  store i64* %100, i64** %97, align 8, !dbg !16
-  %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !16
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %47, align 8, !dbg !16, !tbaa !32
-  %"rubyStr_=== raise ===.i" = load i64, i64* @"rubyStrFrozen_=== raise ===", align 8, !dbg !65
-  %101 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !17
-  %102 = load i64*, i64** %101, align 8, !dbg !17
-  store i64 %38, i64* %102, align 8, !dbg !17, !tbaa !4
-  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !17
-  store i64 %"rubyStr_=== raise ===.i", i64* %103, align 8, !dbg !17, !tbaa !4
-  %104 = getelementptr inbounds i64, i64* %103, i64 1, !dbg !17
-  store i64* %104, i64** %101, align 8, !dbg !17
-  %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %47, align 8, !dbg !17, !tbaa !32
-  %105 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !18
-  %106 = load i64*, i64** %105, align 8, !dbg !18
-  store i64 %65, i64* %106, align 8, !dbg !18, !tbaa !4
-  %107 = getelementptr inbounds i64, i64* %106, i64 1, !dbg !18
-  store i64 20, i64* %107, align 8, !dbg !18, !tbaa !4
-  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !18
-  store i64* %108, i64** %105, align 8, !dbg !18
-  %send9 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test.2, i64 0), !dbg !18
+  call void @sorbet_popFrame() #11, !dbg !53
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %47, align 8, !dbg !53, !tbaa !34
+  %"rubyStr_=== no-raise ===.i" = load i64, i64* @"rubyStrFrozen_=== no-raise ===", align 8, !dbg !66
+  %93 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !17
+  %94 = load i64*, i64** %93, align 8, !dbg !17
+  store i64 %38, i64* %94, align 8, !dbg !17, !tbaa !6
+  %95 = getelementptr inbounds i64, i64* %94, i64 1, !dbg !17
+  store i64 %"rubyStr_=== no-raise ===.i", i64* %95, align 8, !dbg !17, !tbaa !6
+  %96 = getelementptr inbounds i64, i64* %95, i64 1, !dbg !17
+  store i64* %96, i64** %93, align 8, !dbg !17
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !17
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %47, align 8, !dbg !17, !tbaa !34
+  %97 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !18
+  %98 = load i64*, i64** %97, align 8, !dbg !18
+  store i64 %65, i64* %98, align 8, !dbg !18, !tbaa !6
+  %99 = getelementptr inbounds i64, i64* %98, i64 1, !dbg !18
+  store i64 0, i64* %99, align 8, !dbg !18, !tbaa !6
+  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !18
+  store i64* %100, i64** %97, align 8, !dbg !18
+  %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !18
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %47, align 8, !dbg !18, !tbaa !34
+  %"rubyStr_=== raise ===.i" = load i64, i64* @"rubyStrFrozen_=== raise ===", align 8, !dbg !67
+  %101 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !19
+  %102 = load i64*, i64** %101, align 8, !dbg !19
+  store i64 %38, i64* %102, align 8, !dbg !19, !tbaa !6
+  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !19
+  store i64 %"rubyStr_=== raise ===.i", i64* %103, align 8, !dbg !19, !tbaa !6
+  %104 = getelementptr inbounds i64, i64* %103, i64 1, !dbg !19
+  store i64* %104, i64** %101, align 8, !dbg !19
+  %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %47, align 8, !dbg !19, !tbaa !34
+  %105 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !20
+  %106 = load i64*, i64** %105, align 8, !dbg !20
+  store i64 %65, i64* %106, align 8, !dbg !20, !tbaa !6
+  %107 = getelementptr inbounds i64, i64* %106, i64 1, !dbg !20
+  store i64 20, i64* %107, align 8, !dbg !20, !tbaa !6
+  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !20
+  store i64* %108, i64** %105, align 8, !dbg !20
+  %send9 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test.2, i64 0), !dbg !20
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @func_A.test(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #6 !dbg !21 {
+define i64 @func_A.test(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #6 !dbg !23 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !32
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !66
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !66
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !66
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !66, !prof !67
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !34
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !68
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !68
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !68
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !68, !prof !69
 
 postProcess:                                      ; preds = %sorbet_writeLocal.exit, %exception-continue
-  %"<returnValue>.sroa.0.0" = phi i64 [ %13, %exception-continue ], [ %10, %sorbet_writeLocal.exit ], !dbg !68
+  %"<returnValue>.sroa.0.0" = phi i64 [ %13, %exception-continue ], [ %10, %sorbet_writeLocal.exit ], !dbg !70
   ret i64 %"<returnValue>.sroa.0.0"
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !66
-  unreachable, !dbg !66
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !68
+  unreachable, !dbg !68
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !66
-  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !66
-  %2 = load i64*, i64** %1, align 8, !dbg !66, !tbaa !49
-  %3 = load i64, i64* %2, align 8, !dbg !66, !tbaa !4
-  %4 = and i64 %3, 8, !dbg !66
-  %5 = icmp eq i64 %4, 0, !dbg !66
-  br i1 %5, label %6, label %8, !dbg !66, !prof !62
+  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !68
+  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !68
+  %2 = load i64*, i64** %1, align 8, !dbg !68, !tbaa !51
+  %3 = load i64, i64* %2, align 8, !dbg !68, !tbaa !6
+  %4 = and i64 %3, 8, !dbg !68
+  %5 = icmp eq i64 %4, 0, !dbg !68
+  br i1 %5, label %6, label %8, !dbg !68, !prof !64
 
 6:                                                ; preds = %fillRequiredArgs
-  %7 = getelementptr inbounds i64, i64* %2, i64 -4, !dbg !66
-  store i64 %rawArg_x, i64* %7, align 8, !dbg !66, !tbaa !4
-  br label %sorbet_writeLocal.exit, !dbg !66
+  %7 = getelementptr inbounds i64, i64* %2, i64 -4, !dbg !68
+  store i64 %rawArg_x, i64* %7, align 8, !dbg !68, !tbaa !6
+  br label %sorbet_writeLocal.exit, !dbg !68
 
 8:                                                ; preds = %fillRequiredArgs
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %2, i32 noundef -4, i64 %rawArg_x) #11, !dbg !66
-  br label %sorbet_writeLocal.exit, !dbg !66
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %2, i32 noundef -4, i64 %rawArg_x) #11, !dbg !68
+  br label %sorbet_writeLocal.exit, !dbg !68
 
 sorbet_writeLocal.exit:                           ; preds = %6, %8
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !68, !tbaa !32
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !69, !tbaa !32
-  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !69
-  %10 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %9, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.test$block_1", i64** nonnull %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.test$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.test$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.test$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !69
-  %ensureReturnValue = icmp ne i64 %10, 52, !dbg !69
-  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !69
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !70, !tbaa !34
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !71, !tbaa !34
+  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !71
+  %10 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %9, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.test$block_1", i64** nonnull %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.test$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.test$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.test$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !71
+  %ensureReturnValue = icmp ne i64 %10, 52, !dbg !71
+  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !71
 
 exception-continue:                               ; preds = %sorbet_writeLocal.exit
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %0, align 8, !tbaa !32
-  %11 = load i64*, i64** %1, align 8, !dbg !70, !tbaa !49
-  %12 = getelementptr inbounds i64, i64* %11, i64 -5, !dbg !70
-  %13 = load i64, i64* %12, align 8, !dbg !70, !tbaa !4
-  br label %postProcess, !dbg !70
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %0, align 8, !tbaa !34
+  %11 = load i64*, i64** %1, align 8, !dbg !72, !tbaa !51
+  %12 = getelementptr inbounds i64, i64* %11, i64 -5, !dbg !72
+  %13 = load i64, i64* %12, align 8, !dbg !72, !tbaa !6
+  br label %postProcess, !dbg !72
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_A.test$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* %cfp) #7 !dbg !20 {
+define internal noundef i64 @"func_A.test$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* %cfp) #7 !dbg !22 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !32
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !44
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !46
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !71
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !32
-  %rubyStr_begin = load i64, i64* @rubyStrFrozen_begin, align 8, !dbg !72
-  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !19
-  %6 = load i64*, i64** %5, align 8, !dbg !19
-  store i64 %4, i64* %6, align 8, !dbg !19, !tbaa !4
-  %7 = getelementptr inbounds i64, i64* %6, i64 1, !dbg !19
-  store i64 %rubyStr_begin, i64* %7, align 8, !dbg !19, !tbaa !4
-  %8 = getelementptr inbounds i64, i64* %7, i64 1, !dbg !19
-  store i64* %8, i64** %5, align 8, !dbg !19
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !19
-  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !19
-  %10 = load i64*, i64** %9, align 8, !dbg !19, !tbaa !49
-  %11 = getelementptr inbounds i64, i64* %10, i64 -4, !dbg !19
-  %12 = load i64, i64* %11, align 8, !dbg !19, !tbaa !4
-  %13 = and i64 %12, -9, !dbg !19
-  %14 = icmp ne i64 %13, 0, !dbg !19
-  br i1 %14, label %BB5, label %BB7, !dbg !19
+  %4 = load i64, i64* %3, align 8, !tbaa !73
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !34
+  %rubyStr_begin = load i64, i64* @rubyStrFrozen_begin, align 8, !dbg !74
+  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !21
+  %6 = load i64*, i64** %5, align 8, !dbg !21
+  store i64 %4, i64* %6, align 8, !dbg !21, !tbaa !6
+  %7 = getelementptr inbounds i64, i64* %6, i64 1, !dbg !21
+  store i64 %rubyStr_begin, i64* %7, align 8, !dbg !21, !tbaa !6
+  %8 = getelementptr inbounds i64, i64* %7, i64 1, !dbg !21
+  store i64* %8, i64** %5, align 8, !dbg !21
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !21
+  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !21
+  %10 = load i64*, i64** %9, align 8, !dbg !21, !tbaa !51
+  %11 = getelementptr inbounds i64, i64* %10, i64 -4, !dbg !21
+  %12 = load i64, i64* %11, align 8, !dbg !21, !tbaa !6
+  %13 = and i64 %12, -9, !dbg !21
+  %14 = icmp ne i64 %13, 0, !dbg !21
+  br i1 %14, label %BB5, label %BB7, !dbg !21
 
 BB5:                                              ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %pc, align 8, !tbaa !32
-  %15 = load i64*, i64** %9, align 8, !dbg !22, !tbaa !49
-  %16 = getelementptr inbounds i64, i64* %15, i64 -4, !dbg !22
-  %17 = load i64, i64* %16, align 8, !dbg !22, !tbaa !4
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !22
-  %19 = load i64*, i64** %18, align 8, !dbg !22
-  store i64 %4, i64* %19, align 8, !dbg !22, !tbaa !4
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !22
-  store i64 %17, i64* %20, align 8, !dbg !22, !tbaa !4
-  %21 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !22
-  store i64* %21, i64** %18, align 8, !dbg !22
-  %send25 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !22
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %pc, align 8, !dbg !22, !tbaa !32
-  %rubyStr_foo = load i64, i64* @rubyStrFrozen_foo, align 8, !dbg !73
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !23
-  %23 = load i64*, i64** %22, align 8, !dbg !23
-  store i64 %4, i64* %23, align 8, !dbg !23, !tbaa !4
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !23
-  store i64 %rubyStr_foo, i64* %24, align 8, !dbg !23, !tbaa !4
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !23
-  store i64* %25, i64** %22, align 8, !dbg !23
-  %send27 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_raise, i64 0), !dbg !23
-  %26 = load i64*, i64** %9, align 8, !dbg !23, !tbaa !49
-  %27 = load i64, i64* %26, align 8, !dbg !23, !tbaa !4
-  %28 = and i64 %27, 8, !dbg !23
-  %29 = icmp eq i64 %28, 0, !dbg !23
-  br i1 %29, label %30, label %32, !dbg !23, !prof !62
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %pc, align 8, !tbaa !34
+  %15 = load i64*, i64** %9, align 8, !dbg !24, !tbaa !51
+  %16 = getelementptr inbounds i64, i64* %15, i64 -4, !dbg !24
+  %17 = load i64, i64* %16, align 8, !dbg !24, !tbaa !6
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !24
+  %19 = load i64*, i64** %18, align 8, !dbg !24
+  store i64 %4, i64* %19, align 8, !dbg !24, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !24
+  store i64 %17, i64* %20, align 8, !dbg !24, !tbaa !6
+  %21 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !24
+  store i64* %21, i64** %18, align 8, !dbg !24
+  %send25 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !24
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %pc, align 8, !dbg !24, !tbaa !34
+  %rubyStr_foo = load i64, i64* @rubyStrFrozen_foo, align 8, !dbg !75
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !25
+  %23 = load i64*, i64** %22, align 8, !dbg !25
+  store i64 %4, i64* %23, align 8, !dbg !25, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !25
+  store i64 %rubyStr_foo, i64* %24, align 8, !dbg !25, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !25
+  store i64* %25, i64** %22, align 8, !dbg !25
+  %send27 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_raise, i64 0), !dbg !25
+  %26 = load i64*, i64** %9, align 8, !dbg !25, !tbaa !51
+  %27 = load i64, i64* %26, align 8, !dbg !25, !tbaa !6
+  %28 = and i64 %27, 8, !dbg !25
+  %29 = icmp eq i64 %28, 0, !dbg !25
+  br i1 %29, label %30, label %32, !dbg !25, !prof !64
 
 30:                                               ; preds = %BB5
-  %31 = getelementptr inbounds i64, i64* %26, i64 -5, !dbg !23
-  store i64 %send27, i64* %31, align 8, !dbg !23, !tbaa !4
-  br label %BB7, !dbg !23
+  %31 = getelementptr inbounds i64, i64* %26, i64 -5, !dbg !25
+  store i64 %send27, i64* %31, align 8, !dbg !25, !tbaa !6
+  br label %BB7, !dbg !25
 
 32:                                               ; preds = %BB5
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %26, i32 noundef -5, i64 %send27) #11, !dbg !23
-  br label %BB7, !dbg !23
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %26, i32 noundef -5, i64 %send27) #11, !dbg !25
+  br label %BB7, !dbg !25
 
 BB7:                                              ; preds = %32, %30, %functionEntryInitializers
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !32
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !34
   ret i64 52
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_A.test$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #7 !dbg !25 {
+define internal noundef i64 @"func_A.test$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #7 !dbg !27 {
 vm_get_ep.exit34:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !32
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !44
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !46
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !71
+  %4 = load i64, i64* %3, align 8, !tbaa !73
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.test$block_2", align 8
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #11
-  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !32
+  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
   %6 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %5, i64 0, i32 2
-  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !44
+  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !46
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !tbaa !32
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !32
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !24
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !24, !tbaa !44
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !24
-  %13 = load i64*, i64** %12, align 8, !dbg !24
-  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !24
-  %15 = load i64, i64* %14, align 8, !dbg !24, !tbaa !4
-  %16 = and i64 %15, -4, !dbg !24
-  %17 = inttoptr i64 %16 to i64*, !dbg !24
-  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !24
-  %19 = load i64, i64* %18, align 8, !dbg !24, !tbaa !4
-  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !24
-  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !24
-  %22 = load i64*, i64** %21, align 8, !dbg !24
-  store i64 %19, i64* %22, align 8, !dbg !24, !tbaa !4
-  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !24
-  store i64 %20, i64* %23, align 8, !dbg !24, !tbaa !4
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !24
-  store i64* %24, i64** %21, align 8, !dbg !24
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_is_a?", i64 0), !dbg !24
-  %25 = and i64 %send, -9, !dbg !24
-  %26 = icmp ne i64 %25, 0, !dbg !24
-  br i1 %26, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !24
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !tbaa !34
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !34
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !26
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !26, !tbaa !46
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !26
+  %13 = load i64*, i64** %12, align 8, !dbg !26
+  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !26
+  %15 = load i64, i64* %14, align 8, !dbg !26, !tbaa !6
+  %16 = and i64 %15, -4, !dbg !26
+  %17 = inttoptr i64 %16 to i64*, !dbg !26
+  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !26
+  %19 = load i64, i64* %18, align 8, !dbg !26, !tbaa !6
+  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !26
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !26
+  %22 = load i64*, i64** %21, align 8, !dbg !26
+  store i64 %19, i64* %22, align 8, !dbg !26, !tbaa !6
+  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !26
+  store i64 %20, i64* %23, align 8, !dbg !26, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !26
+  store i64* %24, i64** %21, align 8, !dbg !26
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_is_a?", i64 0), !dbg !26
+  %25 = and i64 %send, -9, !dbg !26
+  %26 = icmp ne i64 %25, 0, !dbg !26
+  br i1 %26, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !26
 
 blockExit:                                        ; preds = %78, %76, %63, %61
   tail call void @sorbet_popFrame()
   ret i64 52
 
 vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
-  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !74, !tbaa !32
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2, !dbg !74
-  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !dbg !74, !tbaa !44
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4, !dbg !74
-  %31 = load i64*, i64** %30, align 8, !dbg !74
-  %32 = getelementptr inbounds i64, i64* %31, i64 -1, !dbg !74
-  %33 = load i64, i64* %32, align 8, !dbg !74, !tbaa !4
-  %34 = and i64 %33, -4, !dbg !74
-  %35 = inttoptr i64 %34 to i64*, !dbg !74
-  %36 = load i64, i64* %35, align 8, !dbg !74, !tbaa !4
-  %37 = and i64 %36, 8, !dbg !74
-  %38 = icmp eq i64 %37, 0, !dbg !74
-  br i1 %38, label %39, label %41, !dbg !74, !prof !62
+  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !76, !tbaa !34
+  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2, !dbg !76
+  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !dbg !76, !tbaa !46
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4, !dbg !76
+  %31 = load i64*, i64** %30, align 8, !dbg !76
+  %32 = getelementptr inbounds i64, i64* %31, i64 -1, !dbg !76
+  %33 = load i64, i64* %32, align 8, !dbg !76, !tbaa !6
+  %34 = and i64 %33, -4, !dbg !76
+  %35 = inttoptr i64 %34 to i64*, !dbg !76
+  %36 = load i64, i64* %35, align 8, !dbg !76, !tbaa !6
+  %37 = and i64 %36, 8, !dbg !76
+  %38 = icmp eq i64 %37, 0, !dbg !76
+  br i1 %38, label %39, label %41, !dbg !76, !prof !64
 
 39:                                               ; preds = %vm_get_ep.exit32
-  %40 = getelementptr inbounds i64, i64* %35, i64 -3, !dbg !74
-  store i64 8, i64* %40, align 8, !dbg !74, !tbaa !4
-  br label %vm_get_ep.exit30, !dbg !74
+  %40 = getelementptr inbounds i64, i64* %35, i64 -3, !dbg !76
+  store i64 8, i64* %40, align 8, !dbg !76, !tbaa !6
+  br label %vm_get_ep.exit30, !dbg !76
 
 41:                                               ; preds = %vm_get_ep.exit32
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %35, i32 noundef -3, i64 noundef 8) #11, !dbg !74
-  br label %vm_get_ep.exit30, !dbg !74
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %35, i32 noundef -3, i64 noundef 8) #11, !dbg !76
+  br label %vm_get_ep.exit30, !dbg !76
 
 vm_get_ep.exit30:                                 ; preds = %39, %41
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !75, !tbaa !32
-  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !32
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !26
-  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !26, !tbaa !44
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !26
-  %46 = load i64*, i64** %45, align 8, !dbg !26
-  store i64 %4, i64* %46, align 8, !dbg !26, !tbaa !4
-  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !26
-  store i64 %19, i64* %47, align 8, !dbg !26, !tbaa !4
-  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !26
-  store i64* %48, i64** %45, align 8, !dbg !26
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !26
-  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !32
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 2, !dbg !26
-  %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !26, !tbaa !44
-  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 4, !dbg !26
-  %53 = load i64*, i64** %52, align 8, !dbg !26
-  %54 = getelementptr inbounds i64, i64* %53, i64 -1, !dbg !26
-  %55 = load i64, i64* %54, align 8, !dbg !26, !tbaa !4
-  %56 = and i64 %55, -4, !dbg !26
-  %57 = inttoptr i64 %56 to i64*, !dbg !26
-  %58 = load i64, i64* %57, align 8, !dbg !26, !tbaa !4
-  %59 = and i64 %58, 8, !dbg !26
-  %60 = icmp eq i64 %59, 0, !dbg !26
-  br i1 %60, label %61, label %63, !dbg !26, !prof !62
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !77, !tbaa !34
+  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !34
+  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !28
+  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !28, !tbaa !46
+  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !28
+  %46 = load i64*, i64** %45, align 8, !dbg !28
+  store i64 %4, i64* %46, align 8, !dbg !28, !tbaa !6
+  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !28
+  store i64 %19, i64* %47, align 8, !dbg !28, !tbaa !6
+  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !28
+  store i64* %48, i64** %45, align 8, !dbg !28
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !28
+  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !34
+  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 2, !dbg !28
+  %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !28, !tbaa !46
+  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 4, !dbg !28
+  %53 = load i64*, i64** %52, align 8, !dbg !28
+  %54 = getelementptr inbounds i64, i64* %53, i64 -1, !dbg !28
+  %55 = load i64, i64* %54, align 8, !dbg !28, !tbaa !6
+  %56 = and i64 %55, -4, !dbg !28
+  %57 = inttoptr i64 %56 to i64*, !dbg !28
+  %58 = load i64, i64* %57, align 8, !dbg !28, !tbaa !6
+  %59 = and i64 %58, 8, !dbg !28
+  %60 = icmp eq i64 %59, 0, !dbg !28
+  br i1 %60, label %61, label %63, !dbg !28, !prof !64
 
 61:                                               ; preds = %vm_get_ep.exit30
-  %62 = getelementptr inbounds i64, i64* %57, i64 -5, !dbg !26
-  store i64 %send42, i64* %62, align 8, !dbg !26, !tbaa !4
-  br label %blockExit, !dbg !26
+  %62 = getelementptr inbounds i64, i64* %57, i64 -5, !dbg !28
+  store i64 %send42, i64* %62, align 8, !dbg !28, !tbaa !6
+  br label %blockExit, !dbg !28
 
 63:                                               ; preds = %vm_get_ep.exit30
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %57, i32 noundef -5, i64 %send42) #11, !dbg !26
-  br label %blockExit, !dbg !26
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %57, i32 noundef -5, i64 %send42) #11, !dbg !28
+  br label %blockExit, !dbg !28
 
 vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !tbaa !32
-  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !76, !tbaa !32
-  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2, !dbg !76
-  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !dbg !76, !tbaa !44
-  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %66, i64 0, i32 4, !dbg !76
-  %68 = load i64*, i64** %67, align 8, !dbg !76
-  %69 = getelementptr inbounds i64, i64* %68, i64 -1, !dbg !76
-  %70 = load i64, i64* %69, align 8, !dbg !76, !tbaa !4
-  %71 = and i64 %70, -4, !dbg !76
-  %72 = inttoptr i64 %71 to i64*, !dbg !76
-  %73 = load i64, i64* %72, align 8, !dbg !76, !tbaa !4
-  %74 = and i64 %73, 8, !dbg !76
-  %75 = icmp eq i64 %74, 0, !dbg !76
-  br i1 %75, label %76, label %78, !dbg !76, !prof !62
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !tbaa !34
+  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !34
+  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2, !dbg !78
+  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !dbg !78, !tbaa !46
+  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %66, i64 0, i32 4, !dbg !78
+  %68 = load i64*, i64** %67, align 8, !dbg !78
+  %69 = getelementptr inbounds i64, i64* %68, i64 -1, !dbg !78
+  %70 = load i64, i64* %69, align 8, !dbg !78, !tbaa !6
+  %71 = and i64 %70, -4, !dbg !78
+  %72 = inttoptr i64 %71 to i64*, !dbg !78
+  %73 = load i64, i64* %72, align 8, !dbg !78, !tbaa !6
+  %74 = and i64 %73, 8, !dbg !78
+  %75 = icmp eq i64 %74, 0, !dbg !78
+  br i1 %75, label %76, label %78, !dbg !78, !prof !64
 
 76:                                               ; preds = %vm_get_ep.exit
-  %77 = getelementptr inbounds i64, i64* %72, i64 -7, !dbg !76
-  store i64 20, i64* %77, align 8, !dbg !76, !tbaa !4
-  br label %blockExit, !dbg !76
+  %77 = getelementptr inbounds i64, i64* %72, i64 -7, !dbg !78
+  store i64 20, i64* %77, align 8, !dbg !78, !tbaa !6
+  br label %blockExit, !dbg !78
 
 78:                                               ; preds = %vm_get_ep.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %72, i32 noundef -7, i64 noundef 20) #11, !dbg !76
-  br label %blockExit, !dbg !76
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %72, i32 noundef -7, i64 noundef 20) #11, !dbg !78
+  br label %blockExit, !dbg !78
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_A.test$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #7 !dbg !30 {
+define internal noundef i64 @"func_A.test$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #7 !dbg !32 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !32
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !44
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !46
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !71
+  %4 = load i64, i64* %3, align 8, !tbaa !73
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.test$block_3", align 8
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #11
-  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !32
+  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
   %6 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %5, i64 0, i32 2
-  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !44
+  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !46
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !tbaa !32
-  %rubyStr_ensure = load i64, i64* @rubyStrFrozen_ensure, align 8, !dbg !77
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !32
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !29
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !29, !tbaa !44
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !29
-  %13 = load i64*, i64** %12, align 8, !dbg !29
-  store i64 %4, i64* %13, align 8, !dbg !29, !tbaa !4
-  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !29
-  store i64 %rubyStr_ensure, i64* %14, align 8, !dbg !29, !tbaa !4
-  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !29
-  store i64* %15, i64** %12, align 8, !dbg !29
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.7, i64 0), !dbg !29
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !tbaa !34
+  %rubyStr_ensure = load i64, i64* @rubyStrFrozen_ensure, align 8, !dbg !79
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !31, !tbaa !34
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !31
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !31, !tbaa !46
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !31
+  %13 = load i64*, i64** %12, align 8, !dbg !31
+  store i64 %4, i64* %13, align 8, !dbg !31, !tbaa !6
+  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !31
+  store i64 %rubyStr_ensure, i64* %14, align 8, !dbg !31, !tbaa !6
+  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !31
+  store i64* %15, i64** %12, align 8, !dbg !31
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.7, i64 0), !dbg !31
   tail call void @sorbet_popFrame()
   ret i64 52
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_A.test$block_4"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* %cfp) #7 !dbg !28 {
+define internal noundef i64 @"func_A.test$block_4"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* %cfp) #7 !dbg !30 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !32
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !44
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !46
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !71
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !tbaa !32
-  %rubyStr_else = load i64, i64* @rubyStrFrozen_else, align 8, !dbg !78
-  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !27
-  %6 = load i64*, i64** %5, align 8, !dbg !27
-  store i64 %4, i64* %6, align 8, !dbg !27, !tbaa !4
-  %7 = getelementptr inbounds i64, i64* %6, i64 1, !dbg !27
-  store i64 %rubyStr_else, i64* %7, align 8, !dbg !27, !tbaa !4
-  %8 = getelementptr inbounds i64, i64* %7, i64 1, !dbg !27
-  store i64* %8, i64** %5, align 8, !dbg !27
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !27
-  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !27
-  %10 = load i64*, i64** %9, align 8, !dbg !27, !tbaa !49
-  %11 = load i64, i64* %10, align 8, !dbg !27, !tbaa !4
-  %12 = and i64 %11, 8, !dbg !27
-  %13 = icmp eq i64 %12, 0, !dbg !27
-  br i1 %13, label %14, label %16, !dbg !27, !prof !62
+  %4 = load i64, i64* %3, align 8, !tbaa !73
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !tbaa !34
+  %rubyStr_else = load i64, i64* @rubyStrFrozen_else, align 8, !dbg !80
+  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !29
+  %6 = load i64*, i64** %5, align 8, !dbg !29
+  store i64 %4, i64* %6, align 8, !dbg !29, !tbaa !6
+  %7 = getelementptr inbounds i64, i64* %6, i64 1, !dbg !29
+  store i64 %rubyStr_else, i64* %7, align 8, !dbg !29, !tbaa !6
+  %8 = getelementptr inbounds i64, i64* %7, i64 1, !dbg !29
+  store i64* %8, i64** %5, align 8, !dbg !29
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !29
+  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !29
+  %10 = load i64*, i64** %9, align 8, !dbg !29, !tbaa !51
+  %11 = load i64, i64* %10, align 8, !dbg !29, !tbaa !6
+  %12 = and i64 %11, 8, !dbg !29
+  %13 = icmp eq i64 %12, 0, !dbg !29
+  br i1 %13, label %14, label %16, !dbg !29, !prof !64
 
 14:                                               ; preds = %functionEntryInitializers
-  %15 = getelementptr inbounds i64, i64* %10, i64 -5, !dbg !27
-  store i64 %send, i64* %15, align 8, !dbg !27, !tbaa !4
-  br label %sorbet_writeLocal.exit, !dbg !27
+  %15 = getelementptr inbounds i64, i64* %10, i64 -5, !dbg !29
+  store i64 %send, i64* %15, align 8, !dbg !29, !tbaa !6
+  br label %sorbet_writeLocal.exit, !dbg !29
 
 16:                                               ; preds = %functionEntryInitializers
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %10, i32 noundef -5, i64 %send) #11, !dbg !27
-  br label %sorbet_writeLocal.exit, !dbg !27
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %10, i32 noundef -5, i64 %send) #11, !dbg !29
+  br label %sorbet_writeLocal.exit, !dbg !29
 
 sorbet_writeLocal.exit:                           ; preds = %14, %16
   ret i64 52
@@ -825,7 +825,7 @@ declare void @llvm.assume(i1 noundef) #9
 define linkonce void @const_recompute_A() local_unnamed_addr #7 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !53
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !55
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -845,85 +845,87 @@ attributes #11 = { nounwind }
 attributes #12 = { nounwind allocsize(0,1) }
 attributes #13 = { noreturn }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/exceptions/basic.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 6, column: 3, scope: !9, inlinedAt: !13)
-!9 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L62", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = distinct !DILocation(line: 5, column: 1, scope: !14)
-!14 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!15 = !DILocation(line: 23, column: 1, scope: !14)
-!16 = !DILocation(line: 24, column: 1, scope: !14)
-!17 = !DILocation(line: 26, column: 1, scope: !14)
-!18 = !DILocation(line: 27, column: 1, scope: !14)
-!19 = !DILocation(line: 8, column: 7, scope: !20)
-!20 = distinct !DISubprogram(name: "A.test", linkageName: "func_A.test$block_1", scope: !21, file: !2, line: 6, type: !10, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!21 = distinct !DISubprogram(name: "A.test", linkageName: "func_A.test", scope: null, file: !2, line: 6, type: !10, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!22 = !DILocation(line: 10, column: 9, scope: !20)
-!23 = !DILocation(line: 11, column: 9, scope: !20)
-!24 = !DILocation(line: 13, column: 15, scope: !25)
-!25 = distinct !DISubprogram(name: "A.test", linkageName: "func_A.test$block_2", scope: !21, file: !2, line: 6, type: !10, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!26 = !DILocation(line: 14, column: 7, scope: !25)
-!27 = !DILocation(line: 16, column: 7, scope: !28)
-!28 = distinct !DISubprogram(name: "A.test", linkageName: "func_A.test$block_4", scope: !21, file: !2, line: 6, type: !10, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!29 = !DILocation(line: 18, column: 7, scope: !30)
-!30 = distinct !DISubprogram(name: "A.test", linkageName: "func_A.test$block_3", scope: !21, file: !2, line: 6, type: !10, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!31 = !DILocation(line: 6, column: 3, scope: !9)
-!32 = !{!33, !33, i64 0}
-!33 = !{!"any pointer", !6, i64 0}
-!34 = !{!35, !5, i64 400}
-!35 = !{!"rb_vm_struct", !5, i64 0, !36, i64 8, !33, i64 192, !33, i64 200, !33, i64 208, !40, i64 216, !6, i64 224, !37, i64 264, !37, i64 280, !37, i64 296, !37, i64 312, !5, i64 328, !39, i64 336, !39, i64 340, !39, i64 344, !39, i64 344, !39, i64 344, !39, i64 344, !39, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !33, i64 456, !33, i64 464, !41, i64 472, !42, i64 992, !33, i64 1016, !33, i64 1024, !39, i64 1032, !39, i64 1036, !37, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !39, i64 1136, !33, i64 1144, !33, i64 1152, !33, i64 1160, !33, i64 1168, !33, i64 1176, !33, i64 1184, !39, i64 1192, !43, i64 1200, !6, i64 1232}
-!36 = !{!"rb_global_vm_lock_struct", !33, i64 0, !6, i64 8, !37, i64 48, !33, i64 64, !39, i64 72, !6, i64 80, !6, i64 128, !39, i64 176, !39, i64 180}
-!37 = !{!"list_head", !38, i64 0}
-!38 = !{!"list_node", !33, i64 0, !33, i64 8}
-!39 = !{!"int", !6, i64 0}
-!40 = !{!"long long", !6, i64 0}
-!41 = !{!"", !6, i64 0}
-!42 = !{!"rb_hook_list_struct", !33, i64 0, !39, i64 8, !39, i64 12, !39, i64 16}
-!43 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!44 = !{!45, !33, i64 16}
-!45 = !{!"rb_execution_context_struct", !33, i64 0, !5, i64 8, !33, i64 16, !33, i64 24, !33, i64 32, !39, i64 40, !39, i64 44, !33, i64 48, !33, i64 56, !33, i64 64, !5, i64 72, !5, i64 80, !33, i64 88, !5, i64 96, !33, i64 104, !33, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !46, i64 152}
-!46 = !{!"", !33, i64 0, !33, i64 8, !5, i64 16, !6, i64 24}
-!47 = !{!48, !33, i64 16}
-!48 = !{!"rb_control_frame_struct", !33, i64 0, !33, i64 8, !33, i64 16, !5, i64 24, !33, i64 32, !33, i64 40, !33, i64 48}
-!49 = !{!48, !33, i64 32}
-!50 = !DILocation(line: 0, scope: !14)
-!51 = !DILocation(line: 5, column: 1, scope: !14)
-!52 = !DILocation(line: 0, scope: !9, inlinedAt: !13)
-!53 = !{!40, !40, i64 0}
-!54 = !{!"branch_weights", i32 1, i32 10000}
-!55 = !{!56, !39, i64 8}
-!56 = !{!"rb_sorbet_param_struct", !57, i64 0, !39, i64 4, !39, i64 8, !39, i64 12, !39, i64 16, !39, i64 20, !39, i64 24, !39, i64 28, !33, i64 32, !39, i64 40, !39, i64 44, !39, i64 48, !39, i64 52, !33, i64 56}
-!57 = !{!"", !39, i64 0, !39, i64 0, !39, i64 0, !39, i64 0, !39, i64 0, !39, i64 0, !39, i64 0, !39, i64 0, !39, i64 1, !39, i64 1}
-!58 = !{!56, !39, i64 4}
-!59 = !{!56, !33, i64 32}
-!60 = !{!45, !39, i64 40}
-!61 = !{!45, !39, i64 44}
-!62 = !{!"branch_weights", i32 2000, i32 1}
-!63 = !{!45, !33, i64 56}
-!64 = !DILocation(line: 23, column: 6, scope: !14)
-!65 = !DILocation(line: 26, column: 6, scope: !14)
-!66 = !DILocation(line: 6, column: 3, scope: !21)
-!67 = !{!"branch_weights", i32 4001, i32 4000000}
-!68 = !DILocation(line: 0, scope: !21)
-!69 = !DILocation(line: 8, column: 7, scope: !21)
-!70 = !DILocation(line: 20, column: 3, scope: !21)
-!71 = !{!48, !5, i64 24}
-!72 = !DILocation(line: 8, column: 12, scope: !20)
-!73 = !DILocation(line: 11, column: 15, scope: !20)
-!74 = !DILocation(line: 0, scope: !25)
-!75 = !DILocation(line: 13, column: 5, scope: !25)
-!76 = !DILocation(line: 8, column: 7, scope: !25)
-!77 = !DILocation(line: 18, column: 12, scope: !30)
-!78 = !DILocation(line: 16, column: 12, scope: !28)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/exceptions/basic.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 6, column: 3, scope: !11, inlinedAt: !15)
+!11 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = distinct !DILocation(line: 5, column: 1, scope: !16)
+!16 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!17 = !DILocation(line: 23, column: 1, scope: !16)
+!18 = !DILocation(line: 24, column: 1, scope: !16)
+!19 = !DILocation(line: 26, column: 1, scope: !16)
+!20 = !DILocation(line: 27, column: 1, scope: !16)
+!21 = !DILocation(line: 8, column: 7, scope: !22)
+!22 = distinct !DISubprogram(name: "A.test", linkageName: "func_A.test$block_1", scope: !23, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!23 = distinct !DISubprogram(name: "A.test", linkageName: "func_A.test", scope: null, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!24 = !DILocation(line: 10, column: 9, scope: !22)
+!25 = !DILocation(line: 11, column: 9, scope: !22)
+!26 = !DILocation(line: 13, column: 15, scope: !27)
+!27 = distinct !DISubprogram(name: "A.test", linkageName: "func_A.test$block_2", scope: !23, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!28 = !DILocation(line: 14, column: 7, scope: !27)
+!29 = !DILocation(line: 16, column: 7, scope: !30)
+!30 = distinct !DISubprogram(name: "A.test", linkageName: "func_A.test$block_4", scope: !23, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!31 = !DILocation(line: 18, column: 7, scope: !32)
+!32 = distinct !DISubprogram(name: "A.test", linkageName: "func_A.test$block_3", scope: !23, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!33 = !DILocation(line: 6, column: 3, scope: !11)
+!34 = !{!35, !35, i64 0}
+!35 = !{!"any pointer", !8, i64 0}
+!36 = !{!37, !7, i64 400}
+!37 = !{!"rb_vm_struct", !7, i64 0, !38, i64 8, !35, i64 192, !35, i64 200, !35, i64 208, !42, i64 216, !8, i64 224, !39, i64 264, !39, i64 280, !39, i64 296, !39, i64 312, !7, i64 328, !41, i64 336, !41, i64 340, !41, i64 344, !41, i64 344, !41, i64 344, !41, i64 344, !41, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !35, i64 456, !35, i64 464, !43, i64 472, !44, i64 992, !35, i64 1016, !35, i64 1024, !41, i64 1032, !41, i64 1036, !39, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !41, i64 1136, !35, i64 1144, !35, i64 1152, !35, i64 1160, !35, i64 1168, !35, i64 1176, !35, i64 1184, !41, i64 1192, !45, i64 1200, !8, i64 1232}
+!38 = !{!"rb_global_vm_lock_struct", !35, i64 0, !8, i64 8, !39, i64 48, !35, i64 64, !41, i64 72, !8, i64 80, !8, i64 128, !41, i64 176, !41, i64 180}
+!39 = !{!"list_head", !40, i64 0}
+!40 = !{!"list_node", !35, i64 0, !35, i64 8}
+!41 = !{!"int", !8, i64 0}
+!42 = !{!"long long", !8, i64 0}
+!43 = !{!"", !8, i64 0}
+!44 = !{!"rb_hook_list_struct", !35, i64 0, !41, i64 8, !41, i64 12, !41, i64 16}
+!45 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!46 = !{!47, !35, i64 16}
+!47 = !{!"rb_execution_context_struct", !35, i64 0, !7, i64 8, !35, i64 16, !35, i64 24, !35, i64 32, !41, i64 40, !41, i64 44, !35, i64 48, !35, i64 56, !35, i64 64, !7, i64 72, !7, i64 80, !35, i64 88, !7, i64 96, !35, i64 104, !35, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !48, i64 152}
+!48 = !{!"", !35, i64 0, !35, i64 8, !7, i64 16, !8, i64 24}
+!49 = !{!50, !35, i64 16}
+!50 = !{!"rb_control_frame_struct", !35, i64 0, !35, i64 8, !35, i64 16, !7, i64 24, !35, i64 32, !35, i64 40, !35, i64 48}
+!51 = !{!50, !35, i64 32}
+!52 = !DILocation(line: 0, scope: !16)
+!53 = !DILocation(line: 5, column: 1, scope: !16)
+!54 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
+!55 = !{!42, !42, i64 0}
+!56 = !{!"branch_weights", i32 1, i32 10000}
+!57 = !{!58, !41, i64 8}
+!58 = !{!"rb_sorbet_param_struct", !59, i64 0, !41, i64 4, !41, i64 8, !41, i64 12, !41, i64 16, !41, i64 20, !41, i64 24, !41, i64 28, !35, i64 32, !41, i64 40, !41, i64 44, !41, i64 48, !41, i64 52, !35, i64 56}
+!59 = !{!"", !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 1, !41, i64 1}
+!60 = !{!58, !41, i64 4}
+!61 = !{!58, !35, i64 32}
+!62 = !{!47, !41, i64 40}
+!63 = !{!47, !41, i64 44}
+!64 = !{!"branch_weights", i32 2000, i32 1}
+!65 = !{!47, !35, i64 56}
+!66 = !DILocation(line: 23, column: 6, scope: !16)
+!67 = !DILocation(line: 26, column: 6, scope: !16)
+!68 = !DILocation(line: 6, column: 3, scope: !23)
+!69 = !{!"branch_weights", i32 4001, i32 4000000}
+!70 = !DILocation(line: 0, scope: !23)
+!71 = !DILocation(line: 8, column: 7, scope: !23)
+!72 = !DILocation(line: 20, column: 3, scope: !23)
+!73 = !{!50, !7, i64 24}
+!74 = !DILocation(line: 8, column: 12, scope: !22)
+!75 = !DILocation(line: 11, column: 15, scope: !22)
+!76 = !DILocation(line: 0, scope: !27)
+!77 = !DILocation(line: 13, column: 5, scope: !27)
+!78 = !DILocation(line: 8, column: 7, scope: !27)
+!79 = !DILocation(line: 18, column: 12, scope: !32)
+!80 = !DILocation(line: 16, column: 12, scope: !30)

--- a/test/testdata/compiler/final_method_child_class.llo.exp
+++ b/test/testdata/compiler/final_method_child_class.llo.exp
@@ -183,14 +183,14 @@ declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
   unreachable
 }
@@ -237,10 +237,10 @@ entry:
   %"rubyStr_test/testdata/compiler/final_method_child_class.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/final_method_child_class.rb", align 8
   %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/final_method_child_class.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !8
-  %rubyId_final_method.i = load i64, i64* @rubyIdPrecomputed_final_method, align 8, !dbg !8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_final_method, i64 %rubyId_final_method.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !8
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  %rubyId_final_method.i = load i64, i64* @rubyIdPrecomputed_final_method, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_final_method, i64 %rubyId_final_method.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %14 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @str_final_method, i64 0, i64 0), i64 noundef 12) #10
   call void @rb_gc_register_mark_object(i64 %14) #10
   %rubyId_final_method.i.i = load i64, i64* @rubyIdPrecomputed_final_method, align 8
@@ -250,8 +250,8 @@ entry:
   %16 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_final method!", i64 0, i64 0), i64 noundef 13) #10
   call void @rb_gc_register_mark_object(i64 %16) #10
   store i64 %16, i64* @"rubyStrFrozen_final method!", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !13
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !13
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
   %17 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #10
   store i64 %17, i64* @"<void-singleton>", align 8
   %"rubyId_<top (required)>.i15.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -266,270 +266,270 @@ entry:
   %"rubyStr_test/testdata/compiler/final_method_child_class.rb.i19.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/final_method_child_class.rb", align 8
   %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %"rubyId_block for.i.i", i64 %"rubyStr_test/testdata/compiler/final_method_child_class.rb.i19.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 5)
   store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Parent.<static-init>$block_1", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !15
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 4, i32 noundef 0, i64* noundef null), !dbg !15
-  %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %rubyId_extend9.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend.1, i64 %rubyId_extend9.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !21
+  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !17
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 4, i32 noundef 0, i64* noundef null), !dbg !17
+  %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !19
+  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !21
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
+  %rubyId_extend9.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !22
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend.1, i64 %rubyId_extend9.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !23
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !23
   %"rubyId_<top (required)>.i20.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i21.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/final_method_child_class.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/final_method_child_class.rb", align 8
   %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i21.i", i64 %"rubyId_<top (required)>.i20.i", i64 %"rubyStr_test/testdata/compiler/final_method_child_class.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 15, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Child.<static-init>", align 8
-  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
+  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
   %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
-  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !24
+  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !26
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !28
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !30
   %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
-  %27 = load i64*, i64** %26, align 8, !tbaa !30
-  %28 = load i64, i64* %27, align 8, !tbaa !4
+  %27 = load i64*, i64** %26, align 8, !tbaa !32
+  %28 = load i64, i64* %27, align 8, !tbaa !6
   %29 = and i64 %28, -33
-  store i64 %29, i64* %27, align 8, !tbaa !4
+  store i64 %29, i64* %27, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i) #10
   %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !31, !tbaa !22
-  %31 = load i64, i64* @rb_cObject, align 8, !dbg !32
-  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_Parent, i64 0, i64 0), i64 %31) #10, !dbg !32
-  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #10, !dbg !32
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !33, !tbaa !24
+  %31 = load i64, i64* @rb_cObject, align 8, !dbg !34
+  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_Parent, i64 0, i64 0), i64 %31) #10, !dbg !34
+  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #10, !dbg !34
   %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Parent.<static-init>", align 8
-  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
+  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
   %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
-  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !24
+  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !26
   %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !28
+  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !30
   %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
-  %39 = load i64*, i64** %38, align 8, !tbaa !30
-  %40 = load i64, i64* %39, align 8, !tbaa !4
+  %39 = load i64*, i64** %38, align 8, !tbaa !32
+  %40 = load i64, i64* %39, align 8, !tbaa !6
   %41 = and i64 %40, -33
-  store i64 %41, i64* %39, align 8, !tbaa !4
+  store i64 %41, i64* %39, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i1.i) #10
   %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %42, align 8, !dbg !33, !tbaa !22
-  %rubyId_final.i.i = load i64, i64* @rubyIdPrecomputed_final, align 8, !dbg !35
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_final.i.i) #10, !dbg !35
-  %rubyId_final_method.i.i1 = load i64, i64* @rubyIdPrecomputed_final_method, align 8, !dbg !36
-  %rawSym33.i.i = call i64 @rb_id2sym(i64 %rubyId_final_method.i.i1) #10, !dbg !36
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym33.i.i, i64 %32, i64 %rawSym.i.i, i64 (i64, i64, i32, i64*, i64)* noundef @"func_Parent.<static-init>L62$block_1") #10, !dbg !36
-  %43 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !36, !tbaa !22
-  %44 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 5, !dbg !36
-  %45 = load i32, i32* %44, align 8, !dbg !36, !tbaa !37
-  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 6, !dbg !36
-  %47 = load i32, i32* %46, align 4, !dbg !36, !tbaa !38
-  %48 = xor i32 %47, -1, !dbg !36
-  %49 = and i32 %48, %45, !dbg !36
-  %50 = icmp eq i32 %49, 0, !dbg !36
-  br i1 %50, label %fastSymCallIntrinsic_Static_keep_def.i.i, label %51, !dbg !36, !prof !39
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %42, align 8, !dbg !35, !tbaa !24
+  %rubyId_final.i.i = load i64, i64* @rubyIdPrecomputed_final, align 8, !dbg !37
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_final.i.i) #10, !dbg !37
+  %rubyId_final_method.i.i1 = load i64, i64* @rubyIdPrecomputed_final_method, align 8, !dbg !38
+  %rawSym33.i.i = call i64 @rb_id2sym(i64 %rubyId_final_method.i.i1) #10, !dbg !38
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym33.i.i, i64 %32, i64 %rawSym.i.i, i64 (i64, i64, i32, i64*, i64)* noundef @"func_Parent.<static-init>L62$block_1") #10, !dbg !38
+  %43 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !38, !tbaa !24
+  %44 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 5, !dbg !38
+  %45 = load i32, i32* %44, align 8, !dbg !38, !tbaa !39
+  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 6, !dbg !38
+  %47 = load i32, i32* %46, align 4, !dbg !38, !tbaa !40
+  %48 = xor i32 %47, -1, !dbg !38
+  %49 = and i32 %48, %45, !dbg !38
+  %50 = icmp eq i32 %49, 0, !dbg !38
+  br i1 %50, label %fastSymCallIntrinsic_Static_keep_def.i.i, label %51, !dbg !38, !prof !41
 
 51:                                               ; preds = %entry
-  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 8, !dbg !36
-  %53 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %52, align 8, !dbg !36, !tbaa !40
-  %54 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %53, i32 noundef 0) #10, !dbg !36
-  br label %fastSymCallIntrinsic_Static_keep_def.i.i, !dbg !36
+  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 8, !dbg !38
+  %53 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %52, align 8, !dbg !38, !tbaa !42
+  %54 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %53, i32 noundef 0) #10, !dbg !38
+  br label %fastSymCallIntrinsic_Static_keep_def.i.i, !dbg !38
 
 fastSymCallIntrinsic_Static_keep_def.i.i:         ; preds = %51, %entry
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !36, !tbaa !22
-  %55 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !41
-  %56 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !42
-  %needTakeSlowPath = icmp ne i64 %55, %56, !dbg !41
-  br i1 %needTakeSlowPath, label %57, label %58, !dbg !41, !prof !44
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !38, !tbaa !24
+  %55 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !43
+  %56 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %needTakeSlowPath = icmp ne i64 %55, %56, !dbg !43
+  br i1 %needTakeSlowPath, label %57, label %58, !dbg !43, !prof !46
 
 57:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def.i.i
-  call void @"const_recompute_T::Sig"(), !dbg !41
-  br label %58, !dbg !41
+  call void @"const_recompute_T::Sig"(), !dbg !43
+  br label %58, !dbg !43
 
 58:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def.i.i, %57
-  %59 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !41
-  %60 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !41
-  %61 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !42
-  %guardUpdated = icmp eq i64 %60, %61, !dbg !41
-  call void @llvm.assume(i1 %guardUpdated), !dbg !41
-  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !41
-  %63 = load i64*, i64** %62, align 8, !dbg !41
-  store i64 %32, i64* %63, align 8, !dbg !41, !tbaa !4
-  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !41
-  store i64 %59, i64* %64, align 8, !dbg !41, !tbaa !4
-  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !41
-  store i64* %65, i64** %62, align 8, !dbg !41
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !41
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %42, align 8, !dbg !41, !tbaa !22
-  %66 = load i64, i64* @"guard_epoch_T::Helpers", align 8, !dbg !45
-  %67 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !45, !tbaa !42
-  %needTakeSlowPath3 = icmp ne i64 %66, %67, !dbg !45
-  br i1 %needTakeSlowPath3, label %68, label %69, !dbg !45, !prof !44
+  %59 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !43
+  %60 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !43
+  %61 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %guardUpdated = icmp eq i64 %60, %61, !dbg !43
+  call void @llvm.assume(i1 %guardUpdated), !dbg !43
+  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !43
+  %63 = load i64*, i64** %62, align 8, !dbg !43
+  store i64 %32, i64* %63, align 8, !dbg !43, !tbaa !6
+  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !43
+  store i64 %59, i64* %64, align 8, !dbg !43, !tbaa !6
+  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !43
+  store i64* %65, i64** %62, align 8, !dbg !43
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !43
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %42, align 8, !dbg !43, !tbaa !24
+  %66 = load i64, i64* @"guard_epoch_T::Helpers", align 8, !dbg !47
+  %67 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !47, !tbaa !44
+  %needTakeSlowPath3 = icmp ne i64 %66, %67, !dbg !47
+  br i1 %needTakeSlowPath3, label %68, label %69, !dbg !47, !prof !46
 
 68:                                               ; preds = %58
-  call void @"const_recompute_T::Helpers"(), !dbg !45
-  br label %69, !dbg !45
+  call void @"const_recompute_T::Helpers"(), !dbg !47
+  br label %69, !dbg !47
 
 69:                                               ; preds = %58, %68
-  %70 = load i64, i64* @"guarded_const_T::Helpers", align 8, !dbg !45
-  %71 = load i64, i64* @"guard_epoch_T::Helpers", align 8, !dbg !45
-  %72 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !45, !tbaa !42
-  %guardUpdated4 = icmp eq i64 %71, %72, !dbg !45
-  call void @llvm.assume(i1 %guardUpdated4), !dbg !45
-  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !45
-  %74 = load i64*, i64** %73, align 8, !dbg !45
-  store i64 %32, i64* %74, align 8, !dbg !45, !tbaa !4
-  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !45
-  store i64 %70, i64* %75, align 8, !dbg !45, !tbaa !4
-  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !45
-  store i64* %76, i64** %73, align 8, !dbg !45
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend.1, i64 0), !dbg !45
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %42, align 8, !dbg !45, !tbaa !22
-  %rubyId_final_method55.i.i = load i64, i64* @rubyIdPrecomputed_final_method, align 8, !dbg !46
-  %rawSym56.i.i = call i64 @rb_id2sym(i64 %rubyId_final_method55.i.i) #10, !dbg !46
-  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !46
-  %rawSym57.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #10, !dbg !46
-  %77 = load i64, i64* @guard_epoch_Parent, align 8, !dbg !46
-  %78 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !42
-  %needTakeSlowPath5 = icmp ne i64 %77, %78, !dbg !46
-  br i1 %needTakeSlowPath5, label %79, label %80, !dbg !46, !prof !44
+  %70 = load i64, i64* @"guarded_const_T::Helpers", align 8, !dbg !47
+  %71 = load i64, i64* @"guard_epoch_T::Helpers", align 8, !dbg !47
+  %72 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !47, !tbaa !44
+  %guardUpdated4 = icmp eq i64 %71, %72, !dbg !47
+  call void @llvm.assume(i1 %guardUpdated4), !dbg !47
+  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !47
+  %74 = load i64*, i64** %73, align 8, !dbg !47
+  store i64 %32, i64* %74, align 8, !dbg !47, !tbaa !6
+  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !47
+  store i64 %70, i64* %75, align 8, !dbg !47, !tbaa !6
+  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !47
+  store i64* %76, i64** %73, align 8, !dbg !47
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend.1, i64 0), !dbg !47
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %42, align 8, !dbg !47, !tbaa !24
+  %rubyId_final_method55.i.i = load i64, i64* @rubyIdPrecomputed_final_method, align 8, !dbg !48
+  %rawSym56.i.i = call i64 @rb_id2sym(i64 %rubyId_final_method55.i.i) #10, !dbg !48
+  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !48
+  %rawSym57.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #10, !dbg !48
+  %77 = load i64, i64* @guard_epoch_Parent, align 8, !dbg !48
+  %78 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !44
+  %needTakeSlowPath5 = icmp ne i64 %77, %78, !dbg !48
+  br i1 %needTakeSlowPath5, label %79, label %80, !dbg !48, !prof !46
 
 79:                                               ; preds = %69
-  call void @const_recompute_Parent(), !dbg !46
-  br label %80, !dbg !46
+  call void @const_recompute_Parent(), !dbg !48
+  br label %80, !dbg !48
 
 80:                                               ; preds = %69, %79
-  %81 = load i64, i64* @guarded_const_Parent, align 8, !dbg !46
-  %82 = load i64, i64* @guard_epoch_Parent, align 8, !dbg !46
-  %83 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !42
-  %guardUpdated6 = icmp eq i64 %82, %83, !dbg !46
-  call void @llvm.assume(i1 %guardUpdated6), !dbg !46
-  %stackFrame61.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Parent#final_method", align 8, !dbg !46
-  %84 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !46
-  %85 = bitcast i8* %84 to i16*, !dbg !46
-  %86 = load i16, i16* %85, align 8, !dbg !46
-  %87 = and i16 %86, -384, !dbg !46
-  store i16 %87, i16* %85, align 8, !dbg !46
-  %88 = getelementptr inbounds i8, i8* %84, i64 4, !dbg !46
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %88, i8 0, i64 28, i1 false) #10, !dbg !46
-  call void @sorbet_vm_define_method(i64 %81, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @str_final_method, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Parent#final_method", i8* nonnull %84, %struct.rb_iseq_struct* %stackFrame61.i.i, i1 noundef zeroext false) #10, !dbg !46
-  %89 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !22
-  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %89, i64 0, i32 5, !dbg !46
-  %91 = load i32, i32* %90, align 8, !dbg !46, !tbaa !37
-  %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %89, i64 0, i32 6, !dbg !46
-  %93 = load i32, i32* %92, align 4, !dbg !46, !tbaa !38
-  %94 = xor i32 %93, -1, !dbg !46
-  %95 = and i32 %94, %91, !dbg !46
-  %96 = icmp eq i32 %95, 0, !dbg !46
-  br i1 %96, label %"func_<root>.<static-init>$151.exit", label %97, !dbg !46, !prof !39
+  %81 = load i64, i64* @guarded_const_Parent, align 8, !dbg !48
+  %82 = load i64, i64* @guard_epoch_Parent, align 8, !dbg !48
+  %83 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !44
+  %guardUpdated6 = icmp eq i64 %82, %83, !dbg !48
+  call void @llvm.assume(i1 %guardUpdated6), !dbg !48
+  %stackFrame61.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Parent#final_method", align 8, !dbg !48
+  %84 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !48
+  %85 = bitcast i8* %84 to i16*, !dbg !48
+  %86 = load i16, i16* %85, align 8, !dbg !48
+  %87 = and i16 %86, -384, !dbg !48
+  store i16 %87, i16* %85, align 8, !dbg !48
+  %88 = getelementptr inbounds i8, i8* %84, i64 4, !dbg !48
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %88, i8 0, i64 28, i1 false) #10, !dbg !48
+  call void @sorbet_vm_define_method(i64 %81, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @str_final_method, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Parent#final_method", i8* nonnull %84, %struct.rb_iseq_struct* %stackFrame61.i.i, i1 noundef zeroext false) #10, !dbg !48
+  %89 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !48, !tbaa !24
+  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %89, i64 0, i32 5, !dbg !48
+  %91 = load i32, i32* %90, align 8, !dbg !48, !tbaa !39
+  %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %89, i64 0, i32 6, !dbg !48
+  %93 = load i32, i32* %92, align 4, !dbg !48, !tbaa !40
+  %94 = xor i32 %93, -1, !dbg !48
+  %95 = and i32 %94, %91, !dbg !48
+  %96 = icmp eq i32 %95, 0, !dbg !48
+  br i1 %96, label %"func_<root>.<static-init>$151.exit", label %97, !dbg !48, !prof !41
 
 97:                                               ; preds = %80
-  %98 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %89, i64 0, i32 8, !dbg !46
-  %99 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %98, align 8, !dbg !46, !tbaa !40
-  %100 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %99, i32 noundef 0) #10, !dbg !46
-  br label %"func_<root>.<static-init>$151.exit", !dbg !46
+  %98 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %89, i64 0, i32 8, !dbg !48
+  %99 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %98, align 8, !dbg !48, !tbaa !42
+  %100 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %99, i32 noundef 0) #10, !dbg !48
+  br label %"func_<root>.<static-init>$151.exit", !dbg !48
 
 "func_<root>.<static-init>$151.exit":             ; preds = %80, %97
-  call void @sorbet_popFrame() #10, !dbg !32
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %30, align 8, !dbg !32, !tbaa !22
-  %101 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_Child, i64 0, i64 0), i64 %81) #10, !dbg !47
-  %102 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %101) #10, !dbg !47
+  call void @sorbet_popFrame() #10, !dbg !34
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %30, align 8, !dbg !34, !tbaa !24
+  %101 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_Child, i64 0, i64 0), i64 %81) #10, !dbg !49
+  %102 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %101) #10, !dbg !49
   %stackFrame.i.i2 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Child.<static-init>", align 8
-  %103 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
+  %103 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
   %104 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 2
-  %105 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %104, align 8, !tbaa !24
+  %105 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %104, align 8, !tbaa !26
   %106 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %105, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i2, %struct.rb_iseq_struct** %106, align 8, !tbaa !28
+  store %struct.rb_iseq_struct* %stackFrame.i.i2, %struct.rb_iseq_struct** %106, align 8, !tbaa !30
   %107 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %105, i64 0, i32 4
-  %108 = load i64*, i64** %107, align 8, !tbaa !30
-  %109 = load i64, i64* %108, align 8, !tbaa !4
+  %108 = load i64*, i64** %107, align 8, !tbaa !32
+  %109 = load i64, i64* %108, align 8, !tbaa !6
   %110 = and i64 %109, -33
-  store i64 %110, i64* %108, align 8, !tbaa !4
+  store i64 %110, i64* %108, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %103, %struct.rb_control_frame_struct* %105, %struct.rb_iseq_struct* %stackFrame.i.i2) #10
   %111 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %102, i64 0, i32 0
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %111, align 8, !dbg !48, !tbaa !22
-  call void @sorbet_popFrame() #10, !dbg !47
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %30, align 8, !dbg !47, !tbaa !22
-  %112 = load i64, i64* @guard_epoch_Child, align 8, !dbg !8
-  %113 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !8, !tbaa !42
-  %needTakeSlowPath7 = icmp ne i64 %112, %113, !dbg !8
-  br i1 %needTakeSlowPath7, label %114, label %115, !dbg !8, !prof !44
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %111, align 8, !dbg !50, !tbaa !24
+  call void @sorbet_popFrame() #10, !dbg !49
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %30, align 8, !dbg !49, !tbaa !24
+  %112 = load i64, i64* @guard_epoch_Child, align 8, !dbg !10
+  %113 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !44
+  %needTakeSlowPath7 = icmp ne i64 %112, %113, !dbg !10
+  br i1 %needTakeSlowPath7, label %114, label %115, !dbg !10, !prof !46
 
 114:                                              ; preds = %"func_<root>.<static-init>$151.exit"
-  call void @const_recompute_Child(), !dbg !8
-  br label %115, !dbg !8
+  call void @const_recompute_Child(), !dbg !10
+  br label %115, !dbg !10
 
 115:                                              ; preds = %"func_<root>.<static-init>$151.exit", %114
-  %116 = load i64, i64* @guarded_const_Child, align 8, !dbg !8
-  %117 = load i64, i64* @guard_epoch_Child, align 8, !dbg !8
-  %118 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !8, !tbaa !42
-  %guardUpdated8 = icmp eq i64 %117, %118, !dbg !8
-  call void @llvm.assume(i1 %guardUpdated8), !dbg !8
-  %119 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !8
-  %120 = load i64*, i64** %119, align 8, !dbg !8
-  store i64 %116, i64* %120, align 8, !dbg !8, !tbaa !4
-  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !8
-  store i64* %121, i64** %119, align 8, !dbg !8
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !8
-  %122 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !8
-  %123 = load i64*, i64** %122, align 8, !dbg !8
-  store i64 %send12, i64* %123, align 8, !dbg !8, !tbaa !4
-  %124 = getelementptr inbounds i64, i64* %123, i64 1, !dbg !8
-  store i64* %124, i64** %122, align 8, !dbg !8
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_final_method, i64 0), !dbg !8
+  %116 = load i64, i64* @guarded_const_Child, align 8, !dbg !10
+  %117 = load i64, i64* @guard_epoch_Child, align 8, !dbg !10
+  %118 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !44
+  %guardUpdated8 = icmp eq i64 %117, %118, !dbg !10
+  call void @llvm.assume(i1 %guardUpdated8), !dbg !10
+  %119 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
+  %120 = load i64*, i64** %119, align 8, !dbg !10
+  store i64 %116, i64* %120, align 8, !dbg !10, !tbaa !6
+  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !10
+  store i64* %121, i64** %119, align 8, !dbg !10
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !10
+  %122 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
+  %123 = load i64*, i64** %122, align 8, !dbg !10
+  store i64 %send12, i64* %123, align 8, !dbg !10, !tbaa !6
+  %124 = getelementptr inbounds i64, i64* %123, i64 1, !dbg !10
+  store i64* %124, i64** %122, align 8, !dbg !10
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_final_method, i64 0), !dbg !10
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Parent#final_method"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !14 {
+define i64 @"func_Parent#final_method"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !16 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !tbaa !22
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !51
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !51, !prof !52
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !tbaa !24
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !53
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !53, !prof !54
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #12, !dbg !51
-  unreachable, !dbg !51
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #12, !dbg !53
+  unreachable, !dbg !53
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %0, align 8, !dbg !53, !tbaa !22
-  %"rubyStr_final method!" = load i64, i64* @"rubyStrFrozen_final method!", align 8, !dbg !54
-  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !13
-  %2 = load i64*, i64** %1, align 8, !dbg !13
-  store i64 %selfRaw, i64* %2, align 8, !dbg !13, !tbaa !4
-  %3 = getelementptr inbounds i64, i64* %2, i64 1, !dbg !13
-  store i64 %"rubyStr_final method!", i64* %3, align 8, !dbg !13, !tbaa !4
-  %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !13
-  store i64* %4, i64** %1, align 8, !dbg !13
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !13
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %0, align 8, !dbg !55, !tbaa !24
+  %"rubyStr_final method!" = load i64, i64* @"rubyStrFrozen_final method!", align 8, !dbg !56
+  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !15
+  %2 = load i64*, i64** %1, align 8, !dbg !15
+  store i64 %selfRaw, i64* %2, align 8, !dbg !15, !tbaa !6
+  %3 = getelementptr inbounds i64, i64* %2, i64 1, !dbg !15
+  store i64 %"rubyStr_final method!", i64* %3, align 8, !dbg !15, !tbaa !6
+  %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !15
+  store i64* %4, i64** %1, align 8, !dbg !15
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
   %"<void-singleton>" = load i64, i64* @"<void-singleton>", align 8
   ret i64 %"<void-singleton>"
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_Parent.<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #6 !dbg !18 {
+define internal i64 @"func_Parent.<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #6 !dbg !20 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !24
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !26
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !55
+  %4 = load i64, i64* %3, align 8, !tbaa !57
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Parent.<static-init>$block_1", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !28
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !30
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !30
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !32
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %10, align 8, !tbaa !22
-  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !17
-  %12 = load i64*, i64** %11, align 8, !dbg !17
-  store i64 %4, i64* %12, align 8, !dbg !17, !tbaa !4
-  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !17
-  store i64* %13, i64** %11, align 8, !dbg !17
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_void, i64 0), !dbg !17
-  ret i64 %send, !dbg !56
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %10, align 8, !tbaa !24
+  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !19
+  %12 = load i64*, i64** %11, align 8, !dbg !19
+  store i64 %4, i64* %12, align 8, !dbg !19, !tbaa !6
+  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !19
+  store i64* %13, i64** %11, align 8, !dbg !19
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_void, i64 0), !dbg !19
+  ret i64 %send, !dbg !58
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
@@ -542,7 +542,7 @@ declare void @llvm.assume(i1 noundef) #8
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #6 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !42
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
@@ -551,7 +551,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #6 {
 define linkonce void @"const_recompute_T::Helpers"() local_unnamed_addr #6 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"str_T::Helpers", i64 0, i64 0), i64 10)
   store i64 %1, i64* @"guarded_const_T::Helpers", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !42
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @"guard_epoch_T::Helpers", align 8
   ret void
 }
@@ -560,7 +560,7 @@ define linkonce void @"const_recompute_T::Helpers"() local_unnamed_addr #6 {
 define linkonce void @const_recompute_Parent() local_unnamed_addr #6 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @str_Parent, i64 0, i64 0), i64 6)
   store i64 %1, i64* @guarded_const_Parent, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !42
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @guard_epoch_Parent, align 8
   ret void
 }
@@ -569,7 +569,7 @@ define linkonce void @const_recompute_Parent() local_unnamed_addr #6 {
 define linkonce void @const_recompute_Child() local_unnamed_addr #6 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @str_Child, i64 0, i64 0), i64 5)
   store i64 %1, i64* @guarded_const_Child, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !42
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @guard_epoch_Child, align 8
   ret void
 }
@@ -588,63 +588,65 @@ attributes #10 = { nounwind }
 attributes #11 = { nounwind allocsize(0,1) }
 attributes #12 = { noreturn }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/final_method_child_class.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 20, column: 1, scope: !9)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !DILocation(line: 11, column: 5, scope: !14)
-!14 = distinct !DISubprogram(name: "Parent#final_method", linkageName: "func_Parent#final_method", scope: null, file: !2, line: 10, type: !10, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!15 = !DILocation(line: 9, column: 3, scope: !16)
-!16 = distinct !DISubprogram(name: "Parent.<static-init>", linkageName: "func_Parent.<static-init>L62", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!17 = !DILocation(line: 9, column: 16, scope: !18)
-!18 = distinct !DISubprogram(name: "Parent.<static-init>", linkageName: "func_Parent.<static-init>L62$block_1", scope: !16, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!19 = !DILocation(line: 6, column: 3, scope: !16)
-!20 = !DILocation(line: 7, column: 3, scope: !16)
-!21 = !DILocation(line: 10, column: 3, scope: !16)
-!22 = !{!23, !23, i64 0}
-!23 = !{!"any pointer", !6, i64 0}
-!24 = !{!25, !23, i64 16}
-!25 = !{!"rb_execution_context_struct", !23, i64 0, !5, i64 8, !23, i64 16, !23, i64 24, !23, i64 32, !26, i64 40, !26, i64 44, !23, i64 48, !23, i64 56, !23, i64 64, !5, i64 72, !5, i64 80, !23, i64 88, !5, i64 96, !23, i64 104, !23, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !27, i64 152}
-!26 = !{!"int", !6, i64 0}
-!27 = !{!"", !23, i64 0, !23, i64 8, !5, i64 16, !6, i64 24}
-!28 = !{!29, !23, i64 16}
-!29 = !{!"rb_control_frame_struct", !23, i64 0, !23, i64 8, !23, i64 16, !5, i64 24, !23, i64 32, !23, i64 40, !23, i64 48}
-!30 = !{!29, !23, i64 32}
-!31 = !DILocation(line: 0, scope: !9)
-!32 = !DILocation(line: 5, column: 1, scope: !9)
-!33 = !DILocation(line: 0, scope: !16, inlinedAt: !34)
-!34 = distinct !DILocation(line: 5, column: 1, scope: !9)
-!35 = !DILocation(line: 9, column: 7, scope: !16, inlinedAt: !34)
-!36 = !DILocation(line: 9, column: 3, scope: !16, inlinedAt: !34)
-!37 = !{!25, !26, i64 40}
-!38 = !{!25, !26, i64 44}
-!39 = !{!"branch_weights", i32 2000, i32 1}
-!40 = !{!25, !23, i64 56}
-!41 = !DILocation(line: 6, column: 3, scope: !16, inlinedAt: !34)
-!42 = !{!43, !43, i64 0}
-!43 = !{!"long long", !6, i64 0}
-!44 = !{!"branch_weights", i32 1, i32 10000}
-!45 = !DILocation(line: 7, column: 3, scope: !16, inlinedAt: !34)
-!46 = !DILocation(line: 10, column: 3, scope: !16, inlinedAt: !34)
-!47 = !DILocation(line: 15, column: 1, scope: !9)
-!48 = !DILocation(line: 0, scope: !49, inlinedAt: !50)
-!49 = distinct !DISubprogram(name: "Child.<static-init>", linkageName: "func_Child.<static-init>L188", scope: null, file: !2, line: 15, type: !10, scopeLine: 15, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!50 = distinct !DILocation(line: 15, column: 1, scope: !9)
-!51 = !DILocation(line: 10, column: 3, scope: !14)
-!52 = !{!"branch_weights", i32 1, i32 2000}
-!53 = !DILocation(line: 0, scope: !14)
-!54 = !DILocation(line: 11, column: 10, scope: !14)
-!55 = !{!29, !5, i64 24}
-!56 = !DILocation(line: 9, column: 3, scope: !18)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/final_method_child_class.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 20, column: 1, scope: !11)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !DILocation(line: 11, column: 5, scope: !16)
+!16 = distinct !DISubprogram(name: "Parent#final_method", linkageName: "func_Parent#final_method", scope: null, file: !4, line: 10, type: !12, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!17 = !DILocation(line: 9, column: 3, scope: !18)
+!18 = distinct !DISubprogram(name: "Parent.<static-init>", linkageName: "func_Parent.<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!19 = !DILocation(line: 9, column: 16, scope: !20)
+!20 = distinct !DISubprogram(name: "Parent.<static-init>", linkageName: "func_Parent.<static-init>L62$block_1", scope: !18, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!21 = !DILocation(line: 6, column: 3, scope: !18)
+!22 = !DILocation(line: 7, column: 3, scope: !18)
+!23 = !DILocation(line: 10, column: 3, scope: !18)
+!24 = !{!25, !25, i64 0}
+!25 = !{!"any pointer", !8, i64 0}
+!26 = !{!27, !25, i64 16}
+!27 = !{!"rb_execution_context_struct", !25, i64 0, !7, i64 8, !25, i64 16, !25, i64 24, !25, i64 32, !28, i64 40, !28, i64 44, !25, i64 48, !25, i64 56, !25, i64 64, !7, i64 72, !7, i64 80, !25, i64 88, !7, i64 96, !25, i64 104, !25, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !29, i64 152}
+!28 = !{!"int", !8, i64 0}
+!29 = !{!"", !25, i64 0, !25, i64 8, !7, i64 16, !8, i64 24}
+!30 = !{!31, !25, i64 16}
+!31 = !{!"rb_control_frame_struct", !25, i64 0, !25, i64 8, !25, i64 16, !7, i64 24, !25, i64 32, !25, i64 40, !25, i64 48}
+!32 = !{!31, !25, i64 32}
+!33 = !DILocation(line: 0, scope: !11)
+!34 = !DILocation(line: 5, column: 1, scope: !11)
+!35 = !DILocation(line: 0, scope: !18, inlinedAt: !36)
+!36 = distinct !DILocation(line: 5, column: 1, scope: !11)
+!37 = !DILocation(line: 9, column: 7, scope: !18, inlinedAt: !36)
+!38 = !DILocation(line: 9, column: 3, scope: !18, inlinedAt: !36)
+!39 = !{!27, !28, i64 40}
+!40 = !{!27, !28, i64 44}
+!41 = !{!"branch_weights", i32 2000, i32 1}
+!42 = !{!27, !25, i64 56}
+!43 = !DILocation(line: 6, column: 3, scope: !18, inlinedAt: !36)
+!44 = !{!45, !45, i64 0}
+!45 = !{!"long long", !8, i64 0}
+!46 = !{!"branch_weights", i32 1, i32 10000}
+!47 = !DILocation(line: 7, column: 3, scope: !18, inlinedAt: !36)
+!48 = !DILocation(line: 10, column: 3, scope: !18, inlinedAt: !36)
+!49 = !DILocation(line: 15, column: 1, scope: !11)
+!50 = !DILocation(line: 0, scope: !51, inlinedAt: !52)
+!51 = distinct !DISubprogram(name: "Child.<static-init>", linkageName: "func_Child.<static-init>L188", scope: null, file: !4, line: 15, type: !12, scopeLine: 15, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!52 = distinct !DILocation(line: 15, column: 1, scope: !11)
+!53 = !DILocation(line: 10, column: 3, scope: !16)
+!54 = !{!"branch_weights", i32 1, i32 2000}
+!55 = !DILocation(line: 0, scope: !16)
+!56 = !DILocation(line: 11, column: 10, scope: !16)
+!57 = !{!31, !7, i64 24}
+!58 = !DILocation(line: 9, column: 3, scope: !20)

--- a/test/testdata/compiler/float-intrinsics.llo.exp
+++ b/test/testdata/compiler/float-intrinsics.llo.exp
@@ -285,1321 +285,1321 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #5 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #12
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #5 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #12
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#plus"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !8 {
+define i64 @"func_Object#plus"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !10 {
 functionEntryInitializers:
   %callArgs = alloca [2 x i64], align 8
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !14
-  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !14
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !14
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !14, !prof !15
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !16
+  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !16
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !16
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !16, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #13, !dbg !14
-  unreachable, !dbg !14
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #13, !dbg !16
+  unreachable, !dbg !16
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !14
-  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !14
-  %rawArg_y = load i64, i64* %1, align 8, !dbg !14
-  %2 = and i64 %rawArg_x, 3, !dbg !16
-  %3 = icmp eq i64 %2, 2, !dbg !16
-  br i1 %3, label %typeTestSuccess7, label %4, !dbg !16
+  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !16
+  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !16
+  %rawArg_y = load i64, i64* %1, align 8, !dbg !16
+  %2 = and i64 %rawArg_x, 3, !dbg !18
+  %3 = icmp eq i64 %2, 2, !dbg !18
+  br i1 %3, label %typeTestSuccess7, label %4, !dbg !18
 
 4:                                                ; preds = %fillRequiredArgs
-  %5 = and i64 %rawArg_x, 7, !dbg !16
-  %6 = icmp ne i64 %5, 0, !dbg !16
-  %7 = and i64 %rawArg_x, -9, !dbg !16
-  %8 = icmp eq i64 %7, 0, !dbg !16
-  %9 = or i1 %6, %8, !dbg !16
-  br i1 %9, label %codeRepl22, label %sorbet_isa_Float.exit, !dbg !16
+  %5 = and i64 %rawArg_x, 7, !dbg !18
+  %6 = icmp ne i64 %5, 0, !dbg !18
+  %7 = and i64 %rawArg_x, -9, !dbg !18
+  %8 = icmp eq i64 %7, 0, !dbg !18
+  %9 = or i1 %6, %8, !dbg !18
+  br i1 %9, label %codeRepl22, label %sorbet_isa_Float.exit, !dbg !18
 
 sorbet_isa_Float.exit:                            ; preds = %4
-  %10 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !16
-  %11 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %10, i64 0, i32 0, !dbg !16
-  %12 = load i64, i64* %11, align 8, !dbg !16, !tbaa !17
-  %13 = and i64 %12, 31, !dbg !16
-  %14 = icmp eq i64 %13, 4, !dbg !16
-  br i1 %14, label %typeTestSuccess7, label %codeRepl22, !dbg !16, !prof !19
+  %10 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !18
+  %11 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %10, i64 0, i32 0, !dbg !18
+  %12 = load i64, i64* %11, align 8, !dbg !18, !tbaa !19
+  %13 = and i64 %12, 31, !dbg !18
+  %14 = icmp eq i64 %13, 4, !dbg !18
+  br i1 %14, label %typeTestSuccess7, label %codeRepl22, !dbg !18, !prof !21
 
 codeRepl22:                                       ; preds = %4, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#lt.cold.3"(i64 %rawArg_x) #14, !dbg !16
+  tail call fastcc void @"func_Object#lt.cold.3"(i64 %rawArg_x) #14, !dbg !18
   unreachable
 
 typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !20, !tbaa !12
-  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !21
-  store i64 %rawArg_y, i64* %callArgs0Addr, align 8, !dbg !21
-  %15 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !21
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !22), !dbg !21
-  %16 = load i64, i64* %15, align 8, !dbg !21, !tbaa !4, !alias.scope !22
-  %17 = tail call i64 @rb_float_plus(i64 %rawArg_x, i64 %16) #15, !dbg !21, !noalias !22
-  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !21, !tbaa !12
-  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 5, !dbg !21
-  %20 = load i32, i32* %19, align 8, !dbg !21, !tbaa !25
-  %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 6, !dbg !21
-  %22 = load i32, i32* %21, align 4, !dbg !21, !tbaa !29
-  %23 = xor i32 %22, -1, !dbg !21
-  %24 = and i32 %23, %20, !dbg !21
-  %25 = icmp eq i32 %24, 0, !dbg !21
-  br i1 %25, label %typeTestSuccess14, label %26, !dbg !21, !prof !19
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !22, !tbaa !14
+  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !23
+  store i64 %rawArg_y, i64* %callArgs0Addr, align 8, !dbg !23
+  %15 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !23
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !24), !dbg !23
+  %16 = load i64, i64* %15, align 8, !dbg !23, !tbaa !6, !alias.scope !24
+  %17 = tail call i64 @rb_float_plus(i64 %rawArg_x, i64 %16) #15, !dbg !23, !noalias !24
+  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !14
+  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 5, !dbg !23
+  %20 = load i32, i32* %19, align 8, !dbg !23, !tbaa !27
+  %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 6, !dbg !23
+  %22 = load i32, i32* %21, align 4, !dbg !23, !tbaa !31
+  %23 = xor i32 %22, -1, !dbg !23
+  %24 = and i32 %23, %20, !dbg !23
+  %25 = icmp eq i32 %24, 0, !dbg !23
+  br i1 %25, label %typeTestSuccess14, label %26, !dbg !23, !prof !21
 
 26:                                               ; preds = %typeTestSuccess7
-  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !21
-  %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !21, !tbaa !30
-  %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #15, !dbg !21
-  br label %typeTestSuccess14, !dbg !21
+  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !23
+  %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !23, !tbaa !32
+  %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #15, !dbg !23
+  br label %typeTestSuccess14, !dbg !23
 
 typeTestSuccess14:                                ; preds = %26, %typeTestSuccess7
   ret i64 %17
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#minus"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #6 !dbg !31 {
+define i64 @"func_Object#minus"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #6 !dbg !33 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !32
-  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !32
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !32
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !32, !prof !15
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !34
+  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !34
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !34
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !34, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #13, !dbg !32
-  unreachable, !dbg !32
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #13, !dbg !34
+  unreachable, !dbg !34
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !32
-  %2 = bitcast i64* %argArray to <2 x i64>*, !dbg !32
-  %3 = load <2 x i64>, <2 x i64>* %2, align 8, !dbg !32
-  %4 = extractelement <2 x i64> %3, i32 0, !dbg !33
-  %5 = and i64 %4, 3, !dbg !33
-  %6 = icmp eq i64 %5, 2, !dbg !33
-  br i1 %6, label %typeTestSuccess7, label %7, !dbg !33
+  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !34
+  %2 = bitcast i64* %argArray to <2 x i64>*, !dbg !34
+  %3 = load <2 x i64>, <2 x i64>* %2, align 8, !dbg !34
+  %4 = extractelement <2 x i64> %3, i32 0, !dbg !35
+  %5 = and i64 %4, 3, !dbg !35
+  %6 = icmp eq i64 %5, 2, !dbg !35
+  br i1 %6, label %typeTestSuccess7, label %7, !dbg !35
 
 7:                                                ; preds = %fillRequiredArgs
-  %8 = and i64 %4, 7, !dbg !33
-  %9 = icmp ne i64 %8, 0, !dbg !33
-  %10 = and i64 %4, -9, !dbg !33
-  %11 = icmp eq i64 %10, 0, !dbg !33
-  %12 = or i1 %9, %11, !dbg !33
-  br i1 %12, label %codeRepl20, label %sorbet_isa_Float.exit, !dbg !33
+  %8 = and i64 %4, 7, !dbg !35
+  %9 = icmp ne i64 %8, 0, !dbg !35
+  %10 = and i64 %4, -9, !dbg !35
+  %11 = icmp eq i64 %10, 0, !dbg !35
+  %12 = or i1 %9, %11, !dbg !35
+  br i1 %12, label %codeRepl20, label %sorbet_isa_Float.exit, !dbg !35
 
 sorbet_isa_Float.exit:                            ; preds = %7
-  %13 = inttoptr i64 %4 to %struct.iseq_inline_iv_cache_entry*, !dbg !33
-  %14 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %13, i64 0, i32 0, !dbg !33
-  %15 = load i64, i64* %14, align 8, !dbg !33, !tbaa !17
-  %16 = and i64 %15, 31, !dbg !33
-  %17 = icmp eq i64 %16, 4, !dbg !33
-  br i1 %17, label %typeTestSuccess7, label %codeRepl20, !dbg !33, !prof !19
+  %13 = inttoptr i64 %4 to %struct.iseq_inline_iv_cache_entry*, !dbg !35
+  %14 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %13, i64 0, i32 0, !dbg !35
+  %15 = load i64, i64* %14, align 8, !dbg !35, !tbaa !19
+  %16 = and i64 %15, 31, !dbg !35
+  %17 = icmp eq i64 %16, 4, !dbg !35
+  br i1 %17, label %typeTestSuccess7, label %codeRepl20, !dbg !35, !prof !21
 
 codeRepl20:                                       ; preds = %7, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#lt.cold.3"(i64 %4) #14, !dbg !33
+  tail call fastcc void @"func_Object#lt.cold.3"(i64 %4) #14, !dbg !35
   unreachable
 
 typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !34, !tbaa !12
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !35
-  %19 = load i64*, i64** %18, align 8, !dbg !35
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !35
-  %21 = bitcast i64* %19 to <2 x i64>*, !dbg !35
-  store <2 x i64> %3, <2 x i64>* %21, align 8, !dbg !35, !tbaa !4
-  %22 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !35
-  store i64* %22, i64** %18, align 8, !dbg !35
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_-, i64 0), !dbg !35
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !36, !tbaa !14
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !37
+  %19 = load i64*, i64** %18, align 8, !dbg !37
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !37
+  %21 = bitcast i64* %19 to <2 x i64>*, !dbg !37
+  store <2 x i64> %3, <2 x i64>* %21, align 8, !dbg !37, !tbaa !6
+  %22 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !37
+  store i64* %22, i64** %18, align 8, !dbg !37
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_-, i64 0), !dbg !37
   ret i64 %send
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#lt"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !36 {
+define i64 @"func_Object#lt"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !38 {
 functionEntryInitializers:
   %callArgs = alloca [2 x i64], align 8
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !37
-  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !37
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !37
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !37, !prof !15
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !39
+  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !39
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !39
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !39, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #13, !dbg !37
-  unreachable, !dbg !37
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #13, !dbg !39
+  unreachable, !dbg !39
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !37
-  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !37
-  %rawArg_y = load i64, i64* %1, align 8, !dbg !37
-  %2 = and i64 %rawArg_x, 3, !dbg !38
-  %3 = icmp eq i64 %2, 2, !dbg !38
-  br i1 %3, label %typeTestSuccess7, label %4, !dbg !38
+  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !39
+  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !39
+  %rawArg_y = load i64, i64* %1, align 8, !dbg !39
+  %2 = and i64 %rawArg_x, 3, !dbg !40
+  %3 = icmp eq i64 %2, 2, !dbg !40
+  br i1 %3, label %typeTestSuccess7, label %4, !dbg !40
 
 4:                                                ; preds = %fillRequiredArgs
-  %5 = and i64 %rawArg_x, 7, !dbg !38
-  %6 = icmp ne i64 %5, 0, !dbg !38
-  %7 = and i64 %rawArg_x, -9, !dbg !38
-  %8 = icmp eq i64 %7, 0, !dbg !38
-  %9 = or i1 %6, %8, !dbg !38
-  br i1 %9, label %codeRepl22, label %sorbet_isa_Float.exit, !dbg !38
+  %5 = and i64 %rawArg_x, 7, !dbg !40
+  %6 = icmp ne i64 %5, 0, !dbg !40
+  %7 = and i64 %rawArg_x, -9, !dbg !40
+  %8 = icmp eq i64 %7, 0, !dbg !40
+  %9 = or i1 %6, %8, !dbg !40
+  br i1 %9, label %codeRepl22, label %sorbet_isa_Float.exit, !dbg !40
 
 sorbet_isa_Float.exit:                            ; preds = %4
-  %10 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !38
-  %11 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %10, i64 0, i32 0, !dbg !38
-  %12 = load i64, i64* %11, align 8, !dbg !38, !tbaa !17
-  %13 = and i64 %12, 31, !dbg !38
-  %14 = icmp eq i64 %13, 4, !dbg !38
-  br i1 %14, label %typeTestSuccess7, label %codeRepl22, !dbg !38, !prof !19
+  %10 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !40
+  %11 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %10, i64 0, i32 0, !dbg !40
+  %12 = load i64, i64* %11, align 8, !dbg !40, !tbaa !19
+  %13 = and i64 %12, 31, !dbg !40
+  %14 = icmp eq i64 %13, 4, !dbg !40
+  br i1 %14, label %typeTestSuccess7, label %codeRepl22, !dbg !40, !prof !21
 
 codeRepl22:                                       ; preds = %4, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#lt.cold.3"(i64 %rawArg_x) #14, !dbg !38
+  tail call fastcc void @"func_Object#lt.cold.3"(i64 %rawArg_x) #14, !dbg !40
   unreachable
 
 typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %0, align 8, !dbg !39, !tbaa !12
-  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !40
-  store i64 %rawArg_y, i64* %callArgs0Addr, align 8, !dbg !40
-  %15 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !40
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !41), !dbg !40
-  %16 = load i64, i64* %15, align 8, !dbg !40, !tbaa !4, !alias.scope !41
-  %17 = tail call i64 @sorbet_flo_lt(i64 %rawArg_x, i64 %16) #15, !dbg !40, !noalias !41
-  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !12
-  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 5, !dbg !40
-  %20 = load i32, i32* %19, align 8, !dbg !40, !tbaa !25
-  %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 6, !dbg !40
-  %22 = load i32, i32* %21, align 4, !dbg !40, !tbaa !29
-  %23 = xor i32 %22, -1, !dbg !40
-  %24 = and i32 %23, %20, !dbg !40
-  %25 = icmp eq i32 %24, 0, !dbg !40
-  br i1 %25, label %rb_vm_check_ints.exit, label %26, !dbg !40, !prof !19
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %0, align 8, !dbg !41, !tbaa !14
+  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !42
+  store i64 %rawArg_y, i64* %callArgs0Addr, align 8, !dbg !42
+  %15 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !42
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !43), !dbg !42
+  %16 = load i64, i64* %15, align 8, !dbg !42, !tbaa !6, !alias.scope !43
+  %17 = tail call i64 @sorbet_flo_lt(i64 %rawArg_x, i64 %16) #15, !dbg !42, !noalias !43
+  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !42, !tbaa !14
+  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 5, !dbg !42
+  %20 = load i32, i32* %19, align 8, !dbg !42, !tbaa !27
+  %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 6, !dbg !42
+  %22 = load i32, i32* %21, align 4, !dbg !42, !tbaa !31
+  %23 = xor i32 %22, -1, !dbg !42
+  %24 = and i32 %23, %20, !dbg !42
+  %25 = icmp eq i32 %24, 0, !dbg !42
+  br i1 %25, label %rb_vm_check_ints.exit, label %26, !dbg !42, !prof !21
 
 26:                                               ; preds = %typeTestSuccess7
-  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !40
-  %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !40, !tbaa !30
-  %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #15, !dbg !40
-  br label %rb_vm_check_ints.exit, !dbg !40
+  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !42
+  %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !42, !tbaa !32
+  %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #15, !dbg !42
+  br label %rb_vm_check_ints.exit, !dbg !42
 
 rb_vm_check_ints.exit:                            ; preds = %typeTestSuccess7, %26
   switch i64 %17, label %codeRepl [
     i64 20, label %typeTestSuccess14
     i64 0, label %typeTestSuccess14
-  ], !prof !44
+  ], !prof !46
 
 typeTestSuccess14:                                ; preds = %rb_vm_check_ints.exit, %rb_vm_check_ints.exit
   ret i64 %17
 
 codeRepl:                                         ; preds = %rb_vm_check_ints.exit
-  tail call fastcc void @"func_Object#lt.cold.1"(i64 %17) #14, !dbg !45
+  tail call fastcc void @"func_Object#lt.cold.1"(i64 %17) #14, !dbg !47
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#lte"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !46 {
+define i64 @"func_Object#lte"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !48 {
 functionEntryInitializers:
   %callArgs = alloca [2 x i64], align 8
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !47
-  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !47
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !47
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !47, !prof !15
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !49
+  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !49
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !49
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !49, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #13, !dbg !47
-  unreachable, !dbg !47
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #13, !dbg !49
+  unreachable, !dbg !49
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !47
-  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !47
-  %rawArg_y = load i64, i64* %1, align 8, !dbg !47
-  %2 = and i64 %rawArg_x, 3, !dbg !48
-  %3 = icmp eq i64 %2, 2, !dbg !48
-  br i1 %3, label %typeTestSuccess7, label %4, !dbg !48
+  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !49
+  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !49
+  %rawArg_y = load i64, i64* %1, align 8, !dbg !49
+  %2 = and i64 %rawArg_x, 3, !dbg !50
+  %3 = icmp eq i64 %2, 2, !dbg !50
+  br i1 %3, label %typeTestSuccess7, label %4, !dbg !50
 
 4:                                                ; preds = %fillRequiredArgs
-  %5 = and i64 %rawArg_x, 7, !dbg !48
-  %6 = icmp ne i64 %5, 0, !dbg !48
-  %7 = and i64 %rawArg_x, -9, !dbg !48
-  %8 = icmp eq i64 %7, 0, !dbg !48
-  %9 = or i1 %6, %8, !dbg !48
-  br i1 %9, label %codeRepl22, label %sorbet_isa_Float.exit, !dbg !48
+  %5 = and i64 %rawArg_x, 7, !dbg !50
+  %6 = icmp ne i64 %5, 0, !dbg !50
+  %7 = and i64 %rawArg_x, -9, !dbg !50
+  %8 = icmp eq i64 %7, 0, !dbg !50
+  %9 = or i1 %6, %8, !dbg !50
+  br i1 %9, label %codeRepl22, label %sorbet_isa_Float.exit, !dbg !50
 
 sorbet_isa_Float.exit:                            ; preds = %4
-  %10 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !48
-  %11 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %10, i64 0, i32 0, !dbg !48
-  %12 = load i64, i64* %11, align 8, !dbg !48, !tbaa !17
-  %13 = and i64 %12, 31, !dbg !48
-  %14 = icmp eq i64 %13, 4, !dbg !48
-  br i1 %14, label %typeTestSuccess7, label %codeRepl22, !dbg !48, !prof !19
+  %10 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !50
+  %11 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %10, i64 0, i32 0, !dbg !50
+  %12 = load i64, i64* %11, align 8, !dbg !50, !tbaa !19
+  %13 = and i64 %12, 31, !dbg !50
+  %14 = icmp eq i64 %13, 4, !dbg !50
+  br i1 %14, label %typeTestSuccess7, label %codeRepl22, !dbg !50, !prof !21
 
 codeRepl22:                                       ; preds = %4, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#lt.cold.3"(i64 %rawArg_x) #14, !dbg !48
+  tail call fastcc void @"func_Object#lt.cold.3"(i64 %rawArg_x) #14, !dbg !50
   unreachable
 
 typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %0, align 8, !dbg !49, !tbaa !12
-  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !50
-  store i64 %rawArg_y, i64* %callArgs0Addr, align 8, !dbg !50
-  %15 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !50
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !51), !dbg !50
-  %16 = load i64, i64* %15, align 8, !dbg !50, !tbaa !4, !alias.scope !51
-  %17 = tail call i64 @sorbet_flo_le(i64 %rawArg_x, i64 %16) #15, !dbg !50, !noalias !51
-  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !50, !tbaa !12
-  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 5, !dbg !50
-  %20 = load i32, i32* %19, align 8, !dbg !50, !tbaa !25
-  %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 6, !dbg !50
-  %22 = load i32, i32* %21, align 4, !dbg !50, !tbaa !29
-  %23 = xor i32 %22, -1, !dbg !50
-  %24 = and i32 %23, %20, !dbg !50
-  %25 = icmp eq i32 %24, 0, !dbg !50
-  br i1 %25, label %rb_vm_check_ints.exit, label %26, !dbg !50, !prof !19
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %0, align 8, !dbg !51, !tbaa !14
+  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !52
+  store i64 %rawArg_y, i64* %callArgs0Addr, align 8, !dbg !52
+  %15 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !52
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !53), !dbg !52
+  %16 = load i64, i64* %15, align 8, !dbg !52, !tbaa !6, !alias.scope !53
+  %17 = tail call i64 @sorbet_flo_le(i64 %rawArg_x, i64 %16) #15, !dbg !52, !noalias !53
+  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !14
+  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 5, !dbg !52
+  %20 = load i32, i32* %19, align 8, !dbg !52, !tbaa !27
+  %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 6, !dbg !52
+  %22 = load i32, i32* %21, align 4, !dbg !52, !tbaa !31
+  %23 = xor i32 %22, -1, !dbg !52
+  %24 = and i32 %23, %20, !dbg !52
+  %25 = icmp eq i32 %24, 0, !dbg !52
+  br i1 %25, label %rb_vm_check_ints.exit, label %26, !dbg !52, !prof !21
 
 26:                                               ; preds = %typeTestSuccess7
-  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !50
-  %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !50, !tbaa !30
-  %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #15, !dbg !50
-  br label %rb_vm_check_ints.exit, !dbg !50
+  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !52
+  %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !52, !tbaa !32
+  %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #15, !dbg !52
+  br label %rb_vm_check_ints.exit, !dbg !52
 
 rb_vm_check_ints.exit:                            ; preds = %typeTestSuccess7, %26
   switch i64 %17, label %codeRepl [
     i64 20, label %typeTestSuccess14
     i64 0, label %typeTestSuccess14
-  ], !prof !44
+  ], !prof !46
 
 typeTestSuccess14:                                ; preds = %rb_vm_check_ints.exit, %rb_vm_check_ints.exit
   ret i64 %17
 
 codeRepl:                                         ; preds = %rb_vm_check_ints.exit
-  tail call fastcc void @"func_Object#lt.cold.1"(i64 %17) #14, !dbg !54
+  tail call fastcc void @"func_Object#lt.cold.1"(i64 %17) #14, !dbg !56
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_<root>.<static-init>$151"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #6 !dbg !55 {
+define internal fastcc void @"func_<root>.<static-init>$151"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #6 !dbg !57 {
 fastSymCallIntrinsic_ResolvedSig_sig:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !56
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !58
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !57
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !59
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !59
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !61
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #15
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !60, !tbaa !12
-  %rubyId_plus = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !61
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_plus), !dbg !61
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.<static-init>$151$block_1"), !dbg !61
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !61, !tbaa !12
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !61
-  %11 = load i32, i32* %10, align 8, !dbg !61, !tbaa !25
-  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !61
-  %13 = load i32, i32* %12, align 4, !dbg !61, !tbaa !29
-  %14 = xor i32 %13, -1, !dbg !61
-  %15 = and i32 %14, %11, !dbg !61
-  %16 = icmp eq i32 %15, 0, !dbg !61
-  br i1 %16, label %fastSymCallIntrinsic_ResolvedSig_sig267, label %17, !dbg !61, !prof !19
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !62, !tbaa !14
+  %rubyId_plus = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !63
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_plus), !dbg !63
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.<static-init>$151$block_1"), !dbg !63
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !63, !tbaa !14
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !63
+  %11 = load i32, i32* %10, align 8, !dbg !63, !tbaa !27
+  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !63
+  %13 = load i32, i32* %12, align 4, !dbg !63, !tbaa !31
+  %14 = xor i32 %13, -1, !dbg !63
+  %15 = and i32 %14, %11, !dbg !63
+  %16 = icmp eq i32 %15, 0, !dbg !63
+  br i1 %16, label %fastSymCallIntrinsic_ResolvedSig_sig267, label %17, !dbg !63, !prof !21
 
 17:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig
-  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !61
-  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !61, !tbaa !30
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !61
-  br label %fastSymCallIntrinsic_ResolvedSig_sig267, !dbg !61
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !63
+  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !63, !tbaa !32
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !63
+  br label %fastSymCallIntrinsic_ResolvedSig_sig267, !dbg !63
 
 fastSymCallIntrinsic_ResolvedSig_sig267:          ; preds = %fastSymCallIntrinsic_ResolvedSig_sig, %17
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !61, !tbaa !12
-  %rubyId_minus = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !62
-  %rawSym261 = tail call i64 @rb_id2sym(i64 %rubyId_minus), !dbg !62
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym261, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.<static-init>$151$block_2"), !dbg !62
-  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !62, !tbaa !12
-  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !62
-  %23 = load i32, i32* %22, align 8, !dbg !62, !tbaa !25
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 6, !dbg !62
-  %25 = load i32, i32* %24, align 4, !dbg !62, !tbaa !29
-  %26 = xor i32 %25, -1, !dbg !62
-  %27 = and i32 %26, %23, !dbg !62
-  %28 = icmp eq i32 %27, 0, !dbg !62
-  br i1 %28, label %fastSymCallIntrinsic_ResolvedSig_sig286, label %29, !dbg !62, !prof !19
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !63, !tbaa !14
+  %rubyId_minus = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !64
+  %rawSym261 = tail call i64 @rb_id2sym(i64 %rubyId_minus), !dbg !64
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym261, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.<static-init>$151$block_2"), !dbg !64
+  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !64, !tbaa !14
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !64
+  %23 = load i32, i32* %22, align 8, !dbg !64, !tbaa !27
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 6, !dbg !64
+  %25 = load i32, i32* %24, align 4, !dbg !64, !tbaa !31
+  %26 = xor i32 %25, -1, !dbg !64
+  %27 = and i32 %26, %23, !dbg !64
+  %28 = icmp eq i32 %27, 0, !dbg !64
+  br i1 %28, label %fastSymCallIntrinsic_ResolvedSig_sig286, label %29, !dbg !64, !prof !21
 
 29:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig267
-  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !62
-  %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !62, !tbaa !30
-  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #15, !dbg !62
-  br label %fastSymCallIntrinsic_ResolvedSig_sig286, !dbg !62
+  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !64
+  %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !64, !tbaa !32
+  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #15, !dbg !64
+  br label %fastSymCallIntrinsic_ResolvedSig_sig286, !dbg !64
 
 fastSymCallIntrinsic_ResolvedSig_sig286:          ; preds = %fastSymCallIntrinsic_ResolvedSig_sig267, %29
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %8, align 8, !dbg !62, !tbaa !12
-  %rubyId_lt = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !63
-  %rawSym280 = tail call i64 @rb_id2sym(i64 %rubyId_lt), !dbg !63
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym280, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.<static-init>$151$block_3"), !dbg !63
-  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !63, !tbaa !12
-  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 5, !dbg !63
-  %35 = load i32, i32* %34, align 8, !dbg !63, !tbaa !25
-  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 6, !dbg !63
-  %37 = load i32, i32* %36, align 4, !dbg !63, !tbaa !29
-  %38 = xor i32 %37, -1, !dbg !63
-  %39 = and i32 %38, %35, !dbg !63
-  %40 = icmp eq i32 %39, 0, !dbg !63
-  br i1 %40, label %fastSymCallIntrinsic_ResolvedSig_sig305, label %41, !dbg !63, !prof !19
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %8, align 8, !dbg !64, !tbaa !14
+  %rubyId_lt = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !65
+  %rawSym280 = tail call i64 @rb_id2sym(i64 %rubyId_lt), !dbg !65
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym280, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.<static-init>$151$block_3"), !dbg !65
+  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !14
+  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 5, !dbg !65
+  %35 = load i32, i32* %34, align 8, !dbg !65, !tbaa !27
+  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 6, !dbg !65
+  %37 = load i32, i32* %36, align 4, !dbg !65, !tbaa !31
+  %38 = xor i32 %37, -1, !dbg !65
+  %39 = and i32 %38, %35, !dbg !65
+  %40 = icmp eq i32 %39, 0, !dbg !65
+  br i1 %40, label %fastSymCallIntrinsic_ResolvedSig_sig305, label %41, !dbg !65, !prof !21
 
 41:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig286
-  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 8, !dbg !63
-  %43 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %42, align 8, !dbg !63, !tbaa !30
-  %44 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %43, i32 noundef 0) #15, !dbg !63
-  br label %fastSymCallIntrinsic_ResolvedSig_sig305, !dbg !63
+  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 8, !dbg !65
+  %43 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %42, align 8, !dbg !65, !tbaa !32
+  %44 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %43, i32 noundef 0) #15, !dbg !65
+  br label %fastSymCallIntrinsic_ResolvedSig_sig305, !dbg !65
 
 fastSymCallIntrinsic_ResolvedSig_sig305:          ; preds = %fastSymCallIntrinsic_ResolvedSig_sig286, %41
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %8, align 8, !dbg !63, !tbaa !12
-  %rubyId_lte = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !64
-  %rawSym299 = tail call i64 @rb_id2sym(i64 %rubyId_lte), !dbg !64
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym299, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.<static-init>$151$block_4"), !dbg !64
-  %45 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !64, !tbaa !12
-  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 5, !dbg !64
-  %47 = load i32, i32* %46, align 8, !dbg !64, !tbaa !25
-  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 6, !dbg !64
-  %49 = load i32, i32* %48, align 4, !dbg !64, !tbaa !29
-  %50 = xor i32 %49, -1, !dbg !64
-  %51 = and i32 %50, %47, !dbg !64
-  %52 = icmp eq i32 %51, 0, !dbg !64
-  br i1 %52, label %fastSymCallIntrinsic_Static_keep_def, label %53, !dbg !64, !prof !19
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %8, align 8, !dbg !65, !tbaa !14
+  %rubyId_lte = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !66
+  %rawSym299 = tail call i64 @rb_id2sym(i64 %rubyId_lte), !dbg !66
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym299, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.<static-init>$151$block_4"), !dbg !66
+  %45 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !14
+  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 5, !dbg !66
+  %47 = load i32, i32* %46, align 8, !dbg !66, !tbaa !27
+  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 6, !dbg !66
+  %49 = load i32, i32* %48, align 4, !dbg !66, !tbaa !31
+  %50 = xor i32 %49, -1, !dbg !66
+  %51 = and i32 %50, %47, !dbg !66
+  %52 = icmp eq i32 %51, 0, !dbg !66
+  br i1 %52, label %fastSymCallIntrinsic_Static_keep_def, label %53, !dbg !66, !prof !21
 
 53:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig305
-  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 8, !dbg !64
-  %55 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %54, align 8, !dbg !64, !tbaa !30
-  %56 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %55, i32 noundef 0) #15, !dbg !64
-  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !64
+  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 8, !dbg !66
+  %55 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %54, align 8, !dbg !66, !tbaa !32
+  %56 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %55, i32 noundef 0) #15, !dbg !66
+  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !66
 
 fastSymCallIntrinsic_Static_keep_def:             ; preds = %fastSymCallIntrinsic_ResolvedSig_sig305, %53
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !64, !tbaa !12
-  %57 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !65
-  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !65, !tbaa !66
-  %needTakeSlowPath = icmp ne i64 %57, %58, !dbg !65
-  br i1 %needTakeSlowPath, label %59, label %60, !dbg !65, !prof !68
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !66, !tbaa !14
+  %57 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !67
+  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !68
+  %needTakeSlowPath = icmp ne i64 %57, %58, !dbg !67
+  br i1 %needTakeSlowPath, label %59, label %60, !dbg !67, !prof !70
 
 59:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
-  tail call void @"const_recompute_T::Sig"(), !dbg !65
-  br label %60, !dbg !65
+  tail call void @"const_recompute_T::Sig"(), !dbg !67
+  br label %60, !dbg !67
 
 60:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def, %59
-  %61 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !65
-  %62 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !65
-  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !65, !tbaa !66
-  %guardUpdated = icmp eq i64 %62, %63, !dbg !65
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !65
-  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !65
-  %65 = load i64*, i64** %64, align 8, !dbg !65
-  store i64 %selfRaw, i64* %65, align 8, !dbg !65, !tbaa !4
-  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !65
-  store i64 %61, i64* %66, align 8, !dbg !65, !tbaa !4
-  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !65
-  store i64* %67, i64** %64, align 8, !dbg !65
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !65
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !65, !tbaa !12
-  %rubyId_plus321 = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !69
-  %rawSym322 = tail call i64 @rb_id2sym(i64 %rubyId_plus321), !dbg !69
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !69
-  %rawSym323 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !69
-  %68 = load i64, i64* @rb_cObject, align 8, !dbg !69
-  %stackFrame327 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#plus", align 8, !dbg !69
-  %69 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !69
-  %70 = bitcast i8* %69 to i16*, !dbg !69
-  %71 = load i16, i16* %70, align 8, !dbg !69
-  %72 = and i16 %71, -384, !dbg !69
-  %73 = or i16 %72, 1, !dbg !69
-  store i16 %73, i16* %70, align 8, !dbg !69
-  %74 = getelementptr inbounds i8, i8* %69, i64 8, !dbg !69
-  %75 = bitcast i8* %74 to i32*, !dbg !69
-  store i32 2, i32* %75, align 8, !dbg !69, !tbaa !70
-  %76 = getelementptr inbounds i8, i8* %69, i64 12, !dbg !69
-  %77 = bitcast i8* %76 to i32*, !dbg !69
-  %78 = getelementptr inbounds i8, i8* %69, i64 4, !dbg !69
-  %79 = bitcast i8* %78 to i32*, !dbg !69
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 20, i1 false), !dbg !69
-  store i32 2, i32* %79, align 4, !dbg !69, !tbaa !73
-  %positional_table = alloca i64, i32 2, align 8, !dbg !69
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !69
-  store i64 %rubyId_x, i64* %positional_table, align 8, !dbg !69
-  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !69
-  %80 = getelementptr i64, i64* %positional_table, i32 1, !dbg !69
-  store i64 %rubyId_y, i64* %80, align 8, !dbg !69
-  %81 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !69
-  %82 = bitcast i64* %positional_table to i8*, !dbg !69
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %81, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %82, i64 noundef 16, i1 noundef false) #15, !dbg !69
-  %83 = getelementptr inbounds i8, i8* %69, i64 32, !dbg !69
-  %84 = bitcast i8* %83 to i8**, !dbg !69
-  store i8* %81, i8** %84, align 8, !dbg !69, !tbaa !74
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#plus", i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame327, i1 noundef zeroext false) #15, !dbg !69
-  %85 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !69, !tbaa !12
-  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 5, !dbg !69
-  %87 = load i32, i32* %86, align 8, !dbg !69, !tbaa !25
-  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 6, !dbg !69
-  %89 = load i32, i32* %88, align 4, !dbg !69, !tbaa !29
-  %90 = xor i32 %89, -1, !dbg !69
-  %91 = and i32 %90, %87, !dbg !69
-  %92 = icmp eq i32 %91, 0, !dbg !69
-  br i1 %92, label %fastSymCallIntrinsic_Static_keep_def341, label %93, !dbg !69, !prof !19
+  %61 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !67
+  %62 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !67
+  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !68
+  %guardUpdated = icmp eq i64 %62, %63, !dbg !67
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !67
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !67
+  %65 = load i64*, i64** %64, align 8, !dbg !67
+  store i64 %selfRaw, i64* %65, align 8, !dbg !67, !tbaa !6
+  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !67
+  store i64 %61, i64* %66, align 8, !dbg !67, !tbaa !6
+  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !67
+  store i64* %67, i64** %64, align 8, !dbg !67
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !67
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !67, !tbaa !14
+  %rubyId_plus321 = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !71
+  %rawSym322 = tail call i64 @rb_id2sym(i64 %rubyId_plus321), !dbg !71
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !71
+  %rawSym323 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !71
+  %68 = load i64, i64* @rb_cObject, align 8, !dbg !71
+  %stackFrame327 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#plus", align 8, !dbg !71
+  %69 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !71
+  %70 = bitcast i8* %69 to i16*, !dbg !71
+  %71 = load i16, i16* %70, align 8, !dbg !71
+  %72 = and i16 %71, -384, !dbg !71
+  %73 = or i16 %72, 1, !dbg !71
+  store i16 %73, i16* %70, align 8, !dbg !71
+  %74 = getelementptr inbounds i8, i8* %69, i64 8, !dbg !71
+  %75 = bitcast i8* %74 to i32*, !dbg !71
+  store i32 2, i32* %75, align 8, !dbg !71, !tbaa !72
+  %76 = getelementptr inbounds i8, i8* %69, i64 12, !dbg !71
+  %77 = bitcast i8* %76 to i32*, !dbg !71
+  %78 = getelementptr inbounds i8, i8* %69, i64 4, !dbg !71
+  %79 = bitcast i8* %78 to i32*, !dbg !71
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 20, i1 false), !dbg !71
+  store i32 2, i32* %79, align 4, !dbg !71, !tbaa !75
+  %positional_table = alloca i64, i32 2, align 8, !dbg !71
+  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !71
+  store i64 %rubyId_x, i64* %positional_table, align 8, !dbg !71
+  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !71
+  %80 = getelementptr i64, i64* %positional_table, i32 1, !dbg !71
+  store i64 %rubyId_y, i64* %80, align 8, !dbg !71
+  %81 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !71
+  %82 = bitcast i64* %positional_table to i8*, !dbg !71
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %81, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %82, i64 noundef 16, i1 noundef false) #15, !dbg !71
+  %83 = getelementptr inbounds i8, i8* %69, i64 32, !dbg !71
+  %84 = bitcast i8* %83 to i8**, !dbg !71
+  store i8* %81, i8** %84, align 8, !dbg !71, !tbaa !76
+  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#plus", i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame327, i1 noundef zeroext false) #15, !dbg !71
+  %85 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !71, !tbaa !14
+  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 5, !dbg !71
+  %87 = load i32, i32* %86, align 8, !dbg !71, !tbaa !27
+  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 6, !dbg !71
+  %89 = load i32, i32* %88, align 4, !dbg !71, !tbaa !31
+  %90 = xor i32 %89, -1, !dbg !71
+  %91 = and i32 %90, %87, !dbg !71
+  %92 = icmp eq i32 %91, 0, !dbg !71
+  br i1 %92, label %fastSymCallIntrinsic_Static_keep_def341, label %93, !dbg !71, !prof !21
 
 93:                                               ; preds = %60
-  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 8, !dbg !69
-  %95 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %94, align 8, !dbg !69, !tbaa !30
-  %96 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %95, i32 noundef 0) #15, !dbg !69
-  br label %fastSymCallIntrinsic_Static_keep_def341, !dbg !69
+  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 8, !dbg !71
+  %95 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %94, align 8, !dbg !71, !tbaa !32
+  %96 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %95, i32 noundef 0) #15, !dbg !71
+  br label %fastSymCallIntrinsic_Static_keep_def341, !dbg !71
 
 fastSymCallIntrinsic_Static_keep_def341:          ; preds = %60, %93
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !69, !tbaa !12
-  %rubyId_minus332 = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !75
-  %rawSym333 = tail call i64 @rb_id2sym(i64 %rubyId_minus332), !dbg !75
-  %rubyId_normal334 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !75
-  %rawSym335 = tail call i64 @rb_id2sym(i64 %rubyId_normal334), !dbg !75
-  %stackFrame342 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#minus", align 8, !dbg !75
-  %97 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !75
-  %98 = bitcast i8* %97 to i16*, !dbg !75
-  %99 = load i16, i16* %98, align 8, !dbg !75
-  %100 = and i16 %99, -384, !dbg !75
-  %101 = or i16 %100, 1, !dbg !75
-  store i16 %101, i16* %98, align 8, !dbg !75
-  %102 = getelementptr inbounds i8, i8* %97, i64 8, !dbg !75
-  %103 = bitcast i8* %102 to i32*, !dbg !75
-  store i32 2, i32* %103, align 8, !dbg !75, !tbaa !70
-  %104 = getelementptr inbounds i8, i8* %97, i64 12, !dbg !75
-  %105 = bitcast i8* %104 to i32*, !dbg !75
-  %106 = getelementptr inbounds i8, i8* %97, i64 4, !dbg !75
-  %107 = bitcast i8* %106 to i32*, !dbg !75
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %104, i8 0, i64 20, i1 false), !dbg !75
-  store i32 2, i32* %107, align 4, !dbg !75, !tbaa !73
-  %positional_table344 = alloca i64, i32 2, align 8, !dbg !75
-  %rubyId_x345 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !75
-  store i64 %rubyId_x345, i64* %positional_table344, align 8, !dbg !75
-  %rubyId_y346 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !75
-  %108 = getelementptr i64, i64* %positional_table344, i32 1, !dbg !75
-  store i64 %rubyId_y346, i64* %108, align 8, !dbg !75
-  %109 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !75
-  %110 = bitcast i64* %positional_table344 to i8*, !dbg !75
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %109, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %110, i64 noundef 16, i1 noundef false) #15, !dbg !75
-  %111 = getelementptr inbounds i8, i8* %97, i64 32, !dbg !75
-  %112 = bitcast i8* %111 to i8**, !dbg !75
-  store i8* %109, i8** %112, align 8, !dbg !75, !tbaa !74
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#minus", i8* nonnull %97, %struct.rb_iseq_struct* %stackFrame342, i1 noundef zeroext false) #15, !dbg !75
-  %113 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !75, !tbaa !12
-  %114 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 5, !dbg !75
-  %115 = load i32, i32* %114, align 8, !dbg !75, !tbaa !25
-  %116 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 6, !dbg !75
-  %117 = load i32, i32* %116, align 4, !dbg !75, !tbaa !29
-  %118 = xor i32 %117, -1, !dbg !75
-  %119 = and i32 %118, %115, !dbg !75
-  %120 = icmp eq i32 %119, 0, !dbg !75
-  br i1 %120, label %fastSymCallIntrinsic_Static_keep_def360, label %121, !dbg !75, !prof !19
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !71, !tbaa !14
+  %rubyId_minus332 = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !77
+  %rawSym333 = tail call i64 @rb_id2sym(i64 %rubyId_minus332), !dbg !77
+  %rubyId_normal334 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !77
+  %rawSym335 = tail call i64 @rb_id2sym(i64 %rubyId_normal334), !dbg !77
+  %stackFrame342 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#minus", align 8, !dbg !77
+  %97 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !77
+  %98 = bitcast i8* %97 to i16*, !dbg !77
+  %99 = load i16, i16* %98, align 8, !dbg !77
+  %100 = and i16 %99, -384, !dbg !77
+  %101 = or i16 %100, 1, !dbg !77
+  store i16 %101, i16* %98, align 8, !dbg !77
+  %102 = getelementptr inbounds i8, i8* %97, i64 8, !dbg !77
+  %103 = bitcast i8* %102 to i32*, !dbg !77
+  store i32 2, i32* %103, align 8, !dbg !77, !tbaa !72
+  %104 = getelementptr inbounds i8, i8* %97, i64 12, !dbg !77
+  %105 = bitcast i8* %104 to i32*, !dbg !77
+  %106 = getelementptr inbounds i8, i8* %97, i64 4, !dbg !77
+  %107 = bitcast i8* %106 to i32*, !dbg !77
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %104, i8 0, i64 20, i1 false), !dbg !77
+  store i32 2, i32* %107, align 4, !dbg !77, !tbaa !75
+  %positional_table344 = alloca i64, i32 2, align 8, !dbg !77
+  %rubyId_x345 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !77
+  store i64 %rubyId_x345, i64* %positional_table344, align 8, !dbg !77
+  %rubyId_y346 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !77
+  %108 = getelementptr i64, i64* %positional_table344, i32 1, !dbg !77
+  store i64 %rubyId_y346, i64* %108, align 8, !dbg !77
+  %109 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !77
+  %110 = bitcast i64* %positional_table344 to i8*, !dbg !77
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %109, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %110, i64 noundef 16, i1 noundef false) #15, !dbg !77
+  %111 = getelementptr inbounds i8, i8* %97, i64 32, !dbg !77
+  %112 = bitcast i8* %111 to i8**, !dbg !77
+  store i8* %109, i8** %112, align 8, !dbg !77, !tbaa !76
+  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#minus", i8* nonnull %97, %struct.rb_iseq_struct* %stackFrame342, i1 noundef zeroext false) #15, !dbg !77
+  %113 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !77, !tbaa !14
+  %114 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 5, !dbg !77
+  %115 = load i32, i32* %114, align 8, !dbg !77, !tbaa !27
+  %116 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 6, !dbg !77
+  %117 = load i32, i32* %116, align 4, !dbg !77, !tbaa !31
+  %118 = xor i32 %117, -1, !dbg !77
+  %119 = and i32 %118, %115, !dbg !77
+  %120 = icmp eq i32 %119, 0, !dbg !77
+  br i1 %120, label %fastSymCallIntrinsic_Static_keep_def360, label %121, !dbg !77, !prof !21
 
 121:                                              ; preds = %fastSymCallIntrinsic_Static_keep_def341
-  %122 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 8, !dbg !75
-  %123 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %122, align 8, !dbg !75, !tbaa !30
-  %124 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %123, i32 noundef 0) #15, !dbg !75
-  br label %fastSymCallIntrinsic_Static_keep_def360, !dbg !75
+  %122 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 8, !dbg !77
+  %123 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %122, align 8, !dbg !77, !tbaa !32
+  %124 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %123, i32 noundef 0) #15, !dbg !77
+  br label %fastSymCallIntrinsic_Static_keep_def360, !dbg !77
 
 fastSymCallIntrinsic_Static_keep_def360:          ; preds = %fastSymCallIntrinsic_Static_keep_def341, %121
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !dbg !75, !tbaa !12
-  %rubyId_lt351 = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !76
-  %rawSym352 = tail call i64 @rb_id2sym(i64 %rubyId_lt351), !dbg !76
-  %rubyId_normal353 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !76
-  %rawSym354 = tail call i64 @rb_id2sym(i64 %rubyId_normal353), !dbg !76
-  %stackFrame361 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#lt", align 8, !dbg !76
-  %125 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !76
-  %126 = bitcast i8* %125 to i16*, !dbg !76
-  %127 = load i16, i16* %126, align 8, !dbg !76
-  %128 = and i16 %127, -384, !dbg !76
-  %129 = or i16 %128, 1, !dbg !76
-  store i16 %129, i16* %126, align 8, !dbg !76
-  %130 = getelementptr inbounds i8, i8* %125, i64 8, !dbg !76
-  %131 = bitcast i8* %130 to i32*, !dbg !76
-  store i32 2, i32* %131, align 8, !dbg !76, !tbaa !70
-  %132 = getelementptr inbounds i8, i8* %125, i64 12, !dbg !76
-  %133 = bitcast i8* %132 to i32*, !dbg !76
-  %134 = getelementptr inbounds i8, i8* %125, i64 4, !dbg !76
-  %135 = bitcast i8* %134 to i32*, !dbg !76
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %132, i8 0, i64 20, i1 false), !dbg !76
-  store i32 2, i32* %135, align 4, !dbg !76, !tbaa !73
-  %positional_table363 = alloca i64, i32 2, align 8, !dbg !76
-  %rubyId_x364 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !76
-  store i64 %rubyId_x364, i64* %positional_table363, align 8, !dbg !76
-  %rubyId_y365 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !76
-  %136 = getelementptr i64, i64* %positional_table363, i32 1, !dbg !76
-  store i64 %rubyId_y365, i64* %136, align 8, !dbg !76
-  %137 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !76
-  %138 = bitcast i64* %positional_table363 to i8*, !dbg !76
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %137, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %138, i64 noundef 16, i1 noundef false) #15, !dbg !76
-  %139 = getelementptr inbounds i8, i8* %125, i64 32, !dbg !76
-  %140 = bitcast i8* %139 to i8**, !dbg !76
-  store i8* %137, i8** %140, align 8, !dbg !76, !tbaa !74
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#lt", i8* nonnull %125, %struct.rb_iseq_struct* %stackFrame361, i1 noundef zeroext false) #15, !dbg !76
-  %141 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !76, !tbaa !12
-  %142 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 5, !dbg !76
-  %143 = load i32, i32* %142, align 8, !dbg !76, !tbaa !25
-  %144 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 6, !dbg !76
-  %145 = load i32, i32* %144, align 4, !dbg !76, !tbaa !29
-  %146 = xor i32 %145, -1, !dbg !76
-  %147 = and i32 %146, %143, !dbg !76
-  %148 = icmp eq i32 %147, 0, !dbg !76
-  br i1 %148, label %fastSymCallIntrinsic_Static_keep_def379, label %149, !dbg !76, !prof !19
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !dbg !77, !tbaa !14
+  %rubyId_lt351 = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !78
+  %rawSym352 = tail call i64 @rb_id2sym(i64 %rubyId_lt351), !dbg !78
+  %rubyId_normal353 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !78
+  %rawSym354 = tail call i64 @rb_id2sym(i64 %rubyId_normal353), !dbg !78
+  %stackFrame361 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#lt", align 8, !dbg !78
+  %125 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !78
+  %126 = bitcast i8* %125 to i16*, !dbg !78
+  %127 = load i16, i16* %126, align 8, !dbg !78
+  %128 = and i16 %127, -384, !dbg !78
+  %129 = or i16 %128, 1, !dbg !78
+  store i16 %129, i16* %126, align 8, !dbg !78
+  %130 = getelementptr inbounds i8, i8* %125, i64 8, !dbg !78
+  %131 = bitcast i8* %130 to i32*, !dbg !78
+  store i32 2, i32* %131, align 8, !dbg !78, !tbaa !72
+  %132 = getelementptr inbounds i8, i8* %125, i64 12, !dbg !78
+  %133 = bitcast i8* %132 to i32*, !dbg !78
+  %134 = getelementptr inbounds i8, i8* %125, i64 4, !dbg !78
+  %135 = bitcast i8* %134 to i32*, !dbg !78
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %132, i8 0, i64 20, i1 false), !dbg !78
+  store i32 2, i32* %135, align 4, !dbg !78, !tbaa !75
+  %positional_table363 = alloca i64, i32 2, align 8, !dbg !78
+  %rubyId_x364 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !78
+  store i64 %rubyId_x364, i64* %positional_table363, align 8, !dbg !78
+  %rubyId_y365 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !78
+  %136 = getelementptr i64, i64* %positional_table363, i32 1, !dbg !78
+  store i64 %rubyId_y365, i64* %136, align 8, !dbg !78
+  %137 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !78
+  %138 = bitcast i64* %positional_table363 to i8*, !dbg !78
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %137, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %138, i64 noundef 16, i1 noundef false) #15, !dbg !78
+  %139 = getelementptr inbounds i8, i8* %125, i64 32, !dbg !78
+  %140 = bitcast i8* %139 to i8**, !dbg !78
+  store i8* %137, i8** %140, align 8, !dbg !78, !tbaa !76
+  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#lt", i8* nonnull %125, %struct.rb_iseq_struct* %stackFrame361, i1 noundef zeroext false) #15, !dbg !78
+  %141 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !14
+  %142 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 5, !dbg !78
+  %143 = load i32, i32* %142, align 8, !dbg !78, !tbaa !27
+  %144 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 6, !dbg !78
+  %145 = load i32, i32* %144, align 4, !dbg !78, !tbaa !31
+  %146 = xor i32 %145, -1, !dbg !78
+  %147 = and i32 %146, %143, !dbg !78
+  %148 = icmp eq i32 %147, 0, !dbg !78
+  br i1 %148, label %fastSymCallIntrinsic_Static_keep_def379, label %149, !dbg !78, !prof !21
 
 149:                                              ; preds = %fastSymCallIntrinsic_Static_keep_def360
-  %150 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 8, !dbg !76
-  %151 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %150, align 8, !dbg !76, !tbaa !30
-  %152 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %151, i32 noundef 0) #15, !dbg !76
-  br label %fastSymCallIntrinsic_Static_keep_def379, !dbg !76
+  %150 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 8, !dbg !78
+  %151 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %150, align 8, !dbg !78, !tbaa !32
+  %152 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %151, i32 noundef 0) #15, !dbg !78
+  br label %fastSymCallIntrinsic_Static_keep_def379, !dbg !78
 
 afterSend376:                                     ; preds = %368, %fastSymCallIntrinsic_Static_keep_def379
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %8, align 8, !dbg !77, !tbaa !12
-  %153 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !78
-  %154 = load i64*, i64** %153, align 8, !dbg !78
-  store i64 %selfRaw, i64* %154, align 8, !dbg !78, !tbaa !4
-  %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !78
-  %156 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !78
-  %157 = bitcast i64* %155 to <2 x i64>*, !dbg !78
-  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %157, align 8, !dbg !78, !tbaa !4
-  %158 = getelementptr inbounds i64, i64* %156, i64 1, !dbg !78
-  store i64* %158, i64** %153, align 8, !dbg !78
-  %send9 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus, i64 0), !dbg !78
-  %159 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !79
-  %160 = load i64*, i64** %159, align 8, !dbg !79
-  store i64 %selfRaw, i64* %160, align 8, !dbg !79, !tbaa !4
-  %161 = getelementptr inbounds i64, i64* %160, i64 1, !dbg !79
-  store i64 %send9, i64* %161, align 8, !dbg !79, !tbaa !4
-  %162 = getelementptr inbounds i64, i64* %161, i64 1, !dbg !79
-  store i64* %162, i64** %159, align 8, !dbg !79
-  %send11 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !79
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %8, align 8, !dbg !79, !tbaa !12
-  %163 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !80
-  %164 = load i64*, i64** %163, align 8, !dbg !80
-  store i64 %selfRaw, i64* %164, align 8, !dbg !80, !tbaa !4
-  %165 = getelementptr inbounds i64, i64* %164, i64 1, !dbg !80
-  %166 = getelementptr inbounds i64, i64* %165, i64 1, !dbg !80
-  %167 = bitcast i64* %165 to <2 x i64>*, !dbg !80
-  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %167, align 8, !dbg !80, !tbaa !4
-  %168 = getelementptr inbounds i64, i64* %166, i64 1, !dbg !80
-  store i64* %168, i64** %163, align 8, !dbg !80
-  %send13 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus, i64 0), !dbg !80
-  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !81
-  %170 = load i64*, i64** %169, align 8, !dbg !81
-  store i64 %selfRaw, i64* %170, align 8, !dbg !81, !tbaa !4
-  %171 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !81
-  store i64 %send13, i64* %171, align 8, !dbg !81, !tbaa !4
-  %172 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !81
-  store i64* %172, i64** %169, align 8, !dbg !81
-  %send15 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.18, i64 0), !dbg !81
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %8, align 8, !dbg !81, !tbaa !12
-  %173 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !82
-  %174 = load i64*, i64** %173, align 8, !dbg !82
-  store i64 %selfRaw, i64* %174, align 8, !dbg !82, !tbaa !4
-  %175 = getelementptr inbounds i64, i64* %174, i64 1, !dbg !82
-  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !82
-  %177 = bitcast i64* %175 to <2 x i64>*, !dbg !82
-  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %177, align 8, !dbg !82, !tbaa !4
-  %178 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !82
-  store i64* %178, i64** %173, align 8, !dbg !82
-  %send17 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt, i64 0), !dbg !82
-  %179 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !83
-  %180 = load i64*, i64** %179, align 8, !dbg !83
-  store i64 %selfRaw, i64* %180, align 8, !dbg !83, !tbaa !4
-  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !83
-  store i64 %send17, i64* %181, align 8, !dbg !83, !tbaa !4
-  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !83
-  store i64* %182, i64** %179, align 8, !dbg !83
-  %send19 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.19, i64 0), !dbg !83
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %8, align 8, !dbg !83, !tbaa !12
-  %183 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !84
-  %184 = load i64*, i64** %183, align 8, !dbg !84
-  store i64 %selfRaw, i64* %184, align 8, !dbg !84, !tbaa !4
-  %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !84
-  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !84
-  %187 = bitcast i64* %185 to <2 x i64>*, !dbg !84
-  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %187, align 8, !dbg !84, !tbaa !4
-  %188 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !84
-  store i64* %188, i64** %183, align 8, !dbg !84
-  %send21 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.20, i64 0), !dbg !84
-  %189 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !85
-  %190 = load i64*, i64** %189, align 8, !dbg !85
-  store i64 %selfRaw, i64* %190, align 8, !dbg !85, !tbaa !4
-  %191 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !85
-  store i64 %send21, i64* %191, align 8, !dbg !85, !tbaa !4
-  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !85
-  store i64* %192, i64** %189, align 8, !dbg !85
-  %send23 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.21, i64 0), !dbg !85
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 31), i64** %8, align 8, !dbg !85, !tbaa !12
-  %193 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !86
-  %194 = load i64*, i64** %193, align 8, !dbg !86
-  store i64 %selfRaw, i64* %194, align 8, !dbg !86, !tbaa !4
-  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !86
-  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !86
-  %197 = bitcast i64* %195 to <2 x i64>*, !dbg !86
-  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %197, align 8, !dbg !86, !tbaa !4
-  %198 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !86
-  store i64* %198, i64** %193, align 8, !dbg !86
-  %send25 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte, i64 0), !dbg !86
-  %199 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !87
-  %200 = load i64*, i64** %199, align 8, !dbg !87
-  store i64 %selfRaw, i64* %200, align 8, !dbg !87, !tbaa !4
-  %201 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !87
-  store i64 %send25, i64* %201, align 8, !dbg !87, !tbaa !4
-  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !87
-  store i64* %202, i64** %199, align 8, !dbg !87
-  %send27 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.22, i64 0), !dbg !87
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 32), i64** %8, align 8, !dbg !87, !tbaa !12
-  %203 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !88
-  %204 = load i64*, i64** %203, align 8, !dbg !88
-  store i64 %selfRaw, i64* %204, align 8, !dbg !88, !tbaa !4
-  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !88
-  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !88
-  %207 = bitcast i64* %205 to <2 x i64>*, !dbg !88
-  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %207, align 8, !dbg !88, !tbaa !4
-  %208 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !88
-  store i64* %208, i64** %203, align 8, !dbg !88
-  %send29 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.23, i64 0), !dbg !88
-  %209 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !89
-  %210 = load i64*, i64** %209, align 8, !dbg !89
-  store i64 %selfRaw, i64* %210, align 8, !dbg !89, !tbaa !4
-  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !89
-  store i64 %send29, i64* %211, align 8, !dbg !89, !tbaa !4
-  %212 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !89
-  store i64* %212, i64** %209, align 8, !dbg !89
-  %send31 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.24, i64 0), !dbg !89
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 33), i64** %8, align 8, !dbg !89, !tbaa !12
-  %213 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !90
-  %214 = load i64*, i64** %213, align 8, !dbg !90
-  store i64 %selfRaw, i64* %214, align 8, !dbg !90, !tbaa !4
-  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !90
-  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !90
-  %217 = bitcast i64* %215 to <2 x i64>*, !dbg !90
-  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %217, align 8, !dbg !90, !tbaa !4
-  %218 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !90
-  store i64* %218, i64** %213, align 8, !dbg !90
-  %send33 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.25, i64 0), !dbg !90
-  %219 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !91
-  %220 = load i64*, i64** %219, align 8, !dbg !91
-  store i64 %selfRaw, i64* %220, align 8, !dbg !91, !tbaa !4
-  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !91
-  store i64 %send33, i64* %221, align 8, !dbg !91, !tbaa !4
-  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !91
-  store i64* %222, i64** %219, align 8, !dbg !91
-  %send35 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.26, i64 0), !dbg !91
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 36), i64** %8, align 8, !dbg !91, !tbaa !12
-  %223 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !92
-  %224 = load i64*, i64** %223, align 8, !dbg !92
-  store i64 %selfRaw, i64* %224, align 8, !dbg !92, !tbaa !4
-  %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !92
-  %226 = getelementptr inbounds i64, i64* %225, i64 1, !dbg !92
-  %227 = bitcast i64* %225 to <2 x i64>*, !dbg !92
-  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %227, align 8, !dbg !92, !tbaa !4
-  %228 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !92
-  store i64* %228, i64** %223, align 8, !dbg !92
-  %send37 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.27, i64 0), !dbg !92
-  %229 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !93
-  %230 = load i64*, i64** %229, align 8, !dbg !93
-  store i64 %selfRaw, i64* %230, align 8, !dbg !93, !tbaa !4
-  %231 = getelementptr inbounds i64, i64* %230, i64 1, !dbg !93
-  store i64 %send37, i64* %231, align 8, !dbg !93, !tbaa !4
-  %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !93
-  store i64* %232, i64** %229, align 8, !dbg !93
-  %send39 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.28, i64 0), !dbg !93
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 37), i64** %8, align 8, !dbg !93, !tbaa !12
-  %rubyStr_8.9 = load i64, i64* @rubyStrFrozen_8.9, align 8, !dbg !94
-  %233 = load i64, i64* @rb_mKernel, align 8, !dbg !94
-  %234 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !94
-  %235 = load i64*, i64** %234, align 8, !dbg !94
-  store i64 %233, i64* %235, align 8, !dbg !94, !tbaa !4
-  %236 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !94
-  store i64 %rubyStr_8.9, i64* %236, align 8, !dbg !94, !tbaa !4
-  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !94
-  store i64* %237, i64** %234, align 8, !dbg !94
-  %send41 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational, i64 0), !dbg !94
-  %238 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !95
-  %239 = load i64*, i64** %238, align 8, !dbg !95
-  store i64 %selfRaw, i64* %239, align 8, !dbg !95, !tbaa !4
-  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !95
-  store i64 36028797018963970, i64* %240, align 8, !dbg !95, !tbaa !4
-  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !95
-  store i64 %send41, i64* %241, align 8, !dbg !95, !tbaa !4
-  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !95
-  store i64* %242, i64** %238, align 8, !dbg !95
-  %send43 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.29, i64 0), !dbg !95
-  %243 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !96
-  %244 = load i64*, i64** %243, align 8, !dbg !96
-  store i64 %selfRaw, i64* %244, align 8, !dbg !96, !tbaa !4
-  %245 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !96
-  store i64 %send43, i64* %245, align 8, !dbg !96, !tbaa !4
-  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !96
-  store i64* %246, i64** %243, align 8, !dbg !96
-  %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.30, i64 0), !dbg !96
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 38), i64** %8, align 8, !dbg !96, !tbaa !12
-  %rubyStr_5 = load i64, i64* @rubyStrFrozen_5, align 8, !dbg !97
-  %247 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !97
-  %248 = load i64*, i64** %247, align 8, !dbg !97
-  store i64 %233, i64* %248, align 8, !dbg !97, !tbaa !4
-  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !97
-  store i64 1, i64* %249, align 8, !dbg !97, !tbaa !4
-  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !97
-  store i64 %rubyStr_5, i64* %250, align 8, !dbg !97, !tbaa !4
-  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !97
-  store i64* %251, i64** %247, align 8, !dbg !97
-  %send47 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex, i64 0), !dbg !97
-  %252 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !98
-  %253 = load i64*, i64** %252, align 8, !dbg !98
-  store i64 %selfRaw, i64* %253, align 8, !dbg !98, !tbaa !4
-  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !98
-  store i64 36028797018963970, i64* %254, align 8, !dbg !98, !tbaa !4
-  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !98
-  store i64 %send47, i64* %255, align 8, !dbg !98, !tbaa !4
-  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !98
-  store i64* %256, i64** %252, align 8, !dbg !98
-  %send49 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.31, i64 0), !dbg !98
-  %257 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !99
-  %258 = load i64*, i64** %257, align 8, !dbg !99
-  store i64 %selfRaw, i64* %258, align 8, !dbg !99, !tbaa !4
-  %259 = getelementptr inbounds i64, i64* %258, i64 1, !dbg !99
-  store i64 %send49, i64* %259, align 8, !dbg !99, !tbaa !4
-  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !99
-  store i64* %260, i64** %257, align 8, !dbg !99
-  %send51 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.32, i64 0), !dbg !99
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 40), i64** %8, align 8, !dbg !99, !tbaa !12
-  %261 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !100
-  %262 = load i64*, i64** %261, align 8, !dbg !100
-  store i64 %selfRaw, i64* %262, align 8, !dbg !100, !tbaa !4
-  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !100
-  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !100
-  %265 = bitcast i64* %263 to <2 x i64>*, !dbg !100
-  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %265, align 8, !dbg !100, !tbaa !4
-  %266 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !100
-  store i64* %266, i64** %261, align 8, !dbg !100
-  %send53 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.33, i64 0), !dbg !100
-  %267 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !101
-  %268 = load i64*, i64** %267, align 8, !dbg !101
-  store i64 %selfRaw, i64* %268, align 8, !dbg !101, !tbaa !4
-  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !101
-  store i64 %send53, i64* %269, align 8, !dbg !101, !tbaa !4
-  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !101
-  store i64* %270, i64** %267, align 8, !dbg !101
-  %send55 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.34, i64 0), !dbg !101
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 41), i64** %8, align 8, !dbg !101, !tbaa !12
-  %rubyStr_15.4 = load i64, i64* @rubyStrFrozen_15.4, align 8, !dbg !102
-  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !102
-  %272 = load i64*, i64** %271, align 8, !dbg !102
-  store i64 %233, i64* %272, align 8, !dbg !102, !tbaa !4
-  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !102
-  store i64 %rubyStr_15.4, i64* %273, align 8, !dbg !102, !tbaa !4
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !102
-  store i64* %274, i64** %271, align 8, !dbg !102
-  %send57 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.35, i64 0), !dbg !102
-  %275 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !103
-  %276 = load i64*, i64** %275, align 8, !dbg !103
-  store i64 %selfRaw, i64* %276, align 8, !dbg !103, !tbaa !4
-  %277 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !103
-  store i64 199622053483197234, i64* %277, align 8, !dbg !103, !tbaa !4
-  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !103
-  store i64 %send57, i64* %278, align 8, !dbg !103, !tbaa !4
-  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !103
-  store i64* %279, i64** %275, align 8, !dbg !103
-  %send59 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.36, i64 0), !dbg !103
-  %280 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !104
-  %281 = load i64*, i64** %280, align 8, !dbg !104
-  store i64 %selfRaw, i64* %281, align 8, !dbg !104, !tbaa !4
-  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !104
-  store i64 %send59, i64* %282, align 8, !dbg !104, !tbaa !4
-  %283 = getelementptr inbounds i64, i64* %282, i64 1, !dbg !104
-  store i64* %283, i64** %280, align 8, !dbg !104
-  %send61 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.37, i64 0), !dbg !104
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 42), i64** %8, align 8, !dbg !104, !tbaa !12
-  %rubyStr_18 = load i64, i64* @rubyStrFrozen_18, align 8, !dbg !105
-  %284 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !105
-  %285 = load i64*, i64** %284, align 8, !dbg !105
-  store i64 %233, i64* %285, align 8, !dbg !105, !tbaa !4
-  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !105
-  store i64 1, i64* %286, align 8, !dbg !105, !tbaa !4
-  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !105
-  store i64 %rubyStr_18, i64* %287, align 8, !dbg !105, !tbaa !4
-  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !105
-  store i64* %288, i64** %284, align 8, !dbg !105
-  %send63 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex.38, i64 0), !dbg !105
-  %289 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !106
-  %290 = load i64*, i64** %289, align 8, !dbg !106
-  store i64 %selfRaw, i64* %290, align 8, !dbg !106, !tbaa !4
-  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !106
-  store i64 199565758487855106, i64* %291, align 8, !dbg !106, !tbaa !4
-  %292 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !106
-  store i64 %send63, i64* %292, align 8, !dbg !106, !tbaa !4
-  %293 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !106
-  store i64* %293, i64** %289, align 8, !dbg !106
-  %send65 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.39, i64 0), !dbg !106
-  %294 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !107
-  %295 = load i64*, i64** %294, align 8, !dbg !107
-  store i64 %selfRaw, i64* %295, align 8, !dbg !107, !tbaa !4
-  %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !107
-  store i64 %send65, i64* %296, align 8, !dbg !107, !tbaa !4
-  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !107
-  store i64* %297, i64** %294, align 8, !dbg !107
-  %send67 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.40, i64 0), !dbg !107
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 44), i64** %8, align 8, !dbg !107, !tbaa !12
-  %298 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !108
-  %299 = load i64*, i64** %298, align 8, !dbg !108
-  store i64 %selfRaw, i64* %299, align 8, !dbg !108, !tbaa !4
-  %300 = getelementptr inbounds i64, i64* %299, i64 1, !dbg !108
-  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !108
-  %302 = bitcast i64* %300 to <2 x i64>*, !dbg !108
-  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %302, align 8, !dbg !108, !tbaa !4
-  %303 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !108
-  store i64* %303, i64** %298, align 8, !dbg !108
-  %send69 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.41, i64 0), !dbg !108
-  %304 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !109
-  %305 = load i64*, i64** %304, align 8, !dbg !109
-  store i64 %selfRaw, i64* %305, align 8, !dbg !109, !tbaa !4
-  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !109
-  store i64 %send69, i64* %306, align 8, !dbg !109, !tbaa !4
-  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !109
-  store i64* %307, i64** %304, align 8, !dbg !109
-  %send71 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.42, i64 0), !dbg !109
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 45), i64** %8, align 8, !dbg !109, !tbaa !12
-  %rubyStr_25.4 = load i64, i64* @rubyStrFrozen_25.4, align 8, !dbg !110
-  %308 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !110
-  %309 = load i64*, i64** %308, align 8, !dbg !110
-  store i64 %233, i64* %309, align 8, !dbg !110, !tbaa !4
-  %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !110
-  store i64 %rubyStr_25.4, i64* %310, align 8, !dbg !110, !tbaa !4
-  %311 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !110
-  store i64* %311, i64** %308, align 8, !dbg !110
-  %send73 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.43, i64 0), !dbg !110
-  %312 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !111
-  %313 = load i64*, i64** %312, align 8, !dbg !111
-  store i64 %selfRaw, i64* %313, align 8, !dbg !111, !tbaa !4
-  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !111
-  store i64 113040350646999450, i64* %314, align 8, !dbg !111, !tbaa !4
-  %315 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !111
-  store i64 %send73, i64* %315, align 8, !dbg !111, !tbaa !4
-  %316 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !111
-  store i64* %316, i64** %312, align 8, !dbg !111
-  %send75 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.44, i64 0), !dbg !111
-  %317 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !112
-  %318 = load i64*, i64** %317, align 8, !dbg !112
-  store i64 %selfRaw, i64* %318, align 8, !dbg !112, !tbaa !4
-  %319 = getelementptr inbounds i64, i64* %318, i64 1, !dbg !112
-  store i64 %send75, i64* %319, align 8, !dbg !112, !tbaa !4
-  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !112
-  store i64* %320, i64** %317, align 8, !dbg !112
-  %send77 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.45, i64 0), !dbg !112
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 47), i64** %8, align 8, !dbg !112, !tbaa !12
-  %321 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !113
-  %322 = load i64*, i64** %321, align 8, !dbg !113
-  store i64 %selfRaw, i64* %322, align 8, !dbg !113, !tbaa !4
-  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !113
-  %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !113
-  %325 = bitcast i64* %323 to <2 x i64>*, !dbg !113
-  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %325, align 8, !dbg !113, !tbaa !4
-  %326 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !113
-  store i64* %326, i64** %321, align 8, !dbg !113
-  %send79 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.46, i64 0), !dbg !113
-  %327 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !114
-  %328 = load i64*, i64** %327, align 8, !dbg !114
-  store i64 %selfRaw, i64* %328, align 8, !dbg !114, !tbaa !4
-  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !114
-  store i64 %send79, i64* %329, align 8, !dbg !114, !tbaa !4
-  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !114
-  store i64* %330, i64** %327, align 8, !dbg !114
-  %send81 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.47, i64 0), !dbg !114
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 48), i64** %8, align 8, !dbg !114, !tbaa !12
-  %rubyStr_5.923 = load i64, i64* @rubyStrFrozen_5.923, align 8, !dbg !115
-  %331 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !115
-  %332 = load i64*, i64** %331, align 8, !dbg !115
-  store i64 %233, i64* %332, align 8, !dbg !115, !tbaa !4
-  %333 = getelementptr inbounds i64, i64* %332, i64 1, !dbg !115
-  store i64 %rubyStr_5.923, i64* %333, align 8, !dbg !115, !tbaa !4
-  %334 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !115
-  store i64* %334, i64** %331, align 8, !dbg !115
-  %send83 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.48, i64 0), !dbg !115
-  %335 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !116
-  %336 = load i64*, i64** %335, align 8, !dbg !116
-  store i64 %selfRaw, i64* %336, align 8, !dbg !116, !tbaa !4
-  %337 = getelementptr inbounds i64, i64* %336, i64 1, !dbg !116
-  store i64 113040350646999450, i64* %337, align 8, !dbg !116, !tbaa !4
-  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !116
-  store i64 %send83, i64* %338, align 8, !dbg !116, !tbaa !4
-  %339 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !116
-  store i64* %339, i64** %335, align 8, !dbg !116
-  %send85 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.49, i64 0), !dbg !116
-  %340 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !117
-  %341 = load i64*, i64** %340, align 8, !dbg !117
-  store i64 %selfRaw, i64* %341, align 8, !dbg !117, !tbaa !4
-  %342 = getelementptr inbounds i64, i64* %341, i64 1, !dbg !117
-  store i64 %send85, i64* %342, align 8, !dbg !117, !tbaa !4
-  %343 = getelementptr inbounds i64, i64* %342, i64 1, !dbg !117
-  store i64* %343, i64** %340, align 8, !dbg !117
-  %send87 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.50, i64 0), !dbg !117
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %8, align 8, !dbg !79, !tbaa !14
+  %153 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !80
+  %154 = load i64*, i64** %153, align 8, !dbg !80
+  store i64 %selfRaw, i64* %154, align 8, !dbg !80, !tbaa !6
+  %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !80
+  %156 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !80
+  %157 = bitcast i64* %155 to <2 x i64>*, !dbg !80
+  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %157, align 8, !dbg !80, !tbaa !6
+  %158 = getelementptr inbounds i64, i64* %156, i64 1, !dbg !80
+  store i64* %158, i64** %153, align 8, !dbg !80
+  %send9 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus, i64 0), !dbg !80
+  %159 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !81
+  %160 = load i64*, i64** %159, align 8, !dbg !81
+  store i64 %selfRaw, i64* %160, align 8, !dbg !81, !tbaa !6
+  %161 = getelementptr inbounds i64, i64* %160, i64 1, !dbg !81
+  store i64 %send9, i64* %161, align 8, !dbg !81, !tbaa !6
+  %162 = getelementptr inbounds i64, i64* %161, i64 1, !dbg !81
+  store i64* %162, i64** %159, align 8, !dbg !81
+  %send11 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !81
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %8, align 8, !dbg !81, !tbaa !14
+  %163 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !82
+  %164 = load i64*, i64** %163, align 8, !dbg !82
+  store i64 %selfRaw, i64* %164, align 8, !dbg !82, !tbaa !6
+  %165 = getelementptr inbounds i64, i64* %164, i64 1, !dbg !82
+  %166 = getelementptr inbounds i64, i64* %165, i64 1, !dbg !82
+  %167 = bitcast i64* %165 to <2 x i64>*, !dbg !82
+  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %167, align 8, !dbg !82, !tbaa !6
+  %168 = getelementptr inbounds i64, i64* %166, i64 1, !dbg !82
+  store i64* %168, i64** %163, align 8, !dbg !82
+  %send13 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus, i64 0), !dbg !82
+  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !83
+  %170 = load i64*, i64** %169, align 8, !dbg !83
+  store i64 %selfRaw, i64* %170, align 8, !dbg !83, !tbaa !6
+  %171 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !83
+  store i64 %send13, i64* %171, align 8, !dbg !83, !tbaa !6
+  %172 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !83
+  store i64* %172, i64** %169, align 8, !dbg !83
+  %send15 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.18, i64 0), !dbg !83
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %8, align 8, !dbg !83, !tbaa !14
+  %173 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !84
+  %174 = load i64*, i64** %173, align 8, !dbg !84
+  store i64 %selfRaw, i64* %174, align 8, !dbg !84, !tbaa !6
+  %175 = getelementptr inbounds i64, i64* %174, i64 1, !dbg !84
+  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !84
+  %177 = bitcast i64* %175 to <2 x i64>*, !dbg !84
+  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %177, align 8, !dbg !84, !tbaa !6
+  %178 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !84
+  store i64* %178, i64** %173, align 8, !dbg !84
+  %send17 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt, i64 0), !dbg !84
+  %179 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !85
+  %180 = load i64*, i64** %179, align 8, !dbg !85
+  store i64 %selfRaw, i64* %180, align 8, !dbg !85, !tbaa !6
+  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !85
+  store i64 %send17, i64* %181, align 8, !dbg !85, !tbaa !6
+  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !85
+  store i64* %182, i64** %179, align 8, !dbg !85
+  %send19 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.19, i64 0), !dbg !85
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %8, align 8, !dbg !85, !tbaa !14
+  %183 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !86
+  %184 = load i64*, i64** %183, align 8, !dbg !86
+  store i64 %selfRaw, i64* %184, align 8, !dbg !86, !tbaa !6
+  %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !86
+  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !86
+  %187 = bitcast i64* %185 to <2 x i64>*, !dbg !86
+  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %187, align 8, !dbg !86, !tbaa !6
+  %188 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !86
+  store i64* %188, i64** %183, align 8, !dbg !86
+  %send21 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.20, i64 0), !dbg !86
+  %189 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !87
+  %190 = load i64*, i64** %189, align 8, !dbg !87
+  store i64 %selfRaw, i64* %190, align 8, !dbg !87, !tbaa !6
+  %191 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !87
+  store i64 %send21, i64* %191, align 8, !dbg !87, !tbaa !6
+  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !87
+  store i64* %192, i64** %189, align 8, !dbg !87
+  %send23 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.21, i64 0), !dbg !87
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 31), i64** %8, align 8, !dbg !87, !tbaa !14
+  %193 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !88
+  %194 = load i64*, i64** %193, align 8, !dbg !88
+  store i64 %selfRaw, i64* %194, align 8, !dbg !88, !tbaa !6
+  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !88
+  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !88
+  %197 = bitcast i64* %195 to <2 x i64>*, !dbg !88
+  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %197, align 8, !dbg !88, !tbaa !6
+  %198 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !88
+  store i64* %198, i64** %193, align 8, !dbg !88
+  %send25 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte, i64 0), !dbg !88
+  %199 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !89
+  %200 = load i64*, i64** %199, align 8, !dbg !89
+  store i64 %selfRaw, i64* %200, align 8, !dbg !89, !tbaa !6
+  %201 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !89
+  store i64 %send25, i64* %201, align 8, !dbg !89, !tbaa !6
+  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !89
+  store i64* %202, i64** %199, align 8, !dbg !89
+  %send27 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.22, i64 0), !dbg !89
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 32), i64** %8, align 8, !dbg !89, !tbaa !14
+  %203 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !90
+  %204 = load i64*, i64** %203, align 8, !dbg !90
+  store i64 %selfRaw, i64* %204, align 8, !dbg !90, !tbaa !6
+  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !90
+  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !90
+  %207 = bitcast i64* %205 to <2 x i64>*, !dbg !90
+  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %207, align 8, !dbg !90, !tbaa !6
+  %208 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !90
+  store i64* %208, i64** %203, align 8, !dbg !90
+  %send29 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.23, i64 0), !dbg !90
+  %209 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !91
+  %210 = load i64*, i64** %209, align 8, !dbg !91
+  store i64 %selfRaw, i64* %210, align 8, !dbg !91, !tbaa !6
+  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !91
+  store i64 %send29, i64* %211, align 8, !dbg !91, !tbaa !6
+  %212 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !91
+  store i64* %212, i64** %209, align 8, !dbg !91
+  %send31 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.24, i64 0), !dbg !91
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 33), i64** %8, align 8, !dbg !91, !tbaa !14
+  %213 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !92
+  %214 = load i64*, i64** %213, align 8, !dbg !92
+  store i64 %selfRaw, i64* %214, align 8, !dbg !92, !tbaa !6
+  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !92
+  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !92
+  %217 = bitcast i64* %215 to <2 x i64>*, !dbg !92
+  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %217, align 8, !dbg !92, !tbaa !6
+  %218 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !92
+  store i64* %218, i64** %213, align 8, !dbg !92
+  %send33 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.25, i64 0), !dbg !92
+  %219 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !93
+  %220 = load i64*, i64** %219, align 8, !dbg !93
+  store i64 %selfRaw, i64* %220, align 8, !dbg !93, !tbaa !6
+  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !93
+  store i64 %send33, i64* %221, align 8, !dbg !93, !tbaa !6
+  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !93
+  store i64* %222, i64** %219, align 8, !dbg !93
+  %send35 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.26, i64 0), !dbg !93
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 36), i64** %8, align 8, !dbg !93, !tbaa !14
+  %223 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !94
+  %224 = load i64*, i64** %223, align 8, !dbg !94
+  store i64 %selfRaw, i64* %224, align 8, !dbg !94, !tbaa !6
+  %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !94
+  %226 = getelementptr inbounds i64, i64* %225, i64 1, !dbg !94
+  %227 = bitcast i64* %225 to <2 x i64>*, !dbg !94
+  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %227, align 8, !dbg !94, !tbaa !6
+  %228 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !94
+  store i64* %228, i64** %223, align 8, !dbg !94
+  %send37 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.27, i64 0), !dbg !94
+  %229 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !95
+  %230 = load i64*, i64** %229, align 8, !dbg !95
+  store i64 %selfRaw, i64* %230, align 8, !dbg !95, !tbaa !6
+  %231 = getelementptr inbounds i64, i64* %230, i64 1, !dbg !95
+  store i64 %send37, i64* %231, align 8, !dbg !95, !tbaa !6
+  %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !95
+  store i64* %232, i64** %229, align 8, !dbg !95
+  %send39 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.28, i64 0), !dbg !95
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 37), i64** %8, align 8, !dbg !95, !tbaa !14
+  %rubyStr_8.9 = load i64, i64* @rubyStrFrozen_8.9, align 8, !dbg !96
+  %233 = load i64, i64* @rb_mKernel, align 8, !dbg !96
+  %234 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !96
+  %235 = load i64*, i64** %234, align 8, !dbg !96
+  store i64 %233, i64* %235, align 8, !dbg !96, !tbaa !6
+  %236 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !96
+  store i64 %rubyStr_8.9, i64* %236, align 8, !dbg !96, !tbaa !6
+  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !96
+  store i64* %237, i64** %234, align 8, !dbg !96
+  %send41 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational, i64 0), !dbg !96
+  %238 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !97
+  %239 = load i64*, i64** %238, align 8, !dbg !97
+  store i64 %selfRaw, i64* %239, align 8, !dbg !97, !tbaa !6
+  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !97
+  store i64 36028797018963970, i64* %240, align 8, !dbg !97, !tbaa !6
+  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !97
+  store i64 %send41, i64* %241, align 8, !dbg !97, !tbaa !6
+  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !97
+  store i64* %242, i64** %238, align 8, !dbg !97
+  %send43 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.29, i64 0), !dbg !97
+  %243 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !98
+  %244 = load i64*, i64** %243, align 8, !dbg !98
+  store i64 %selfRaw, i64* %244, align 8, !dbg !98, !tbaa !6
+  %245 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !98
+  store i64 %send43, i64* %245, align 8, !dbg !98, !tbaa !6
+  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !98
+  store i64* %246, i64** %243, align 8, !dbg !98
+  %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.30, i64 0), !dbg !98
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 38), i64** %8, align 8, !dbg !98, !tbaa !14
+  %rubyStr_5 = load i64, i64* @rubyStrFrozen_5, align 8, !dbg !99
+  %247 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !99
+  %248 = load i64*, i64** %247, align 8, !dbg !99
+  store i64 %233, i64* %248, align 8, !dbg !99, !tbaa !6
+  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !99
+  store i64 1, i64* %249, align 8, !dbg !99, !tbaa !6
+  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !99
+  store i64 %rubyStr_5, i64* %250, align 8, !dbg !99, !tbaa !6
+  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !99
+  store i64* %251, i64** %247, align 8, !dbg !99
+  %send47 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex, i64 0), !dbg !99
+  %252 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !100
+  %253 = load i64*, i64** %252, align 8, !dbg !100
+  store i64 %selfRaw, i64* %253, align 8, !dbg !100, !tbaa !6
+  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !100
+  store i64 36028797018963970, i64* %254, align 8, !dbg !100, !tbaa !6
+  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !100
+  store i64 %send47, i64* %255, align 8, !dbg !100, !tbaa !6
+  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !100
+  store i64* %256, i64** %252, align 8, !dbg !100
+  %send49 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.31, i64 0), !dbg !100
+  %257 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !101
+  %258 = load i64*, i64** %257, align 8, !dbg !101
+  store i64 %selfRaw, i64* %258, align 8, !dbg !101, !tbaa !6
+  %259 = getelementptr inbounds i64, i64* %258, i64 1, !dbg !101
+  store i64 %send49, i64* %259, align 8, !dbg !101, !tbaa !6
+  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !101
+  store i64* %260, i64** %257, align 8, !dbg !101
+  %send51 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.32, i64 0), !dbg !101
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 40), i64** %8, align 8, !dbg !101, !tbaa !14
+  %261 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !102
+  %262 = load i64*, i64** %261, align 8, !dbg !102
+  store i64 %selfRaw, i64* %262, align 8, !dbg !102, !tbaa !6
+  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !102
+  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !102
+  %265 = bitcast i64* %263 to <2 x i64>*, !dbg !102
+  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %265, align 8, !dbg !102, !tbaa !6
+  %266 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !102
+  store i64* %266, i64** %261, align 8, !dbg !102
+  %send53 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.33, i64 0), !dbg !102
+  %267 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !103
+  %268 = load i64*, i64** %267, align 8, !dbg !103
+  store i64 %selfRaw, i64* %268, align 8, !dbg !103, !tbaa !6
+  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !103
+  store i64 %send53, i64* %269, align 8, !dbg !103, !tbaa !6
+  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !103
+  store i64* %270, i64** %267, align 8, !dbg !103
+  %send55 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.34, i64 0), !dbg !103
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 41), i64** %8, align 8, !dbg !103, !tbaa !14
+  %rubyStr_15.4 = load i64, i64* @rubyStrFrozen_15.4, align 8, !dbg !104
+  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !104
+  %272 = load i64*, i64** %271, align 8, !dbg !104
+  store i64 %233, i64* %272, align 8, !dbg !104, !tbaa !6
+  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !104
+  store i64 %rubyStr_15.4, i64* %273, align 8, !dbg !104, !tbaa !6
+  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !104
+  store i64* %274, i64** %271, align 8, !dbg !104
+  %send57 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.35, i64 0), !dbg !104
+  %275 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !105
+  %276 = load i64*, i64** %275, align 8, !dbg !105
+  store i64 %selfRaw, i64* %276, align 8, !dbg !105, !tbaa !6
+  %277 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !105
+  store i64 199622053483197234, i64* %277, align 8, !dbg !105, !tbaa !6
+  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !105
+  store i64 %send57, i64* %278, align 8, !dbg !105, !tbaa !6
+  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !105
+  store i64* %279, i64** %275, align 8, !dbg !105
+  %send59 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.36, i64 0), !dbg !105
+  %280 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !106
+  %281 = load i64*, i64** %280, align 8, !dbg !106
+  store i64 %selfRaw, i64* %281, align 8, !dbg !106, !tbaa !6
+  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !106
+  store i64 %send59, i64* %282, align 8, !dbg !106, !tbaa !6
+  %283 = getelementptr inbounds i64, i64* %282, i64 1, !dbg !106
+  store i64* %283, i64** %280, align 8, !dbg !106
+  %send61 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.37, i64 0), !dbg !106
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 42), i64** %8, align 8, !dbg !106, !tbaa !14
+  %rubyStr_18 = load i64, i64* @rubyStrFrozen_18, align 8, !dbg !107
+  %284 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !107
+  %285 = load i64*, i64** %284, align 8, !dbg !107
+  store i64 %233, i64* %285, align 8, !dbg !107, !tbaa !6
+  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !107
+  store i64 1, i64* %286, align 8, !dbg !107, !tbaa !6
+  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !107
+  store i64 %rubyStr_18, i64* %287, align 8, !dbg !107, !tbaa !6
+  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !107
+  store i64* %288, i64** %284, align 8, !dbg !107
+  %send63 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex.38, i64 0), !dbg !107
+  %289 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !108
+  %290 = load i64*, i64** %289, align 8, !dbg !108
+  store i64 %selfRaw, i64* %290, align 8, !dbg !108, !tbaa !6
+  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !108
+  store i64 199565758487855106, i64* %291, align 8, !dbg !108, !tbaa !6
+  %292 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !108
+  store i64 %send63, i64* %292, align 8, !dbg !108, !tbaa !6
+  %293 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !108
+  store i64* %293, i64** %289, align 8, !dbg !108
+  %send65 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.39, i64 0), !dbg !108
+  %294 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !109
+  %295 = load i64*, i64** %294, align 8, !dbg !109
+  store i64 %selfRaw, i64* %295, align 8, !dbg !109, !tbaa !6
+  %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !109
+  store i64 %send65, i64* %296, align 8, !dbg !109, !tbaa !6
+  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !109
+  store i64* %297, i64** %294, align 8, !dbg !109
+  %send67 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.40, i64 0), !dbg !109
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 44), i64** %8, align 8, !dbg !109, !tbaa !14
+  %298 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !110
+  %299 = load i64*, i64** %298, align 8, !dbg !110
+  store i64 %selfRaw, i64* %299, align 8, !dbg !110, !tbaa !6
+  %300 = getelementptr inbounds i64, i64* %299, i64 1, !dbg !110
+  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !110
+  %302 = bitcast i64* %300 to <2 x i64>*, !dbg !110
+  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %302, align 8, !dbg !110, !tbaa !6
+  %303 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !110
+  store i64* %303, i64** %298, align 8, !dbg !110
+  %send69 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.41, i64 0), !dbg !110
+  %304 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !111
+  %305 = load i64*, i64** %304, align 8, !dbg !111
+  store i64 %selfRaw, i64* %305, align 8, !dbg !111, !tbaa !6
+  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !111
+  store i64 %send69, i64* %306, align 8, !dbg !111, !tbaa !6
+  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !111
+  store i64* %307, i64** %304, align 8, !dbg !111
+  %send71 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.42, i64 0), !dbg !111
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 45), i64** %8, align 8, !dbg !111, !tbaa !14
+  %rubyStr_25.4 = load i64, i64* @rubyStrFrozen_25.4, align 8, !dbg !112
+  %308 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !112
+  %309 = load i64*, i64** %308, align 8, !dbg !112
+  store i64 %233, i64* %309, align 8, !dbg !112, !tbaa !6
+  %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !112
+  store i64 %rubyStr_25.4, i64* %310, align 8, !dbg !112, !tbaa !6
+  %311 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !112
+  store i64* %311, i64** %308, align 8, !dbg !112
+  %send73 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.43, i64 0), !dbg !112
+  %312 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !113
+  %313 = load i64*, i64** %312, align 8, !dbg !113
+  store i64 %selfRaw, i64* %313, align 8, !dbg !113, !tbaa !6
+  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !113
+  store i64 113040350646999450, i64* %314, align 8, !dbg !113, !tbaa !6
+  %315 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !113
+  store i64 %send73, i64* %315, align 8, !dbg !113, !tbaa !6
+  %316 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !113
+  store i64* %316, i64** %312, align 8, !dbg !113
+  %send75 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.44, i64 0), !dbg !113
+  %317 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !114
+  %318 = load i64*, i64** %317, align 8, !dbg !114
+  store i64 %selfRaw, i64* %318, align 8, !dbg !114, !tbaa !6
+  %319 = getelementptr inbounds i64, i64* %318, i64 1, !dbg !114
+  store i64 %send75, i64* %319, align 8, !dbg !114, !tbaa !6
+  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !114
+  store i64* %320, i64** %317, align 8, !dbg !114
+  %send77 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.45, i64 0), !dbg !114
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 47), i64** %8, align 8, !dbg !114, !tbaa !14
+  %321 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !115
+  %322 = load i64*, i64** %321, align 8, !dbg !115
+  store i64 %selfRaw, i64* %322, align 8, !dbg !115, !tbaa !6
+  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !115
+  %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !115
+  %325 = bitcast i64* %323 to <2 x i64>*, !dbg !115
+  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %325, align 8, !dbg !115, !tbaa !6
+  %326 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !115
+  store i64* %326, i64** %321, align 8, !dbg !115
+  %send79 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.46, i64 0), !dbg !115
+  %327 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !116
+  %328 = load i64*, i64** %327, align 8, !dbg !116
+  store i64 %selfRaw, i64* %328, align 8, !dbg !116, !tbaa !6
+  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !116
+  store i64 %send79, i64* %329, align 8, !dbg !116, !tbaa !6
+  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !116
+  store i64* %330, i64** %327, align 8, !dbg !116
+  %send81 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.47, i64 0), !dbg !116
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 48), i64** %8, align 8, !dbg !116, !tbaa !14
+  %rubyStr_5.923 = load i64, i64* @rubyStrFrozen_5.923, align 8, !dbg !117
+  %331 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !117
+  %332 = load i64*, i64** %331, align 8, !dbg !117
+  store i64 %233, i64* %332, align 8, !dbg !117, !tbaa !6
+  %333 = getelementptr inbounds i64, i64* %332, i64 1, !dbg !117
+  store i64 %rubyStr_5.923, i64* %333, align 8, !dbg !117, !tbaa !6
+  %334 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !117
+  store i64* %334, i64** %331, align 8, !dbg !117
+  %send83 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.48, i64 0), !dbg !117
+  %335 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !118
+  %336 = load i64*, i64** %335, align 8, !dbg !118
+  store i64 %selfRaw, i64* %336, align 8, !dbg !118, !tbaa !6
+  %337 = getelementptr inbounds i64, i64* %336, i64 1, !dbg !118
+  store i64 113040350646999450, i64* %337, align 8, !dbg !118, !tbaa !6
+  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !118
+  store i64 %send83, i64* %338, align 8, !dbg !118, !tbaa !6
+  %339 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !118
+  store i64* %339, i64** %335, align 8, !dbg !118
+  %send85 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.49, i64 0), !dbg !118
+  %340 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !119
+  %341 = load i64*, i64** %340, align 8, !dbg !119
+  store i64 %selfRaw, i64* %341, align 8, !dbg !119, !tbaa !6
+  %342 = getelementptr inbounds i64, i64* %341, i64 1, !dbg !119
+  store i64 %send85, i64* %342, align 8, !dbg !119, !tbaa !6
+  %343 = getelementptr inbounds i64, i64* %342, i64 1, !dbg !119
+  store i64* %343, i64** %340, align 8, !dbg !119
+  %send87 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.50, i64 0), !dbg !119
   ret void
 
 fastSymCallIntrinsic_Static_keep_def379:          ; preds = %fastSymCallIntrinsic_Static_keep_def360, %149
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %8, align 8, !dbg !76, !tbaa !12
-  %rubyId_lte370 = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !77
-  %rawSym371 = tail call i64 @rb_id2sym(i64 %rubyId_lte370), !dbg !77
-  %rubyId_normal372 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !77
-  %rawSym373 = tail call i64 @rb_id2sym(i64 %rubyId_normal372), !dbg !77
-  %stackFrame380 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#lte", align 8, !dbg !77
-  %344 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !77
-  %345 = bitcast i8* %344 to i16*, !dbg !77
-  %346 = load i16, i16* %345, align 8, !dbg !77
-  %347 = and i16 %346, -384, !dbg !77
-  %348 = or i16 %347, 1, !dbg !77
-  store i16 %348, i16* %345, align 8, !dbg !77
-  %349 = getelementptr inbounds i8, i8* %344, i64 8, !dbg !77
-  %350 = bitcast i8* %349 to i32*, !dbg !77
-  store i32 2, i32* %350, align 8, !dbg !77, !tbaa !70
-  %351 = getelementptr inbounds i8, i8* %344, i64 12, !dbg !77
-  %352 = bitcast i8* %351 to i32*, !dbg !77
-  %353 = getelementptr inbounds i8, i8* %344, i64 4, !dbg !77
-  %354 = bitcast i8* %353 to i32*, !dbg !77
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %351, i8 0, i64 20, i1 false), !dbg !77
-  store i32 2, i32* %354, align 4, !dbg !77, !tbaa !73
-  %positional_table382 = alloca i64, i32 2, align 8, !dbg !77
-  %rubyId_x383 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !77
-  store i64 %rubyId_x383, i64* %positional_table382, align 8, !dbg !77
-  %rubyId_y384 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !77
-  %355 = getelementptr i64, i64* %positional_table382, i32 1, !dbg !77
-  store i64 %rubyId_y384, i64* %355, align 8, !dbg !77
-  %356 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !77
-  %357 = bitcast i64* %positional_table382 to i8*, !dbg !77
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %356, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %357, i64 noundef 16, i1 noundef false) #15, !dbg !77
-  %358 = getelementptr inbounds i8, i8* %344, i64 32, !dbg !77
-  %359 = bitcast i8* %358 to i8**, !dbg !77
-  store i8* %356, i8** %359, align 8, !dbg !77, !tbaa !74
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#lte", i8* nonnull %344, %struct.rb_iseq_struct* %stackFrame380, i1 noundef zeroext false) #15, !dbg !77
-  %360 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !77, !tbaa !12
-  %361 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 5, !dbg !77
-  %362 = load i32, i32* %361, align 8, !dbg !77, !tbaa !25
-  %363 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 6, !dbg !77
-  %364 = load i32, i32* %363, align 4, !dbg !77, !tbaa !29
-  %365 = xor i32 %364, -1, !dbg !77
-  %366 = and i32 %365, %362, !dbg !77
-  %367 = icmp eq i32 %366, 0, !dbg !77
-  br i1 %367, label %afterSend376, label %368, !dbg !77, !prof !19
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %8, align 8, !dbg !78, !tbaa !14
+  %rubyId_lte370 = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !79
+  %rawSym371 = tail call i64 @rb_id2sym(i64 %rubyId_lte370), !dbg !79
+  %rubyId_normal372 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !79
+  %rawSym373 = tail call i64 @rb_id2sym(i64 %rubyId_normal372), !dbg !79
+  %stackFrame380 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#lte", align 8, !dbg !79
+  %344 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !79
+  %345 = bitcast i8* %344 to i16*, !dbg !79
+  %346 = load i16, i16* %345, align 8, !dbg !79
+  %347 = and i16 %346, -384, !dbg !79
+  %348 = or i16 %347, 1, !dbg !79
+  store i16 %348, i16* %345, align 8, !dbg !79
+  %349 = getelementptr inbounds i8, i8* %344, i64 8, !dbg !79
+  %350 = bitcast i8* %349 to i32*, !dbg !79
+  store i32 2, i32* %350, align 8, !dbg !79, !tbaa !72
+  %351 = getelementptr inbounds i8, i8* %344, i64 12, !dbg !79
+  %352 = bitcast i8* %351 to i32*, !dbg !79
+  %353 = getelementptr inbounds i8, i8* %344, i64 4, !dbg !79
+  %354 = bitcast i8* %353 to i32*, !dbg !79
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %351, i8 0, i64 20, i1 false), !dbg !79
+  store i32 2, i32* %354, align 4, !dbg !79, !tbaa !75
+  %positional_table382 = alloca i64, i32 2, align 8, !dbg !79
+  %rubyId_x383 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !79
+  store i64 %rubyId_x383, i64* %positional_table382, align 8, !dbg !79
+  %rubyId_y384 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !79
+  %355 = getelementptr i64, i64* %positional_table382, i32 1, !dbg !79
+  store i64 %rubyId_y384, i64* %355, align 8, !dbg !79
+  %356 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !79
+  %357 = bitcast i64* %positional_table382 to i8*, !dbg !79
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %356, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %357, i64 noundef 16, i1 noundef false) #15, !dbg !79
+  %358 = getelementptr inbounds i8, i8* %344, i64 32, !dbg !79
+  %359 = bitcast i8* %358 to i8**, !dbg !79
+  store i8* %356, i8** %359, align 8, !dbg !79, !tbaa !76
+  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#lte", i8* nonnull %344, %struct.rb_iseq_struct* %stackFrame380, i1 noundef zeroext false) #15, !dbg !79
+  %360 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !79, !tbaa !14
+  %361 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 5, !dbg !79
+  %362 = load i32, i32* %361, align 8, !dbg !79, !tbaa !27
+  %363 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 6, !dbg !79
+  %364 = load i32, i32* %363, align 4, !dbg !79, !tbaa !31
+  %365 = xor i32 %364, -1, !dbg !79
+  %366 = and i32 %365, %362, !dbg !79
+  %367 = icmp eq i32 %366, 0, !dbg !79
+  br i1 %367, label %afterSend376, label %368, !dbg !79, !prof !21
 
 368:                                              ; preds = %fastSymCallIntrinsic_Static_keep_def379
-  %369 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 8, !dbg !77
-  %370 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %369, align 8, !dbg !77, !tbaa !30
-  %371 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %370, i32 noundef 0) #15, !dbg !77
-  br label %afterSend376, !dbg !77
+  %369 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 8, !dbg !79
+  %370 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %369, align 8, !dbg !79, !tbaa !32
+  %371 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %370, i32 noundef 0) #15, !dbg !79
+  br label %afterSend376, !dbg !79
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !118 {
+define internal i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !120 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !56
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !58
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !119
+  %4 = load i64, i64* %3, align 8, !tbaa !121
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !57
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !59
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !59
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !61
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !12
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !120
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !120
-  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !121
-  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_y), !dbg !121
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !122
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !122, !tbaa !66
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !122
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !122, !prof !68
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !14
+  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !122
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !122
+  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !123
+  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_y), !dbg !123
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !124
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !124, !tbaa !68
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !124
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !124, !prof !70
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !122
-  br label %14, !dbg !122
+  tail call void @const_recompute_T(), !dbg !124
+  br label %14, !dbg !124
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !122
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !122
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !122, !tbaa !66
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !122
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !122
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !122
-  %19 = load i64*, i64** %18, align 8, !dbg !122
-  store i64 %15, i64* %19, align 8, !dbg !122, !tbaa !4
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !122
-  store i64* %20, i64** %18, align 8, !dbg !122
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped, i64 0), !dbg !122
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !123
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !123
-  %23 = load i64*, i64** %22, align 8, !dbg !123
-  store i64 %4, i64* %23, align 8, !dbg !123, !tbaa !4
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !123
-  store i64 %21, i64* %24, align 8, !dbg !123, !tbaa !4
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !123
-  store i64 %send, i64* %25, align 8, !dbg !123, !tbaa !4
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !123
-  store i64* %26, i64** %22, align 8, !dbg !123
-  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !123
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !124
-  %28 = load i64*, i64** %27, align 8, !dbg !124
-  store i64 %15, i64* %28, align 8, !dbg !124, !tbaa !4
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !124
-  store i64* %29, i64** %27, align 8, !dbg !124
-  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.1, i64 0), !dbg !124
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !123
-  %31 = load i64*, i64** %30, align 8, !dbg !123
-  store i64 %send38, i64* %31, align 8, !dbg !123, !tbaa !4
-  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !123
-  store i64 %send40, i64* %32, align 8, !dbg !123, !tbaa !4
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !123
-  store i64* %33, i64** %30, align 8, !dbg !123
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !123
-  ret i64 %send42, !dbg !125
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !124
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !124
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !124, !tbaa !68
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !124
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !124
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !124
+  %19 = load i64*, i64** %18, align 8, !dbg !124
+  store i64 %15, i64* %19, align 8, !dbg !124, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !124
+  store i64* %20, i64** %18, align 8, !dbg !124
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped, i64 0), !dbg !124
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !125
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !125
+  %23 = load i64*, i64** %22, align 8, !dbg !125
+  store i64 %4, i64* %23, align 8, !dbg !125, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !125
+  store i64 %21, i64* %24, align 8, !dbg !125, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !125
+  store i64 %send, i64* %25, align 8, !dbg !125, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !125
+  store i64* %26, i64** %22, align 8, !dbg !125
+  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !125
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !126
+  %28 = load i64*, i64** %27, align 8, !dbg !126
+  store i64 %15, i64* %28, align 8, !dbg !126, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !126
+  store i64* %29, i64** %27, align 8, !dbg !126
+  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.1, i64 0), !dbg !126
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !125
+  %31 = load i64*, i64** %30, align 8, !dbg !125
+  store i64 %send38, i64* %31, align 8, !dbg !125, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !125
+  store i64 %send40, i64* %32, align 8, !dbg !125, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !125
+  store i64* %33, i64** %30, align 8, !dbg !125
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !125
+  ret i64 %send42, !dbg !127
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$151$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !126 {
+define internal i64 @"func_<root>.<static-init>$151$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !128 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !56
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !58
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !119
+  %4 = load i64, i64* %3, align 8, !tbaa !121
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_2", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !57
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !59
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !59
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !61
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %10, align 8, !tbaa !12
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !127
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !127
-  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !128
-  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_y), !dbg !128
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !129
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !129, !tbaa !66
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !129
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !129, !prof !68
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %10, align 8, !tbaa !14
+  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !129
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !129
+  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !130
+  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_y), !dbg !130
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !131
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !131, !tbaa !68
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !131
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !131, !prof !70
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !129
-  br label %14, !dbg !129
+  tail call void @const_recompute_T(), !dbg !131
+  br label %14, !dbg !131
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !129
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !129
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !129, !tbaa !66
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !129
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !129
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !129
-  %19 = load i64*, i64** %18, align 8, !dbg !129
-  store i64 %15, i64* %19, align 8, !dbg !129, !tbaa !4
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !129
-  store i64* %20, i64** %18, align 8, !dbg !129
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.3, i64 0), !dbg !129
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !130
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !130
-  %23 = load i64*, i64** %22, align 8, !dbg !130
-  store i64 %4, i64* %23, align 8, !dbg !130, !tbaa !4
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !130
-  store i64 %21, i64* %24, align 8, !dbg !130, !tbaa !4
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !130
-  store i64 %send, i64* %25, align 8, !dbg !130, !tbaa !4
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !130
-  store i64* %26, i64** %22, align 8, !dbg !130
-  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.4, i64 0), !dbg !130
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !131
-  %28 = load i64*, i64** %27, align 8, !dbg !131
-  store i64 %15, i64* %28, align 8, !dbg !131, !tbaa !4
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !131
-  store i64* %29, i64** %27, align 8, !dbg !131
-  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.5, i64 0), !dbg !131
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !130
-  %31 = load i64*, i64** %30, align 8, !dbg !130
-  store i64 %send38, i64* %31, align 8, !dbg !130, !tbaa !4
-  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !130
-  store i64 %send40, i64* %32, align 8, !dbg !130, !tbaa !4
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !130
-  store i64* %33, i64** %30, align 8, !dbg !130
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.6, i64 0), !dbg !130
-  ret i64 %send42, !dbg !132
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !131
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !131
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !131, !tbaa !68
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !131
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !131
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !131
+  %19 = load i64*, i64** %18, align 8, !dbg !131
+  store i64 %15, i64* %19, align 8, !dbg !131, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !131
+  store i64* %20, i64** %18, align 8, !dbg !131
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.3, i64 0), !dbg !131
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !132
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !132
+  %23 = load i64*, i64** %22, align 8, !dbg !132
+  store i64 %4, i64* %23, align 8, !dbg !132, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !132
+  store i64 %21, i64* %24, align 8, !dbg !132, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !132
+  store i64 %send, i64* %25, align 8, !dbg !132, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !132
+  store i64* %26, i64** %22, align 8, !dbg !132
+  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.4, i64 0), !dbg !132
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !133
+  %28 = load i64*, i64** %27, align 8, !dbg !133
+  store i64 %15, i64* %28, align 8, !dbg !133, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !133
+  store i64* %29, i64** %27, align 8, !dbg !133
+  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.5, i64 0), !dbg !133
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !132
+  %31 = load i64*, i64** %30, align 8, !dbg !132
+  store i64 %send38, i64* %31, align 8, !dbg !132, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !132
+  store i64 %send40, i64* %32, align 8, !dbg !132, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !132
+  store i64* %33, i64** %30, align 8, !dbg !132
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.6, i64 0), !dbg !132
+  ret i64 %send42, !dbg !134
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$151$block_3"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !133 {
+define internal i64 @"func_<root>.<static-init>$151$block_3"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !135 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !56
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !58
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !119
+  %4 = load i64, i64* %3, align 8, !tbaa !121
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_3", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !57
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !59
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !59
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !61
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %10, align 8, !tbaa !12
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !134
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !134
-  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !135
-  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_y), !dbg !135
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !136
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !136, !tbaa !66
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !136
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !136, !prof !68
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %10, align 8, !tbaa !14
+  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !136
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !136
+  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !137
+  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_y), !dbg !137
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !138
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !138, !tbaa !68
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !138
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !138, !prof !70
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !136
-  br label %14, !dbg !136
+  tail call void @const_recompute_T(), !dbg !138
+  br label %14, !dbg !138
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !136
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !136
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !136, !tbaa !66
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !136
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !136
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !136
-  %19 = load i64*, i64** %18, align 8, !dbg !136
-  store i64 %15, i64* %19, align 8, !dbg !136, !tbaa !4
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !136
-  store i64* %20, i64** %18, align 8, !dbg !136
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.8, i64 0), !dbg !136
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !137
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !137
-  %23 = load i64*, i64** %22, align 8, !dbg !137
-  store i64 %4, i64* %23, align 8, !dbg !137, !tbaa !4
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !137
-  store i64 %21, i64* %24, align 8, !dbg !137, !tbaa !4
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !137
-  store i64 %send, i64* %25, align 8, !dbg !137, !tbaa !4
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !137
-  store i64* %26, i64** %22, align 8, !dbg !137
-  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.9, i64 0), !dbg !137
-  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !137
-  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !137, !tbaa !66
-  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !137
-  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !137, !prof !68
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !138
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !138
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !138, !tbaa !68
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !138
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !138
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !138
+  %19 = load i64*, i64** %18, align 8, !dbg !138
+  store i64 %15, i64* %19, align 8, !dbg !138, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !138
+  store i64* %20, i64** %18, align 8, !dbg !138
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.8, i64 0), !dbg !138
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !139
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !139
+  %23 = load i64*, i64** %22, align 8, !dbg !139
+  store i64 %4, i64* %23, align 8, !dbg !139, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !139
+  store i64 %21, i64* %24, align 8, !dbg !139, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !139
+  store i64 %send, i64* %25, align 8, !dbg !139, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !139
+  store i64* %26, i64** %22, align 8, !dbg !139
+  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.9, i64 0), !dbg !139
+  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !139
+  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !139, !tbaa !68
+  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !139
+  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !139, !prof !70
 
 29:                                               ; preds = %14
-  tail call void @"const_recompute_T::Boolean"(), !dbg !137
-  br label %30, !dbg !137
+  tail call void @"const_recompute_T::Boolean"(), !dbg !139
+  br label %30, !dbg !139
 
 30:                                               ; preds = %14, %29
-  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !137
-  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !137
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !137, !tbaa !66
-  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !137
-  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !137
-  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !137
-  %35 = load i64*, i64** %34, align 8, !dbg !137
-  store i64 %send34, i64* %35, align 8, !dbg !137, !tbaa !4
-  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !137
-  store i64 %31, i64* %36, align 8, !dbg !137, !tbaa !4
-  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !137
-  store i64* %37, i64** %34, align 8, !dbg !137
-  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.10, i64 0), !dbg !137
-  ret i64 %send36, !dbg !138
+  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !139
+  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !139
+  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !139, !tbaa !68
+  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !139
+  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !139
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !139
+  %35 = load i64*, i64** %34, align 8, !dbg !139
+  store i64 %send34, i64* %35, align 8, !dbg !139, !tbaa !6
+  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !139
+  store i64 %31, i64* %36, align 8, !dbg !139, !tbaa !6
+  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !139
+  store i64* %37, i64** %34, align 8, !dbg !139
+  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.10, i64 0), !dbg !139
+  ret i64 %send36, !dbg !140
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$151$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !139 {
+define internal i64 @"func_<root>.<static-init>$151$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !141 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !56
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !58
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !119
+  %4 = load i64, i64* %3, align 8, !tbaa !121
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_4", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !57
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !59
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !59
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !61
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %10, align 8, !tbaa !12
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !140
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !140
-  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !141
-  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_y), !dbg !141
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !142
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !142, !tbaa !66
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !142
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !142, !prof !68
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %10, align 8, !tbaa !14
+  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !142
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !142
+  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !143
+  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_y), !dbg !143
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !144
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !144, !tbaa !68
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !144
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !144, !prof !70
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !142
-  br label %14, !dbg !142
+  tail call void @const_recompute_T(), !dbg !144
+  br label %14, !dbg !144
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !142
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !142
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !142, !tbaa !66
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !142
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !142
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !142
-  %19 = load i64*, i64** %18, align 8, !dbg !142
-  store i64 %15, i64* %19, align 8, !dbg !142, !tbaa !4
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !142
-  store i64* %20, i64** %18, align 8, !dbg !142
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.12, i64 0), !dbg !142
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !143
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !143
-  %23 = load i64*, i64** %22, align 8, !dbg !143
-  store i64 %4, i64* %23, align 8, !dbg !143, !tbaa !4
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !143
-  store i64 %21, i64* %24, align 8, !dbg !143, !tbaa !4
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !143
-  store i64 %send, i64* %25, align 8, !dbg !143, !tbaa !4
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !143
-  store i64* %26, i64** %22, align 8, !dbg !143
-  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.13, i64 0), !dbg !143
-  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !143
-  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !143, !tbaa !66
-  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !143
-  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !143, !prof !68
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !144
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !144
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !144, !tbaa !68
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !144
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !144
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !144
+  %19 = load i64*, i64** %18, align 8, !dbg !144
+  store i64 %15, i64* %19, align 8, !dbg !144, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !144
+  store i64* %20, i64** %18, align 8, !dbg !144
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.12, i64 0), !dbg !144
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !145
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !145
+  %23 = load i64*, i64** %22, align 8, !dbg !145
+  store i64 %4, i64* %23, align 8, !dbg !145, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !145
+  store i64 %21, i64* %24, align 8, !dbg !145, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !145
+  store i64 %send, i64* %25, align 8, !dbg !145, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !145
+  store i64* %26, i64** %22, align 8, !dbg !145
+  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.13, i64 0), !dbg !145
+  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !145
+  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !145, !tbaa !68
+  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !145
+  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !145, !prof !70
 
 29:                                               ; preds = %14
-  tail call void @"const_recompute_T::Boolean"(), !dbg !143
-  br label %30, !dbg !143
+  tail call void @"const_recompute_T::Boolean"(), !dbg !145
+  br label %30, !dbg !145
 
 30:                                               ; preds = %14, %29
-  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !143
-  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !143
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !143, !tbaa !66
-  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !143
-  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !143
-  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !143
-  %35 = load i64*, i64** %34, align 8, !dbg !143
-  store i64 %send34, i64* %35, align 8, !dbg !143, !tbaa !4
-  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !143
-  store i64 %31, i64* %36, align 8, !dbg !143, !tbaa !4
-  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !143
-  store i64* %37, i64** %34, align 8, !dbg !143
-  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.14, i64 0), !dbg !143
-  ret i64 %send36, !dbg !144
+  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !145
+  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !145
+  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !145, !tbaa !68
+  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !145
+  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !145
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !145
+  %35 = load i64*, i64** %34, align 8, !dbg !145
+  store i64 %send34, i64* %35, align 8, !dbg !145, !tbaa !6
+  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !145
+  store i64 %31, i64* %36, align 8, !dbg !145, !tbaa !6
+  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !145
+  store i64* %37, i64** %34, align 8, !dbg !145
+  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.14, i64 0), !dbg !145
+  ret i64 %send36, !dbg !146
 }
 
 ; Function Attrs: ssp
@@ -1610,10 +1610,10 @@ entry:
   %locals.i177.i = alloca i64, i32 0, align 8
   %locals.i175.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, i32 2, align 8, !dbg !123
-  %keywords17.i = alloca i64, i32 2, align 8, !dbg !130
-  %keywords34.i = alloca i64, i32 2, align 8, !dbg !137
-  %keywords49.i = alloca i64, i32 2, align 8, !dbg !143
+  %keywords.i = alloca i64, i32 2, align 8, !dbg !125
+  %keywords17.i = alloca i64, i32 2, align 8, !dbg !132
+  %keywords34.i = alloca i64, i32 2, align 8, !dbg !139
+  %keywords49.i = alloca i64, i32 2, align 8, !dbg !145
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %0)
@@ -1684,8 +1684,8 @@ entry:
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i174.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %31 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %30, i64 %rubyId_minus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i174.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i175.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %31, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#minus", align 8
-  %rubyId_-.i = load i64, i64* @rubyIdPrecomputed_-, align 8, !dbg !35
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_-, i64 %rubyId_-.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !35
+  %rubyId_-.i = load i64, i64* @rubyIdPrecomputed_-, align 8, !dbg !37
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_-, i64 %rubyId_-.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !37
   %32 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #15
   call void @rb_gc_register_mark_object(i64 %32) #15
   %rubyId_lt.i.i = load i64, i64* @rubyIdPrecomputed_lt, align 8
@@ -1735,188 +1735,188 @@ entry:
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i194.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %43 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block for.i193.i", i64 %"rubyId_block for.i192.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i194.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i191.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %43, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_4", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !61
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !61
-  %rubyId_untyped.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !122
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !122
-  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !123
-  %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !123
-  %44 = call i64 @rb_id2sym(i64 %rubyId_x.i) #15, !dbg !123
-  store i64 %44, i64* %keywords.i, align 8, !dbg !123
-  %rubyId_y.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !123
-  %45 = call i64 @rb_id2sym(i64 %rubyId_y.i) #15, !dbg !123
-  %46 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !123
-  store i64 %45, i64* %46, align 8, !dbg !123
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords.i), !dbg !123
-  %rubyId_untyped8.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !124
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped8.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !124
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !123
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !123
-  %rubyId_sig11.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !62
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.2, i64 %rubyId_sig11.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !62
-  %rubyId_untyped14.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !129
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.3, i64 %rubyId_untyped14.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !129
-  %rubyId_params16.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !130
-  %rubyId_x18.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !130
-  %47 = call i64 @rb_id2sym(i64 %rubyId_x18.i) #15, !dbg !130
-  store i64 %47, i64* %keywords17.i, align 8, !dbg !130
-  %rubyId_y20.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !130
-  %48 = call i64 @rb_id2sym(i64 %rubyId_y20.i) #15, !dbg !130
-  %49 = getelementptr i64, i64* %keywords17.i, i32 1, !dbg !130
-  store i64 %48, i64* %49, align 8, !dbg !130
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.4, i64 %rubyId_params16.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords17.i), !dbg !130
-  %rubyId_untyped24.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !131
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.5, i64 %rubyId_untyped24.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !131
-  %rubyId_returns26.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !130
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.6, i64 %rubyId_returns26.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !130
-  %rubyId_sig28.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !63
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.7, i64 %rubyId_sig28.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !63
-  %rubyId_untyped31.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !136
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.8, i64 %rubyId_untyped31.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !136
-  %rubyId_params33.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !137
-  %rubyId_x35.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !137
-  %50 = call i64 @rb_id2sym(i64 %rubyId_x35.i) #15, !dbg !137
-  store i64 %50, i64* %keywords34.i, align 8, !dbg !137
-  %rubyId_y37.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !137
-  %51 = call i64 @rb_id2sym(i64 %rubyId_y37.i) #15, !dbg !137
-  %52 = getelementptr i64, i64* %keywords34.i, i32 1, !dbg !137
-  store i64 %51, i64* %52, align 8, !dbg !137
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.9, i64 %rubyId_params33.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords34.i), !dbg !137
-  %rubyId_returns41.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !137
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.10, i64 %rubyId_returns41.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !137
-  %rubyId_sig43.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !64
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.11, i64 %rubyId_sig43.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !64
-  %rubyId_untyped46.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !142
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.12, i64 %rubyId_untyped46.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !142
-  %rubyId_params48.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !143
-  %rubyId_x50.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !143
-  %53 = call i64 @rb_id2sym(i64 %rubyId_x50.i) #15, !dbg !143
-  store i64 %53, i64* %keywords49.i, align 8, !dbg !143
-  %rubyId_y52.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !143
-  %54 = call i64 @rb_id2sym(i64 %rubyId_y52.i) #15, !dbg !143
-  %55 = getelementptr i64, i64* %keywords49.i, i32 1, !dbg !143
-  store i64 %54, i64* %55, align 8, !dbg !143
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.13, i64 %rubyId_params48.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords49.i), !dbg !143
-  %rubyId_returns56.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !143
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.14, i64 %rubyId_returns56.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !143
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !65
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !65
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !69
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !69
-  %rubyId_keep_def61.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !75
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.15, i64 %rubyId_keep_def61.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !75
-  %rubyId_keep_def63.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !76
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.16, i64 %rubyId_keep_def63.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !76
-  %rubyId_keep_def65.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !77
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.17, i64 %rubyId_keep_def65.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !77
-  %rubyId_plus.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !78
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus, i64 %rubyId_plus.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !78
-  %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !79
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !79
-  %rubyId_minus.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !80
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus, i64 %rubyId_minus.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !80
-  %rubyId_p73.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !81
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.18, i64 %rubyId_p73.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !81
-  %rubyId_lt.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !82
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt, i64 %rubyId_lt.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !82
-  %rubyId_p78.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !83
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.19, i64 %rubyId_p78.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !83
-  %rubyId_lt81.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !84
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.20, i64 %rubyId_lt81.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !84
-  %rubyId_p84.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !85
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.21, i64 %rubyId_p84.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !85
-  %rubyId_lte.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !86
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte, i64 %rubyId_lte.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !86
-  %rubyId_p89.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !87
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.22, i64 %rubyId_p89.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !87
-  %rubyId_lte92.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !88
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.23, i64 %rubyId_lte92.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !88
-  %rubyId_p95.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !89
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.24, i64 %rubyId_p95.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !89
-  %rubyId_lte98.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !90
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.25, i64 %rubyId_lte98.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !90
-  %rubyId_p101.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !91
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.26, i64 %rubyId_p101.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !91
-  %rubyId_plus104.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !92
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.27, i64 %rubyId_plus104.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !92
-  %rubyId_p107.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !93
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.28, i64 %rubyId_p107.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !93
+  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !63
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !63
+  %rubyId_untyped.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !124
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !124
+  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !125
+  %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !125
+  %44 = call i64 @rb_id2sym(i64 %rubyId_x.i) #15, !dbg !125
+  store i64 %44, i64* %keywords.i, align 8, !dbg !125
+  %rubyId_y.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !125
+  %45 = call i64 @rb_id2sym(i64 %rubyId_y.i) #15, !dbg !125
+  %46 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !125
+  store i64 %45, i64* %46, align 8, !dbg !125
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords.i), !dbg !125
+  %rubyId_untyped8.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !126
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped8.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !126
+  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !125
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !125
+  %rubyId_sig11.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !64
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.2, i64 %rubyId_sig11.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !64
+  %rubyId_untyped14.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !131
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.3, i64 %rubyId_untyped14.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !131
+  %rubyId_params16.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !132
+  %rubyId_x18.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !132
+  %47 = call i64 @rb_id2sym(i64 %rubyId_x18.i) #15, !dbg !132
+  store i64 %47, i64* %keywords17.i, align 8, !dbg !132
+  %rubyId_y20.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !132
+  %48 = call i64 @rb_id2sym(i64 %rubyId_y20.i) #15, !dbg !132
+  %49 = getelementptr i64, i64* %keywords17.i, i32 1, !dbg !132
+  store i64 %48, i64* %49, align 8, !dbg !132
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.4, i64 %rubyId_params16.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords17.i), !dbg !132
+  %rubyId_untyped24.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !133
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.5, i64 %rubyId_untyped24.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !133
+  %rubyId_returns26.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !132
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.6, i64 %rubyId_returns26.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !132
+  %rubyId_sig28.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !65
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.7, i64 %rubyId_sig28.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !65
+  %rubyId_untyped31.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !138
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.8, i64 %rubyId_untyped31.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !138
+  %rubyId_params33.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !139
+  %rubyId_x35.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !139
+  %50 = call i64 @rb_id2sym(i64 %rubyId_x35.i) #15, !dbg !139
+  store i64 %50, i64* %keywords34.i, align 8, !dbg !139
+  %rubyId_y37.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !139
+  %51 = call i64 @rb_id2sym(i64 %rubyId_y37.i) #15, !dbg !139
+  %52 = getelementptr i64, i64* %keywords34.i, i32 1, !dbg !139
+  store i64 %51, i64* %52, align 8, !dbg !139
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.9, i64 %rubyId_params33.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords34.i), !dbg !139
+  %rubyId_returns41.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !139
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.10, i64 %rubyId_returns41.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !139
+  %rubyId_sig43.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !66
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.11, i64 %rubyId_sig43.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !66
+  %rubyId_untyped46.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !144
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.12, i64 %rubyId_untyped46.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !144
+  %rubyId_params48.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !145
+  %rubyId_x50.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !145
+  %53 = call i64 @rb_id2sym(i64 %rubyId_x50.i) #15, !dbg !145
+  store i64 %53, i64* %keywords49.i, align 8, !dbg !145
+  %rubyId_y52.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !145
+  %54 = call i64 @rb_id2sym(i64 %rubyId_y52.i) #15, !dbg !145
+  %55 = getelementptr i64, i64* %keywords49.i, i32 1, !dbg !145
+  store i64 %54, i64* %55, align 8, !dbg !145
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.13, i64 %rubyId_params48.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords49.i), !dbg !145
+  %rubyId_returns56.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !145
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.14, i64 %rubyId_returns56.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !145
+  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !67
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !67
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !71
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !71
+  %rubyId_keep_def61.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !77
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.15, i64 %rubyId_keep_def61.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !77
+  %rubyId_keep_def63.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !78
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.16, i64 %rubyId_keep_def63.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !78
+  %rubyId_keep_def65.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !79
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.17, i64 %rubyId_keep_def65.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !79
+  %rubyId_plus.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !80
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus, i64 %rubyId_plus.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !80
+  %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !81
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !81
+  %rubyId_minus.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !82
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus, i64 %rubyId_minus.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !82
+  %rubyId_p73.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !83
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.18, i64 %rubyId_p73.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !83
+  %rubyId_lt.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !84
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt, i64 %rubyId_lt.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !84
+  %rubyId_p78.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !85
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.19, i64 %rubyId_p78.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !85
+  %rubyId_lt81.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !86
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.20, i64 %rubyId_lt81.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !86
+  %rubyId_p84.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !87
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.21, i64 %rubyId_p84.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !87
+  %rubyId_lte.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !88
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte, i64 %rubyId_lte.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !88
+  %rubyId_p89.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !89
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.22, i64 %rubyId_p89.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !89
+  %rubyId_lte92.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !90
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.23, i64 %rubyId_lte92.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !90
+  %rubyId_p95.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !91
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.24, i64 %rubyId_p95.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !91
+  %rubyId_lte98.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !92
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.25, i64 %rubyId_lte98.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !92
+  %rubyId_p101.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !93
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.26, i64 %rubyId_p101.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !93
+  %rubyId_plus104.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !94
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.27, i64 %rubyId_plus104.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !94
+  %rubyId_p107.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !95
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.28, i64 %rubyId_p107.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !95
   %56 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_8.9, i64 0, i64 0), i64 noundef 3) #15
   call void @rb_gc_register_mark_object(i64 %56) #15
   store i64 %56, i64* @rubyStrFrozen_8.9, align 8
-  %rubyId_Rational.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !94
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !94
-  %rubyId_plus111.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !95
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.29, i64 %rubyId_plus111.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !95
-  %rubyId_p114.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !96
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.30, i64 %rubyId_p114.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !96
+  %rubyId_Rational.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !96
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !96
+  %rubyId_plus111.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !97
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.29, i64 %rubyId_plus111.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !97
+  %rubyId_p114.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !98
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.30, i64 %rubyId_p114.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !98
   %57 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_5, i64 0, i64 0), i64 noundef 1) #15
   call void @rb_gc_register_mark_object(i64 %57) #15
   store i64 %57, i64* @rubyStrFrozen_5, align 8
-  %rubyId_Complex.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !97
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex, i64 %rubyId_Complex.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !97
-  %rubyId_plus118.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !98
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.31, i64 %rubyId_plus118.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !98
-  %rubyId_p121.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !99
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.32, i64 %rubyId_p121.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !99
-  %rubyId_minus124.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !100
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.33, i64 %rubyId_minus124.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !100
-  %rubyId_p127.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !101
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.34, i64 %rubyId_p127.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !101
+  %rubyId_Complex.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !99
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex, i64 %rubyId_Complex.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !99
+  %rubyId_plus118.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !100
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.31, i64 %rubyId_plus118.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !100
+  %rubyId_p121.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !101
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.32, i64 %rubyId_p121.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !101
+  %rubyId_minus124.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !102
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.33, i64 %rubyId_minus124.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !102
+  %rubyId_p127.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !103
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.34, i64 %rubyId_p127.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !103
   %58 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_15.4, i64 0, i64 0), i64 noundef 4) #15
   call void @rb_gc_register_mark_object(i64 %58) #15
   store i64 %58, i64* @rubyStrFrozen_15.4, align 8
-  %rubyId_Rational130.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !102
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.35, i64 %rubyId_Rational130.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !102
-  %rubyId_minus132.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !103
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.36, i64 %rubyId_minus132.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !103
-  %rubyId_p135.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !104
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.37, i64 %rubyId_p135.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
+  %rubyId_Rational130.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !104
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.35, i64 %rubyId_Rational130.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
+  %rubyId_minus132.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !105
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.36, i64 %rubyId_minus132.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !105
+  %rubyId_p135.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !106
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.37, i64 %rubyId_p135.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !106
   %59 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_18, i64 0, i64 0), i64 noundef 2) #15
   call void @rb_gc_register_mark_object(i64 %59) #15
   store i64 %59, i64* @rubyStrFrozen_18, align 8
-  %rubyId_Complex138.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !105
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.38, i64 %rubyId_Complex138.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !105
-  %rubyId_minus140.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !106
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.39, i64 %rubyId_minus140.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !106
-  %rubyId_p143.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !107
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.40, i64 %rubyId_p143.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !107
-  %rubyId_lt146.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !108
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.41, i64 %rubyId_lt146.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !108
-  %rubyId_p149.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !109
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.42, i64 %rubyId_p149.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !109
+  %rubyId_Complex138.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !107
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.38, i64 %rubyId_Complex138.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !107
+  %rubyId_minus140.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !108
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.39, i64 %rubyId_minus140.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !108
+  %rubyId_p143.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !109
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.40, i64 %rubyId_p143.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !109
+  %rubyId_lt146.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !110
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.41, i64 %rubyId_lt146.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !110
+  %rubyId_p149.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !111
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.42, i64 %rubyId_p149.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !111
   %60 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_25.4, i64 0, i64 0), i64 noundef 4) #15
   call void @rb_gc_register_mark_object(i64 %60) #15
   store i64 %60, i64* @rubyStrFrozen_25.4, align 8
-  %rubyId_Rational152.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !110
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.43, i64 %rubyId_Rational152.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !110
-  %rubyId_lt154.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !111
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.44, i64 %rubyId_lt154.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !111
-  %rubyId_p157.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !112
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.45, i64 %rubyId_p157.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
-  %rubyId_lte160.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !113
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.46, i64 %rubyId_lte160.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !113
-  %rubyId_p163.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !114
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.47, i64 %rubyId_p163.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !114
+  %rubyId_Rational152.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !112
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.43, i64 %rubyId_Rational152.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
+  %rubyId_lt154.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !113
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.44, i64 %rubyId_lt154.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !113
+  %rubyId_p157.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !114
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.45, i64 %rubyId_p157.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !114
+  %rubyId_lte160.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !115
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.46, i64 %rubyId_lte160.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !115
+  %rubyId_p163.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !116
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.47, i64 %rubyId_p163.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !116
   %61 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_5.923, i64 0, i64 0), i64 noundef 5) #15
   call void @rb_gc_register_mark_object(i64 %61) #15
   store i64 %61, i64* @rubyStrFrozen_5.923, align 8
-  %rubyId_Rational166.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !115
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.48, i64 %rubyId_Rational166.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !115
-  %rubyId_lte168.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !116
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.49, i64 %rubyId_lte168.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !116
-  %rubyId_p171.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !117
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.50, i64 %rubyId_p171.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !117
+  %rubyId_Rational166.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !117
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.48, i64 %rubyId_Rational166.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !117
+  %rubyId_lte168.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !118
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.49, i64 %rubyId_lte168.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !118
+  %rubyId_p171.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !119
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.50, i64 %rubyId_p171.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !119
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %3)
-  %62 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !12
+  %62 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %63 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %62, i64 0, i32 18
-  %64 = load i64, i64* %63, align 8, !tbaa !145
-  %65 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %64 = load i64, i64* %63, align 8, !tbaa !147
+  %65 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %65, i64 0, i32 2
-  %67 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %66, align 8, !tbaa !56
+  %67 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %66, align 8, !tbaa !58
   call fastcc void @"func_<root>.<static-init>$151"(i64 %64, %struct.rb_control_frame_struct* %67) #15
   ret void
 }
@@ -1934,17 +1934,17 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #4
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #9
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#lt.cold.1"(i64 %0) unnamed_addr #10 !dbg !153 {
+define internal fastcc void @"func_Object#lt.cold.1"(i64 %0) unnamed_addr #10 !dbg !155 {
 newFuncRoot:
   tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @"str_T::Boolean", i64 0, i64 0)) #13
   unreachable
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#lt.cold.3"(i64 %rawArg_x) unnamed_addr #10 !dbg !155 {
+define internal fastcc void @"func_Object#lt.cold.3"(i64 %rawArg_x) unnamed_addr #10 !dbg !157 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_Float, i64 0, i64 0)) #13, !dbg !156
-  unreachable, !dbg !156
+  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_Float, i64 0, i64 0)) #13, !dbg !158
+  unreachable, !dbg !158
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
@@ -1954,7 +1954,7 @@ declare void @llvm.assume(i1 noundef) #11
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #7 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !66
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !68
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
@@ -1963,7 +1963,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #7 {
 define linkonce void @const_recompute_T() local_unnamed_addr #7 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_T, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_T, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !66
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !68
   store i64 %2, i64* @guard_epoch_T, align 8
   ret void
 }
@@ -1972,7 +1972,7 @@ define linkonce void @const_recompute_T() local_unnamed_addr #7 {
 define linkonce void @"const_recompute_T::Boolean"() local_unnamed_addr #7 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"str_T::Boolean", i64 0, i64 0), i64 10)
   store i64 %1, i64* @"guarded_const_T::Boolean", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !66
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !68
   store i64 %2, i64* @"guard_epoch_T::Boolean", align 8
   ret void
 }
@@ -1995,163 +1995,165 @@ attributes #14 = { noinline }
 attributes #15 = { nounwind }
 attributes #16 = { nounwind allocsize(0,1) }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/float-intrinsics.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "Object#plus", linkageName: "func_Object#plus", scope: null, file: !2, line: 8, type: !9, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = !DISubroutineType(types: !10)
-!10 = !{!11}
-!11 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!12 = !{!13, !13, i64 0}
-!13 = !{!"any pointer", !6, i64 0}
-!14 = !DILocation(line: 8, column: 1, scope: !8)
-!15 = !{!"branch_weights", i32 4001, i32 4000000}
-!16 = !DILocation(line: 8, column: 10, scope: !8)
-!17 = !{!18, !5, i64 0}
-!18 = !{!"RBasic", !5, i64 0, !5, i64 8}
-!19 = !{!"branch_weights", i32 2000, i32 1}
-!20 = !DILocation(line: 8, column: 13, scope: !8)
-!21 = !DILocation(line: 9, column: 3, scope: !8)
-!22 = !{!23}
-!23 = distinct !{!23, !24, !"sorbet_int_rb_float_plus: argument 0"}
-!24 = distinct !{!24, !"sorbet_int_rb_float_plus"}
-!25 = !{!26, !27, i64 40}
-!26 = !{!"rb_execution_context_struct", !13, i64 0, !5, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !27, i64 40, !27, i64 44, !13, i64 48, !13, i64 56, !13, i64 64, !5, i64 72, !5, i64 80, !13, i64 88, !5, i64 96, !13, i64 104, !13, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !28, i64 152}
-!27 = !{!"int", !6, i64 0}
-!28 = !{!"", !13, i64 0, !13, i64 8, !5, i64 16, !6, i64 24}
-!29 = !{!26, !27, i64 44}
-!30 = !{!26, !13, i64 56}
-!31 = distinct !DISubprogram(name: "Object#minus", linkageName: "func_Object#minus", scope: null, file: !2, line: 13, type: !9, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!32 = !DILocation(line: 13, column: 1, scope: !31)
-!33 = !DILocation(line: 13, column: 11, scope: !31)
-!34 = !DILocation(line: 13, column: 14, scope: !31)
-!35 = !DILocation(line: 14, column: 3, scope: !31)
-!36 = distinct !DISubprogram(name: "Object#lt", linkageName: "func_Object#lt", scope: null, file: !2, line: 18, type: !9, scopeLine: 18, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!37 = !DILocation(line: 18, column: 1, scope: !36)
-!38 = !DILocation(line: 18, column: 8, scope: !36)
-!39 = !DILocation(line: 18, column: 11, scope: !36)
-!40 = !DILocation(line: 19, column: 3, scope: !36)
-!41 = !{!42}
-!42 = distinct !{!42, !43, !"sorbet_int_flo_lt: argument 0"}
-!43 = distinct !{!43, !"sorbet_int_flo_lt"}
-!44 = !{!"branch_weights", i32 1, i32 2001, i32 2000}
-!45 = !DILocation(line: 0, scope: !36)
-!46 = distinct !DISubprogram(name: "Object#lte", linkageName: "func_Object#lte", scope: null, file: !2, line: 23, type: !9, scopeLine: 23, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!47 = !DILocation(line: 23, column: 1, scope: !46)
-!48 = !DILocation(line: 23, column: 9, scope: !46)
-!49 = !DILocation(line: 23, column: 12, scope: !46)
-!50 = !DILocation(line: 24, column: 3, scope: !46)
-!51 = !{!52}
-!52 = distinct !{!52, !53, !"sorbet_int_flo_le: argument 0"}
-!53 = distinct !{!53, !"sorbet_int_flo_le"}
-!54 = !DILocation(line: 0, scope: !46)
-!55 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!56 = !{!26, !13, i64 16}
-!57 = !{!58, !13, i64 16}
-!58 = !{!"rb_control_frame_struct", !13, i64 0, !13, i64 8, !13, i64 16, !5, i64 24, !13, i64 32, !13, i64 40, !13, i64 48}
-!59 = !{!58, !13, i64 32}
-!60 = !DILocation(line: 0, scope: !55)
-!61 = !DILocation(line: 7, column: 1, scope: !55)
-!62 = !DILocation(line: 12, column: 1, scope: !55)
-!63 = !DILocation(line: 17, column: 1, scope: !55)
-!64 = !DILocation(line: 22, column: 1, scope: !55)
-!65 = !DILocation(line: 5, column: 1, scope: !55)
-!66 = !{!67, !67, i64 0}
-!67 = !{!"long long", !6, i64 0}
-!68 = !{!"branch_weights", i32 1, i32 10000}
-!69 = !DILocation(line: 8, column: 1, scope: !55)
-!70 = !{!71, !27, i64 8}
-!71 = !{!"rb_sorbet_param_struct", !72, i64 0, !27, i64 4, !27, i64 8, !27, i64 12, !27, i64 16, !27, i64 20, !27, i64 24, !27, i64 28, !13, i64 32, !27, i64 40, !27, i64 44, !27, i64 48, !27, i64 52, !13, i64 56}
-!72 = !{!"", !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 1, !27, i64 1}
-!73 = !{!71, !27, i64 4}
-!74 = !{!71, !13, i64 32}
-!75 = !DILocation(line: 13, column: 1, scope: !55)
-!76 = !DILocation(line: 18, column: 1, scope: !55)
-!77 = !DILocation(line: 23, column: 1, scope: !55)
-!78 = !DILocation(line: 27, column: 3, scope: !55)
-!79 = !DILocation(line: 27, column: 1, scope: !55)
-!80 = !DILocation(line: 28, column: 3, scope: !55)
-!81 = !DILocation(line: 28, column: 1, scope: !55)
-!82 = !DILocation(line: 29, column: 3, scope: !55)
-!83 = !DILocation(line: 29, column: 1, scope: !55)
-!84 = !DILocation(line: 30, column: 3, scope: !55)
-!85 = !DILocation(line: 30, column: 1, scope: !55)
-!86 = !DILocation(line: 31, column: 3, scope: !55)
-!87 = !DILocation(line: 31, column: 1, scope: !55)
-!88 = !DILocation(line: 32, column: 3, scope: !55)
-!89 = !DILocation(line: 32, column: 1, scope: !55)
-!90 = !DILocation(line: 33, column: 3, scope: !55)
-!91 = !DILocation(line: 33, column: 1, scope: !55)
-!92 = !DILocation(line: 36, column: 3, scope: !55)
-!93 = !DILocation(line: 36, column: 1, scope: !55)
-!94 = !DILocation(line: 37, column: 13, scope: !55)
-!95 = !DILocation(line: 37, column: 3, scope: !55)
-!96 = !DILocation(line: 37, column: 1, scope: !55)
-!97 = !DILocation(line: 38, column: 13, scope: !55)
-!98 = !DILocation(line: 38, column: 3, scope: !55)
-!99 = !DILocation(line: 38, column: 1, scope: !55)
-!100 = !DILocation(line: 40, column: 3, scope: !55)
-!101 = !DILocation(line: 40, column: 1, scope: !55)
-!102 = !DILocation(line: 41, column: 15, scope: !55)
-!103 = !DILocation(line: 41, column: 3, scope: !55)
-!104 = !DILocation(line: 41, column: 1, scope: !55)
-!105 = !DILocation(line: 42, column: 15, scope: !55)
-!106 = !DILocation(line: 42, column: 3, scope: !55)
-!107 = !DILocation(line: 42, column: 1, scope: !55)
-!108 = !DILocation(line: 44, column: 3, scope: !55)
-!109 = !DILocation(line: 44, column: 1, scope: !55)
-!110 = !DILocation(line: 45, column: 12, scope: !55)
-!111 = !DILocation(line: 45, column: 3, scope: !55)
-!112 = !DILocation(line: 45, column: 1, scope: !55)
-!113 = !DILocation(line: 47, column: 3, scope: !55)
-!114 = !DILocation(line: 47, column: 1, scope: !55)
-!115 = !DILocation(line: 48, column: 13, scope: !55)
-!116 = !DILocation(line: 48, column: 3, scope: !55)
-!117 = !DILocation(line: 48, column: 1, scope: !55)
-!118 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !55, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!119 = !{!58, !5, i64 24}
-!120 = !DILocation(line: 7, column: 13, scope: !118)
-!121 = !DILocation(line: 7, column: 23, scope: !118)
-!122 = !DILocation(line: 7, column: 26, scope: !118)
-!123 = !DILocation(line: 7, column: 6, scope: !118)
-!124 = !DILocation(line: 7, column: 45, scope: !118)
-!125 = !DILocation(line: 7, column: 1, scope: !118)
-!126 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_2", scope: !55, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!127 = !DILocation(line: 12, column: 13, scope: !126)
-!128 = !DILocation(line: 12, column: 23, scope: !126)
-!129 = !DILocation(line: 12, column: 26, scope: !126)
-!130 = !DILocation(line: 12, column: 6, scope: !126)
-!131 = !DILocation(line: 12, column: 45, scope: !126)
-!132 = !DILocation(line: 12, column: 1, scope: !126)
-!133 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_3", scope: !55, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!134 = !DILocation(line: 17, column: 13, scope: !133)
-!135 = !DILocation(line: 17, column: 23, scope: !133)
-!136 = !DILocation(line: 17, column: 26, scope: !133)
-!137 = !DILocation(line: 17, column: 6, scope: !133)
-!138 = !DILocation(line: 17, column: 1, scope: !133)
-!139 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_4", scope: !55, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!140 = !DILocation(line: 22, column: 13, scope: !139)
-!141 = !DILocation(line: 22, column: 23, scope: !139)
-!142 = !DILocation(line: 22, column: 26, scope: !139)
-!143 = !DILocation(line: 22, column: 6, scope: !139)
-!144 = !DILocation(line: 22, column: 1, scope: !139)
-!145 = !{!146, !5, i64 400}
-!146 = !{!"rb_vm_struct", !5, i64 0, !147, i64 8, !13, i64 192, !13, i64 200, !13, i64 208, !67, i64 216, !6, i64 224, !148, i64 264, !148, i64 280, !148, i64 296, !148, i64 312, !5, i64 328, !27, i64 336, !27, i64 340, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !13, i64 456, !13, i64 464, !150, i64 472, !151, i64 992, !13, i64 1016, !13, i64 1024, !27, i64 1032, !27, i64 1036, !148, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !27, i64 1136, !13, i64 1144, !13, i64 1152, !13, i64 1160, !13, i64 1168, !13, i64 1176, !13, i64 1184, !27, i64 1192, !152, i64 1200, !6, i64 1232}
-!147 = !{!"rb_global_vm_lock_struct", !13, i64 0, !6, i64 8, !148, i64 48, !13, i64 64, !27, i64 72, !6, i64 80, !6, i64 128, !27, i64 176, !27, i64 180}
-!148 = !{!"list_head", !149, i64 0}
-!149 = !{!"list_node", !13, i64 0, !13, i64 8}
-!150 = !{!"", !6, i64 0}
-!151 = !{!"rb_hook_list_struct", !13, i64 0, !27, i64 8, !27, i64 12, !27, i64 16}
-!152 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!153 = distinct !DISubprogram(name: "func_Object#lt.cold.1", linkageName: "func_Object#lt.cold.1", scope: null, file: !2, type: !154, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!154 = !DISubroutineType(types: !3)
-!155 = distinct !DISubprogram(name: "func_Object#lt.cold.3", linkageName: "func_Object#lt.cold.3", scope: null, file: !2, type: !154, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!156 = !DILocation(line: 18, column: 8, scope: !155)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/float-intrinsics.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "Object#plus", linkageName: "func_Object#plus", scope: null, file: !4, line: 8, type: !11, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!14 = !{!15, !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !DILocation(line: 8, column: 1, scope: !10)
+!17 = !{!"branch_weights", i32 4001, i32 4000000}
+!18 = !DILocation(line: 8, column: 10, scope: !10)
+!19 = !{!20, !7, i64 0}
+!20 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!21 = !{!"branch_weights", i32 2000, i32 1}
+!22 = !DILocation(line: 8, column: 13, scope: !10)
+!23 = !DILocation(line: 9, column: 3, scope: !10)
+!24 = !{!25}
+!25 = distinct !{!25, !26, !"sorbet_int_rb_float_plus: argument 0"}
+!26 = distinct !{!26, !"sorbet_int_rb_float_plus"}
+!27 = !{!28, !29, i64 40}
+!28 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !29, i64 40, !29, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !30, i64 152}
+!29 = !{!"int", !8, i64 0}
+!30 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!31 = !{!28, !29, i64 44}
+!32 = !{!28, !15, i64 56}
+!33 = distinct !DISubprogram(name: "Object#minus", linkageName: "func_Object#minus", scope: null, file: !4, line: 13, type: !11, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!34 = !DILocation(line: 13, column: 1, scope: !33)
+!35 = !DILocation(line: 13, column: 11, scope: !33)
+!36 = !DILocation(line: 13, column: 14, scope: !33)
+!37 = !DILocation(line: 14, column: 3, scope: !33)
+!38 = distinct !DISubprogram(name: "Object#lt", linkageName: "func_Object#lt", scope: null, file: !4, line: 18, type: !11, scopeLine: 18, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!39 = !DILocation(line: 18, column: 1, scope: !38)
+!40 = !DILocation(line: 18, column: 8, scope: !38)
+!41 = !DILocation(line: 18, column: 11, scope: !38)
+!42 = !DILocation(line: 19, column: 3, scope: !38)
+!43 = !{!44}
+!44 = distinct !{!44, !45, !"sorbet_int_flo_lt: argument 0"}
+!45 = distinct !{!45, !"sorbet_int_flo_lt"}
+!46 = !{!"branch_weights", i32 1, i32 2001, i32 2000}
+!47 = !DILocation(line: 0, scope: !38)
+!48 = distinct !DISubprogram(name: "Object#lte", linkageName: "func_Object#lte", scope: null, file: !4, line: 23, type: !11, scopeLine: 23, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!49 = !DILocation(line: 23, column: 1, scope: !48)
+!50 = !DILocation(line: 23, column: 9, scope: !48)
+!51 = !DILocation(line: 23, column: 12, scope: !48)
+!52 = !DILocation(line: 24, column: 3, scope: !48)
+!53 = !{!54}
+!54 = distinct !{!54, !55, !"sorbet_int_flo_le: argument 0"}
+!55 = distinct !{!55, !"sorbet_int_flo_le"}
+!56 = !DILocation(line: 0, scope: !48)
+!57 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!58 = !{!28, !15, i64 16}
+!59 = !{!60, !15, i64 16}
+!60 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!61 = !{!60, !15, i64 32}
+!62 = !DILocation(line: 0, scope: !57)
+!63 = !DILocation(line: 7, column: 1, scope: !57)
+!64 = !DILocation(line: 12, column: 1, scope: !57)
+!65 = !DILocation(line: 17, column: 1, scope: !57)
+!66 = !DILocation(line: 22, column: 1, scope: !57)
+!67 = !DILocation(line: 5, column: 1, scope: !57)
+!68 = !{!69, !69, i64 0}
+!69 = !{!"long long", !8, i64 0}
+!70 = !{!"branch_weights", i32 1, i32 10000}
+!71 = !DILocation(line: 8, column: 1, scope: !57)
+!72 = !{!73, !29, i64 8}
+!73 = !{!"rb_sorbet_param_struct", !74, i64 0, !29, i64 4, !29, i64 8, !29, i64 12, !29, i64 16, !29, i64 20, !29, i64 24, !29, i64 28, !15, i64 32, !29, i64 40, !29, i64 44, !29, i64 48, !29, i64 52, !15, i64 56}
+!74 = !{!"", !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 1, !29, i64 1}
+!75 = !{!73, !29, i64 4}
+!76 = !{!73, !15, i64 32}
+!77 = !DILocation(line: 13, column: 1, scope: !57)
+!78 = !DILocation(line: 18, column: 1, scope: !57)
+!79 = !DILocation(line: 23, column: 1, scope: !57)
+!80 = !DILocation(line: 27, column: 3, scope: !57)
+!81 = !DILocation(line: 27, column: 1, scope: !57)
+!82 = !DILocation(line: 28, column: 3, scope: !57)
+!83 = !DILocation(line: 28, column: 1, scope: !57)
+!84 = !DILocation(line: 29, column: 3, scope: !57)
+!85 = !DILocation(line: 29, column: 1, scope: !57)
+!86 = !DILocation(line: 30, column: 3, scope: !57)
+!87 = !DILocation(line: 30, column: 1, scope: !57)
+!88 = !DILocation(line: 31, column: 3, scope: !57)
+!89 = !DILocation(line: 31, column: 1, scope: !57)
+!90 = !DILocation(line: 32, column: 3, scope: !57)
+!91 = !DILocation(line: 32, column: 1, scope: !57)
+!92 = !DILocation(line: 33, column: 3, scope: !57)
+!93 = !DILocation(line: 33, column: 1, scope: !57)
+!94 = !DILocation(line: 36, column: 3, scope: !57)
+!95 = !DILocation(line: 36, column: 1, scope: !57)
+!96 = !DILocation(line: 37, column: 13, scope: !57)
+!97 = !DILocation(line: 37, column: 3, scope: !57)
+!98 = !DILocation(line: 37, column: 1, scope: !57)
+!99 = !DILocation(line: 38, column: 13, scope: !57)
+!100 = !DILocation(line: 38, column: 3, scope: !57)
+!101 = !DILocation(line: 38, column: 1, scope: !57)
+!102 = !DILocation(line: 40, column: 3, scope: !57)
+!103 = !DILocation(line: 40, column: 1, scope: !57)
+!104 = !DILocation(line: 41, column: 15, scope: !57)
+!105 = !DILocation(line: 41, column: 3, scope: !57)
+!106 = !DILocation(line: 41, column: 1, scope: !57)
+!107 = !DILocation(line: 42, column: 15, scope: !57)
+!108 = !DILocation(line: 42, column: 3, scope: !57)
+!109 = !DILocation(line: 42, column: 1, scope: !57)
+!110 = !DILocation(line: 44, column: 3, scope: !57)
+!111 = !DILocation(line: 44, column: 1, scope: !57)
+!112 = !DILocation(line: 45, column: 12, scope: !57)
+!113 = !DILocation(line: 45, column: 3, scope: !57)
+!114 = !DILocation(line: 45, column: 1, scope: !57)
+!115 = !DILocation(line: 47, column: 3, scope: !57)
+!116 = !DILocation(line: 47, column: 1, scope: !57)
+!117 = !DILocation(line: 48, column: 13, scope: !57)
+!118 = !DILocation(line: 48, column: 3, scope: !57)
+!119 = !DILocation(line: 48, column: 1, scope: !57)
+!120 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!121 = !{!60, !7, i64 24}
+!122 = !DILocation(line: 7, column: 13, scope: !120)
+!123 = !DILocation(line: 7, column: 23, scope: !120)
+!124 = !DILocation(line: 7, column: 26, scope: !120)
+!125 = !DILocation(line: 7, column: 6, scope: !120)
+!126 = !DILocation(line: 7, column: 45, scope: !120)
+!127 = !DILocation(line: 7, column: 1, scope: !120)
+!128 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_2", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!129 = !DILocation(line: 12, column: 13, scope: !128)
+!130 = !DILocation(line: 12, column: 23, scope: !128)
+!131 = !DILocation(line: 12, column: 26, scope: !128)
+!132 = !DILocation(line: 12, column: 6, scope: !128)
+!133 = !DILocation(line: 12, column: 45, scope: !128)
+!134 = !DILocation(line: 12, column: 1, scope: !128)
+!135 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_3", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!136 = !DILocation(line: 17, column: 13, scope: !135)
+!137 = !DILocation(line: 17, column: 23, scope: !135)
+!138 = !DILocation(line: 17, column: 26, scope: !135)
+!139 = !DILocation(line: 17, column: 6, scope: !135)
+!140 = !DILocation(line: 17, column: 1, scope: !135)
+!141 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_4", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!142 = !DILocation(line: 22, column: 13, scope: !141)
+!143 = !DILocation(line: 22, column: 23, scope: !141)
+!144 = !DILocation(line: 22, column: 26, scope: !141)
+!145 = !DILocation(line: 22, column: 6, scope: !141)
+!146 = !DILocation(line: 22, column: 1, scope: !141)
+!147 = !{!148, !7, i64 400}
+!148 = !{!"rb_vm_struct", !7, i64 0, !149, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !69, i64 216, !8, i64 224, !150, i64 264, !150, i64 280, !150, i64 296, !150, i64 312, !7, i64 328, !29, i64 336, !29, i64 340, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !152, i64 472, !153, i64 992, !15, i64 1016, !15, i64 1024, !29, i64 1032, !29, i64 1036, !150, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !29, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !29, i64 1192, !154, i64 1200, !8, i64 1232}
+!149 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !150, i64 48, !15, i64 64, !29, i64 72, !8, i64 80, !8, i64 128, !29, i64 176, !29, i64 180}
+!150 = !{!"list_head", !151, i64 0}
+!151 = !{!"list_node", !15, i64 0, !15, i64 8}
+!152 = !{!"", !8, i64 0}
+!153 = !{!"rb_hook_list_struct", !15, i64 0, !29, i64 8, !29, i64 12, !29, i64 16}
+!154 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!155 = distinct !DISubprogram(name: "func_Object#lt.cold.1", linkageName: "func_Object#lt.cold.1", scope: null, file: !4, type: !156, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!156 = !DISubroutineType(types: !5)
+!157 = distinct !DISubprogram(name: "func_Object#lt.cold.3", linkageName: "func_Object#lt.cold.3", scope: null, file: !4, type: !156, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!158 = !DILocation(line: 18, column: 8, scope: !157)

--- a/test/testdata/compiler/globalfields.llo.exp
+++ b/test/testdata/compiler/globalfields.llo.exp
@@ -184,14 +184,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
   unreachable
 }
@@ -199,7 +199,7 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
 ; Function Attrs: sspreq
 define void @Init_globalfields() local_unnamed_addr #5 {
 entry:
-  %positional_table.i.i = alloca i64, align 8, !dbg !8
+  %positional_table.i.i = alloca i64, align 8, !dbg !10
   %locals.i22.i = alloca i64, i32 0, align 8
   %locals.i18.i = alloca i64, i32 0, align 8
   %locals.i16.i = alloca i64, i32 0, align 8
@@ -235,23 +235,23 @@ entry:
   %"rubyStr_test/testdata/compiler/globalfields.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
   %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !15
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !15
-  %rubyId_read.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !16
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !16
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !17
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
+  %rubyId_read.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !18
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !18
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   %12 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_value, i64 0, i64 0), i64 noundef 5) #11
   call void @rb_gc_register_mark_object(i64 %12) #11
   store i64 %12, i64* @rubyStrFrozen_value, align 8
-  %rubyId_write.i = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !18
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_write, i64 %rubyId_write.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  %rubyId_read4.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.1, i64 %rubyId_read4.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !19
-  %rubyId_puts6.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts6.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %rubyId_puts9.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts9.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
+  %rubyId_write.i = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !20
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_write, i64 %rubyId_write.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
+  %rubyId_read4.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !21
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.1, i64 %rubyId_read4.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !21
+  %rubyId_puts6.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !22
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts6.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
+  %rubyId_puts9.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts9.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
   %13 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
   call void @rb_gc_register_mark_object(i64 %13) #11
   %rubyId_write.i.i = load i64, i64* @rubyIdPrecomputed_write, align 8
@@ -269,245 +269,245 @@ entry:
   %"rubyStr_test/testdata/compiler/globalfields.rb.i21.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
   %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i20.i", i64 %"rubyId_<top (required)>.i19.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i22.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.<static-init>", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !22
-  %rubyId_keep_def13.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def13.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !23
-  %18 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !24
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
+  %rubyId_keep_def13.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !25
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def13.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !25
+  %18 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !26
   %19 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %18, i64 0, i32 18
-  %20 = load i64, i64* %19, align 8, !tbaa !26
-  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %20 = load i64, i64* %19, align 8, !tbaa !28
+  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !26
   %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 2
-  %23 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %22, align 8, !tbaa !36
+  %23 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %22, align 8, !tbaa !38
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %24, align 8, !tbaa !39
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %24, align 8, !tbaa !41
   %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 4
-  %26 = load i64*, i64** %25, align 8, !tbaa !41
-  %27 = load i64, i64* %26, align 8, !tbaa !4
+  %26 = load i64*, i64** %25, align 8, !tbaa !43
+  %27 = load i64, i64* %26, align 8, !tbaa !6
   %28 = and i64 %27, -33
-  store i64 %28, i64* %26, align 8, !tbaa !4
+  store i64 %28, i64* %26, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %21, %struct.rb_control_frame_struct* %23, %struct.rb_iseq_struct* %stackFrame.i) #11
   %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %29, align 8, !dbg !42, !tbaa !24
-  %30 = load i64, i64* @rb_cObject, align 8, !dbg !43
-  %31 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %30) #11, !dbg !43
-  %32 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %31) #11, !dbg !43
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %29, align 8, !dbg !44, !tbaa !26
+  %30 = load i64, i64* @rb_cObject, align 8, !dbg !45
+  %31 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %30) #11, !dbg !45
+  %32 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %31) #11, !dbg !45
   %33 = bitcast i64* %positional_table.i.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %33) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.<static-init>", align 8
-  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !26
   %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
-  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !36
+  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !38
   %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !39
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !41
   %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
-  %39 = load i64*, i64** %38, align 8, !tbaa !41
-  %40 = load i64, i64* %39, align 8, !tbaa !4
+  %39 = load i64*, i64** %38, align 8, !tbaa !43
+  %40 = load i64, i64* %39, align 8, !tbaa !6
   %41 = and i64 %40, -33
-  store i64 %41, i64* %39, align 8, !tbaa !4
+  store i64 %41, i64* %39, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i.i) #11
   %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !44, !tbaa !24
-  %rubyId_write.i.i1 = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !8
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_write.i.i1) #11, !dbg !8
-  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !8
-  %rawSym17.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !8
-  %43 = load i64, i64* @guard_epoch_A, align 8, !dbg !8
-  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !8, !tbaa !45
-  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !8
-  br i1 %needTakeSlowPath, label %45, label %46, !dbg !8, !prof !46
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !46, !tbaa !26
+  %rubyId_write.i.i1 = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !10
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_write.i.i1) #11, !dbg !10
+  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !10
+  %rawSym17.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !10
+  %43 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !47
+  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !10
+  br i1 %needTakeSlowPath, label %45, label %46, !dbg !10, !prof !48
 
 45:                                               ; preds = %entry
-  call void @const_recompute_A(), !dbg !8
-  br label %46, !dbg !8
+  call void @const_recompute_A(), !dbg !10
+  br label %46, !dbg !10
 
 46:                                               ; preds = %entry, %45
-  %47 = load i64, i64* @guarded_const_A, align 8, !dbg !8
-  %48 = load i64, i64* @guard_epoch_A, align 8, !dbg !8
-  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !8, !tbaa !45
-  %guardUpdated = icmp eq i64 %48, %49, !dbg !8
-  call void @llvm.assume(i1 %guardUpdated), !dbg !8
-  %stackFrame18.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#write", align 8, !dbg !8
-  %50 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !8
-  %51 = bitcast i8* %50 to i16*, !dbg !8
-  %52 = load i16, i16* %51, align 8, !dbg !8
-  %53 = and i16 %52, -384, !dbg !8
-  %54 = or i16 %53, 1, !dbg !8
-  store i16 %54, i16* %51, align 8, !dbg !8
-  %55 = getelementptr inbounds i8, i8* %50, i64 8, !dbg !8
-  %56 = bitcast i8* %55 to i32*, !dbg !8
-  store i32 1, i32* %56, align 8, !dbg !8, !tbaa !47
-  %57 = getelementptr inbounds i8, i8* %50, i64 12, !dbg !8
-  %58 = getelementptr inbounds i8, i8* %50, i64 4, !dbg !8
-  %59 = bitcast i8* %58 to i32*, !dbg !8
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %57, i8 0, i64 20, i1 false) #11, !dbg !8
-  store i32 1, i32* %59, align 4, !dbg !8, !tbaa !50
-  %rubyId_v.i.i = load i64, i64* @rubyIdPrecomputed_v, align 8, !dbg !8
-  store i64 %rubyId_v.i.i, i64* %positional_table.i.i, align 8, !dbg !8
-  %60 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !8
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %60, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %33, i64 noundef 8, i1 noundef false) #11, !dbg !8
-  %61 = getelementptr inbounds i8, i8* %50, i64 32, !dbg !8
-  %62 = bitcast i8* %61 to i8**, !dbg !8
-  store i8* %60, i8** %62, align 8, !dbg !8, !tbaa !51
-  call void @sorbet_vm_define_method(i64 %47, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#write", i8* nonnull %50, %struct.rb_iseq_struct* %stackFrame18.i.i, i1 noundef zeroext false) #11, !dbg !8
-  %63 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !8, !tbaa !24
-  %64 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %63, i64 0, i32 5, !dbg !8
-  %65 = load i32, i32* %64, align 8, !dbg !8, !tbaa !52
-  %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %63, i64 0, i32 6, !dbg !8
-  %67 = load i32, i32* %66, align 4, !dbg !8, !tbaa !53
-  %68 = xor i32 %67, -1, !dbg !8
-  %69 = and i32 %68, %65, !dbg !8
-  %70 = icmp eq i32 %69, 0, !dbg !8
-  br i1 %70, label %fastSymCallIntrinsic_Static_keep_def31.i.i, label %71, !dbg !8, !prof !54
+  %47 = load i64, i64* @guarded_const_A, align 8, !dbg !10
+  %48 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !47
+  %guardUpdated = icmp eq i64 %48, %49, !dbg !10
+  call void @llvm.assume(i1 %guardUpdated), !dbg !10
+  %stackFrame18.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#write", align 8, !dbg !10
+  %50 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %51 = bitcast i8* %50 to i16*, !dbg !10
+  %52 = load i16, i16* %51, align 8, !dbg !10
+  %53 = and i16 %52, -384, !dbg !10
+  %54 = or i16 %53, 1, !dbg !10
+  store i16 %54, i16* %51, align 8, !dbg !10
+  %55 = getelementptr inbounds i8, i8* %50, i64 8, !dbg !10
+  %56 = bitcast i8* %55 to i32*, !dbg !10
+  store i32 1, i32* %56, align 8, !dbg !10, !tbaa !49
+  %57 = getelementptr inbounds i8, i8* %50, i64 12, !dbg !10
+  %58 = getelementptr inbounds i8, i8* %50, i64 4, !dbg !10
+  %59 = bitcast i8* %58 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %57, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %59, align 4, !dbg !10, !tbaa !52
+  %rubyId_v.i.i = load i64, i64* @rubyIdPrecomputed_v, align 8, !dbg !10
+  store i64 %rubyId_v.i.i, i64* %positional_table.i.i, align 8, !dbg !10
+  %60 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %60, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %33, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %61 = getelementptr inbounds i8, i8* %50, i64 32, !dbg !10
+  %62 = bitcast i8* %61 to i8**, !dbg !10
+  store i8* %60, i8** %62, align 8, !dbg !10, !tbaa !53
+  call void @sorbet_vm_define_method(i64 %47, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#write", i8* nonnull %50, %struct.rb_iseq_struct* %stackFrame18.i.i, i1 noundef zeroext false) #11, !dbg !10
+  %63 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !26
+  %64 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %63, i64 0, i32 5, !dbg !10
+  %65 = load i32, i32* %64, align 8, !dbg !10, !tbaa !54
+  %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %63, i64 0, i32 6, !dbg !10
+  %67 = load i32, i32* %66, align 4, !dbg !10, !tbaa !55
+  %68 = xor i32 %67, -1, !dbg !10
+  %69 = and i32 %68, %65, !dbg !10
+  %70 = icmp eq i32 %69, 0, !dbg !10
+  br i1 %70, label %fastSymCallIntrinsic_Static_keep_def31.i.i, label %71, !dbg !10, !prof !56
 
 71:                                               ; preds = %46
-  %72 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %63, i64 0, i32 8, !dbg !8
-  %73 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %72, align 8, !dbg !8, !tbaa !55
-  %74 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %73, i32 noundef 0) #11, !dbg !8
-  br label %fastSymCallIntrinsic_Static_keep_def31.i.i, !dbg !8
+  %72 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %63, i64 0, i32 8, !dbg !10
+  %73 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %72, align 8, !dbg !10, !tbaa !57
+  %74 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %73, i32 noundef 0) #11, !dbg !10
+  br label %fastSymCallIntrinsic_Static_keep_def31.i.i, !dbg !10
 
 fastSymCallIntrinsic_Static_keep_def31.i.i:       ; preds = %71, %46
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %42, align 8, !dbg !8, !tbaa !24
-  %rubyId_read.i.i2 = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !56
-  %rawSym23.i.i = call i64 @rb_id2sym(i64 %rubyId_read.i.i2) #11, !dbg !56
-  %rubyId_normal24.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !56
-  %rawSym25.i.i = call i64 @rb_id2sym(i64 %rubyId_normal24.i.i) #11, !dbg !56
-  %stackFrame32.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#read", align 8, !dbg !56
-  %75 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !56
-  %76 = bitcast i8* %75 to i16*, !dbg !56
-  %77 = load i16, i16* %76, align 8, !dbg !56
-  %78 = and i16 %77, -384, !dbg !56
-  store i16 %78, i16* %76, align 8, !dbg !56
-  %79 = getelementptr inbounds i8, i8* %75, i64 4, !dbg !56
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %79, i8 0, i64 28, i1 false) #11, !dbg !56
-  call void @sorbet_vm_define_method(i64 %47, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#read", i8* nonnull %75, %struct.rb_iseq_struct* %stackFrame32.i.i, i1 noundef zeroext false) #11, !dbg !56
-  %80 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !56, !tbaa !24
-  %81 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 5, !dbg !56
-  %82 = load i32, i32* %81, align 8, !dbg !56, !tbaa !52
-  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 6, !dbg !56
-  %84 = load i32, i32* %83, align 4, !dbg !56, !tbaa !53
-  %85 = xor i32 %84, -1, !dbg !56
-  %86 = and i32 %85, %82, !dbg !56
-  %87 = icmp eq i32 %86, 0, !dbg !56
-  br i1 %87, label %"func_<root>.<static-init>$151.exit", label %88, !dbg !56, !prof !54
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %42, align 8, !dbg !10, !tbaa !26
+  %rubyId_read.i.i2 = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !58
+  %rawSym23.i.i = call i64 @rb_id2sym(i64 %rubyId_read.i.i2) #11, !dbg !58
+  %rubyId_normal24.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !58
+  %rawSym25.i.i = call i64 @rb_id2sym(i64 %rubyId_normal24.i.i) #11, !dbg !58
+  %stackFrame32.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#read", align 8, !dbg !58
+  %75 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !58
+  %76 = bitcast i8* %75 to i16*, !dbg !58
+  %77 = load i16, i16* %76, align 8, !dbg !58
+  %78 = and i16 %77, -384, !dbg !58
+  store i16 %78, i16* %76, align 8, !dbg !58
+  %79 = getelementptr inbounds i8, i8* %75, i64 4, !dbg !58
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %79, i8 0, i64 28, i1 false) #11, !dbg !58
+  call void @sorbet_vm_define_method(i64 %47, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#read", i8* nonnull %75, %struct.rb_iseq_struct* %stackFrame32.i.i, i1 noundef zeroext false) #11, !dbg !58
+  %80 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !58, !tbaa !26
+  %81 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 5, !dbg !58
+  %82 = load i32, i32* %81, align 8, !dbg !58, !tbaa !54
+  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 6, !dbg !58
+  %84 = load i32, i32* %83, align 4, !dbg !58, !tbaa !55
+  %85 = xor i32 %84, -1, !dbg !58
+  %86 = and i32 %85, %82, !dbg !58
+  %87 = icmp eq i32 %86, 0, !dbg !58
+  br i1 %87, label %"func_<root>.<static-init>$151.exit", label %88, !dbg !58, !prof !56
 
 88:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def31.i.i
-  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 8, !dbg !56
-  %90 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %89, align 8, !dbg !56, !tbaa !55
-  %91 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %90, i32 noundef 0) #11, !dbg !56
-  br label %"func_<root>.<static-init>$151.exit", !dbg !56
+  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 8, !dbg !58
+  %90 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %89, align 8, !dbg !58, !tbaa !57
+  %91 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %90, i32 noundef 0) #11, !dbg !58
+  br label %"func_<root>.<static-init>$151.exit", !dbg !58
 
 "func_<root>.<static-init>$151.exit":             ; preds = %fastSymCallIntrinsic_Static_keep_def31.i.i, %88
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %33) #11
-  call void @sorbet_popFrame() #11, !dbg !43
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %29, align 8, !dbg !43, !tbaa !24
-  %92 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !15
-  %93 = load i64*, i64** %92, align 8, !dbg !15
-  store i64 %47, i64* %93, align 8, !dbg !15, !tbaa !4
-  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !15
-  store i64* %94, i64** %92, align 8, !dbg !15
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !15
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %29, align 8, !dbg !15, !tbaa !24
-  %95 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !16
-  %96 = load i64*, i64** %95, align 8, !dbg !16
-  store i64 %send, i64* %96, align 8, !dbg !16, !tbaa !4
-  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !16
-  store i64* %97, i64** %95, align 8, !dbg !16
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !16
-  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !17
-  %99 = load i64*, i64** %98, align 8, !dbg !17
-  store i64 %20, i64* %99, align 8, !dbg !17, !tbaa !4
-  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !17
-  store i64 %send4, i64* %100, align 8, !dbg !17, !tbaa !4
-  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !17
-  store i64* %101, i64** %98, align 8, !dbg !17
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %29, align 8, !dbg !17, !tbaa !24
-  %rubyStr_value.i = load i64, i64* @rubyStrFrozen_value, align 8, !dbg !57
-  %102 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !18
-  %103 = load i64*, i64** %102, align 8, !dbg !18
-  store i64 %send, i64* %103, align 8, !dbg !18, !tbaa !4
-  %104 = getelementptr inbounds i64, i64* %103, i64 1, !dbg !18
-  store i64 %rubyStr_value.i, i64* %104, align 8, !dbg !18, !tbaa !4
-  %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !18
-  store i64* %105, i64** %102, align 8, !dbg !18
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !18
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %29, align 8, !dbg !18, !tbaa !24
-  %106 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !19
-  %107 = load i64*, i64** %106, align 8, !dbg !19
-  store i64 %send, i64* %107, align 8, !dbg !19, !tbaa !4
-  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !19
-  store i64* %108, i64** %106, align 8, !dbg !19
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.1, i64 0), !dbg !19
-  %109 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !20
-  %110 = load i64*, i64** %109, align 8, !dbg !20
-  store i64 %20, i64* %110, align 8, !dbg !20, !tbaa !4
-  %111 = getelementptr inbounds i64, i64* %110, i64 1, !dbg !20
-  store i64 %send10, i64* %111, align 8, !dbg !20, !tbaa !4
-  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !20
-  store i64* %112, i64** %109, align 8, !dbg !20
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !20
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %29, align 8, !dbg !20, !tbaa !24
-  %"rubyId_$f.i" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !21
-  %113 = call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f.i") #11, !dbg !21
-  %114 = call i64 @rb_gvar_get(%struct.rb_global_entry* %113) #11, !dbg !21
-  %115 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !21
-  %116 = load i64*, i64** %115, align 8, !dbg !21
-  store i64 %20, i64* %116, align 8, !dbg !21, !tbaa !4
-  %117 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !21
-  store i64 %114, i64* %117, align 8, !dbg !21, !tbaa !4
-  %118 = getelementptr inbounds i64, i64* %117, i64 1, !dbg !21
-  store i64* %118, i64** %115, align 8, !dbg !21
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !21
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %29, align 8, !dbg !21, !tbaa !24
-  %119 = call i64 @sorbet_setConstant(i64 %30, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_F, i64 0, i64 0), i64 noundef 1, i64 noundef 3) #11, !dbg !58
+  call void @sorbet_popFrame() #11, !dbg !45
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %29, align 8, !dbg !45, !tbaa !26
+  %92 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !17
+  %93 = load i64*, i64** %92, align 8, !dbg !17
+  store i64 %47, i64* %93, align 8, !dbg !17, !tbaa !6
+  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !17
+  store i64* %94, i64** %92, align 8, !dbg !17
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !17
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %29, align 8, !dbg !17, !tbaa !26
+  %95 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !18
+  %96 = load i64*, i64** %95, align 8, !dbg !18
+  store i64 %send, i64* %96, align 8, !dbg !18, !tbaa !6
+  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !18
+  store i64* %97, i64** %95, align 8, !dbg !18
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
+  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !19
+  %99 = load i64*, i64** %98, align 8, !dbg !19
+  store i64 %20, i64* %99, align 8, !dbg !19, !tbaa !6
+  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !19
+  store i64 %send4, i64* %100, align 8, !dbg !19, !tbaa !6
+  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !19
+  store i64* %101, i64** %98, align 8, !dbg !19
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %29, align 8, !dbg !19, !tbaa !26
+  %rubyStr_value.i = load i64, i64* @rubyStrFrozen_value, align 8, !dbg !59
+  %102 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !20
+  %103 = load i64*, i64** %102, align 8, !dbg !20
+  store i64 %send, i64* %103, align 8, !dbg !20, !tbaa !6
+  %104 = getelementptr inbounds i64, i64* %103, i64 1, !dbg !20
+  store i64 %rubyStr_value.i, i64* %104, align 8, !dbg !20, !tbaa !6
+  %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !20
+  store i64* %105, i64** %102, align 8, !dbg !20
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !20
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %29, align 8, !dbg !20, !tbaa !26
+  %106 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !21
+  %107 = load i64*, i64** %106, align 8, !dbg !21
+  store i64 %send, i64* %107, align 8, !dbg !21, !tbaa !6
+  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !21
+  store i64* %108, i64** %106, align 8, !dbg !21
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.1, i64 0), !dbg !21
+  %109 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !22
+  %110 = load i64*, i64** %109, align 8, !dbg !22
+  store i64 %20, i64* %110, align 8, !dbg !22, !tbaa !6
+  %111 = getelementptr inbounds i64, i64* %110, i64 1, !dbg !22
+  store i64 %send10, i64* %111, align 8, !dbg !22, !tbaa !6
+  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !22
+  store i64* %112, i64** %109, align 8, !dbg !22
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !22
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %29, align 8, !dbg !22, !tbaa !26
+  %"rubyId_$f.i" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !23
+  %113 = call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f.i") #11, !dbg !23
+  %114 = call i64 @rb_gvar_get(%struct.rb_global_entry* %113) #11, !dbg !23
+  %115 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !23
+  %116 = load i64*, i64** %115, align 8, !dbg !23
+  store i64 %20, i64* %116, align 8, !dbg !23, !tbaa !6
+  %117 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !23
+  store i64 %114, i64* %117, align 8, !dbg !23, !tbaa !6
+  %118 = getelementptr inbounds i64, i64* %117, i64 1, !dbg !23
+  store i64* %118, i64** %115, align 8, !dbg !23
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !23
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %29, align 8, !dbg !23, !tbaa !26
+  %119 = call i64 @sorbet_setConstant(i64 %30, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_F, i64 0, i64 0), i64 noundef 1, i64 noundef 3) #11, !dbg !60
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_A#write"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !59 {
+define i64 @"func_A#write"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !61 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !24
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !60
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !60
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !60
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !60, !prof !61
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !26
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !62
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !62
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !62
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !62, !prof !63
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !60
-  unreachable, !dbg !60
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !62
+  unreachable, !dbg !62
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_v = load i64, i64* %argArray, align 8, !dbg !60
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !62, !tbaa !24
-  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !63
-  %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !63
-  %2 = tail call i64 @rb_gvar_set(%struct.rb_global_entry* %1, i64 %rawArg_v) #11, !dbg !63
-  %"rubyId_$f7" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !64
-  %3 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f7") #11, !dbg !64
-  %4 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %3) #11, !dbg !64
+  %rawArg_v = load i64, i64* %argArray, align 8, !dbg !62
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !64, !tbaa !26
+  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !65
+  %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !65
+  %2 = tail call i64 @rb_gvar_set(%struct.rb_global_entry* %1, i64 %rawArg_v) #11, !dbg !65
+  %"rubyId_$f7" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !66
+  %3 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f7") #11, !dbg !66
+  %4 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %3) #11, !dbg !66
   ret i64 %4
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_A#read"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !65 {
+define i64 @"func_A#read"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !67 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !tbaa !24
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !66
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !66, !prof !67
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !tbaa !26
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !68
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !68, !prof !69
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !66
-  unreachable, !dbg !66
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !68
+  unreachable, !dbg !68
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !68, !tbaa !24
-  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !69
-  %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !69
-  %2 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %1) #11, !dbg !69
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !70, !tbaa !26
+  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !71
+  %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !71
+  %2 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %1) #11, !dbg !71
   ret i64 %2
 }
 
@@ -527,7 +527,7 @@ declare void @llvm.assume(i1 noundef) #8
 define linkonce void @const_recompute_A() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !45
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !47
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -547,76 +547,78 @@ attributes #11 = { nounwind }
 attributes #12 = { nounwind allocsize(0,1) }
 attributes #13 = { noreturn }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/globalfields.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 6, column: 3, scope: !9, inlinedAt: !13)
-!9 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L62", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = distinct !DILocation(line: 5, column: 1, scope: !14)
-!14 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!15 = !DILocation(line: 14, column: 5, scope: !14)
-!16 = !DILocation(line: 15, column: 6, scope: !14)
-!17 = !DILocation(line: 15, column: 1, scope: !14)
-!18 = !DILocation(line: 16, column: 1, scope: !14)
-!19 = !DILocation(line: 17, column: 6, scope: !14)
-!20 = !DILocation(line: 17, column: 1, scope: !14)
-!21 = !DILocation(line: 18, column: 1, scope: !14)
-!22 = !DILocation(line: 6, column: 3, scope: !9)
-!23 = !DILocation(line: 9, column: 3, scope: !9)
-!24 = !{!25, !25, i64 0}
-!25 = !{!"any pointer", !6, i64 0}
-!26 = !{!27, !5, i64 400}
-!27 = !{!"rb_vm_struct", !5, i64 0, !28, i64 8, !25, i64 192, !25, i64 200, !25, i64 208, !32, i64 216, !6, i64 224, !29, i64 264, !29, i64 280, !29, i64 296, !29, i64 312, !5, i64 328, !31, i64 336, !31, i64 340, !31, i64 344, !31, i64 344, !31, i64 344, !31, i64 344, !31, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !25, i64 456, !25, i64 464, !33, i64 472, !34, i64 992, !25, i64 1016, !25, i64 1024, !31, i64 1032, !31, i64 1036, !29, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !31, i64 1136, !25, i64 1144, !25, i64 1152, !25, i64 1160, !25, i64 1168, !25, i64 1176, !25, i64 1184, !31, i64 1192, !35, i64 1200, !6, i64 1232}
-!28 = !{!"rb_global_vm_lock_struct", !25, i64 0, !6, i64 8, !29, i64 48, !25, i64 64, !31, i64 72, !6, i64 80, !6, i64 128, !31, i64 176, !31, i64 180}
-!29 = !{!"list_head", !30, i64 0}
-!30 = !{!"list_node", !25, i64 0, !25, i64 8}
-!31 = !{!"int", !6, i64 0}
-!32 = !{!"long long", !6, i64 0}
-!33 = !{!"", !6, i64 0}
-!34 = !{!"rb_hook_list_struct", !25, i64 0, !31, i64 8, !31, i64 12, !31, i64 16}
-!35 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!36 = !{!37, !25, i64 16}
-!37 = !{!"rb_execution_context_struct", !25, i64 0, !5, i64 8, !25, i64 16, !25, i64 24, !25, i64 32, !31, i64 40, !31, i64 44, !25, i64 48, !25, i64 56, !25, i64 64, !5, i64 72, !5, i64 80, !25, i64 88, !5, i64 96, !25, i64 104, !25, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !38, i64 152}
-!38 = !{!"", !25, i64 0, !25, i64 8, !5, i64 16, !6, i64 24}
-!39 = !{!40, !25, i64 16}
-!40 = !{!"rb_control_frame_struct", !25, i64 0, !25, i64 8, !25, i64 16, !5, i64 24, !25, i64 32, !25, i64 40, !25, i64 48}
-!41 = !{!40, !25, i64 32}
-!42 = !DILocation(line: 0, scope: !14)
-!43 = !DILocation(line: 5, column: 1, scope: !14)
-!44 = !DILocation(line: 0, scope: !9, inlinedAt: !13)
-!45 = !{!32, !32, i64 0}
-!46 = !{!"branch_weights", i32 1, i32 10000}
-!47 = !{!48, !31, i64 8}
-!48 = !{!"rb_sorbet_param_struct", !49, i64 0, !31, i64 4, !31, i64 8, !31, i64 12, !31, i64 16, !31, i64 20, !31, i64 24, !31, i64 28, !25, i64 32, !31, i64 40, !31, i64 44, !31, i64 48, !31, i64 52, !25, i64 56}
-!49 = !{!"", !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 1, !31, i64 1}
-!50 = !{!48, !31, i64 4}
-!51 = !{!48, !25, i64 32}
-!52 = !{!37, !31, i64 40}
-!53 = !{!37, !31, i64 44}
-!54 = !{!"branch_weights", i32 2000, i32 1}
-!55 = !{!37, !25, i64 56}
-!56 = !DILocation(line: 9, column: 3, scope: !9, inlinedAt: !13)
-!57 = !DILocation(line: 16, column: 9, scope: !14)
-!58 = !DILocation(line: 19, column: 5, scope: !14)
-!59 = distinct !DISubprogram(name: "A#write", linkageName: "func_A#write", scope: null, file: !2, line: 6, type: !10, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!60 = !DILocation(line: 6, column: 3, scope: !59)
-!61 = !{!"branch_weights", i32 4001, i32 4000000}
-!62 = !DILocation(line: 6, column: 13, scope: !59)
-!63 = !DILocation(line: 7, column: 10, scope: !59)
-!64 = !DILocation(line: 7, column: 5, scope: !59)
-!65 = distinct !DISubprogram(name: "A#read", linkageName: "func_A#read", scope: null, file: !2, line: 9, type: !10, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!66 = !DILocation(line: 9, column: 3, scope: !65)
-!67 = !{!"branch_weights", i32 1, i32 2000}
-!68 = !DILocation(line: 0, scope: !65)
-!69 = !DILocation(line: 10, column: 5, scope: !65)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/globalfields.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 6, column: 3, scope: !11, inlinedAt: !15)
+!11 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = distinct !DILocation(line: 5, column: 1, scope: !16)
+!16 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!17 = !DILocation(line: 14, column: 5, scope: !16)
+!18 = !DILocation(line: 15, column: 6, scope: !16)
+!19 = !DILocation(line: 15, column: 1, scope: !16)
+!20 = !DILocation(line: 16, column: 1, scope: !16)
+!21 = !DILocation(line: 17, column: 6, scope: !16)
+!22 = !DILocation(line: 17, column: 1, scope: !16)
+!23 = !DILocation(line: 18, column: 1, scope: !16)
+!24 = !DILocation(line: 6, column: 3, scope: !11)
+!25 = !DILocation(line: 9, column: 3, scope: !11)
+!26 = !{!27, !27, i64 0}
+!27 = !{!"any pointer", !8, i64 0}
+!28 = !{!29, !7, i64 400}
+!29 = !{!"rb_vm_struct", !7, i64 0, !30, i64 8, !27, i64 192, !27, i64 200, !27, i64 208, !34, i64 216, !8, i64 224, !31, i64 264, !31, i64 280, !31, i64 296, !31, i64 312, !7, i64 328, !33, i64 336, !33, i64 340, !33, i64 344, !33, i64 344, !33, i64 344, !33, i64 344, !33, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !27, i64 456, !27, i64 464, !35, i64 472, !36, i64 992, !27, i64 1016, !27, i64 1024, !33, i64 1032, !33, i64 1036, !31, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !33, i64 1136, !27, i64 1144, !27, i64 1152, !27, i64 1160, !27, i64 1168, !27, i64 1176, !27, i64 1184, !33, i64 1192, !37, i64 1200, !8, i64 1232}
+!30 = !{!"rb_global_vm_lock_struct", !27, i64 0, !8, i64 8, !31, i64 48, !27, i64 64, !33, i64 72, !8, i64 80, !8, i64 128, !33, i64 176, !33, i64 180}
+!31 = !{!"list_head", !32, i64 0}
+!32 = !{!"list_node", !27, i64 0, !27, i64 8}
+!33 = !{!"int", !8, i64 0}
+!34 = !{!"long long", !8, i64 0}
+!35 = !{!"", !8, i64 0}
+!36 = !{!"rb_hook_list_struct", !27, i64 0, !33, i64 8, !33, i64 12, !33, i64 16}
+!37 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!38 = !{!39, !27, i64 16}
+!39 = !{!"rb_execution_context_struct", !27, i64 0, !7, i64 8, !27, i64 16, !27, i64 24, !27, i64 32, !33, i64 40, !33, i64 44, !27, i64 48, !27, i64 56, !27, i64 64, !7, i64 72, !7, i64 80, !27, i64 88, !7, i64 96, !27, i64 104, !27, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !40, i64 152}
+!40 = !{!"", !27, i64 0, !27, i64 8, !7, i64 16, !8, i64 24}
+!41 = !{!42, !27, i64 16}
+!42 = !{!"rb_control_frame_struct", !27, i64 0, !27, i64 8, !27, i64 16, !7, i64 24, !27, i64 32, !27, i64 40, !27, i64 48}
+!43 = !{!42, !27, i64 32}
+!44 = !DILocation(line: 0, scope: !16)
+!45 = !DILocation(line: 5, column: 1, scope: !16)
+!46 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
+!47 = !{!34, !34, i64 0}
+!48 = !{!"branch_weights", i32 1, i32 10000}
+!49 = !{!50, !33, i64 8}
+!50 = !{!"rb_sorbet_param_struct", !51, i64 0, !33, i64 4, !33, i64 8, !33, i64 12, !33, i64 16, !33, i64 20, !33, i64 24, !33, i64 28, !27, i64 32, !33, i64 40, !33, i64 44, !33, i64 48, !33, i64 52, !27, i64 56}
+!51 = !{!"", !33, i64 0, !33, i64 0, !33, i64 0, !33, i64 0, !33, i64 0, !33, i64 0, !33, i64 0, !33, i64 0, !33, i64 1, !33, i64 1}
+!52 = !{!50, !33, i64 4}
+!53 = !{!50, !27, i64 32}
+!54 = !{!39, !33, i64 40}
+!55 = !{!39, !33, i64 44}
+!56 = !{!"branch_weights", i32 2000, i32 1}
+!57 = !{!39, !27, i64 56}
+!58 = !DILocation(line: 9, column: 3, scope: !11, inlinedAt: !15)
+!59 = !DILocation(line: 16, column: 9, scope: !16)
+!60 = !DILocation(line: 19, column: 5, scope: !16)
+!61 = distinct !DISubprogram(name: "A#write", linkageName: "func_A#write", scope: null, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!62 = !DILocation(line: 6, column: 3, scope: !61)
+!63 = !{!"branch_weights", i32 4001, i32 4000000}
+!64 = !DILocation(line: 6, column: 13, scope: !61)
+!65 = !DILocation(line: 7, column: 10, scope: !61)
+!66 = !DILocation(line: 7, column: 5, scope: !61)
+!67 = distinct !DISubprogram(name: "A#read", linkageName: "func_A#read", scope: null, file: !4, line: 9, type: !12, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!68 = !DILocation(line: 9, column: 3, scope: !67)
+!69 = !{!"branch_weights", i32 1, i32 2000}
+!70 = !DILocation(line: 0, scope: !67)
+!71 = !DILocation(line: 10, column: 5, scope: !67)

--- a/test/testdata/compiler/hello.llo.exp
+++ b/test/testdata/compiler/hello.llo.exp
@@ -117,14 +117,14 @@ declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #4
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #4
   unreachable
 }
@@ -153,34 +153,34 @@ entry:
   %5 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_hello world", i64 0, i64 0), i64 noundef 11) #5
   call void @rb_gc_register_mark_object(i64 %5) #5
   store i64 %5, i64* @"rubyStrFrozen_hello world", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !8
-  %6 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !13
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
+  %6 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
   %7 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %6, i64 0, i32 18
-  %8 = load i64, i64* %7, align 8, !tbaa !15
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %8 = load i64, i64* %7, align 8, !tbaa !17
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !25
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !27
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %12, align 8, !tbaa !28
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %12, align 8, !tbaa !30
   %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4
-  %14 = load i64*, i64** %13, align 8, !tbaa !30
-  %15 = load i64, i64* %14, align 8, !tbaa !4
+  %14 = load i64*, i64** %13, align 8, !tbaa !32
+  %15 = load i64, i64* %14, align 8, !tbaa !6
   %16 = and i64 %15, -33
-  store i64 %16, i64* %14, align 8, !tbaa !4
+  store i64 %16, i64* %14, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %9, %struct.rb_control_frame_struct* %11, %struct.rb_iseq_struct* %stackFrame.i) #5
   %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %17, align 8, !dbg !31, !tbaa !13
-  %"rubyStr_hello world.i" = load i64, i64* @"rubyStrFrozen_hello world", align 8, !dbg !32
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !8
-  %19 = load i64*, i64** %18, align 8, !dbg !8
-  store i64 %8, i64* %19, align 8, !dbg !8, !tbaa !4
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !8
-  store i64 %"rubyStr_hello world.i", i64* %20, align 8, !dbg !8, !tbaa !4
-  %21 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !8
-  store i64* %21, i64** %18, align 8, !dbg !8
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !8
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %17, align 8, !dbg !33, !tbaa !15
+  %"rubyStr_hello world.i" = load i64, i64* @"rubyStrFrozen_hello world", align 8, !dbg !34
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !10
+  %19 = load i64*, i64** %18, align 8, !dbg !10
+  store i64 %8, i64* %19, align 8, !dbg !10, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !10
+  store i64 %"rubyStr_hello world.i", i64* %20, align 8, !dbg !10, !tbaa !6
+  %21 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !10
+  store i64* %21, i64** %18, align 8, !dbg !10
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
   ret void
 }
 
@@ -191,39 +191,41 @@ attributes #3 = { sspreq }
 attributes #4 = { noreturn nounwind }
 attributes #5 = { nounwind }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/hello.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 4, column: 1, scope: !9)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !{!14, !14, i64 0}
-!14 = !{!"any pointer", !6, i64 0}
-!15 = !{!16, !5, i64 400}
-!16 = !{!"rb_vm_struct", !5, i64 0, !17, i64 8, !14, i64 192, !14, i64 200, !14, i64 208, !21, i64 216, !6, i64 224, !18, i64 264, !18, i64 280, !18, i64 296, !18, i64 312, !5, i64 328, !20, i64 336, !20, i64 340, !20, i64 344, !20, i64 344, !20, i64 344, !20, i64 344, !20, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !14, i64 456, !14, i64 464, !22, i64 472, !23, i64 992, !14, i64 1016, !14, i64 1024, !20, i64 1032, !20, i64 1036, !18, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !20, i64 1136, !14, i64 1144, !14, i64 1152, !14, i64 1160, !14, i64 1168, !14, i64 1176, !14, i64 1184, !20, i64 1192, !24, i64 1200, !6, i64 1232}
-!17 = !{!"rb_global_vm_lock_struct", !14, i64 0, !6, i64 8, !18, i64 48, !14, i64 64, !20, i64 72, !6, i64 80, !6, i64 128, !20, i64 176, !20, i64 180}
-!18 = !{!"list_head", !19, i64 0}
-!19 = !{!"list_node", !14, i64 0, !14, i64 8}
-!20 = !{!"int", !6, i64 0}
-!21 = !{!"long long", !6, i64 0}
-!22 = !{!"", !6, i64 0}
-!23 = !{!"rb_hook_list_struct", !14, i64 0, !20, i64 8, !20, i64 12, !20, i64 16}
-!24 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!25 = !{!26, !14, i64 16}
-!26 = !{!"rb_execution_context_struct", !14, i64 0, !5, i64 8, !14, i64 16, !14, i64 24, !14, i64 32, !20, i64 40, !20, i64 44, !14, i64 48, !14, i64 56, !14, i64 64, !5, i64 72, !5, i64 80, !14, i64 88, !5, i64 96, !14, i64 104, !14, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !27, i64 152}
-!27 = !{!"", !14, i64 0, !14, i64 8, !5, i64 16, !6, i64 24}
-!28 = !{!29, !14, i64 16}
-!29 = !{!"rb_control_frame_struct", !14, i64 0, !14, i64 8, !14, i64 16, !5, i64 24, !14, i64 32, !14, i64 40, !14, i64 48}
-!30 = !{!29, !14, i64 32}
-!31 = !DILocation(line: 0, scope: !9)
-!32 = !DILocation(line: 4, column: 6, scope: !9)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/hello.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 4, column: 1, scope: !11)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !{!16, !16, i64 0}
+!16 = !{!"any pointer", !8, i64 0}
+!17 = !{!18, !7, i64 400}
+!18 = !{!"rb_vm_struct", !7, i64 0, !19, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !23, i64 216, !8, i64 224, !20, i64 264, !20, i64 280, !20, i64 296, !20, i64 312, !7, i64 328, !22, i64 336, !22, i64 340, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !24, i64 472, !25, i64 992, !16, i64 1016, !16, i64 1024, !22, i64 1032, !22, i64 1036, !20, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !22, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !22, i64 1192, !26, i64 1200, !8, i64 1232}
+!19 = !{!"rb_global_vm_lock_struct", !16, i64 0, !8, i64 8, !20, i64 48, !16, i64 64, !22, i64 72, !8, i64 80, !8, i64 128, !22, i64 176, !22, i64 180}
+!20 = !{!"list_head", !21, i64 0}
+!21 = !{!"list_node", !16, i64 0, !16, i64 8}
+!22 = !{!"int", !8, i64 0}
+!23 = !{!"long long", !8, i64 0}
+!24 = !{!"", !8, i64 0}
+!25 = !{!"rb_hook_list_struct", !16, i64 0, !22, i64 8, !22, i64 12, !22, i64 16}
+!26 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!27 = !{!28, !16, i64 16}
+!28 = !{!"rb_execution_context_struct", !16, i64 0, !7, i64 8, !16, i64 16, !16, i64 24, !16, i64 32, !22, i64 40, !22, i64 44, !16, i64 48, !16, i64 56, !16, i64 64, !7, i64 72, !7, i64 80, !16, i64 88, !7, i64 96, !16, i64 104, !16, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !29, i64 152}
+!29 = !{!"", !16, i64 0, !16, i64 8, !7, i64 16, !8, i64 24}
+!30 = !{!31, !16, i64 16}
+!31 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !7, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
+!32 = !{!31, !16, i64 32}
+!33 = !DILocation(line: 0, scope: !11)
+!34 = !DILocation(line: 4, column: 6, scope: !11)

--- a/test/testdata/compiler/intrinsics/bang.llo.exp
+++ b/test/testdata/compiler/intrinsics/bang.llo.exp
@@ -176,14 +176,14 @@ declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
   unreachable
 }
@@ -225,8 +225,8 @@ entry:
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
   %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_test.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !8
+  %rubyId_test.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %11 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #11
   call void @rb_gc_register_mark_object(i64 %11) #11
   %"rubyId_!.i.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8
@@ -236,335 +236,335 @@ entry:
   %13 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @"str_bad bang overload", i64 0, i64 0), i64 noundef 17) #11
   call void @rb_gc_register_mark_object(i64 %13) #11
   store i64 %13, i64* @"rubyStrFrozen_bad bang overload", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !13
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !13
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
   %"rubyId_<top (required)>.i22.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i23.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
   %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i23.i", i64 %"rubyId_<top (required)>.i22.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.<static-init>", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !15
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !15
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !17
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !17
   %15 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
   call void @rb_gc_register_mark_object(i64 %15) #11
   %rubyId_test.i.i = load i64, i64* @rubyIdPrecomputed_test, align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
   %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i27.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.test, align 8
-  %rubyId_puts3.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts3.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_puts6.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts6.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %rubyId_puts9.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts9.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
+  %rubyId_puts3.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts3.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  %rubyId_puts6.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts6.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
+  %rubyId_puts9.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !22
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts9.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
   %17 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_hello, i64 0, i64 0), i64 noundef 5) #11
   call void @rb_gc_register_mark_object(i64 %17) #11
   store i64 %17, i64* @rubyStrFrozen_hello, align 8
-  %rubyId_puts12.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts12.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
-  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
+  %rubyId_puts12.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts12.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
+  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
   %"rubyId_<top (required)>.i28.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i29.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
   %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i29.i", i64 %"rubyId_<top (required)>.i28.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 12, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.<static-init>", align 8
-  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
-  %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !26
+  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !26
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !26
+  %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !28
   %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 2
-  %21 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %20, align 8, !tbaa !28
+  %21 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %20, align 8, !tbaa !30
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %22, align 8, !tbaa !32
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %22, align 8, !tbaa !34
   %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 4
-  %24 = load i64*, i64** %23, align 8, !tbaa !34
-  %25 = load i64, i64* %24, align 8, !tbaa !4
+  %24 = load i64*, i64** %23, align 8, !tbaa !36
+  %25 = load i64, i64* %24, align 8, !tbaa !6
   %26 = and i64 %25, -33
-  store i64 %26, i64* %24, align 8, !tbaa !4
+  store i64 %26, i64* %24, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %19, %struct.rb_control_frame_struct* %21, %struct.rb_iseq_struct* %stackFrame.i) #11
   %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %27, align 8, !dbg !35, !tbaa !26
-  %28 = load i64, i64* @rb_cObject, align 8, !dbg !36
-  %29 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 %28) #11, !dbg !36
-  %30 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %29) #11, !dbg !36
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %27, align 8, !dbg !37, !tbaa !28
+  %28 = load i64, i64* @rb_cObject, align 8, !dbg !38
+  %29 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 %28) #11, !dbg !38
+  %30 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %29) #11, !dbg !38
   %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.<static-init>", align 8
-  %31 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !26
+  %31 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !28
   %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 2
-  %33 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %32, align 8, !tbaa !28
+  %33 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %32, align 8, !tbaa !30
   %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %34, align 8, !tbaa !32
+  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %34, align 8, !tbaa !34
   %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 4
-  %36 = load i64*, i64** %35, align 8, !tbaa !34
-  %37 = load i64, i64* %36, align 8, !tbaa !4
+  %36 = load i64*, i64** %35, align 8, !tbaa !36
+  %37 = load i64, i64* %36, align 8, !tbaa !6
   %38 = and i64 %37, -33
-  store i64 %38, i64* %36, align 8, !tbaa !4
+  store i64 %38, i64* %36, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %31, %struct.rb_control_frame_struct* %33, %struct.rb_iseq_struct* %stackFrame.i1.i) #11
   %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %39, align 8, !dbg !37, !tbaa !26
-  %"rubyId_!.i.i1" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !39
-  %rawSym.i2.i = call i64 @rb_id2sym(i64 %"rubyId_!.i.i1") #11, !dbg !39
-  %rubyId_normal.i3.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !39
-  %rawSym7.i4.i = call i64 @rb_id2sym(i64 %rubyId_normal.i3.i) #11, !dbg !39
-  %40 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !39
-  %41 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !39, !tbaa !40
-  %needTakeSlowPath = icmp ne i64 %40, %41, !dbg !39
-  br i1 %needTakeSlowPath, label %42, label %43, !dbg !39, !prof !42
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %39, align 8, !dbg !39, !tbaa !28
+  %"rubyId_!.i.i1" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !41
+  %rawSym.i2.i = call i64 @rb_id2sym(i64 %"rubyId_!.i.i1") #11, !dbg !41
+  %rubyId_normal.i3.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !41
+  %rawSym7.i4.i = call i64 @rb_id2sym(i64 %rubyId_normal.i3.i) #11, !dbg !41
+  %40 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !41
+  %41 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !42
+  %needTakeSlowPath = icmp ne i64 %40, %41, !dbg !41
+  br i1 %needTakeSlowPath, label %42, label %43, !dbg !41, !prof !44
 
 42:                                               ; preds = %entry
-  call void @const_recompute_Bad(), !dbg !39
-  br label %43, !dbg !39
+  call void @const_recompute_Bad(), !dbg !41
+  br label %43, !dbg !41
 
 43:                                               ; preds = %entry, %42
-  %44 = load i64, i64* @guarded_const_Bad, align 8, !dbg !39
-  %45 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !39
-  %46 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !39, !tbaa !40
-  %guardUpdated = icmp eq i64 %45, %46, !dbg !39
-  call void @llvm.assume(i1 %guardUpdated), !dbg !39
-  %stackFrame8.i5.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#!", align 8, !dbg !39
-  %47 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !39
-  %48 = bitcast i8* %47 to i16*, !dbg !39
-  %49 = load i16, i16* %48, align 8, !dbg !39
-  %50 = and i16 %49, -384, !dbg !39
-  store i16 %50, i16* %48, align 8, !dbg !39
-  %51 = getelementptr inbounds i8, i8* %47, i64 4, !dbg !39
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %51, i8 0, i64 28, i1 false) #11, !dbg !39
-  call void @sorbet_vm_define_method(i64 %44, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Bad#!", i8* nonnull %47, %struct.rb_iseq_struct* %stackFrame8.i5.i, i1 noundef zeroext false) #11, !dbg !39
-  %52 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !39, !tbaa !26
-  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 5, !dbg !39
-  %54 = load i32, i32* %53, align 8, !dbg !39, !tbaa !43
-  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 6, !dbg !39
-  %56 = load i32, i32* %55, align 4, !dbg !39, !tbaa !44
-  %57 = xor i32 %56, -1, !dbg !39
-  %58 = and i32 %57, %54, !dbg !39
-  %59 = icmp eq i32 %58, 0, !dbg !39
-  br i1 %59, label %"func_Bad.<static-init>L62.exit.i", label %60, !dbg !39, !prof !45
+  %44 = load i64, i64* @guarded_const_Bad, align 8, !dbg !41
+  %45 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !41
+  %46 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !42
+  %guardUpdated = icmp eq i64 %45, %46, !dbg !41
+  call void @llvm.assume(i1 %guardUpdated), !dbg !41
+  %stackFrame8.i5.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#!", align 8, !dbg !41
+  %47 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !41
+  %48 = bitcast i8* %47 to i16*, !dbg !41
+  %49 = load i16, i16* %48, align 8, !dbg !41
+  %50 = and i16 %49, -384, !dbg !41
+  store i16 %50, i16* %48, align 8, !dbg !41
+  %51 = getelementptr inbounds i8, i8* %47, i64 4, !dbg !41
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %51, i8 0, i64 28, i1 false) #11, !dbg !41
+  call void @sorbet_vm_define_method(i64 %44, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Bad#!", i8* nonnull %47, %struct.rb_iseq_struct* %stackFrame8.i5.i, i1 noundef zeroext false) #11, !dbg !41
+  %52 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !41, !tbaa !28
+  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 5, !dbg !41
+  %54 = load i32, i32* %53, align 8, !dbg !41, !tbaa !45
+  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 6, !dbg !41
+  %56 = load i32, i32* %55, align 4, !dbg !41, !tbaa !46
+  %57 = xor i32 %56, -1, !dbg !41
+  %58 = and i32 %57, %54, !dbg !41
+  %59 = icmp eq i32 %58, 0, !dbg !41
+  br i1 %59, label %"func_Bad.<static-init>L62.exit.i", label %60, !dbg !41, !prof !47
 
 60:                                               ; preds = %43
-  %61 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 8, !dbg !39
-  %62 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %61, align 8, !dbg !39, !tbaa !46
-  %63 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %62, i32 noundef 0) #11, !dbg !39
-  br label %"func_Bad.<static-init>L62.exit.i", !dbg !39
+  %61 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 8, !dbg !41
+  %62 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %61, align 8, !dbg !41, !tbaa !48
+  %63 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %62, i32 noundef 0) #11, !dbg !41
+  br label %"func_Bad.<static-init>L62.exit.i", !dbg !41
 
 "func_Bad.<static-init>L62.exit.i":               ; preds = %60, %43
-  call void @sorbet_popFrame() #11, !dbg !36
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %27, align 8, !dbg !36, !tbaa !26
-  %64 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0)) #11, !dbg !47
-  %65 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %64) #11, !dbg !47
+  call void @sorbet_popFrame() #11, !dbg !38
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %27, align 8, !dbg !38, !tbaa !28
+  %64 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0)) #11, !dbg !49
+  %65 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %64) #11, !dbg !49
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.<static-init>", align 8
-  %66 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !26
+  %66 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !28
   %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 2
-  %68 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %67, align 8, !tbaa !28
+  %68 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %67, align 8, !tbaa !30
   %69 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %68, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %69, align 8, !tbaa !32
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %69, align 8, !tbaa !34
   %70 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %68, i64 0, i32 4
-  %71 = load i64*, i64** %70, align 8, !tbaa !34
-  %72 = load i64, i64* %71, align 8, !tbaa !4
+  %71 = load i64*, i64** %70, align 8, !tbaa !36
+  %72 = load i64, i64* %71, align 8, !tbaa !6
   %73 = and i64 %72, -33
-  store i64 %73, i64* %71, align 8, !tbaa !4
+  store i64 %73, i64* %71, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %66, %struct.rb_control_frame_struct* %68, %struct.rb_iseq_struct* %stackFrame.i.i) #11
   %74 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %74, align 8, !dbg !48, !tbaa !26
-  %rubyId_test.i.i2 = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !50
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_test.i.i2) #11, !dbg !50
-  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !50
-  %rawSym7.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !50
-  %75 = load i64, i64* @guard_epoch_Main, align 8, !dbg !50
-  %76 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !40
-  %needTakeSlowPath3 = icmp ne i64 %75, %76, !dbg !50
-  br i1 %needTakeSlowPath3, label %77, label %78, !dbg !50, !prof !42
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %74, align 8, !dbg !50, !tbaa !28
+  %rubyId_test.i.i2 = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !52
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_test.i.i2) #11, !dbg !52
+  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !52
+  %rawSym7.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !52
+  %75 = load i64, i64* @guard_epoch_Main, align 8, !dbg !52
+  %76 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !42
+  %needTakeSlowPath3 = icmp ne i64 %75, %76, !dbg !52
+  br i1 %needTakeSlowPath3, label %77, label %78, !dbg !52, !prof !44
 
 77:                                               ; preds = %"func_Bad.<static-init>L62.exit.i"
-  call void @const_recompute_Main(), !dbg !50
-  br label %78, !dbg !50
+  call void @const_recompute_Main(), !dbg !52
+  br label %78, !dbg !52
 
 78:                                               ; preds = %"func_Bad.<static-init>L62.exit.i", %77
-  %79 = load i64, i64* @guarded_const_Main, align 8, !dbg !50
-  %80 = load i64, i64* @guard_epoch_Main, align 8, !dbg !50
-  %81 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !40
-  %guardUpdated4 = icmp eq i64 %80, %81, !dbg !50
-  call void @llvm.assume(i1 %guardUpdated4), !dbg !50
-  %stackFrame8.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.test, align 8, !dbg !50
-  %82 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !50
-  %83 = bitcast i8* %82 to i16*, !dbg !50
-  %84 = load i16, i16* %83, align 8, !dbg !50
-  %85 = and i16 %84, -384, !dbg !50
-  store i16 %85, i16* %83, align 8, !dbg !50
-  %86 = getelementptr inbounds i8, i8* %82, i64 4, !dbg !50
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %86, i8 0, i64 28, i1 false) #11, !dbg !50
-  call void @sorbet_vm_define_method(i64 %79, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_Main.test, i8* nonnull %82, %struct.rb_iseq_struct* %stackFrame8.i.i, i1 noundef zeroext true) #11, !dbg !50
-  %87 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !50, !tbaa !26
-  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 5, !dbg !50
-  %89 = load i32, i32* %88, align 8, !dbg !50, !tbaa !43
-  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 6, !dbg !50
-  %91 = load i32, i32* %90, align 4, !dbg !50, !tbaa !44
-  %92 = xor i32 %91, -1, !dbg !50
-  %93 = and i32 %92, %89, !dbg !50
-  %94 = icmp eq i32 %93, 0, !dbg !50
-  br i1 %94, label %"func_<root>.<static-init>$151.exit", label %95, !dbg !50, !prof !45
+  %79 = load i64, i64* @guarded_const_Main, align 8, !dbg !52
+  %80 = load i64, i64* @guard_epoch_Main, align 8, !dbg !52
+  %81 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !42
+  %guardUpdated4 = icmp eq i64 %80, %81, !dbg !52
+  call void @llvm.assume(i1 %guardUpdated4), !dbg !52
+  %stackFrame8.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.test, align 8, !dbg !52
+  %82 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !52
+  %83 = bitcast i8* %82 to i16*, !dbg !52
+  %84 = load i16, i16* %83, align 8, !dbg !52
+  %85 = and i16 %84, -384, !dbg !52
+  store i16 %85, i16* %83, align 8, !dbg !52
+  %86 = getelementptr inbounds i8, i8* %82, i64 4, !dbg !52
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %86, i8 0, i64 28, i1 false) #11, !dbg !52
+  call void @sorbet_vm_define_method(i64 %79, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_Main.test, i8* nonnull %82, %struct.rb_iseq_struct* %stackFrame8.i.i, i1 noundef zeroext true) #11, !dbg !52
+  %87 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !28
+  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 5, !dbg !52
+  %89 = load i32, i32* %88, align 8, !dbg !52, !tbaa !45
+  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 6, !dbg !52
+  %91 = load i32, i32* %90, align 4, !dbg !52, !tbaa !46
+  %92 = xor i32 %91, -1, !dbg !52
+  %93 = and i32 %92, %89, !dbg !52
+  %94 = icmp eq i32 %93, 0, !dbg !52
+  br i1 %94, label %"func_<root>.<static-init>$151.exit", label %95, !dbg !52, !prof !47
 
 95:                                               ; preds = %78
-  %96 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 8, !dbg !50
-  %97 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %96, align 8, !dbg !50, !tbaa !46
-  %98 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %97, i32 noundef 0) #11, !dbg !50
-  br label %"func_<root>.<static-init>$151.exit", !dbg !50
+  %96 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 8, !dbg !52
+  %97 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %96, align 8, !dbg !52, !tbaa !48
+  %98 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %97, i32 noundef 0) #11, !dbg !52
+  br label %"func_<root>.<static-init>$151.exit", !dbg !52
 
 "func_<root>.<static-init>$151.exit":             ; preds = %78, %95
-  call void @sorbet_popFrame() #11, !dbg !47
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %27, align 8, !dbg !47, !tbaa !26
-  %99 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 1, !dbg !8
-  %100 = load i64*, i64** %99, align 8, !dbg !8
-  store i64 %79, i64* %100, align 8, !dbg !8, !tbaa !4
-  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !8
-  store i64* %101, i64** %99, align 8, !dbg !8
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !8
+  call void @sorbet_popFrame() #11, !dbg !49
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %27, align 8, !dbg !49, !tbaa !28
+  %99 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 1, !dbg !10
+  %100 = load i64*, i64** %99, align 8, !dbg !10
+  store i64 %79, i64* %100, align 8, !dbg !10, !tbaa !6
+  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !10
+  store i64* %101, i64** %99, align 8, !dbg !10
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !10
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define noundef i64 @"func_Bad#!"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !14 {
+define noundef i64 @"func_Bad#!"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !16 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !26
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !51
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !51, !prof !52
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !28
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !53
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !53, !prof !54
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !51
-  unreachable, !dbg !51
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !53
+  unreachable, !dbg !53
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !53, !tbaa !26
-  %"rubyStr_bad bang overload" = load i64, i64* @"rubyStrFrozen_bad bang overload", align 8, !dbg !54
-  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !13
-  %2 = load i64*, i64** %1, align 8, !dbg !13
-  store i64 %selfRaw, i64* %2, align 8, !dbg !13, !tbaa !4
-  %3 = getelementptr inbounds i64, i64* %2, i64 1, !dbg !13
-  store i64 %"rubyStr_bad bang overload", i64* %3, align 8, !dbg !13, !tbaa !4
-  %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !13
-  store i64* %4, i64** %1, align 8, !dbg !13
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !13
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !13, !tbaa !26
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !55, !tbaa !28
+  %"rubyStr_bad bang overload" = load i64, i64* @"rubyStrFrozen_bad bang overload", align 8, !dbg !56
+  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !15
+  %2 = load i64*, i64** %1, align 8, !dbg !15
+  store i64 %selfRaw, i64* %2, align 8, !dbg !15, !tbaa !6
+  %3 = getelementptr inbounds i64, i64* %2, i64 1, !dbg !15
+  store i64 %"rubyStr_bad bang overload", i64* %3, align 8, !dbg !15, !tbaa !6
+  %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !15
+  store i64* %4, i64** %1, align 8, !dbg !15
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !15, !tbaa !28
   ret i64 20
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @func_Main.test(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !18 {
+define i64 @func_Main.test(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !20 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !26
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !55
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !55, !prof !52
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !28
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !57
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !57, !prof !54
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !55
-  unreachable, !dbg !55
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !57
+  unreachable, !dbg !57
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !56, !tbaa !26
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !57), !dbg !60
-  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !17
-  %2 = load i64*, i64** %1, align 8, !dbg !17
-  store i64 %selfRaw, i64* %2, align 8, !dbg !17, !tbaa !4
-  %3 = getelementptr inbounds i64, i64* %2, i64 1, !dbg !17
-  store i64 0, i64* %3, align 8, !dbg !17, !tbaa !4
-  %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !17
-  store i64* %4, i64** %1, align 8, !dbg !17
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %0, align 8, !dbg !17, !tbaa !26
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !61), !dbg !64
-  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !19
-  %6 = load i64*, i64** %5, align 8, !dbg !19
-  store i64 %selfRaw, i64* %6, align 8, !dbg !19, !tbaa !4
-  %7 = getelementptr inbounds i64, i64* %6, i64 1, !dbg !19
-  store i64 20, i64* %7, align 8, !dbg !19, !tbaa !4
-  %8 = getelementptr inbounds i64, i64* %7, i64 1, !dbg !19
-  store i64* %8, i64** %5, align 8, !dbg !19
-  %send109 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !dbg !19, !tbaa !26
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !65), !dbg !68
-  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !20
-  %10 = load i64*, i64** %9, align 8, !dbg !20
-  store i64 %selfRaw, i64* %10, align 8, !dbg !20, !tbaa !4
-  %11 = getelementptr inbounds i64, i64* %10, i64 1, !dbg !20
-  store i64 20, i64* %11, align 8, !dbg !20, !tbaa !4
-  %12 = getelementptr inbounds i64, i64* %11, i64 1, !dbg !20
-  store i64* %12, i64** %9, align 8, !dbg !20
-  %send111 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !20
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !20, !tbaa !26
-  %rubyStr_hello = load i64, i64* @rubyStrFrozen_hello, align 8, !dbg !69
-  %"rubyId_!69" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !70
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !71), !dbg !70
-  %13 = and i64 %rubyStr_hello, -9, !dbg !70
-  %14 = icmp eq i64 %13, 0, !dbg !70
-  br i1 %14, label %sorbet_bang.exit105, label %15, !dbg !70
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !58, !tbaa !28
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !59), !dbg !62
+  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !19
+  %2 = load i64*, i64** %1, align 8, !dbg !19
+  store i64 %selfRaw, i64* %2, align 8, !dbg !19, !tbaa !6
+  %3 = getelementptr inbounds i64, i64* %2, i64 1, !dbg !19
+  store i64 0, i64* %3, align 8, !dbg !19, !tbaa !6
+  %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !19
+  store i64* %4, i64** %1, align 8, !dbg !19
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %0, align 8, !dbg !19, !tbaa !28
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !63), !dbg !66
+  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !21
+  %6 = load i64*, i64** %5, align 8, !dbg !21
+  store i64 %selfRaw, i64* %6, align 8, !dbg !21, !tbaa !6
+  %7 = getelementptr inbounds i64, i64* %6, i64 1, !dbg !21
+  store i64 20, i64* %7, align 8, !dbg !21, !tbaa !6
+  %8 = getelementptr inbounds i64, i64* %7, i64 1, !dbg !21
+  store i64* %8, i64** %5, align 8, !dbg !21
+  %send109 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !21
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !dbg !21, !tbaa !28
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !67), !dbg !70
+  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !22
+  %10 = load i64*, i64** %9, align 8, !dbg !22
+  store i64 %selfRaw, i64* %10, align 8, !dbg !22, !tbaa !6
+  %11 = getelementptr inbounds i64, i64* %10, i64 1, !dbg !22
+  store i64 20, i64* %11, align 8, !dbg !22, !tbaa !6
+  %12 = getelementptr inbounds i64, i64* %11, i64 1, !dbg !22
+  store i64* %12, i64** %9, align 8, !dbg !22
+  %send111 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !22
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !22, !tbaa !28
+  %rubyStr_hello = load i64, i64* @rubyStrFrozen_hello, align 8, !dbg !71
+  %"rubyId_!69" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !72
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !73), !dbg !72
+  %13 = and i64 %rubyStr_hello, -9, !dbg !72
+  %14 = icmp eq i64 %13, 0, !dbg !72
+  br i1 %14, label %sorbet_bang.exit105, label %15, !dbg !72
 
 15:                                               ; preds = %fillRequiredArgs
-  %16 = icmp eq i64 %rubyStr_hello, 20, !dbg !70
-  br i1 %16, label %sorbet_bang.exit105, label %17, !dbg !70
+  %16 = icmp eq i64 %rubyStr_hello, 20, !dbg !72
+  br i1 %16, label %sorbet_bang.exit105, label %17, !dbg !72
 
 17:                                               ; preds = %15
-  %18 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %rubyStr_hello, i64 %"rubyId_!69", i32 noundef 0, i64* noundef null) #11, !dbg !70
-  br label %sorbet_bang.exit105, !dbg !70
+  %18 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %rubyStr_hello, i64 %"rubyId_!69", i32 noundef 0, i64* noundef null) #11, !dbg !72
+  br label %sorbet_bang.exit105, !dbg !72
 
 sorbet_bang.exit105:                              ; preds = %fillRequiredArgs, %15, %17
-  %19 = phi i64 [ %18, %17 ], [ 0, %15 ], [ 20, %fillRequiredArgs ], !dbg !70
-  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !21
-  %21 = load i64*, i64** %20, align 8, !dbg !21
-  store i64 %selfRaw, i64* %21, align 8, !dbg !21, !tbaa !4
-  %22 = getelementptr inbounds i64, i64* %21, i64 1, !dbg !21
-  store i64 %19, i64* %22, align 8, !dbg !21, !tbaa !4
-  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !21
-  store i64* %23, i64** %20, align 8, !dbg !21
-  %send113 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !21
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %0, align 8, !dbg !21, !tbaa !26
-  %24 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !22
-  %25 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !40
-  %needTakeSlowPath = icmp ne i64 %24, %25, !dbg !22
-  br i1 %needTakeSlowPath, label %26, label %27, !dbg !22, !prof !42
+  %19 = phi i64 [ %18, %17 ], [ 0, %15 ], [ 20, %fillRequiredArgs ], !dbg !72
+  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !23
+  %21 = load i64*, i64** %20, align 8, !dbg !23
+  store i64 %selfRaw, i64* %21, align 8, !dbg !23, !tbaa !6
+  %22 = getelementptr inbounds i64, i64* %21, i64 1, !dbg !23
+  store i64 %19, i64* %22, align 8, !dbg !23, !tbaa !6
+  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !23
+  store i64* %23, i64** %20, align 8, !dbg !23
+  %send113 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !23
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %0, align 8, !dbg !23, !tbaa !28
+  %24 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !24
+  %25 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !42
+  %needTakeSlowPath = icmp ne i64 %24, %25, !dbg !24
+  br i1 %needTakeSlowPath, label %26, label %27, !dbg !24, !prof !44
 
 26:                                               ; preds = %sorbet_bang.exit105
-  tail call void @const_recompute_Bad(), !dbg !22
-  br label %27, !dbg !22
+  tail call void @const_recompute_Bad(), !dbg !24
+  br label %27, !dbg !24
 
 27:                                               ; preds = %sorbet_bang.exit105, %26
-  %28 = load i64, i64* @guarded_const_Bad, align 8, !dbg !22
-  %29 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !22
-  %30 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !40
-  %guardUpdated = icmp eq i64 %29, %30, !dbg !22
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !22
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !22
-  %32 = load i64*, i64** %31, align 8, !dbg !22
-  store i64 %28, i64* %32, align 8, !dbg !22, !tbaa !4
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !22
-  store i64* %33, i64** %31, align 8, !dbg !22
-  %send115 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !22
-  %"rubyId_!85" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !74
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !75), !dbg !74
-  %34 = and i64 %send115, -9, !dbg !74
-  %35 = icmp eq i64 %34, 0, !dbg !74
-  br i1 %35, label %sorbet_bang.exit, label %36, !dbg !74
+  %28 = load i64, i64* @guarded_const_Bad, align 8, !dbg !24
+  %29 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !24
+  %30 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !42
+  %guardUpdated = icmp eq i64 %29, %30, !dbg !24
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !24
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !24
+  %32 = load i64*, i64** %31, align 8, !dbg !24
+  store i64 %28, i64* %32, align 8, !dbg !24, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !24
+  store i64* %33, i64** %31, align 8, !dbg !24
+  %send115 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !24
+  %"rubyId_!85" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !76
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !77), !dbg !76
+  %34 = and i64 %send115, -9, !dbg !76
+  %35 = icmp eq i64 %34, 0, !dbg !76
+  br i1 %35, label %sorbet_bang.exit, label %36, !dbg !76
 
 36:                                               ; preds = %27
-  %37 = icmp eq i64 %send115, 20, !dbg !74
-  br i1 %37, label %sorbet_bang.exit, label %38, !dbg !74
+  %37 = icmp eq i64 %send115, 20, !dbg !76
+  br i1 %37, label %sorbet_bang.exit, label %38, !dbg !76
 
 38:                                               ; preds = %36
-  %39 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %send115, i64 %"rubyId_!85", i32 noundef 0, i64* noundef null) #11, !dbg !74
-  br label %sorbet_bang.exit, !dbg !74
+  %39 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %send115, i64 %"rubyId_!85", i32 noundef 0, i64* noundef null) #11, !dbg !76
+  br label %sorbet_bang.exit, !dbg !76
 
 sorbet_bang.exit:                                 ; preds = %27, %36, %38
-  %40 = phi i64 [ %39, %38 ], [ 0, %36 ], [ 20, %27 ], !dbg !74
-  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !23
-  %42 = load i64*, i64** %41, align 8, !dbg !23
-  store i64 %selfRaw, i64* %42, align 8, !dbg !23, !tbaa !4
-  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !23
-  store i64 %40, i64* %43, align 8, !dbg !23, !tbaa !4
-  %44 = getelementptr inbounds i64, i64* %43, i64 1, !dbg !23
-  store i64* %44, i64** %41, align 8, !dbg !23
-  %send117 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !23
+  %40 = phi i64 [ %39, %38 ], [ 0, %36 ], [ 20, %27 ], !dbg !76
+  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !25
+  %42 = load i64*, i64** %41, align 8, !dbg !25
+  store i64 %selfRaw, i64* %42, align 8, !dbg !25, !tbaa !6
+  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !25
+  store i64 %40, i64* %43, align 8, !dbg !25, !tbaa !6
+  %44 = getelementptr inbounds i64, i64* %43, i64 1, !dbg !25
+  store i64* %44, i64** %41, align 8, !dbg !25
+  %send117 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !25
   ret i64 %send117
 }
 
@@ -581,7 +581,7 @@ declare void @llvm.assume(i1 noundef) #8
 define linkonce void @const_recompute_Bad() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 3)
   store i64 %1, i64* @guarded_const_Bad, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !40
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !42
   store i64 %2, i64* @guard_epoch_Bad, align 8
   ret void
 }
@@ -590,7 +590,7 @@ define linkonce void @const_recompute_Bad() local_unnamed_addr #9 {
 define linkonce void @const_recompute_Main() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0), i64 4)
   store i64 %1, i64* @guarded_const_Main, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !40
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !42
   store i64 %2, i64* @guard_epoch_Main, align 8
   ret void
 }
@@ -610,84 +610,86 @@ attributes #11 = { nounwind }
 attributes #12 = { nounwind allocsize(0,1) }
 attributes #13 = { noreturn }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/intrinsics/bang.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 22, column: 1, scope: !9)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !DILocation(line: 7, column: 5, scope: !14)
-!14 = distinct !DISubprogram(name: "Bad#!", linkageName: "func_Bad#!", scope: null, file: !2, line: 6, type: !10, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!15 = !DILocation(line: 6, column: 3, scope: !16)
-!16 = distinct !DISubprogram(name: "Bad.<static-init>", linkageName: "func_Bad.<static-init>L62", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!17 = !DILocation(line: 14, column: 5, scope: !18)
-!18 = distinct !DISubprogram(name: "Main.test", linkageName: "func_Main.test", scope: null, file: !2, line: 13, type: !10, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!19 = !DILocation(line: 15, column: 5, scope: !18)
-!20 = !DILocation(line: 16, column: 5, scope: !18)
-!21 = !DILocation(line: 17, column: 5, scope: !18)
-!22 = !DILocation(line: 18, column: 11, scope: !18)
-!23 = !DILocation(line: 18, column: 5, scope: !18)
-!24 = !DILocation(line: 13, column: 3, scope: !25)
-!25 = distinct !DISubprogram(name: "Main.<static-init>", linkageName: "func_Main.<static-init>L129", scope: null, file: !2, line: 12, type: !10, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!26 = !{!27, !27, i64 0}
-!27 = !{!"any pointer", !6, i64 0}
-!28 = !{!29, !27, i64 16}
-!29 = !{!"rb_execution_context_struct", !27, i64 0, !5, i64 8, !27, i64 16, !27, i64 24, !27, i64 32, !30, i64 40, !30, i64 44, !27, i64 48, !27, i64 56, !27, i64 64, !5, i64 72, !5, i64 80, !27, i64 88, !5, i64 96, !27, i64 104, !27, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !31, i64 152}
-!30 = !{!"int", !6, i64 0}
-!31 = !{!"", !27, i64 0, !27, i64 8, !5, i64 16, !6, i64 24}
-!32 = !{!33, !27, i64 16}
-!33 = !{!"rb_control_frame_struct", !27, i64 0, !27, i64 8, !27, i64 16, !5, i64 24, !27, i64 32, !27, i64 40, !27, i64 48}
-!34 = !{!33, !27, i64 32}
-!35 = !DILocation(line: 0, scope: !9)
-!36 = !DILocation(line: 5, column: 1, scope: !9)
-!37 = !DILocation(line: 0, scope: !16, inlinedAt: !38)
-!38 = distinct !DILocation(line: 5, column: 1, scope: !9)
-!39 = !DILocation(line: 6, column: 3, scope: !16, inlinedAt: !38)
-!40 = !{!41, !41, i64 0}
-!41 = !{!"long long", !6, i64 0}
-!42 = !{!"branch_weights", i32 1, i32 10000}
-!43 = !{!29, !30, i64 40}
-!44 = !{!29, !30, i64 44}
-!45 = !{!"branch_weights", i32 2000, i32 1}
-!46 = !{!29, !27, i64 56}
-!47 = !DILocation(line: 12, column: 1, scope: !9)
-!48 = !DILocation(line: 0, scope: !25, inlinedAt: !49)
-!49 = distinct !DILocation(line: 12, column: 1, scope: !9)
-!50 = !DILocation(line: 13, column: 3, scope: !25, inlinedAt: !49)
-!51 = !DILocation(line: 6, column: 3, scope: !14)
-!52 = !{!"branch_weights", i32 1, i32 2000}
-!53 = !DILocation(line: 0, scope: !14)
-!54 = !DILocation(line: 7, column: 10, scope: !14)
-!55 = !DILocation(line: 13, column: 3, scope: !18)
-!56 = !DILocation(line: 0, scope: !18)
-!57 = !{!58}
-!58 = distinct !{!58, !59, !"sorbet_bang: argument 0"}
-!59 = distinct !{!59, !"sorbet_bang"}
-!60 = !DILocation(line: 14, column: 10, scope: !18)
-!61 = !{!62}
-!62 = distinct !{!62, !63, !"sorbet_bang: argument 0"}
-!63 = distinct !{!63, !"sorbet_bang"}
-!64 = !DILocation(line: 15, column: 10, scope: !18)
-!65 = !{!66}
-!66 = distinct !{!66, !67, !"sorbet_bang: argument 0"}
-!67 = distinct !{!67, !"sorbet_bang"}
-!68 = !DILocation(line: 16, column: 10, scope: !18)
-!69 = !DILocation(line: 17, column: 11, scope: !18)
-!70 = !DILocation(line: 17, column: 10, scope: !18)
-!71 = !{!72}
-!72 = distinct !{!72, !73, !"sorbet_bang: argument 0"}
-!73 = distinct !{!73, !"sorbet_bang"}
-!74 = !DILocation(line: 18, column: 10, scope: !18)
-!75 = !{!76}
-!76 = distinct !{!76, !77, !"sorbet_bang: argument 0"}
-!77 = distinct !{!77, !"sorbet_bang"}
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/intrinsics/bang.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 22, column: 1, scope: !11)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !DILocation(line: 7, column: 5, scope: !16)
+!16 = distinct !DISubprogram(name: "Bad#!", linkageName: "func_Bad#!", scope: null, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!17 = !DILocation(line: 6, column: 3, scope: !18)
+!18 = distinct !DISubprogram(name: "Bad.<static-init>", linkageName: "func_Bad.<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!19 = !DILocation(line: 14, column: 5, scope: !20)
+!20 = distinct !DISubprogram(name: "Main.test", linkageName: "func_Main.test", scope: null, file: !4, line: 13, type: !12, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!21 = !DILocation(line: 15, column: 5, scope: !20)
+!22 = !DILocation(line: 16, column: 5, scope: !20)
+!23 = !DILocation(line: 17, column: 5, scope: !20)
+!24 = !DILocation(line: 18, column: 11, scope: !20)
+!25 = !DILocation(line: 18, column: 5, scope: !20)
+!26 = !DILocation(line: 13, column: 3, scope: !27)
+!27 = distinct !DISubprogram(name: "Main.<static-init>", linkageName: "func_Main.<static-init>L129", scope: null, file: !4, line: 12, type: !12, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!28 = !{!29, !29, i64 0}
+!29 = !{!"any pointer", !8, i64 0}
+!30 = !{!31, !29, i64 16}
+!31 = !{!"rb_execution_context_struct", !29, i64 0, !7, i64 8, !29, i64 16, !29, i64 24, !29, i64 32, !32, i64 40, !32, i64 44, !29, i64 48, !29, i64 56, !29, i64 64, !7, i64 72, !7, i64 80, !29, i64 88, !7, i64 96, !29, i64 104, !29, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !33, i64 152}
+!32 = !{!"int", !8, i64 0}
+!33 = !{!"", !29, i64 0, !29, i64 8, !7, i64 16, !8, i64 24}
+!34 = !{!35, !29, i64 16}
+!35 = !{!"rb_control_frame_struct", !29, i64 0, !29, i64 8, !29, i64 16, !7, i64 24, !29, i64 32, !29, i64 40, !29, i64 48}
+!36 = !{!35, !29, i64 32}
+!37 = !DILocation(line: 0, scope: !11)
+!38 = !DILocation(line: 5, column: 1, scope: !11)
+!39 = !DILocation(line: 0, scope: !18, inlinedAt: !40)
+!40 = distinct !DILocation(line: 5, column: 1, scope: !11)
+!41 = !DILocation(line: 6, column: 3, scope: !18, inlinedAt: !40)
+!42 = !{!43, !43, i64 0}
+!43 = !{!"long long", !8, i64 0}
+!44 = !{!"branch_weights", i32 1, i32 10000}
+!45 = !{!31, !32, i64 40}
+!46 = !{!31, !32, i64 44}
+!47 = !{!"branch_weights", i32 2000, i32 1}
+!48 = !{!31, !29, i64 56}
+!49 = !DILocation(line: 12, column: 1, scope: !11)
+!50 = !DILocation(line: 0, scope: !27, inlinedAt: !51)
+!51 = distinct !DILocation(line: 12, column: 1, scope: !11)
+!52 = !DILocation(line: 13, column: 3, scope: !27, inlinedAt: !51)
+!53 = !DILocation(line: 6, column: 3, scope: !16)
+!54 = !{!"branch_weights", i32 1, i32 2000}
+!55 = !DILocation(line: 0, scope: !16)
+!56 = !DILocation(line: 7, column: 10, scope: !16)
+!57 = !DILocation(line: 13, column: 3, scope: !20)
+!58 = !DILocation(line: 0, scope: !20)
+!59 = !{!60}
+!60 = distinct !{!60, !61, !"sorbet_bang: argument 0"}
+!61 = distinct !{!61, !"sorbet_bang"}
+!62 = !DILocation(line: 14, column: 10, scope: !20)
+!63 = !{!64}
+!64 = distinct !{!64, !65, !"sorbet_bang: argument 0"}
+!65 = distinct !{!65, !"sorbet_bang"}
+!66 = !DILocation(line: 15, column: 10, scope: !20)
+!67 = !{!68}
+!68 = distinct !{!68, !69, !"sorbet_bang: argument 0"}
+!69 = distinct !{!69, !"sorbet_bang"}
+!70 = !DILocation(line: 16, column: 10, scope: !20)
+!71 = !DILocation(line: 17, column: 11, scope: !20)
+!72 = !DILocation(line: 17, column: 10, scope: !20)
+!73 = !{!74}
+!74 = distinct !{!74, !75, !"sorbet_bang: argument 0"}
+!75 = distinct !{!75, !"sorbet_bang"}
+!76 = !DILocation(line: 18, column: 10, scope: !20)
+!77 = !{!78}
+!78 = distinct !{!78, !79, !"sorbet_bang: argument 0"}
+!79 = distinct !{!79, !"sorbet_bang"}

--- a/test/testdata/compiler/intrinsics/t_must.llo.exp
+++ b/test/testdata/compiler/intrinsics/t_must.llo.exp
@@ -208,130 +208,130 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #13
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #13
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_Test.<static-init>L62"(%struct.rb_control_frame_struct* %cfp) unnamed_addr #5 !dbg !8 {
+define internal fastcc void @"func_Test.<static-init>L62"(%struct.rb_control_frame_struct* %cfp) unnamed_addr #5 !dbg !10 {
 fastSymCallIntrinsic_Static_keep_self_def:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.<static-init>", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !14
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !18
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !20
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !20
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !22
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #14
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !21, !tbaa !12
-  %rubyId_test_known_nil = load i64, i64* @rubyIdPrecomputed_test_known_nil, align 8, !dbg !22
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_test_known_nil), !dbg !22
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !22
-  %rawSym17 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !22
-  %9 = load i64, i64* @guard_epoch_Test, align 8, !dbg !22
-  %10 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !23
-  %needTakeSlowPath = icmp ne i64 %9, %10, !dbg !22
-  br i1 %needTakeSlowPath, label %11, label %12, !dbg !22, !prof !25
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !23, !tbaa !14
+  %rubyId_test_known_nil = load i64, i64* @rubyIdPrecomputed_test_known_nil, align 8, !dbg !24
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_test_known_nil), !dbg !24
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !24
+  %rawSym17 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !24
+  %9 = load i64, i64* @guard_epoch_Test, align 8, !dbg !24
+  %10 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !25
+  %needTakeSlowPath = icmp ne i64 %9, %10, !dbg !24
+  br i1 %needTakeSlowPath, label %11, label %12, !dbg !24, !prof !27
 
 11:                                               ; preds = %fastSymCallIntrinsic_Static_keep_self_def
-  tail call void @const_recompute_Test(), !dbg !22
-  br label %12, !dbg !22
+  tail call void @const_recompute_Test(), !dbg !24
+  br label %12, !dbg !24
 
 12:                                               ; preds = %fastSymCallIntrinsic_Static_keep_self_def, %11
-  %13 = load i64, i64* @guarded_const_Test, align 8, !dbg !22
-  %14 = load i64, i64* @guard_epoch_Test, align 8, !dbg !22
-  %15 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !23
-  %guardUpdated = icmp eq i64 %14, %15, !dbg !22
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !22
-  %stackFrame18 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.test_known_nil, align 8, !dbg !22
-  %16 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !22
-  %17 = bitcast i8* %16 to i16*, !dbg !22
-  %18 = load i16, i16* %17, align 8, !dbg !22
-  %19 = and i16 %18, -384, !dbg !22
-  store i16 %19, i16* %17, align 8, !dbg !22
-  %20 = getelementptr inbounds i8, i8* %16, i64 4, !dbg !22
-  %21 = bitcast i8* %20 to i32*, !dbg !22
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %20, i8 0, i64 28, i1 false), !dbg !22
-  tail call void @sorbet_vm_define_method(i64 %13, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_test_known_nil, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_Test.test_known_nil, i8* nonnull %16, %struct.rb_iseq_struct* %stackFrame18, i1 noundef zeroext true) #14, !dbg !22
-  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !22, !tbaa !12
-  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 5, !dbg !22
-  %24 = load i32, i32* %23, align 8, !dbg !22, !tbaa !26
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 6, !dbg !22
-  %26 = load i32, i32* %25, align 4, !dbg !22, !tbaa !27
-  %27 = xor i32 %26, -1, !dbg !22
-  %28 = and i32 %27, %24, !dbg !22
-  %29 = icmp eq i32 %28, 0, !dbg !22
-  br i1 %29, label %fastSymCallIntrinsic_Static_keep_self_def31, label %30, !dbg !22, !prof !28
+  %13 = load i64, i64* @guarded_const_Test, align 8, !dbg !24
+  %14 = load i64, i64* @guard_epoch_Test, align 8, !dbg !24
+  %15 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !25
+  %guardUpdated = icmp eq i64 %14, %15, !dbg !24
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !24
+  %stackFrame18 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.test_known_nil, align 8, !dbg !24
+  %16 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !24
+  %17 = bitcast i8* %16 to i16*, !dbg !24
+  %18 = load i16, i16* %17, align 8, !dbg !24
+  %19 = and i16 %18, -384, !dbg !24
+  store i16 %19, i16* %17, align 8, !dbg !24
+  %20 = getelementptr inbounds i8, i8* %16, i64 4, !dbg !24
+  %21 = bitcast i8* %20 to i32*, !dbg !24
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %20, i8 0, i64 28, i1 false), !dbg !24
+  tail call void @sorbet_vm_define_method(i64 %13, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_test_known_nil, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_Test.test_known_nil, i8* nonnull %16, %struct.rb_iseq_struct* %stackFrame18, i1 noundef zeroext true) #14, !dbg !24
+  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !14
+  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 5, !dbg !24
+  %24 = load i32, i32* %23, align 8, !dbg !24, !tbaa !28
+  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 6, !dbg !24
+  %26 = load i32, i32* %25, align 4, !dbg !24, !tbaa !29
+  %27 = xor i32 %26, -1, !dbg !24
+  %28 = and i32 %27, %24, !dbg !24
+  %29 = icmp eq i32 %28, 0, !dbg !24
+  br i1 %29, label %fastSymCallIntrinsic_Static_keep_self_def31, label %30, !dbg !24, !prof !30
 
 30:                                               ; preds = %12
-  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 8, !dbg !22
-  %32 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %31, align 8, !dbg !22, !tbaa !29
-  %33 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %32, i32 noundef 0) #14, !dbg !22
-  br label %fastSymCallIntrinsic_Static_keep_self_def31, !dbg !22
+  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 8, !dbg !24
+  %32 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %31, align 8, !dbg !24, !tbaa !31
+  %33 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %32, i32 noundef 0) #14, !dbg !24
+  br label %fastSymCallIntrinsic_Static_keep_self_def31, !dbg !24
 
 afterSend28:                                      ; preds = %57, %fastSymCallIntrinsic_Static_keep_self_def31
   ret void
 
 fastSymCallIntrinsic_Static_keep_self_def31:      ; preds = %12, %30
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !22, !tbaa !12
-  %rubyId_test_nilable_arg = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !30
-  %rawSym23 = tail call i64 @rb_id2sym(i64 %rubyId_test_nilable_arg), !dbg !30
-  %rubyId_normal24 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !30
-  %rawSym25 = tail call i64 @rb_id2sym(i64 %rubyId_normal24), !dbg !30
-  %stackFrame32 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.test_nilable_arg, align 8, !dbg !30
-  %34 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !30
-  %35 = bitcast i8* %34 to i16*, !dbg !30
-  %36 = load i16, i16* %35, align 8, !dbg !30
-  %37 = and i16 %36, -384, !dbg !30
-  %38 = or i16 %37, 1, !dbg !30
-  store i16 %38, i16* %35, align 8, !dbg !30
-  %39 = getelementptr inbounds i8, i8* %34, i64 8, !dbg !30
-  %40 = bitcast i8* %39 to i32*, !dbg !30
-  store i32 1, i32* %40, align 8, !dbg !30, !tbaa !31
-  %41 = getelementptr inbounds i8, i8* %34, i64 12, !dbg !30
-  %42 = bitcast i8* %41 to i32*, !dbg !30
-  %43 = getelementptr inbounds i8, i8* %34, i64 4, !dbg !30
-  %44 = bitcast i8* %43 to i32*, !dbg !30
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %41, i8 0, i64 20, i1 false), !dbg !30
-  store i32 1, i32* %44, align 4, !dbg !30, !tbaa !34
-  %positional_table = alloca i64, align 8, !dbg !30
-  %rubyId_arg = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !30
-  store i64 %rubyId_arg, i64* %positional_table, align 8, !dbg !30
-  %45 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #15, !dbg !30
-  %46 = bitcast i64* %positional_table to i8*, !dbg !30
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %45, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %46, i64 noundef 8, i1 noundef false) #14, !dbg !30
-  %47 = getelementptr inbounds i8, i8* %34, i64 32, !dbg !30
-  %48 = bitcast i8* %47 to i8**, !dbg !30
-  store i8* %45, i8** %48, align 8, !dbg !30, !tbaa !35
-  tail call void @sorbet_vm_define_method(i64 %13, i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_Test.test_nilable_arg, i8* nonnull %34, %struct.rb_iseq_struct* %stackFrame32, i1 noundef zeroext true) #14, !dbg !30
-  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !12
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 5, !dbg !30
-  %51 = load i32, i32* %50, align 8, !dbg !30, !tbaa !26
-  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 6, !dbg !30
-  %53 = load i32, i32* %52, align 4, !dbg !30, !tbaa !27
-  %54 = xor i32 %53, -1, !dbg !30
-  %55 = and i32 %54, %51, !dbg !30
-  %56 = icmp eq i32 %55, 0, !dbg !30
-  br i1 %56, label %afterSend28, label %57, !dbg !30, !prof !28
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !24, !tbaa !14
+  %rubyId_test_nilable_arg = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !32
+  %rawSym23 = tail call i64 @rb_id2sym(i64 %rubyId_test_nilable_arg), !dbg !32
+  %rubyId_normal24 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !32
+  %rawSym25 = tail call i64 @rb_id2sym(i64 %rubyId_normal24), !dbg !32
+  %stackFrame32 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.test_nilable_arg, align 8, !dbg !32
+  %34 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !32
+  %35 = bitcast i8* %34 to i16*, !dbg !32
+  %36 = load i16, i16* %35, align 8, !dbg !32
+  %37 = and i16 %36, -384, !dbg !32
+  %38 = or i16 %37, 1, !dbg !32
+  store i16 %38, i16* %35, align 8, !dbg !32
+  %39 = getelementptr inbounds i8, i8* %34, i64 8, !dbg !32
+  %40 = bitcast i8* %39 to i32*, !dbg !32
+  store i32 1, i32* %40, align 8, !dbg !32, !tbaa !33
+  %41 = getelementptr inbounds i8, i8* %34, i64 12, !dbg !32
+  %42 = bitcast i8* %41 to i32*, !dbg !32
+  %43 = getelementptr inbounds i8, i8* %34, i64 4, !dbg !32
+  %44 = bitcast i8* %43 to i32*, !dbg !32
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %41, i8 0, i64 20, i1 false), !dbg !32
+  store i32 1, i32* %44, align 4, !dbg !32, !tbaa !36
+  %positional_table = alloca i64, align 8, !dbg !32
+  %rubyId_arg = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !32
+  store i64 %rubyId_arg, i64* %positional_table, align 8, !dbg !32
+  %45 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #15, !dbg !32
+  %46 = bitcast i64* %positional_table to i8*, !dbg !32
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %45, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %46, i64 noundef 8, i1 noundef false) #14, !dbg !32
+  %47 = getelementptr inbounds i8, i8* %34, i64 32, !dbg !32
+  %48 = bitcast i8* %47 to i8**, !dbg !32
+  store i8* %45, i8** %48, align 8, !dbg !32, !tbaa !37
+  tail call void @sorbet_vm_define_method(i64 %13, i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_Test.test_nilable_arg, i8* nonnull %34, %struct.rb_iseq_struct* %stackFrame32, i1 noundef zeroext true) #14, !dbg !32
+  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !32, !tbaa !14
+  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 5, !dbg !32
+  %51 = load i32, i32* %50, align 8, !dbg !32, !tbaa !28
+  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 6, !dbg !32
+  %53 = load i32, i32* %52, align 4, !dbg !32, !tbaa !29
+  %54 = xor i32 %53, -1, !dbg !32
+  %55 = and i32 %54, %51, !dbg !32
+  %56 = icmp eq i32 %55, 0, !dbg !32
+  br i1 %56, label %afterSend28, label %57, !dbg !32, !prof !30
 
 57:                                               ; preds = %fastSymCallIntrinsic_Static_keep_self_def31
-  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 8, !dbg !30
-  %59 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %58, align 8, !dbg !30, !tbaa !29
-  %60 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %59, i32 noundef 0) #14, !dbg !30
-  br label %afterSend28, !dbg !30
+  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 8, !dbg !32
+  %59 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %58, align 8, !dbg !32, !tbaa !31
+  %60 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %59, i32 noundef 0) #14, !dbg !32
+  br label %afterSend28, !dbg !32
 }
 
 ; Function Attrs: sspreq
@@ -386,14 +386,14 @@ entry:
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
   %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_test_known_nil.i = load i64, i64* @rubyIdPrecomputed_test_known_nil, align 8, !dbg !36
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_known_nil, i64 %rubyId_test_known_nil.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !36
-  %rubyId_test_nilable_arg.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !38
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !38
-  %rubyId_test_nilable_arg2.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !39
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.1, i64 %rubyId_test_nilable_arg2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !39
-  %rubyId_test_nilable_arg4.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !40
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.2, i64 %rubyId_test_nilable_arg4.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !40
+  %rubyId_test_known_nil.i = load i64, i64* @rubyIdPrecomputed_test_known_nil, align 8, !dbg !38
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_known_nil, i64 %rubyId_test_known_nil.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !38
+  %rubyId_test_nilable_arg.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !40
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !40
+  %rubyId_test_nilable_arg2.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !41
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.1, i64 %rubyId_test_nilable_arg2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !41
+  %rubyId_test_nilable_arg4.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !42
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.2, i64 %rubyId_test_nilable_arg4.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !42
   %19 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_test_known_nil, i64 0, i64 0), i64 noundef 14) #14
   call void @rb_gc_register_mark_object(i64 %19) #14
   %20 = bitcast i64* %locals.i23.i to i8*
@@ -432,12 +432,12 @@ entry:
   store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.test_known_nil$block_3", align 8
   %29 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #14
   store i64 %29, i64* @"<retry-singleton>", align 8
-  %rubyId_must.i = load i64, i64* @rubyIdPrecomputed_must, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_must, i64 %rubyId_must.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !41
-  %"rubyId_is_a?.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !44
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
+  %rubyId_must.i = load i64, i64* @rubyIdPrecomputed_must, align 8, !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_must, i64 %rubyId_must.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !43
+  %"rubyId_is_a?.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
   %30 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 noundef 16) #14
   call void @rb_gc_register_mark_object(i64 %30) #14
   %31 = bitcast i64* %locals.i28.i to i8*
@@ -472,623 +472,623 @@ entry:
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i40.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
   %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_ensure for.i39.i", i64 %"rubyId_ensure for.i38.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i40.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i37.i, i32 noundef 5, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
   store %struct.rb_iseq_struct* %38, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.test_nilable_arg$block_3", align 8
-  %rubyId_must9.i = load i64, i64* @rubyIdPrecomputed_must, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_must.3, i64 %rubyId_must9.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
+  %rubyId_must9.i = load i64, i64* @rubyIdPrecomputed_must, align 8, !dbg !49
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_must.3, i64 %rubyId_must9.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
   %39 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_ wasn't nil", i64 0, i64 0), i64 noundef 11) #14
   call void @rb_gc_register_mark_object(i64 %39) #14
   store i64 %39, i64* @"rubyStrFrozen_ wasn't nil", align 8
-  %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !50
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
-  %"rubyId_is_a?14.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !51
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?.5", i64 %"rubyId_is_a?14.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !51
-  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !53
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !53
+  %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !52
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !52
+  %"rubyId_is_a?14.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !53
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?.5", i64 %"rubyId_is_a?14.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !53
+  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !55
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !55
   %"rubyId_<top (required)>.i41.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i42.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i43.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
   %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i42.i", i64 %"rubyId_<top (required)>.i41.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i43.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i44.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.<static-init>", align 8
-  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !22
-  %rubyId_keep_self_def20.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !30
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def.7, i64 %rubyId_keep_self_def20.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !30
-  %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
+  %rubyId_keep_self_def20.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !32
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def.7, i64 %rubyId_keep_self_def20.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !32
+  %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 2
-  %43 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %42, align 8, !tbaa !14
+  %43 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %42, align 8, !tbaa !16
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %44, align 8, !tbaa !18
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %44, align 8, !tbaa !20
   %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 4
-  %46 = load i64*, i64** %45, align 8, !tbaa !20
-  %47 = load i64, i64* %46, align 8, !tbaa !4
+  %46 = load i64*, i64** %45, align 8, !tbaa !22
+  %47 = load i64, i64* %46, align 8, !tbaa !6
   %48 = and i64 %47, -33
-  store i64 %48, i64* %46, align 8, !tbaa !4
+  store i64 %48, i64* %46, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %41, %struct.rb_control_frame_struct* %43, %struct.rb_iseq_struct* %stackFrame.i) #14
   %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %49, align 8, !dbg !54, !tbaa !12
-  %50 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Test, i64 0, i64 0)) #14, !dbg !55
-  %51 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %50) #14, !dbg !55
-  call fastcc void @"func_Test.<static-init>L62"(%struct.rb_control_frame_struct* %51) #14, !dbg !55
-  call void @sorbet_popFrame() #14, !dbg !55
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %49, align 8, !dbg !55, !tbaa !12
-  %52 = load i64, i64* @guard_epoch_Test, align 8, !dbg !36
-  %53 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !36, !tbaa !23
-  %needTakeSlowPath = icmp ne i64 %52, %53, !dbg !36
-  br i1 %needTakeSlowPath, label %54, label %55, !dbg !36, !prof !25
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %49, align 8, !dbg !56, !tbaa !14
+  %50 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Test, i64 0, i64 0)) #14, !dbg !57
+  %51 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %50) #14, !dbg !57
+  call fastcc void @"func_Test.<static-init>L62"(%struct.rb_control_frame_struct* %51) #14, !dbg !57
+  call void @sorbet_popFrame() #14, !dbg !57
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %49, align 8, !dbg !57, !tbaa !14
+  %52 = load i64, i64* @guard_epoch_Test, align 8, !dbg !38
+  %53 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !25
+  %needTakeSlowPath = icmp ne i64 %52, %53, !dbg !38
+  br i1 %needTakeSlowPath, label %54, label %55, !dbg !38, !prof !27
 
 54:                                               ; preds = %entry
-  call void @const_recompute_Test(), !dbg !36
-  br label %55, !dbg !36
+  call void @const_recompute_Test(), !dbg !38
+  br label %55, !dbg !38
 
 55:                                               ; preds = %entry, %54
-  %56 = load i64, i64* @guarded_const_Test, align 8, !dbg !36
-  %57 = load i64, i64* @guard_epoch_Test, align 8, !dbg !36
-  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !36, !tbaa !23
-  %guardUpdated = icmp eq i64 %57, %58, !dbg !36
-  call void @llvm.assume(i1 %guardUpdated), !dbg !36
-  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !36
-  %60 = load i64*, i64** %59, align 8, !dbg !36
-  store i64 %56, i64* %60, align 8, !dbg !36, !tbaa !4
-  %61 = getelementptr inbounds i64, i64* %60, i64 1, !dbg !36
-  store i64* %61, i64** %59, align 8, !dbg !36
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_known_nil, i64 0), !dbg !36
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %49, align 8, !dbg !36, !tbaa !12
-  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !38
-  %63 = load i64*, i64** %62, align 8, !dbg !38
-  store i64 %56, i64* %63, align 8, !dbg !38, !tbaa !4
-  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !38
-  store i64 21, i64* %64, align 8, !dbg !38, !tbaa !4
-  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !38
-  store i64* %65, i64** %62, align 8, !dbg !38
-  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg, i64 0), !dbg !38
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %49, align 8, !dbg !38, !tbaa !12
-  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !39
-  %67 = load i64*, i64** %66, align 8, !dbg !39
-  store i64 %56, i64* %67, align 8, !dbg !39, !tbaa !4
-  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !39
-  store i64 0, i64* %68, align 8, !dbg !39, !tbaa !4
-  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !39
-  store i64* %69, i64** %66, align 8, !dbg !39
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.1, i64 0), !dbg !39
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %49, align 8, !dbg !39, !tbaa !12
-  %70 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !40
-  %71 = load i64*, i64** %70, align 8, !dbg !40
-  store i64 %56, i64* %71, align 8, !dbg !40, !tbaa !4
-  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !40
-  store i64 8, i64* %72, align 8, !dbg !40, !tbaa !4
-  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !40
-  store i64* %73, i64** %70, align 8, !dbg !40
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.2, i64 0), !dbg !40
+  %56 = load i64, i64* @guarded_const_Test, align 8, !dbg !38
+  %57 = load i64, i64* @guard_epoch_Test, align 8, !dbg !38
+  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !25
+  %guardUpdated = icmp eq i64 %57, %58, !dbg !38
+  call void @llvm.assume(i1 %guardUpdated), !dbg !38
+  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !38
+  %60 = load i64*, i64** %59, align 8, !dbg !38
+  store i64 %56, i64* %60, align 8, !dbg !38, !tbaa !6
+  %61 = getelementptr inbounds i64, i64* %60, i64 1, !dbg !38
+  store i64* %61, i64** %59, align 8, !dbg !38
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_known_nil, i64 0), !dbg !38
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %49, align 8, !dbg !38, !tbaa !14
+  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !40
+  %63 = load i64*, i64** %62, align 8, !dbg !40
+  store i64 %56, i64* %63, align 8, !dbg !40, !tbaa !6
+  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !40
+  store i64 21, i64* %64, align 8, !dbg !40, !tbaa !6
+  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !40
+  store i64* %65, i64** %62, align 8, !dbg !40
+  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg, i64 0), !dbg !40
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %49, align 8, !dbg !40, !tbaa !14
+  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !41
+  %67 = load i64*, i64** %66, align 8, !dbg !41
+  store i64 %56, i64* %67, align 8, !dbg !41, !tbaa !6
+  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !41
+  store i64 0, i64* %68, align 8, !dbg !41, !tbaa !6
+  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !41
+  store i64* %69, i64** %66, align 8, !dbg !41
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.1, i64 0), !dbg !41
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %49, align 8, !dbg !41, !tbaa !14
+  %70 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !42
+  %71 = load i64*, i64** %70, align 8, !dbg !42
+  store i64 %56, i64* %71, align 8, !dbg !42, !tbaa !6
+  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !42
+  store i64 8, i64* %72, align 8, !dbg !42, !tbaa !6
+  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !42
+  store i64* %73, i64** %70, align 8, !dbg !42
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.2, i64 0), !dbg !42
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @func_Test.test_known_nil(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !43 {
+define i64 @func_Test.test_known_nil(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !45 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !56
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !56, !prof !57
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !58
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !58, !prof !59
 
 postProcess:                                      ; preds = %fillRequiredArgs, %exception-continue
-  %"<returnValue>.sroa.0.0" = phi i64 [ %6, %exception-continue ], [ %2, %fillRequiredArgs ], !dbg !58
+  %"<returnValue>.sroa.0.0" = phi i64 [ %6, %exception-continue ], [ %2, %fillRequiredArgs ], !dbg !60
   ret i64 %"<returnValue>.sroa.0.0"
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #16, !dbg !56
-  unreachable, !dbg !56
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #16, !dbg !58
+  unreachable, !dbg !58
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !58, !tbaa !12
-  %1 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !59, !tbaa !12
-  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !59
-  %2 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %1, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_known_nil$block_1", i64** nonnull align 8 dereferenceable(8) %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_known_nil$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_known_nil$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_known_nil$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !59
-  %ensureReturnValue = icmp ne i64 %2, 52, !dbg !59
-  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !59
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !60, !tbaa !14
+  %1 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !61, !tbaa !14
+  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !61
+  %2 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %1, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_known_nil$block_1", i64** nonnull align 8 dereferenceable(8) %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_known_nil$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_known_nil$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_known_nil$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !61
+  %ensureReturnValue = icmp ne i64 %2, 52, !dbg !61
+  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !61
 
 exception-continue:                               ; preds = %fillRequiredArgs
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %0, align 8, !tbaa !12
-  %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !60
-  %4 = load i64*, i64** %3, align 8, !dbg !60, !tbaa !20
-  %5 = getelementptr inbounds i64, i64* %4, i64 -5, !dbg !60
-  %6 = load i64, i64* %5, align 8, !dbg !60, !tbaa !4
-  br label %postProcess, !dbg !60
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %0, align 8, !tbaa !14
+  %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !62
+  %4 = load i64*, i64** %3, align 8, !dbg !62, !tbaa !22
+  %5 = getelementptr inbounds i64, i64* %4, i64 -5, !dbg !62
+  %6 = load i64, i64* %5, align 8, !dbg !62, !tbaa !6
+  br label %postProcess, !dbg !62
 }
 
 ; Function Attrs: nounwind ssp
-define internal noundef i64 @"func_Test.test_known_nil$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* %cfp) #7 !dbg !42 {
+define internal noundef i64 @"func_Test.test_known_nil$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* %cfp) #7 !dbg !44 {
 fastSymCallIntrinsic_T_must:
   %callArgs = alloca [2 x i64], align 8
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !12
-  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !41
-  store i64 8, i64* %callArgs0Addr, align 8, !dbg !41
-  %0 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !41
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !61), !dbg !41
-  %1 = load i64, i64* %0, align 8, !dbg !41, !tbaa !4, !alias.scope !61
-  %2 = icmp eq i64 %1, 8, !dbg !41
-  br i1 %2, label %11, label %sorbet_T_must.exit, !dbg !41, !prof !57
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !14
+  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !43
+  store i64 8, i64* %callArgs0Addr, align 8, !dbg !43
+  %0 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !43
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !63), !dbg !43
+  %1 = load i64, i64* %0, align 8, !dbg !43, !tbaa !6, !alias.scope !63
+  %2 = icmp eq i64 %1, 8, !dbg !43
+  br i1 %2, label %11, label %sorbet_T_must.exit, !dbg !43, !prof !59
 
 afterSend:                                        ; preds = %21, %sorbet_T_must.exit
-  %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !41
-  %4 = load i64*, i64** %3, align 8, !dbg !41, !tbaa !20
-  %5 = load i64, i64* %4, align 8, !dbg !41, !tbaa !4
-  %6 = and i64 %5, 8, !dbg !41
-  %7 = icmp eq i64 %6, 0, !dbg !41
-  br i1 %7, label %8, label %10, !dbg !41, !prof !28
+  %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !43
+  %4 = load i64*, i64** %3, align 8, !dbg !43, !tbaa !22
+  %5 = load i64, i64* %4, align 8, !dbg !43, !tbaa !6
+  %6 = and i64 %5, 8, !dbg !43
+  %7 = icmp eq i64 %6, 0, !dbg !43
+  br i1 %7, label %8, label %10, !dbg !43, !prof !30
 
 8:                                                ; preds = %afterSend
-  %9 = getelementptr inbounds i64, i64* %4, i64 -5, !dbg !41
-  store i64 %1, i64* %9, align 8, !dbg !41, !tbaa !4
-  br label %sorbet_writeLocal.exit, !dbg !41
+  %9 = getelementptr inbounds i64, i64* %4, i64 -5, !dbg !43
+  store i64 %1, i64* %9, align 8, !dbg !43, !tbaa !6
+  br label %sorbet_writeLocal.exit, !dbg !43
 
 10:                                               ; preds = %afterSend
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %4, i32 noundef -5, i64 %1) #14, !dbg !41
-  br label %sorbet_writeLocal.exit, !dbg !41
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %4, i32 noundef -5, i64 %1) #14, !dbg !43
+  br label %sorbet_writeLocal.exit, !dbg !43
 
 sorbet_writeLocal.exit:                           ; preds = %8, %10
   ret i64 52
 
 11:                                               ; preds = %fastSymCallIntrinsic_T_must
-  %12 = load i64, i64* @rb_eTypeError, align 8, !dbg !41, !tbaa !4, !noalias !61
-  tail call void (i64, i8*, ...) @rb_raise(i64 %12, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #13, !dbg !41, !noalias !61
-  unreachable, !dbg !41
+  %12 = load i64, i64* @rb_eTypeError, align 8, !dbg !43, !tbaa !6, !noalias !63
+  tail call void (i64, i8*, ...) @rb_raise(i64 %12, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #13, !dbg !43, !noalias !63
+  unreachable, !dbg !43
 
 sorbet_T_must.exit:                               ; preds = %fastSymCallIntrinsic_T_must
-  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !41, !tbaa !12
-  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 5, !dbg !41
-  %15 = load i32, i32* %14, align 8, !dbg !41, !tbaa !26
-  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 6, !dbg !41
-  %17 = load i32, i32* %16, align 4, !dbg !41, !tbaa !27
-  %18 = xor i32 %17, -1, !dbg !41
-  %19 = and i32 %18, %15, !dbg !41
-  %20 = icmp eq i32 %19, 0, !dbg !41
-  br i1 %20, label %afterSend, label %21, !dbg !41, !prof !28
+  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !43, !tbaa !14
+  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 5, !dbg !43
+  %15 = load i32, i32* %14, align 8, !dbg !43, !tbaa !28
+  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 6, !dbg !43
+  %17 = load i32, i32* %16, align 4, !dbg !43, !tbaa !29
+  %18 = xor i32 %17, -1, !dbg !43
+  %19 = and i32 %18, %15, !dbg !43
+  %20 = icmp eq i32 %19, 0, !dbg !43
+  br i1 %20, label %afterSend, label %21, !dbg !43, !prof !30
 
 21:                                               ; preds = %sorbet_T_must.exit
-  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 8, !dbg !41
-  %23 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %22, align 8, !dbg !41, !tbaa !29
-  %24 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %23, i32 noundef 0) #14, !dbg !41
-  br label %afterSend, !dbg !41
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 8, !dbg !43
+  %23 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %22, align 8, !dbg !43, !tbaa !31
+  %24 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %23, i32 noundef 0) #14, !dbg !43
+  br label %afterSend, !dbg !43
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.test_known_nil$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !45 {
+define internal noundef i64 @"func_Test.test_known_nil$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !47 {
 vm_get_ep.exit34:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !14
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !64
+  %4 = load i64, i64* %3, align 8, !tbaa !66
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.test_known_nil$block_2", align 8
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #14
-  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %6 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %5, i64 0, i32 2
-  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !14
+  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !16
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !tbaa !12
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !44, !tbaa !12
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !44
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !44, !tbaa !14
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !44
-  %13 = load i64*, i64** %12, align 8, !dbg !44
-  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !44
-  %15 = load i64, i64* %14, align 8, !dbg !44, !tbaa !4
-  %16 = and i64 %15, -4, !dbg !44
-  %17 = inttoptr i64 %16 to i64*, !dbg !44
-  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !44
-  %19 = load i64, i64* %18, align 8, !dbg !44, !tbaa !4
-  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !44
-  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !44
-  %22 = load i64*, i64** %21, align 8, !dbg !44
-  store i64 %19, i64* %22, align 8, !dbg !44, !tbaa !4
-  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !44
-  store i64 %20, i64* %23, align 8, !dbg !44, !tbaa !4
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !44
-  store i64* %24, i64** %21, align 8, !dbg !44
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_is_a?", i64 0), !dbg !44
-  %25 = and i64 %send, -9, !dbg !44
-  %26 = icmp ne i64 %25, 0, !dbg !44
-  br i1 %26, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !44
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !tbaa !14
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !14
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !46
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !46, !tbaa !16
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !46
+  %13 = load i64*, i64** %12, align 8, !dbg !46
+  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !46
+  %15 = load i64, i64* %14, align 8, !dbg !46, !tbaa !6
+  %16 = and i64 %15, -4, !dbg !46
+  %17 = inttoptr i64 %16 to i64*, !dbg !46
+  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !46
+  %19 = load i64, i64* %18, align 8, !dbg !46, !tbaa !6
+  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !46
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !46
+  %22 = load i64*, i64** %21, align 8, !dbg !46
+  store i64 %19, i64* %22, align 8, !dbg !46, !tbaa !6
+  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !46
+  store i64 %20, i64* %23, align 8, !dbg !46, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !46
+  store i64* %24, i64** %21, align 8, !dbg !46
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_is_a?", i64 0), !dbg !46
+  %25 = and i64 %send, -9, !dbg !46
+  %26 = icmp ne i64 %25, 0, !dbg !46
+  br i1 %26, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !46
 
 blockExit:                                        ; preds = %78, %76, %63, %61
   tail call void @sorbet_popFrame()
   ret i64 52
 
 vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
-  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !12
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2, !dbg !65
-  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !dbg !65, !tbaa !14
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4, !dbg !65
-  %31 = load i64*, i64** %30, align 8, !dbg !65
-  %32 = getelementptr inbounds i64, i64* %31, i64 -1, !dbg !65
-  %33 = load i64, i64* %32, align 8, !dbg !65, !tbaa !4
-  %34 = and i64 %33, -4, !dbg !65
-  %35 = inttoptr i64 %34 to i64*, !dbg !65
-  %36 = load i64, i64* %35, align 8, !dbg !65, !tbaa !4
-  %37 = and i64 %36, 8, !dbg !65
-  %38 = icmp eq i64 %37, 0, !dbg !65
-  br i1 %38, label %39, label %41, !dbg !65, !prof !28
+  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !67, !tbaa !14
+  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2, !dbg !67
+  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !dbg !67, !tbaa !16
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4, !dbg !67
+  %31 = load i64*, i64** %30, align 8, !dbg !67
+  %32 = getelementptr inbounds i64, i64* %31, i64 -1, !dbg !67
+  %33 = load i64, i64* %32, align 8, !dbg !67, !tbaa !6
+  %34 = and i64 %33, -4, !dbg !67
+  %35 = inttoptr i64 %34 to i64*, !dbg !67
+  %36 = load i64, i64* %35, align 8, !dbg !67, !tbaa !6
+  %37 = and i64 %36, 8, !dbg !67
+  %38 = icmp eq i64 %37, 0, !dbg !67
+  br i1 %38, label %39, label %41, !dbg !67, !prof !30
 
 39:                                               ; preds = %vm_get_ep.exit32
-  %40 = getelementptr inbounds i64, i64* %35, i64 -3, !dbg !65
-  store i64 8, i64* %40, align 8, !dbg !65, !tbaa !4
-  br label %vm_get_ep.exit30, !dbg !65
+  %40 = getelementptr inbounds i64, i64* %35, i64 -3, !dbg !67
+  store i64 8, i64* %40, align 8, !dbg !67, !tbaa !6
+  br label %vm_get_ep.exit30, !dbg !67
 
 41:                                               ; preds = %vm_get_ep.exit32
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %35, i32 noundef -3, i64 noundef 8) #14, !dbg !65
-  br label %vm_get_ep.exit30, !dbg !65
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %35, i32 noundef -3, i64 noundef 8) #14, !dbg !67
+  br label %vm_get_ep.exit30, !dbg !67
 
 vm_get_ep.exit30:                                 ; preds = %39, %41
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %8, align 8, !dbg !66, !tbaa !12
-  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !12
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !46
-  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !46, !tbaa !14
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !46
-  %46 = load i64*, i64** %45, align 8, !dbg !46
-  store i64 %4, i64* %46, align 8, !dbg !46, !tbaa !4
-  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !46
-  store i64 %19, i64* %47, align 8, !dbg !46, !tbaa !4
-  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !46
-  store i64* %48, i64** %45, align 8, !dbg !46
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !46
-  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !12
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 2, !dbg !46
-  %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !46, !tbaa !14
-  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 4, !dbg !46
-  %53 = load i64*, i64** %52, align 8, !dbg !46
-  %54 = getelementptr inbounds i64, i64* %53, i64 -1, !dbg !46
-  %55 = load i64, i64* %54, align 8, !dbg !46, !tbaa !4
-  %56 = and i64 %55, -4, !dbg !46
-  %57 = inttoptr i64 %56 to i64*, !dbg !46
-  %58 = load i64, i64* %57, align 8, !dbg !46, !tbaa !4
-  %59 = and i64 %58, 8, !dbg !46
-  %60 = icmp eq i64 %59, 0, !dbg !46
-  br i1 %60, label %61, label %63, !dbg !46, !prof !28
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %8, align 8, !dbg !68, !tbaa !14
+  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !48, !tbaa !14
+  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !48
+  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !48, !tbaa !16
+  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !48
+  %46 = load i64*, i64** %45, align 8, !dbg !48
+  store i64 %4, i64* %46, align 8, !dbg !48, !tbaa !6
+  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !48
+  store i64 %19, i64* %47, align 8, !dbg !48, !tbaa !6
+  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !48
+  store i64* %48, i64** %45, align 8, !dbg !48
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !48
+  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !48, !tbaa !14
+  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 2, !dbg !48
+  %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !48, !tbaa !16
+  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 4, !dbg !48
+  %53 = load i64*, i64** %52, align 8, !dbg !48
+  %54 = getelementptr inbounds i64, i64* %53, i64 -1, !dbg !48
+  %55 = load i64, i64* %54, align 8, !dbg !48, !tbaa !6
+  %56 = and i64 %55, -4, !dbg !48
+  %57 = inttoptr i64 %56 to i64*, !dbg !48
+  %58 = load i64, i64* %57, align 8, !dbg !48, !tbaa !6
+  %59 = and i64 %58, 8, !dbg !48
+  %60 = icmp eq i64 %59, 0, !dbg !48
+  br i1 %60, label %61, label %63, !dbg !48, !prof !30
 
 61:                                               ; preds = %vm_get_ep.exit30
-  %62 = getelementptr inbounds i64, i64* %57, i64 -5, !dbg !46
-  store i64 %send42, i64* %62, align 8, !dbg !46, !tbaa !4
-  br label %blockExit, !dbg !46
+  %62 = getelementptr inbounds i64, i64* %57, i64 -5, !dbg !48
+  store i64 %send42, i64* %62, align 8, !dbg !48, !tbaa !6
+  br label %blockExit, !dbg !48
 
 63:                                               ; preds = %vm_get_ep.exit30
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %57, i32 noundef -5, i64 %send42) #14, !dbg !46
-  br label %blockExit, !dbg !46
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %57, i32 noundef -5, i64 %send42) #14, !dbg !48
+  br label %blockExit, !dbg !48
 
 vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !tbaa !12
-  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !67, !tbaa !12
-  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2, !dbg !67
-  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !dbg !67, !tbaa !14
-  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %66, i64 0, i32 4, !dbg !67
-  %68 = load i64*, i64** %67, align 8, !dbg !67
-  %69 = getelementptr inbounds i64, i64* %68, i64 -1, !dbg !67
-  %70 = load i64, i64* %69, align 8, !dbg !67, !tbaa !4
-  %71 = and i64 %70, -4, !dbg !67
-  %72 = inttoptr i64 %71 to i64*, !dbg !67
-  %73 = load i64, i64* %72, align 8, !dbg !67, !tbaa !4
-  %74 = and i64 %73, 8, !dbg !67
-  %75 = icmp eq i64 %74, 0, !dbg !67
-  br i1 %75, label %76, label %78, !dbg !67, !prof !28
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !tbaa !14
+  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !69, !tbaa !14
+  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2, !dbg !69
+  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !dbg !69, !tbaa !16
+  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %66, i64 0, i32 4, !dbg !69
+  %68 = load i64*, i64** %67, align 8, !dbg !69
+  %69 = getelementptr inbounds i64, i64* %68, i64 -1, !dbg !69
+  %70 = load i64, i64* %69, align 8, !dbg !69, !tbaa !6
+  %71 = and i64 %70, -4, !dbg !69
+  %72 = inttoptr i64 %71 to i64*, !dbg !69
+  %73 = load i64, i64* %72, align 8, !dbg !69, !tbaa !6
+  %74 = and i64 %73, 8, !dbg !69
+  %75 = icmp eq i64 %74, 0, !dbg !69
+  br i1 %75, label %76, label %78, !dbg !69, !prof !30
 
 76:                                               ; preds = %vm_get_ep.exit
-  %77 = getelementptr inbounds i64, i64* %72, i64 -6, !dbg !67
-  store i64 20, i64* %77, align 8, !dbg !67, !tbaa !4
-  br label %blockExit, !dbg !67
+  %77 = getelementptr inbounds i64, i64* %72, i64 -6, !dbg !69
+  store i64 20, i64* %77, align 8, !dbg !69, !tbaa !6
+  br label %blockExit, !dbg !69
 
 78:                                               ; preds = %vm_get_ep.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %72, i32 noundef -6, i64 noundef 20) #14, !dbg !67
-  br label %blockExit, !dbg !67
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %72, i32 noundef -6, i64 noundef 20) #14, !dbg !69
+  br label %blockExit, !dbg !69
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.test_known_nil$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !68 {
+define internal noundef i64 @"func_Test.test_known_nil$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !70 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.test_known_nil$block_3", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !14
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #14
-  %3 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %3 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %4 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %3, i64 0, i32 2
-  %5 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %4, align 8, !tbaa !14
+  %5 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %4, align 8, !tbaa !16
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %6, align 8, !tbaa !12
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %6, align 8, !tbaa !14
   tail call void @sorbet_popFrame()
   ret i64 52
 }
 
 ; Function Attrs: argmemonly nofree norecurse nosync nounwind ssp willreturn writeonly
-define internal noundef i64 @"func_Test.test_known_nil$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !69 {
+define internal noundef i64 @"func_Test.test_known_nil$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !71 {
 functionEntryInitializers:
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %pc, align 8, !tbaa !12
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %pc, align 8, !tbaa !14
   ret i64 52
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @func_Test.test_nilable_arg(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !49 {
+define i64 @func_Test.test_nilable_arg(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !51 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !70
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !70
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !70
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !70, !prof !71
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !72
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !72
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !72
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !72, !prof !73
 
 postProcess:                                      ; preds = %sorbet_writeLocal.exit, %exception-continue
-  %"<returnValue>.sroa.0.0" = phi i64 [ %13, %exception-continue ], [ %10, %sorbet_writeLocal.exit ], !dbg !72
+  %"<returnValue>.sroa.0.0" = phi i64 [ %13, %exception-continue ], [ %10, %sorbet_writeLocal.exit ], !dbg !74
   ret i64 %"<returnValue>.sroa.0.0"
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #16, !dbg !70
-  unreachable, !dbg !70
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #16, !dbg !72
+  unreachable, !dbg !72
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !70
-  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !70
-  %2 = load i64*, i64** %1, align 8, !dbg !70, !tbaa !20
-  %3 = load i64, i64* %2, align 8, !dbg !70, !tbaa !4
-  %4 = and i64 %3, 8, !dbg !70
-  %5 = icmp eq i64 %4, 0, !dbg !70
-  br i1 %5, label %6, label %8, !dbg !70, !prof !28
+  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !72
+  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !72
+  %2 = load i64*, i64** %1, align 8, !dbg !72, !tbaa !22
+  %3 = load i64, i64* %2, align 8, !dbg !72, !tbaa !6
+  %4 = and i64 %3, 8, !dbg !72
+  %5 = icmp eq i64 %4, 0, !dbg !72
+  br i1 %5, label %6, label %8, !dbg !72, !prof !30
 
 6:                                                ; preds = %fillRequiredArgs
-  %7 = getelementptr inbounds i64, i64* %2, i64 -4, !dbg !70
-  store i64 %rawArg_arg, i64* %7, align 8, !dbg !70, !tbaa !4
-  br label %sorbet_writeLocal.exit, !dbg !70
+  %7 = getelementptr inbounds i64, i64* %2, i64 -4, !dbg !72
+  store i64 %rawArg_arg, i64* %7, align 8, !dbg !72, !tbaa !6
+  br label %sorbet_writeLocal.exit, !dbg !72
 
 8:                                                ; preds = %fillRequiredArgs
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %2, i32 noundef -4, i64 %rawArg_arg) #14, !dbg !70
-  br label %sorbet_writeLocal.exit, !dbg !70
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %2, i32 noundef -4, i64 %rawArg_arg) #14, !dbg !72
+  br label %sorbet_writeLocal.exit, !dbg !72
 
 sorbet_writeLocal.exit:                           ; preds = %6, %8
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !dbg !72, !tbaa !12
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !73, !tbaa !12
-  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !73
-  %10 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %9, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_nilable_arg$block_1", i64** nonnull %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_nilable_arg$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_nilable_arg$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_nilable_arg$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !73
-  %ensureReturnValue = icmp ne i64 %10, 52, !dbg !73
-  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !73
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !dbg !74, !tbaa !14
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !75, !tbaa !14
+  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !75
+  %10 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %9, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_nilable_arg$block_1", i64** nonnull %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_nilable_arg$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_nilable_arg$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.test_nilable_arg$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !75
+  %ensureReturnValue = icmp ne i64 %10, 52, !dbg !75
+  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !75
 
 exception-continue:                               ; preds = %sorbet_writeLocal.exit
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %0, align 8, !tbaa !12
-  %11 = load i64*, i64** %1, align 8, !dbg !74, !tbaa !20
-  %12 = getelementptr inbounds i64, i64* %11, i64 -6, !dbg !74
-  %13 = load i64, i64* %12, align 8, !dbg !74, !tbaa !4
-  br label %postProcess, !dbg !74
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %0, align 8, !tbaa !14
+  %11 = load i64*, i64** %1, align 8, !dbg !76, !tbaa !22
+  %12 = getelementptr inbounds i64, i64* %11, i64 -6, !dbg !76
+  %13 = load i64, i64* %12, align 8, !dbg !76, !tbaa !6
+  br label %postProcess, !dbg !76
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.test_nilable_arg$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(40) %cfp) #8 !dbg !48 {
+define internal noundef i64 @"func_Test.test_nilable_arg$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(40) %cfp) #8 !dbg !50 {
 fastSymCallIntrinsic_T_must:
   %callArgs = alloca [3 x i64], align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !14
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !64
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !tbaa !12
-  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !47
-  %6 = load i64*, i64** %5, align 8, !dbg !47, !tbaa !20
-  %7 = getelementptr inbounds i64, i64* %6, i64 -4, !dbg !47
-  %8 = load i64, i64* %7, align 8, !dbg !47, !tbaa !4
-  %callArgs0Addr = getelementptr [3 x i64], [3 x i64]* %callArgs, i32 0, i64 0, !dbg !47
-  store i64 %8, i64* %callArgs0Addr, align 8, !dbg !47
-  %9 = getelementptr [3 x i64], [3 x i64]* %callArgs, i64 0, i64 0, !dbg !47
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !75), !dbg !47
-  %10 = load i64, i64* %9, align 8, !dbg !47, !tbaa !4, !alias.scope !75
-  %11 = icmp eq i64 %10, 8, !dbg !47
-  br i1 %11, label %26, label %sorbet_T_must.exit, !dbg !47, !prof !57
+  %4 = load i64, i64* %3, align 8, !tbaa !66
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !tbaa !14
+  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !49
+  %6 = load i64*, i64** %5, align 8, !dbg !49, !tbaa !22
+  %7 = getelementptr inbounds i64, i64* %6, i64 -4, !dbg !49
+  %8 = load i64, i64* %7, align 8, !dbg !49, !tbaa !6
+  %callArgs0Addr = getelementptr [3 x i64], [3 x i64]* %callArgs, i32 0, i64 0, !dbg !49
+  store i64 %8, i64* %callArgs0Addr, align 8, !dbg !49
+  %9 = getelementptr [3 x i64], [3 x i64]* %callArgs, i64 0, i64 0, !dbg !49
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !77), !dbg !49
+  %10 = load i64, i64* %9, align 8, !dbg !49, !tbaa !6, !alias.scope !77
+  %11 = icmp eq i64 %10, 8, !dbg !49
+  br i1 %11, label %26, label %sorbet_T_must.exit, !dbg !49, !prof !59
 
 afterSend:                                        ; preds = %36, %sorbet_T_must.exit
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %pc, align 8, !dbg !47, !tbaa !12
-  %"rubyStr_ wasn't nil" = load i64, i64* @"rubyStrFrozen_ wasn't nil", align 8, !dbg !78
-  %12 = load i64*, i64** %5, align 8, !dbg !79, !tbaa !20
-  %13 = getelementptr inbounds i64, i64* %12, i64 -4, !dbg !79
-  %14 = load i64, i64* %13, align 8, !dbg !79, !tbaa !4
-  store i64 %14, i64* %callArgs0Addr, align 8, !dbg !79
-  %callArgs1Addr = getelementptr [3 x i64], [3 x i64]* %callArgs, i32 0, i64 1, !dbg !79
-  store i64 %"rubyStr_ wasn't nil", i64* %callArgs1Addr, align 8, !dbg !79
-  %"rubyId_<string-interpolate>" = load i64, i64* @"rubyIdPrecomputed_<string-interpolate>", align 8, !dbg !79
-  %rawSendResult13 = call i64 @sorbet_stringInterpolate(i64 noundef 8, i64 %"rubyId_<string-interpolate>", i32 noundef 2, i64* noundef nonnull %9, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0), !dbg !79
-  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !50
-  %16 = load i64*, i64** %15, align 8, !dbg !50
-  store i64 %4, i64* %16, align 8, !dbg !50, !tbaa !4
-  %17 = getelementptr inbounds i64, i64* %16, i64 1, !dbg !50
-  store i64 %rawSendResult13, i64* %17, align 8, !dbg !50, !tbaa !4
-  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !50
-  store i64* %18, i64** %15, align 8, !dbg !50
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !50
-  %19 = load i64*, i64** %5, align 8, !dbg !50, !tbaa !20
-  %20 = load i64, i64* %19, align 8, !dbg !50, !tbaa !4
-  %21 = and i64 %20, 8, !dbg !50
-  %22 = icmp eq i64 %21, 0, !dbg !50
-  br i1 %22, label %23, label %25, !dbg !50, !prof !28
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %pc, align 8, !dbg !49, !tbaa !14
+  %"rubyStr_ wasn't nil" = load i64, i64* @"rubyStrFrozen_ wasn't nil", align 8, !dbg !80
+  %12 = load i64*, i64** %5, align 8, !dbg !81, !tbaa !22
+  %13 = getelementptr inbounds i64, i64* %12, i64 -4, !dbg !81
+  %14 = load i64, i64* %13, align 8, !dbg !81, !tbaa !6
+  store i64 %14, i64* %callArgs0Addr, align 8, !dbg !81
+  %callArgs1Addr = getelementptr [3 x i64], [3 x i64]* %callArgs, i32 0, i64 1, !dbg !81
+  store i64 %"rubyStr_ wasn't nil", i64* %callArgs1Addr, align 8, !dbg !81
+  %"rubyId_<string-interpolate>" = load i64, i64* @"rubyIdPrecomputed_<string-interpolate>", align 8, !dbg !81
+  %rawSendResult13 = call i64 @sorbet_stringInterpolate(i64 noundef 8, i64 %"rubyId_<string-interpolate>", i32 noundef 2, i64* noundef nonnull %9, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0), !dbg !81
+  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !52
+  %16 = load i64*, i64** %15, align 8, !dbg !52
+  store i64 %4, i64* %16, align 8, !dbg !52, !tbaa !6
+  %17 = getelementptr inbounds i64, i64* %16, i64 1, !dbg !52
+  store i64 %rawSendResult13, i64* %17, align 8, !dbg !52, !tbaa !6
+  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !52
+  store i64* %18, i64** %15, align 8, !dbg !52
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !52
+  %19 = load i64*, i64** %5, align 8, !dbg !52, !tbaa !22
+  %20 = load i64, i64* %19, align 8, !dbg !52, !tbaa !6
+  %21 = and i64 %20, 8, !dbg !52
+  %22 = icmp eq i64 %21, 0, !dbg !52
+  br i1 %22, label %23, label %25, !dbg !52, !prof !30
 
 23:                                               ; preds = %afterSend
-  %24 = getelementptr inbounds i64, i64* %19, i64 -6, !dbg !50
-  store i64 %send, i64* %24, align 8, !dbg !50, !tbaa !4
-  br label %sorbet_writeLocal.exit, !dbg !50
+  %24 = getelementptr inbounds i64, i64* %19, i64 -6, !dbg !52
+  store i64 %send, i64* %24, align 8, !dbg !52, !tbaa !6
+  br label %sorbet_writeLocal.exit, !dbg !52
 
 25:                                               ; preds = %afterSend
-  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %19, i32 noundef -6, i64 %send) #14, !dbg !50
-  br label %sorbet_writeLocal.exit, !dbg !50
+  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %19, i32 noundef -6, i64 %send) #14, !dbg !52
+  br label %sorbet_writeLocal.exit, !dbg !52
 
 sorbet_writeLocal.exit:                           ; preds = %23, %25
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !dbg !50, !tbaa !12
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !dbg !52, !tbaa !14
   ret i64 52
 
 26:                                               ; preds = %fastSymCallIntrinsic_T_must
-  %27 = load i64, i64* @rb_eTypeError, align 8, !dbg !47, !tbaa !4, !noalias !75
-  tail call void (i64, i8*, ...) @rb_raise(i64 %27, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #13, !dbg !47, !noalias !75
-  unreachable, !dbg !47
+  %27 = load i64, i64* @rb_eTypeError, align 8, !dbg !49, !tbaa !6, !noalias !77
+  tail call void (i64, i8*, ...) @rb_raise(i64 %27, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #13, !dbg !49, !noalias !77
+  unreachable, !dbg !49
 
 sorbet_T_must.exit:                               ; preds = %fastSymCallIntrinsic_T_must
-  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !12
-  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 5, !dbg !47
-  %30 = load i32, i32* %29, align 8, !dbg !47, !tbaa !26
-  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 6, !dbg !47
-  %32 = load i32, i32* %31, align 4, !dbg !47, !tbaa !27
-  %33 = xor i32 %32, -1, !dbg !47
-  %34 = and i32 %33, %30, !dbg !47
-  %35 = icmp eq i32 %34, 0, !dbg !47
-  br i1 %35, label %afterSend, label %36, !dbg !47, !prof !28
+  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !14
+  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 5, !dbg !49
+  %30 = load i32, i32* %29, align 8, !dbg !49, !tbaa !28
+  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 6, !dbg !49
+  %32 = load i32, i32* %31, align 4, !dbg !49, !tbaa !29
+  %33 = xor i32 %32, -1, !dbg !49
+  %34 = and i32 %33, %30, !dbg !49
+  %35 = icmp eq i32 %34, 0, !dbg !49
+  br i1 %35, label %afterSend, label %36, !dbg !49, !prof !30
 
 36:                                               ; preds = %sorbet_T_must.exit
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 8, !dbg !47
-  %38 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %37, align 8, !dbg !47, !tbaa !29
-  %39 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %38, i32 noundef 0) #14, !dbg !47
-  br label %afterSend, !dbg !47
+  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 8, !dbg !49
+  %38 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %37, align 8, !dbg !49, !tbaa !31
+  %39 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %38, i32 noundef 0) #14, !dbg !49
+  br label %afterSend, !dbg !49
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.test_nilable_arg$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !52 {
+define internal noundef i64 @"func_Test.test_nilable_arg$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !54 {
 vm_get_ep.exit34:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !14
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !64
+  %4 = load i64, i64* %3, align 8, !tbaa !66
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.test_nilable_arg$block_2", align 8
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #14
-  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %6 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %5, i64 0, i32 2
-  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !14
+  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !16
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !tbaa !12
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !51, !tbaa !12
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !51
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !51, !tbaa !14
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !51
-  %13 = load i64*, i64** %12, align 8, !dbg !51
-  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !51
-  %15 = load i64, i64* %14, align 8, !dbg !51, !tbaa !4
-  %16 = and i64 %15, -4, !dbg !51
-  %17 = inttoptr i64 %16 to i64*, !dbg !51
-  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !51
-  %19 = load i64, i64* %18, align 8, !dbg !51, !tbaa !4
-  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !51
-  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !51
-  %22 = load i64*, i64** %21, align 8, !dbg !51
-  store i64 %19, i64* %22, align 8, !dbg !51, !tbaa !4
-  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !51
-  store i64 %20, i64* %23, align 8, !dbg !51, !tbaa !4
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !51
-  store i64* %24, i64** %21, align 8, !dbg !51
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_is_a?.5", i64 0), !dbg !51
-  %25 = and i64 %send, -9, !dbg !51
-  %26 = icmp ne i64 %25, 0, !dbg !51
-  br i1 %26, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !51
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !tbaa !14
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !53, !tbaa !14
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !53
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !53, !tbaa !16
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !53
+  %13 = load i64*, i64** %12, align 8, !dbg !53
+  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !53
+  %15 = load i64, i64* %14, align 8, !dbg !53, !tbaa !6
+  %16 = and i64 %15, -4, !dbg !53
+  %17 = inttoptr i64 %16 to i64*, !dbg !53
+  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !53
+  %19 = load i64, i64* %18, align 8, !dbg !53, !tbaa !6
+  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !53
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !53
+  %22 = load i64*, i64** %21, align 8, !dbg !53
+  store i64 %19, i64* %22, align 8, !dbg !53, !tbaa !6
+  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !53
+  store i64 %20, i64* %23, align 8, !dbg !53, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !53
+  store i64* %24, i64** %21, align 8, !dbg !53
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_is_a?.5", i64 0), !dbg !53
+  %25 = and i64 %send, -9, !dbg !53
+  %26 = icmp ne i64 %25, 0, !dbg !53
+  br i1 %26, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !53
 
 blockExit:                                        ; preds = %78, %76, %63, %61
   tail call void @sorbet_popFrame()
   ret i64 52
 
 vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
-  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !12
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2, !dbg !80
-  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !dbg !80, !tbaa !14
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4, !dbg !80
-  %31 = load i64*, i64** %30, align 8, !dbg !80
-  %32 = getelementptr inbounds i64, i64* %31, i64 -1, !dbg !80
-  %33 = load i64, i64* %32, align 8, !dbg !80, !tbaa !4
-  %34 = and i64 %33, -4, !dbg !80
-  %35 = inttoptr i64 %34 to i64*, !dbg !80
-  %36 = load i64, i64* %35, align 8, !dbg !80, !tbaa !4
-  %37 = and i64 %36, 8, !dbg !80
-  %38 = icmp eq i64 %37, 0, !dbg !80
-  br i1 %38, label %39, label %41, !dbg !80, !prof !28
+  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !82, !tbaa !14
+  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2, !dbg !82
+  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !dbg !82, !tbaa !16
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4, !dbg !82
+  %31 = load i64*, i64** %30, align 8, !dbg !82
+  %32 = getelementptr inbounds i64, i64* %31, i64 -1, !dbg !82
+  %33 = load i64, i64* %32, align 8, !dbg !82, !tbaa !6
+  %34 = and i64 %33, -4, !dbg !82
+  %35 = inttoptr i64 %34 to i64*, !dbg !82
+  %36 = load i64, i64* %35, align 8, !dbg !82, !tbaa !6
+  %37 = and i64 %36, 8, !dbg !82
+  %38 = icmp eq i64 %37, 0, !dbg !82
+  br i1 %38, label %39, label %41, !dbg !82, !prof !30
 
 39:                                               ; preds = %vm_get_ep.exit32
-  %40 = getelementptr inbounds i64, i64* %35, i64 -3, !dbg !80
-  store i64 8, i64* %40, align 8, !dbg !80, !tbaa !4
-  br label %vm_get_ep.exit30, !dbg !80
+  %40 = getelementptr inbounds i64, i64* %35, i64 -3, !dbg !82
+  store i64 8, i64* %40, align 8, !dbg !82, !tbaa !6
+  br label %vm_get_ep.exit30, !dbg !82
 
 41:                                               ; preds = %vm_get_ep.exit32
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %35, i32 noundef -3, i64 noundef 8) #14, !dbg !80
-  br label %vm_get_ep.exit30, !dbg !80
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %35, i32 noundef -3, i64 noundef 8) #14, !dbg !82
+  br label %vm_get_ep.exit30, !dbg !82
 
 vm_get_ep.exit30:                                 ; preds = %39, %41
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %8, align 8, !dbg !81, !tbaa !12
-  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !53, !tbaa !12
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !53
-  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !53, !tbaa !14
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !53
-  %46 = load i64*, i64** %45, align 8, !dbg !53
-  store i64 %4, i64* %46, align 8, !dbg !53, !tbaa !4
-  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !53
-  store i64 %19, i64* %47, align 8, !dbg !53, !tbaa !4
-  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !53
-  store i64* %48, i64** %45, align 8, !dbg !53
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !53
-  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !53, !tbaa !12
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 2, !dbg !53
-  %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !53, !tbaa !14
-  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 4, !dbg !53
-  %53 = load i64*, i64** %52, align 8, !dbg !53
-  %54 = getelementptr inbounds i64, i64* %53, i64 -1, !dbg !53
-  %55 = load i64, i64* %54, align 8, !dbg !53, !tbaa !4
-  %56 = and i64 %55, -4, !dbg !53
-  %57 = inttoptr i64 %56 to i64*, !dbg !53
-  %58 = load i64, i64* %57, align 8, !dbg !53, !tbaa !4
-  %59 = and i64 %58, 8, !dbg !53
-  %60 = icmp eq i64 %59, 0, !dbg !53
-  br i1 %60, label %61, label %63, !dbg !53, !prof !28
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %8, align 8, !dbg !83, !tbaa !14
+  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !55, !tbaa !14
+  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !55
+  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !55, !tbaa !16
+  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !55
+  %46 = load i64*, i64** %45, align 8, !dbg !55
+  store i64 %4, i64* %46, align 8, !dbg !55, !tbaa !6
+  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !55
+  store i64 %19, i64* %47, align 8, !dbg !55, !tbaa !6
+  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !55
+  store i64* %48, i64** %45, align 8, !dbg !55
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !55
+  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !55, !tbaa !14
+  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 2, !dbg !55
+  %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !55, !tbaa !16
+  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 4, !dbg !55
+  %53 = load i64*, i64** %52, align 8, !dbg !55
+  %54 = getelementptr inbounds i64, i64* %53, i64 -1, !dbg !55
+  %55 = load i64, i64* %54, align 8, !dbg !55, !tbaa !6
+  %56 = and i64 %55, -4, !dbg !55
+  %57 = inttoptr i64 %56 to i64*, !dbg !55
+  %58 = load i64, i64* %57, align 8, !dbg !55, !tbaa !6
+  %59 = and i64 %58, 8, !dbg !55
+  %60 = icmp eq i64 %59, 0, !dbg !55
+  br i1 %60, label %61, label %63, !dbg !55, !prof !30
 
 61:                                               ; preds = %vm_get_ep.exit30
-  %62 = getelementptr inbounds i64, i64* %57, i64 -6, !dbg !53
-  store i64 %send42, i64* %62, align 8, !dbg !53, !tbaa !4
-  br label %blockExit, !dbg !53
+  %62 = getelementptr inbounds i64, i64* %57, i64 -6, !dbg !55
+  store i64 %send42, i64* %62, align 8, !dbg !55, !tbaa !6
+  br label %blockExit, !dbg !55
 
 63:                                               ; preds = %vm_get_ep.exit30
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %57, i32 noundef -6, i64 %send42) #14, !dbg !53
-  br label %blockExit, !dbg !53
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %57, i32 noundef -6, i64 %send42) #14, !dbg !55
+  br label %blockExit, !dbg !55
 
 vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %8, align 8, !tbaa !12
-  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !82, !tbaa !12
-  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2, !dbg !82
-  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !dbg !82, !tbaa !14
-  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %66, i64 0, i32 4, !dbg !82
-  %68 = load i64*, i64** %67, align 8, !dbg !82
-  %69 = getelementptr inbounds i64, i64* %68, i64 -1, !dbg !82
-  %70 = load i64, i64* %69, align 8, !dbg !82, !tbaa !4
-  %71 = and i64 %70, -4, !dbg !82
-  %72 = inttoptr i64 %71 to i64*, !dbg !82
-  %73 = load i64, i64* %72, align 8, !dbg !82, !tbaa !4
-  %74 = and i64 %73, 8, !dbg !82
-  %75 = icmp eq i64 %74, 0, !dbg !82
-  br i1 %75, label %76, label %78, !dbg !82, !prof !28
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %8, align 8, !tbaa !14
+  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !84, !tbaa !14
+  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2, !dbg !84
+  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !dbg !84, !tbaa !16
+  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %66, i64 0, i32 4, !dbg !84
+  %68 = load i64*, i64** %67, align 8, !dbg !84
+  %69 = getelementptr inbounds i64, i64* %68, i64 -1, !dbg !84
+  %70 = load i64, i64* %69, align 8, !dbg !84, !tbaa !6
+  %71 = and i64 %70, -4, !dbg !84
+  %72 = inttoptr i64 %71 to i64*, !dbg !84
+  %73 = load i64, i64* %72, align 8, !dbg !84, !tbaa !6
+  %74 = and i64 %73, 8, !dbg !84
+  %75 = icmp eq i64 %74, 0, !dbg !84
+  br i1 %75, label %76, label %78, !dbg !84, !prof !30
 
 76:                                               ; preds = %vm_get_ep.exit
-  %77 = getelementptr inbounds i64, i64* %72, i64 -7, !dbg !82
-  store i64 20, i64* %77, align 8, !dbg !82, !tbaa !4
-  br label %blockExit, !dbg !82
+  %77 = getelementptr inbounds i64, i64* %72, i64 -7, !dbg !84
+  store i64 20, i64* %77, align 8, !dbg !84, !tbaa !6
+  br label %blockExit, !dbg !84
 
 78:                                               ; preds = %vm_get_ep.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %72, i32 noundef -7, i64 noundef 20) #14, !dbg !82
-  br label %blockExit, !dbg !82
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %72, i32 noundef -7, i64 noundef 20) #14, !dbg !84
+  br label %blockExit, !dbg !84
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.test_nilable_arg$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !83 {
+define internal noundef i64 @"func_Test.test_nilable_arg$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !85 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.test_nilable_arg$block_3", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !14
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #14
-  %3 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %3 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %4 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %3, i64 0, i32 2
-  %5 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %4, align 8, !tbaa !14
+  %5 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %4, align 8, !tbaa !16
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %6, align 8, !tbaa !12
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %6, align 8, !tbaa !14
   tail call void @sorbet_popFrame()
   ret i64 52
 }
 
 ; Function Attrs: argmemonly nofree norecurse nosync nounwind ssp willreturn writeonly
-define internal noundef i64 @"func_Test.test_nilable_arg$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !84 {
+define internal noundef i64 @"func_Test.test_nilable_arg$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !86 {
 functionEntryInitializers:
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %pc, align 8, !tbaa !12
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %pc, align 8, !tbaa !14
   ret i64 52
 }
 
@@ -1111,7 +1111,7 @@ declare void @llvm.assume(i1 noundef) #12
 define linkonce void @const_recompute_Test() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @str_Test, i64 0, i64 0), i64 4)
   store i64 %1, i64* @guarded_const_Test, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !23
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !25
   store i64 %2, i64* @guard_epoch_Test, align 8
   ret void
 }
@@ -1134,91 +1134,93 @@ attributes #14 = { nounwind }
 attributes #15 = { nounwind allocsize(0,1) }
 attributes #16 = { noreturn }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/intrinsics/t_must.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "Test.<static-init>", linkageName: "func_Test.<static-init>L62", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = !DISubroutineType(types: !10)
-!10 = !{!11}
-!11 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!12 = !{!13, !13, i64 0}
-!13 = !{!"any pointer", !6, i64 0}
-!14 = !{!15, !13, i64 16}
-!15 = !{!"rb_execution_context_struct", !13, i64 0, !5, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !16, i64 40, !16, i64 44, !13, i64 48, !13, i64 56, !13, i64 64, !5, i64 72, !5, i64 80, !13, i64 88, !5, i64 96, !13, i64 104, !13, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !17, i64 152}
-!16 = !{!"int", !6, i64 0}
-!17 = !{!"", !13, i64 0, !13, i64 8, !5, i64 16, !6, i64 24}
-!18 = !{!19, !13, i64 16}
-!19 = !{!"rb_control_frame_struct", !13, i64 0, !13, i64 8, !13, i64 16, !5, i64 24, !13, i64 32, !13, i64 40, !13, i64 48}
-!20 = !{!19, !13, i64 32}
-!21 = !DILocation(line: 0, scope: !8)
-!22 = !DILocation(line: 6, column: 3, scope: !8)
-!23 = !{!24, !24, i64 0}
-!24 = !{!"long long", !6, i64 0}
-!25 = !{!"branch_weights", i32 1, i32 10000}
-!26 = !{!15, !16, i64 40}
-!27 = !{!15, !16, i64 44}
-!28 = !{!"branch_weights", i32 2000, i32 1}
-!29 = !{!15, !13, i64 56}
-!30 = !DILocation(line: 14, column: 3, scope: !8)
-!31 = !{!32, !16, i64 8}
-!32 = !{!"rb_sorbet_param_struct", !33, i64 0, !16, i64 4, !16, i64 8, !16, i64 12, !16, i64 16, !16, i64 20, !16, i64 24, !16, i64 28, !13, i64 32, !16, i64 40, !16, i64 44, !16, i64 48, !16, i64 52, !13, i64 56}
-!33 = !{!"", !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 1, !16, i64 1}
-!34 = !{!32, !16, i64 4}
-!35 = !{!32, !13, i64 32}
-!36 = !DILocation(line: 24, column: 1, scope: !37)
-!37 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!38 = !DILocation(line: 25, column: 1, scope: !37)
-!39 = !DILocation(line: 26, column: 1, scope: !37)
-!40 = !DILocation(line: 27, column: 1, scope: !37)
-!41 = !DILocation(line: 8, column: 7, scope: !42)
-!42 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.test_known_nil$block_1", scope: !43, file: !2, line: 6, type: !9, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!43 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.test_known_nil", scope: null, file: !2, line: 6, type: !9, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!44 = !DILocation(line: 9, column: 15, scope: !45)
-!45 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.test_known_nil$block_2", scope: !43, file: !2, line: 6, type: !9, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!46 = !DILocation(line: 10, column: 7, scope: !45)
-!47 = !DILocation(line: 16, column: 7, scope: !48)
-!48 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.test_nilable_arg$block_1", scope: !49, file: !2, line: 14, type: !9, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!49 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.test_nilable_arg", scope: null, file: !2, line: 14, type: !9, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!50 = !DILocation(line: 17, column: 7, scope: !48)
-!51 = !DILocation(line: 18, column: 15, scope: !52)
-!52 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.test_nilable_arg$block_2", scope: !49, file: !2, line: 14, type: !9, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!53 = !DILocation(line: 19, column: 7, scope: !52)
-!54 = !DILocation(line: 0, scope: !37)
-!55 = !DILocation(line: 5, column: 1, scope: !37)
-!56 = !DILocation(line: 6, column: 3, scope: !43)
-!57 = !{!"branch_weights", i32 1, i32 2000}
-!58 = !DILocation(line: 0, scope: !43)
-!59 = !DILocation(line: 8, column: 7, scope: !43)
-!60 = !DILocation(line: 12, column: 3, scope: !43)
-!61 = !{!62}
-!62 = distinct !{!62, !63, !"sorbet_T_must: argument 0"}
-!63 = distinct !{!63, !"sorbet_T_must"}
-!64 = !{!19, !5, i64 24}
-!65 = !DILocation(line: 0, scope: !45)
-!66 = !DILocation(line: 9, column: 5, scope: !45)
-!67 = !DILocation(line: 8, column: 7, scope: !45)
-!68 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.test_known_nil$block_3", scope: !43, file: !2, line: 6, type: !9, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!69 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.test_known_nil$block_4", scope: !43, file: !2, line: 6, type: !9, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!70 = !DILocation(line: 14, column: 3, scope: !49)
-!71 = !{!"branch_weights", i32 4001, i32 4000000}
-!72 = !DILocation(line: 0, scope: !49)
-!73 = !DILocation(line: 16, column: 7, scope: !49)
-!74 = !DILocation(line: 21, column: 3, scope: !49)
-!75 = !{!76}
-!76 = distinct !{!76, !77, !"sorbet_T_must: argument 0"}
-!77 = distinct !{!77, !"sorbet_T_must"}
-!78 = !DILocation(line: 17, column: 19, scope: !48)
-!79 = !DILocation(line: 17, column: 12, scope: !48)
-!80 = !DILocation(line: 0, scope: !52)
-!81 = !DILocation(line: 18, column: 5, scope: !52)
-!82 = !DILocation(line: 16, column: 7, scope: !52)
-!83 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.test_nilable_arg$block_3", scope: !49, file: !2, line: 14, type: !9, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!84 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.test_nilable_arg$block_4", scope: !49, file: !2, line: 14, type: !9, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/intrinsics/t_must.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "Test.<static-init>", linkageName: "func_Test.<static-init>L62", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!14 = !{!15, !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !{!17, !15, i64 16}
+!17 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !18, i64 40, !18, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !19, i64 152}
+!18 = !{!"int", !8, i64 0}
+!19 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!20 = !{!21, !15, i64 16}
+!21 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!22 = !{!21, !15, i64 32}
+!23 = !DILocation(line: 0, scope: !10)
+!24 = !DILocation(line: 6, column: 3, scope: !10)
+!25 = !{!26, !26, i64 0}
+!26 = !{!"long long", !8, i64 0}
+!27 = !{!"branch_weights", i32 1, i32 10000}
+!28 = !{!17, !18, i64 40}
+!29 = !{!17, !18, i64 44}
+!30 = !{!"branch_weights", i32 2000, i32 1}
+!31 = !{!17, !15, i64 56}
+!32 = !DILocation(line: 14, column: 3, scope: !10)
+!33 = !{!34, !18, i64 8}
+!34 = !{!"rb_sorbet_param_struct", !35, i64 0, !18, i64 4, !18, i64 8, !18, i64 12, !18, i64 16, !18, i64 20, !18, i64 24, !18, i64 28, !15, i64 32, !18, i64 40, !18, i64 44, !18, i64 48, !18, i64 52, !15, i64 56}
+!35 = !{!"", !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 1, !18, i64 1}
+!36 = !{!34, !18, i64 4}
+!37 = !{!34, !15, i64 32}
+!38 = !DILocation(line: 24, column: 1, scope: !39)
+!39 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!40 = !DILocation(line: 25, column: 1, scope: !39)
+!41 = !DILocation(line: 26, column: 1, scope: !39)
+!42 = !DILocation(line: 27, column: 1, scope: !39)
+!43 = !DILocation(line: 8, column: 7, scope: !44)
+!44 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.test_known_nil$block_1", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!45 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.test_known_nil", scope: null, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!46 = !DILocation(line: 9, column: 15, scope: !47)
+!47 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.test_known_nil$block_2", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!48 = !DILocation(line: 10, column: 7, scope: !47)
+!49 = !DILocation(line: 16, column: 7, scope: !50)
+!50 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.test_nilable_arg$block_1", scope: !51, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!51 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.test_nilable_arg", scope: null, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!52 = !DILocation(line: 17, column: 7, scope: !50)
+!53 = !DILocation(line: 18, column: 15, scope: !54)
+!54 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.test_nilable_arg$block_2", scope: !51, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!55 = !DILocation(line: 19, column: 7, scope: !54)
+!56 = !DILocation(line: 0, scope: !39)
+!57 = !DILocation(line: 5, column: 1, scope: !39)
+!58 = !DILocation(line: 6, column: 3, scope: !45)
+!59 = !{!"branch_weights", i32 1, i32 2000}
+!60 = !DILocation(line: 0, scope: !45)
+!61 = !DILocation(line: 8, column: 7, scope: !45)
+!62 = !DILocation(line: 12, column: 3, scope: !45)
+!63 = !{!64}
+!64 = distinct !{!64, !65, !"sorbet_T_must: argument 0"}
+!65 = distinct !{!65, !"sorbet_T_must"}
+!66 = !{!21, !7, i64 24}
+!67 = !DILocation(line: 0, scope: !47)
+!68 = !DILocation(line: 9, column: 5, scope: !47)
+!69 = !DILocation(line: 8, column: 7, scope: !47)
+!70 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.test_known_nil$block_3", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!71 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.test_known_nil$block_4", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!72 = !DILocation(line: 14, column: 3, scope: !51)
+!73 = !{!"branch_weights", i32 4001, i32 4000000}
+!74 = !DILocation(line: 0, scope: !51)
+!75 = !DILocation(line: 16, column: 7, scope: !51)
+!76 = !DILocation(line: 21, column: 3, scope: !51)
+!77 = !{!78}
+!78 = distinct !{!78, !79, !"sorbet_T_must: argument 0"}
+!79 = distinct !{!79, !"sorbet_T_must"}
+!80 = !DILocation(line: 17, column: 19, scope: !50)
+!81 = !DILocation(line: 17, column: 12, scope: !50)
+!82 = !DILocation(line: 0, scope: !54)
+!83 = !DILocation(line: 18, column: 5, scope: !54)
+!84 = !DILocation(line: 16, column: 7, scope: !54)
+!85 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.test_nilable_arg$block_3", scope: !51, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!86 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.test_nilable_arg$block_4", scope: !51, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)

--- a/test/testdata/compiler/literal_hash.llo.exp
+++ b/test/testdata/compiler/literal_hash.llo.exp
@@ -158,14 +158,14 @@ declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #5
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #5
   unreachable
 }
@@ -335,70 +335,70 @@ entry:
   %38 = call i64 @sorbet_globalConstRegister(i64 %37) #6
   store i64 %38, i64* @ruby_hashLiteral7, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %20)
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 7, i32 noundef 0, i64* noundef null), !dbg !8
-  %39 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !13
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 7, i32 noundef 0, i64* noundef null), !dbg !10
+  %39 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
   %40 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %39, i64 0, i32 18
-  %41 = load i64, i64* %40, align 8, !tbaa !15
-  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %41 = load i64, i64* %40, align 8, !tbaa !17
+  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2
-  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !tbaa !25
+  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !tbaa !27
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %45, align 8, !tbaa !28
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %45, align 8, !tbaa !30
   %46 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 4
-  %47 = load i64*, i64** %46, align 8, !tbaa !30
-  %48 = load i64, i64* %47, align 8, !tbaa !4
+  %47 = load i64*, i64** %46, align 8, !tbaa !32
+  %48 = load i64, i64* %47, align 8, !tbaa !6
   %49 = and i64 %48, -33
-  store i64 %49, i64* %47, align 8, !tbaa !4
+  store i64 %49, i64* %47, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %42, %struct.rb_control_frame_struct* %44, %struct.rb_iseq_struct* %stackFrame.i) #6
   %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 0
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %50, align 8, !dbg !31, !tbaa !13
-  %rubyId_do.i = load i64, i64* @rubyIdPrecomputed_do, align 8, !dbg !32
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_do.i) #6, !dbg !32
-  %hashLiteral.i = load i64, i64* @ruby_hashLiteral1, align 8, !dbg !33
-  %duplicatedHash.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral.i) #6, !dbg !33
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %50, align 8, !dbg !33, !tbaa !13
-  %hashLiteral81.i = load i64, i64* @ruby_hashLiteral2, align 8, !dbg !34
-  %duplicatedHash82.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral81.i) #6, !dbg !34
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %50, align 8, !dbg !34, !tbaa !13
-  %hashLiteral88.i = load i64, i64* @ruby_hashLiteral3, align 8, !dbg !35
-  %duplicatedHash89.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral88.i) #6, !dbg !35
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %50, align 8, !dbg !35, !tbaa !13
-  %hashLiteral95.i = load i64, i64* @ruby_hashLiteral4, align 8, !dbg !36
-  %duplicatedHash96.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral95.i) #6, !dbg !36
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %50, align 8, !dbg !36, !tbaa !13
-  %hashLiteral102.i = load i64, i64* @ruby_hashLiteral5, align 8, !dbg !37
-  %duplicatedHash103.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral102.i) #6, !dbg !37
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %50, align 8, !dbg !37, !tbaa !13
-  %hashLiteral109.i = load i64, i64* @ruby_hashLiteral6, align 8, !dbg !38
-  %duplicatedHash110.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral109.i) #6, !dbg !38
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %50, align 8, !dbg !38, !tbaa !13
-  %rubyId_symbol.i = load i64, i64* @rubyIdPrecomputed_symbol, align 8, !dbg !39
-  %rawSym111.i = call i64 @rb_id2sym(i64 %rubyId_symbol.i) #6, !dbg !39
-  %hashLiteral116.i = load i64, i64* @ruby_hashLiteral7, align 8, !dbg !40
-  %duplicatedHash117.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral116.i) #6, !dbg !40
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %50, align 8, !dbg !40, !tbaa !13
-  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !8
-  %52 = load i64*, i64** %51, align 8, !dbg !8
-  store i64 %41, i64* %52, align 8, !dbg !8, !tbaa !4
-  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !8
-  store i64 %duplicatedHash.i, i64* %53, align 8, !dbg !8, !tbaa !4
-  %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !8
-  store i64 %duplicatedHash82.i, i64* %54, align 8, !dbg !8, !tbaa !4
-  %55 = getelementptr inbounds i64, i64* %54, i64 1, !dbg !8
-  store i64 %duplicatedHash89.i, i64* %55, align 8, !dbg !8, !tbaa !4
-  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !8
-  store i64 %duplicatedHash96.i, i64* %56, align 8, !dbg !8, !tbaa !4
-  %57 = getelementptr inbounds i64, i64* %56, i64 1, !dbg !8
-  store i64 %duplicatedHash103.i, i64* %57, align 8, !dbg !8, !tbaa !4
-  %58 = getelementptr inbounds i64, i64* %57, i64 1, !dbg !8
-  store i64 %duplicatedHash110.i, i64* %58, align 8, !dbg !8, !tbaa !4
-  %59 = getelementptr inbounds i64, i64* %58, i64 1, !dbg !8
-  store i64 %duplicatedHash117.i, i64* %59, align 8, !dbg !8, !tbaa !4
-  %60 = getelementptr inbounds i64, i64* %59, i64 1, !dbg !8
-  store i64* %60, i64** %51, align 8, !dbg !8
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !8
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %50, align 8, !dbg !33, !tbaa !15
+  %rubyId_do.i = load i64, i64* @rubyIdPrecomputed_do, align 8, !dbg !34
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_do.i) #6, !dbg !34
+  %hashLiteral.i = load i64, i64* @ruby_hashLiteral1, align 8, !dbg !35
+  %duplicatedHash.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral.i) #6, !dbg !35
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %50, align 8, !dbg !35, !tbaa !15
+  %hashLiteral81.i = load i64, i64* @ruby_hashLiteral2, align 8, !dbg !36
+  %duplicatedHash82.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral81.i) #6, !dbg !36
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %50, align 8, !dbg !36, !tbaa !15
+  %hashLiteral88.i = load i64, i64* @ruby_hashLiteral3, align 8, !dbg !37
+  %duplicatedHash89.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral88.i) #6, !dbg !37
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %50, align 8, !dbg !37, !tbaa !15
+  %hashLiteral95.i = load i64, i64* @ruby_hashLiteral4, align 8, !dbg !38
+  %duplicatedHash96.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral95.i) #6, !dbg !38
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %50, align 8, !dbg !38, !tbaa !15
+  %hashLiteral102.i = load i64, i64* @ruby_hashLiteral5, align 8, !dbg !39
+  %duplicatedHash103.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral102.i) #6, !dbg !39
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %50, align 8, !dbg !39, !tbaa !15
+  %hashLiteral109.i = load i64, i64* @ruby_hashLiteral6, align 8, !dbg !40
+  %duplicatedHash110.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral109.i) #6, !dbg !40
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %50, align 8, !dbg !40, !tbaa !15
+  %rubyId_symbol.i = load i64, i64* @rubyIdPrecomputed_symbol, align 8, !dbg !41
+  %rawSym111.i = call i64 @rb_id2sym(i64 %rubyId_symbol.i) #6, !dbg !41
+  %hashLiteral116.i = load i64, i64* @ruby_hashLiteral7, align 8, !dbg !42
+  %duplicatedHash117.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral116.i) #6, !dbg !42
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %50, align 8, !dbg !42, !tbaa !15
+  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !10
+  %52 = load i64*, i64** %51, align 8, !dbg !10
+  store i64 %41, i64* %52, align 8, !dbg !10, !tbaa !6
+  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !10
+  store i64 %duplicatedHash.i, i64* %53, align 8, !dbg !10, !tbaa !6
+  %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !10
+  store i64 %duplicatedHash82.i, i64* %54, align 8, !dbg !10, !tbaa !6
+  %55 = getelementptr inbounds i64, i64* %54, i64 1, !dbg !10
+  store i64 %duplicatedHash89.i, i64* %55, align 8, !dbg !10, !tbaa !6
+  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !10
+  store i64 %duplicatedHash96.i, i64* %56, align 8, !dbg !10, !tbaa !6
+  %57 = getelementptr inbounds i64, i64* %56, i64 1, !dbg !10
+  store i64 %duplicatedHash103.i, i64* %57, align 8, !dbg !10, !tbaa !6
+  %58 = getelementptr inbounds i64, i64* %57, i64 1, !dbg !10
+  store i64 %duplicatedHash110.i, i64* %58, align 8, !dbg !10, !tbaa !6
+  %59 = getelementptr inbounds i64, i64* %58, i64 1, !dbg !10
+  store i64 %duplicatedHash117.i, i64* %59, align 8, !dbg !10, !tbaa !6
+  %60 = getelementptr inbounds i64, i64* %59, i64 1, !dbg !10
+  store i64* %60, i64** %51, align 8, !dbg !10
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
   ret void
 }
 
@@ -416,47 +416,49 @@ attributes #4 = { argmemonly nofree nosync nounwind willreturn }
 attributes #5 = { noreturn nounwind }
 attributes #6 = { nounwind }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/literal_hash.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 14, column: 1, scope: !9)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 6, type: !10, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !{!14, !14, i64 0}
-!14 = !{!"any pointer", !6, i64 0}
-!15 = !{!16, !5, i64 400}
-!16 = !{!"rb_vm_struct", !5, i64 0, !17, i64 8, !14, i64 192, !14, i64 200, !14, i64 208, !21, i64 216, !6, i64 224, !18, i64 264, !18, i64 280, !18, i64 296, !18, i64 312, !5, i64 328, !20, i64 336, !20, i64 340, !20, i64 344, !20, i64 344, !20, i64 344, !20, i64 344, !20, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !14, i64 456, !14, i64 464, !22, i64 472, !23, i64 992, !14, i64 1016, !14, i64 1024, !20, i64 1032, !20, i64 1036, !18, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !20, i64 1136, !14, i64 1144, !14, i64 1152, !14, i64 1160, !14, i64 1168, !14, i64 1176, !14, i64 1184, !20, i64 1192, !24, i64 1200, !6, i64 1232}
-!17 = !{!"rb_global_vm_lock_struct", !14, i64 0, !6, i64 8, !18, i64 48, !14, i64 64, !20, i64 72, !6, i64 80, !6, i64 128, !20, i64 176, !20, i64 180}
-!18 = !{!"list_head", !19, i64 0}
-!19 = !{!"list_node", !14, i64 0, !14, i64 8}
-!20 = !{!"int", !6, i64 0}
-!21 = !{!"long long", !6, i64 0}
-!22 = !{!"", !6, i64 0}
-!23 = !{!"rb_hook_list_struct", !14, i64 0, !20, i64 8, !20, i64 12, !20, i64 16}
-!24 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!25 = !{!26, !14, i64 16}
-!26 = !{!"rb_execution_context_struct", !14, i64 0, !5, i64 8, !14, i64 16, !14, i64 24, !14, i64 32, !20, i64 40, !20, i64 44, !14, i64 48, !14, i64 56, !14, i64 64, !5, i64 72, !5, i64 80, !14, i64 88, !5, i64 96, !14, i64 104, !14, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !27, i64 152}
-!27 = !{!"", !14, i64 0, !14, i64 8, !5, i64 16, !6, i64 24}
-!28 = !{!29, !14, i64 16}
-!29 = !{!"rb_control_frame_struct", !14, i64 0, !14, i64 8, !14, i64 16, !5, i64 24, !14, i64 32, !14, i64 40, !14, i64 48}
-!30 = !{!29, !14, i64 32}
-!31 = !DILocation(line: 0, scope: !9)
-!32 = !DILocation(line: 6, column: 99, scope: !9)
-!33 = !DILocation(line: 6, column: 5, scope: !9)
-!34 = !DILocation(line: 8, column: 5, scope: !9)
-!35 = !DILocation(line: 9, column: 5, scope: !9)
-!36 = !DILocation(line: 10, column: 5, scope: !9)
-!37 = !DILocation(line: 11, column: 5, scope: !9)
-!38 = !DILocation(line: 12, column: 5, scope: !9)
-!39 = !DILocation(line: 13, column: 7, scope: !9)
-!40 = !DILocation(line: 13, column: 5, scope: !9)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/literal_hash.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 14, column: 1, scope: !11)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !{!16, !16, i64 0}
+!16 = !{!"any pointer", !8, i64 0}
+!17 = !{!18, !7, i64 400}
+!18 = !{!"rb_vm_struct", !7, i64 0, !19, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !23, i64 216, !8, i64 224, !20, i64 264, !20, i64 280, !20, i64 296, !20, i64 312, !7, i64 328, !22, i64 336, !22, i64 340, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !24, i64 472, !25, i64 992, !16, i64 1016, !16, i64 1024, !22, i64 1032, !22, i64 1036, !20, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !22, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !22, i64 1192, !26, i64 1200, !8, i64 1232}
+!19 = !{!"rb_global_vm_lock_struct", !16, i64 0, !8, i64 8, !20, i64 48, !16, i64 64, !22, i64 72, !8, i64 80, !8, i64 128, !22, i64 176, !22, i64 180}
+!20 = !{!"list_head", !21, i64 0}
+!21 = !{!"list_node", !16, i64 0, !16, i64 8}
+!22 = !{!"int", !8, i64 0}
+!23 = !{!"long long", !8, i64 0}
+!24 = !{!"", !8, i64 0}
+!25 = !{!"rb_hook_list_struct", !16, i64 0, !22, i64 8, !22, i64 12, !22, i64 16}
+!26 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!27 = !{!28, !16, i64 16}
+!28 = !{!"rb_execution_context_struct", !16, i64 0, !7, i64 8, !16, i64 16, !16, i64 24, !16, i64 32, !22, i64 40, !22, i64 44, !16, i64 48, !16, i64 56, !16, i64 64, !7, i64 72, !7, i64 80, !16, i64 88, !7, i64 96, !16, i64 104, !16, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !29, i64 152}
+!29 = !{!"", !16, i64 0, !16, i64 8, !7, i64 16, !8, i64 24}
+!30 = !{!31, !16, i64 16}
+!31 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !7, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
+!32 = !{!31, !16, i64 32}
+!33 = !DILocation(line: 0, scope: !11)
+!34 = !DILocation(line: 6, column: 99, scope: !11)
+!35 = !DILocation(line: 6, column: 5, scope: !11)
+!36 = !DILocation(line: 8, column: 5, scope: !11)
+!37 = !DILocation(line: 9, column: 5, scope: !11)
+!38 = !DILocation(line: 10, column: 5, scope: !11)
+!39 = !DILocation(line: 11, column: 5, scope: !11)
+!40 = !DILocation(line: 12, column: 5, scope: !11)
+!41 = !DILocation(line: 13, column: 7, scope: !11)
+!42 = !DILocation(line: 13, column: 5, scope: !11)

--- a/test/testdata/compiler/literals.llo.exp
+++ b/test/testdata/compiler/literals.llo.exp
@@ -127,14 +127,14 @@ declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #4
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #4
   unreachable
 }
@@ -162,105 +162,105 @@ entry:
   %"rubyStr_test/testdata/compiler/literals.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/literals.rb", align 8
   %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/literals.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !8
-  %rubyId_puts1.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !13
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !13
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
+  %rubyId_puts1.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
   %6 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_str, i64 0, i64 0), i64 noundef 3) #5
   call void @rb_gc_register_mark_object(i64 %6) #5
   store i64 %6, i64* @rubyStrFrozen_str, align 8
-  %rubyId_puts4.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !14
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts4.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !14
-  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %rubyId_puts10.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !16
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts10.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
-  %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !18
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !19
+  %rubyId_puts4.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !16
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts4.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
+  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
+  %rubyId_puts10.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !18
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts10.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
+  %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !20
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
+  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !21
   %8 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %7, i64 0, i32 18
-  %9 = load i64, i64* %8, align 8, !tbaa !21
-  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !19
+  %9 = load i64, i64* %8, align 8, !tbaa !23
+  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !21
   %11 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %10, i64 0, i32 2
-  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !31
+  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !33
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !34
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !36
   %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 4
-  %15 = load i64*, i64** %14, align 8, !tbaa !36
-  %16 = load i64, i64* %15, align 8, !tbaa !4
+  %15 = load i64*, i64** %14, align 8, !tbaa !38
+  %16 = load i64, i64* %15, align 8, !tbaa !6
   %17 = and i64 %16, -33
-  store i64 %17, i64* %15, align 8, !tbaa !4
+  store i64 %17, i64* %15, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #5
   %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !37, !tbaa !19
-  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !8
-  %20 = load i64*, i64** %19, align 8, !dbg !8
-  store i64 %9, i64* %20, align 8, !dbg !8, !tbaa !4
-  %21 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !8
-  store i64 85, i64* %21, align 8, !dbg !8, !tbaa !4
-  %22 = getelementptr inbounds i64, i64* %21, i64 1, !dbg !8
-  store i64* %22, i64** %19, align 8, !dbg !8
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !8
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %18, align 8, !dbg !8, !tbaa !19
-  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !13
-  %24 = load i64*, i64** %23, align 8, !dbg !13
-  store i64 %9, i64* %24, align 8, !dbg !13, !tbaa !4
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !13
-  store i64 56565211319773434, i64* %25, align 8, !dbg !13, !tbaa !4
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !13
-  store i64* %26, i64** %23, align 8, !dbg !13
-  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !13
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %18, align 8, !dbg !13, !tbaa !19
-  %rubyStr_str.i = load i64, i64* @rubyStrFrozen_str, align 8, !dbg !38
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !14
-  %28 = load i64*, i64** %27, align 8, !dbg !14
-  store i64 %9, i64* %28, align 8, !dbg !14, !tbaa !4
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !14
-  store i64 %rubyStr_str.i, i64* %29, align 8, !dbg !14, !tbaa !4
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !14
-  store i64* %30, i64** %27, align 8, !dbg !14
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !14
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %18, align 8, !dbg !14, !tbaa !19
-  %rubyId_sym.i = load i64, i64* @rubyIdPrecomputed_sym, align 8, !dbg !39
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_sym.i) #5, !dbg !39
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !15
-  %32 = load i64*, i64** %31, align 8, !dbg !15
-  store i64 %9, i64* %32, align 8, !dbg !15, !tbaa !4
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !15
-  store i64 %rawSym.i, i64* %33, align 8, !dbg !15, !tbaa !4
-  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !15
-  store i64* %34, i64** %31, align 8, !dbg !15
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !15
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %18, align 8, !dbg !15, !tbaa !19
-  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !16
-  %36 = load i64*, i64** %35, align 8, !dbg !16
-  store i64 %9, i64* %36, align 8, !dbg !16, !tbaa !4
-  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !16
-  store i64 0, i64* %37, align 8, !dbg !16, !tbaa !4
-  %38 = getelementptr inbounds i64, i64* %37, i64 1, !dbg !16
-  store i64* %38, i64** %35, align 8, !dbg !16
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !16
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %18, align 8, !dbg !16, !tbaa !19
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !17
-  %40 = load i64*, i64** %39, align 8, !dbg !17
-  store i64 %9, i64* %40, align 8, !dbg !17, !tbaa !4
-  %41 = getelementptr inbounds i64, i64* %40, i64 1, !dbg !17
-  store i64 20, i64* %41, align 8, !dbg !17, !tbaa !4
-  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !17
-  store i64* %42, i64** %39, align 8, !dbg !17
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %18, align 8, !dbg !17, !tbaa !19
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !18
-  %44 = load i64*, i64** %43, align 8, !dbg !18
-  store i64 %9, i64* %44, align 8, !dbg !18, !tbaa !4
-  %45 = getelementptr inbounds i64, i64* %44, i64 1, !dbg !18
-  store i64 8, i64* %45, align 8, !dbg !18, !tbaa !4
-  %46 = getelementptr inbounds i64, i64* %45, i64 1, !dbg !18
-  store i64* %46, i64** %43, align 8, !dbg !18
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !18
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !39, !tbaa !21
+  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !10
+  %20 = load i64*, i64** %19, align 8, !dbg !10
+  store i64 %9, i64* %20, align 8, !dbg !10, !tbaa !6
+  %21 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !10
+  store i64 85, i64* %21, align 8, !dbg !10, !tbaa !6
+  %22 = getelementptr inbounds i64, i64* %21, i64 1, !dbg !10
+  store i64* %22, i64** %19, align 8, !dbg !10
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %18, align 8, !dbg !10, !tbaa !21
+  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !15
+  %24 = load i64*, i64** %23, align 8, !dbg !15
+  store i64 %9, i64* %24, align 8, !dbg !15, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !15
+  store i64 56565211319773434, i64* %25, align 8, !dbg !15, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !15
+  store i64* %26, i64** %23, align 8, !dbg !15
+  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !15
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %18, align 8, !dbg !15, !tbaa !21
+  %rubyStr_str.i = load i64, i64* @rubyStrFrozen_str, align 8, !dbg !40
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !16
+  %28 = load i64*, i64** %27, align 8, !dbg !16
+  store i64 %9, i64* %28, align 8, !dbg !16, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !16
+  store i64 %rubyStr_str.i, i64* %29, align 8, !dbg !16, !tbaa !6
+  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !16
+  store i64* %30, i64** %27, align 8, !dbg !16
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !16
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %18, align 8, !dbg !16, !tbaa !21
+  %rubyId_sym.i = load i64, i64* @rubyIdPrecomputed_sym, align 8, !dbg !41
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_sym.i) #5, !dbg !41
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !17
+  %32 = load i64*, i64** %31, align 8, !dbg !17
+  store i64 %9, i64* %32, align 8, !dbg !17, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !17
+  store i64 %rawSym.i, i64* %33, align 8, !dbg !17, !tbaa !6
+  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !17
+  store i64* %34, i64** %31, align 8, !dbg !17
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !17
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %18, align 8, !dbg !17, !tbaa !21
+  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !18
+  %36 = load i64*, i64** %35, align 8, !dbg !18
+  store i64 %9, i64* %36, align 8, !dbg !18, !tbaa !6
+  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !18
+  store i64 0, i64* %37, align 8, !dbg !18, !tbaa !6
+  %38 = getelementptr inbounds i64, i64* %37, i64 1, !dbg !18
+  store i64* %38, i64** %35, align 8, !dbg !18
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !18
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %18, align 8, !dbg !18, !tbaa !21
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !19
+  %40 = load i64*, i64** %39, align 8, !dbg !19
+  store i64 %9, i64* %40, align 8, !dbg !19, !tbaa !6
+  %41 = getelementptr inbounds i64, i64* %40, i64 1, !dbg !19
+  store i64 20, i64* %41, align 8, !dbg !19, !tbaa !6
+  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !19
+  store i64* %42, i64** %39, align 8, !dbg !19
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %18, align 8, !dbg !19, !tbaa !21
+  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !20
+  %44 = load i64*, i64** %43, align 8, !dbg !20
+  store i64 %9, i64* %44, align 8, !dbg !20, !tbaa !6
+  %45 = getelementptr inbounds i64, i64* %44, i64 1, !dbg !20
+  store i64 8, i64* %45, align 8, !dbg !20, !tbaa !6
+  %46 = getelementptr inbounds i64, i64* %45, i64 1, !dbg !20
+  store i64* %46, i64** %43, align 8, !dbg !20
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !20
   ret void
 }
 
@@ -271,46 +271,48 @@ attributes #3 = { sspreq }
 attributes #4 = { noreturn nounwind }
 attributes #5 = { nounwind }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/literals.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 4, column: 1, scope: !9)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !DILocation(line: 5, column: 1, scope: !9)
-!14 = !DILocation(line: 6, column: 1, scope: !9)
-!15 = !DILocation(line: 7, column: 1, scope: !9)
-!16 = !DILocation(line: 8, column: 1, scope: !9)
-!17 = !DILocation(line: 9, column: 1, scope: !9)
-!18 = !DILocation(line: 10, column: 1, scope: !9)
-!19 = !{!20, !20, i64 0}
-!20 = !{!"any pointer", !6, i64 0}
-!21 = !{!22, !5, i64 400}
-!22 = !{!"rb_vm_struct", !5, i64 0, !23, i64 8, !20, i64 192, !20, i64 200, !20, i64 208, !27, i64 216, !6, i64 224, !24, i64 264, !24, i64 280, !24, i64 296, !24, i64 312, !5, i64 328, !26, i64 336, !26, i64 340, !26, i64 344, !26, i64 344, !26, i64 344, !26, i64 344, !26, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !20, i64 456, !20, i64 464, !28, i64 472, !29, i64 992, !20, i64 1016, !20, i64 1024, !26, i64 1032, !26, i64 1036, !24, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !26, i64 1136, !20, i64 1144, !20, i64 1152, !20, i64 1160, !20, i64 1168, !20, i64 1176, !20, i64 1184, !26, i64 1192, !30, i64 1200, !6, i64 1232}
-!23 = !{!"rb_global_vm_lock_struct", !20, i64 0, !6, i64 8, !24, i64 48, !20, i64 64, !26, i64 72, !6, i64 80, !6, i64 128, !26, i64 176, !26, i64 180}
-!24 = !{!"list_head", !25, i64 0}
-!25 = !{!"list_node", !20, i64 0, !20, i64 8}
-!26 = !{!"int", !6, i64 0}
-!27 = !{!"long long", !6, i64 0}
-!28 = !{!"", !6, i64 0}
-!29 = !{!"rb_hook_list_struct", !20, i64 0, !26, i64 8, !26, i64 12, !26, i64 16}
-!30 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!31 = !{!32, !20, i64 16}
-!32 = !{!"rb_execution_context_struct", !20, i64 0, !5, i64 8, !20, i64 16, !20, i64 24, !20, i64 32, !26, i64 40, !26, i64 44, !20, i64 48, !20, i64 56, !20, i64 64, !5, i64 72, !5, i64 80, !20, i64 88, !5, i64 96, !20, i64 104, !20, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !33, i64 152}
-!33 = !{!"", !20, i64 0, !20, i64 8, !5, i64 16, !6, i64 24}
-!34 = !{!35, !20, i64 16}
-!35 = !{!"rb_control_frame_struct", !20, i64 0, !20, i64 8, !20, i64 16, !5, i64 24, !20, i64 32, !20, i64 40, !20, i64 48}
-!36 = !{!35, !20, i64 32}
-!37 = !DILocation(line: 0, scope: !9)
-!38 = !DILocation(line: 6, column: 6, scope: !9)
-!39 = !DILocation(line: 7, column: 6, scope: !9)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/literals.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 4, column: 1, scope: !11)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !DILocation(line: 5, column: 1, scope: !11)
+!16 = !DILocation(line: 6, column: 1, scope: !11)
+!17 = !DILocation(line: 7, column: 1, scope: !11)
+!18 = !DILocation(line: 8, column: 1, scope: !11)
+!19 = !DILocation(line: 9, column: 1, scope: !11)
+!20 = !DILocation(line: 10, column: 1, scope: !11)
+!21 = !{!22, !22, i64 0}
+!22 = !{!"any pointer", !8, i64 0}
+!23 = !{!24, !7, i64 400}
+!24 = !{!"rb_vm_struct", !7, i64 0, !25, i64 8, !22, i64 192, !22, i64 200, !22, i64 208, !29, i64 216, !8, i64 224, !26, i64 264, !26, i64 280, !26, i64 296, !26, i64 312, !7, i64 328, !28, i64 336, !28, i64 340, !28, i64 344, !28, i64 344, !28, i64 344, !28, i64 344, !28, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !22, i64 456, !22, i64 464, !30, i64 472, !31, i64 992, !22, i64 1016, !22, i64 1024, !28, i64 1032, !28, i64 1036, !26, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !28, i64 1136, !22, i64 1144, !22, i64 1152, !22, i64 1160, !22, i64 1168, !22, i64 1176, !22, i64 1184, !28, i64 1192, !32, i64 1200, !8, i64 1232}
+!25 = !{!"rb_global_vm_lock_struct", !22, i64 0, !8, i64 8, !26, i64 48, !22, i64 64, !28, i64 72, !8, i64 80, !8, i64 128, !28, i64 176, !28, i64 180}
+!26 = !{!"list_head", !27, i64 0}
+!27 = !{!"list_node", !22, i64 0, !22, i64 8}
+!28 = !{!"int", !8, i64 0}
+!29 = !{!"long long", !8, i64 0}
+!30 = !{!"", !8, i64 0}
+!31 = !{!"rb_hook_list_struct", !22, i64 0, !28, i64 8, !28, i64 12, !28, i64 16}
+!32 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!33 = !{!34, !22, i64 16}
+!34 = !{!"rb_execution_context_struct", !22, i64 0, !7, i64 8, !22, i64 16, !22, i64 24, !22, i64 32, !28, i64 40, !28, i64 44, !22, i64 48, !22, i64 56, !22, i64 64, !7, i64 72, !7, i64 80, !22, i64 88, !7, i64 96, !22, i64 104, !22, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !35, i64 152}
+!35 = !{!"", !22, i64 0, !22, i64 8, !7, i64 16, !8, i64 24}
+!36 = !{!37, !22, i64 16}
+!37 = !{!"rb_control_frame_struct", !22, i64 0, !22, i64 8, !22, i64 16, !7, i64 24, !22, i64 32, !22, i64 40, !22, i64 48}
+!38 = !{!37, !22, i64 32}
+!39 = !DILocation(line: 0, scope: !11)
+!40 = !DILocation(line: 6, column: 6, scope: !11)
+!41 = !DILocation(line: 7, column: 6, scope: !11)

--- a/test/testdata/compiler/repeated_casts.llo.exp
+++ b/test/testdata/compiler/repeated_casts.llo.exp
@@ -168,204 +168,204 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #12
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #12
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#doubleCast"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #7 !dbg !8 {
+define i64 @"func_Object#doubleCast"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #7 !dbg !10 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !14
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !14
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !14
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !14, !prof !15
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !16
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !16
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !16
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !16, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !14
-  unreachable, !dbg !14
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !16
+  unreachable, !dbg !16
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !14
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !16, !tbaa !12
-  %1 = load i64, i64* @guard_epoch_A, align 8, !dbg !17
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !17, !tbaa !18
-  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !17
-  br i1 %needTakeSlowPath, label %3, label %4, !dbg !17, !prof !20
+  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !16
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !18, !tbaa !14
+  %1 = load i64, i64* @guard_epoch_A, align 8, !dbg !19
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !19, !tbaa !20
+  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !19
+  br i1 %needTakeSlowPath, label %3, label %4, !dbg !19, !prof !22
 
 3:                                                ; preds = %fillRequiredArgs
-  tail call void @const_recompute_A(), !dbg !17
-  br label %4, !dbg !17
+  tail call void @const_recompute_A(), !dbg !19
+  br label %4, !dbg !19
 
 4:                                                ; preds = %fillRequiredArgs, %3
-  %5 = load i64, i64* @guarded_const_A, align 8, !dbg !17
-  %6 = load i64, i64* @guard_epoch_A, align 8, !dbg !17
-  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !17, !tbaa !18
-  %guardUpdated = icmp eq i64 %6, %7, !dbg !17
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !17
-  %8 = tail call i64 @rb_obj_is_kind_of(i64 %rawArg_a, i64 %5), !dbg !17
-  %9 = icmp eq i64 %8, 20, !dbg !17
-  br i1 %9, label %typeTestSuccess, label %codeRepl, !dbg !17, !prof !21
+  %5 = load i64, i64* @guarded_const_A, align 8, !dbg !19
+  %6 = load i64, i64* @guard_epoch_A, align 8, !dbg !19
+  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !19, !tbaa !20
+  %guardUpdated = icmp eq i64 %6, %7, !dbg !19
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !19
+  %8 = tail call i64 @rb_obj_is_kind_of(i64 %rawArg_a, i64 %5), !dbg !19
+  %9 = icmp eq i64 %8, 20, !dbg !19
+  br i1 %9, label %typeTestSuccess, label %codeRepl, !dbg !19, !prof !23
 
 typeTestSuccess:                                  ; preds = %4
-  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !17
-  %11 = load i64*, i64** %10, align 8, !dbg !17
-  store i64 %rawArg_a, i64* %11, align 8, !dbg !17, !tbaa !4
-  %12 = getelementptr inbounds i64, i64* %11, i64 1, !dbg !17
-  store i64* %12, i64** %10, align 8, !dbg !17
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !17, !tbaa !12
-  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !22
-  %14 = load i64*, i64** %13, align 8, !dbg !22
-  store i64 %rawArg_a, i64* %14, align 8, !dbg !22, !tbaa !4
-  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !22
-  store i64* %15, i64** %13, align 8, !dbg !22
-  %send33 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !22
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !19
+  %11 = load i64*, i64** %10, align 8, !dbg !19
+  store i64 %rawArg_a, i64* %11, align 8, !dbg !19, !tbaa !6
+  %12 = getelementptr inbounds i64, i64* %11, i64 1, !dbg !19
+  store i64* %12, i64** %10, align 8, !dbg !19
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !19, !tbaa !14
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !24
+  %14 = load i64*, i64** %13, align 8, !dbg !24
+  store i64 %rawArg_a, i64* %14, align 8, !dbg !24, !tbaa !6
+  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !24
+  store i64* %15, i64** %13, align 8, !dbg !24
+  %send33 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !24
   ret i64 %send33
 
 codeRepl:                                         ; preds = %4
-  tail call fastcc void @"func_Object#doubleCast.cold.1"(i64 %rawArg_a) #14, !dbg !17
+  tail call fastcc void @"func_Object#doubleCast.cold.1"(i64 %rawArg_a) #14, !dbg !19
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_<root>.<static-init>$151"(%struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !23 {
+define internal fastcc void @"func_<root>.<static-init>$151"(%struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !25 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !24
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !26
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !28
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !30
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !30
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !32
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #15
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %8, align 8, !dbg !31, !tbaa !12
-  %9 = load i64, i64* @rb_cObject, align 8, !dbg !32
-  %10 = tail call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %9) #15, !dbg !32
-  %11 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %10) #15, !dbg !32
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %8, align 8, !dbg !33, !tbaa !14
+  %9 = load i64, i64* @rb_cObject, align 8, !dbg !34
+  %10 = tail call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %9) #15, !dbg !34
+  %11 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %10) #15, !dbg !34
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.<static-init>", align 8
-  %12 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %12 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %13 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %12, i64 0, i32 2
-  %14 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %13, align 8, !tbaa !24
+  %14 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %13, align 8, !tbaa !26
   %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %15, align 8, !tbaa !28
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %15, align 8, !tbaa !30
   %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 4
-  %17 = load i64*, i64** %16, align 8, !tbaa !30
-  %18 = load i64, i64* %17, align 8, !tbaa !4
+  %17 = load i64*, i64** %16, align 8, !tbaa !32
+  %18 = load i64, i64* %17, align 8, !tbaa !6
   %19 = and i64 %18, -33
-  store i64 %19, i64* %17, align 8, !tbaa !4
+  store i64 %19, i64* %17, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %12, %struct.rb_control_frame_struct* %14, %struct.rb_iseq_struct* %stackFrame.i) #15
   %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %20, align 8, !dbg !33, !tbaa !12
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !36
-  %rawSym.i = tail call i64 @rb_id2sym(i64 %rubyId_foo.i) #15, !dbg !36
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !36
-  %rawSym7.i = tail call i64 @rb_id2sym(i64 %rubyId_normal.i) #15, !dbg !36
-  %21 = load i64, i64* @guard_epoch_A, align 8, !dbg !36
-  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !36, !tbaa !18
-  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !36
-  br i1 %needTakeSlowPath, label %23, label %24, !dbg !36, !prof !20
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %20, align 8, !dbg !35, !tbaa !14
+  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !38
+  %rawSym.i = tail call i64 @rb_id2sym(i64 %rubyId_foo.i) #15, !dbg !38
+  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !38
+  %rawSym7.i = tail call i64 @rb_id2sym(i64 %rubyId_normal.i) #15, !dbg !38
+  %21 = load i64, i64* @guard_epoch_A, align 8, !dbg !38
+  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !20
+  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !38
+  br i1 %needTakeSlowPath, label %23, label %24, !dbg !38, !prof !22
 
 23:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_A(), !dbg !36
-  br label %24, !dbg !36
+  tail call void @const_recompute_A(), !dbg !38
+  br label %24, !dbg !38
 
 24:                                               ; preds = %functionEntryInitializers, %23
-  %25 = load i64, i64* @guarded_const_A, align 8, !dbg !36
-  %26 = load i64, i64* @guard_epoch_A, align 8, !dbg !36
-  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !36, !tbaa !18
-  %guardUpdated = icmp eq i64 %26, %27, !dbg !36
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !36
-  %stackFrame8.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#foo", align 8, !dbg !36
-  %28 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !36
-  %29 = bitcast i8* %28 to i16*, !dbg !36
-  %30 = load i16, i16* %29, align 8, !dbg !36
-  %31 = and i16 %30, -384, !dbg !36
-  store i16 %31, i16* %29, align 8, !dbg !36
-  %32 = getelementptr inbounds i8, i8* %28, i64 4, !dbg !36
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %32, i8 0, i64 28, i1 false) #15, !dbg !36
-  tail call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#foo", i8* nonnull %28, %struct.rb_iseq_struct* %stackFrame8.i, i1 noundef zeroext false) #15, !dbg !36
-  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !36, !tbaa !12
-  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 5, !dbg !36
-  %35 = load i32, i32* %34, align 8, !dbg !36, !tbaa !37
-  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 6, !dbg !36
-  %37 = load i32, i32* %36, align 4, !dbg !36, !tbaa !38
-  %38 = xor i32 %37, -1, !dbg !36
-  %39 = and i32 %38, %35, !dbg !36
-  %40 = icmp eq i32 %39, 0, !dbg !36
-  br i1 %40, label %fastSymCallIntrinsic_Static_keep_def, label %41, !dbg !36, !prof !21
+  %25 = load i64, i64* @guarded_const_A, align 8, !dbg !38
+  %26 = load i64, i64* @guard_epoch_A, align 8, !dbg !38
+  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !20
+  %guardUpdated = icmp eq i64 %26, %27, !dbg !38
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !38
+  %stackFrame8.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#foo", align 8, !dbg !38
+  %28 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !38
+  %29 = bitcast i8* %28 to i16*, !dbg !38
+  %30 = load i16, i16* %29, align 8, !dbg !38
+  %31 = and i16 %30, -384, !dbg !38
+  store i16 %31, i16* %29, align 8, !dbg !38
+  %32 = getelementptr inbounds i8, i8* %28, i64 4, !dbg !38
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %32, i8 0, i64 28, i1 false) #15, !dbg !38
+  tail call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#foo", i8* nonnull %28, %struct.rb_iseq_struct* %stackFrame8.i, i1 noundef zeroext false) #15, !dbg !38
+  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !38, !tbaa !14
+  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 5, !dbg !38
+  %35 = load i32, i32* %34, align 8, !dbg !38, !tbaa !39
+  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 6, !dbg !38
+  %37 = load i32, i32* %36, align 4, !dbg !38, !tbaa !40
+  %38 = xor i32 %37, -1, !dbg !38
+  %39 = and i32 %38, %35, !dbg !38
+  %40 = icmp eq i32 %39, 0, !dbg !38
+  br i1 %40, label %fastSymCallIntrinsic_Static_keep_def, label %41, !dbg !38, !prof !23
 
 41:                                               ; preds = %24
-  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 8, !dbg !36
-  %43 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %42, align 8, !dbg !36, !tbaa !39
-  %44 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %43, i32 noundef 0) #15, !dbg !36
-  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !36
+  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 8, !dbg !38
+  %43 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %42, align 8, !dbg !38, !tbaa !41
+  %44 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %43, i32 noundef 0) #15, !dbg !38
+  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !38
 
 afterSend19:                                      ; preds = %68, %fastSymCallIntrinsic_Static_keep_def
   ret void
 
 fastSymCallIntrinsic_Static_keep_def:             ; preds = %41, %24
-  tail call void @sorbet_popFrame() #15, !dbg !32
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !32, !tbaa !12
-  %rubyId_doubleCast = load i64, i64* @rubyIdPrecomputed_doubleCast, align 8, !dbg !40
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_doubleCast), !dbg !40
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !40
-  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !40
-  %stackFrame20 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#doubleCast", align 8, !dbg !40
-  %45 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !40
-  %46 = bitcast i8* %45 to i16*, !dbg !40
-  %47 = load i16, i16* %46, align 8, !dbg !40
-  %48 = and i16 %47, -384, !dbg !40
-  %49 = or i16 %48, 1, !dbg !40
-  store i16 %49, i16* %46, align 8, !dbg !40
-  %50 = getelementptr inbounds i8, i8* %45, i64 8, !dbg !40
-  %51 = bitcast i8* %50 to i32*, !dbg !40
-  store i32 1, i32* %51, align 8, !dbg !40, !tbaa !41
-  %52 = getelementptr inbounds i8, i8* %45, i64 12, !dbg !40
-  %53 = bitcast i8* %52 to i32*, !dbg !40
-  %54 = getelementptr inbounds i8, i8* %45, i64 4, !dbg !40
-  %55 = bitcast i8* %54 to i32*, !dbg !40
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %52, i8 0, i64 20, i1 false), !dbg !40
-  store i32 1, i32* %55, align 4, !dbg !40, !tbaa !44
-  %positional_table = alloca i64, align 8, !dbg !40
-  %rubyId_a = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !40
-  store i64 %rubyId_a, i64* %positional_table, align 8, !dbg !40
-  %56 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !40
-  %57 = bitcast i64* %positional_table to i8*, !dbg !40
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %56, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %57, i64 noundef 8, i1 noundef false) #15, !dbg !40
-  %58 = getelementptr inbounds i8, i8* %45, i64 32, !dbg !40
-  %59 = bitcast i8* %58 to i8**, !dbg !40
-  store i8* %56, i8** %59, align 8, !dbg !40, !tbaa !45
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#doubleCast", i8* nonnull %45, %struct.rb_iseq_struct* %stackFrame20, i1 noundef zeroext false) #15, !dbg !40
-  %60 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !12
-  %61 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %60, i64 0, i32 5, !dbg !40
-  %62 = load i32, i32* %61, align 8, !dbg !40, !tbaa !37
-  %63 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %60, i64 0, i32 6, !dbg !40
-  %64 = load i32, i32* %63, align 4, !dbg !40, !tbaa !38
-  %65 = xor i32 %64, -1, !dbg !40
-  %66 = and i32 %65, %62, !dbg !40
-  %67 = icmp eq i32 %66, 0, !dbg !40
-  br i1 %67, label %afterSend19, label %68, !dbg !40, !prof !21
+  tail call void @sorbet_popFrame() #15, !dbg !34
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !34, !tbaa !14
+  %rubyId_doubleCast = load i64, i64* @rubyIdPrecomputed_doubleCast, align 8, !dbg !42
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_doubleCast), !dbg !42
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !42
+  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !42
+  %stackFrame20 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#doubleCast", align 8, !dbg !42
+  %45 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !42
+  %46 = bitcast i8* %45 to i16*, !dbg !42
+  %47 = load i16, i16* %46, align 8, !dbg !42
+  %48 = and i16 %47, -384, !dbg !42
+  %49 = or i16 %48, 1, !dbg !42
+  store i16 %49, i16* %46, align 8, !dbg !42
+  %50 = getelementptr inbounds i8, i8* %45, i64 8, !dbg !42
+  %51 = bitcast i8* %50 to i32*, !dbg !42
+  store i32 1, i32* %51, align 8, !dbg !42, !tbaa !43
+  %52 = getelementptr inbounds i8, i8* %45, i64 12, !dbg !42
+  %53 = bitcast i8* %52 to i32*, !dbg !42
+  %54 = getelementptr inbounds i8, i8* %45, i64 4, !dbg !42
+  %55 = bitcast i8* %54 to i32*, !dbg !42
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %52, i8 0, i64 20, i1 false), !dbg !42
+  store i32 1, i32* %55, align 4, !dbg !42, !tbaa !46
+  %positional_table = alloca i64, align 8, !dbg !42
+  %rubyId_a = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !42
+  store i64 %rubyId_a, i64* %positional_table, align 8, !dbg !42
+  %56 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !42
+  %57 = bitcast i64* %positional_table to i8*, !dbg !42
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %56, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %57, i64 noundef 8, i1 noundef false) #15, !dbg !42
+  %58 = getelementptr inbounds i8, i8* %45, i64 32, !dbg !42
+  %59 = bitcast i8* %58 to i8**, !dbg !42
+  store i8* %56, i8** %59, align 8, !dbg !42, !tbaa !47
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#doubleCast", i8* nonnull %45, %struct.rb_iseq_struct* %stackFrame20, i1 noundef zeroext false) #15, !dbg !42
+  %60 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !42, !tbaa !14
+  %61 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %60, i64 0, i32 5, !dbg !42
+  %62 = load i32, i32* %61, align 8, !dbg !42, !tbaa !39
+  %63 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %60, i64 0, i32 6, !dbg !42
+  %64 = load i32, i32* %63, align 4, !dbg !42, !tbaa !40
+  %65 = xor i32 %64, -1, !dbg !42
+  %66 = and i32 %65, %62, !dbg !42
+  %67 = icmp eq i32 %66, 0, !dbg !42
+  br i1 %67, label %afterSend19, label %68, !dbg !42, !prof !23
 
 68:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
-  %69 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %60, i64 0, i32 8, !dbg !40
-  %70 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %69, align 8, !dbg !40, !tbaa !39
-  %71 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %70, i32 noundef 0) #15, !dbg !40
-  br label %afterSend19, !dbg !40
+  %69 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %60, i64 0, i32 8, !dbg !42
+  %70 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %69, align 8, !dbg !42, !tbaa !41
+  %71 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %70, i32 noundef 0) #15, !dbg !42
+  br label %afterSend19, !dbg !42
 }
 
 ; Function Attrs: ssp
@@ -400,10 +400,10 @@ entry:
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
   %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_doubleCast.i.i, i64 %rubyId_doubleCast.i.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 1)
   store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#doubleCast", align 8
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_foo1.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo1.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
+  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !19
+  %rubyId_foo1.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo1.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
   %9 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
   call void @rb_gc_register_mark_object(i64 %9) #15
   store i64 %9, i64* @"rubyStrFrozen_<top (required)>", align 8
@@ -411,8 +411,8 @@ entry:
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i6.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
   %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i6.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i7.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !40
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !40
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !42
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !42
   %11 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #15
   call void @rb_gc_register_mark_object(i64 %11) #15
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
@@ -424,31 +424,31 @@ entry:
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i12.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
   %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i11.i", i64 %"rubyId_<top (required)>.i10.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i12.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i13.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.<static-init>", align 8
-  %rubyId_keep_def4.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.2, i64 %rubyId_keep_def4.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !46
-  %14 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !12
+  %rubyId_keep_def4.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.2, i64 %rubyId_keep_def4.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !48
+  %14 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %15 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %14, i64 0, i32 18
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2
-  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !24
+  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !26
   call fastcc void @"func_<root>.<static-init>$151"(%struct.rb_control_frame_struct* %18) #15
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define noundef i64 @"func_A#foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #7 !dbg !47 {
+define noundef i64 @"func_A#foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #7 !dbg !49 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !48
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !48, !prof !49
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !50
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !50, !prof !51
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !48
-  unreachable, !dbg !48
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !50
+  unreachable, !dbg !50
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !50, !tbaa !12
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !52, !tbaa !14
   ret i64 8
 }
 
@@ -456,10 +456,10 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #9
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#doubleCast.cold.1"(i64 %rawArg_a) unnamed_addr #10 !dbg !51 {
+define internal fastcc void @"func_Object#doubleCast.cold.1"(i64 %rawArg_a) unnamed_addr #10 !dbg !53 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_a, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0)) #13, !dbg !53
-  unreachable, !dbg !53
+  tail call void @sorbet_cast_failure(i64 %rawArg_a, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0)) #13, !dbg !55
+  unreachable, !dbg !55
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
@@ -469,7 +469,7 @@ declare void @llvm.assume(i1 noundef) #11
 define linkonce void @const_recompute_A() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !18
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !20
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -492,60 +492,62 @@ attributes #14 = { noinline }
 attributes #15 = { nounwind }
 attributes #16 = { nounwind allocsize(0,1) }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/repeated_casts.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "Object#doubleCast", linkageName: "func_Object#doubleCast", scope: null, file: !2, line: 8, type: !9, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = !DISubroutineType(types: !10)
-!10 = !{!11}
-!11 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!12 = !{!13, !13, i64 0}
-!13 = !{!"any pointer", !6, i64 0}
-!14 = !DILocation(line: 8, column: 1, scope: !8)
-!15 = !{!"branch_weights", i32 4001, i32 4000000}
-!16 = !DILocation(line: 8, column: 16, scope: !8)
-!17 = !DILocation(line: 9, column: 3, scope: !8)
-!18 = !{!19, !19, i64 0}
-!19 = !{!"long long", !6, i64 0}
-!20 = !{!"branch_weights", i32 1, i32 10000}
-!21 = !{!"branch_weights", i32 2000, i32 1}
-!22 = !DILocation(line: 10, column: 3, scope: !8)
-!23 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !9, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!24 = !{!25, !13, i64 16}
-!25 = !{!"rb_execution_context_struct", !13, i64 0, !5, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !26, i64 40, !26, i64 44, !13, i64 48, !13, i64 56, !13, i64 64, !5, i64 72, !5, i64 80, !13, i64 88, !5, i64 96, !13, i64 104, !13, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !27, i64 152}
-!26 = !{!"int", !6, i64 0}
-!27 = !{!"", !13, i64 0, !13, i64 8, !5, i64 16, !6, i64 24}
-!28 = !{!29, !13, i64 16}
-!29 = !{!"rb_control_frame_struct", !13, i64 0, !13, i64 8, !13, i64 16, !5, i64 24, !13, i64 32, !13, i64 40, !13, i64 48}
-!30 = !{!29, !13, i64 32}
-!31 = !DILocation(line: 0, scope: !23)
-!32 = !DILocation(line: 4, column: 1, scope: !23)
-!33 = !DILocation(line: 0, scope: !34, inlinedAt: !35)
-!34 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L61", scope: null, file: !2, line: 4, type: !9, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!35 = distinct !DILocation(line: 4, column: 1, scope: !23)
-!36 = !DILocation(line: 5, column: 3, scope: !34, inlinedAt: !35)
-!37 = !{!25, !26, i64 40}
-!38 = !{!25, !26, i64 44}
-!39 = !{!25, !13, i64 56}
-!40 = !DILocation(line: 8, column: 1, scope: !23)
-!41 = !{!42, !26, i64 8}
-!42 = !{!"rb_sorbet_param_struct", !43, i64 0, !26, i64 4, !26, i64 8, !26, i64 12, !26, i64 16, !26, i64 20, !26, i64 24, !26, i64 28, !13, i64 32, !26, i64 40, !26, i64 44, !26, i64 48, !26, i64 52, !13, i64 56}
-!43 = !{!"", !26, i64 0, !26, i64 0, !26, i64 0, !26, i64 0, !26, i64 0, !26, i64 0, !26, i64 0, !26, i64 0, !26, i64 1, !26, i64 1}
-!44 = !{!42, !26, i64 4}
-!45 = !{!42, !13, i64 32}
-!46 = !DILocation(line: 5, column: 3, scope: !34)
-!47 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#foo", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!48 = !DILocation(line: 5, column: 3, scope: !47)
-!49 = !{!"branch_weights", i32 1, i32 2000}
-!50 = !DILocation(line: 0, scope: !47)
-!51 = distinct !DISubprogram(name: "func_Object#doubleCast.cold.1", linkageName: "func_Object#doubleCast.cold.1", scope: null, file: !2, type: !52, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!52 = !DISubroutineType(types: !3)
-!53 = !DILocation(line: 9, column: 3, scope: !51)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/repeated_casts.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "Object#doubleCast", linkageName: "func_Object#doubleCast", scope: null, file: !4, line: 8, type: !11, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!14 = !{!15, !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !DILocation(line: 8, column: 1, scope: !10)
+!17 = !{!"branch_weights", i32 4001, i32 4000000}
+!18 = !DILocation(line: 8, column: 16, scope: !10)
+!19 = !DILocation(line: 9, column: 3, scope: !10)
+!20 = !{!21, !21, i64 0}
+!21 = !{!"long long", !8, i64 0}
+!22 = !{!"branch_weights", i32 1, i32 10000}
+!23 = !{!"branch_weights", i32 2000, i32 1}
+!24 = !DILocation(line: 10, column: 3, scope: !10)
+!25 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!26 = !{!27, !15, i64 16}
+!27 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !28, i64 40, !28, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !29, i64 152}
+!28 = !{!"int", !8, i64 0}
+!29 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!30 = !{!31, !15, i64 16}
+!31 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!32 = !{!31, !15, i64 32}
+!33 = !DILocation(line: 0, scope: !25)
+!34 = !DILocation(line: 4, column: 1, scope: !25)
+!35 = !DILocation(line: 0, scope: !36, inlinedAt: !37)
+!36 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L61", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!37 = distinct !DILocation(line: 4, column: 1, scope: !25)
+!38 = !DILocation(line: 5, column: 3, scope: !36, inlinedAt: !37)
+!39 = !{!27, !28, i64 40}
+!40 = !{!27, !28, i64 44}
+!41 = !{!27, !15, i64 56}
+!42 = !DILocation(line: 8, column: 1, scope: !25)
+!43 = !{!44, !28, i64 8}
+!44 = !{!"rb_sorbet_param_struct", !45, i64 0, !28, i64 4, !28, i64 8, !28, i64 12, !28, i64 16, !28, i64 20, !28, i64 24, !28, i64 28, !15, i64 32, !28, i64 40, !28, i64 44, !28, i64 48, !28, i64 52, !15, i64 56}
+!45 = !{!"", !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 1, !28, i64 1}
+!46 = !{!44, !28, i64 4}
+!47 = !{!44, !15, i64 32}
+!48 = !DILocation(line: 5, column: 3, scope: !36)
+!49 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#foo", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!50 = !DILocation(line: 5, column: 3, scope: !49)
+!51 = !{!"branch_weights", i32 1, i32 2000}
+!52 = !DILocation(line: 0, scope: !49)
+!53 = distinct !DISubprogram(name: "func_Object#doubleCast.cold.1", linkageName: "func_Object#doubleCast.cold.1", scope: null, file: !4, type: !54, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!54 = !DISubroutineType(types: !5)
+!55 = !DILocation(line: 9, column: 3, scope: !53)

--- a/test/testdata/compiler/send_with_block_param.llo.exp
+++ b/test/testdata/compiler/send_with_block_param.llo.exp
@@ -141,14 +141,14 @@ declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) loc
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #6
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #6
   unreachable
 }
@@ -192,78 +192,78 @@ entry:
   %12 = call i64 @sorbet_globalConstRegister(i64 %11) #7
   store i64 %12, i64* @ruby_hashLiteral1, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %8)
-  %rubyId_unsafe.i = load i64, i64* @rubyIdPrecomputed_unsafe, align 8, !dbg !8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_unsafe, i64 %rubyId_unsafe.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !8
-  %rubyId_map.i = load i64, i64* @rubyIdPrecomputed_map, align 8, !dbg !13
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %rubyId_map.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !13
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !14
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !14
-  %13 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %rubyId_unsafe.i = load i64, i64* @rubyIdPrecomputed_unsafe, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_unsafe, i64 %rubyId_unsafe.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
+  %rubyId_map.i = load i64, i64* @rubyIdPrecomputed_map, align 8, !dbg !15
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %rubyId_map.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !15
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !16
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
+  %13 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !17
   %14 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %13, i64 0, i32 18
-  %15 = load i64, i64* %14, align 8, !tbaa !17
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %15 = load i64, i64* %14, align 8, !tbaa !19
+  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !17
   %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2
-  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !27
+  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !29
   %19 = bitcast [4 x i64]* %callArgs.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %19)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %20 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !27
+  %20 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !29
   %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %21, align 8, !tbaa !30
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %21, align 8, !tbaa !32
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 4
-  %23 = load i64*, i64** %22, align 8, !tbaa !32
-  %24 = load i64, i64* %23, align 8, !tbaa !4
+  %23 = load i64*, i64** %22, align 8, !tbaa !34
+  %24 = load i64, i64* %23, align 8, !tbaa !6
   %25 = and i64 %24, -33
-  store i64 %25, i64* %23, align 8, !tbaa !4
+  store i64 %25, i64* %23, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %16, %struct.rb_control_frame_struct* %20, %struct.rb_iseq_struct* %stackFrame.i) #7
   %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 0
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %26, align 8, !dbg !33, !tbaa !15
-  %hashLiteral.i = load i64, i64* @ruby_hashLiteral1, align 8, !dbg !34
-  %duplicatedHash.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral.i) #7, !dbg !34
-  %callArgs0Addr.i = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i32 0, i64 0, !dbg !8
-  store i64 %duplicatedHash.i, i64* %callArgs0Addr.i, align 8, !dbg !8
-  %27 = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i64 0, i64 0, !dbg !8
-  call void @llvm.experimental.noalias.scope.decl(metadata !35) #7, !dbg !8
-  %28 = load i64, i64* %27, align 8, !dbg !8, !tbaa !4, !alias.scope !35
-  %29 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !8, !tbaa !15
-  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 5, !dbg !8
-  %31 = load i32, i32* %30, align 8, !dbg !8, !tbaa !38
-  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 6, !dbg !8
-  %33 = load i32, i32* %32, align 4, !dbg !8, !tbaa !39
-  %34 = xor i32 %33, -1, !dbg !8
-  %35 = and i32 %34, %31, !dbg !8
-  %36 = icmp eq i32 %35, 0, !dbg !8
-  br i1 %36, label %"func_<root>.<static-init>$151.exit", label %37, !dbg !8, !prof !40
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %26, align 8, !dbg !35, !tbaa !17
+  %hashLiteral.i = load i64, i64* @ruby_hashLiteral1, align 8, !dbg !36
+  %duplicatedHash.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral.i) #7, !dbg !36
+  %callArgs0Addr.i = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i32 0, i64 0, !dbg !10
+  store i64 %duplicatedHash.i, i64* %callArgs0Addr.i, align 8, !dbg !10
+  %27 = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i64 0, i64 0, !dbg !10
+  call void @llvm.experimental.noalias.scope.decl(metadata !37) #7, !dbg !10
+  %28 = load i64, i64* %27, align 8, !dbg !10, !tbaa !6, !alias.scope !37
+  %29 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !17
+  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 5, !dbg !10
+  %31 = load i32, i32* %30, align 8, !dbg !10, !tbaa !40
+  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 6, !dbg !10
+  %33 = load i32, i32* %32, align 4, !dbg !10, !tbaa !41
+  %34 = xor i32 %33, -1, !dbg !10
+  %35 = and i32 %34, %31, !dbg !10
+  %36 = icmp eq i32 %35, 0, !dbg !10
+  br i1 %36, label %"func_<root>.<static-init>$151.exit", label %37, !dbg !10, !prof !42
 
 37:                                               ; preds = %entry
-  %38 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 8, !dbg !8
-  %39 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %38, align 8, !dbg !8, !tbaa !41
-  %40 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %39, i32 noundef 0) #7, !dbg !8
-  br label %"func_<root>.<static-init>$151.exit", !dbg !8
+  %38 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 8, !dbg !10
+  %39 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %38, align 8, !dbg !10, !tbaa !43
+  %40 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %39, i32 noundef 0) #7, !dbg !10
+  br label %"func_<root>.<static-init>$151.exit", !dbg !10
 
 "func_<root>.<static-init>$151.exit":             ; preds = %entry, %37
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %26, align 8, !dbg !8, !tbaa !15
-  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !13
-  call void @llvm.experimental.noalias.scope.decl(metadata !42) #7, !dbg !13
-  %41 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %27) #7, !dbg !13
-  %rubyId_map.i1 = load i64, i64* @rubyIdPrecomputed_map, align 8, !dbg !13
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_map.i1) #7, !dbg !13
-  %42 = call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @.str.6, i64 0, i64 0), i64 noundef 7) #7, !dbg !13
-  %43 = call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_makeBlockHandlerProc.rb_funcallv_data, i64 %28, i64 %42, i32 noundef 0, i64* noundef null) #7, !dbg !13
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !13
-  %45 = load i64*, i64** %44, align 8, !dbg !13
-  store i64 %41, i64* %45, align 8, !dbg !13, !tbaa !4
-  %46 = getelementptr inbounds i64, i64* %45, i64 1, !dbg !13
-  store i64* %46, i64** %44, align 8, !dbg !13
-  %send.i = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %43) #7, !dbg !13
-  %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !14
-  %48 = load i64*, i64** %47, align 8, !dbg !14
-  store i64 %15, i64* %48, align 8, !dbg !14, !tbaa !4
-  %49 = getelementptr inbounds i64, i64* %48, i64 1, !dbg !14
-  store i64 %send.i, i64* %49, align 8, !dbg !14, !tbaa !4
-  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !14
-  store i64* %50, i64** %47, align 8, !dbg !14
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !14
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %26, align 8, !dbg !10, !tbaa !17
+  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !15
+  call void @llvm.experimental.noalias.scope.decl(metadata !44) #7, !dbg !15
+  %41 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %27) #7, !dbg !15
+  %rubyId_map.i1 = load i64, i64* @rubyIdPrecomputed_map, align 8, !dbg !15
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_map.i1) #7, !dbg !15
+  %42 = call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @.str.6, i64 0, i64 0), i64 noundef 7) #7, !dbg !15
+  %43 = call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_makeBlockHandlerProc.rb_funcallv_data, i64 %28, i64 %42, i32 noundef 0, i64* noundef null) #7, !dbg !15
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !15
+  %45 = load i64*, i64** %44, align 8, !dbg !15
+  store i64 %41, i64* %45, align 8, !dbg !15, !tbaa !6
+  %46 = getelementptr inbounds i64, i64* %45, i64 1, !dbg !15
+  store i64* %46, i64** %44, align 8, !dbg !15
+  %send.i = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %43) #7, !dbg !15
+  %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !16
+  %48 = load i64*, i64** %47, align 8, !dbg !16
+  store i64 %15, i64* %48, align 8, !dbg !16, !tbaa !6
+  %49 = getelementptr inbounds i64, i64* %48, i64 1, !dbg !16
+  store i64 %send.i, i64* %49, align 8, !dbg !16, !tbaa !6
+  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !16
+  store i64* %50, i64** %47, align 8, !dbg !16
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !16
   call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %19)
   ret void
 }
@@ -286,51 +286,53 @@ attributes #5 = { argmemonly nofree nosync nounwind willreturn }
 attributes #6 = { noreturn nounwind }
 attributes #7 = { nounwind }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/send_with_block_param.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 4, column: 5, scope: !9)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !DILocation(line: 6, column: 6, scope: !9)
-!14 = !DILocation(line: 6, column: 1, scope: !9)
-!15 = !{!16, !16, i64 0}
-!16 = !{!"any pointer", !6, i64 0}
-!17 = !{!18, !5, i64 400}
-!18 = !{!"rb_vm_struct", !5, i64 0, !19, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !23, i64 216, !6, i64 224, !20, i64 264, !20, i64 280, !20, i64 296, !20, i64 312, !5, i64 328, !22, i64 336, !22, i64 340, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !16, i64 456, !16, i64 464, !24, i64 472, !25, i64 992, !16, i64 1016, !16, i64 1024, !22, i64 1032, !22, i64 1036, !20, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !22, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !22, i64 1192, !26, i64 1200, !6, i64 1232}
-!19 = !{!"rb_global_vm_lock_struct", !16, i64 0, !6, i64 8, !20, i64 48, !16, i64 64, !22, i64 72, !6, i64 80, !6, i64 128, !22, i64 176, !22, i64 180}
-!20 = !{!"list_head", !21, i64 0}
-!21 = !{!"list_node", !16, i64 0, !16, i64 8}
-!22 = !{!"int", !6, i64 0}
-!23 = !{!"long long", !6, i64 0}
-!24 = !{!"", !6, i64 0}
-!25 = !{!"rb_hook_list_struct", !16, i64 0, !22, i64 8, !22, i64 12, !22, i64 16}
-!26 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!27 = !{!28, !16, i64 16}
-!28 = !{!"rb_execution_context_struct", !16, i64 0, !5, i64 8, !16, i64 16, !16, i64 24, !16, i64 32, !22, i64 40, !22, i64 44, !16, i64 48, !16, i64 56, !16, i64 64, !5, i64 72, !5, i64 80, !16, i64 88, !5, i64 96, !16, i64 104, !16, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !29, i64 152}
-!29 = !{!"", !16, i64 0, !16, i64 8, !5, i64 16, !6, i64 24}
-!30 = !{!31, !16, i64 16}
-!31 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !5, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
-!32 = !{!31, !16, i64 32}
-!33 = !DILocation(line: 0, scope: !9)
-!34 = !DILocation(line: 4, column: 14, scope: !9)
-!35 = !{!36}
-!36 = distinct !{!36, !37, !"sorbet_T_unsafe: argument 0"}
-!37 = distinct !{!37, !"sorbet_T_unsafe"}
-!38 = !{!28, !22, i64 40}
-!39 = !{!28, !22, i64 44}
-!40 = !{!"branch_weights", i32 2000, i32 1}
-!41 = !{!28, !16, i64 56}
-!42 = !{!43}
-!43 = distinct !{!43, !44, !"sorbet_buildArrayIntrinsic: argument 0"}
-!44 = distinct !{!44, !"sorbet_buildArrayIntrinsic"}
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/send_with_block_param.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 4, column: 5, scope: !11)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !DILocation(line: 6, column: 6, scope: !11)
+!16 = !DILocation(line: 6, column: 1, scope: !11)
+!17 = !{!18, !18, i64 0}
+!18 = !{!"any pointer", !8, i64 0}
+!19 = !{!20, !7, i64 400}
+!20 = !{!"rb_vm_struct", !7, i64 0, !21, i64 8, !18, i64 192, !18, i64 200, !18, i64 208, !25, i64 216, !8, i64 224, !22, i64 264, !22, i64 280, !22, i64 296, !22, i64 312, !7, i64 328, !24, i64 336, !24, i64 340, !24, i64 344, !24, i64 344, !24, i64 344, !24, i64 344, !24, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !18, i64 456, !18, i64 464, !26, i64 472, !27, i64 992, !18, i64 1016, !18, i64 1024, !24, i64 1032, !24, i64 1036, !22, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !24, i64 1136, !18, i64 1144, !18, i64 1152, !18, i64 1160, !18, i64 1168, !18, i64 1176, !18, i64 1184, !24, i64 1192, !28, i64 1200, !8, i64 1232}
+!21 = !{!"rb_global_vm_lock_struct", !18, i64 0, !8, i64 8, !22, i64 48, !18, i64 64, !24, i64 72, !8, i64 80, !8, i64 128, !24, i64 176, !24, i64 180}
+!22 = !{!"list_head", !23, i64 0}
+!23 = !{!"list_node", !18, i64 0, !18, i64 8}
+!24 = !{!"int", !8, i64 0}
+!25 = !{!"long long", !8, i64 0}
+!26 = !{!"", !8, i64 0}
+!27 = !{!"rb_hook_list_struct", !18, i64 0, !24, i64 8, !24, i64 12, !24, i64 16}
+!28 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!29 = !{!30, !18, i64 16}
+!30 = !{!"rb_execution_context_struct", !18, i64 0, !7, i64 8, !18, i64 16, !18, i64 24, !18, i64 32, !24, i64 40, !24, i64 44, !18, i64 48, !18, i64 56, !18, i64 64, !7, i64 72, !7, i64 80, !18, i64 88, !7, i64 96, !18, i64 104, !18, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !31, i64 152}
+!31 = !{!"", !18, i64 0, !18, i64 8, !7, i64 16, !8, i64 24}
+!32 = !{!33, !18, i64 16}
+!33 = !{!"rb_control_frame_struct", !18, i64 0, !18, i64 8, !18, i64 16, !7, i64 24, !18, i64 32, !18, i64 40, !18, i64 48}
+!34 = !{!33, !18, i64 32}
+!35 = !DILocation(line: 0, scope: !11)
+!36 = !DILocation(line: 4, column: 14, scope: !11)
+!37 = !{!38}
+!38 = distinct !{!38, !39, !"sorbet_T_unsafe: argument 0"}
+!39 = distinct !{!39, !"sorbet_T_unsafe"}
+!40 = !{!30, !24, i64 40}
+!41 = !{!30, !24, i64 44}
+!42 = !{!"branch_weights", i32 2000, i32 1}
+!43 = !{!30, !18, i64 56}
+!44 = !{!45}
+!45 = distinct !{!45, !46, !"sorbet_buildArrayIntrinsic: argument 0"}
+!46 = distinct !{!46, !"sorbet_buildArrayIntrinsic"}

--- a/test/testdata/compiler/sig_rewriter.llo.exp
+++ b/test/testdata/compiler/sig_rewriter.llo.exp
@@ -171,14 +171,14 @@ declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
   unreachable
 }
@@ -222,12 +222,12 @@ entry:
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
   %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !8
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !13
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !13
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
   %13 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #10
   call void @rb_gc_register_mark_object(i64 %13) #10
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
@@ -246,208 +246,208 @@ entry:
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
   %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %"rubyId_block for.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.<static-init>$block_1", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !14
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !14
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !16
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !18
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !19
-  %18 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !20
+  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !16
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !16
+  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !18
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
+  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !20
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !21
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !21
+  %18 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !22
   %19 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %18, i64 0, i32 18
-  %20 = load i64, i64* %19, align 8, !tbaa !22
-  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
+  %20 = load i64, i64* %19, align 8, !tbaa !24
+  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
   %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 2
-  %23 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %22, align 8, !tbaa !32
+  %23 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %22, align 8, !tbaa !34
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %24, align 8, !tbaa !35
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %24, align 8, !tbaa !37
   %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 4
-  %26 = load i64*, i64** %25, align 8, !tbaa !37
-  %27 = load i64, i64* %26, align 8, !tbaa !4
+  %26 = load i64*, i64** %25, align 8, !tbaa !39
+  %27 = load i64, i64* %26, align 8, !tbaa !6
   %28 = and i64 %27, -33
-  store i64 %28, i64* %26, align 8, !tbaa !4
+  store i64 %28, i64* %26, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %21, %struct.rb_control_frame_struct* %23, %struct.rb_iseq_struct* %stackFrame.i) #10
   %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %29, align 8, !dbg !38, !tbaa !20
-  %30 = load i64, i64* @rb_cObject, align 8, !dbg !39
-  %31 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %30) #10, !dbg !39
-  %32 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %31) #10, !dbg !39
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %29, align 8, !dbg !40, !tbaa !22
+  %30 = load i64, i64* @rb_cObject, align 8, !dbg !41
+  %31 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %30) #10, !dbg !41
+  %32 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %31) #10, !dbg !41
   %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.<static-init>", align 8
-  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
+  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
   %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 2
-  %35 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %34, align 8, !tbaa !32
+  %35 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %34, align 8, !tbaa !34
   %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %36, align 8, !tbaa !35
+  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %36, align 8, !tbaa !37
   %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 4
-  %38 = load i64*, i64** %37, align 8, !tbaa !37
-  %39 = load i64, i64* %38, align 8, !tbaa !4
+  %38 = load i64*, i64** %37, align 8, !tbaa !39
+  %39 = load i64, i64* %38, align 8, !tbaa !6
   %40 = and i64 %39, -33
-  store i64 %40, i64* %38, align 8, !tbaa !4
+  store i64 %40, i64* %38, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %33, %struct.rb_control_frame_struct* %35, %struct.rb_iseq_struct* %stackFrame.i.i1) #10
   %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %41, align 8, !dbg !40, !tbaa !20
-  %rubyId_foo.i.i2 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !42
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_foo.i.i2) #10, !dbg !42
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %31, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.<static-init>L62$block_1") #10, !dbg !42
-  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !42, !tbaa !20
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 5, !dbg !42
-  %44 = load i32, i32* %43, align 8, !dbg !42, !tbaa !43
-  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 6, !dbg !42
-  %46 = load i32, i32* %45, align 4, !dbg !42, !tbaa !44
-  %47 = xor i32 %46, -1, !dbg !42
-  %48 = and i32 %47, %44, !dbg !42
-  %49 = icmp eq i32 %48, 0, !dbg !42
-  br i1 %49, label %fastSymCallIntrinsic_Static_keep_def.i.i, label %50, !dbg !42, !prof !45
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %41, align 8, !dbg !42, !tbaa !22
+  %rubyId_foo.i.i2 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !44
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_foo.i.i2) #10, !dbg !44
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %31, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.<static-init>L62$block_1") #10, !dbg !44
+  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !44, !tbaa !22
+  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 5, !dbg !44
+  %44 = load i32, i32* %43, align 8, !dbg !44, !tbaa !45
+  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 6, !dbg !44
+  %46 = load i32, i32* %45, align 4, !dbg !44, !tbaa !46
+  %47 = xor i32 %46, -1, !dbg !44
+  %48 = and i32 %47, %44, !dbg !44
+  %49 = icmp eq i32 %48, 0, !dbg !44
+  br i1 %49, label %fastSymCallIntrinsic_Static_keep_def.i.i, label %50, !dbg !44, !prof !47
 
 50:                                               ; preds = %entry
-  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 8, !dbg !42
-  %52 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %51, align 8, !dbg !42, !tbaa !46
-  %53 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %52, i32 noundef 0) #10, !dbg !42
-  br label %fastSymCallIntrinsic_Static_keep_def.i.i, !dbg !42
+  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 8, !dbg !44
+  %52 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %51, align 8, !dbg !44, !tbaa !48
+  %53 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %52, i32 noundef 0) #10, !dbg !44
+  br label %fastSymCallIntrinsic_Static_keep_def.i.i, !dbg !44
 
 fastSymCallIntrinsic_Static_keep_def.i.i:         ; preds = %50, %entry
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %41, align 8, !dbg !42, !tbaa !20
-  %54 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !47
-  %55 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !47, !tbaa !48
-  %needTakeSlowPath = icmp ne i64 %54, %55, !dbg !47
-  br i1 %needTakeSlowPath, label %56, label %57, !dbg !47, !prof !49
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %41, align 8, !dbg !44, !tbaa !22
+  %54 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !49
+  %55 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !49, !tbaa !50
+  %needTakeSlowPath = icmp ne i64 %54, %55, !dbg !49
+  br i1 %needTakeSlowPath, label %56, label %57, !dbg !49, !prof !51
 
 56:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def.i.i
-  call void @"const_recompute_T::Sig"(), !dbg !47
-  br label %57, !dbg !47
+  call void @"const_recompute_T::Sig"(), !dbg !49
+  br label %57, !dbg !49
 
 57:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def.i.i, %56
-  %58 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !47
-  %59 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !47
-  %60 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !47, !tbaa !48
-  %guardUpdated = icmp eq i64 %59, %60, !dbg !47
-  call void @llvm.assume(i1 %guardUpdated), !dbg !47
-  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !47
-  %62 = load i64*, i64** %61, align 8, !dbg !47
-  store i64 %31, i64* %62, align 8, !dbg !47, !tbaa !4
-  %63 = getelementptr inbounds i64, i64* %62, i64 1, !dbg !47
-  store i64 %58, i64* %63, align 8, !dbg !47, !tbaa !4
-  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !47
-  store i64* %64, i64** %61, align 8, !dbg !47
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !47
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %41, align 8, !dbg !47, !tbaa !20
-  %rubyId_foo40.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !50
-  %rawSym41.i.i = call i64 @rb_id2sym(i64 %rubyId_foo40.i.i) #10, !dbg !50
-  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !50
-  %rawSym42.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #10, !dbg !50
-  %65 = load i64, i64* @guard_epoch_A, align 8, !dbg !50
-  %66 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !48
-  %needTakeSlowPath3 = icmp ne i64 %65, %66, !dbg !50
-  br i1 %needTakeSlowPath3, label %67, label %68, !dbg !50, !prof !49
+  %58 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !49
+  %59 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !49
+  %60 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !49, !tbaa !50
+  %guardUpdated = icmp eq i64 %59, %60, !dbg !49
+  call void @llvm.assume(i1 %guardUpdated), !dbg !49
+  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !49
+  %62 = load i64*, i64** %61, align 8, !dbg !49
+  store i64 %31, i64* %62, align 8, !dbg !49, !tbaa !6
+  %63 = getelementptr inbounds i64, i64* %62, i64 1, !dbg !49
+  store i64 %58, i64* %63, align 8, !dbg !49, !tbaa !6
+  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !49
+  store i64* %64, i64** %61, align 8, !dbg !49
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !49
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %41, align 8, !dbg !49, !tbaa !22
+  %rubyId_foo40.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !52
+  %rawSym41.i.i = call i64 @rb_id2sym(i64 %rubyId_foo40.i.i) #10, !dbg !52
+  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !52
+  %rawSym42.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #10, !dbg !52
+  %65 = load i64, i64* @guard_epoch_A, align 8, !dbg !52
+  %66 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !50
+  %needTakeSlowPath3 = icmp ne i64 %65, %66, !dbg !52
+  br i1 %needTakeSlowPath3, label %67, label %68, !dbg !52, !prof !51
 
 67:                                               ; preds = %57
-  call void @const_recompute_A(), !dbg !50
-  br label %68, !dbg !50
+  call void @const_recompute_A(), !dbg !52
+  br label %68, !dbg !52
 
 68:                                               ; preds = %57, %67
-  %69 = load i64, i64* @guarded_const_A, align 8, !dbg !50
-  %70 = load i64, i64* @guard_epoch_A, align 8, !dbg !50
-  %71 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !48
-  %guardUpdated4 = icmp eq i64 %70, %71, !dbg !50
-  call void @llvm.assume(i1 %guardUpdated4), !dbg !50
-  %stackFrame46.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#foo", align 8, !dbg !50
-  %72 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !50
-  %73 = bitcast i8* %72 to i16*, !dbg !50
-  %74 = load i16, i16* %73, align 8, !dbg !50
-  %75 = and i16 %74, -384, !dbg !50
-  store i16 %75, i16* %73, align 8, !dbg !50
-  %76 = getelementptr inbounds i8, i8* %72, i64 4, !dbg !50
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 28, i1 false) #10, !dbg !50
-  call void @sorbet_vm_define_method(i64 %69, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#foo", i8* nonnull %72, %struct.rb_iseq_struct* %stackFrame46.i.i, i1 noundef zeroext false) #10, !dbg !50
-  %77 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !50, !tbaa !20
-  %78 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 5, !dbg !50
-  %79 = load i32, i32* %78, align 8, !dbg !50, !tbaa !43
-  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 6, !dbg !50
-  %81 = load i32, i32* %80, align 4, !dbg !50, !tbaa !44
-  %82 = xor i32 %81, -1, !dbg !50
-  %83 = and i32 %82, %79, !dbg !50
-  %84 = icmp eq i32 %83, 0, !dbg !50
-  br i1 %84, label %"func_<root>.<static-init>$151.exit", label %85, !dbg !50, !prof !45
+  %69 = load i64, i64* @guarded_const_A, align 8, !dbg !52
+  %70 = load i64, i64* @guard_epoch_A, align 8, !dbg !52
+  %71 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !50
+  %guardUpdated4 = icmp eq i64 %70, %71, !dbg !52
+  call void @llvm.assume(i1 %guardUpdated4), !dbg !52
+  %stackFrame46.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#foo", align 8, !dbg !52
+  %72 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !52
+  %73 = bitcast i8* %72 to i16*, !dbg !52
+  %74 = load i16, i16* %73, align 8, !dbg !52
+  %75 = and i16 %74, -384, !dbg !52
+  store i16 %75, i16* %73, align 8, !dbg !52
+  %76 = getelementptr inbounds i8, i8* %72, i64 4, !dbg !52
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 28, i1 false) #10, !dbg !52
+  call void @sorbet_vm_define_method(i64 %69, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#foo", i8* nonnull %72, %struct.rb_iseq_struct* %stackFrame46.i.i, i1 noundef zeroext false) #10, !dbg !52
+  %77 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !22
+  %78 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 5, !dbg !52
+  %79 = load i32, i32* %78, align 8, !dbg !52, !tbaa !45
+  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 6, !dbg !52
+  %81 = load i32, i32* %80, align 4, !dbg !52, !tbaa !46
+  %82 = xor i32 %81, -1, !dbg !52
+  %83 = and i32 %82, %79, !dbg !52
+  %84 = icmp eq i32 %83, 0, !dbg !52
+  br i1 %84, label %"func_<root>.<static-init>$151.exit", label %85, !dbg !52, !prof !47
 
 85:                                               ; preds = %68
-  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 8, !dbg !50
-  %87 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %86, align 8, !dbg !50, !tbaa !46
-  %88 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %87, i32 noundef 0) #10, !dbg !50
-  br label %"func_<root>.<static-init>$151.exit", !dbg !50
+  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 8, !dbg !52
+  %87 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %86, align 8, !dbg !52, !tbaa !48
+  %88 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %87, i32 noundef 0) #10, !dbg !52
+  br label %"func_<root>.<static-init>$151.exit", !dbg !52
 
 "func_<root>.<static-init>$151.exit":             ; preds = %68, %85
-  call void @sorbet_popFrame() #10, !dbg !39
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %29, align 8, !dbg !39, !tbaa !20
-  %89 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !8
-  %90 = load i64*, i64** %89, align 8, !dbg !8
-  store i64 %69, i64* %90, align 8, !dbg !8, !tbaa !4
-  %91 = getelementptr inbounds i64, i64* %90, i64 1, !dbg !8
-  store i64* %91, i64** %89, align 8, !dbg !8
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !8
-  %92 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !8
-  %93 = load i64*, i64** %92, align 8, !dbg !8
-  store i64 %send6, i64* %93, align 8, !dbg !8, !tbaa !4
-  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !8
-  store i64* %94, i64** %92, align 8, !dbg !8
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !8
-  %95 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !13
-  %96 = load i64*, i64** %95, align 8, !dbg !13
-  store i64 %20, i64* %96, align 8, !dbg !13, !tbaa !4
-  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !13
-  store i64 %send8, i64* %97, align 8, !dbg !13, !tbaa !4
-  %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !13
-  store i64* %98, i64** %95, align 8, !dbg !13
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !13
+  call void @sorbet_popFrame() #10, !dbg !41
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %29, align 8, !dbg !41, !tbaa !22
+  %89 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !10
+  %90 = load i64*, i64** %89, align 8, !dbg !10
+  store i64 %69, i64* %90, align 8, !dbg !10, !tbaa !6
+  %91 = getelementptr inbounds i64, i64* %90, i64 1, !dbg !10
+  store i64* %91, i64** %89, align 8, !dbg !10
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !10
+  %92 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !10
+  %93 = load i64*, i64** %92, align 8, !dbg !10
+  store i64 %send6, i64* %93, align 8, !dbg !10, !tbaa !6
+  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !10
+  store i64* %94, i64** %92, align 8, !dbg !10
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !10
+  %95 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !15
+  %96 = load i64*, i64** %95, align 8, !dbg !15
+  store i64 %20, i64* %96, align 8, !dbg !15, !tbaa !6
+  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !15
+  store i64 %send8, i64* %97, align 8, !dbg !15, !tbaa !6
+  %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !15
+  store i64* %98, i64** %95, align 8, !dbg !15
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define noundef i64 @"func_A#foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #5 !dbg !51 {
+define noundef i64 @"func_A#foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #5 !dbg !53 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !20
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !52
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !52, !prof !53
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !22
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !54
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !54, !prof !55
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #12, !dbg !52
-  unreachable, !dbg !52
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #12, !dbg !54
+  unreachable, !dbg !54
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !54, !tbaa !20
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !56, !tbaa !22
   ret i64 183
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_A.<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #6 !dbg !17 {
+define internal i64 @"func_A.<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #6 !dbg !19 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !32
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !34
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !55
+  %4 = load i64, i64* %3, align 8, !tbaa !57
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.<static-init>$block_1", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !35
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !37
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !37
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !39
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !20
-  %11 = load i64, i64* @rb_cInteger, align 8, !dbg !16
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !16
-  %13 = load i64*, i64** %12, align 8, !dbg !16
-  store i64 %4, i64* %13, align 8, !dbg !16, !tbaa !4
-  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !16
-  store i64 %11, i64* %14, align 8, !dbg !16, !tbaa !4
-  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !16
-  store i64* %15, i64** %12, align 8, !dbg !16
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !16
-  ret i64 %send, !dbg !56
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !22
+  %11 = load i64, i64* @rb_cInteger, align 8, !dbg !18
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !18
+  %13 = load i64*, i64** %12, align 8, !dbg !18
+  store i64 %4, i64* %13, align 8, !dbg !18, !tbaa !6
+  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !18
+  store i64 %11, i64* %14, align 8, !dbg !18, !tbaa !6
+  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !18
+  store i64* %15, i64** %12, align 8, !dbg !18
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !18
+  ret i64 %send, !dbg !58
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
@@ -460,7 +460,7 @@ declare void @llvm.assume(i1 noundef) #8
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #6 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !48
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !50
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
@@ -469,7 +469,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #6 {
 define linkonce void @const_recompute_A() local_unnamed_addr #6 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !48
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !50
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -488,63 +488,65 @@ attributes #10 = { nounwind }
 attributes #11 = { nounwind allocsize(0,1) }
 attributes #12 = { noreturn }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/sig_rewriter.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 13, column: 6, scope: !9)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !DILocation(line: 13, column: 1, scope: !9)
-!14 = !DILocation(line: 7, column: 3, scope: !15)
-!15 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L62", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!16 = !DILocation(line: 7, column: 8, scope: !17)
-!17 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L62$block_1", scope: !15, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!18 = !DILocation(line: 6, column: 3, scope: !15)
-!19 = !DILocation(line: 8, column: 3, scope: !15)
-!20 = !{!21, !21, i64 0}
-!21 = !{!"any pointer", !6, i64 0}
-!22 = !{!23, !5, i64 400}
-!23 = !{!"rb_vm_struct", !5, i64 0, !24, i64 8, !21, i64 192, !21, i64 200, !21, i64 208, !28, i64 216, !6, i64 224, !25, i64 264, !25, i64 280, !25, i64 296, !25, i64 312, !5, i64 328, !27, i64 336, !27, i64 340, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !21, i64 456, !21, i64 464, !29, i64 472, !30, i64 992, !21, i64 1016, !21, i64 1024, !27, i64 1032, !27, i64 1036, !25, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !27, i64 1136, !21, i64 1144, !21, i64 1152, !21, i64 1160, !21, i64 1168, !21, i64 1176, !21, i64 1184, !27, i64 1192, !31, i64 1200, !6, i64 1232}
-!24 = !{!"rb_global_vm_lock_struct", !21, i64 0, !6, i64 8, !25, i64 48, !21, i64 64, !27, i64 72, !6, i64 80, !6, i64 128, !27, i64 176, !27, i64 180}
-!25 = !{!"list_head", !26, i64 0}
-!26 = !{!"list_node", !21, i64 0, !21, i64 8}
-!27 = !{!"int", !6, i64 0}
-!28 = !{!"long long", !6, i64 0}
-!29 = !{!"", !6, i64 0}
-!30 = !{!"rb_hook_list_struct", !21, i64 0, !27, i64 8, !27, i64 12, !27, i64 16}
-!31 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!32 = !{!33, !21, i64 16}
-!33 = !{!"rb_execution_context_struct", !21, i64 0, !5, i64 8, !21, i64 16, !21, i64 24, !21, i64 32, !27, i64 40, !27, i64 44, !21, i64 48, !21, i64 56, !21, i64 64, !5, i64 72, !5, i64 80, !21, i64 88, !5, i64 96, !21, i64 104, !21, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !34, i64 152}
-!34 = !{!"", !21, i64 0, !21, i64 8, !5, i64 16, !6, i64 24}
-!35 = !{!36, !21, i64 16}
-!36 = !{!"rb_control_frame_struct", !21, i64 0, !21, i64 8, !21, i64 16, !5, i64 24, !21, i64 32, !21, i64 40, !21, i64 48}
-!37 = !{!36, !21, i64 32}
-!38 = !DILocation(line: 0, scope: !9)
-!39 = !DILocation(line: 5, column: 1, scope: !9)
-!40 = !DILocation(line: 0, scope: !15, inlinedAt: !41)
-!41 = distinct !DILocation(line: 5, column: 1, scope: !9)
-!42 = !DILocation(line: 7, column: 3, scope: !15, inlinedAt: !41)
-!43 = !{!33, !27, i64 40}
-!44 = !{!33, !27, i64 44}
-!45 = !{!"branch_weights", i32 2000, i32 1}
-!46 = !{!33, !21, i64 56}
-!47 = !DILocation(line: 6, column: 3, scope: !15, inlinedAt: !41)
-!48 = !{!28, !28, i64 0}
-!49 = !{!"branch_weights", i32 1, i32 10000}
-!50 = !DILocation(line: 8, column: 3, scope: !15, inlinedAt: !41)
-!51 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#foo", scope: null, file: !2, line: 8, type: !10, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!52 = !DILocation(line: 8, column: 3, scope: !51)
-!53 = !{!"branch_weights", i32 1, i32 2000}
-!54 = !DILocation(line: 0, scope: !51)
-!55 = !{!36, !5, i64 24}
-!56 = !DILocation(line: 7, column: 3, scope: !17)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/sig_rewriter.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 13, column: 6, scope: !11)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !DILocation(line: 13, column: 1, scope: !11)
+!16 = !DILocation(line: 7, column: 3, scope: !17)
+!17 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!18 = !DILocation(line: 7, column: 8, scope: !19)
+!19 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.<static-init>L62$block_1", scope: !17, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!20 = !DILocation(line: 6, column: 3, scope: !17)
+!21 = !DILocation(line: 8, column: 3, scope: !17)
+!22 = !{!23, !23, i64 0}
+!23 = !{!"any pointer", !8, i64 0}
+!24 = !{!25, !7, i64 400}
+!25 = !{!"rb_vm_struct", !7, i64 0, !26, i64 8, !23, i64 192, !23, i64 200, !23, i64 208, !30, i64 216, !8, i64 224, !27, i64 264, !27, i64 280, !27, i64 296, !27, i64 312, !7, i64 328, !29, i64 336, !29, i64 340, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !23, i64 456, !23, i64 464, !31, i64 472, !32, i64 992, !23, i64 1016, !23, i64 1024, !29, i64 1032, !29, i64 1036, !27, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !29, i64 1136, !23, i64 1144, !23, i64 1152, !23, i64 1160, !23, i64 1168, !23, i64 1176, !23, i64 1184, !29, i64 1192, !33, i64 1200, !8, i64 1232}
+!26 = !{!"rb_global_vm_lock_struct", !23, i64 0, !8, i64 8, !27, i64 48, !23, i64 64, !29, i64 72, !8, i64 80, !8, i64 128, !29, i64 176, !29, i64 180}
+!27 = !{!"list_head", !28, i64 0}
+!28 = !{!"list_node", !23, i64 0, !23, i64 8}
+!29 = !{!"int", !8, i64 0}
+!30 = !{!"long long", !8, i64 0}
+!31 = !{!"", !8, i64 0}
+!32 = !{!"rb_hook_list_struct", !23, i64 0, !29, i64 8, !29, i64 12, !29, i64 16}
+!33 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!34 = !{!35, !23, i64 16}
+!35 = !{!"rb_execution_context_struct", !23, i64 0, !7, i64 8, !23, i64 16, !23, i64 24, !23, i64 32, !29, i64 40, !29, i64 44, !23, i64 48, !23, i64 56, !23, i64 64, !7, i64 72, !7, i64 80, !23, i64 88, !7, i64 96, !23, i64 104, !23, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !36, i64 152}
+!36 = !{!"", !23, i64 0, !23, i64 8, !7, i64 16, !8, i64 24}
+!37 = !{!38, !23, i64 16}
+!38 = !{!"rb_control_frame_struct", !23, i64 0, !23, i64 8, !23, i64 16, !7, i64 24, !23, i64 32, !23, i64 40, !23, i64 48}
+!39 = !{!38, !23, i64 32}
+!40 = !DILocation(line: 0, scope: !11)
+!41 = !DILocation(line: 5, column: 1, scope: !11)
+!42 = !DILocation(line: 0, scope: !17, inlinedAt: !43)
+!43 = distinct !DILocation(line: 5, column: 1, scope: !11)
+!44 = !DILocation(line: 7, column: 3, scope: !17, inlinedAt: !43)
+!45 = !{!35, !29, i64 40}
+!46 = !{!35, !29, i64 44}
+!47 = !{!"branch_weights", i32 2000, i32 1}
+!48 = !{!35, !23, i64 56}
+!49 = !DILocation(line: 6, column: 3, scope: !17, inlinedAt: !43)
+!50 = !{!30, !30, i64 0}
+!51 = !{!"branch_weights", i32 1, i32 10000}
+!52 = !DILocation(line: 8, column: 3, scope: !17, inlinedAt: !43)
+!53 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#foo", scope: null, file: !4, line: 8, type: !12, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!54 = !DILocation(line: 8, column: 3, scope: !53)
+!55 = !{!"branch_weights", i32 1, i32 2000}
+!56 = !DILocation(line: 0, scope: !53)
+!57 = !{!38, !7, i64 24}
+!58 = !DILocation(line: 7, column: 3, scope: !19)

--- a/test/testdata/compiler/splat_assign.llo.exp
+++ b/test/testdata/compiler/splat_assign.llo.exp
@@ -133,14 +133,14 @@ declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) loc
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #6
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #6
   unreachable
 }
@@ -171,437 +171,437 @@ entry:
   %"rubyStr_test/testdata/compiler/splat_assign.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/splat_assign.rb", align 8
   %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/splat_assign.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 8)
   store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !8
-  %rubyId_puts12.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !13
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts12.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !13
-  %rubyId_puts21.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !14
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.10, i64 %rubyId_puts21.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !14
-  %8 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
+  %rubyId_puts12.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts12.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
+  %rubyId_puts21.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !16
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.10, i64 %rubyId_puts21.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
+  %8 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !17
   %9 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %8, i64 0, i32 18
-  %10 = load i64, i64* %9, align 8, !tbaa !17
-  %11 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %10 = load i64, i64* %9, align 8, !tbaa !19
+  %11 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !17
   %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %11, i64 0, i32 2
-  %13 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %12, align 8, !tbaa !27
+  %13 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %12, align 8, !tbaa !29
   %14 = bitcast [8 x i64]* %callArgs.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 64, i8* nonnull %14)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %12, align 8, !tbaa !27
+  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %12, align 8, !tbaa !29
   %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !30
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !32
   %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 4
-  %18 = load i64*, i64** %17, align 8, !tbaa !32
-  %19 = load i64, i64* %18, align 8, !tbaa !4
+  %18 = load i64*, i64** %17, align 8, !tbaa !34
+  %19 = load i64, i64* %18, align 8, !tbaa !6
   %20 = and i64 %19, -33
-  store i64 %20, i64* %18, align 8, !tbaa !4
+  store i64 %20, i64* %18, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %11, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #7
   %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !dbg !33, !tbaa !15
-  %callArgs0Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i32 0, i64 0, !dbg !34
-  %callArgs1Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i32 0, i64 1, !dbg !34
-  %callArgs2Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i32 0, i64 2, !dbg !34
-  %22 = bitcast i64* %callArgs0Addr.i to <4 x i64>*, !dbg !34
-  store <4 x i64> <i64 3, i64 5, i64 7, i64 9>, <4 x i64>* %22, align 8, !dbg !34
-  %callArgs4Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i32 0, i64 4, !dbg !34
-  %23 = bitcast i64* %callArgs4Addr.i to <2 x i64>*, !dbg !34
-  store <2 x i64> <i64 11, i64 13>, <2 x i64>* %23, align 8, !dbg !34
-  %callArgs6Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i32 0, i64 6, !dbg !34
-  store i64 15, i64* %callArgs6Addr.i, align 8, !dbg !34
-  %24 = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i64 0, i64 0, !dbg !34
-  call void @llvm.experimental.noalias.scope.decl(metadata !35) #7, !dbg !34
-  %25 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull align 8 %24) #7, !dbg !34
-  store i64 %25, i64* %callArgs0Addr.i, align 8, !dbg !38
-  %26 = bitcast i64* %callArgs1Addr.i to <2 x i64>*, !dbg !38
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %26, align 8, !dbg !38
-  call void @llvm.experimental.noalias.scope.decl(metadata !39) #7, !dbg !38
-  %27 = load i64, i64* %24, align 8, !dbg !38, !tbaa !4, !alias.scope !39
-  %28 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !38
-  %29 = getelementptr inbounds i64, i64* %24, i64 2, !dbg !38
-  %30 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %27, i64 3, i64 5) #7, !dbg !38, !noalias !39
-  %"rubyId_[].i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !38
-  store i64 1, i64* %callArgs0Addr.i, align 8, !dbg !38
-  call void @llvm.experimental.noalias.scope.decl(metadata !42) #7, !dbg !38
-  %31 = load i64, i64* %24, align 8, !dbg !38, !tbaa !4, !alias.scope !42
-  %32 = and i64 %31, 1, !dbg !38
-  %33 = icmp eq i64 %32, 0, !dbg !38
-  br i1 %33, label %37, label %34, !dbg !38, !prof !45
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !dbg !35, !tbaa !17
+  %callArgs0Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i32 0, i64 0, !dbg !36
+  %callArgs1Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i32 0, i64 1, !dbg !36
+  %callArgs2Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i32 0, i64 2, !dbg !36
+  %22 = bitcast i64* %callArgs0Addr.i to <4 x i64>*, !dbg !36
+  store <4 x i64> <i64 3, i64 5, i64 7, i64 9>, <4 x i64>* %22, align 8, !dbg !36
+  %callArgs4Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i32 0, i64 4, !dbg !36
+  %23 = bitcast i64* %callArgs4Addr.i to <2 x i64>*, !dbg !36
+  store <2 x i64> <i64 11, i64 13>, <2 x i64>* %23, align 8, !dbg !36
+  %callArgs6Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i32 0, i64 6, !dbg !36
+  store i64 15, i64* %callArgs6Addr.i, align 8, !dbg !36
+  %24 = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i64 0, i64 0, !dbg !36
+  call void @llvm.experimental.noalias.scope.decl(metadata !37) #7, !dbg !36
+  %25 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull align 8 %24) #7, !dbg !36
+  store i64 %25, i64* %callArgs0Addr.i, align 8, !dbg !40
+  %26 = bitcast i64* %callArgs1Addr.i to <2 x i64>*, !dbg !40
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %26, align 8, !dbg !40
+  call void @llvm.experimental.noalias.scope.decl(metadata !41) #7, !dbg !40
+  %27 = load i64, i64* %24, align 8, !dbg !40, !tbaa !6, !alias.scope !41
+  %28 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !40
+  %29 = getelementptr inbounds i64, i64* %24, i64 2, !dbg !40
+  %30 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %27, i64 3, i64 5) #7, !dbg !40, !noalias !41
+  %"rubyId_[].i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !40
+  store i64 1, i64* %callArgs0Addr.i, align 8, !dbg !40
+  call void @llvm.experimental.noalias.scope.decl(metadata !44) #7, !dbg !40
+  %31 = load i64, i64* %24, align 8, !dbg !40, !tbaa !6, !alias.scope !44
+  %32 = and i64 %31, 1, !dbg !40
+  %33 = icmp eq i64 %32, 0, !dbg !40
+  br i1 %33, label %37, label %34, !dbg !40, !prof !47
 
 34:                                               ; preds = %entry
-  %35 = ashr i64 %31, 1, !dbg !38
-  %36 = call i64 @rb_ary_entry(i64 %30, i64 %35) #7, !dbg !38
-  br label %sorbet_rb_array_square_br.exit370.i, !dbg !38
+  %35 = ashr i64 %31, 1, !dbg !40
+  %36 = call i64 @rb_ary_entry(i64 %30, i64 %35) #7, !dbg !40
+  br label %sorbet_rb_array_square_br.exit370.i, !dbg !40
 
 37:                                               ; preds = %entry
-  %38 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %30, i64 %"rubyId_[].i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !38
-  br label %sorbet_rb_array_square_br.exit370.i, !dbg !38
+  %38 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %30, i64 %"rubyId_[].i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !40
+  br label %sorbet_rb_array_square_br.exit370.i, !dbg !40
 
 sorbet_rb_array_square_br.exit370.i:              ; preds = %37, %34
-  %39 = phi i64 [ %38, %37 ], [ %36, %34 ], !dbg !38
-  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !38, !tbaa !15
-  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 5, !dbg !38
-  %42 = load i32, i32* %41, align 8, !dbg !38, !tbaa !46
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 6, !dbg !38
-  %44 = load i32, i32* %43, align 4, !dbg !38, !tbaa !47
-  %45 = xor i32 %44, -1, !dbg !38
-  %46 = and i32 %45, %42, !dbg !38
-  %47 = icmp eq i32 %46, 0, !dbg !38
-  br i1 %47, label %rb_vm_check_ints.exit3.i, label %48, !dbg !38, !prof !48
+  %39 = phi i64 [ %38, %37 ], [ %36, %34 ], !dbg !40
+  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
+  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 5, !dbg !40
+  %42 = load i32, i32* %41, align 8, !dbg !40, !tbaa !48
+  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 6, !dbg !40
+  %44 = load i32, i32* %43, align 4, !dbg !40, !tbaa !49
+  %45 = xor i32 %44, -1, !dbg !40
+  %46 = and i32 %45, %42, !dbg !40
+  %47 = icmp eq i32 %46, 0, !dbg !40
+  br i1 %47, label %rb_vm_check_ints.exit3.i, label %48, !dbg !40, !prof !50
 
 48:                                               ; preds = %sorbet_rb_array_square_br.exit370.i
-  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 8, !dbg !38
-  %50 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %49, align 8, !dbg !38, !tbaa !49
-  %51 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %50, i32 noundef 0) #7, !dbg !38
-  br label %rb_vm_check_ints.exit3.i, !dbg !38
+  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 8, !dbg !40
+  %50 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %49, align 8, !dbg !40, !tbaa !51
+  %51 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %50, i32 noundef 0) #7, !dbg !40
+  br label %rb_vm_check_ints.exit3.i, !dbg !40
 
 rb_vm_check_ints.exit3.i:                         ; preds = %48, %sorbet_rb_array_square_br.exit370.i
-  %"rubyId_[]135.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !38
-  store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !38
-  call void @llvm.experimental.noalias.scope.decl(metadata !50) #7, !dbg !38
-  %52 = load i64, i64* %24, align 8, !dbg !38, !tbaa !4, !alias.scope !50
-  %53 = and i64 %52, 1, !dbg !38
-  %54 = icmp eq i64 %53, 0, !dbg !38
-  br i1 %54, label %58, label %55, !dbg !38, !prof !45
+  %"rubyId_[]135.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !40
+  store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !40
+  call void @llvm.experimental.noalias.scope.decl(metadata !52) #7, !dbg !40
+  %52 = load i64, i64* %24, align 8, !dbg !40, !tbaa !6, !alias.scope !52
+  %53 = and i64 %52, 1, !dbg !40
+  %54 = icmp eq i64 %53, 0, !dbg !40
+  br i1 %54, label %58, label %55, !dbg !40, !prof !47
 
 55:                                               ; preds = %rb_vm_check_ints.exit3.i
-  %56 = ashr i64 %52, 1, !dbg !38
-  %57 = call i64 @rb_ary_entry(i64 %30, i64 %56) #7, !dbg !38
-  br label %sorbet_rb_array_square_br.exit371.i, !dbg !38
+  %56 = ashr i64 %52, 1, !dbg !40
+  %57 = call i64 @rb_ary_entry(i64 %30, i64 %56) #7, !dbg !40
+  br label %sorbet_rb_array_square_br.exit371.i, !dbg !40
 
 58:                                               ; preds = %rb_vm_check_ints.exit3.i
-  %59 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %30, i64 %"rubyId_[]135.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !38
-  br label %sorbet_rb_array_square_br.exit371.i, !dbg !38
+  %59 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %30, i64 %"rubyId_[]135.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !40
+  br label %sorbet_rb_array_square_br.exit371.i, !dbg !40
 
 sorbet_rb_array_square_br.exit371.i:              ; preds = %58, %55
-  %60 = phi i64 [ %59, %58 ], [ %57, %55 ], !dbg !38
-  %61 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !38, !tbaa !15
-  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 5, !dbg !38
-  %63 = load i32, i32* %62, align 8, !dbg !38, !tbaa !46
-  %64 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 6, !dbg !38
-  %65 = load i32, i32* %64, align 4, !dbg !38, !tbaa !47
-  %66 = xor i32 %65, -1, !dbg !38
-  %67 = and i32 %66, %63, !dbg !38
-  %68 = icmp eq i32 %67, 0, !dbg !38
-  br i1 %68, label %rb_vm_check_ints.exit5.i, label %69, !dbg !38, !prof !48
+  %60 = phi i64 [ %59, %58 ], [ %57, %55 ], !dbg !40
+  %61 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
+  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 5, !dbg !40
+  %63 = load i32, i32* %62, align 8, !dbg !40, !tbaa !48
+  %64 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 6, !dbg !40
+  %65 = load i32, i32* %64, align 4, !dbg !40, !tbaa !49
+  %66 = xor i32 %65, -1, !dbg !40
+  %67 = and i32 %66, %63, !dbg !40
+  %68 = icmp eq i32 %67, 0, !dbg !40
+  br i1 %68, label %rb_vm_check_ints.exit5.i, label %69, !dbg !40, !prof !50
 
 69:                                               ; preds = %sorbet_rb_array_square_br.exit371.i
-  %70 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 8, !dbg !38
-  %71 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %70, align 8, !dbg !38, !tbaa !49
-  %72 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %71, i32 noundef 0) #7, !dbg !38
-  br label %rb_vm_check_ints.exit5.i, !dbg !38
+  %70 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 8, !dbg !40
+  %71 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %70, align 8, !dbg !40, !tbaa !51
+  %72 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %71, i32 noundef 0) #7, !dbg !40
+  br label %rb_vm_check_ints.exit5.i, !dbg !40
 
 rb_vm_check_ints.exit5.i:                         ; preds = %69, %sorbet_rb_array_square_br.exit371.i
-  %"rubyId_[]148.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !38
-  store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !38
-  call void @llvm.experimental.noalias.scope.decl(metadata !53) #7, !dbg !38
-  %73 = load i64, i64* %24, align 8, !dbg !38, !tbaa !4, !alias.scope !53
-  %74 = and i64 %73, 1, !dbg !38
-  %75 = icmp eq i64 %74, 0, !dbg !38
-  br i1 %75, label %79, label %76, !dbg !38, !prof !45
+  %"rubyId_[]148.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !40
+  store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !40
+  call void @llvm.experimental.noalias.scope.decl(metadata !55) #7, !dbg !40
+  %73 = load i64, i64* %24, align 8, !dbg !40, !tbaa !6, !alias.scope !55
+  %74 = and i64 %73, 1, !dbg !40
+  %75 = icmp eq i64 %74, 0, !dbg !40
+  br i1 %75, label %79, label %76, !dbg !40, !prof !47
 
 76:                                               ; preds = %rb_vm_check_ints.exit5.i
-  %77 = ashr i64 %73, 1, !dbg !38
-  %78 = call i64 @rb_ary_entry(i64 %30, i64 %77) #7, !dbg !38
-  br label %sorbet_rb_array_square_br.exit372.i, !dbg !38
+  %77 = ashr i64 %73, 1, !dbg !40
+  %78 = call i64 @rb_ary_entry(i64 %30, i64 %77) #7, !dbg !40
+  br label %sorbet_rb_array_square_br.exit372.i, !dbg !40
 
 79:                                               ; preds = %rb_vm_check_ints.exit5.i
-  %80 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %30, i64 %"rubyId_[]148.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !38
-  br label %sorbet_rb_array_square_br.exit372.i, !dbg !38
+  %80 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %30, i64 %"rubyId_[]148.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !40
+  br label %sorbet_rb_array_square_br.exit372.i, !dbg !40
 
 sorbet_rb_array_square_br.exit372.i:              ; preds = %79, %76
-  %81 = phi i64 [ %80, %79 ], [ %78, %76 ], !dbg !38
-  %82 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !38, !tbaa !15
-  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 5, !dbg !38
-  %84 = load i32, i32* %83, align 8, !dbg !38, !tbaa !46
-  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 6, !dbg !38
-  %86 = load i32, i32* %85, align 4, !dbg !38, !tbaa !47
-  %87 = xor i32 %86, -1, !dbg !38
-  %88 = and i32 %87, %84, !dbg !38
-  %89 = icmp eq i32 %88, 0, !dbg !38
-  br i1 %89, label %rb_vm_check_ints.exit7.i, label %90, !dbg !38, !prof !48
+  %81 = phi i64 [ %80, %79 ], [ %78, %76 ], !dbg !40
+  %82 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
+  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 5, !dbg !40
+  %84 = load i32, i32* %83, align 8, !dbg !40, !tbaa !48
+  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 6, !dbg !40
+  %86 = load i32, i32* %85, align 4, !dbg !40, !tbaa !49
+  %87 = xor i32 %86, -1, !dbg !40
+  %88 = and i32 %87, %84, !dbg !40
+  %89 = icmp eq i32 %88, 0, !dbg !40
+  br i1 %89, label %rb_vm_check_ints.exit7.i, label %90, !dbg !40, !prof !50
 
 90:                                               ; preds = %sorbet_rb_array_square_br.exit372.i
-  %91 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 8, !dbg !38
-  %92 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %91, align 8, !dbg !38, !tbaa !49
-  %93 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %92, i32 noundef 0) #7, !dbg !38
-  br label %rb_vm_check_ints.exit7.i, !dbg !38
+  %91 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 8, !dbg !40
+  %92 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %91, align 8, !dbg !40, !tbaa !51
+  %93 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %92, i32 noundef 0) #7, !dbg !40
+  br label %rb_vm_check_ints.exit7.i, !dbg !40
 
 rb_vm_check_ints.exit7.i:                         ; preds = %90, %sorbet_rb_array_square_br.exit372.i
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %21, align 8, !dbg !33, !tbaa !15
-  store i64 %39, i64* %callArgs0Addr.i, align 8, !dbg !56
-  store i64 %60, i64* %callArgs1Addr.i, align 8, !dbg !56
-  store i64 %81, i64* %callArgs2Addr.i, align 8, !dbg !56
-  call void @llvm.experimental.noalias.scope.decl(metadata !57) #7, !dbg !56
-  %94 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %24) #7, !dbg !56
-  %95 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 1, !dbg !8
-  %96 = load i64*, i64** %95, align 8, !dbg !8
-  store i64 %10, i64* %96, align 8, !dbg !8, !tbaa !4
-  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !8
-  store i64 %94, i64* %97, align 8, !dbg !8, !tbaa !4
-  %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !8
-  store i64* %98, i64** %95, align 8, !dbg !8
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !8
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %21, align 8, !dbg !8, !tbaa !15
-  %99 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !60
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %99, align 8, !dbg !60
-  call void @llvm.experimental.noalias.scope.decl(metadata !61) #7, !dbg !60
-  %100 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %24) #7, !dbg !60
-  store i64 %100, i64* %callArgs0Addr.i, align 8, !dbg !64
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %26, align 8, !dbg !64
-  call void @llvm.experimental.noalias.scope.decl(metadata !65) #7, !dbg !64
-  %101 = load i64, i64* %24, align 8, !dbg !64, !tbaa !4, !alias.scope !65
-  %102 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %101, i64 3, i64 5) #7, !dbg !64, !noalias !65
-  %"rubyId_[]207.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !64
-  store i64 1, i64* %callArgs0Addr.i, align 8, !dbg !64
-  call void @llvm.experimental.noalias.scope.decl(metadata !68) #7, !dbg !64
-  %103 = load i64, i64* %24, align 8, !dbg !64, !tbaa !4, !alias.scope !68
-  %104 = and i64 %103, 1, !dbg !64
-  %105 = icmp eq i64 %104, 0, !dbg !64
-  br i1 %105, label %109, label %106, !dbg !64, !prof !45
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %21, align 8, !dbg !35, !tbaa !17
+  store i64 %39, i64* %callArgs0Addr.i, align 8, !dbg !58
+  store i64 %60, i64* %callArgs1Addr.i, align 8, !dbg !58
+  store i64 %81, i64* %callArgs2Addr.i, align 8, !dbg !58
+  call void @llvm.experimental.noalias.scope.decl(metadata !59) #7, !dbg !58
+  %94 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %24) #7, !dbg !58
+  %95 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 1, !dbg !10
+  %96 = load i64*, i64** %95, align 8, !dbg !10
+  store i64 %10, i64* %96, align 8, !dbg !10, !tbaa !6
+  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !10
+  store i64 %94, i64* %97, align 8, !dbg !10, !tbaa !6
+  %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !10
+  store i64* %98, i64** %95, align 8, !dbg !10
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %21, align 8, !dbg !10, !tbaa !17
+  %99 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !62
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %99, align 8, !dbg !62
+  call void @llvm.experimental.noalias.scope.decl(metadata !63) #7, !dbg !62
+  %100 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %24) #7, !dbg !62
+  store i64 %100, i64* %callArgs0Addr.i, align 8, !dbg !66
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %26, align 8, !dbg !66
+  call void @llvm.experimental.noalias.scope.decl(metadata !67) #7, !dbg !66
+  %101 = load i64, i64* %24, align 8, !dbg !66, !tbaa !6, !alias.scope !67
+  %102 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %101, i64 3, i64 5) #7, !dbg !66, !noalias !67
+  %"rubyId_[]207.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !66
+  store i64 1, i64* %callArgs0Addr.i, align 8, !dbg !66
+  call void @llvm.experimental.noalias.scope.decl(metadata !70) #7, !dbg !66
+  %103 = load i64, i64* %24, align 8, !dbg !66, !tbaa !6, !alias.scope !70
+  %104 = and i64 %103, 1, !dbg !66
+  %105 = icmp eq i64 %104, 0, !dbg !66
+  br i1 %105, label %109, label %106, !dbg !66, !prof !47
 
 106:                                              ; preds = %rb_vm_check_ints.exit7.i
-  %107 = ashr i64 %103, 1, !dbg !64
-  %108 = call i64 @rb_ary_entry(i64 %102, i64 %107) #7, !dbg !64
-  br label %sorbet_rb_array_square_br.exit373.i, !dbg !64
+  %107 = ashr i64 %103, 1, !dbg !66
+  %108 = call i64 @rb_ary_entry(i64 %102, i64 %107) #7, !dbg !66
+  br label %sorbet_rb_array_square_br.exit373.i, !dbg !66
 
 109:                                              ; preds = %rb_vm_check_ints.exit7.i
-  %110 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %102, i64 %"rubyId_[]207.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !64
-  br label %sorbet_rb_array_square_br.exit373.i, !dbg !64
+  %110 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %102, i64 %"rubyId_[]207.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !66
+  br label %sorbet_rb_array_square_br.exit373.i, !dbg !66
 
 sorbet_rb_array_square_br.exit373.i:              ; preds = %109, %106
-  %111 = phi i64 [ %110, %109 ], [ %108, %106 ], !dbg !64
-  %112 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !64, !tbaa !15
-  %113 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %112, i64 0, i32 5, !dbg !64
-  %114 = load i32, i32* %113, align 8, !dbg !64, !tbaa !46
-  %115 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %112, i64 0, i32 6, !dbg !64
-  %116 = load i32, i32* %115, align 4, !dbg !64, !tbaa !47
-  %117 = xor i32 %116, -1, !dbg !64
-  %118 = and i32 %117, %114, !dbg !64
-  %119 = icmp eq i32 %118, 0, !dbg !64
-  br i1 %119, label %rb_vm_check_ints.exit8.i, label %120, !dbg !64, !prof !48
+  %111 = phi i64 [ %110, %109 ], [ %108, %106 ], !dbg !66
+  %112 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !17
+  %113 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %112, i64 0, i32 5, !dbg !66
+  %114 = load i32, i32* %113, align 8, !dbg !66, !tbaa !48
+  %115 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %112, i64 0, i32 6, !dbg !66
+  %116 = load i32, i32* %115, align 4, !dbg !66, !tbaa !49
+  %117 = xor i32 %116, -1, !dbg !66
+  %118 = and i32 %117, %114, !dbg !66
+  %119 = icmp eq i32 %118, 0, !dbg !66
+  br i1 %119, label %rb_vm_check_ints.exit8.i, label %120, !dbg !66, !prof !50
 
 120:                                              ; preds = %sorbet_rb_array_square_br.exit373.i
-  %121 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %112, i64 0, i32 8, !dbg !64
-  %122 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %121, align 8, !dbg !64, !tbaa !49
-  %123 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %122, i32 noundef 0) #7, !dbg !64
-  br label %rb_vm_check_ints.exit8.i, !dbg !64
+  %121 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %112, i64 0, i32 8, !dbg !66
+  %122 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %121, align 8, !dbg !66, !tbaa !51
+  %123 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %122, i32 noundef 0) #7, !dbg !66
+  br label %rb_vm_check_ints.exit8.i, !dbg !66
 
 rb_vm_check_ints.exit8.i:                         ; preds = %120, %sorbet_rb_array_square_br.exit373.i
-  %"rubyId_[]220.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !64
-  store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !64
-  call void @llvm.experimental.noalias.scope.decl(metadata !71) #7, !dbg !64
-  %124 = load i64, i64* %24, align 8, !dbg !64, !tbaa !4, !alias.scope !71
-  %125 = and i64 %124, 1, !dbg !64
-  %126 = icmp eq i64 %125, 0, !dbg !64
-  br i1 %126, label %130, label %127, !dbg !64, !prof !45
+  %"rubyId_[]220.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !66
+  store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !66
+  call void @llvm.experimental.noalias.scope.decl(metadata !73) #7, !dbg !66
+  %124 = load i64, i64* %24, align 8, !dbg !66, !tbaa !6, !alias.scope !73
+  %125 = and i64 %124, 1, !dbg !66
+  %126 = icmp eq i64 %125, 0, !dbg !66
+  br i1 %126, label %130, label %127, !dbg !66, !prof !47
 
 127:                                              ; preds = %rb_vm_check_ints.exit8.i
-  %128 = ashr i64 %124, 1, !dbg !64
-  %129 = call i64 @rb_ary_entry(i64 %102, i64 %128) #7, !dbg !64
-  br label %sorbet_rb_array_square_br.exit374.i, !dbg !64
+  %128 = ashr i64 %124, 1, !dbg !66
+  %129 = call i64 @rb_ary_entry(i64 %102, i64 %128) #7, !dbg !66
+  br label %sorbet_rb_array_square_br.exit374.i, !dbg !66
 
 130:                                              ; preds = %rb_vm_check_ints.exit8.i
-  %131 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %102, i64 %"rubyId_[]220.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !64
-  br label %sorbet_rb_array_square_br.exit374.i, !dbg !64
+  %131 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %102, i64 %"rubyId_[]220.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !66
+  br label %sorbet_rb_array_square_br.exit374.i, !dbg !66
 
 sorbet_rb_array_square_br.exit374.i:              ; preds = %130, %127
-  %132 = phi i64 [ %131, %130 ], [ %129, %127 ], !dbg !64
-  %133 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !64, !tbaa !15
-  %134 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 5, !dbg !64
-  %135 = load i32, i32* %134, align 8, !dbg !64, !tbaa !46
-  %136 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 6, !dbg !64
-  %137 = load i32, i32* %136, align 4, !dbg !64, !tbaa !47
-  %138 = xor i32 %137, -1, !dbg !64
-  %139 = and i32 %138, %135, !dbg !64
-  %140 = icmp eq i32 %139, 0, !dbg !64
-  br i1 %140, label %rb_vm_check_ints.exit6.i, label %141, !dbg !64, !prof !48
+  %132 = phi i64 [ %131, %130 ], [ %129, %127 ], !dbg !66
+  %133 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !17
+  %134 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 5, !dbg !66
+  %135 = load i32, i32* %134, align 8, !dbg !66, !tbaa !48
+  %136 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 6, !dbg !66
+  %137 = load i32, i32* %136, align 4, !dbg !66, !tbaa !49
+  %138 = xor i32 %137, -1, !dbg !66
+  %139 = and i32 %138, %135, !dbg !66
+  %140 = icmp eq i32 %139, 0, !dbg !66
+  br i1 %140, label %rb_vm_check_ints.exit6.i, label %141, !dbg !66, !prof !50
 
 141:                                              ; preds = %sorbet_rb_array_square_br.exit374.i
-  %142 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 8, !dbg !64
-  %143 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %142, align 8, !dbg !64, !tbaa !49
-  %144 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %143, i32 noundef 0) #7, !dbg !64
-  br label %rb_vm_check_ints.exit6.i, !dbg !64
+  %142 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 8, !dbg !66
+  %143 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %142, align 8, !dbg !66, !tbaa !51
+  %144 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %143, i32 noundef 0) #7, !dbg !66
+  br label %rb_vm_check_ints.exit6.i, !dbg !66
 
 rb_vm_check_ints.exit6.i:                         ; preds = %141, %sorbet_rb_array_square_br.exit374.i
-  %"rubyId_[]233.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !64
-  store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !64
-  call void @llvm.experimental.noalias.scope.decl(metadata !74) #7, !dbg !64
-  %145 = load i64, i64* %24, align 8, !dbg !64, !tbaa !4, !alias.scope !74
-  %146 = and i64 %145, 1, !dbg !64
-  %147 = icmp eq i64 %146, 0, !dbg !64
-  br i1 %147, label %151, label %148, !dbg !64, !prof !45
+  %"rubyId_[]233.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !66
+  store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !66
+  call void @llvm.experimental.noalias.scope.decl(metadata !76) #7, !dbg !66
+  %145 = load i64, i64* %24, align 8, !dbg !66, !tbaa !6, !alias.scope !76
+  %146 = and i64 %145, 1, !dbg !66
+  %147 = icmp eq i64 %146, 0, !dbg !66
+  br i1 %147, label %151, label %148, !dbg !66, !prof !47
 
 148:                                              ; preds = %rb_vm_check_ints.exit6.i
-  %149 = ashr i64 %145, 1, !dbg !64
-  %150 = call i64 @rb_ary_entry(i64 %102, i64 %149) #7, !dbg !64
-  br label %sorbet_rb_array_square_br.exit375.i, !dbg !64
+  %149 = ashr i64 %145, 1, !dbg !66
+  %150 = call i64 @rb_ary_entry(i64 %102, i64 %149) #7, !dbg !66
+  br label %sorbet_rb_array_square_br.exit375.i, !dbg !66
 
 151:                                              ; preds = %rb_vm_check_ints.exit6.i
-  %152 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %102, i64 %"rubyId_[]233.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !64
-  br label %sorbet_rb_array_square_br.exit375.i, !dbg !64
+  %152 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %102, i64 %"rubyId_[]233.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !66
+  br label %sorbet_rb_array_square_br.exit375.i, !dbg !66
 
 sorbet_rb_array_square_br.exit375.i:              ; preds = %151, %148
-  %153 = phi i64 [ %152, %151 ], [ %150, %148 ], !dbg !64
-  %154 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !64, !tbaa !15
-  %155 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %154, i64 0, i32 5, !dbg !64
-  %156 = load i32, i32* %155, align 8, !dbg !64, !tbaa !46
-  %157 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %154, i64 0, i32 6, !dbg !64
-  %158 = load i32, i32* %157, align 4, !dbg !64, !tbaa !47
-  %159 = xor i32 %158, -1, !dbg !64
-  %160 = and i32 %159, %156, !dbg !64
-  %161 = icmp eq i32 %160, 0, !dbg !64
-  br i1 %161, label %rb_vm_check_ints.exit4.i, label %162, !dbg !64, !prof !48
+  %153 = phi i64 [ %152, %151 ], [ %150, %148 ], !dbg !66
+  %154 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !17
+  %155 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %154, i64 0, i32 5, !dbg !66
+  %156 = load i32, i32* %155, align 8, !dbg !66, !tbaa !48
+  %157 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %154, i64 0, i32 6, !dbg !66
+  %158 = load i32, i32* %157, align 4, !dbg !66, !tbaa !49
+  %159 = xor i32 %158, -1, !dbg !66
+  %160 = and i32 %159, %156, !dbg !66
+  %161 = icmp eq i32 %160, 0, !dbg !66
+  br i1 %161, label %rb_vm_check_ints.exit4.i, label %162, !dbg !66, !prof !50
 
 162:                                              ; preds = %sorbet_rb_array_square_br.exit375.i
-  %163 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %154, i64 0, i32 8, !dbg !64
-  %164 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %163, align 8, !dbg !64, !tbaa !49
-  %165 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %164, i32 noundef 0) #7, !dbg !64
-  br label %rb_vm_check_ints.exit4.i, !dbg !64
+  %163 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %154, i64 0, i32 8, !dbg !66
+  %164 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %163, align 8, !dbg !66, !tbaa !51
+  %165 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %164, i32 noundef 0) #7, !dbg !66
+  br label %rb_vm_check_ints.exit4.i, !dbg !66
 
 rb_vm_check_ints.exit4.i:                         ; preds = %162, %sorbet_rb_array_square_br.exit375.i
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %21, align 8, !dbg !33, !tbaa !15
-  store i64 %111, i64* %callArgs0Addr.i, align 8, !dbg !77
-  store i64 %132, i64* %callArgs1Addr.i, align 8, !dbg !77
-  store i64 %153, i64* %callArgs2Addr.i, align 8, !dbg !77
-  call void @llvm.experimental.noalias.scope.decl(metadata !78) #7, !dbg !77
-  %166 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %24) #7, !dbg !77
-  %167 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 1, !dbg !13
-  %168 = load i64*, i64** %167, align 8, !dbg !13
-  store i64 %10, i64* %168, align 8, !dbg !13, !tbaa !4
-  %169 = getelementptr inbounds i64, i64* %168, i64 1, !dbg !13
-  store i64 %166, i64* %169, align 8, !dbg !13, !tbaa !4
-  %170 = getelementptr inbounds i64, i64* %169, i64 1, !dbg !13
-  store i64* %170, i64** %167, align 8, !dbg !13
-  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !13
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %21, align 8, !dbg !33, !tbaa !15
-  call void @llvm.experimental.noalias.scope.decl(metadata !81) #7, !dbg !84
-  %171 = call i64 @rb_ary_new() #7, !dbg !84
-  store i64 %171, i64* %callArgs0Addr.i, align 8, !dbg !85
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %26, align 8, !dbg !85
-  call void @llvm.experimental.noalias.scope.decl(metadata !86) #7, !dbg !85
-  %172 = load i64, i64* %24, align 8, !dbg !85, !tbaa !4, !alias.scope !86
-  %173 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %172, i64 3, i64 5) #7, !dbg !85, !noalias !86
-  %"rubyId_[]287.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !85
-  store i64 1, i64* %callArgs0Addr.i, align 8, !dbg !85
-  call void @llvm.experimental.noalias.scope.decl(metadata !89) #7, !dbg !85
-  %174 = load i64, i64* %24, align 8, !dbg !85, !tbaa !4, !alias.scope !89
-  %175 = and i64 %174, 1, !dbg !85
-  %176 = icmp eq i64 %175, 0, !dbg !85
-  br i1 %176, label %180, label %177, !dbg !85, !prof !45
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %21, align 8, !dbg !35, !tbaa !17
+  store i64 %111, i64* %callArgs0Addr.i, align 8, !dbg !79
+  store i64 %132, i64* %callArgs1Addr.i, align 8, !dbg !79
+  store i64 %153, i64* %callArgs2Addr.i, align 8, !dbg !79
+  call void @llvm.experimental.noalias.scope.decl(metadata !80) #7, !dbg !79
+  %166 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %24) #7, !dbg !79
+  %167 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 1, !dbg !15
+  %168 = load i64*, i64** %167, align 8, !dbg !15
+  store i64 %10, i64* %168, align 8, !dbg !15, !tbaa !6
+  %169 = getelementptr inbounds i64, i64* %168, i64 1, !dbg !15
+  store i64 %166, i64* %169, align 8, !dbg !15, !tbaa !6
+  %170 = getelementptr inbounds i64, i64* %169, i64 1, !dbg !15
+  store i64* %170, i64** %167, align 8, !dbg !15
+  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !15
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %21, align 8, !dbg !35, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !83) #7, !dbg !86
+  %171 = call i64 @rb_ary_new() #7, !dbg !86
+  store i64 %171, i64* %callArgs0Addr.i, align 8, !dbg !87
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %26, align 8, !dbg !87
+  call void @llvm.experimental.noalias.scope.decl(metadata !88) #7, !dbg !87
+  %172 = load i64, i64* %24, align 8, !dbg !87, !tbaa !6, !alias.scope !88
+  %173 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %172, i64 3, i64 5) #7, !dbg !87, !noalias !88
+  %"rubyId_[]287.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !87
+  store i64 1, i64* %callArgs0Addr.i, align 8, !dbg !87
+  call void @llvm.experimental.noalias.scope.decl(metadata !91) #7, !dbg !87
+  %174 = load i64, i64* %24, align 8, !dbg !87, !tbaa !6, !alias.scope !91
+  %175 = and i64 %174, 1, !dbg !87
+  %176 = icmp eq i64 %175, 0, !dbg !87
+  br i1 %176, label %180, label %177, !dbg !87, !prof !47
 
 177:                                              ; preds = %rb_vm_check_ints.exit4.i
-  %178 = ashr i64 %174, 1, !dbg !85
-  %179 = call i64 @rb_ary_entry(i64 %173, i64 %178) #7, !dbg !85
-  br label %sorbet_rb_array_square_br.exit376.i, !dbg !85
+  %178 = ashr i64 %174, 1, !dbg !87
+  %179 = call i64 @rb_ary_entry(i64 %173, i64 %178) #7, !dbg !87
+  br label %sorbet_rb_array_square_br.exit376.i, !dbg !87
 
 180:                                              ; preds = %rb_vm_check_ints.exit4.i
-  %181 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %173, i64 %"rubyId_[]287.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !85
-  br label %sorbet_rb_array_square_br.exit376.i, !dbg !85
+  %181 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %173, i64 %"rubyId_[]287.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !87
+  br label %sorbet_rb_array_square_br.exit376.i, !dbg !87
 
 sorbet_rb_array_square_br.exit376.i:              ; preds = %180, %177
-  %182 = phi i64 [ %181, %180 ], [ %179, %177 ], !dbg !85
-  %183 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !85, !tbaa !15
-  %184 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %183, i64 0, i32 5, !dbg !85
-  %185 = load i32, i32* %184, align 8, !dbg !85, !tbaa !46
-  %186 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %183, i64 0, i32 6, !dbg !85
-  %187 = load i32, i32* %186, align 4, !dbg !85, !tbaa !47
-  %188 = xor i32 %187, -1, !dbg !85
-  %189 = and i32 %188, %185, !dbg !85
-  %190 = icmp eq i32 %189, 0, !dbg !85
-  br i1 %190, label %rb_vm_check_ints.exit2.i, label %191, !dbg !85, !prof !48
+  %182 = phi i64 [ %181, %180 ], [ %179, %177 ], !dbg !87
+  %183 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !87, !tbaa !17
+  %184 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %183, i64 0, i32 5, !dbg !87
+  %185 = load i32, i32* %184, align 8, !dbg !87, !tbaa !48
+  %186 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %183, i64 0, i32 6, !dbg !87
+  %187 = load i32, i32* %186, align 4, !dbg !87, !tbaa !49
+  %188 = xor i32 %187, -1, !dbg !87
+  %189 = and i32 %188, %185, !dbg !87
+  %190 = icmp eq i32 %189, 0, !dbg !87
+  br i1 %190, label %rb_vm_check_ints.exit2.i, label %191, !dbg !87, !prof !50
 
 191:                                              ; preds = %sorbet_rb_array_square_br.exit376.i
-  %192 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %183, i64 0, i32 8, !dbg !85
-  %193 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %192, align 8, !dbg !85, !tbaa !49
-  %194 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %193, i32 noundef 0) #7, !dbg !85
-  br label %rb_vm_check_ints.exit2.i, !dbg !85
+  %192 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %183, i64 0, i32 8, !dbg !87
+  %193 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %192, align 8, !dbg !87, !tbaa !51
+  %194 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %193, i32 noundef 0) #7, !dbg !87
+  br label %rb_vm_check_ints.exit2.i, !dbg !87
 
 rb_vm_check_ints.exit2.i:                         ; preds = %191, %sorbet_rb_array_square_br.exit376.i
-  %"rubyId_[]300.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !85
-  store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !85
-  call void @llvm.experimental.noalias.scope.decl(metadata !92) #7, !dbg !85
-  %195 = load i64, i64* %24, align 8, !dbg !85, !tbaa !4, !alias.scope !92
-  %196 = and i64 %195, 1, !dbg !85
-  %197 = icmp eq i64 %196, 0, !dbg !85
-  br i1 %197, label %201, label %198, !dbg !85, !prof !45
+  %"rubyId_[]300.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !87
+  store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !87
+  call void @llvm.experimental.noalias.scope.decl(metadata !94) #7, !dbg !87
+  %195 = load i64, i64* %24, align 8, !dbg !87, !tbaa !6, !alias.scope !94
+  %196 = and i64 %195, 1, !dbg !87
+  %197 = icmp eq i64 %196, 0, !dbg !87
+  br i1 %197, label %201, label %198, !dbg !87, !prof !47
 
 198:                                              ; preds = %rb_vm_check_ints.exit2.i
-  %199 = ashr i64 %195, 1, !dbg !85
-  %200 = call i64 @rb_ary_entry(i64 %173, i64 %199) #7, !dbg !85
-  br label %sorbet_rb_array_square_br.exit369.i, !dbg !85
+  %199 = ashr i64 %195, 1, !dbg !87
+  %200 = call i64 @rb_ary_entry(i64 %173, i64 %199) #7, !dbg !87
+  br label %sorbet_rb_array_square_br.exit369.i, !dbg !87
 
 201:                                              ; preds = %rb_vm_check_ints.exit2.i
-  %202 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %173, i64 %"rubyId_[]300.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !85
-  br label %sorbet_rb_array_square_br.exit369.i, !dbg !85
+  %202 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %173, i64 %"rubyId_[]300.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !87
+  br label %sorbet_rb_array_square_br.exit369.i, !dbg !87
 
 sorbet_rb_array_square_br.exit369.i:              ; preds = %201, %198
-  %203 = phi i64 [ %202, %201 ], [ %200, %198 ], !dbg !85
-  %204 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !85, !tbaa !15
-  %205 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %204, i64 0, i32 5, !dbg !85
-  %206 = load i32, i32* %205, align 8, !dbg !85, !tbaa !46
-  %207 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %204, i64 0, i32 6, !dbg !85
-  %208 = load i32, i32* %207, align 4, !dbg !85, !tbaa !47
-  %209 = xor i32 %208, -1, !dbg !85
-  %210 = and i32 %209, %206, !dbg !85
-  %211 = icmp eq i32 %210, 0, !dbg !85
-  br i1 %211, label %rb_vm_check_ints.exit1.i, label %212, !dbg !85, !prof !48
+  %203 = phi i64 [ %202, %201 ], [ %200, %198 ], !dbg !87
+  %204 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !87, !tbaa !17
+  %205 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %204, i64 0, i32 5, !dbg !87
+  %206 = load i32, i32* %205, align 8, !dbg !87, !tbaa !48
+  %207 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %204, i64 0, i32 6, !dbg !87
+  %208 = load i32, i32* %207, align 4, !dbg !87, !tbaa !49
+  %209 = xor i32 %208, -1, !dbg !87
+  %210 = and i32 %209, %206, !dbg !87
+  %211 = icmp eq i32 %210, 0, !dbg !87
+  br i1 %211, label %rb_vm_check_ints.exit1.i, label %212, !dbg !87, !prof !50
 
 212:                                              ; preds = %sorbet_rb_array_square_br.exit369.i
-  %213 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %204, i64 0, i32 8, !dbg !85
-  %214 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %213, align 8, !dbg !85, !tbaa !49
-  %215 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %214, i32 noundef 0) #7, !dbg !85
-  br label %rb_vm_check_ints.exit1.i, !dbg !85
+  %213 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %204, i64 0, i32 8, !dbg !87
+  %214 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %213, align 8, !dbg !87, !tbaa !51
+  %215 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %214, i32 noundef 0) #7, !dbg !87
+  br label %rb_vm_check_ints.exit1.i, !dbg !87
 
 rb_vm_check_ints.exit1.i:                         ; preds = %212, %sorbet_rb_array_square_br.exit369.i
-  %"rubyId_[]313.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !85
-  store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !85
-  call void @llvm.experimental.noalias.scope.decl(metadata !95) #7, !dbg !85
-  %216 = load i64, i64* %24, align 8, !dbg !85, !tbaa !4, !alias.scope !95
-  %217 = and i64 %216, 1, !dbg !85
-  %218 = icmp eq i64 %217, 0, !dbg !85
-  br i1 %218, label %222, label %219, !dbg !85, !prof !45
+  %"rubyId_[]313.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !87
+  store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !87
+  call void @llvm.experimental.noalias.scope.decl(metadata !97) #7, !dbg !87
+  %216 = load i64, i64* %24, align 8, !dbg !87, !tbaa !6, !alias.scope !97
+  %217 = and i64 %216, 1, !dbg !87
+  %218 = icmp eq i64 %217, 0, !dbg !87
+  br i1 %218, label %222, label %219, !dbg !87, !prof !47
 
 219:                                              ; preds = %rb_vm_check_ints.exit1.i
-  %220 = ashr i64 %216, 1, !dbg !85
-  %221 = call i64 @rb_ary_entry(i64 %173, i64 %220) #7, !dbg !85
-  br label %sorbet_rb_array_square_br.exit.i, !dbg !85
+  %220 = ashr i64 %216, 1, !dbg !87
+  %221 = call i64 @rb_ary_entry(i64 %173, i64 %220) #7, !dbg !87
+  br label %sorbet_rb_array_square_br.exit.i, !dbg !87
 
 222:                                              ; preds = %rb_vm_check_ints.exit1.i
-  %223 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %173, i64 %"rubyId_[]313.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !85
-  br label %sorbet_rb_array_square_br.exit.i, !dbg !85
+  %223 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %173, i64 %"rubyId_[]313.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !87
+  br label %sorbet_rb_array_square_br.exit.i, !dbg !87
 
 sorbet_rb_array_square_br.exit.i:                 ; preds = %222, %219
-  %224 = phi i64 [ %223, %222 ], [ %221, %219 ], !dbg !85
-  %225 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !85, !tbaa !15
-  %226 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %225, i64 0, i32 5, !dbg !85
-  %227 = load i32, i32* %226, align 8, !dbg !85, !tbaa !46
-  %228 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %225, i64 0, i32 6, !dbg !85
-  %229 = load i32, i32* %228, align 4, !dbg !85, !tbaa !47
-  %230 = xor i32 %229, -1, !dbg !85
-  %231 = and i32 %230, %227, !dbg !85
-  %232 = icmp eq i32 %231, 0, !dbg !85
-  br i1 %232, label %"func_<root>.<static-init>$151.exit", label %233, !dbg !85, !prof !48
+  %224 = phi i64 [ %223, %222 ], [ %221, %219 ], !dbg !87
+  %225 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !87, !tbaa !17
+  %226 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %225, i64 0, i32 5, !dbg !87
+  %227 = load i32, i32* %226, align 8, !dbg !87, !tbaa !48
+  %228 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %225, i64 0, i32 6, !dbg !87
+  %229 = load i32, i32* %228, align 4, !dbg !87, !tbaa !49
+  %230 = xor i32 %229, -1, !dbg !87
+  %231 = and i32 %230, %227, !dbg !87
+  %232 = icmp eq i32 %231, 0, !dbg !87
+  br i1 %232, label %"func_<root>.<static-init>$151.exit", label %233, !dbg !87, !prof !50
 
 233:                                              ; preds = %sorbet_rb_array_square_br.exit.i
-  %234 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %225, i64 0, i32 8, !dbg !85
-  %235 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %234, align 8, !dbg !85, !tbaa !49
-  %236 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %235, i32 noundef 0) #7, !dbg !85
-  br label %"func_<root>.<static-init>$151.exit", !dbg !85
+  %234 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %225, i64 0, i32 8, !dbg !87
+  %235 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %234, align 8, !dbg !87, !tbaa !51
+  %236 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %235, i32 noundef 0) #7, !dbg !87
+  br label %"func_<root>.<static-init>$151.exit", !dbg !87
 
 "func_<root>.<static-init>$151.exit":             ; preds = %sorbet_rb_array_square_br.exit.i, %233
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %21, align 8, !dbg !33, !tbaa !15
-  store i64 %182, i64* %callArgs0Addr.i, align 8, !dbg !98
-  store i64 %203, i64* %callArgs1Addr.i, align 8, !dbg !98
-  store i64 %224, i64* %callArgs2Addr.i, align 8, !dbg !98
-  call void @llvm.experimental.noalias.scope.decl(metadata !99) #7, !dbg !98
-  %237 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %24) #7, !dbg !98
-  %238 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 1, !dbg !14
-  %239 = load i64*, i64** %238, align 8, !dbg !14
-  store i64 %10, i64* %239, align 8, !dbg !14, !tbaa !4
-  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !14
-  store i64 %237, i64* %240, align 8, !dbg !14, !tbaa !4
-  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !14
-  store i64* %241, i64** %238, align 8, !dbg !14
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.10, i64 0), !dbg !14
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %21, align 8, !dbg !35, !tbaa !17
+  store i64 %182, i64* %callArgs0Addr.i, align 8, !dbg !100
+  store i64 %203, i64* %callArgs1Addr.i, align 8, !dbg !100
+  store i64 %224, i64* %callArgs2Addr.i, align 8, !dbg !100
+  call void @llvm.experimental.noalias.scope.decl(metadata !101) #7, !dbg !100
+  %237 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %24) #7, !dbg !100
+  %238 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 1, !dbg !16
+  %239 = load i64*, i64** %238, align 8, !dbg !16
+  store i64 %10, i64* %239, align 8, !dbg !16, !tbaa !6
+  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !16
+  store i64 %237, i64* %240, align 8, !dbg !16, !tbaa !6
+  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !16
+  store i64* %241, i64** %238, align 8, !dbg !16
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.10, i64 0), !dbg !16
   call void @llvm.lifetime.end.p0i8(i64 64, i8* nonnull %14)
   ret void
 }
@@ -624,108 +624,110 @@ attributes #5 = { argmemonly nofree nosync nounwind willreturn }
 attributes #6 = { noreturn nounwind }
 attributes #7 = { nounwind }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/splat_assign.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 6, column: 1, scope: !9)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !DILocation(line: 9, column: 1, scope: !9)
-!14 = !DILocation(line: 12, column: 1, scope: !9)
-!15 = !{!16, !16, i64 0}
-!16 = !{!"any pointer", !6, i64 0}
-!17 = !{!18, !5, i64 400}
-!18 = !{!"rb_vm_struct", !5, i64 0, !19, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !23, i64 216, !6, i64 224, !20, i64 264, !20, i64 280, !20, i64 296, !20, i64 312, !5, i64 328, !22, i64 336, !22, i64 340, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !16, i64 456, !16, i64 464, !24, i64 472, !25, i64 992, !16, i64 1016, !16, i64 1024, !22, i64 1032, !22, i64 1036, !20, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !22, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !22, i64 1192, !26, i64 1200, !6, i64 1232}
-!19 = !{!"rb_global_vm_lock_struct", !16, i64 0, !6, i64 8, !20, i64 48, !16, i64 64, !22, i64 72, !6, i64 80, !6, i64 128, !22, i64 176, !22, i64 180}
-!20 = !{!"list_head", !21, i64 0}
-!21 = !{!"list_node", !16, i64 0, !16, i64 8}
-!22 = !{!"int", !6, i64 0}
-!23 = !{!"long long", !6, i64 0}
-!24 = !{!"", !6, i64 0}
-!25 = !{!"rb_hook_list_struct", !16, i64 0, !22, i64 8, !22, i64 12, !22, i64 16}
-!26 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!27 = !{!28, !16, i64 16}
-!28 = !{!"rb_execution_context_struct", !16, i64 0, !5, i64 8, !16, i64 16, !16, i64 24, !16, i64 32, !22, i64 40, !22, i64 44, !16, i64 48, !16, i64 56, !16, i64 64, !5, i64 72, !5, i64 80, !16, i64 88, !5, i64 96, !16, i64 104, !16, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !29, i64 152}
-!29 = !{!"", !16, i64 0, !16, i64 8, !5, i64 16, !6, i64 24}
-!30 = !{!31, !16, i64 16}
-!31 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !5, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
-!32 = !{!31, !16, i64 32}
-!33 = !DILocation(line: 0, scope: !9)
-!34 = !DILocation(line: 5, column: 11, scope: !9)
-!35 = !{!36}
-!36 = distinct !{!36, !37, !"sorbet_buildArrayIntrinsic: argument 0"}
-!37 = distinct !{!37, !"sorbet_buildArrayIntrinsic"}
-!38 = !DILocation(line: 5, column: 1, scope: !9)
-!39 = !{!40}
-!40 = distinct !{!40, !41, !"sorbet_expandSplatIntrinsic: argument 0"}
-!41 = distinct !{!41, !"sorbet_expandSplatIntrinsic"}
-!42 = !{!43}
-!43 = distinct !{!43, !44, !"sorbet_rb_array_square_br: argument 0"}
-!44 = distinct !{!44, !"sorbet_rb_array_square_br"}
-!45 = !{!"branch_weights", i32 1, i32 2000}
-!46 = !{!28, !22, i64 40}
-!47 = !{!28, !22, i64 44}
-!48 = !{!"branch_weights", i32 2000, i32 1}
-!49 = !{!28, !16, i64 56}
-!50 = !{!51}
-!51 = distinct !{!51, !52, !"sorbet_rb_array_square_br: argument 0"}
-!52 = distinct !{!52, !"sorbet_rb_array_square_br"}
-!53 = !{!54}
-!54 = distinct !{!54, !55, !"sorbet_rb_array_square_br: argument 0"}
-!55 = distinct !{!55, !"sorbet_rb_array_square_br"}
-!56 = !DILocation(line: 6, column: 6, scope: !9)
-!57 = !{!58}
-!58 = distinct !{!58, !59, !"sorbet_buildArrayIntrinsic: argument 0"}
-!59 = distinct !{!59, !"sorbet_buildArrayIntrinsic"}
-!60 = !DILocation(line: 8, column: 11, scope: !9)
-!61 = !{!62}
-!62 = distinct !{!62, !63, !"sorbet_buildArrayIntrinsic: argument 0"}
-!63 = distinct !{!63, !"sorbet_buildArrayIntrinsic"}
-!64 = !DILocation(line: 8, column: 1, scope: !9)
-!65 = !{!66}
-!66 = distinct !{!66, !67, !"sorbet_expandSplatIntrinsic: argument 0"}
-!67 = distinct !{!67, !"sorbet_expandSplatIntrinsic"}
-!68 = !{!69}
-!69 = distinct !{!69, !70, !"sorbet_rb_array_square_br: argument 0"}
-!70 = distinct !{!70, !"sorbet_rb_array_square_br"}
-!71 = !{!72}
-!72 = distinct !{!72, !73, !"sorbet_rb_array_square_br: argument 0"}
-!73 = distinct !{!73, !"sorbet_rb_array_square_br"}
-!74 = !{!75}
-!75 = distinct !{!75, !76, !"sorbet_rb_array_square_br: argument 0"}
-!76 = distinct !{!76, !"sorbet_rb_array_square_br"}
-!77 = !DILocation(line: 9, column: 6, scope: !9)
-!78 = !{!79}
-!79 = distinct !{!79, !80, !"sorbet_buildArrayIntrinsic: argument 0"}
-!80 = distinct !{!80, !"sorbet_buildArrayIntrinsic"}
-!81 = !{!82}
-!82 = distinct !{!82, !83, !"sorbet_buildArrayIntrinsic: argument 0"}
-!83 = distinct !{!83, !"sorbet_buildArrayIntrinsic"}
-!84 = !DILocation(line: 11, column: 11, scope: !9)
-!85 = !DILocation(line: 11, column: 1, scope: !9)
-!86 = !{!87}
-!87 = distinct !{!87, !88, !"sorbet_expandSplatIntrinsic: argument 0"}
-!88 = distinct !{!88, !"sorbet_expandSplatIntrinsic"}
-!89 = !{!90}
-!90 = distinct !{!90, !91, !"sorbet_rb_array_square_br: argument 0"}
-!91 = distinct !{!91, !"sorbet_rb_array_square_br"}
-!92 = !{!93}
-!93 = distinct !{!93, !94, !"sorbet_rb_array_square_br: argument 0"}
-!94 = distinct !{!94, !"sorbet_rb_array_square_br"}
-!95 = !{!96}
-!96 = distinct !{!96, !97, !"sorbet_rb_array_square_br: argument 0"}
-!97 = distinct !{!97, !"sorbet_rb_array_square_br"}
-!98 = !DILocation(line: 12, column: 6, scope: !9)
-!99 = !{!100}
-!100 = distinct !{!100, !101, !"sorbet_buildArrayIntrinsic: argument 0"}
-!101 = distinct !{!101, !"sorbet_buildArrayIntrinsic"}
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/splat_assign.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 6, column: 1, scope: !11)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !DILocation(line: 9, column: 1, scope: !11)
+!16 = !DILocation(line: 12, column: 1, scope: !11)
+!17 = !{!18, !18, i64 0}
+!18 = !{!"any pointer", !8, i64 0}
+!19 = !{!20, !7, i64 400}
+!20 = !{!"rb_vm_struct", !7, i64 0, !21, i64 8, !18, i64 192, !18, i64 200, !18, i64 208, !25, i64 216, !8, i64 224, !22, i64 264, !22, i64 280, !22, i64 296, !22, i64 312, !7, i64 328, !24, i64 336, !24, i64 340, !24, i64 344, !24, i64 344, !24, i64 344, !24, i64 344, !24, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !18, i64 456, !18, i64 464, !26, i64 472, !27, i64 992, !18, i64 1016, !18, i64 1024, !24, i64 1032, !24, i64 1036, !22, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !24, i64 1136, !18, i64 1144, !18, i64 1152, !18, i64 1160, !18, i64 1168, !18, i64 1176, !18, i64 1184, !24, i64 1192, !28, i64 1200, !8, i64 1232}
+!21 = !{!"rb_global_vm_lock_struct", !18, i64 0, !8, i64 8, !22, i64 48, !18, i64 64, !24, i64 72, !8, i64 80, !8, i64 128, !24, i64 176, !24, i64 180}
+!22 = !{!"list_head", !23, i64 0}
+!23 = !{!"list_node", !18, i64 0, !18, i64 8}
+!24 = !{!"int", !8, i64 0}
+!25 = !{!"long long", !8, i64 0}
+!26 = !{!"", !8, i64 0}
+!27 = !{!"rb_hook_list_struct", !18, i64 0, !24, i64 8, !24, i64 12, !24, i64 16}
+!28 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!29 = !{!30, !18, i64 16}
+!30 = !{!"rb_execution_context_struct", !18, i64 0, !7, i64 8, !18, i64 16, !18, i64 24, !18, i64 32, !24, i64 40, !24, i64 44, !18, i64 48, !18, i64 56, !18, i64 64, !7, i64 72, !7, i64 80, !18, i64 88, !7, i64 96, !18, i64 104, !18, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !31, i64 152}
+!31 = !{!"", !18, i64 0, !18, i64 8, !7, i64 16, !8, i64 24}
+!32 = !{!33, !18, i64 16}
+!33 = !{!"rb_control_frame_struct", !18, i64 0, !18, i64 8, !18, i64 16, !7, i64 24, !18, i64 32, !18, i64 40, !18, i64 48}
+!34 = !{!33, !18, i64 32}
+!35 = !DILocation(line: 0, scope: !11)
+!36 = !DILocation(line: 5, column: 11, scope: !11)
+!37 = !{!38}
+!38 = distinct !{!38, !39, !"sorbet_buildArrayIntrinsic: argument 0"}
+!39 = distinct !{!39, !"sorbet_buildArrayIntrinsic"}
+!40 = !DILocation(line: 5, column: 1, scope: !11)
+!41 = !{!42}
+!42 = distinct !{!42, !43, !"sorbet_expandSplatIntrinsic: argument 0"}
+!43 = distinct !{!43, !"sorbet_expandSplatIntrinsic"}
+!44 = !{!45}
+!45 = distinct !{!45, !46, !"sorbet_rb_array_square_br: argument 0"}
+!46 = distinct !{!46, !"sorbet_rb_array_square_br"}
+!47 = !{!"branch_weights", i32 1, i32 2000}
+!48 = !{!30, !24, i64 40}
+!49 = !{!30, !24, i64 44}
+!50 = !{!"branch_weights", i32 2000, i32 1}
+!51 = !{!30, !18, i64 56}
+!52 = !{!53}
+!53 = distinct !{!53, !54, !"sorbet_rb_array_square_br: argument 0"}
+!54 = distinct !{!54, !"sorbet_rb_array_square_br"}
+!55 = !{!56}
+!56 = distinct !{!56, !57, !"sorbet_rb_array_square_br: argument 0"}
+!57 = distinct !{!57, !"sorbet_rb_array_square_br"}
+!58 = !DILocation(line: 6, column: 6, scope: !11)
+!59 = !{!60}
+!60 = distinct !{!60, !61, !"sorbet_buildArrayIntrinsic: argument 0"}
+!61 = distinct !{!61, !"sorbet_buildArrayIntrinsic"}
+!62 = !DILocation(line: 8, column: 11, scope: !11)
+!63 = !{!64}
+!64 = distinct !{!64, !65, !"sorbet_buildArrayIntrinsic: argument 0"}
+!65 = distinct !{!65, !"sorbet_buildArrayIntrinsic"}
+!66 = !DILocation(line: 8, column: 1, scope: !11)
+!67 = !{!68}
+!68 = distinct !{!68, !69, !"sorbet_expandSplatIntrinsic: argument 0"}
+!69 = distinct !{!69, !"sorbet_expandSplatIntrinsic"}
+!70 = !{!71}
+!71 = distinct !{!71, !72, !"sorbet_rb_array_square_br: argument 0"}
+!72 = distinct !{!72, !"sorbet_rb_array_square_br"}
+!73 = !{!74}
+!74 = distinct !{!74, !75, !"sorbet_rb_array_square_br: argument 0"}
+!75 = distinct !{!75, !"sorbet_rb_array_square_br"}
+!76 = !{!77}
+!77 = distinct !{!77, !78, !"sorbet_rb_array_square_br: argument 0"}
+!78 = distinct !{!78, !"sorbet_rb_array_square_br"}
+!79 = !DILocation(line: 9, column: 6, scope: !11)
+!80 = !{!81}
+!81 = distinct !{!81, !82, !"sorbet_buildArrayIntrinsic: argument 0"}
+!82 = distinct !{!82, !"sorbet_buildArrayIntrinsic"}
+!83 = !{!84}
+!84 = distinct !{!84, !85, !"sorbet_buildArrayIntrinsic: argument 0"}
+!85 = distinct !{!85, !"sorbet_buildArrayIntrinsic"}
+!86 = !DILocation(line: 11, column: 11, scope: !11)
+!87 = !DILocation(line: 11, column: 1, scope: !11)
+!88 = !{!89}
+!89 = distinct !{!89, !90, !"sorbet_expandSplatIntrinsic: argument 0"}
+!90 = distinct !{!90, !"sorbet_expandSplatIntrinsic"}
+!91 = !{!92}
+!92 = distinct !{!92, !93, !"sorbet_rb_array_square_br: argument 0"}
+!93 = distinct !{!93, !"sorbet_rb_array_square_br"}
+!94 = !{!95}
+!95 = distinct !{!95, !96, !"sorbet_rb_array_square_br: argument 0"}
+!96 = distinct !{!96, !"sorbet_rb_array_square_br"}
+!97 = !{!98}
+!98 = distinct !{!98, !99, !"sorbet_rb_array_square_br: argument 0"}
+!99 = distinct !{!99, !"sorbet_rb_array_square_br"}
+!100 = !DILocation(line: 12, column: 6, scope: !11)
+!101 = !{!102}
+!102 = distinct !{!102, !103, !"sorbet_buildArrayIntrinsic: argument 0"}
+!103 = distinct !{!103, !"sorbet_buildArrayIntrinsic"}

--- a/test/testdata/compiler/unsafe.llo.exp
+++ b/test/testdata/compiler/unsafe.llo.exp
@@ -120,14 +120,14 @@ declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) loc
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #6
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #6
   unreachable
 }
@@ -156,59 +156,59 @@ entry:
   %"rubyStr_test/testdata/compiler/unsafe.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/unsafe.rb", align 8
   %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/unsafe.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_unsafe.i = load i64, i64* @rubyIdPrecomputed_unsafe, align 8, !dbg !8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_unsafe, i64 %rubyId_unsafe.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !13
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !13
-  %6 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %rubyId_unsafe.i = load i64, i64* @rubyIdPrecomputed_unsafe, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_unsafe, i64 %rubyId_unsafe.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
+  %6 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !16
   %7 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %6, i64 0, i32 18
-  %8 = load i64, i64* %7, align 8, !tbaa !16
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %8 = load i64, i64* %7, align 8, !tbaa !18
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !16
   %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !26
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !28
   %12 = bitcast [2 x i64]* %callArgs.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %12)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !29
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !31
   %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4
-  %15 = load i64*, i64** %14, align 8, !tbaa !31
-  %16 = load i64, i64* %15, align 8, !tbaa !4
+  %15 = load i64*, i64** %14, align 8, !tbaa !33
+  %16 = load i64, i64* %15, align 8, !tbaa !6
   %17 = and i64 %16, -33
-  store i64 %17, i64* %15, align 8, !tbaa !4
+  store i64 %17, i64* %15, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %9, %struct.rb_control_frame_struct* %11, %struct.rb_iseq_struct* %stackFrame.i) #7
   %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !32, !tbaa !14
-  %callArgs0Addr.i = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i32 0, i64 0, !dbg !8
-  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !8
-  %19 = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i64 0, i64 0, !dbg !8
-  call void @llvm.experimental.noalias.scope.decl(metadata !33) #7, !dbg !8
-  %20 = load i64, i64* %19, align 8, !dbg !8, !tbaa !4, !alias.scope !33
-  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !8, !tbaa !14
-  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !8
-  %23 = load i32, i32* %22, align 8, !dbg !8, !tbaa !36
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 6, !dbg !8
-  %25 = load i32, i32* %24, align 4, !dbg !8, !tbaa !37
-  %26 = xor i32 %25, -1, !dbg !8
-  %27 = and i32 %26, %23, !dbg !8
-  %28 = icmp eq i32 %27, 0, !dbg !8
-  br i1 %28, label %"func_<root>.<static-init>$151.exit", label %29, !dbg !8, !prof !38
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !34, !tbaa !16
+  %callArgs0Addr.i = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i32 0, i64 0, !dbg !10
+  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !10
+  %19 = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i64 0, i64 0, !dbg !10
+  call void @llvm.experimental.noalias.scope.decl(metadata !35) #7, !dbg !10
+  %20 = load i64, i64* %19, align 8, !dbg !10, !tbaa !6, !alias.scope !35
+  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !16
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !10
+  %23 = load i32, i32* %22, align 8, !dbg !10, !tbaa !38
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 6, !dbg !10
+  %25 = load i32, i32* %24, align 4, !dbg !10, !tbaa !39
+  %26 = xor i32 %25, -1, !dbg !10
+  %27 = and i32 %26, %23, !dbg !10
+  %28 = icmp eq i32 %27, 0, !dbg !10
+  br i1 %28, label %"func_<root>.<static-init>$151.exit", label %29, !dbg !10, !prof !40
 
 29:                                               ; preds = %entry
-  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !8
-  %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !8, !tbaa !39
-  %32 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #7, !dbg !8
-  br label %"func_<root>.<static-init>$151.exit", !dbg !8
+  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !10
+  %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !10, !tbaa !41
+  %32 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #7, !dbg !10
+  br label %"func_<root>.<static-init>$151.exit", !dbg !10
 
 "func_<root>.<static-init>$151.exit":             ; preds = %entry, %29
-  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !13
-  %34 = load i64*, i64** %33, align 8, !dbg !13
-  store i64 %8, i64* %34, align 8, !dbg !13, !tbaa !4
-  %35 = getelementptr inbounds i64, i64* %34, i64 1, !dbg !13
-  store i64 %20, i64* %35, align 8, !dbg !13, !tbaa !4
-  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !13
-  store i64* %36, i64** %33, align 8, !dbg !13
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !13
+  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !15
+  %34 = load i64*, i64** %33, align 8, !dbg !15
+  store i64 %8, i64* %34, align 8, !dbg !15, !tbaa !6
+  %35 = getelementptr inbounds i64, i64* %34, i64 1, !dbg !15
+  store i64 %20, i64* %35, align 8, !dbg !15, !tbaa !6
+  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !15
+  store i64* %36, i64** %33, align 8, !dbg !15
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %12)
   ret void
 }
@@ -231,46 +231,48 @@ attributes #5 = { argmemonly nofree nosync nounwind willreturn }
 attributes #6 = { noreturn nounwind }
 attributes #7 = { nounwind }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/compiler/unsafe.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 4, column: 6, scope: !9)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !DILocation(line: 4, column: 1, scope: !9)
-!14 = !{!15, !15, i64 0}
-!15 = !{!"any pointer", !6, i64 0}
-!16 = !{!17, !5, i64 400}
-!17 = !{!"rb_vm_struct", !5, i64 0, !18, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !22, i64 216, !6, i64 224, !19, i64 264, !19, i64 280, !19, i64 296, !19, i64 312, !5, i64 328, !21, i64 336, !21, i64 340, !21, i64 344, !21, i64 344, !21, i64 344, !21, i64 344, !21, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !15, i64 456, !15, i64 464, !23, i64 472, !24, i64 992, !15, i64 1016, !15, i64 1024, !21, i64 1032, !21, i64 1036, !19, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !21, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !21, i64 1192, !25, i64 1200, !6, i64 1232}
-!18 = !{!"rb_global_vm_lock_struct", !15, i64 0, !6, i64 8, !19, i64 48, !15, i64 64, !21, i64 72, !6, i64 80, !6, i64 128, !21, i64 176, !21, i64 180}
-!19 = !{!"list_head", !20, i64 0}
-!20 = !{!"list_node", !15, i64 0, !15, i64 8}
-!21 = !{!"int", !6, i64 0}
-!22 = !{!"long long", !6, i64 0}
-!23 = !{!"", !6, i64 0}
-!24 = !{!"rb_hook_list_struct", !15, i64 0, !21, i64 8, !21, i64 12, !21, i64 16}
-!25 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!26 = !{!27, !15, i64 16}
-!27 = !{!"rb_execution_context_struct", !15, i64 0, !5, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !21, i64 40, !21, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !5, i64 72, !5, i64 80, !15, i64 88, !5, i64 96, !15, i64 104, !15, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !28, i64 152}
-!28 = !{!"", !15, i64 0, !15, i64 8, !5, i64 16, !6, i64 24}
-!29 = !{!30, !15, i64 16}
-!30 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !5, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
-!31 = !{!30, !15, i64 32}
-!32 = !DILocation(line: 0, scope: !9)
-!33 = !{!34}
-!34 = distinct !{!34, !35, !"sorbet_T_unsafe: argument 0"}
-!35 = distinct !{!35, !"sorbet_T_unsafe"}
-!36 = !{!27, !21, i64 40}
-!37 = !{!27, !21, i64 44}
-!38 = !{!"branch_weights", i32 2000, i32 1}
-!39 = !{!27, !15, i64 56}
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/compiler/unsafe.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 4, column: 6, scope: !11)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !DILocation(line: 4, column: 1, scope: !11)
+!16 = !{!17, !17, i64 0}
+!17 = !{!"any pointer", !8, i64 0}
+!18 = !{!19, !7, i64 400}
+!19 = !{!"rb_vm_struct", !7, i64 0, !20, i64 8, !17, i64 192, !17, i64 200, !17, i64 208, !24, i64 216, !8, i64 224, !21, i64 264, !21, i64 280, !21, i64 296, !21, i64 312, !7, i64 328, !23, i64 336, !23, i64 340, !23, i64 344, !23, i64 344, !23, i64 344, !23, i64 344, !23, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !17, i64 456, !17, i64 464, !25, i64 472, !26, i64 992, !17, i64 1016, !17, i64 1024, !23, i64 1032, !23, i64 1036, !21, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !23, i64 1136, !17, i64 1144, !17, i64 1152, !17, i64 1160, !17, i64 1168, !17, i64 1176, !17, i64 1184, !23, i64 1192, !27, i64 1200, !8, i64 1232}
+!20 = !{!"rb_global_vm_lock_struct", !17, i64 0, !8, i64 8, !21, i64 48, !17, i64 64, !23, i64 72, !8, i64 80, !8, i64 128, !23, i64 176, !23, i64 180}
+!21 = !{!"list_head", !22, i64 0}
+!22 = !{!"list_node", !17, i64 0, !17, i64 8}
+!23 = !{!"int", !8, i64 0}
+!24 = !{!"long long", !8, i64 0}
+!25 = !{!"", !8, i64 0}
+!26 = !{!"rb_hook_list_struct", !17, i64 0, !23, i64 8, !23, i64 12, !23, i64 16}
+!27 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!28 = !{!29, !17, i64 16}
+!29 = !{!"rb_execution_context_struct", !17, i64 0, !7, i64 8, !17, i64 16, !17, i64 24, !17, i64 32, !23, i64 40, !23, i64 44, !17, i64 48, !17, i64 56, !17, i64 64, !7, i64 72, !7, i64 80, !17, i64 88, !7, i64 96, !17, i64 104, !17, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !30, i64 152}
+!30 = !{!"", !17, i64 0, !17, i64 8, !7, i64 16, !8, i64 24}
+!31 = !{!32, !17, i64 16}
+!32 = !{!"rb_control_frame_struct", !17, i64 0, !17, i64 8, !17, i64 16, !7, i64 24, !17, i64 32, !17, i64 40, !17, i64 48}
+!33 = !{!32, !17, i64 32}
+!34 = !DILocation(line: 0, scope: !11)
+!35 = !{!36}
+!36 = distinct !{!36, !37, !"sorbet_T_unsafe: argument 0"}
+!37 = distinct !{!37, !"sorbet_T_unsafe"}
+!38 = !{!29, !23, i64 40}
+!39 = !{!29, !23, i64 44}
+!40 = !{!"branch_weights", i32 2000, i32 1}
+!41 = !{!29, !17, i64 56}

--- a/test/testdata/ruby_benchmark/app_fib.llo.exp
+++ b/test/testdata/ruby_benchmark/app_fib.llo.exp
@@ -209,211 +209,211 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #7 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #7 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_HasFib.<static-init>L64"(%struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !8 {
+define internal fastcc void @"func_HasFib.<static-init>L64"(%struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !10 {
 fastSymCallIntrinsic_Static_sig:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_HasFib.<static-init>", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !14
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !18
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !20
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !20
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !22
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #16
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !21, !tbaa !12
-  %rubyId_final = load i64, i64* @rubyIdPrecomputed_final, align 8, !dbg !22
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_final), !dbg !22
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !12
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !23
-  %11 = load i32, i32* %10, align 8, !dbg !23, !tbaa !24
-  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !23
-  %13 = load i32, i32* %12, align 4, !dbg !23, !tbaa !25
-  %14 = xor i32 %13, -1, !dbg !23
-  %15 = and i32 %14, %11, !dbg !23
-  %16 = icmp eq i32 %15, 0, !dbg !23
-  br i1 %16, label %fastSymCallIntrinsic_Static_keep_self_def, label %17, !dbg !23, !prof !26
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !23, !tbaa !14
+  %rubyId_final = load i64, i64* @rubyIdPrecomputed_final, align 8, !dbg !24
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_final), !dbg !24
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !25, !tbaa !14
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !25
+  %11 = load i32, i32* %10, align 8, !dbg !25, !tbaa !26
+  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !25
+  %13 = load i32, i32* %12, align 4, !dbg !25, !tbaa !27
+  %14 = xor i32 %13, -1, !dbg !25
+  %15 = and i32 %14, %11, !dbg !25
+  %16 = icmp eq i32 %15, 0, !dbg !25
+  br i1 %16, label %fastSymCallIntrinsic_Static_keep_self_def, label %17, !dbg !25, !prof !28
 
 17:                                               ; preds = %fastSymCallIntrinsic_Static_sig
-  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !23
-  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !23, !tbaa !27
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !23
-  br label %fastSymCallIntrinsic_Static_keep_self_def, !dbg !23
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !25
+  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !25, !tbaa !29
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !25
+  br label %fastSymCallIntrinsic_Static_keep_self_def, !dbg !25
 
 afterSend32:                                      ; preds = %51, %24
   ret void
 
 fastSymCallIntrinsic_Static_keep_self_def:        ; preds = %fastSymCallIntrinsic_Static_sig, %17
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !23, !tbaa !12
-  %rubyId_fib = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !28
-  %rawSym28 = tail call i64 @rb_id2sym(i64 %rubyId_fib), !dbg !28
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !28
-  %rawSym29 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !28
-  %21 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !28
-  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !28, !tbaa !29
-  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !28
-  br i1 %needTakeSlowPath, label %23, label %24, !dbg !28, !prof !31
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !25, !tbaa !14
+  %rubyId_fib = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !30
+  %rawSym28 = tail call i64 @rb_id2sym(i64 %rubyId_fib), !dbg !30
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !30
+  %rawSym29 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !30
+  %21 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !30
+  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
+  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !30
+  br i1 %needTakeSlowPath, label %23, label %24, !dbg !30, !prof !33
 
 23:                                               ; preds = %fastSymCallIntrinsic_Static_keep_self_def
-  tail call void @const_recompute_HasFib(), !dbg !28
-  br label %24, !dbg !28
+  tail call void @const_recompute_HasFib(), !dbg !30
+  br label %24, !dbg !30
 
 24:                                               ; preds = %fastSymCallIntrinsic_Static_keep_self_def, %23
-  %25 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !28
-  %26 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !28
-  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !28, !tbaa !29
-  %guardUpdated = icmp eq i64 %26, %27, !dbg !28
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !28
-  %stackFrame33 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.fib, align 8, !dbg !28
-  %28 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !28
-  %29 = bitcast i8* %28 to i16*, !dbg !28
-  %30 = load i16, i16* %29, align 8, !dbg !28
-  %31 = and i16 %30, -384, !dbg !28
-  %32 = or i16 %31, 1, !dbg !28
-  store i16 %32, i16* %29, align 8, !dbg !28
-  %33 = getelementptr inbounds i8, i8* %28, i64 8, !dbg !28
-  %34 = bitcast i8* %33 to i32*, !dbg !28
-  store i32 1, i32* %34, align 8, !dbg !28, !tbaa !32
-  %35 = getelementptr inbounds i8, i8* %28, i64 12, !dbg !28
-  %36 = bitcast i8* %35 to i32*, !dbg !28
-  %37 = getelementptr inbounds i8, i8* %28, i64 4, !dbg !28
-  %38 = bitcast i8* %37 to i32*, !dbg !28
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %35, i8 0, i64 20, i1 false), !dbg !28
-  store i32 1, i32* %38, align 4, !dbg !28, !tbaa !35
-  %positional_table = alloca i64, align 8, !dbg !28
-  %rubyId_n = load i64, i64* @rubyIdPrecomputed_n, align 8, !dbg !28
-  store i64 %rubyId_n, i64* %positional_table, align 8, !dbg !28
-  %39 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !28
-  %40 = bitcast i64* %positional_table to i8*, !dbg !28
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %39, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %40, i64 noundef 8, i1 noundef false) #16, !dbg !28
-  %41 = getelementptr inbounds i8, i8* %28, i64 32, !dbg !28
-  %42 = bitcast i8* %41 to i8**, !dbg !28
-  store i8* %39, i8** %42, align 8, !dbg !28, !tbaa !36
-  tail call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_fib, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_HasFib.fib, i8* nonnull %28, %struct.rb_iseq_struct* %stackFrame33, i1 noundef zeroext true) #16, !dbg !28
-  %43 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !12
-  %44 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 5, !dbg !28
-  %45 = load i32, i32* %44, align 8, !dbg !28, !tbaa !24
-  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 6, !dbg !28
-  %47 = load i32, i32* %46, align 4, !dbg !28, !tbaa !25
-  %48 = xor i32 %47, -1, !dbg !28
-  %49 = and i32 %48, %45, !dbg !28
-  %50 = icmp eq i32 %49, 0, !dbg !28
-  br i1 %50, label %afterSend32, label %51, !dbg !28, !prof !26
+  %25 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !30
+  %26 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !30
+  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
+  %guardUpdated = icmp eq i64 %26, %27, !dbg !30
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !30
+  %stackFrame33 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.fib, align 8, !dbg !30
+  %28 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !30
+  %29 = bitcast i8* %28 to i16*, !dbg !30
+  %30 = load i16, i16* %29, align 8, !dbg !30
+  %31 = and i16 %30, -384, !dbg !30
+  %32 = or i16 %31, 1, !dbg !30
+  store i16 %32, i16* %29, align 8, !dbg !30
+  %33 = getelementptr inbounds i8, i8* %28, i64 8, !dbg !30
+  %34 = bitcast i8* %33 to i32*, !dbg !30
+  store i32 1, i32* %34, align 8, !dbg !30, !tbaa !34
+  %35 = getelementptr inbounds i8, i8* %28, i64 12, !dbg !30
+  %36 = bitcast i8* %35 to i32*, !dbg !30
+  %37 = getelementptr inbounds i8, i8* %28, i64 4, !dbg !30
+  %38 = bitcast i8* %37 to i32*, !dbg !30
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %35, i8 0, i64 20, i1 false), !dbg !30
+  store i32 1, i32* %38, align 4, !dbg !30, !tbaa !37
+  %positional_table = alloca i64, align 8, !dbg !30
+  %rubyId_n = load i64, i64* @rubyIdPrecomputed_n, align 8, !dbg !30
+  store i64 %rubyId_n, i64* %positional_table, align 8, !dbg !30
+  %39 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !30
+  %40 = bitcast i64* %positional_table to i8*, !dbg !30
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %39, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %40, i64 noundef 8, i1 noundef false) #16, !dbg !30
+  %41 = getelementptr inbounds i8, i8* %28, i64 32, !dbg !30
+  %42 = bitcast i8* %41 to i8**, !dbg !30
+  store i8* %39, i8** %42, align 8, !dbg !30, !tbaa !38
+  tail call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_fib, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_HasFib.fib, i8* nonnull %28, %struct.rb_iseq_struct* %stackFrame33, i1 noundef zeroext true) #16, !dbg !30
+  %43 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !14
+  %44 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 5, !dbg !30
+  %45 = load i32, i32* %44, align 8, !dbg !30, !tbaa !26
+  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 6, !dbg !30
+  %47 = load i32, i32* %46, align 4, !dbg !30, !tbaa !27
+  %48 = xor i32 %47, -1, !dbg !30
+  %49 = and i32 %48, %45, !dbg !30
+  %50 = icmp eq i32 %49, 0, !dbg !30
+  br i1 %50, label %afterSend32, label %51, !dbg !30, !prof !28
 
 51:                                               ; preds = %24
-  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 8, !dbg !28
-  %53 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %52, align 8, !dbg !28, !tbaa !27
-  %54 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %53, i32 noundef 0) #16, !dbg !28
-  br label %afterSend32, !dbg !28
+  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 8, !dbg !30
+  %53 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %52, align 8, !dbg !30, !tbaa !29
+  %54 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %53, i32 noundef 0) #16, !dbg !30
+  br label %afterSend32, !dbg !30
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @func_HasFib.fib(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #8 !dbg !37 {
+define i64 @func_HasFib.fib(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #8 !dbg !39 {
 functionEntryInitializers:
   %callArgs = alloca [2 x i64], align 8
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !38
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !38
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !38
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !38, !prof !39
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !40
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !40
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !40
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !40, !prof !41
 
 BB3:                                              ; preds = %rb_vm_check_ints.exit98
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %0, align 8, !tbaa !12
-  store i64 3, i64* %callArgs0Addr, align 8, !dbg !40
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !41), !dbg !40
-  %1 = load i64, i64* %68, align 8, !dbg !40, !tbaa !4, !alias.scope !41
-  %2 = and i64 %1, %70, !dbg !40
-  %3 = icmp eq i64 %2, 0, !dbg !40
-  br i1 %3, label %13, label %4, !dbg !40, !prof !39
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %0, align 8, !tbaa !14
+  store i64 3, i64* %callArgs0Addr, align 8, !dbg !42
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !43), !dbg !42
+  %1 = load i64, i64* %68, align 8, !dbg !42, !tbaa !6, !alias.scope !43
+  %2 = and i64 %1, %70, !dbg !42
+  %3 = icmp eq i64 %2, 0, !dbg !42
+  br i1 %3, label %13, label %4, !dbg !42, !prof !41
 
 4:                                                ; preds = %BB3
-  %5 = add nsw i64 %1, -1, !dbg !40
-  %6 = tail call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 %rawArg_n, i64 %5) #18, !dbg !40
-  %7 = extractvalue { i64, i1 } %6, 1, !dbg !40
-  %8 = extractvalue { i64, i1 } %6, 0, !dbg !40
-  br i1 %7, label %9, label %sorbet_rb_int_minus.exit, !dbg !40
+  %5 = add nsw i64 %1, -1, !dbg !42
+  %6 = tail call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 %rawArg_n, i64 %5) #18, !dbg !42
+  %7 = extractvalue { i64, i1 } %6, 1, !dbg !42
+  %8 = extractvalue { i64, i1 } %6, 0, !dbg !42
+  br i1 %7, label %9, label %sorbet_rb_int_minus.exit, !dbg !42
 
 9:                                                ; preds = %4
-  %10 = ashr i64 %8, 1, !dbg !40
-  %11 = xor i64 %10, -9223372036854775808, !dbg !40
-  %12 = tail call i64 @rb_int2big(i64 %11) #16, !dbg !40, !noalias !41
-  br label %sorbet_rb_int_minus.exit, !dbg !40
+  %10 = ashr i64 %8, 1, !dbg !42
+  %11 = xor i64 %10, -9223372036854775808, !dbg !42
+  %12 = tail call i64 @rb_int2big(i64 %11) #16, !dbg !42, !noalias !43
+  br label %sorbet_rb_int_minus.exit, !dbg !42
 
 13:                                               ; preds = %BB3
-  %14 = tail call i64 @sorbet_rb_int_minus_slowpath(i64 %rawArg_n, i64 %1) #16, !dbg !40, !noalias !41
-  br label %sorbet_rb_int_minus.exit, !dbg !40
+  %14 = tail call i64 @sorbet_rb_int_minus_slowpath(i64 %rawArg_n, i64 %1) #16, !dbg !42, !noalias !43
+  br label %sorbet_rb_int_minus.exit, !dbg !42
 
 sorbet_rb_int_minus.exit:                         ; preds = %9, %4, %13
-  %15 = phi i64 [ %14, %13 ], [ %12, %9 ], [ %8, %4 ], !dbg !40
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !12
-  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 5, !dbg !40
-  %18 = load i32, i32* %17, align 8, !dbg !40, !tbaa !24
-  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 6, !dbg !40
-  %20 = load i32, i32* %19, align 4, !dbg !40, !tbaa !25
-  %21 = xor i32 %20, -1, !dbg !40
-  %22 = and i32 %21, %18, !dbg !40
-  %23 = icmp eq i32 %22, 0, !dbg !40
-  br i1 %23, label %rb_vm_check_ints.exit, label %24, !dbg !40, !prof !26
+  %15 = phi i64 [ %14, %13 ], [ %12, %9 ], [ %8, %4 ], !dbg !42
+  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !42, !tbaa !14
+  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 5, !dbg !42
+  %18 = load i32, i32* %17, align 8, !dbg !42, !tbaa !26
+  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 6, !dbg !42
+  %20 = load i32, i32* %19, align 4, !dbg !42, !tbaa !27
+  %21 = xor i32 %20, -1, !dbg !42
+  %22 = and i32 %21, %18, !dbg !42
+  %23 = icmp eq i32 %22, 0, !dbg !42
+  br i1 %23, label %rb_vm_check_ints.exit, label %24, !dbg !42, !prof !28
 
 24:                                               ; preds = %sorbet_rb_int_minus.exit
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 8, !dbg !40
-  %26 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %25, align 8, !dbg !40, !tbaa !27
-  %27 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %26, i32 noundef 0) #16, !dbg !40
-  br label %rb_vm_check_ints.exit, !dbg !40
+  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 8, !dbg !42
+  %26 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %25, align 8, !dbg !42, !tbaa !29
+  %27 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %26, i32 noundef 0) #16, !dbg !42
+  br label %rb_vm_check_ints.exit, !dbg !42
 
 rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_minus.exit, %24
-  %28 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !44
-  %29 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !44, !tbaa !29
-  %needTakeSlowPath = icmp ne i64 %28, %29, !dbg !44
-  br i1 %needTakeSlowPath, label %30, label %31, !dbg !44, !prof !31
+  %28 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !46
+  %29 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !31
+  %needTakeSlowPath = icmp ne i64 %28, %29, !dbg !46
+  br i1 %needTakeSlowPath, label %30, label %31, !dbg !46, !prof !33
 
 30:                                               ; preds = %rb_vm_check_ints.exit
-  tail call void @const_recompute_HasFib(), !dbg !44
-  br label %31, !dbg !44
+  tail call void @const_recompute_HasFib(), !dbg !46
+  br label %31, !dbg !46
 
 31:                                               ; preds = %rb_vm_check_ints.exit, %30
-  %32 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !44
-  %33 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !44
-  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !44, !tbaa !29
-  %guardUpdated = icmp eq i64 %33, %34, !dbg !44
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !44
-  %35 = icmp eq i64 %selfRaw, %32, !dbg !44
-  br i1 %35, label %fastFinalCall_fib, label %36, !dbg !44
+  %32 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !46
+  %33 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !46
+  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !31
+  %guardUpdated = icmp eq i64 %33, %34, !dbg !46
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !46
+  %35 = icmp eq i64 %selfRaw, %32, !dbg !46
+  br i1 %35, label %fastFinalCall_fib, label %36, !dbg !46
 
 36:                                               ; preds = %31
-  %37 = load i64, i64* @rb_cModule, align 8, !dbg !44, !tbaa !4
-  %38 = tail call i64 @rb_obj_is_kind_of(i64 %selfRaw, i64 %37), !dbg !44
-  %39 = icmp eq i64 %38, 0, !dbg !44
-  br i1 %39, label %slowFinalCall_fib, label %sorbet_isa_class_of.exit, !dbg !44, !prof !45
+  %37 = load i64, i64* @rb_cModule, align 8, !dbg !46, !tbaa !6
+  %38 = tail call i64 @rb_obj_is_kind_of(i64 %selfRaw, i64 %37), !dbg !46
+  %39 = icmp eq i64 %38, 0, !dbg !46
+  br i1 %39, label %slowFinalCall_fib, label %sorbet_isa_class_of.exit, !dbg !46, !prof !47
 
 sorbet_isa_class_of.exit:                         ; preds = %36
-  %40 = tail call i64 @rb_class_inherited_p(i64 %selfRaw, i64 %32) #19, !dbg !44
-  %41 = icmp ne i64 %40, 0, !dbg !44
-  br i1 %41, label %fastFinalCall_fib, label %slowFinalCall_fib, !dbg !44, !prof !26
+  %40 = tail call i64 @rb_class_inherited_p(i64 %selfRaw, i64 %32) #19, !dbg !46
+  %41 = icmp ne i64 %40, 0, !dbg !46
+  br i1 %41, label %fastFinalCall_fib, label %slowFinalCall_fib, !dbg !46, !prof !28
 
 BB4:                                              ; preds = %183, %sorbet_rb_int_plus.exit, %"alternativeCallIntrinsic_Integer_+"
-  %"<returnMethodTemp>.sroa.0.0" = phi i64 [ %send107, %"alternativeCallIntrinsic_Integer_+" ], [ %174, %sorbet_rb_int_plus.exit ], [ %174, %183 ], !dbg !46
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !12
+  %"<returnMethodTemp>.sroa.0.0" = phi i64 [ %send107, %"alternativeCallIntrinsic_Integer_+" ], [ %174, %sorbet_rb_int_plus.exit ], [ %174, %183 ], !dbg !48
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !14
   %42 = and i64 %"<returnMethodTemp>.sroa.0.0", 1
   %43 = icmp eq i64 %42, 0
-  br i1 %43, label %44, label %typeTestSuccess77, !prof !47
+  br i1 %43, label %44, label %typeTestSuccess77, !prof !49
 
 44:                                               ; preds = %BB4
   %45 = and i64 %"<returnMethodTemp>.sroa.0.0", 7
@@ -426,271 +426,271 @@ BB4:                                              ; preds = %183, %sorbet_rb_int
 sorbet_isa_Integer.exit:                          ; preds = %44
   %50 = inttoptr i64 %"<returnMethodTemp>.sroa.0.0" to %struct.iseq_inline_iv_cache_entry*
   %51 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %50, i64 0, i32 0
-  %52 = load i64, i64* %51, align 8, !tbaa !48
+  %52 = load i64, i64* %51, align 8, !tbaa !50
   %53 = and i64 %52, 31
   %54 = icmp eq i64 %53, 10
-  br i1 %54, label %typeTestSuccess77, label %codeRepl, !prof !26
+  br i1 %54, label %typeTestSuccess77, label %codeRepl, !prof !28
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #20, !dbg !38
-  unreachable, !dbg !38
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #20, !dbg !40
+  unreachable, !dbg !40
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_n = load i64, i64* %argArray, align 8, !dbg !38
-  %55 = and i64 %rawArg_n, 1, !dbg !50
-  %56 = icmp eq i64 %55, 0, !dbg !50
-  br i1 %56, label %57, label %typeTestSuccess, !dbg !50, !prof !47
+  %rawArg_n = load i64, i64* %argArray, align 8, !dbg !40
+  %55 = and i64 %rawArg_n, 1, !dbg !52
+  %56 = icmp eq i64 %55, 0, !dbg !52
+  br i1 %56, label %57, label %typeTestSuccess, !dbg !52, !prof !49
 
 57:                                               ; preds = %fillRequiredArgs
-  %58 = and i64 %rawArg_n, 7, !dbg !50
-  %59 = icmp ne i64 %58, 0, !dbg !50
-  %60 = and i64 %rawArg_n, -9, !dbg !50
-  %61 = icmp eq i64 %60, 0, !dbg !50
-  %62 = or i1 %59, %61, !dbg !50
-  br i1 %62, label %codeRepl103, label %sorbet_isa_Integer.exit109, !dbg !50
+  %58 = and i64 %rawArg_n, 7, !dbg !52
+  %59 = icmp ne i64 %58, 0, !dbg !52
+  %60 = and i64 %rawArg_n, -9, !dbg !52
+  %61 = icmp eq i64 %60, 0, !dbg !52
+  %62 = or i1 %59, %61, !dbg !52
+  br i1 %62, label %codeRepl103, label %sorbet_isa_Integer.exit109, !dbg !52
 
 sorbet_isa_Integer.exit109:                       ; preds = %57
-  %63 = inttoptr i64 %rawArg_n to %struct.iseq_inline_iv_cache_entry*, !dbg !50
-  %64 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %63, i64 0, i32 0, !dbg !50
-  %65 = load i64, i64* %64, align 8, !dbg !50, !tbaa !48
-  %66 = and i64 %65, 31, !dbg !50
-  %67 = icmp eq i64 %66, 10, !dbg !50
-  br i1 %67, label %typeTestSuccess, label %codeRepl103, !dbg !50, !prof !26
+  %63 = inttoptr i64 %rawArg_n to %struct.iseq_inline_iv_cache_entry*, !dbg !52
+  %64 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %63, i64 0, i32 0, !dbg !52
+  %65 = load i64, i64* %64, align 8, !dbg !52, !tbaa !50
+  %66 = and i64 %65, 31, !dbg !52
+  %67 = icmp eq i64 %66, 10, !dbg !52
+  br i1 %67, label %typeTestSuccess, label %codeRepl103, !dbg !52, !prof !28
 
 typeTestSuccess:                                  ; preds = %fillRequiredArgs, %sorbet_isa_Integer.exit109
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !50, !tbaa !12
-  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !51
-  store i64 7, i64* %callArgs0Addr, align 8, !dbg !51
-  %68 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !51
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !52), !dbg !51
-  %69 = load i64, i64* %68, align 8, !dbg !51, !tbaa !4, !alias.scope !52
-  %70 = and i64 %rawArg_n, 1, !dbg !51
-  %71 = and i64 %69, %70, !dbg !51
-  %72 = icmp eq i64 %71, 0, !dbg !51
-  br i1 %72, label %78, label %73, !dbg !51, !prof !39
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !52, !tbaa !14
+  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !53
+  store i64 7, i64* %callArgs0Addr, align 8, !dbg !53
+  %68 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !53
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !54), !dbg !53
+  %69 = load i64, i64* %68, align 8, !dbg !53, !tbaa !6, !alias.scope !54
+  %70 = and i64 %rawArg_n, 1, !dbg !53
+  %71 = and i64 %69, %70, !dbg !53
+  %72 = icmp eq i64 %71, 0, !dbg !53
+  br i1 %72, label %78, label %73, !dbg !53, !prof !41
 
 73:                                               ; preds = %typeTestSuccess
-  %74 = ashr i64 %rawArg_n, 1, !dbg !51
-  %75 = ashr i64 %69, 1, !dbg !51
-  %76 = icmp slt i64 %74, %75, !dbg !51
-  %77 = select i1 %76, i64 20, i64 0, !dbg !51
-  br label %sorbet_rb_int_lt.exit, !dbg !51
+  %74 = ashr i64 %rawArg_n, 1, !dbg !53
+  %75 = ashr i64 %69, 1, !dbg !53
+  %76 = icmp slt i64 %74, %75, !dbg !53
+  %77 = select i1 %76, i64 20, i64 0, !dbg !53
+  br label %sorbet_rb_int_lt.exit, !dbg !53
 
 78:                                               ; preds = %typeTestSuccess
-  %79 = tail call i64 @sorbet_rb_int_lt_slowpath(i64 %rawArg_n, i64 %69) #16, !dbg !51, !noalias !52
-  br label %sorbet_rb_int_lt.exit, !dbg !51
+  %79 = tail call i64 @sorbet_rb_int_lt_slowpath(i64 %rawArg_n, i64 %69) #16, !dbg !53, !noalias !54
+  br label %sorbet_rb_int_lt.exit, !dbg !53
 
 sorbet_rb_int_lt.exit:                            ; preds = %78, %73
   %rawSendResult95 = phi i64 [ %77, %73 ], [ %79, %78 ]
-  %80 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !51, !tbaa !12
-  %81 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 5, !dbg !51
-  %82 = load i32, i32* %81, align 8, !dbg !51, !tbaa !24
-  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 6, !dbg !51
-  %84 = load i32, i32* %83, align 4, !dbg !51, !tbaa !25
-  %85 = xor i32 %84, -1, !dbg !51
-  %86 = and i32 %85, %82, !dbg !51
-  %87 = icmp eq i32 %86, 0, !dbg !51
-  br i1 %87, label %rb_vm_check_ints.exit98, label %88, !dbg !51, !prof !26
+  %80 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !53, !tbaa !14
+  %81 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 5, !dbg !53
+  %82 = load i32, i32* %81, align 8, !dbg !53, !tbaa !26
+  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 6, !dbg !53
+  %84 = load i32, i32* %83, align 4, !dbg !53, !tbaa !27
+  %85 = xor i32 %84, -1, !dbg !53
+  %86 = and i32 %85, %82, !dbg !53
+  %87 = icmp eq i32 %86, 0, !dbg !53
+  br i1 %87, label %rb_vm_check_ints.exit98, label %88, !dbg !53, !prof !28
 
 88:                                               ; preds = %sorbet_rb_int_lt.exit
-  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 8, !dbg !51
-  %90 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %89, align 8, !dbg !51, !tbaa !27
-  %91 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %90, i32 noundef 0) #16, !dbg !51
-  br label %rb_vm_check_ints.exit98, !dbg !51
+  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 8, !dbg !53
+  %90 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %89, align 8, !dbg !53, !tbaa !29
+  %91 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %90, i32 noundef 0) #16, !dbg !53
+  br label %rb_vm_check_ints.exit98, !dbg !53
 
 rb_vm_check_ints.exit98:                          ; preds = %sorbet_rb_int_lt.exit, %88
-  %92 = and i64 %rawSendResult95, -9, !dbg !51
-  %93 = icmp ne i64 %92, 0, !dbg !51
-  br i1 %93, label %BB4.thread, label %BB3, !dbg !51
+  %92 = and i64 %rawSendResult95, -9, !dbg !53
+  %93 = icmp ne i64 %92, 0, !dbg !53
+  br i1 %93, label %BB4.thread, label %BB3, !dbg !53
 
 BB4.thread:                                       ; preds = %rb_vm_check_ints.exit98
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !12
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !14
   br label %typeTestSuccess77
 
 codeRepl103:                                      ; preds = %57, %sorbet_isa_Integer.exit109
-  tail call fastcc void @func_HasFib.fib.cold.2(i64 %rawArg_n) #21, !dbg !50
+  tail call fastcc void @func_HasFib.fib.cold.2(i64 %rawArg_n) #21, !dbg !52
   unreachable
 
 fastFinalCall_fib:                                ; preds = %31, %sorbet_isa_class_of.exit
-  store i64 %15, i64* %callArgs0Addr, align 8, !dbg !44
-  %94 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.fib, align 8, !dbg !44
-  %95 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.3, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !44, !tbaa !55
-  %96 = icmp eq %struct.rb_callable_method_entry_struct* %95, null, !dbg !44
-  br i1 %96, label %97, label %sorbet_callFuncDirect.exit96, !dbg !44, !prof !47
+  store i64 %15, i64* %callArgs0Addr, align 8, !dbg !46
+  %94 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.fib, align 8, !dbg !46
+  %95 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.3, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !46, !tbaa !57
+  %96 = icmp eq %struct.rb_callable_method_entry_struct* %95, null, !dbg !46
+  br i1 %96, label %97, label %sorbet_callFuncDirect.exit96, !dbg !46, !prof !49
 
 97:                                               ; preds = %fastFinalCall_fib
-  tail call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.3, i64 %selfRaw) #16, !dbg !44
-  br label %sorbet_callFuncDirect.exit96, !dbg !44
+  tail call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.3, i64 %selfRaw) #16, !dbg !46
+  br label %sorbet_callFuncDirect.exit96, !dbg !46
 
 sorbet_callFuncDirect.exit96:                     ; preds = %fastFinalCall_fib, %97
-  %98 = tail call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.3, i64 %selfRaw, %struct.rb_iseq_struct* %94) #16, !dbg !44
-  %99 = call i64 @func_HasFib.fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %68, i64 %selfRaw, %struct.rb_control_frame_struct* align 8 %98) #16, !dbg !44
-  tail call void @sorbet_popFrame() #16, !dbg !44
-  br label %afterFinalCall_fib, !dbg !44
+  %98 = tail call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.3, i64 %selfRaw, %struct.rb_iseq_struct* %94) #16, !dbg !46
+  %99 = call i64 @func_HasFib.fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %68, i64 %selfRaw, %struct.rb_control_frame_struct* align 8 %98) #16, !dbg !46
+  tail call void @sorbet_popFrame() #16, !dbg !46
+  br label %afterFinalCall_fib, !dbg !46
 
 slowFinalCall_fib:                                ; preds = %36, %sorbet_isa_class_of.exit
-  %100 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !44
-  %101 = load i64*, i64** %100, align 8, !dbg !44
-  store i64 %selfRaw, i64* %101, align 8, !dbg !44, !tbaa !4
-  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !44
-  store i64 %15, i64* %102, align 8, !dbg !44, !tbaa !4
-  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !44
-  store i64* %103, i64** %100, align 8, !dbg !44
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fib.4, i64 0), !dbg !44
-  br label %afterFinalCall_fib, !dbg !44
+  %100 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !46
+  %101 = load i64*, i64** %100, align 8, !dbg !46
+  store i64 %selfRaw, i64* %101, align 8, !dbg !46, !tbaa !6
+  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !46
+  store i64 %15, i64* %102, align 8, !dbg !46, !tbaa !6
+  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !46
+  store i64* %103, i64** %100, align 8, !dbg !46
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fib.4, i64 0), !dbg !46
+  br label %afterFinalCall_fib, !dbg !46
 
 afterFinalCall_fib:                               ; preds = %slowFinalCall_fib, %sorbet_callFuncDirect.exit96
   %104 = phi i1 [ true, %sorbet_callFuncDirect.exit96 ], [ false, %slowFinalCall_fib ]
-  %finalCallResult_fib = phi i64 [ %99, %sorbet_callFuncDirect.exit96 ], [ %send, %slowFinalCall_fib ], !dbg !44
-  store i64 5, i64* %callArgs0Addr, align 8, !dbg !61
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !62), !dbg !61
-  %105 = load i64, i64* %68, align 8, !dbg !61, !tbaa !4, !alias.scope !62
-  %106 = and i64 %105, %70, !dbg !61
-  %107 = icmp eq i64 %106, 0, !dbg !61
-  br i1 %107, label %117, label %108, !dbg !61, !prof !39
+  %finalCallResult_fib = phi i64 [ %99, %sorbet_callFuncDirect.exit96 ], [ %send, %slowFinalCall_fib ], !dbg !46
+  store i64 5, i64* %callArgs0Addr, align 8, !dbg !63
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !64), !dbg !63
+  %105 = load i64, i64* %68, align 8, !dbg !63, !tbaa !6, !alias.scope !64
+  %106 = and i64 %105, %70, !dbg !63
+  %107 = icmp eq i64 %106, 0, !dbg !63
+  br i1 %107, label %117, label %108, !dbg !63, !prof !41
 
 108:                                              ; preds = %afterFinalCall_fib
-  %109 = add nsw i64 %105, -1, !dbg !61
-  %110 = tail call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 %rawArg_n, i64 %109) #18, !dbg !61
-  %111 = extractvalue { i64, i1 } %110, 1, !dbg !61
-  %112 = extractvalue { i64, i1 } %110, 0, !dbg !61
-  br i1 %111, label %113, label %sorbet_rb_int_minus.exit97, !dbg !61
+  %109 = add nsw i64 %105, -1, !dbg !63
+  %110 = tail call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 %rawArg_n, i64 %109) #18, !dbg !63
+  %111 = extractvalue { i64, i1 } %110, 1, !dbg !63
+  %112 = extractvalue { i64, i1 } %110, 0, !dbg !63
+  br i1 %111, label %113, label %sorbet_rb_int_minus.exit97, !dbg !63
 
 113:                                              ; preds = %108
-  %114 = ashr i64 %112, 1, !dbg !61
-  %115 = xor i64 %114, -9223372036854775808, !dbg !61
-  %116 = tail call i64 @rb_int2big(i64 %115) #16, !dbg !61, !noalias !62
-  br label %sorbet_rb_int_minus.exit97, !dbg !61
+  %114 = ashr i64 %112, 1, !dbg !63
+  %115 = xor i64 %114, -9223372036854775808, !dbg !63
+  %116 = tail call i64 @rb_int2big(i64 %115) #16, !dbg !63, !noalias !64
+  br label %sorbet_rb_int_minus.exit97, !dbg !63
 
 117:                                              ; preds = %afterFinalCall_fib
-  %118 = tail call i64 @sorbet_rb_int_minus_slowpath(i64 %rawArg_n, i64 %105) #16, !dbg !61, !noalias !62
-  br label %sorbet_rb_int_minus.exit97, !dbg !61
+  %118 = tail call i64 @sorbet_rb_int_minus_slowpath(i64 %rawArg_n, i64 %105) #16, !dbg !63, !noalias !64
+  br label %sorbet_rb_int_minus.exit97, !dbg !63
 
 sorbet_rb_int_minus.exit97:                       ; preds = %113, %108, %117
-  %119 = phi i64 [ %118, %117 ], [ %116, %113 ], [ %112, %108 ], !dbg !61
-  %120 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !61, !tbaa !12
-  %121 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 5, !dbg !61
-  %122 = load i32, i32* %121, align 8, !dbg !61, !tbaa !24
-  %123 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 6, !dbg !61
-  %124 = load i32, i32* %123, align 4, !dbg !61, !tbaa !25
-  %125 = xor i32 %124, -1, !dbg !61
-  %126 = and i32 %125, %122, !dbg !61
-  %127 = icmp eq i32 %126, 0, !dbg !61
-  br i1 %127, label %rb_vm_check_ints.exit101, label %128, !dbg !61, !prof !26
+  %119 = phi i64 [ %118, %117 ], [ %116, %113 ], [ %112, %108 ], !dbg !63
+  %120 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !63, !tbaa !14
+  %121 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 5, !dbg !63
+  %122 = load i32, i32* %121, align 8, !dbg !63, !tbaa !26
+  %123 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 6, !dbg !63
+  %124 = load i32, i32* %123, align 4, !dbg !63, !tbaa !27
+  %125 = xor i32 %124, -1, !dbg !63
+  %126 = and i32 %125, %122, !dbg !63
+  %127 = icmp eq i32 %126, 0, !dbg !63
+  br i1 %127, label %rb_vm_check_ints.exit101, label %128, !dbg !63, !prof !28
 
 128:                                              ; preds = %sorbet_rb_int_minus.exit97
-  %129 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 8, !dbg !61
-  %130 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %129, align 8, !dbg !61, !tbaa !27
-  %131 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %130, i32 noundef 0) #16, !dbg !61
-  br label %rb_vm_check_ints.exit101, !dbg !61
+  %129 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 8, !dbg !63
+  %130 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %129, align 8, !dbg !63, !tbaa !29
+  %131 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %130, i32 noundef 0) #16, !dbg !63
+  br label %rb_vm_check_ints.exit101, !dbg !63
 
 rb_vm_check_ints.exit101:                         ; preds = %sorbet_rb_int_minus.exit97, %128
-  br i1 %104, label %fastFinalCall_fib59, label %slowFinalCall_fib60, !dbg !65
+  br i1 %104, label %fastFinalCall_fib59, label %slowFinalCall_fib60, !dbg !67
 
 fastFinalCall_fib59:                              ; preds = %rb_vm_check_ints.exit101
-  store i64 %119, i64* %callArgs0Addr, align 8, !dbg !65
-  %132 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.fib, align 8, !dbg !65
-  %133 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.6, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !65, !tbaa !55
-  %134 = icmp eq %struct.rb_callable_method_entry_struct* %133, null, !dbg !65
-  br i1 %134, label %135, label %sorbet_callFuncDirect.exit, !dbg !65, !prof !47
+  store i64 %119, i64* %callArgs0Addr, align 8, !dbg !67
+  %132 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.fib, align 8, !dbg !67
+  %133 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.6, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !67, !tbaa !57
+  %134 = icmp eq %struct.rb_callable_method_entry_struct* %133, null, !dbg !67
+  br i1 %134, label %135, label %sorbet_callFuncDirect.exit, !dbg !67, !prof !49
 
 135:                                              ; preds = %fastFinalCall_fib59
-  tail call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.6, i64 %selfRaw) #16, !dbg !65
-  br label %sorbet_callFuncDirect.exit, !dbg !65
+  tail call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.6, i64 %selfRaw) #16, !dbg !67
+  br label %sorbet_callFuncDirect.exit, !dbg !67
 
 sorbet_callFuncDirect.exit:                       ; preds = %fastFinalCall_fib59, %135
-  %136 = tail call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.6, i64 %selfRaw, %struct.rb_iseq_struct* %132) #16, !dbg !65
-  %137 = call i64 @func_HasFib.fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %68, i64 %selfRaw, %struct.rb_control_frame_struct* align 8 %136) #16, !dbg !65
-  tail call void @sorbet_popFrame() #16, !dbg !65
-  br label %afterFinalCall_fib61, !dbg !65
+  %136 = tail call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.6, i64 %selfRaw, %struct.rb_iseq_struct* %132) #16, !dbg !67
+  %137 = call i64 @func_HasFib.fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %68, i64 %selfRaw, %struct.rb_control_frame_struct* align 8 %136) #16, !dbg !67
+  tail call void @sorbet_popFrame() #16, !dbg !67
+  br label %afterFinalCall_fib61, !dbg !67
 
 slowFinalCall_fib60:                              ; preds = %rb_vm_check_ints.exit101
-  %138 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !65
-  %139 = load i64*, i64** %138, align 8, !dbg !65
-  store i64 %selfRaw, i64* %139, align 8, !dbg !65, !tbaa !4
-  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !65
-  store i64 %119, i64* %140, align 8, !dbg !65, !tbaa !4
-  %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !65
-  store i64* %141, i64** %138, align 8, !dbg !65
-  %send105 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fib.7, i64 0), !dbg !65
-  br label %afterFinalCall_fib61, !dbg !65
+  %138 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !67
+  %139 = load i64*, i64** %138, align 8, !dbg !67
+  store i64 %selfRaw, i64* %139, align 8, !dbg !67, !tbaa !6
+  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !67
+  store i64 %119, i64* %140, align 8, !dbg !67, !tbaa !6
+  %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !67
+  store i64* %141, i64** %138, align 8, !dbg !67
+  %send105 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fib.7, i64 0), !dbg !67
+  br label %afterFinalCall_fib61, !dbg !67
 
 afterFinalCall_fib61:                             ; preds = %slowFinalCall_fib60, %sorbet_callFuncDirect.exit
-  %finalCallResult_fib66 = phi i64 [ %137, %sorbet_callFuncDirect.exit ], [ %send105, %slowFinalCall_fib60 ], !dbg !65
-  %142 = and i64 %finalCallResult_fib, 1, !dbg !44
-  %143 = icmp eq i64 %142, 0, !dbg !44
-  br i1 %143, label %144, label %"fastSymCallIntrinsic_Integer_+", !dbg !44, !prof !47
+  %finalCallResult_fib66 = phi i64 [ %137, %sorbet_callFuncDirect.exit ], [ %send105, %slowFinalCall_fib60 ], !dbg !67
+  %142 = and i64 %finalCallResult_fib, 1, !dbg !46
+  %143 = icmp eq i64 %142, 0, !dbg !46
+  br i1 %143, label %144, label %"fastSymCallIntrinsic_Integer_+", !dbg !46, !prof !49
 
 144:                                              ; preds = %afterFinalCall_fib61
-  %145 = and i64 %finalCallResult_fib, 7, !dbg !44
-  %146 = icmp ne i64 %145, 0, !dbg !44
-  %147 = and i64 %finalCallResult_fib, -9, !dbg !44
-  %148 = icmp eq i64 %147, 0, !dbg !44
-  %149 = or i1 %146, %148, !dbg !44
-  br i1 %149, label %"alternativeCallIntrinsic_Integer_+", label %sorbet_isa_Integer.exit108, !dbg !44
+  %145 = and i64 %finalCallResult_fib, 7, !dbg !46
+  %146 = icmp ne i64 %145, 0, !dbg !46
+  %147 = and i64 %finalCallResult_fib, -9, !dbg !46
+  %148 = icmp eq i64 %147, 0, !dbg !46
+  %149 = or i1 %146, %148, !dbg !46
+  br i1 %149, label %"alternativeCallIntrinsic_Integer_+", label %sorbet_isa_Integer.exit108, !dbg !46
 
 sorbet_isa_Integer.exit108:                       ; preds = %144
-  %150 = inttoptr i64 %finalCallResult_fib to %struct.iseq_inline_iv_cache_entry*, !dbg !44
-  %151 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %150, i64 0, i32 0, !dbg !44
-  %152 = load i64, i64* %151, align 8, !dbg !44, !tbaa !48
-  %153 = and i64 %152, 31, !dbg !44
-  %154 = icmp eq i64 %153, 10, !dbg !44
-  br i1 %154, label %"fastSymCallIntrinsic_Integer_+", label %"alternativeCallIntrinsic_Integer_+", !dbg !44, !prof !26
+  %150 = inttoptr i64 %finalCallResult_fib to %struct.iseq_inline_iv_cache_entry*, !dbg !46
+  %151 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %150, i64 0, i32 0, !dbg !46
+  %152 = load i64, i64* %151, align 8, !dbg !46, !tbaa !50
+  %153 = and i64 %152, 31, !dbg !46
+  %154 = icmp eq i64 %153, 10, !dbg !46
+  br i1 %154, label %"fastSymCallIntrinsic_Integer_+", label %"alternativeCallIntrinsic_Integer_+", !dbg !46, !prof !28
 
 "alternativeCallIntrinsic_Integer_+":             ; preds = %144, %sorbet_isa_Integer.exit108
-  %155 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !44
-  %156 = load i64*, i64** %155, align 8, !dbg !44
-  store i64 %finalCallResult_fib, i64* %156, align 8, !dbg !44, !tbaa !4
-  %157 = getelementptr inbounds i64, i64* %156, i64 1, !dbg !44
-  store i64 %finalCallResult_fib66, i64* %157, align 8, !dbg !44, !tbaa !4
-  %158 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !44
-  store i64* %158, i64** %155, align 8, !dbg !44
-  %send107 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !44
-  br label %BB4, !dbg !44
+  %155 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !46
+  %156 = load i64*, i64** %155, align 8, !dbg !46
+  store i64 %finalCallResult_fib, i64* %156, align 8, !dbg !46, !tbaa !6
+  %157 = getelementptr inbounds i64, i64* %156, i64 1, !dbg !46
+  store i64 %finalCallResult_fib66, i64* %157, align 8, !dbg !46, !tbaa !6
+  %158 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !46
+  store i64* %158, i64** %155, align 8, !dbg !46
+  %send107 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !46
+  br label %BB4, !dbg !46
 
 "fastSymCallIntrinsic_Integer_+":                 ; preds = %afterFinalCall_fib61, %sorbet_isa_Integer.exit108
-  store i64 %finalCallResult_fib66, i64* %callArgs0Addr, align 8, !dbg !44
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !66), !dbg !44
-  %159 = load i64, i64* %68, align 8, !dbg !44, !tbaa !4, !alias.scope !66
-  %160 = and i64 %finalCallResult_fib, 1, !dbg !44
-  %161 = and i64 %160, %159, !dbg !44
-  %162 = icmp eq i64 %161, 0, !dbg !44
-  br i1 %162, label %172, label %163, !dbg !44, !prof !39
+  store i64 %finalCallResult_fib66, i64* %callArgs0Addr, align 8, !dbg !46
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !68), !dbg !46
+  %159 = load i64, i64* %68, align 8, !dbg !46, !tbaa !6, !alias.scope !68
+  %160 = and i64 %finalCallResult_fib, 1, !dbg !46
+  %161 = and i64 %160, %159, !dbg !46
+  %162 = icmp eq i64 %161, 0, !dbg !46
+  br i1 %162, label %172, label %163, !dbg !46, !prof !41
 
 163:                                              ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %164 = add nsw i64 %159, -1, !dbg !44
-  %165 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %finalCallResult_fib, i64 %164) #18, !dbg !44
-  %166 = extractvalue { i64, i1 } %165, 1, !dbg !44
-  %167 = extractvalue { i64, i1 } %165, 0, !dbg !44
-  br i1 %166, label %168, label %sorbet_rb_int_plus.exit, !dbg !44
+  %164 = add nsw i64 %159, -1, !dbg !46
+  %165 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %finalCallResult_fib, i64 %164) #18, !dbg !46
+  %166 = extractvalue { i64, i1 } %165, 1, !dbg !46
+  %167 = extractvalue { i64, i1 } %165, 0, !dbg !46
+  br i1 %166, label %168, label %sorbet_rb_int_plus.exit, !dbg !46
 
 168:                                              ; preds = %163
-  %169 = ashr i64 %167, 1, !dbg !44
-  %170 = xor i64 %169, -9223372036854775808, !dbg !44
-  %171 = tail call i64 @rb_int2big(i64 %170) #16, !dbg !44, !noalias !66
-  br label %sorbet_rb_int_plus.exit, !dbg !44
+  %169 = ashr i64 %167, 1, !dbg !46
+  %170 = xor i64 %169, -9223372036854775808, !dbg !46
+  %171 = tail call i64 @rb_int2big(i64 %170) #16, !dbg !46, !noalias !68
+  br label %sorbet_rb_int_plus.exit, !dbg !46
 
 172:                                              ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %173 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %finalCallResult_fib, i64 %159) #16, !dbg !44, !noalias !66
-  br label %sorbet_rb_int_plus.exit, !dbg !44
+  %173 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %finalCallResult_fib, i64 %159) #16, !dbg !46, !noalias !68
+  br label %sorbet_rb_int_plus.exit, !dbg !46
 
 sorbet_rb_int_plus.exit:                          ; preds = %168, %163, %172
-  %174 = phi i64 [ %173, %172 ], [ %171, %168 ], [ %167, %163 ], !dbg !44
-  %175 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !44, !tbaa !12
-  %176 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 5, !dbg !44
-  %177 = load i32, i32* %176, align 8, !dbg !44, !tbaa !24
-  %178 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 6, !dbg !44
-  %179 = load i32, i32* %178, align 4, !dbg !44, !tbaa !25
-  %180 = xor i32 %179, -1, !dbg !44
-  %181 = and i32 %180, %177, !dbg !44
-  %182 = icmp eq i32 %181, 0, !dbg !44
-  br i1 %182, label %BB4, label %183, !dbg !44, !prof !26
+  %174 = phi i64 [ %173, %172 ], [ %171, %168 ], [ %167, %163 ], !dbg !46
+  %175 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !14
+  %176 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 5, !dbg !46
+  %177 = load i32, i32* %176, align 8, !dbg !46, !tbaa !26
+  %178 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 6, !dbg !46
+  %179 = load i32, i32* %178, align 4, !dbg !46, !tbaa !27
+  %180 = xor i32 %179, -1, !dbg !46
+  %181 = and i32 %180, %177, !dbg !46
+  %182 = icmp eq i32 %181, 0, !dbg !46
+  br i1 %182, label %BB4, label %183, !dbg !46, !prof !28
 
 183:                                              ; preds = %sorbet_rb_int_plus.exit
-  %184 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 8, !dbg !44
-  %185 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %184, align 8, !dbg !44, !tbaa !27
-  %186 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %185, i32 noundef 0) #16, !dbg !44
-  br label %BB4, !dbg !44
+  %184 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 8, !dbg !46
+  %185 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %184, align 8, !dbg !46, !tbaa !29
+  %186 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %185, i32 noundef 0) #16, !dbg !46
+  br label %BB4, !dbg !46
 
 typeTestSuccess77:                                ; preds = %BB4.thread, %BB4, %sorbet_isa_Integer.exit
   %"<returnMethodTemp>.sroa.0.0111" = phi i64 [ 3, %BB4.thread ], [ %"<returnMethodTemp>.sroa.0.0", %BB4 ], [ %"<returnMethodTemp>.sroa.0.0", %sorbet_isa_Integer.exit ]
@@ -698,7 +698,7 @@ typeTestSuccess77:                                ; preds = %BB4.thread, %BB4, %
 
 codeRepl:                                         ; preds = %44, %sorbet_isa_Integer.exit
   %"<returnMethodTemp>.sroa.0.0112" = phi i64 [ %"<returnMethodTemp>.sroa.0.0", %44 ], [ %"<returnMethodTemp>.sroa.0.0", %sorbet_isa_Integer.exit ]
-  tail call fastcc void @func_HasFib.fib.cold.1(i64 %"<returnMethodTemp>.sroa.0.0112") #21, !dbg !46
+  tail call fastcc void @func_HasFib.fib.cold.1(i64 %"<returnMethodTemp>.sroa.0.0112") #21, !dbg !48
   unreachable
 }
 
@@ -709,7 +709,7 @@ entry:
   %locals.i27.i = alloca i64, i32 0, align 8
   %locals.i23.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, align 8, !dbg !69
+  %keywords.i = alloca i64, align 8, !dbg !71
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
@@ -749,26 +749,26 @@ entry:
   %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
   %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_fib1.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !71
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %rubyId_fib1.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !71
-  %rubyId_fib2.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !71
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.2, i64 %rubyId_fib2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !71
+  %rubyId_fib1.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !73
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %rubyId_fib1.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !73
+  %rubyId_fib2.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !73
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.2, i64 %rubyId_fib2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !73
   %17 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_fib, i64 0, i64 0), i64 noundef 3) #16
   call void @rb_gc_register_mark_object(i64 %17) #16
   %rubyId_fib.i.i = load i64, i64* @rubyIdPrecomputed_fib, align 8
   %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
   %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %rubyId_fib.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.fib, align 8
-  %rubyId_fib6.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.3, i64 %rubyId_fib6.i, i32 noundef 4, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !44
-  %rubyId_fib7.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.4, i64 %rubyId_fib7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !44
-  %rubyId_fib12.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !65
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.6, i64 %rubyId_fib12.i, i32 noundef 4, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !65
-  %rubyId_fib14.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !65
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.7, i64 %rubyId_fib14.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !65
-  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !44
+  %rubyId_fib6.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.3, i64 %rubyId_fib6.i, i32 noundef 4, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !46
+  %rubyId_fib7.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.4, i64 %rubyId_fib7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
+  %rubyId_fib12.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !67
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.6, i64 %rubyId_fib12.i, i32 noundef 4, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !67
+  %rubyId_fib14.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !67
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.7, i64 %rubyId_fib14.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !67
+  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
   %"rubyId_<top (required)>.i24.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i25.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
@@ -781,71 +781,71 @@ entry:
   %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
   %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_block for.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_HasFib.<static-init>$block_1", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !23
-  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !69
-  %rubyId_n.i = load i64, i64* @rubyIdPrecomputed_n, align 8, !dbg !69
-  %22 = call i64 @rb_id2sym(i64 %rubyId_n.i) #16, !dbg !69
-  store i64 %22, i64* %keywords.i, align 8, !dbg !69
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !69
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !69
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !69
-  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !28
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !28
+  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !25
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !25
+  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !71
+  %rubyId_n.i = load i64, i64* @rubyIdPrecomputed_n, align 8, !dbg !71
+  %22 = call i64 @rb_id2sym(i64 %rubyId_n.i) #16, !dbg !71
+  store i64 %22, i64* %keywords.i, align 8, !dbg !71
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !71
+  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !71
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !71
+  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !30
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !30
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
-  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
-  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !14
+  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !16
   %26 = bitcast [2 x i64]* %callArgs.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %26)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %27, align 8, !tbaa !18
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %27, align 8, !tbaa !20
   %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
-  %29 = load i64*, i64** %28, align 8, !tbaa !20
-  %30 = load i64, i64* %29, align 8, !tbaa !4
+  %29 = load i64*, i64** %28, align 8, !tbaa !22
+  %30 = load i64, i64* %29, align 8, !tbaa !6
   %31 = and i64 %30, -33
-  store i64 %31, i64* %29, align 8, !tbaa !4
+  store i64 %31, i64* %29, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %23, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #16
   %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %32, align 8, !dbg !73, !tbaa !12
-  %33 = load i64, i64* @rb_cObject, align 8, !dbg !74
-  %34 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_HasFib, i64 0, i64 0), i64 %33) #16, !dbg !74
-  %35 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %34) #16, !dbg !74
-  call fastcc void @"func_HasFib.<static-init>L64"(%struct.rb_control_frame_struct* %35) #16, !dbg !74
-  call void @sorbet_popFrame() #16, !dbg !74
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %32, align 8, !dbg !74, !tbaa !12
-  %36 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !71
-  %37 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !71, !tbaa !29
-  %needTakeSlowPath = icmp ne i64 %36, %37, !dbg !71
-  br i1 %needTakeSlowPath, label %38, label %39, !dbg !71, !prof !31
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %32, align 8, !dbg !75, !tbaa !14
+  %33 = load i64, i64* @rb_cObject, align 8, !dbg !76
+  %34 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_HasFib, i64 0, i64 0), i64 %33) #16, !dbg !76
+  %35 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %34) #16, !dbg !76
+  call fastcc void @"func_HasFib.<static-init>L64"(%struct.rb_control_frame_struct* %35) #16, !dbg !76
+  call void @sorbet_popFrame() #16, !dbg !76
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %32, align 8, !dbg !76, !tbaa !14
+  %36 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !73
+  %37 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !73, !tbaa !31
+  %needTakeSlowPath = icmp ne i64 %36, %37, !dbg !73
+  br i1 %needTakeSlowPath, label %38, label %39, !dbg !73, !prof !33
 
 38:                                               ; preds = %entry
-  call void @const_recompute_HasFib(), !dbg !71
-  br label %39, !dbg !71
+  call void @const_recompute_HasFib(), !dbg !73
+  br label %39, !dbg !73
 
 39:                                               ; preds = %entry, %38
-  %40 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !71
-  %41 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !71
-  %42 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !71, !tbaa !29
-  %guardUpdated = icmp eq i64 %41, %42, !dbg !71
-  call void @llvm.assume(i1 %guardUpdated), !dbg !71
-  %callArgs0Addr.i = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i32 0, i64 0, !dbg !71
-  store i64 69, i64* %callArgs0Addr.i, align 8, !dbg !71
-  %43 = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i64 0, i64 0, !dbg !71
-  %44 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.fib, align 8, !dbg !71
-  %45 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.1, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !71, !tbaa !55
-  %46 = icmp eq %struct.rb_callable_method_entry_struct* %45, null, !dbg !71
-  br i1 %46, label %47, label %"func_<root>.<static-init>$151.exit", !dbg !71, !prof !47
+  %40 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !73
+  %41 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !73
+  %42 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !73, !tbaa !31
+  %guardUpdated = icmp eq i64 %41, %42, !dbg !73
+  call void @llvm.assume(i1 %guardUpdated), !dbg !73
+  %callArgs0Addr.i = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i32 0, i64 0, !dbg !73
+  store i64 69, i64* %callArgs0Addr.i, align 8, !dbg !73
+  %43 = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i64 0, i64 0, !dbg !73
+  %44 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.fib, align 8, !dbg !73
+  %45 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.1, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !73, !tbaa !57
+  %46 = icmp eq %struct.rb_callable_method_entry_struct* %45, null, !dbg !73
+  br i1 %46, label %47, label %"func_<root>.<static-init>$151.exit", !dbg !73, !prof !49
 
 47:                                               ; preds = %39
-  call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %40) #16, !dbg !71
-  br label %"func_<root>.<static-init>$151.exit", !dbg !71
+  call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %40) #16, !dbg !73
+  br label %"func_<root>.<static-init>$151.exit", !dbg !73
 
 "func_<root>.<static-init>$151.exit":             ; preds = %39, %47
-  %48 = call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %40, %struct.rb_iseq_struct* %44) #16, !dbg !71
-  %49 = call i64 @func_HasFib.fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %43, i64 %40, %struct.rb_control_frame_struct* align 8 %48) #16, !dbg !71
-  call void @sorbet_popFrame() #16, !dbg !71
+  %48 = call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %40, %struct.rb_iseq_struct* %44) #16, !dbg !73
+  %49 = call i64 @func_HasFib.fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %43, i64 %40, %struct.rb_control_frame_struct* align 8 %48) #16, !dbg !73
+  call void @sorbet_popFrame() #16, !dbg !73
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %26)
   ret void
 }
@@ -863,17 +863,17 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #6
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #6
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @func_HasFib.fib.cold.1(i64 %"<returnMethodTemp>.sroa.0.0") unnamed_addr #12 !dbg !75 {
+define internal fastcc void @func_HasFib.fib.cold.1(i64 %"<returnMethodTemp>.sroa.0.0") unnamed_addr #12 !dbg !77 {
 newFuncRoot:
   tail call void @sorbet_cast_failure(i64 %"<returnMethodTemp>.sroa.0.0", i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20
   unreachable
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @func_HasFib.fib.cold.2(i64 %rawArg_n) unnamed_addr #12 !dbg !77 {
+define internal fastcc void @func_HasFib.fib.cold.2(i64 %rawArg_n) unnamed_addr #12 !dbg !79 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_n, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !78
-  unreachable, !dbg !78
+  tail call void @sorbet_cast_failure(i64 %rawArg_n, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !80
+  unreachable, !dbg !80
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
@@ -883,7 +883,7 @@ declare void @llvm.assume(i1 noundef) #13
 define linkonce void @const_recompute_HasFib() local_unnamed_addr #14 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @str_HasFib, i64 0, i64 0), i64 6)
   store i64 %1, i64* @guarded_const_HasFib, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !29
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !31
   store i64 %2, i64* @guard_epoch_HasFib, align 8
   ret void
 }
@@ -911,85 +911,87 @@ attributes #19 = { nounwind readnone willreturn }
 attributes #20 = { noreturn }
 attributes #21 = { noinline }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/ruby_benchmark/app_fib.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "HasFib.<static-init>", linkageName: "func_HasFib.<static-init>L64", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = !DISubroutineType(types: !10)
-!10 = !{!11}
-!11 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!12 = !{!13, !13, i64 0}
-!13 = !{!"any pointer", !6, i64 0}
-!14 = !{!15, !13, i64 16}
-!15 = !{!"rb_execution_context_struct", !13, i64 0, !5, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !16, i64 40, !16, i64 44, !13, i64 48, !13, i64 56, !13, i64 64, !5, i64 72, !5, i64 80, !13, i64 88, !5, i64 96, !13, i64 104, !13, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !17, i64 152}
-!16 = !{!"int", !6, i64 0}
-!17 = !{!"", !13, i64 0, !13, i64 8, !5, i64 16, !6, i64 24}
-!18 = !{!19, !13, i64 16}
-!19 = !{!"rb_control_frame_struct", !13, i64 0, !13, i64 8, !13, i64 16, !5, i64 24, !13, i64 32, !13, i64 40, !13, i64 48}
-!20 = !{!19, !13, i64 32}
-!21 = !DILocation(line: 0, scope: !8)
-!22 = !DILocation(line: 6, column: 30, scope: !8)
-!23 = !DILocation(line: 6, column: 3, scope: !8)
-!24 = !{!15, !16, i64 40}
-!25 = !{!15, !16, i64 44}
-!26 = !{!"branch_weights", i32 2000, i32 1}
-!27 = !{!15, !13, i64 56}
-!28 = !DILocation(line: 7, column: 3, scope: !8)
-!29 = !{!30, !30, i64 0}
-!30 = !{!"long long", !6, i64 0}
-!31 = !{!"branch_weights", i32 1, i32 10000}
-!32 = !{!33, !16, i64 8}
-!33 = !{!"rb_sorbet_param_struct", !34, i64 0, !16, i64 4, !16, i64 8, !16, i64 12, !16, i64 16, !16, i64 20, !16, i64 24, !16, i64 28, !13, i64 32, !16, i64 40, !16, i64 44, !16, i64 48, !16, i64 52, !13, i64 56}
-!34 = !{!"", !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 1, !16, i64 1}
-!35 = !{!33, !16, i64 4}
-!36 = !{!33, !13, i64 32}
-!37 = distinct !DISubprogram(name: "HasFib.fib", linkageName: "func_HasFib.fib", scope: null, file: !2, line: 7, type: !9, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!38 = !DILocation(line: 7, column: 3, scope: !37)
-!39 = !{!"branch_weights", i32 4001, i32 4000000}
-!40 = !DILocation(line: 11, column: 11, scope: !37)
-!41 = !{!42}
-!42 = distinct !{!42, !43, !"sorbet_rb_int_minus: argument 0"}
-!43 = distinct !{!43, !"sorbet_rb_int_minus"}
-!44 = !DILocation(line: 11, column: 7, scope: !37)
-!45 = !{!"branch_weights", i32 1073205, i32 2146410443}
-!46 = !DILocation(line: 0, scope: !37)
-!47 = !{!"branch_weights", i32 1, i32 2000}
-!48 = !{!49, !5, i64 0}
-!49 = !{!"RBasic", !5, i64 0, !5, i64 8}
-!50 = !DILocation(line: 7, column: 16, scope: !37)
-!51 = !DILocation(line: 8, column: 8, scope: !37)
-!52 = !{!53}
-!53 = distinct !{!53, !54, !"sorbet_rb_int_lt: argument 0"}
-!54 = distinct !{!54, !"sorbet_rb_int_lt"}
-!55 = !{!56, !13, i64 32}
-!56 = !{!"FunctionInlineCache", !57, i64 0}
-!57 = !{!"rb_kwarg_call_data", !58, i64 0, !59, i64 64}
-!58 = !{!"rb_call_cache", !30, i64 0, !6, i64 8, !13, i64 32, !5, i64 40, !13, i64 48, !6, i64 56}
-!59 = !{!"rb_call_info_with_kwarg", !60, i64 0, !13, i64 16}
-!60 = !{!"rb_call_info", !5, i64 0, !16, i64 8, !16, i64 12}
-!61 = !DILocation(line: 11, column: 22, scope: !37)
-!62 = !{!63}
-!63 = distinct !{!63, !64, !"sorbet_rb_int_minus: argument 0"}
-!64 = distinct !{!64, !"sorbet_rb_int_minus"}
-!65 = !DILocation(line: 11, column: 18, scope: !37)
-!66 = !{!67}
-!67 = distinct !{!67, !68, !"sorbet_rb_int_plus: argument 0"}
-!68 = distinct !{!68, !"sorbet_rb_int_plus"}
-!69 = !DILocation(line: 6, column: 39, scope: !70)
-!70 = distinct !DISubprogram(name: "HasFib.<static-init>", linkageName: "func_HasFib.<static-init>L64$block_1", scope: !8, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!71 = !DILocation(line: 16, column: 1, scope: !72)
-!72 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!73 = !DILocation(line: 0, scope: !72)
-!74 = !DILocation(line: 5, column: 1, scope: !72)
-!75 = distinct !DISubprogram(name: "func_HasFib.fib.cold.1", linkageName: "func_HasFib.fib.cold.1", scope: null, file: !2, type: !76, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!76 = !DISubroutineType(types: !3)
-!77 = distinct !DISubprogram(name: "func_HasFib.fib.cold.2", linkageName: "func_HasFib.fib.cold.2", scope: null, file: !2, type: !76, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!78 = !DILocation(line: 7, column: 16, scope: !77)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/ruby_benchmark/app_fib.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "HasFib.<static-init>", linkageName: "func_HasFib.<static-init>L64", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!14 = !{!15, !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !{!17, !15, i64 16}
+!17 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !18, i64 40, !18, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !19, i64 152}
+!18 = !{!"int", !8, i64 0}
+!19 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!20 = !{!21, !15, i64 16}
+!21 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!22 = !{!21, !15, i64 32}
+!23 = !DILocation(line: 0, scope: !10)
+!24 = !DILocation(line: 6, column: 30, scope: !10)
+!25 = !DILocation(line: 6, column: 3, scope: !10)
+!26 = !{!17, !18, i64 40}
+!27 = !{!17, !18, i64 44}
+!28 = !{!"branch_weights", i32 2000, i32 1}
+!29 = !{!17, !15, i64 56}
+!30 = !DILocation(line: 7, column: 3, scope: !10)
+!31 = !{!32, !32, i64 0}
+!32 = !{!"long long", !8, i64 0}
+!33 = !{!"branch_weights", i32 1, i32 10000}
+!34 = !{!35, !18, i64 8}
+!35 = !{!"rb_sorbet_param_struct", !36, i64 0, !18, i64 4, !18, i64 8, !18, i64 12, !18, i64 16, !18, i64 20, !18, i64 24, !18, i64 28, !15, i64 32, !18, i64 40, !18, i64 44, !18, i64 48, !18, i64 52, !15, i64 56}
+!36 = !{!"", !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 1, !18, i64 1}
+!37 = !{!35, !18, i64 4}
+!38 = !{!35, !15, i64 32}
+!39 = distinct !DISubprogram(name: "HasFib.fib", linkageName: "func_HasFib.fib", scope: null, file: !4, line: 7, type: !11, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!40 = !DILocation(line: 7, column: 3, scope: !39)
+!41 = !{!"branch_weights", i32 4001, i32 4000000}
+!42 = !DILocation(line: 11, column: 11, scope: !39)
+!43 = !{!44}
+!44 = distinct !{!44, !45, !"sorbet_rb_int_minus: argument 0"}
+!45 = distinct !{!45, !"sorbet_rb_int_minus"}
+!46 = !DILocation(line: 11, column: 7, scope: !39)
+!47 = !{!"branch_weights", i32 1073205, i32 2146410443}
+!48 = !DILocation(line: 0, scope: !39)
+!49 = !{!"branch_weights", i32 1, i32 2000}
+!50 = !{!51, !7, i64 0}
+!51 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!52 = !DILocation(line: 7, column: 16, scope: !39)
+!53 = !DILocation(line: 8, column: 8, scope: !39)
+!54 = !{!55}
+!55 = distinct !{!55, !56, !"sorbet_rb_int_lt: argument 0"}
+!56 = distinct !{!56, !"sorbet_rb_int_lt"}
+!57 = !{!58, !15, i64 32}
+!58 = !{!"FunctionInlineCache", !59, i64 0}
+!59 = !{!"rb_kwarg_call_data", !60, i64 0, !61, i64 64}
+!60 = !{!"rb_call_cache", !32, i64 0, !8, i64 8, !15, i64 32, !7, i64 40, !15, i64 48, !8, i64 56}
+!61 = !{!"rb_call_info_with_kwarg", !62, i64 0, !15, i64 16}
+!62 = !{!"rb_call_info", !7, i64 0, !18, i64 8, !18, i64 12}
+!63 = !DILocation(line: 11, column: 22, scope: !39)
+!64 = !{!65}
+!65 = distinct !{!65, !66, !"sorbet_rb_int_minus: argument 0"}
+!66 = distinct !{!66, !"sorbet_rb_int_minus"}
+!67 = !DILocation(line: 11, column: 18, scope: !39)
+!68 = !{!69}
+!69 = distinct !{!69, !70, !"sorbet_rb_int_plus: argument 0"}
+!70 = distinct !{!70, !"sorbet_rb_int_plus"}
+!71 = !DILocation(line: 6, column: 39, scope: !72)
+!72 = distinct !DISubprogram(name: "HasFib.<static-init>", linkageName: "func_HasFib.<static-init>L64$block_1", scope: !10, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!73 = !DILocation(line: 16, column: 1, scope: !74)
+!74 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!75 = !DILocation(line: 0, scope: !74)
+!76 = !DILocation(line: 5, column: 1, scope: !74)
+!77 = distinct !DISubprogram(name: "func_HasFib.fib.cold.1", linkageName: "func_HasFib.fib.cold.1", scope: null, file: !4, type: !78, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!78 = !DISubroutineType(types: !5)
+!79 = distinct !DISubprogram(name: "func_HasFib.fib.cold.2", linkageName: "func_HasFib.fib.cold.2", scope: null, file: !4, type: !78, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!80 = !DILocation(line: 7, column: 16, scope: !79)

--- a/test/testdata/ruby_benchmark/app_strconcat.llo.exp
+++ b/test/testdata/ruby_benchmark/app_strconcat.llo.exp
@@ -135,14 +135,14 @@ declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) loc
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #7
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #7
   unreachable
 }
@@ -173,27 +173,27 @@ entry:
   %"rubyStr_test/testdata/ruby_benchmark/app_strconcat.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_strconcat.rb", align 8
   %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/app_strconcat.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 6)
   store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_<", i64 %"rubyId_<.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !8
+  %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_<", i64 %"rubyId_<.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
   %7 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_ ", i64 0, i64 0), i64 noundef 1) #8
   call void @rb_gc_register_mark_object(i64 %7) #8
   store i64 %7, i64* @"rubyStrFrozen_ ", align 8
-  %"rubyId_+6.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !13
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+.3", i64 %"rubyId_+6.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !13
-  %8 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %"rubyId_+6.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !15
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+.3", i64 %"rubyId_+6.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
+  %8 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !16
   %9 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %8, i64 0, i32 2
-  %10 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %9, align 8, !tbaa !16
+  %10 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %9, align 8, !tbaa !18
   %11 = bitcast [6 x i64]* %callArgs.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 48, i8* nonnull %11)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %9, align 8, !tbaa !16
+  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %9, align 8, !tbaa !18
   %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !20
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !22
   %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 4
-  %15 = load i64*, i64** %14, align 8, !tbaa !22
-  %16 = load i64, i64* %15, align 8, !tbaa !4
+  %15 = load i64*, i64** %14, align 8, !tbaa !24
+  %16 = load i64, i64* %15, align 8, !tbaa !6
   %17 = and i64 %16, -33
-  store i64 %17, i64* %15, align 8, !tbaa !4
+  store i64 %17, i64* %15, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %8, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #8
   %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 0
   %callArgs0Addr.i = getelementptr [6 x i64], [6 x i64]* %callArgs.i, i32 0, i64 0
@@ -202,293 +202,293 @@ entry:
   %callArgs2Addr.i = getelementptr [6 x i64], [6 x i64]* %callArgs.i, i32 0, i64 2
   %callArgs3Addr.i = getelementptr [6 x i64], [6 x i64]* %callArgs.i, i32 0, i64 3
   %callArgs4Addr.i = getelementptr [6 x i64], [6 x i64]* %callArgs.i, i32 0, i64 4
-  br label %BB2.i, !dbg !23
+  br label %BB2.i, !dbg !25
 
 BB2.i:                                            ; preds = %BB2.i.backedge, %entry
-  %i.sroa.0.0.i = phi i64 [ 1, %entry ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !24
-  store i64* getelementptr inbounds ([9 x i64], [9 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %18, align 8, !tbaa !14
-  %20 = and i64 %i.sroa.0.0.i, 1, !dbg !8
-  %21 = icmp eq i64 %20, 0, !dbg !8
-  br i1 %21, label %22, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !8, !prof !25
+  %i.sroa.0.0.i = phi i64 [ 1, %entry ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !26
+  store i64* getelementptr inbounds ([9 x i64], [9 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %18, align 8, !tbaa !16
+  %20 = and i64 %i.sroa.0.0.i, 1, !dbg !10
+  %21 = icmp eq i64 %20, 0, !dbg !10
+  br i1 %21, label %22, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !10, !prof !27
 
 22:                                               ; preds = %BB2.i
-  %23 = and i64 %i.sroa.0.0.i, 7, !dbg !8
-  %24 = icmp ne i64 %23, 0, !dbg !8
-  %25 = and i64 %i.sroa.0.0.i, -9, !dbg !8
-  %26 = icmp eq i64 %25, 0, !dbg !8
-  %27 = or i1 %24, %26, !dbg !8
-  br i1 %27, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !8, !prof !26
+  %23 = and i64 %i.sroa.0.0.i, 7, !dbg !10
+  %24 = icmp ne i64 %23, 0, !dbg !10
+  %25 = and i64 %i.sroa.0.0.i, -9, !dbg !10
+  %26 = icmp eq i64 %25, 0, !dbg !10
+  %27 = or i1 %24, %26, !dbg !10
+  br i1 %27, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !10, !prof !28
 
 sorbet_isa_Integer.exit:                          ; preds = %22
-  %28 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !8
-  %29 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %28, i64 0, i32 0, !dbg !8
-  %30 = load i64, i64* %29, align 8, !dbg !8, !tbaa !27
-  %31 = and i64 %30, 31, !dbg !8
-  %32 = icmp eq i64 %31, 10, !dbg !8
-  br i1 %32, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !8, !prof !29
+  %28 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !10
+  %29 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %28, i64 0, i32 0, !dbg !10
+  %30 = load i64, i64* %29, align 8, !dbg !10, !tbaa !29
+  %31 = and i64 %30, 31, !dbg !10
+  %32 = icmp eq i64 %31, 10, !dbg !10
+  br i1 %32, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !10, !prof !31
 
 BB5.i:                                            ; preds = %afterSend.i
-  store i64* getelementptr inbounds ([9 x i64], [9 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %18, align 8, !tbaa !14
-  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !30
-  call void @llvm.experimental.noalias.scope.decl(metadata !31) #8, !dbg !30
-  %33 = load i64, i64* %19, align 8, !dbg !30, !tbaa !4, !alias.scope !31
-  %34 = and i64 %33, 1, !dbg !30
-  %35 = icmp eq i64 %34, 0, !dbg !30
-  br i1 %35, label %45, label %36, !dbg !30, !prof !34
+  store i64* getelementptr inbounds ([9 x i64], [9 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %18, align 8, !tbaa !16
+  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !32
+  call void @llvm.experimental.noalias.scope.decl(metadata !33) #8, !dbg !32
+  %33 = load i64, i64* %19, align 8, !dbg !32, !tbaa !6, !alias.scope !33
+  %34 = and i64 %33, 1, !dbg !32
+  %35 = icmp eq i64 %34, 0, !dbg !32
+  br i1 %35, label %45, label %36, !dbg !32, !prof !36
 
 36:                                               ; preds = %BB5.i
-  %37 = add nsw i64 %33, -1, !dbg !30
-  %38 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 3, i64 %37) #9, !dbg !30
-  %39 = extractvalue { i64, i1 } %38, 1, !dbg !30
-  %40 = extractvalue { i64, i1 } %38, 0, !dbg !30
-  br i1 %39, label %41, label %sorbet_rb_int_plus.exit118.i, !dbg !30
+  %37 = add nsw i64 %33, -1, !dbg !32
+  %38 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 3, i64 %37) #9, !dbg !32
+  %39 = extractvalue { i64, i1 } %38, 1, !dbg !32
+  %40 = extractvalue { i64, i1 } %38, 0, !dbg !32
+  br i1 %39, label %41, label %sorbet_rb_int_plus.exit118.i, !dbg !32
 
 41:                                               ; preds = %36
-  %42 = ashr i64 %40, 1, !dbg !30
-  %43 = xor i64 %42, -9223372036854775808, !dbg !30
-  %44 = call i64 @rb_int2big(i64 %43) #8, !dbg !30, !noalias !31
-  br label %sorbet_rb_int_plus.exit118.i, !dbg !30
+  %42 = ashr i64 %40, 1, !dbg !32
+  %43 = xor i64 %42, -9223372036854775808, !dbg !32
+  %44 = call i64 @rb_int2big(i64 %43) #8, !dbg !32, !noalias !33
+  br label %sorbet_rb_int_plus.exit118.i, !dbg !32
 
 45:                                               ; preds = %BB5.i
-  %46 = call i64 @sorbet_rb_int_plus_slowpath(i64 noundef 3, i64 %33) #8, !dbg !30, !noalias !31
-  br label %sorbet_rb_int_plus.exit118.i, !dbg !30
+  %46 = call i64 @sorbet_rb_int_plus_slowpath(i64 noundef 3, i64 %33) #8, !dbg !32, !noalias !33
+  br label %sorbet_rb_int_plus.exit118.i, !dbg !32
 
 sorbet_rb_int_plus.exit118.i:                     ; preds = %45, %41, %36
-  %47 = phi i64 [ %46, %45 ], [ %44, %41 ], [ %40, %36 ], !dbg !30
-  %48 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !14
-  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 5, !dbg !30
-  %50 = load i32, i32* %49, align 8, !dbg !30, !tbaa !35
-  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 6, !dbg !30
-  %52 = load i32, i32* %51, align 4, !dbg !30, !tbaa !36
-  %53 = xor i32 %52, -1, !dbg !30
-  %54 = and i32 %53, %50, !dbg !30
-  %55 = icmp eq i32 %54, 0, !dbg !30
-  br i1 %55, label %rb_vm_check_ints.exit3.i, label %56, !dbg !30, !prof !29
+  %47 = phi i64 [ %46, %45 ], [ %44, %41 ], [ %40, %36 ], !dbg !32
+  %48 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !32, !tbaa !16
+  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 5, !dbg !32
+  %50 = load i32, i32* %49, align 8, !dbg !32, !tbaa !37
+  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 6, !dbg !32
+  %52 = load i32, i32* %51, align 4, !dbg !32, !tbaa !38
+  %53 = xor i32 %52, -1, !dbg !32
+  %54 = and i32 %53, %50, !dbg !32
+  %55 = icmp eq i32 %54, 0, !dbg !32
+  br i1 %55, label %rb_vm_check_ints.exit3.i, label %56, !dbg !32, !prof !31
 
 56:                                               ; preds = %sorbet_rb_int_plus.exit118.i
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 8, !dbg !30
-  %58 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %57, align 8, !dbg !30, !tbaa !37
-  %59 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %58, i32 noundef 0) #8, !dbg !30
-  br label %rb_vm_check_ints.exit3.i, !dbg !30
+  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 8, !dbg !32
+  %58 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %57, align 8, !dbg !32, !tbaa !39
+  %59 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %58, i32 noundef 0) #8, !dbg !32
+  br label %rb_vm_check_ints.exit3.i, !dbg !32
 
 rb_vm_check_ints.exit3.i:                         ; preds = %56, %sorbet_rb_int_plus.exit118.i
-  %"rubyStr_ .i" = load i64, i64* @"rubyStrFrozen_ ", align 8, !dbg !38
-  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !39
-  call void @llvm.experimental.noalias.scope.decl(metadata !40) #8, !dbg !39
-  %60 = load i64, i64* %19, align 8, !dbg !39, !tbaa !4, !alias.scope !40
-  %61 = and i64 %60, 1, !dbg !39
-  %62 = icmp eq i64 %61, 0, !dbg !39
-  br i1 %62, label %72, label %63, !dbg !39, !prof !34
+  %"rubyStr_ .i" = load i64, i64* @"rubyStrFrozen_ ", align 8, !dbg !40
+  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !41
+  call void @llvm.experimental.noalias.scope.decl(metadata !42) #8, !dbg !41
+  %60 = load i64, i64* %19, align 8, !dbg !41, !tbaa !6, !alias.scope !42
+  %61 = and i64 %60, 1, !dbg !41
+  %62 = icmp eq i64 %61, 0, !dbg !41
+  br i1 %62, label %72, label %63, !dbg !41, !prof !36
 
 63:                                               ; preds = %rb_vm_check_ints.exit3.i
-  %64 = add nsw i64 %60, -1, !dbg !39
-  %65 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 3, i64 %64) #9, !dbg !39
-  %66 = extractvalue { i64, i1 } %65, 1, !dbg !39
-  %67 = extractvalue { i64, i1 } %65, 0, !dbg !39
-  br i1 %66, label %68, label %sorbet_rb_int_plus.exit119.i, !dbg !39
+  %64 = add nsw i64 %60, -1, !dbg !41
+  %65 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 3, i64 %64) #9, !dbg !41
+  %66 = extractvalue { i64, i1 } %65, 1, !dbg !41
+  %67 = extractvalue { i64, i1 } %65, 0, !dbg !41
+  br i1 %66, label %68, label %sorbet_rb_int_plus.exit119.i, !dbg !41
 
 68:                                               ; preds = %63
-  %69 = ashr i64 %67, 1, !dbg !39
-  %70 = xor i64 %69, -9223372036854775808, !dbg !39
-  %71 = call i64 @rb_int2big(i64 %70) #8, !dbg !39, !noalias !40
-  br label %sorbet_rb_int_plus.exit119.i, !dbg !39
+  %69 = ashr i64 %67, 1, !dbg !41
+  %70 = xor i64 %69, -9223372036854775808, !dbg !41
+  %71 = call i64 @rb_int2big(i64 %70) #8, !dbg !41, !noalias !42
+  br label %sorbet_rb_int_plus.exit119.i, !dbg !41
 
 72:                                               ; preds = %rb_vm_check_ints.exit3.i
-  %73 = call i64 @sorbet_rb_int_plus_slowpath(i64 noundef 3, i64 %60) #8, !dbg !39, !noalias !40
-  br label %sorbet_rb_int_plus.exit119.i, !dbg !39
+  %73 = call i64 @sorbet_rb_int_plus_slowpath(i64 noundef 3, i64 %60) #8, !dbg !41, !noalias !42
+  br label %sorbet_rb_int_plus.exit119.i, !dbg !41
 
 sorbet_rb_int_plus.exit119.i:                     ; preds = %72, %68, %63
-  %74 = phi i64 [ %73, %72 ], [ %71, %68 ], [ %67, %63 ], !dbg !39
-  %75 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !39, !tbaa !14
-  %76 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %75, i64 0, i32 5, !dbg !39
-  %77 = load i32, i32* %76, align 8, !dbg !39, !tbaa !35
-  %78 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %75, i64 0, i32 6, !dbg !39
-  %79 = load i32, i32* %78, align 4, !dbg !39, !tbaa !36
-  %80 = xor i32 %79, -1, !dbg !39
-  %81 = and i32 %80, %77, !dbg !39
-  %82 = icmp eq i32 %81, 0, !dbg !39
-  br i1 %82, label %rb_vm_check_ints.exit6.i, label %83, !dbg !39, !prof !29
+  %74 = phi i64 [ %73, %72 ], [ %71, %68 ], [ %67, %63 ], !dbg !41
+  %75 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !41, !tbaa !16
+  %76 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %75, i64 0, i32 5, !dbg !41
+  %77 = load i32, i32* %76, align 8, !dbg !41, !tbaa !37
+  %78 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %75, i64 0, i32 6, !dbg !41
+  %79 = load i32, i32* %78, align 4, !dbg !41, !tbaa !38
+  %80 = xor i32 %79, -1, !dbg !41
+  %81 = and i32 %80, %77, !dbg !41
+  %82 = icmp eq i32 %81, 0, !dbg !41
+  br i1 %82, label %rb_vm_check_ints.exit6.i, label %83, !dbg !41, !prof !31
 
 83:                                               ; preds = %sorbet_rb_int_plus.exit119.i
-  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %75, i64 0, i32 8, !dbg !39
-  %85 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %84, align 8, !dbg !39, !tbaa !37
-  %86 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %85, i32 noundef 0) #8, !dbg !39
-  br label %rb_vm_check_ints.exit6.i, !dbg !39
+  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %75, i64 0, i32 8, !dbg !41
+  %85 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %84, align 8, !dbg !41, !tbaa !39
+  %86 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %85, i32 noundef 0) #8, !dbg !41
+  br label %rb_vm_check_ints.exit6.i, !dbg !41
 
 rb_vm_check_ints.exit6.i:                         ; preds = %83, %sorbet_rb_int_plus.exit119.i
-  %"rubyStr_ 64.i" = load i64, i64* @"rubyStrFrozen_ ", align 8, !dbg !43
-  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !44
-  call void @llvm.experimental.noalias.scope.decl(metadata !45) #8, !dbg !44
-  %87 = load i64, i64* %19, align 8, !dbg !44, !tbaa !4, !alias.scope !45
-  %88 = and i64 %87, 1, !dbg !44
-  %89 = icmp eq i64 %88, 0, !dbg !44
-  br i1 %89, label %99, label %90, !dbg !44, !prof !34
+  %"rubyStr_ 64.i" = load i64, i64* @"rubyStrFrozen_ ", align 8, !dbg !45
+  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !46
+  call void @llvm.experimental.noalias.scope.decl(metadata !47) #8, !dbg !46
+  %87 = load i64, i64* %19, align 8, !dbg !46, !tbaa !6, !alias.scope !47
+  %88 = and i64 %87, 1, !dbg !46
+  %89 = icmp eq i64 %88, 0, !dbg !46
+  br i1 %89, label %99, label %90, !dbg !46, !prof !36
 
 90:                                               ; preds = %rb_vm_check_ints.exit6.i
-  %91 = add nsw i64 %87, -1, !dbg !44
-  %92 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 3, i64 %91) #9, !dbg !44
-  %93 = extractvalue { i64, i1 } %92, 1, !dbg !44
-  %94 = extractvalue { i64, i1 } %92, 0, !dbg !44
-  br i1 %93, label %95, label %sorbet_rb_int_plus.exit120.i, !dbg !44
+  %91 = add nsw i64 %87, -1, !dbg !46
+  %92 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 3, i64 %91) #9, !dbg !46
+  %93 = extractvalue { i64, i1 } %92, 1, !dbg !46
+  %94 = extractvalue { i64, i1 } %92, 0, !dbg !46
+  br i1 %93, label %95, label %sorbet_rb_int_plus.exit120.i, !dbg !46
 
 95:                                               ; preds = %90
-  %96 = ashr i64 %94, 1, !dbg !44
-  %97 = xor i64 %96, -9223372036854775808, !dbg !44
-  %98 = call i64 @rb_int2big(i64 %97) #8, !dbg !44, !noalias !45
-  br label %sorbet_rb_int_plus.exit120.i, !dbg !44
+  %96 = ashr i64 %94, 1, !dbg !46
+  %97 = xor i64 %96, -9223372036854775808, !dbg !46
+  %98 = call i64 @rb_int2big(i64 %97) #8, !dbg !46, !noalias !47
+  br label %sorbet_rb_int_plus.exit120.i, !dbg !46
 
 99:                                               ; preds = %rb_vm_check_ints.exit6.i
-  %100 = call i64 @sorbet_rb_int_plus_slowpath(i64 noundef 3, i64 %87) #8, !dbg !44, !noalias !45
-  br label %sorbet_rb_int_plus.exit120.i, !dbg !44
+  %100 = call i64 @sorbet_rb_int_plus_slowpath(i64 noundef 3, i64 %87) #8, !dbg !46, !noalias !47
+  br label %sorbet_rb_int_plus.exit120.i, !dbg !46
 
 sorbet_rb_int_plus.exit120.i:                     ; preds = %99, %95, %90
-  %101 = phi i64 [ %100, %99 ], [ %98, %95 ], [ %94, %90 ], !dbg !44
-  %102 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !44, !tbaa !14
-  %103 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %102, i64 0, i32 5, !dbg !44
-  %104 = load i32, i32* %103, align 8, !dbg !44, !tbaa !35
-  %105 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %102, i64 0, i32 6, !dbg !44
-  %106 = load i32, i32* %105, align 4, !dbg !44, !tbaa !36
-  %107 = xor i32 %106, -1, !dbg !44
-  %108 = and i32 %107, %104, !dbg !44
-  %109 = icmp eq i32 %108, 0, !dbg !44
-  br i1 %109, label %rb_vm_check_ints.exit5.i, label %110, !dbg !44, !prof !29
+  %101 = phi i64 [ %100, %99 ], [ %98, %95 ], [ %94, %90 ], !dbg !46
+  %102 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !16
+  %103 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %102, i64 0, i32 5, !dbg !46
+  %104 = load i32, i32* %103, align 8, !dbg !46, !tbaa !37
+  %105 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %102, i64 0, i32 6, !dbg !46
+  %106 = load i32, i32* %105, align 4, !dbg !46, !tbaa !38
+  %107 = xor i32 %106, -1, !dbg !46
+  %108 = and i32 %107, %104, !dbg !46
+  %109 = icmp eq i32 %108, 0, !dbg !46
+  br i1 %109, label %rb_vm_check_ints.exit5.i, label %110, !dbg !46, !prof !31
 
 110:                                              ; preds = %sorbet_rb_int_plus.exit120.i
-  %111 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %102, i64 0, i32 8, !dbg !44
-  %112 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %111, align 8, !dbg !44, !tbaa !37
-  %113 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %112, i32 noundef 0) #8, !dbg !44
-  br label %rb_vm_check_ints.exit5.i, !dbg !44
+  %111 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %102, i64 0, i32 8, !dbg !46
+  %112 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %111, align 8, !dbg !46, !tbaa !39
+  %113 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %112, i32 noundef 0) #8, !dbg !46
+  br label %rb_vm_check_ints.exit5.i, !dbg !46
 
 rb_vm_check_ints.exit5.i:                         ; preds = %110, %sorbet_rb_int_plus.exit120.i
-  store i64 %47, i64* %callArgs0Addr.i, align 8, !dbg !48
-  store i64 %"rubyStr_ .i", i64* %callArgs1Addr.i, align 8, !dbg !48
-  store i64 %74, i64* %callArgs2Addr.i, align 8, !dbg !48
-  store i64 %"rubyStr_ 64.i", i64* %callArgs3Addr.i, align 8, !dbg !48
-  store i64 %101, i64* %callArgs4Addr.i, align 8, !dbg !48
-  %"rubyId_<string-interpolate>.i" = load i64, i64* @"rubyIdPrecomputed_<string-interpolate>", align 8, !dbg !48
-  %rawSendResult89.i = call i64 @sorbet_stringInterpolate(i64 noundef 8, i64 %"rubyId_<string-interpolate>.i", i32 noundef 5, i64* noundef nonnull %19, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #8, !dbg !48
-  store i64* getelementptr inbounds ([9 x i64], [9 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %18, align 8, !dbg !48, !tbaa !14
-  br i1 %114, label %"fastSymCallIntrinsic_Integer_+97.i", label %"alternativeCallIntrinsic_Integer_+96.i", !dbg !13
+  store i64 %47, i64* %callArgs0Addr.i, align 8, !dbg !50
+  store i64 %"rubyStr_ .i", i64* %callArgs1Addr.i, align 8, !dbg !50
+  store i64 %74, i64* %callArgs2Addr.i, align 8, !dbg !50
+  store i64 %"rubyStr_ 64.i", i64* %callArgs3Addr.i, align 8, !dbg !50
+  store i64 %101, i64* %callArgs4Addr.i, align 8, !dbg !50
+  %"rubyId_<string-interpolate>.i" = load i64, i64* @"rubyIdPrecomputed_<string-interpolate>", align 8, !dbg !50
+  %rawSendResult89.i = call i64 @sorbet_stringInterpolate(i64 noundef 8, i64 %"rubyId_<string-interpolate>.i", i32 noundef 5, i64* noundef nonnull %19, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #8, !dbg !50
+  store i64* getelementptr inbounds ([9 x i64], [9 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %18, align 8, !dbg !50, !tbaa !16
+  br i1 %114, label %"fastSymCallIntrinsic_Integer_+97.i", label %"alternativeCallIntrinsic_Integer_+96.i", !dbg !15
 
 afterSend.i:                                      ; preds = %142, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
   %114 = phi i1 [ %117, %"alternativeCallIntrinsic_Integer_<.i" ], [ %122, %sorbet_rb_int_lt.exit.i ], [ %122, %142 ]
-  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult117.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult117.i, %142 ], !dbg !8
-  %115 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !8
-  %116 = icmp ne i64 %115, 0, !dbg !8
-  br i1 %116, label %BB5.i, label %"func_<root>.<static-init>$151.exit", !dbg !8
+  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult117.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult117.i, %142 ], !dbg !10
+  %115 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !10
+  %116 = icmp ne i64 %115, 0, !dbg !10
+  br i1 %116, label %BB5.i, label %"func_<root>.<static-init>$151.exit", !dbg !10
 
 "alternativeCallIntrinsic_Integer_<.i":           ; preds = %22, %sorbet_isa_Integer.exit
   %117 = phi i1 [ %32, %sorbet_isa_Integer.exit ], [ false, %22 ]
-  %118 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !8
-  %119 = load i64*, i64** %118, align 8, !dbg !8
-  store i64 %i.sroa.0.0.i, i64* %119, align 8, !dbg !8, !tbaa !4
-  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !8
-  store i64 4000001, i64* %120, align 8, !dbg !8, !tbaa !4
-  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !8
-  store i64* %121, i64** %118, align 8, !dbg !8
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !8
-  br label %afterSend.i, !dbg !8
+  %118 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !10
+  %119 = load i64*, i64** %118, align 8, !dbg !10
+  store i64 %i.sroa.0.0.i, i64* %119, align 8, !dbg !10, !tbaa !6
+  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !10
+  store i64 4000001, i64* %120, align 8, !dbg !10, !tbaa !6
+  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !10
+  store i64* %121, i64** %118, align 8, !dbg !10
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !10
+  br label %afterSend.i, !dbg !10
 
 "fastSymCallIntrinsic_Integer_<.i":               ; preds = %BB2.i, %sorbet_isa_Integer.exit
   %122 = phi i1 [ %32, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
-  store i64 4000001, i64* %callArgs0Addr.i, align 8, !dbg !8
-  call void @llvm.experimental.noalias.scope.decl(metadata !49) #8, !dbg !8
-  %123 = load i64, i64* %19, align 8, !dbg !8, !tbaa !4, !alias.scope !49
-  %124 = and i64 %i.sroa.0.0.i, 1, !dbg !8
-  %125 = and i64 %124, %123, !dbg !8
-  %126 = icmp eq i64 %125, 0, !dbg !8
-  br i1 %126, label %132, label %127, !dbg !8, !prof !34
+  store i64 4000001, i64* %callArgs0Addr.i, align 8, !dbg !10
+  call void @llvm.experimental.noalias.scope.decl(metadata !51) #8, !dbg !10
+  %123 = load i64, i64* %19, align 8, !dbg !10, !tbaa !6, !alias.scope !51
+  %124 = and i64 %i.sroa.0.0.i, 1, !dbg !10
+  %125 = and i64 %124, %123, !dbg !10
+  %126 = icmp eq i64 %125, 0, !dbg !10
+  br i1 %126, label %132, label %127, !dbg !10, !prof !36
 
 127:                                              ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %128 = ashr i64 %i.sroa.0.0.i, 1, !dbg !8
-  %129 = ashr i64 %123, 1, !dbg !8
-  %130 = icmp slt i64 %128, %129, !dbg !8
-  %131 = select i1 %130, i64 20, i64 0, !dbg !8
-  br label %sorbet_rb_int_lt.exit.i, !dbg !8
+  %128 = ashr i64 %i.sroa.0.0.i, 1, !dbg !10
+  %129 = ashr i64 %123, 1, !dbg !10
+  %130 = icmp slt i64 %128, %129, !dbg !10
+  %131 = select i1 %130, i64 20, i64 0, !dbg !10
+  br label %sorbet_rb_int_lt.exit.i, !dbg !10
 
 132:                                              ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %133 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 %123) #8, !dbg !8, !noalias !49
-  br label %sorbet_rb_int_lt.exit.i, !dbg !8
+  %133 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 %123) #8, !dbg !10, !noalias !51
+  br label %sorbet_rb_int_lt.exit.i, !dbg !10
 
 sorbet_rb_int_lt.exit.i:                          ; preds = %132, %127
   %rawSendResult117.i = phi i64 [ %131, %127 ], [ %133, %132 ]
-  %134 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !8, !tbaa !14
-  %135 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %134, i64 0, i32 5, !dbg !8
-  %136 = load i32, i32* %135, align 8, !dbg !8, !tbaa !35
-  %137 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %134, i64 0, i32 6, !dbg !8
-  %138 = load i32, i32* %137, align 4, !dbg !8, !tbaa !36
-  %139 = xor i32 %138, -1, !dbg !8
-  %140 = and i32 %139, %136, !dbg !8
-  %141 = icmp eq i32 %140, 0, !dbg !8
-  br i1 %141, label %afterSend.i, label %142, !dbg !8, !prof !29
+  %134 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !16
+  %135 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %134, i64 0, i32 5, !dbg !10
+  %136 = load i32, i32* %135, align 8, !dbg !10, !tbaa !37
+  %137 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %134, i64 0, i32 6, !dbg !10
+  %138 = load i32, i32* %137, align 4, !dbg !10, !tbaa !38
+  %139 = xor i32 %138, -1, !dbg !10
+  %140 = and i32 %139, %136, !dbg !10
+  %141 = icmp eq i32 %140, 0, !dbg !10
+  br i1 %141, label %afterSend.i, label %142, !dbg !10, !prof !31
 
 142:                                              ; preds = %sorbet_rb_int_lt.exit.i
-  %143 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %134, i64 0, i32 8, !dbg !8
-  %144 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %143, align 8, !dbg !8, !tbaa !37
-  %145 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %144, i32 noundef 0) #8, !dbg !8
-  br label %afterSend.i, !dbg !8
+  %143 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %134, i64 0, i32 8, !dbg !10
+  %144 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %143, align 8, !dbg !10, !tbaa !39
+  %145 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %144, i32 noundef 0) #8, !dbg !10
+  br label %afterSend.i, !dbg !10
 
 "alternativeCallIntrinsic_Integer_+96.i":         ; preds = %rb_vm_check_ints.exit5.i
-  %146 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !13
-  %147 = load i64*, i64** %146, align 8, !dbg !13
-  store i64 %i.sroa.0.0.i, i64* %147, align 8, !dbg !13, !tbaa !4
-  %148 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !13
-  store i64 3, i64* %148, align 8, !dbg !13, !tbaa !4
-  %149 = getelementptr inbounds i64, i64* %148, i64 1, !dbg !13
-  store i64* %149, i64** %146, align 8, !dbg !13
-  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+.3", i64 0), !dbg !13
-  br label %BB2.i.backedge, !dbg !13
+  %146 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !15
+  %147 = load i64*, i64** %146, align 8, !dbg !15
+  store i64 %i.sroa.0.0.i, i64* %147, align 8, !dbg !15, !tbaa !6
+  %148 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !15
+  store i64 3, i64* %148, align 8, !dbg !15, !tbaa !6
+  %149 = getelementptr inbounds i64, i64* %148, i64 1, !dbg !15
+  store i64* %149, i64** %146, align 8, !dbg !15
+  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+.3", i64 0), !dbg !15
+  br label %BB2.i.backedge, !dbg !15
 
 "fastSymCallIntrinsic_Integer_+97.i":             ; preds = %rb_vm_check_ints.exit5.i
-  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !13
-  call void @llvm.experimental.noalias.scope.decl(metadata !52) #8, !dbg !13
-  %150 = load i64, i64* %19, align 8, !dbg !13, !tbaa !4, !alias.scope !52
-  %151 = and i64 %i.sroa.0.0.i, 1, !dbg !13
-  %152 = and i64 %151, %150, !dbg !13
-  %153 = icmp eq i64 %152, 0, !dbg !13
-  br i1 %153, label %163, label %154, !dbg !13, !prof !34
+  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !15
+  call void @llvm.experimental.noalias.scope.decl(metadata !54) #8, !dbg !15
+  %150 = load i64, i64* %19, align 8, !dbg !15, !tbaa !6, !alias.scope !54
+  %151 = and i64 %i.sroa.0.0.i, 1, !dbg !15
+  %152 = and i64 %151, %150, !dbg !15
+  %153 = icmp eq i64 %152, 0, !dbg !15
+  br i1 %153, label %163, label %154, !dbg !15, !prof !36
 
 154:                                              ; preds = %"fastSymCallIntrinsic_Integer_+97.i"
-  %155 = add nsw i64 %150, -1, !dbg !13
-  %156 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 %155) #9, !dbg !13
-  %157 = extractvalue { i64, i1 } %156, 1, !dbg !13
-  %158 = extractvalue { i64, i1 } %156, 0, !dbg !13
-  br i1 %157, label %159, label %sorbet_rb_int_plus.exit.i, !dbg !13
+  %155 = add nsw i64 %150, -1, !dbg !15
+  %156 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 %155) #9, !dbg !15
+  %157 = extractvalue { i64, i1 } %156, 1, !dbg !15
+  %158 = extractvalue { i64, i1 } %156, 0, !dbg !15
+  br i1 %157, label %159, label %sorbet_rb_int_plus.exit.i, !dbg !15
 
 159:                                              ; preds = %154
-  %160 = ashr i64 %158, 1, !dbg !13
-  %161 = xor i64 %160, -9223372036854775808, !dbg !13
-  %162 = call i64 @rb_int2big(i64 %161) #8, !dbg !13, !noalias !52
-  br label %sorbet_rb_int_plus.exit.i, !dbg !13
+  %160 = ashr i64 %158, 1, !dbg !15
+  %161 = xor i64 %160, -9223372036854775808, !dbg !15
+  %162 = call i64 @rb_int2big(i64 %161) #8, !dbg !15, !noalias !54
+  br label %sorbet_rb_int_plus.exit.i, !dbg !15
 
 163:                                              ; preds = %"fastSymCallIntrinsic_Integer_+97.i"
-  %164 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 %150) #8, !dbg !13, !noalias !52
-  br label %sorbet_rb_int_plus.exit.i, !dbg !13
+  %164 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 %150) #8, !dbg !15, !noalias !54
+  br label %sorbet_rb_int_plus.exit.i, !dbg !15
 
 sorbet_rb_int_plus.exit.i:                        ; preds = %163, %159, %154
-  %165 = phi i64 [ %164, %163 ], [ %162, %159 ], [ %158, %154 ], !dbg !13
-  %166 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !13, !tbaa !14
-  %167 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 5, !dbg !13
-  %168 = load i32, i32* %167, align 8, !dbg !13, !tbaa !35
-  %169 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 6, !dbg !13
-  %170 = load i32, i32* %169, align 4, !dbg !13, !tbaa !36
-  %171 = xor i32 %170, -1, !dbg !13
-  %172 = and i32 %171, %168, !dbg !13
-  %173 = icmp eq i32 %172, 0, !dbg !13
-  br i1 %173, label %BB2.i.backedge, label %174, !dbg !13, !prof !29
+  %165 = phi i64 [ %164, %163 ], [ %162, %159 ], [ %158, %154 ], !dbg !15
+  %166 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !15, !tbaa !16
+  %167 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 5, !dbg !15
+  %168 = load i32, i32* %167, align 8, !dbg !15, !tbaa !37
+  %169 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 6, !dbg !15
+  %170 = load i32, i32* %169, align 4, !dbg !15, !tbaa !38
+  %171 = xor i32 %170, -1, !dbg !15
+  %172 = and i32 %171, %168, !dbg !15
+  %173 = icmp eq i32 %172, 0, !dbg !15
+  br i1 %173, label %BB2.i.backedge, label %174, !dbg !15, !prof !31
 
 174:                                              ; preds = %sorbet_rb_int_plus.exit.i
-  %175 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 8, !dbg !13
-  %176 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %175, align 8, !dbg !13, !tbaa !37
-  %177 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %176, i32 noundef 0) #8, !dbg !13
-  br label %BB2.i.backedge, !dbg !13
+  %175 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 8, !dbg !15
+  %176 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %175, align 8, !dbg !15, !tbaa !39
+  %177 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %176, i32 noundef 0) #8, !dbg !15
+  br label %BB2.i.backedge, !dbg !15
 
 BB2.i.backedge:                                   ; preds = %174, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+96.i"
   %i.sroa.0.0.i.be = phi i64 [ %send2, %"alternativeCallIntrinsic_Integer_+96.i" ], [ %165, %sorbet_rb_int_plus.exit.i ], [ %165, %174 ]
   br label %BB2.i
 
 "func_<root>.<static-init>$151.exit":             ; preds = %afterSend.i
-  store i64* getelementptr inbounds ([9 x i64], [9 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %18, align 8, !tbaa !14
+  store i64* getelementptr inbounds ([9 x i64], [9 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %18, align 8, !tbaa !16
   call void @llvm.lifetime.end.p0i8(i64 48, i8* nonnull %11)
   ret void
 }
@@ -513,61 +513,63 @@ attributes #7 = { noreturn nounwind }
 attributes #8 = { nounwind }
 attributes #9 = { nounwind willreturn }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/ruby_benchmark/app_strconcat.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = !DILocation(line: 5, column: 7, scope: !9)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !DILocation(line: 7, column: 3, scope: !9)
-!14 = !{!15, !15, i64 0}
-!15 = !{!"any pointer", !6, i64 0}
-!16 = !{!17, !15, i64 16}
-!17 = !{!"rb_execution_context_struct", !15, i64 0, !5, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !18, i64 40, !18, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !5, i64 72, !5, i64 80, !15, i64 88, !5, i64 96, !15, i64 104, !15, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !19, i64 152}
-!18 = !{!"int", !6, i64 0}
-!19 = !{!"", !15, i64 0, !15, i64 8, !5, i64 16, !6, i64 24}
-!20 = !{!21, !15, i64 16}
-!21 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !5, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
-!22 = !{!21, !15, i64 32}
-!23 = !DILocation(line: 4, column: 5, scope: !9)
-!24 = !DILocation(line: 0, scope: !9)
-!25 = !{!"branch_weights", i32 1, i32 2000}
-!26 = !{!"branch_weights", i32 1073205, i32 2146410443}
-!27 = !{!28, !5, i64 0}
-!28 = !{!"RBasic", !5, i64 0, !5, i64 8}
-!29 = !{!"branch_weights", i32 2000, i32 1}
-!30 = !DILocation(line: 6, column: 6, scope: !9)
-!31 = !{!32}
-!32 = distinct !{!32, !33, !"sorbet_rb_int_plus: argument 0"}
-!33 = distinct !{!33, !"sorbet_rb_int_plus"}
-!34 = !{!"branch_weights", i32 4001, i32 4000000}
-!35 = !{!17, !18, i64 40}
-!36 = !{!17, !18, i64 44}
-!37 = !{!17, !15, i64 56}
-!38 = !DILocation(line: 6, column: 10, scope: !9)
-!39 = !DILocation(line: 6, column: 13, scope: !9)
-!40 = !{!41}
-!41 = distinct !{!41, !42, !"sorbet_rb_int_plus: argument 0"}
-!42 = distinct !{!42, !"sorbet_rb_int_plus"}
-!43 = !DILocation(line: 6, column: 17, scope: !9)
-!44 = !DILocation(line: 6, column: 20, scope: !9)
-!45 = !{!46}
-!46 = distinct !{!46, !47, !"sorbet_rb_int_plus: argument 0"}
-!47 = distinct !{!47, !"sorbet_rb_int_plus"}
-!48 = !DILocation(line: 6, column: 3, scope: !9)
-!49 = !{!50}
-!50 = distinct !{!50, !51, !"sorbet_rb_int_lt: argument 0"}
-!51 = distinct !{!51, !"sorbet_rb_int_lt"}
-!52 = !{!53}
-!53 = distinct !{!53, !54, !"sorbet_rb_int_plus: argument 0"}
-!54 = distinct !{!54, !"sorbet_rb_int_plus"}
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/ruby_benchmark/app_strconcat.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !DILocation(line: 5, column: 7, scope: !11)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !DILocation(line: 7, column: 3, scope: !11)
+!16 = !{!17, !17, i64 0}
+!17 = !{!"any pointer", !8, i64 0}
+!18 = !{!19, !17, i64 16}
+!19 = !{!"rb_execution_context_struct", !17, i64 0, !7, i64 8, !17, i64 16, !17, i64 24, !17, i64 32, !20, i64 40, !20, i64 44, !17, i64 48, !17, i64 56, !17, i64 64, !7, i64 72, !7, i64 80, !17, i64 88, !7, i64 96, !17, i64 104, !17, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !21, i64 152}
+!20 = !{!"int", !8, i64 0}
+!21 = !{!"", !17, i64 0, !17, i64 8, !7, i64 16, !8, i64 24}
+!22 = !{!23, !17, i64 16}
+!23 = !{!"rb_control_frame_struct", !17, i64 0, !17, i64 8, !17, i64 16, !7, i64 24, !17, i64 32, !17, i64 40, !17, i64 48}
+!24 = !{!23, !17, i64 32}
+!25 = !DILocation(line: 4, column: 5, scope: !11)
+!26 = !DILocation(line: 0, scope: !11)
+!27 = !{!"branch_weights", i32 1, i32 2000}
+!28 = !{!"branch_weights", i32 1073205, i32 2146410443}
+!29 = !{!30, !7, i64 0}
+!30 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!31 = !{!"branch_weights", i32 2000, i32 1}
+!32 = !DILocation(line: 6, column: 6, scope: !11)
+!33 = !{!34}
+!34 = distinct !{!34, !35, !"sorbet_rb_int_plus: argument 0"}
+!35 = distinct !{!35, !"sorbet_rb_int_plus"}
+!36 = !{!"branch_weights", i32 4001, i32 4000000}
+!37 = !{!19, !20, i64 40}
+!38 = !{!19, !20, i64 44}
+!39 = !{!19, !17, i64 56}
+!40 = !DILocation(line: 6, column: 10, scope: !11)
+!41 = !DILocation(line: 6, column: 13, scope: !11)
+!42 = !{!43}
+!43 = distinct !{!43, !44, !"sorbet_rb_int_plus: argument 0"}
+!44 = distinct !{!44, !"sorbet_rb_int_plus"}
+!45 = !DILocation(line: 6, column: 17, scope: !11)
+!46 = !DILocation(line: 6, column: 20, scope: !11)
+!47 = !{!48}
+!48 = distinct !{!48, !49, !"sorbet_rb_int_plus: argument 0"}
+!49 = distinct !{!49, !"sorbet_rb_int_plus"}
+!50 = !DILocation(line: 6, column: 3, scope: !11)
+!51 = !{!52}
+!52 = distinct !{!52, !53, !"sorbet_rb_int_lt: argument 0"}
+!53 = distinct !{!53, !"sorbet_rb_int_lt"}
+!54 = !{!55}
+!55 = distinct !{!55, !56, !"sorbet_rb_int_plus: argument 0"}
+!56 = distinct !{!56, !"sorbet_rb_int_plus"}

--- a/test/testdata/ruby_benchmark/match_gt4.llo.exp
+++ b/test/testdata/ruby_benchmark/match_gt4.llo.exp
@@ -146,62 +146,62 @@ declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*,
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #8
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #8
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #4 !dbg !8 {
+define internal i64 @"func_<root>.<static-init>$151$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #4 !dbg !10 {
 fastSymCallIntrinsic_Regexp_new:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !15
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !21
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !21
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !23
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -129
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %8, align 8, !tbaa !13
-  %"rubyRegexp_(.)(.)(\\d+)(\\d)" = load i64, i64* @"rubyRegexpFrozen_(.)(.)(\\d+)(\\d)", align 8, !dbg !22
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !22, !tbaa !13
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !22
-  %11 = load i32, i32* %10, align 8, !dbg !22, !tbaa !23
-  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !22
-  %13 = load i32, i32* %12, align 4, !dbg !22, !tbaa !24
-  %14 = xor i32 %13, -1, !dbg !22
-  %15 = and i32 %14, %11, !dbg !22
-  %16 = icmp eq i32 %15, 0, !dbg !22
-  br i1 %16, label %afterSend, label %21, !dbg !22, !prof !25
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %8, align 8, !tbaa !15
+  %"rubyRegexp_(.)(.)(\\d+)(\\d)" = load i64, i64* @"rubyRegexpFrozen_(.)(.)(\\d+)(\\d)", align 8, !dbg !24
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !15
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !24
+  %11 = load i32, i32* %10, align 8, !dbg !24, !tbaa !25
+  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !24
+  %13 = load i32, i32* %12, align 4, !dbg !24, !tbaa !26
+  %14 = xor i32 %13, -1, !dbg !24
+  %15 = and i32 %14, %11, !dbg !24
+  %16 = icmp eq i32 %15, 0, !dbg !24
+  br i1 %16, label %afterSend, label %21, !dbg !24, !prof !27
 
 afterSend:                                        ; preds = %21, %fastSymCallIntrinsic_Regexp_new
-  %rubyStr_THX1138. = load i64, i64* @rubyStrFrozen_THX1138., align 8, !dbg !26
-  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !22
-  %18 = load i64*, i64** %17, align 8, !dbg !22
-  store i64 %"rubyRegexp_(.)(.)(\\d+)(\\d)", i64* %18, align 8, !dbg !22, !tbaa !4
-  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !22
-  store i64 %rubyStr_THX1138., i64* %19, align 8, !dbg !22, !tbaa !4
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !22
-  store i64* %20, i64** %17, align 8, !dbg !22
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_match, i64 0), !dbg !22
-  ret i64 %send, !dbg !27
+  %rubyStr_THX1138. = load i64, i64* @rubyStrFrozen_THX1138., align 8, !dbg !28
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !24
+  %18 = load i64*, i64** %17, align 8, !dbg !24
+  store i64 %"rubyRegexp_(.)(.)(\\d+)(\\d)", i64* %18, align 8, !dbg !24, !tbaa !6
+  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !24
+  store i64 %rubyStr_THX1138., i64* %19, align 8, !dbg !24, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !24
+  store i64* %20, i64** %17, align 8, !dbg !24
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_match, i64 0), !dbg !24
+  ret i64 %send, !dbg !29
 
 21:                                               ; preds = %fastSymCallIntrinsic_Regexp_new
-  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !22
-  %23 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %22, align 8, !dbg !22, !tbaa !28
-  %24 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %23, i32 noundef 0) #9, !dbg !22
-  br label %afterSend, !dbg !22
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
+  %23 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %22, align 8, !dbg !24, !tbaa !30
+  %24 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %23, i32 noundef 0) #9, !dbg !24
+  br label %afterSend, !dbg !24
 }
 
 ; Function Attrs: sspreq
@@ -244,130 +244,130 @@ entry:
   %12 = call i64 @rb_reg_new(i8* noundef getelementptr inbounds ([16 x i8], [16 x i8]* @"str_(.)(.)(\\d+)(\\d)", i64 0, i64 0), i64 noundef 15, i32 noundef 0) #9
   call void @rb_gc_register_mark_object(i64 %12) #9
   store i64 %12, i64* @"rubyRegexpFrozen_(.)(.)(\\d+)(\\d)", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !22
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !24
   %13 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_THX1138., i64 0, i64 0), i64 noundef 8) #9
   call void @rb_gc_register_mark_object(i64 %13) #9
   store i64 %13, i64* @rubyStrFrozen_THX1138., align 8
-  %rubyId_match.i = load i64, i64* @rubyIdPrecomputed_match, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_match, i64 %rubyId_match.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
-  %14 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !13
+  %rubyId_match.i = load i64, i64* @rubyIdPrecomputed_match, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_match, i64 %rubyId_match.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
+  %14 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %15 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 2
-  %16 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %15, align 8, !tbaa !15
+  %16 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %15, align 8, !tbaa !17
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %17, align 8, !tbaa !19
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %17, align 8, !tbaa !21
   %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 4
-  %19 = load i64*, i64** %18, align 8, !tbaa !21
-  %20 = load i64, i64* %19, align 8, !tbaa !4
+  %19 = load i64*, i64** %18, align 8, !tbaa !23
+  %20 = load i64, i64* %19, align 8, !tbaa !6
   %21 = and i64 %20, -33
-  store i64 %21, i64* %19, align 8, !tbaa !4
+  store i64 %21, i64* %19, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %14, %struct.rb_control_frame_struct* %16, %struct.rb_iseq_struct* %stackFrame.i) #9
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 0
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %22, align 8, !dbg !29, !tbaa !13
-  %rubyId_times.i = load i64, i64* @rubyIdPrecomputed_times, align 8, !dbg !30
-  %23 = bitcast %struct.sorbet_inlineIntrinsicEnv* %0 to i8*, !dbg !30
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %23) #9, !dbg !30
-  %24 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 0, !dbg !30
-  store i64 2000001, i64* %24, align 8, !dbg !30, !tbaa !31
-  %25 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 1, !dbg !30
-  store i64 %rubyId_times.i, i64* %25, align 8, !dbg !30, !tbaa !33
-  %26 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 2, !dbg !30
-  store i32 0, i32* %26, align 8, !dbg !30, !tbaa !34
-  %27 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 3, !dbg !30
-  %28 = bitcast i64** %27 to i8*, !dbg !30
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %28, i8 0, i64 16, i1 false) #9, !dbg !30
-  %29 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !13
-  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 2, !dbg !30
-  %31 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %30, align 8, !dbg !30, !tbaa !15
-  call void @llvm.experimental.noalias.scope.decl(metadata !35) #9, !dbg !30
-  %32 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_1", i8* null, i32 noundef 0, i32 noundef -1) #9, !dbg !30
-  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %31, i64 0, i32 3, !dbg !30
-  %34 = bitcast i64* %33 to %struct.rb_captured_block*, !dbg !30
-  %35 = getelementptr inbounds i64, i64* %33, i64 2, !dbg !30
-  %36 = bitcast i64* %35 to %struct.vm_ifunc**, !dbg !30
-  store %struct.vm_ifunc* %32, %struct.vm_ifunc** %36, align 8, !dbg !30, !tbaa !38
-  call void @llvm.experimental.noalias.scope.decl(metadata !39) #9, !dbg !30
-  %37 = ptrtoint %struct.rb_captured_block* %34 to i64, !dbg !30
-  %38 = or i64 %37, 3, !dbg !30
-  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 17, !dbg !30
-  store i64 %38, i64* %39, align 8, !dbg !30, !tbaa !42
-  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !43, !tbaa !13
-  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 17, !dbg !43
-  %42 = load i64, i64* %41, align 8, !dbg !43, !tbaa !42
-  %43 = and i64 %42, -4, !dbg !43
-  %44 = inttoptr i64 %43 to %struct.rb_captured_block*, !dbg !43
-  store i64 0, i64* %41, align 8, !dbg !43, !tbaa !42
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %44) #9, !dbg !43
-  br label %45, !dbg !43
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %22, align 8, !dbg !31, !tbaa !15
+  %rubyId_times.i = load i64, i64* @rubyIdPrecomputed_times, align 8, !dbg !32
+  %23 = bitcast %struct.sorbet_inlineIntrinsicEnv* %0 to i8*, !dbg !32
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %23) #9, !dbg !32
+  %24 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 0, !dbg !32
+  store i64 2000001, i64* %24, align 8, !dbg !32, !tbaa !33
+  %25 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 1, !dbg !32
+  store i64 %rubyId_times.i, i64* %25, align 8, !dbg !32, !tbaa !35
+  %26 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 2, !dbg !32
+  store i32 0, i32* %26, align 8, !dbg !32, !tbaa !36
+  %27 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 3, !dbg !32
+  %28 = bitcast i64** %27 to i8*, !dbg !32
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %28, i8 0, i64 16, i1 false) #9, !dbg !32
+  %29 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !32, !tbaa !15
+  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 2, !dbg !32
+  %31 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %30, align 8, !dbg !32, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !37) #9, !dbg !32
+  %32 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$151$block_1", i8* null, i32 noundef 0, i32 noundef -1) #9, !dbg !32
+  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %31, i64 0, i32 3, !dbg !32
+  %34 = bitcast i64* %33 to %struct.rb_captured_block*, !dbg !32
+  %35 = getelementptr inbounds i64, i64* %33, i64 2, !dbg !32
+  %36 = bitcast i64* %35 to %struct.vm_ifunc**, !dbg !32
+  store %struct.vm_ifunc* %32, %struct.vm_ifunc** %36, align 8, !dbg !32, !tbaa !40
+  call void @llvm.experimental.noalias.scope.decl(metadata !41) #9, !dbg !32
+  %37 = ptrtoint %struct.rb_captured_block* %34 to i64, !dbg !32
+  %38 = or i64 %37, 3, !dbg !32
+  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 17, !dbg !32
+  store i64 %38, i64* %39, align 8, !dbg !32, !tbaa !44
+  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !15
+  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 17, !dbg !45
+  %42 = load i64, i64* %41, align 8, !dbg !45, !tbaa !44
+  %43 = and i64 %42, -4, !dbg !45
+  %44 = inttoptr i64 %43 to %struct.rb_captured_block*, !dbg !45
+  store i64 0, i64* %41, align 8, !dbg !45, !tbaa !44
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %44) #9, !dbg !45
+  br label %45, !dbg !45
 
 45:                                               ; preds = %"func_<root>.<static-init>$151$block_1.exit4.i.i", %entry
-  %46 = phi i64 [ 0, %entry ], [ %72, %"func_<root>.<static-init>$151$block_1.exit4.i.i" ], !dbg !43
-  %47 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !13
-  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 2, !dbg !30
-  %49 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %48, align 8, !dbg !30, !tbaa !15
-  %stackFrame.i1.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8, !dbg !30
-  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 2, !dbg !30
-  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %50, align 8, !dbg !30, !tbaa !19
-  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 4, !dbg !30
-  %52 = load i64*, i64** %51, align 8, !dbg !30, !tbaa !21
-  %53 = load i64, i64* %52, align 8, !dbg !30, !tbaa !4
-  %54 = and i64 %53, -129, !dbg !30
-  store i64 %54, i64* %52, align 8, !dbg !30, !tbaa !4
-  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 0, !dbg !30
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %55, align 8, !dbg !30, !tbaa !13
-  %"rubyRegexp_(.)(.)(\\d+)(\\d).i2.i.i" = load i64, i64* @"rubyRegexpFrozen_(.)(.)(\\d+)(\\d)", align 8, !dbg !45
-  %56 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !13
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 5, !dbg !45
-  %58 = load i32, i32* %57, align 8, !dbg !45, !tbaa !23
-  %59 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 6, !dbg !45
-  %60 = load i32, i32* %59, align 4, !dbg !45, !tbaa !24
-  %61 = xor i32 %60, -1, !dbg !45
-  %62 = and i32 %61, %58, !dbg !45
-  %63 = icmp eq i32 %62, 0, !dbg !45
-  br i1 %63, label %"func_<root>.<static-init>$151$block_1.exit4.i.i", label %64, !dbg !45, !prof !25
+  %46 = phi i64 [ 0, %entry ], [ %72, %"func_<root>.<static-init>$151$block_1.exit4.i.i" ], !dbg !45
+  %47 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !32, !tbaa !15
+  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 2, !dbg !32
+  %49 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %48, align 8, !dbg !32, !tbaa !17
+  %stackFrame.i1.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151$block_1", align 8, !dbg !32
+  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 2, !dbg !32
+  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %50, align 8, !dbg !32, !tbaa !21
+  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 4, !dbg !32
+  %52 = load i64*, i64** %51, align 8, !dbg !32, !tbaa !23
+  %53 = load i64, i64* %52, align 8, !dbg !32, !tbaa !6
+  %54 = and i64 %53, -129, !dbg !32
+  store i64 %54, i64* %52, align 8, !dbg !32, !tbaa !6
+  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 0, !dbg !32
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %55, align 8, !dbg !32, !tbaa !15
+  %"rubyRegexp_(.)(.)(\\d+)(\\d).i2.i.i" = load i64, i64* @"rubyRegexpFrozen_(.)(.)(\\d+)(\\d)", align 8, !dbg !47
+  %56 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !15
+  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 5, !dbg !47
+  %58 = load i32, i32* %57, align 8, !dbg !47, !tbaa !25
+  %59 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 6, !dbg !47
+  %60 = load i32, i32* %59, align 4, !dbg !47, !tbaa !26
+  %61 = xor i32 %60, -1, !dbg !47
+  %62 = and i32 %61, %58, !dbg !47
+  %63 = icmp eq i32 %62, 0, !dbg !47
+  br i1 %63, label %"func_<root>.<static-init>$151$block_1.exit4.i.i", label %64, !dbg !47, !prof !27
 
 64:                                               ; preds = %45
-  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 8, !dbg !45
-  %66 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %65, align 8, !dbg !45, !tbaa !28
-  %67 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %66, i32 noundef 0) #9, !dbg !45
-  br label %"func_<root>.<static-init>$151$block_1.exit4.i.i", !dbg !45
+  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 8, !dbg !47
+  %66 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %65, align 8, !dbg !47, !tbaa !30
+  %67 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %66, i32 noundef 0) #9, !dbg !47
+  br label %"func_<root>.<static-init>$151$block_1.exit4.i.i", !dbg !47
 
 "func_<root>.<static-init>$151$block_1.exit4.i.i": ; preds = %64, %45
-  %rubyStr_THX1138..i3.i.i = load i64, i64* @rubyStrFrozen_THX1138., align 8, !dbg !47
-  %68 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 1, !dbg !45
-  %69 = load i64*, i64** %68, align 8, !dbg !45
-  store i64 %"rubyRegexp_(.)(.)(\\d+)(\\d).i2.i.i", i64* %69, align 8, !dbg !45, !tbaa !4
-  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !45
-  store i64 %rubyStr_THX1138..i3.i.i, i64* %70, align 8, !dbg !45, !tbaa !4
-  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !45
-  store i64* %71, i64** %68, align 8, !dbg !45
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_match, i64 0), !dbg !45
-  %72 = add nuw nsw i64 %46, 1, !dbg !43
-  %73 = icmp eq i64 %72, 1000000, !dbg !43
-  br i1 %73, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %45, !dbg !43, !llvm.loop !48
+  %rubyStr_THX1138..i3.i.i = load i64, i64* @rubyStrFrozen_THX1138., align 8, !dbg !49
+  %68 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 1, !dbg !47
+  %69 = load i64*, i64** %68, align 8, !dbg !47
+  store i64 %"rubyRegexp_(.)(.)(\\d+)(\\d).i2.i.i", i64* %69, align 8, !dbg !47, !tbaa !6
+  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !47
+  store i64 %rubyStr_THX1138..i3.i.i, i64* %70, align 8, !dbg !47, !tbaa !6
+  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !47
+  store i64* %71, i64** %68, align 8, !dbg !47
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_match, i64 0), !dbg !47
+  %72 = add nuw nsw i64 %46, 1, !dbg !45
+  %73 = icmp eq i64 %72, 1000000, !dbg !45
+  br i1 %73, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %45, !dbg !45, !llvm.loop !50
 
 forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %"func_<root>.<static-init>$151$block_1.exit4.i.i"
-  call void @sorbet_popFrame() #9, !dbg !43
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %23) #9, !dbg !30
-  %74 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !13
-  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 5, !dbg !30
-  %76 = load i32, i32* %75, align 8, !dbg !30, !tbaa !23
-  %77 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 6, !dbg !30
-  %78 = load i32, i32* %77, align 4, !dbg !30, !tbaa !24
-  %79 = xor i32 %78, -1, !dbg !30
-  %80 = and i32 %79, %76, !dbg !30
-  %81 = icmp eq i32 %80, 0, !dbg !30
-  br i1 %81, label %"func_<root>.<static-init>$151.exit", label %82, !dbg !30, !prof !25
+  call void @sorbet_popFrame() #9, !dbg !45
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %23) #9, !dbg !32
+  %74 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !32, !tbaa !15
+  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 5, !dbg !32
+  %76 = load i32, i32* %75, align 8, !dbg !32, !tbaa !25
+  %77 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 6, !dbg !32
+  %78 = load i32, i32* %77, align 4, !dbg !32, !tbaa !26
+  %79 = xor i32 %78, -1, !dbg !32
+  %80 = and i32 %79, %76, !dbg !32
+  %81 = icmp eq i32 %80, 0, !dbg !32
+  br i1 %81, label %"func_<root>.<static-init>$151.exit", label %82, !dbg !32, !prof !27
 
 82:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
-  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 8, !dbg !30
-  %84 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %83, align 8, !dbg !30, !tbaa !28
-  %85 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %84, i32 noundef 0) #9, !dbg !30
-  br label %"func_<root>.<static-init>$151.exit", !dbg !30
+  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 8, !dbg !32
+  %84 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %83, align 8, !dbg !32, !tbaa !30
+  %85 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %84, i32 noundef 0) #9, !dbg !32
+  br label %"func_<root>.<static-init>$151.exit", !dbg !32
 
 "func_<root>.<static-init>$151.exit":             ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %82
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %22, align 8, !tbaa !13
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %22, align 8, !tbaa !15
   ret void
 }
 
@@ -388,56 +388,58 @@ attributes #7 = { argmemonly nofree nosync nounwind willreturn writeonly }
 attributes #8 = { noreturn nounwind }
 attributes #9 = { nounwind }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/ruby_benchmark/match_gt4.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !9, file: !2, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!10 = !DISubroutineType(types: !11)
-!11 = !{!12}
-!12 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!13 = !{!14, !14, i64 0}
-!14 = !{!"any pointer", !6, i64 0}
-!15 = !{!16, !14, i64 16}
-!16 = !{!"rb_execution_context_struct", !14, i64 0, !5, i64 8, !14, i64 16, !14, i64 24, !14, i64 32, !17, i64 40, !17, i64 44, !14, i64 48, !14, i64 56, !14, i64 64, !5, i64 72, !5, i64 80, !14, i64 88, !5, i64 96, !14, i64 104, !14, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !18, i64 152}
-!17 = !{!"int", !6, i64 0}
-!18 = !{!"", !14, i64 0, !14, i64 8, !5, i64 16, !6, i64 24}
-!19 = !{!20, !14, i64 16}
-!20 = !{!"rb_control_frame_struct", !14, i64 0, !14, i64 8, !14, i64 16, !5, i64 24, !14, i64 32, !14, i64 40, !14, i64 48}
-!21 = !{!20, !14, i64 32}
-!22 = !DILocation(line: 4, column: 17, scope: !8)
-!23 = !{!16, !17, i64 40}
-!24 = !{!16, !17, i64 44}
-!25 = !{!"branch_weights", i32 2000, i32 1}
-!26 = !DILocation(line: 4, column: 41, scope: !8)
-!27 = !DILocation(line: 4, column: 1, scope: !8)
-!28 = !{!16, !14, i64 56}
-!29 = !DILocation(line: 0, scope: !9)
-!30 = !DILocation(line: 4, column: 1, scope: !9)
-!31 = !{!32, !5, i64 0}
-!32 = !{!"sorbet_inlineIntrinsicEnv", !5, i64 0, !5, i64 8, !17, i64 16, !14, i64 24, !5, i64 32}
-!33 = !{!32, !5, i64 8}
-!34 = !{!32, !17, i64 16}
-!35 = !{!36}
-!36 = distinct !{!36, !37, !"rb_vm_ifunc_proc_new: argument 0"}
-!37 = distinct !{!37, !"rb_vm_ifunc_proc_new"}
-!38 = !{!6, !6, i64 0}
-!39 = !{!40}
-!40 = distinct !{!40, !41, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!41 = distinct !{!41, !"VM_BH_FROM_IFUNC_BLOCK"}
-!42 = !{!16, !5, i64 128}
-!43 = !DILocation(line: 4, column: 1, scope: !9, inlinedAt: !44)
-!44 = distinct !DILocation(line: 4, column: 1, scope: !9)
-!45 = !DILocation(line: 4, column: 17, scope: !8, inlinedAt: !46)
-!46 = distinct !DILocation(line: 4, column: 1, scope: !9, inlinedAt: !44)
-!47 = !DILocation(line: 4, column: 41, scope: !8, inlinedAt: !46)
-!48 = distinct !{!48, !49}
-!49 = !{!"llvm.loop.unroll.disable"}
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/ruby_benchmark/match_gt4.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151$block_1", scope: !11, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !{!16, !16, i64 0}
+!16 = !{!"any pointer", !8, i64 0}
+!17 = !{!18, !16, i64 16}
+!18 = !{!"rb_execution_context_struct", !16, i64 0, !7, i64 8, !16, i64 16, !16, i64 24, !16, i64 32, !19, i64 40, !19, i64 44, !16, i64 48, !16, i64 56, !16, i64 64, !7, i64 72, !7, i64 80, !16, i64 88, !7, i64 96, !16, i64 104, !16, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !20, i64 152}
+!19 = !{!"int", !8, i64 0}
+!20 = !{!"", !16, i64 0, !16, i64 8, !7, i64 16, !8, i64 24}
+!21 = !{!22, !16, i64 16}
+!22 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !7, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
+!23 = !{!22, !16, i64 32}
+!24 = !DILocation(line: 4, column: 17, scope: !10)
+!25 = !{!18, !19, i64 40}
+!26 = !{!18, !19, i64 44}
+!27 = !{!"branch_weights", i32 2000, i32 1}
+!28 = !DILocation(line: 4, column: 41, scope: !10)
+!29 = !DILocation(line: 4, column: 1, scope: !10)
+!30 = !{!18, !16, i64 56}
+!31 = !DILocation(line: 0, scope: !11)
+!32 = !DILocation(line: 4, column: 1, scope: !11)
+!33 = !{!34, !7, i64 0}
+!34 = !{!"sorbet_inlineIntrinsicEnv", !7, i64 0, !7, i64 8, !19, i64 16, !16, i64 24, !7, i64 32}
+!35 = !{!34, !7, i64 8}
+!36 = !{!34, !19, i64 16}
+!37 = !{!38}
+!38 = distinct !{!38, !39, !"rb_vm_ifunc_proc_new: argument 0"}
+!39 = distinct !{!39, !"rb_vm_ifunc_proc_new"}
+!40 = !{!8, !8, i64 0}
+!41 = !{!42}
+!42 = distinct !{!42, !43, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!43 = distinct !{!43, !"VM_BH_FROM_IFUNC_BLOCK"}
+!44 = !{!18, !7, i64 128}
+!45 = !DILocation(line: 4, column: 1, scope: !11, inlinedAt: !46)
+!46 = distinct !DILocation(line: 4, column: 1, scope: !11)
+!47 = !DILocation(line: 4, column: 17, scope: !10, inlinedAt: !48)
+!48 = distinct !DILocation(line: 4, column: 1, scope: !11, inlinedAt: !46)
+!49 = !DILocation(line: 4, column: 41, scope: !10, inlinedAt: !48)
+!50 = distinct !{!50, !51}
+!51 = !{!"llvm.loop.unroll.disable"}

--- a/test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.llo.exp
@@ -228,171 +228,171 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #14
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #14
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_AttrReaderNoSig.<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !8 {
+define internal fastcc void @"func_AttrReaderNoSig.<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !10 {
 fastSymCallIntrinsic_ResolvedSig_sig:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.<static-init>", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !14
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !18
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !20
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !20
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !22
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #15
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !21, !tbaa !12
-  %rubyId_initialize = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !22
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_initialize), !dbg !22
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_AttrReaderNoSig.<static-init>L62$block_1"), !dbg !22
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !22, !tbaa !12
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !22
-  %11 = load i32, i32* %10, align 8, !dbg !22, !tbaa !23
-  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !22
-  %13 = load i32, i32* %12, align 4, !dbg !22, !tbaa !24
-  %14 = xor i32 %13, -1, !dbg !22
-  %15 = and i32 %14, %11, !dbg !22
-  %16 = icmp eq i32 %15, 0, !dbg !22
-  br i1 %16, label %fastSymCallIntrinsic_Static_keep_def, label %17, !dbg !22, !prof !25
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !23, !tbaa !14
+  %rubyId_initialize = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !24
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_initialize), !dbg !24
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_AttrReaderNoSig.<static-init>L62$block_1"), !dbg !24
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !14
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !24
+  %11 = load i32, i32* %10, align 8, !dbg !24, !tbaa !25
+  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !24
+  %13 = load i32, i32* %12, align 4, !dbg !24, !tbaa !26
+  %14 = xor i32 %13, -1, !dbg !24
+  %15 = and i32 %14, %11, !dbg !24
+  %16 = icmp eq i32 %15, 0, !dbg !24
+  br i1 %16, label %fastSymCallIntrinsic_Static_keep_def, label %17, !dbg !24, !prof !27
 
 17:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig
-  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !22
-  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !22, !tbaa !26
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !22
-  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !22
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
+  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !24, !tbaa !28
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !24
+  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !24
 
 fastSymCallIntrinsic_Static_keep_def:             ; preds = %fastSymCallIntrinsic_ResolvedSig_sig, %17
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !22, !tbaa !12
-  %21 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !27
-  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !27, !tbaa !28
-  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !27
-  br i1 %needTakeSlowPath, label %23, label %24, !dbg !27, !prof !30
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !24, !tbaa !14
+  %21 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !29
+  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !29, !tbaa !30
+  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !29
+  br i1 %needTakeSlowPath, label %23, label %24, !dbg !29, !prof !32
 
 23:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
-  tail call void @"const_recompute_T::Sig"(), !dbg !27
-  br label %24, !dbg !27
+  tail call void @"const_recompute_T::Sig"(), !dbg !29
+  br label %24, !dbg !29
 
 24:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def, %23
-  %25 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !27
-  %26 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !27
-  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !27, !tbaa !28
-  %guardUpdated = icmp eq i64 %26, %27, !dbg !27
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !27
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !27
-  %29 = load i64*, i64** %28, align 8, !dbg !27
-  store i64 %selfRaw, i64* %29, align 8, !dbg !27, !tbaa !4
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !27
-  store i64 %25, i64* %30, align 8, !dbg !27, !tbaa !4
-  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !27
-  store i64* %31, i64** %28, align 8, !dbg !27
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !27
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !27, !tbaa !12
-  %rubyId_initialize48 = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !31
-  %rawSym49 = tail call i64 @rb_id2sym(i64 %rubyId_initialize48), !dbg !31
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !31
-  %rawSym50 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !31
-  %32 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !31
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !31, !tbaa !28
-  %needTakeSlowPath3 = icmp ne i64 %32, %33, !dbg !31
-  br i1 %needTakeSlowPath3, label %34, label %35, !dbg !31, !prof !30
+  %25 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !29
+  %26 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !29
+  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !29, !tbaa !30
+  %guardUpdated = icmp eq i64 %26, %27, !dbg !29
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !29
+  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !29
+  %29 = load i64*, i64** %28, align 8, !dbg !29
+  store i64 %selfRaw, i64* %29, align 8, !dbg !29, !tbaa !6
+  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !29
+  store i64 %25, i64* %30, align 8, !dbg !29, !tbaa !6
+  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !29
+  store i64* %31, i64** %28, align 8, !dbg !29
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !29
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !29, !tbaa !14
+  %rubyId_initialize48 = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !33
+  %rawSym49 = tail call i64 @rb_id2sym(i64 %rubyId_initialize48), !dbg !33
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !33
+  %rawSym50 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !33
+  %32 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !33
+  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !30
+  %needTakeSlowPath3 = icmp ne i64 %32, %33, !dbg !33
+  br i1 %needTakeSlowPath3, label %34, label %35, !dbg !33, !prof !32
 
 34:                                               ; preds = %24
-  tail call void @const_recompute_AttrReaderNoSig(), !dbg !31
-  br label %35, !dbg !31
+  tail call void @const_recompute_AttrReaderNoSig(), !dbg !33
+  br label %35, !dbg !33
 
 35:                                               ; preds = %24, %34
-  %36 = load i64, i64* @guarded_const_AttrReaderNoSig, align 8, !dbg !31
-  %37 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !31
-  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !31, !tbaa !28
-  %guardUpdated4 = icmp eq i64 %37, %38, !dbg !31
-  tail call void @llvm.assume(i1 %guardUpdated4), !dbg !31
-  %stackFrame54 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig#initialize", align 8, !dbg !31
-  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !31
-  %40 = bitcast i8* %39 to i16*, !dbg !31
-  %41 = load i16, i16* %40, align 8, !dbg !31
-  %42 = and i16 %41, -384, !dbg !31
-  %43 = or i16 %42, 1, !dbg !31
-  store i16 %43, i16* %40, align 8, !dbg !31
-  %44 = getelementptr inbounds i8, i8* %39, i64 8, !dbg !31
-  %45 = bitcast i8* %44 to i32*, !dbg !31
-  store i32 1, i32* %45, align 8, !dbg !31, !tbaa !32
-  %46 = getelementptr inbounds i8, i8* %39, i64 12, !dbg !31
-  %47 = bitcast i8* %46 to i32*, !dbg !31
-  %48 = getelementptr inbounds i8, i8* %39, i64 4, !dbg !31
-  %49 = bitcast i8* %48 to i32*, !dbg !31
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 20, i1 false), !dbg !31
-  store i32 1, i32* %49, align 4, !dbg !31, !tbaa !35
-  %positional_table = alloca i64, align 8, !dbg !31
-  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !31
-  store i64 %rubyId_foo, i64* %positional_table, align 8, !dbg !31
-  %50 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !31
-  %51 = bitcast i64* %positional_table to i8*, !dbg !31
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %50, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %51, i64 noundef 8, i1 noundef false) #15, !dbg !31
-  %52 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !31
-  %53 = bitcast i8* %52 to i8**, !dbg !31
-  store i8* %50, i8** %53, align 8, !dbg !31, !tbaa !36
-  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderNoSig#initialize", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame54, i1 noundef zeroext false) #15, !dbg !31
-  %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !31, !tbaa !12
-  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 5, !dbg !31
-  %56 = load i32, i32* %55, align 8, !dbg !31, !tbaa !23
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 6, !dbg !31
-  %58 = load i32, i32* %57, align 4, !dbg !31, !tbaa !24
-  %59 = xor i32 %58, -1, !dbg !31
-  %60 = and i32 %59, %56, !dbg !31
-  %61 = icmp eq i32 %60, 0, !dbg !31
-  br i1 %61, label %fastSymCallIntrinsic_Static_keep_def67, label %62, !dbg !31, !prof !25
+  %36 = load i64, i64* @guarded_const_AttrReaderNoSig, align 8, !dbg !33
+  %37 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !33
+  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !30
+  %guardUpdated4 = icmp eq i64 %37, %38, !dbg !33
+  tail call void @llvm.assume(i1 %guardUpdated4), !dbg !33
+  %stackFrame54 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig#initialize", align 8, !dbg !33
+  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !33
+  %40 = bitcast i8* %39 to i16*, !dbg !33
+  %41 = load i16, i16* %40, align 8, !dbg !33
+  %42 = and i16 %41, -384, !dbg !33
+  %43 = or i16 %42, 1, !dbg !33
+  store i16 %43, i16* %40, align 8, !dbg !33
+  %44 = getelementptr inbounds i8, i8* %39, i64 8, !dbg !33
+  %45 = bitcast i8* %44 to i32*, !dbg !33
+  store i32 1, i32* %45, align 8, !dbg !33, !tbaa !34
+  %46 = getelementptr inbounds i8, i8* %39, i64 12, !dbg !33
+  %47 = bitcast i8* %46 to i32*, !dbg !33
+  %48 = getelementptr inbounds i8, i8* %39, i64 4, !dbg !33
+  %49 = bitcast i8* %48 to i32*, !dbg !33
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 20, i1 false), !dbg !33
+  store i32 1, i32* %49, align 4, !dbg !33, !tbaa !37
+  %positional_table = alloca i64, align 8, !dbg !33
+  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !33
+  store i64 %rubyId_foo, i64* %positional_table, align 8, !dbg !33
+  %50 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !33
+  %51 = bitcast i64* %positional_table to i8*, !dbg !33
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %50, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %51, i64 noundef 8, i1 noundef false) #15, !dbg !33
+  %52 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !33
+  %53 = bitcast i8* %52 to i8**, !dbg !33
+  store i8* %50, i8** %53, align 8, !dbg !33, !tbaa !38
+  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderNoSig#initialize", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame54, i1 noundef zeroext false) #15, !dbg !33
+  %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !33, !tbaa !14
+  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 5, !dbg !33
+  %56 = load i32, i32* %55, align 8, !dbg !33, !tbaa !25
+  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 6, !dbg !33
+  %58 = load i32, i32* %57, align 4, !dbg !33, !tbaa !26
+  %59 = xor i32 %58, -1, !dbg !33
+  %60 = and i32 %59, %56, !dbg !33
+  %61 = icmp eq i32 %60, 0, !dbg !33
+  br i1 %61, label %fastSymCallIntrinsic_Static_keep_def67, label %62, !dbg !33, !prof !27
 
 62:                                               ; preds = %35
-  %63 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 8, !dbg !31
-  %64 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %63, align 8, !dbg !31, !tbaa !26
-  %65 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %64, i32 noundef 0) #15, !dbg !31
-  br label %fastSymCallIntrinsic_Static_keep_def67, !dbg !31
+  %63 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 8, !dbg !33
+  %64 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %63, align 8, !dbg !33, !tbaa !28
+  %65 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %64, i32 noundef 0) #15, !dbg !33
+  br label %fastSymCallIntrinsic_Static_keep_def67, !dbg !33
 
 afterSend64:                                      ; preds = %79, %fastSymCallIntrinsic_Static_keep_def67
   ret void
 
 fastSymCallIntrinsic_Static_keep_def67:           ; preds = %35, %62
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !31, !tbaa !12
-  %rubyId_foo59 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !37
-  %rawSym60 = tail call i64 @rb_id2sym(i64 %rubyId_foo59), !dbg !37
-  %rubyId_attr_reader = load i64, i64* @rubyIdPrecomputed_attr_reader, align 8, !dbg !37
-  %rawSym61 = tail call i64 @rb_id2sym(i64 %rubyId_attr_reader), !dbg !37
-  %66 = tail call i64 @rb_intern(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0)) #15, !dbg !37
-  %67 = tail call i64 @rb_id2str(i64 %66) #15, !dbg !37
-  %68 = tail call i64 (i8*, ...) @rb_sprintf(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i64 %67) #15, !dbg !37
-  %69 = tail call i64 @rb_intern_str(i64 %68) #15, !dbg !37
-  %70 = inttoptr i64 %69 to i8*, !dbg !37
-  tail call void @rb_add_method(i64 %36, i64 %66, i32 noundef 4, i8* %70, i32 noundef 1) #15, !dbg !37
-  %71 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !12
-  %72 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 5, !dbg !37
-  %73 = load i32, i32* %72, align 8, !dbg !37, !tbaa !23
-  %74 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 6, !dbg !37
-  %75 = load i32, i32* %74, align 4, !dbg !37, !tbaa !24
-  %76 = xor i32 %75, -1, !dbg !37
-  %77 = and i32 %76, %73, !dbg !37
-  %78 = icmp eq i32 %77, 0, !dbg !37
-  br i1 %78, label %afterSend64, label %79, !dbg !37, !prof !25
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !33, !tbaa !14
+  %rubyId_foo59 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !39
+  %rawSym60 = tail call i64 @rb_id2sym(i64 %rubyId_foo59), !dbg !39
+  %rubyId_attr_reader = load i64, i64* @rubyIdPrecomputed_attr_reader, align 8, !dbg !39
+  %rawSym61 = tail call i64 @rb_id2sym(i64 %rubyId_attr_reader), !dbg !39
+  %66 = tail call i64 @rb_intern(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0)) #15, !dbg !39
+  %67 = tail call i64 @rb_id2str(i64 %66) #15, !dbg !39
+  %68 = tail call i64 (i8*, ...) @rb_sprintf(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i64 %67) #15, !dbg !39
+  %69 = tail call i64 @rb_intern_str(i64 %68) #15, !dbg !39
+  %70 = inttoptr i64 %69 to i8*, !dbg !39
+  tail call void @rb_add_method(i64 %36, i64 %66, i32 noundef 4, i8* %70, i32 noundef 1) #15, !dbg !39
+  %71 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !39, !tbaa !14
+  %72 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 5, !dbg !39
+  %73 = load i32, i32* %72, align 8, !dbg !39, !tbaa !25
+  %74 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 6, !dbg !39
+  %75 = load i32, i32* %74, align 4, !dbg !39, !tbaa !26
+  %76 = xor i32 %75, -1, !dbg !39
+  %77 = and i32 %76, %73, !dbg !39
+  %78 = icmp eq i32 %77, 0, !dbg !39
+  br i1 %78, label %afterSend64, label %79, !dbg !39, !prof !27
 
 79:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def67
-  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 8, !dbg !37
-  %81 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %80, align 8, !dbg !37, !tbaa !26
-  %82 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %81, i32 noundef 0) #15, !dbg !37
-  br label %afterSend64, !dbg !37
+  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 8, !dbg !39
+  %81 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %80, align 8, !dbg !39, !tbaa !28
+  %82 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %81, i32 noundef 0) #15, !dbg !39
+  br label %afterSend64, !dbg !39
 }
 
 ; Function Attrs: sspreq
@@ -401,7 +401,7 @@ entry:
   %locals.i25.i = alloca i64, i32 0, align 8
   %locals.i21.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, align 8, !dbg !38
+  %keywords.i = alloca i64, align 8, !dbg !40
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
@@ -449,20 +449,20 @@ entry:
   %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
   %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !40
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !40
-  %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !42
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_<", i64 %"rubyId_<.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !42
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !43
-  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !44
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !45
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
-  %rubyId_foo5.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !46
-  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !42
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !42
+  %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !44
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_<", i64 %"rubyId_<.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !44
+  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !45
+  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
+  %rubyId_foo5.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !48
+  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !49
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
   %20 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
   call void @rb_gc_register_mark_object(i64 %20) #15
   %rubyId_initialize.i.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8
@@ -483,328 +483,328 @@ entry:
   %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
   %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %24, i64 %"rubyId_block for.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.<static-init>$block_1", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !22
-  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !38
-  %rubyId_foo12.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !38
-  %26 = call i64 @rb_id2sym(i64 %rubyId_foo12.i) #15, !dbg !38
-  store i64 %26, i64* %keywords.i, align 8, !dbg !38
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !38
-  %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !38
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !38
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !27
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !27
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !31
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !31
-  %rubyId_keep_def18.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !37
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def18.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !37
+  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
+  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !40
+  %rubyId_foo12.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
+  %26 = call i64 @rb_id2sym(i64 %rubyId_foo12.i) #15, !dbg !40
+  store i64 %26, i64* %keywords.i, align 8, !dbg !40
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !40
+  %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !40
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !40
+  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !29
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !33
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !33
+  %rubyId_keep_def18.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !39
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def18.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !39
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
-  %27 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !12
+  %27 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %28 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %27, i64 0, i32 18
-  %29 = load i64, i64* %28, align 8, !tbaa !48
-  %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %29 = load i64, i64* %28, align 8, !tbaa !50
+  %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 2
-  %32 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %31, align 8, !tbaa !14
+  %32 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %31, align 8, !tbaa !16
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %33, align 8, !tbaa !18
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %33, align 8, !tbaa !20
   %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 4
-  %35 = load i64*, i64** %34, align 8, !tbaa !20
-  %36 = load i64, i64* %35, align 8, !tbaa !4
+  %35 = load i64*, i64** %34, align 8, !tbaa !22
+  %36 = load i64, i64* %35, align 8, !tbaa !6
   %37 = and i64 %36, -33
-  store i64 %37, i64* %35, align 8, !tbaa !4
+  store i64 %37, i64* %35, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %30, %struct.rb_control_frame_struct* %32, %struct.rb_iseq_struct* %stackFrame.i) #15
   %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %38, align 8, !dbg !56, !tbaa !12
-  %39 = load i64, i64* @rb_cObject, align 8, !dbg !57
-  %40 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([16 x i8], [16 x i8]* @str_AttrReaderNoSig, i64 0, i64 0), i64 %39) #15, !dbg !57
-  %41 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %40) #15, !dbg !57
-  call fastcc void @"func_AttrReaderNoSig.<static-init>L62"(i64 %40, %struct.rb_control_frame_struct* %41) #15, !dbg !57
-  call void @sorbet_popFrame() #15, !dbg !57
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %38, align 8, !dbg !57, !tbaa !12
-  %42 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !40
-  %43 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !40, !tbaa !28
-  %needTakeSlowPath = icmp ne i64 %42, %43, !dbg !40
-  br i1 %needTakeSlowPath, label %44, label %45, !dbg !40, !prof !30
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %38, align 8, !dbg !58, !tbaa !14
+  %39 = load i64, i64* @rb_cObject, align 8, !dbg !59
+  %40 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([16 x i8], [16 x i8]* @str_AttrReaderNoSig, i64 0, i64 0), i64 %39) #15, !dbg !59
+  %41 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %40) #15, !dbg !59
+  call fastcc void @"func_AttrReaderNoSig.<static-init>L62"(i64 %40, %struct.rb_control_frame_struct* %41) #15, !dbg !59
+  call void @sorbet_popFrame() #15, !dbg !59
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %38, align 8, !dbg !59, !tbaa !14
+  %42 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !42
+  %43 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !42, !tbaa !30
+  %needTakeSlowPath = icmp ne i64 %42, %43, !dbg !42
+  br i1 %needTakeSlowPath, label %44, label %45, !dbg !42, !prof !32
 
 44:                                               ; preds = %entry
-  call void @const_recompute_AttrReaderNoSig(), !dbg !40
-  br label %45, !dbg !40
+  call void @const_recompute_AttrReaderNoSig(), !dbg !42
+  br label %45, !dbg !42
 
 45:                                               ; preds = %entry, %44
-  %46 = load i64, i64* @guarded_const_AttrReaderNoSig, align 8, !dbg !40
-  %47 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !40
-  %48 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !40, !tbaa !28
-  %guardUpdated = icmp eq i64 %47, %48, !dbg !40
-  call void @llvm.assume(i1 %guardUpdated), !dbg !40
-  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !40
-  %50 = load i64*, i64** %49, align 8, !dbg !40
-  store i64 %46, i64* %50, align 8, !dbg !40, !tbaa !4
-  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !40
-  store i64 2497, i64* %51, align 8, !dbg !40, !tbaa !4
-  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !40
-  store i64* %52, i64** %49, align 8, !dbg !40
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !40
-  br label %BB2.i, !dbg !58
+  %46 = load i64, i64* @guarded_const_AttrReaderNoSig, align 8, !dbg !42
+  %47 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !42
+  %48 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !42, !tbaa !30
+  %guardUpdated = icmp eq i64 %47, %48, !dbg !42
+  call void @llvm.assume(i1 %guardUpdated), !dbg !42
+  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !42
+  %50 = load i64*, i64** %49, align 8, !dbg !42
+  store i64 %46, i64* %50, align 8, !dbg !42, !tbaa !6
+  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !42
+  store i64 2497, i64* %51, align 8, !dbg !42, !tbaa !6
+  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !42
+  store i64* %52, i64** %49, align 8, !dbg !42
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !42
+  br label %BB2.i, !dbg !60
 
 BB2.i:                                            ; preds = %BB2.i.backedge, %45
-  %i.sroa.0.0.i = phi i64 [ 1, %45 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !56
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %38, align 8, !tbaa !12
-  %53 = and i64 %i.sroa.0.0.i, 1, !dbg !42
-  %54 = icmp eq i64 %53, 0, !dbg !42
-  br i1 %54, label %55, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !42, !prof !59
+  %i.sroa.0.0.i = phi i64 [ 1, %45 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !58
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %38, align 8, !tbaa !14
+  %53 = and i64 %i.sroa.0.0.i, 1, !dbg !44
+  %54 = icmp eq i64 %53, 0, !dbg !44
+  br i1 %54, label %55, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !44, !prof !61
 
 55:                                               ; preds = %BB2.i
-  %56 = and i64 %i.sroa.0.0.i, 7, !dbg !42
-  %57 = icmp ne i64 %56, 0, !dbg !42
-  %58 = and i64 %i.sroa.0.0.i, -9, !dbg !42
-  %59 = icmp eq i64 %58, 0, !dbg !42
-  %60 = or i1 %57, %59, !dbg !42
-  br i1 %60, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !42, !prof !60
+  %56 = and i64 %i.sroa.0.0.i, 7, !dbg !44
+  %57 = icmp ne i64 %56, 0, !dbg !44
+  %58 = and i64 %i.sroa.0.0.i, -9, !dbg !44
+  %59 = icmp eq i64 %58, 0, !dbg !44
+  %60 = or i1 %57, %59, !dbg !44
+  br i1 %60, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !44, !prof !62
 
 sorbet_isa_Integer.exit:                          ; preds = %55
-  %61 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !42
-  %62 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %61, i64 0, i32 0, !dbg !42
-  %63 = load i64, i64* %62, align 8, !dbg !42, !tbaa !61
-  %64 = and i64 %63, 31, !dbg !42
-  %65 = icmp eq i64 %64, 10, !dbg !42
-  br i1 %65, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !42, !prof !25
+  %61 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !44
+  %62 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %61, i64 0, i32 0, !dbg !44
+  %63 = load i64, i64* %62, align 8, !dbg !44, !tbaa !63
+  %64 = and i64 %63, 31, !dbg !44
+  %65 = icmp eq i64 %64, 10, !dbg !44
+  br i1 %65, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !44, !prof !27
 
 BB5.i:                                            ; preds = %afterSend37.i
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %38, align 8, !tbaa !12
-  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !43
-  %67 = load i64*, i64** %66, align 8, !dbg !43
-  store i64 %send, i64* %67, align 8, !dbg !43, !tbaa !4
-  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !43
-  store i64* %68, i64** %66, align 8, !dbg !43
-  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %38, align 8, !dbg !43, !tbaa !12
-  br i1 %69, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !44
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %38, align 8, !tbaa !14
+  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !45
+  %67 = load i64*, i64** %66, align 8, !dbg !45
+  store i64 %send, i64* %67, align 8, !dbg !45, !tbaa !6
+  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !45
+  store i64* %68, i64** %66, align 8, !dbg !45
+  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !45
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %38, align 8, !dbg !45, !tbaa !14
+  br i1 %69, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !46
 
 afterSend37.i:                                    ; preds = %94, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
   %69 = phi i1 [ %72, %"alternativeCallIntrinsic_Integer_<.i" ], [ %77, %sorbet_rb_int_lt.exit.i ], [ %77, %94 ]
-  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send4, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult89.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult89.i, %94 ], !dbg !42
-  %70 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !42
-  %71 = icmp ne i64 %70, 0, !dbg !42
-  br i1 %71, label %BB5.i, label %"func_<root>.<static-init>$151.exit", !dbg !42
+  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send4, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult89.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult89.i, %94 ], !dbg !44
+  %70 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !44
+  %71 = icmp ne i64 %70, 0, !dbg !44
+  br i1 %71, label %BB5.i, label %"func_<root>.<static-init>$151.exit", !dbg !44
 
 "alternativeCallIntrinsic_Integer_<.i":           ; preds = %55, %sorbet_isa_Integer.exit
   %72 = phi i1 [ %65, %sorbet_isa_Integer.exit ], [ false, %55 ]
-  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !42
-  %74 = load i64*, i64** %73, align 8, !dbg !42
-  store i64 %i.sroa.0.0.i, i64* %74, align 8, !dbg !42, !tbaa !4
-  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !42
-  store i64 20000001, i64* %75, align 8, !dbg !42, !tbaa !4
-  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !42
-  store i64* %76, i64** %73, align 8, !dbg !42
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !42
-  br label %afterSend37.i, !dbg !42
+  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !44
+  %74 = load i64*, i64** %73, align 8, !dbg !44
+  store i64 %i.sroa.0.0.i, i64* %74, align 8, !dbg !44, !tbaa !6
+  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !44
+  store i64 20000001, i64* %75, align 8, !dbg !44, !tbaa !6
+  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !44
+  store i64* %76, i64** %73, align 8, !dbg !44
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !44
+  br label %afterSend37.i, !dbg !44
 
 "fastSymCallIntrinsic_Integer_<.i":               ; preds = %BB2.i, %sorbet_isa_Integer.exit
   %77 = phi i1 [ %65, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
-  call void @llvm.experimental.noalias.scope.decl(metadata !63) #15, !dbg !42
-  %78 = and i64 %i.sroa.0.0.i, 1, !dbg !42
-  %79 = icmp eq i64 %78, 0, !dbg !42
-  br i1 %79, label %84, label %80, !dbg !42, !prof !66
+  call void @llvm.experimental.noalias.scope.decl(metadata !65) #15, !dbg !44
+  %78 = and i64 %i.sroa.0.0.i, 1, !dbg !44
+  %79 = icmp eq i64 %78, 0, !dbg !44
+  br i1 %79, label %84, label %80, !dbg !44, !prof !68
 
 80:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %81 = ashr i64 %i.sroa.0.0.i, 1, !dbg !42
-  %82 = icmp slt i64 %81, 10000000, !dbg !42
-  %83 = select i1 %82, i64 20, i64 0, !dbg !42
-  br label %sorbet_rb_int_lt.exit.i, !dbg !42
+  %81 = ashr i64 %i.sroa.0.0.i, 1, !dbg !44
+  %82 = icmp slt i64 %81, 10000000, !dbg !44
+  %83 = select i1 %82, i64 20, i64 0, !dbg !44
+  br label %sorbet_rb_int_lt.exit.i, !dbg !44
 
 84:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %85 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !42, !noalias !63
-  br label %sorbet_rb_int_lt.exit.i, !dbg !42
+  %85 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !44, !noalias !65
+  br label %sorbet_rb_int_lt.exit.i, !dbg !44
 
 sorbet_rb_int_lt.exit.i:                          ; preds = %84, %80
   %rawSendResult89.i = phi i64 [ %83, %80 ], [ %85, %84 ]
-  %86 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !42, !tbaa !12
-  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %86, i64 0, i32 5, !dbg !42
-  %88 = load i32, i32* %87, align 8, !dbg !42, !tbaa !23
-  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %86, i64 0, i32 6, !dbg !42
-  %90 = load i32, i32* %89, align 4, !dbg !42, !tbaa !24
-  %91 = xor i32 %90, -1, !dbg !42
-  %92 = and i32 %91, %88, !dbg !42
-  %93 = icmp eq i32 %92, 0, !dbg !42
-  br i1 %93, label %afterSend37.i, label %94, !dbg !42, !prof !25
+  %86 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !44, !tbaa !14
+  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %86, i64 0, i32 5, !dbg !44
+  %88 = load i32, i32* %87, align 8, !dbg !44, !tbaa !25
+  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %86, i64 0, i32 6, !dbg !44
+  %90 = load i32, i32* %89, align 4, !dbg !44, !tbaa !26
+  %91 = xor i32 %90, -1, !dbg !44
+  %92 = and i32 %91, %88, !dbg !44
+  %93 = icmp eq i32 %92, 0, !dbg !44
+  br i1 %93, label %afterSend37.i, label %94, !dbg !44, !prof !27
 
 94:                                               ; preds = %sorbet_rb_int_lt.exit.i
-  %95 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %86, i64 0, i32 8, !dbg !42
-  %96 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %95, align 8, !dbg !42, !tbaa !26
-  %97 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %96, i32 noundef 0) #15, !dbg !42
-  br label %afterSend37.i, !dbg !42
+  %95 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %86, i64 0, i32 8, !dbg !44
+  %96 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %95, align 8, !dbg !44, !tbaa !28
+  %97 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %96, i32 noundef 0) #15, !dbg !44
+  br label %afterSend37.i, !dbg !44
 
 "alternativeCallIntrinsic_Integer_+.i":           ; preds = %BB5.i
-  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !44
-  %99 = load i64*, i64** %98, align 8, !dbg !44
-  store i64 %i.sroa.0.0.i, i64* %99, align 8, !dbg !44, !tbaa !4
-  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !44
-  store i64 3, i64* %100, align 8, !dbg !44, !tbaa !4
-  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !44
-  store i64* %101, i64** %98, align 8, !dbg !44
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !44
-  br label %BB2.i.backedge, !dbg !44
+  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !46
+  %99 = load i64*, i64** %98, align 8, !dbg !46
+  store i64 %i.sroa.0.0.i, i64* %99, align 8, !dbg !46, !tbaa !6
+  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !46
+  store i64 3, i64* %100, align 8, !dbg !46, !tbaa !6
+  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !46
+  store i64* %101, i64** %98, align 8, !dbg !46
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !46
+  br label %BB2.i.backedge, !dbg !46
 
 "fastSymCallIntrinsic_Integer_+.i":               ; preds = %BB5.i
-  call void @llvm.experimental.noalias.scope.decl(metadata !67) #15, !dbg !44
-  %102 = and i64 %i.sroa.0.0.i, 1, !dbg !44
-  %103 = icmp eq i64 %102, 0, !dbg !44
-  br i1 %103, label %112, label %104, !dbg !44, !prof !66
+  call void @llvm.experimental.noalias.scope.decl(metadata !69) #15, !dbg !46
+  %102 = and i64 %i.sroa.0.0.i, 1, !dbg !46
+  %103 = icmp eq i64 %102, 0, !dbg !46
+  br i1 %103, label %112, label %104, !dbg !46, !prof !68
 
 104:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %105 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !44
-  %106 = extractvalue { i64, i1 } %105, 1, !dbg !44
-  %107 = extractvalue { i64, i1 } %105, 0, !dbg !44
-  br i1 %106, label %108, label %sorbet_rb_int_plus.exit.i, !dbg !44
+  %105 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !46
+  %106 = extractvalue { i64, i1 } %105, 1, !dbg !46
+  %107 = extractvalue { i64, i1 } %105, 0, !dbg !46
+  br i1 %106, label %108, label %sorbet_rb_int_plus.exit.i, !dbg !46
 
 108:                                              ; preds = %104
-  %109 = ashr i64 %107, 1, !dbg !44
-  %110 = xor i64 %109, -9223372036854775808, !dbg !44
-  %111 = call i64 @rb_int2big(i64 %110) #15, !dbg !44
-  br label %sorbet_rb_int_plus.exit.i, !dbg !44
+  %109 = ashr i64 %107, 1, !dbg !46
+  %110 = xor i64 %109, -9223372036854775808, !dbg !46
+  %111 = call i64 @rb_int2big(i64 %110) #15, !dbg !46
+  br label %sorbet_rb_int_plus.exit.i, !dbg !46
 
 112:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %113 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !44, !noalias !67
-  br label %sorbet_rb_int_plus.exit.i, !dbg !44
+  %113 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !46, !noalias !69
+  br label %sorbet_rb_int_plus.exit.i, !dbg !46
 
 sorbet_rb_int_plus.exit.i:                        ; preds = %112, %108, %104
-  %114 = phi i64 [ %113, %112 ], [ %111, %108 ], [ %107, %104 ], !dbg !44
-  %115 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !44, !tbaa !12
-  %116 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %115, i64 0, i32 5, !dbg !44
-  %117 = load i32, i32* %116, align 8, !dbg !44, !tbaa !23
-  %118 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %115, i64 0, i32 6, !dbg !44
-  %119 = load i32, i32* %118, align 4, !dbg !44, !tbaa !24
-  %120 = xor i32 %119, -1, !dbg !44
-  %121 = and i32 %120, %117, !dbg !44
-  %122 = icmp eq i32 %121, 0, !dbg !44
-  br i1 %122, label %BB2.i.backedge, label %123, !dbg !44, !prof !25
+  %114 = phi i64 [ %113, %112 ], [ %111, %108 ], [ %107, %104 ], !dbg !46
+  %115 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !14
+  %116 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %115, i64 0, i32 5, !dbg !46
+  %117 = load i32, i32* %116, align 8, !dbg !46, !tbaa !25
+  %118 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %115, i64 0, i32 6, !dbg !46
+  %119 = load i32, i32* %118, align 4, !dbg !46, !tbaa !26
+  %120 = xor i32 %119, -1, !dbg !46
+  %121 = and i32 %120, %117, !dbg !46
+  %122 = icmp eq i32 %121, 0, !dbg !46
+  br i1 %122, label %BB2.i.backedge, label %123, !dbg !46, !prof !27
 
 123:                                              ; preds = %sorbet_rb_int_plus.exit.i
-  %124 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %115, i64 0, i32 8, !dbg !44
-  %125 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %124, align 8, !dbg !44, !tbaa !26
-  %126 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %125, i32 noundef 0) #15, !dbg !44
-  br label %BB2.i.backedge, !dbg !44
+  %124 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %115, i64 0, i32 8, !dbg !46
+  %125 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %124, align 8, !dbg !46, !tbaa !28
+  %126 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %125, i32 noundef 0) #15, !dbg !46
+  br label %BB2.i.backedge, !dbg !46
 
 BB2.i.backedge:                                   ; preds = %123, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
   %i.sroa.0.0.i.be = phi i64 [ %send6, %"alternativeCallIntrinsic_Integer_+.i" ], [ %114, %sorbet_rb_int_plus.exit.i ], [ %114, %123 ]
   br label %BB2.i
 
 "func_<root>.<static-init>$151.exit":             ; preds = %afterSend37.i
-  %i.sroa.0.0.i.lcssa = phi i64 [ %i.sroa.0.0.i, %afterSend37.i ], !dbg !56
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %38, align 8, !tbaa !12
-  %127 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !45
-  %128 = load i64*, i64** %127, align 8, !dbg !45
-  store i64 %29, i64* %128, align 8, !dbg !45, !tbaa !4
-  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !45
-  store i64 %i.sroa.0.0.i.lcssa, i64* %129, align 8, !dbg !45, !tbaa !4
-  %130 = getelementptr inbounds i64, i64* %129, i64 1, !dbg !45
-  store i64* %130, i64** %127, align 8, !dbg !45
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !45
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %38, align 8, !dbg !45, !tbaa !12
-  %131 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !46
-  %132 = load i64*, i64** %131, align 8, !dbg !46
-  store i64 %send, i64* %132, align 8, !dbg !46, !tbaa !4
-  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !46
-  store i64* %133, i64** %131, align 8, !dbg !46
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !46
-  %134 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !47
-  %135 = load i64*, i64** %134, align 8, !dbg !47
-  store i64 %29, i64* %135, align 8, !dbg !47, !tbaa !4
-  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !47
-  store i64 %send10, i64* %136, align 8, !dbg !47, !tbaa !4
-  %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !47
-  store i64* %137, i64** %134, align 8, !dbg !47
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !47
+  %i.sroa.0.0.i.lcssa = phi i64 [ %i.sroa.0.0.i, %afterSend37.i ], !dbg !58
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %38, align 8, !tbaa !14
+  %127 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !47
+  %128 = load i64*, i64** %127, align 8, !dbg !47
+  store i64 %29, i64* %128, align 8, !dbg !47, !tbaa !6
+  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !47
+  store i64 %i.sroa.0.0.i.lcssa, i64* %129, align 8, !dbg !47, !tbaa !6
+  %130 = getelementptr inbounds i64, i64* %129, i64 1, !dbg !47
+  store i64* %130, i64** %127, align 8, !dbg !47
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !47
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %38, align 8, !dbg !47, !tbaa !14
+  %131 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !48
+  %132 = load i64*, i64** %131, align 8, !dbg !48
+  store i64 %send, i64* %132, align 8, !dbg !48, !tbaa !6
+  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !48
+  store i64* %133, i64** %131, align 8, !dbg !48
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !48
+  %134 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !49
+  %135 = load i64*, i64** %134, align 8, !dbg !49
+  store i64 %29, i64* %135, align 8, !dbg !49, !tbaa !6
+  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !49
+  store i64 %send10, i64* %136, align 8, !dbg !49, !tbaa !6
+  %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !49
+  store i64* %137, i64** %134, align 8, !dbg !49
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !49
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_AttrReaderNoSig#initialize"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #7 !dbg !70 {
+define i64 @"func_AttrReaderNoSig#initialize"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #7 !dbg !72 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !71
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !71
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !71
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !71, !prof !66
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !73
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !73
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !73
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !73, !prof !68
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #18, !dbg !71
-  unreachable, !dbg !71
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #18, !dbg !73
+  unreachable, !dbg !73
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_foo = load i64, i64* %argArray, align 8, !dbg !71
-  %1 = and i64 %rawArg_foo, 1, !dbg !72
-  %2 = icmp eq i64 %1, 0, !dbg !72
-  br i1 %2, label %3, label %typeTestSuccess, !dbg !72, !prof !59
+  %rawArg_foo = load i64, i64* %argArray, align 8, !dbg !73
+  %1 = and i64 %rawArg_foo, 1, !dbg !74
+  %2 = icmp eq i64 %1, 0, !dbg !74
+  br i1 %2, label %3, label %typeTestSuccess, !dbg !74, !prof !61
 
 3:                                                ; preds = %fillRequiredArgs
-  %4 = and i64 %rawArg_foo, 7, !dbg !72
-  %5 = icmp ne i64 %4, 0, !dbg !72
-  %6 = and i64 %rawArg_foo, -9, !dbg !72
-  %7 = icmp eq i64 %6, 0, !dbg !72
-  %8 = or i1 %5, %7, !dbg !72
-  br i1 %8, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !72
+  %4 = and i64 %rawArg_foo, 7, !dbg !74
+  %5 = icmp ne i64 %4, 0, !dbg !74
+  %6 = and i64 %rawArg_foo, -9, !dbg !74
+  %7 = icmp eq i64 %6, 0, !dbg !74
+  %8 = or i1 %5, %7, !dbg !74
+  br i1 %8, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !74
 
 sorbet_isa_Integer.exit:                          ; preds = %3
-  %9 = inttoptr i64 %rawArg_foo to %struct.iseq_inline_iv_cache_entry*, !dbg !72
-  %10 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %9, i64 0, i32 0, !dbg !72
-  %11 = load i64, i64* %10, align 8, !dbg !72, !tbaa !61
-  %12 = and i64 %11, 31, !dbg !72
-  %13 = icmp eq i64 %12, 10, !dbg !72
-  br i1 %13, label %typeTestSuccess, label %codeRepl, !dbg !72, !prof !25
+  %9 = inttoptr i64 %rawArg_foo to %struct.iseq_inline_iv_cache_entry*, !dbg !74
+  %10 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %9, i64 0, i32 0, !dbg !74
+  %11 = load i64, i64* %10, align 8, !dbg !74, !tbaa !63
+  %12 = and i64 %11, 31, !dbg !74
+  %13 = icmp eq i64 %12, 10, !dbg !74
+  br i1 %13, label %typeTestSuccess, label %codeRepl, !dbg !74, !prof !27
 
 typeTestSuccess:                                  ; preds = %fillRequiredArgs, %sorbet_isa_Integer.exit
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !72, !tbaa !12
-  %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !73
-  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %rawArg_foo, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #15, !dbg !73
-  %"rubyId_@foo13" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !74
-  %14 = tail call i64 @sorbet_vm_getivar(i64 %selfRaw, i64 %"rubyId_@foo13", %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo.3") #15, !dbg !74
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !74, !tbaa !14
+  %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !75
+  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %rawArg_foo, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #15, !dbg !75
+  %"rubyId_@foo13" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !76
+  %14 = tail call i64 @sorbet_vm_getivar(i64 %selfRaw, i64 %"rubyId_@foo13", %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo.3") #15, !dbg !76
   %"<void-singleton>" = load i64, i64* @"<void-singleton>", align 8
   ret i64 %"<void-singleton>"
 
 codeRepl:                                         ; preds = %3, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_AttrReaderNoSig#initialize.cold.1"(i64 %rawArg_foo) #19, !dbg !72
+  tail call fastcc void @"func_AttrReaderNoSig#initialize.cold.1"(i64 %rawArg_foo) #19, !dbg !74
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_AttrReaderNoSig.<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #9 !dbg !39 {
+define internal i64 @"func_AttrReaderNoSig.<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #9 !dbg !41 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !14
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !75
+  %4 = load i64, i64* %3, align 8, !tbaa !77
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.<static-init>$block_1", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !18
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !20
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !20
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !22
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !12
-  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !76
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !76
-  %11 = load i64, i64* @rb_cInteger, align 8, !dbg !38
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !38
-  %13 = load i64*, i64** %12, align 8, !dbg !38
-  store i64 %4, i64* %13, align 8, !dbg !38, !tbaa !4
-  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !38
-  store i64 %11, i64* %14, align 8, !dbg !38, !tbaa !4
-  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !38
-  store i64* %15, i64** %12, align 8, !dbg !38
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !38
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !38
-  %17 = load i64*, i64** %16, align 8, !dbg !38
-  store i64 %send, i64* %17, align 8, !dbg !38, !tbaa !4
-  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !38
-  store i64* %18, i64** %16, align 8, !dbg !38
-  %send17 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_void, i64 0), !dbg !38
-  ret i64 %send17, !dbg !77
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !14
+  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !78
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !78
+  %11 = load i64, i64* @rb_cInteger, align 8, !dbg !40
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !40
+  %13 = load i64*, i64** %12, align 8, !dbg !40
+  store i64 %4, i64* %13, align 8, !dbg !40, !tbaa !6
+  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !40
+  store i64 %11, i64* %14, align 8, !dbg !40, !tbaa !6
+  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !40
+  store i64* %15, i64** %12, align 8, !dbg !40
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !40
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !40
+  %17 = load i64*, i64** %16, align 8, !dbg !40
+  store i64 %send, i64* %17, align 8, !dbg !40, !tbaa !6
+  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !40
+  store i64* %18, i64** %16, align 8, !dbg !40
+  %send17 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_void, i64 0), !dbg !40
+  ret i64 %send17, !dbg !79
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
@@ -820,10 +820,10 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_AttrReaderNoSig#initialize.cold.1"(i64 %rawArg_foo) unnamed_addr #12 !dbg !78 {
+define internal fastcc void @"func_AttrReaderNoSig#initialize.cold.1"(i64 %rawArg_foo) unnamed_addr #12 !dbg !80 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_foo, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !80
-  unreachable, !dbg !80
+  tail call void @sorbet_cast_failure(i64 %rawArg_foo, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !82
+  unreachable, !dbg !82
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
@@ -833,7 +833,7 @@ declare void @llvm.assume(i1 noundef) #13
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !28
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !30
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
@@ -842,7 +842,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #9 {
 define linkonce void @const_recompute_AttrReaderNoSig() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @str_AttrReaderNoSig, i64 0, i64 0), i64 15)
   store i64 %1, i64* @guarded_const_AttrReaderNoSig, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !28
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !30
   store i64 %2, i64* @guard_epoch_AttrReaderNoSig, align 8
   ret void
 }
@@ -868,87 +868,89 @@ attributes #17 = { nounwind willreturn }
 attributes #18 = { noreturn }
 attributes #19 = { noinline }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "AttrReaderNoSig.<static-init>", linkageName: "func_AttrReaderNoSig.<static-init>L62", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = !DISubroutineType(types: !10)
-!10 = !{!11}
-!11 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!12 = !{!13, !13, i64 0}
-!13 = !{!"any pointer", !6, i64 0}
-!14 = !{!15, !13, i64 16}
-!15 = !{!"rb_execution_context_struct", !13, i64 0, !5, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !16, i64 40, !16, i64 44, !13, i64 48, !13, i64 56, !13, i64 64, !5, i64 72, !5, i64 80, !13, i64 88, !5, i64 96, !13, i64 104, !13, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !17, i64 152}
-!16 = !{!"int", !6, i64 0}
-!17 = !{!"", !13, i64 0, !13, i64 8, !5, i64 16, !6, i64 24}
-!18 = !{!19, !13, i64 16}
-!19 = !{!"rb_control_frame_struct", !13, i64 0, !13, i64 8, !13, i64 16, !5, i64 24, !13, i64 32, !13, i64 40, !13, i64 48}
-!20 = !{!19, !13, i64 32}
-!21 = !DILocation(line: 0, scope: !8)
-!22 = !DILocation(line: 7, column: 3, scope: !8)
-!23 = !{!15, !16, i64 40}
-!24 = !{!15, !16, i64 44}
-!25 = !{!"branch_weights", i32 2000, i32 1}
-!26 = !{!15, !13, i64 56}
-!27 = !DILocation(line: 6, column: 3, scope: !8)
-!28 = !{!29, !29, i64 0}
-!29 = !{!"long long", !6, i64 0}
-!30 = !{!"branch_weights", i32 1, i32 10000}
-!31 = !DILocation(line: 8, column: 3, scope: !8)
-!32 = !{!33, !16, i64 8}
-!33 = !{!"rb_sorbet_param_struct", !34, i64 0, !16, i64 4, !16, i64 8, !16, i64 12, !16, i64 16, !16, i64 20, !16, i64 24, !16, i64 28, !13, i64 32, !16, i64 40, !16, i64 44, !16, i64 48, !16, i64 52, !13, i64 56}
-!34 = !{!"", !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 1, !16, i64 1}
-!35 = !{!33, !16, i64 4}
-!36 = !{!33, !13, i64 32}
-!37 = !DILocation(line: 13, column: 3, scope: !8)
-!38 = !DILocation(line: 7, column: 8, scope: !39)
-!39 = distinct !DISubprogram(name: "AttrReaderNoSig.<static-init>", linkageName: "func_AttrReaderNoSig.<static-init>L62$block_1", scope: !8, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!40 = !DILocation(line: 16, column: 5, scope: !41)
-!41 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!42 = !DILocation(line: 19, column: 7, scope: !41)
-!43 = !DILocation(line: 21, column: 3, scope: !41)
-!44 = !DILocation(line: 23, column: 3, scope: !41)
-!45 = !DILocation(line: 26, column: 1, scope: !41)
-!46 = !DILocation(line: 27, column: 6, scope: !41)
-!47 = !DILocation(line: 27, column: 1, scope: !41)
-!48 = !{!49, !5, i64 400}
-!49 = !{!"rb_vm_struct", !5, i64 0, !50, i64 8, !13, i64 192, !13, i64 200, !13, i64 208, !29, i64 216, !6, i64 224, !51, i64 264, !51, i64 280, !51, i64 296, !51, i64 312, !5, i64 328, !16, i64 336, !16, i64 340, !16, i64 344, !16, i64 344, !16, i64 344, !16, i64 344, !16, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !13, i64 456, !13, i64 464, !53, i64 472, !54, i64 992, !13, i64 1016, !13, i64 1024, !16, i64 1032, !16, i64 1036, !51, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !16, i64 1136, !13, i64 1144, !13, i64 1152, !13, i64 1160, !13, i64 1168, !13, i64 1176, !13, i64 1184, !16, i64 1192, !55, i64 1200, !6, i64 1232}
-!50 = !{!"rb_global_vm_lock_struct", !13, i64 0, !6, i64 8, !51, i64 48, !13, i64 64, !16, i64 72, !6, i64 80, !6, i64 128, !16, i64 176, !16, i64 180}
-!51 = !{!"list_head", !52, i64 0}
-!52 = !{!"list_node", !13, i64 0, !13, i64 8}
-!53 = !{!"", !6, i64 0}
-!54 = !{!"rb_hook_list_struct", !13, i64 0, !16, i64 8, !16, i64 12, !16, i64 16}
-!55 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!56 = !DILocation(line: 0, scope: !41)
-!57 = !DILocation(line: 5, column: 1, scope: !41)
-!58 = !DILocation(line: 18, column: 5, scope: !41)
-!59 = !{!"branch_weights", i32 1, i32 2000}
-!60 = !{!"branch_weights", i32 1073205, i32 2146410443}
-!61 = !{!62, !5, i64 0}
-!62 = !{!"RBasic", !5, i64 0, !5, i64 8}
-!63 = !{!64}
-!64 = distinct !{!64, !65, !"sorbet_rb_int_lt: argument 0"}
-!65 = distinct !{!65, !"sorbet_rb_int_lt"}
-!66 = !{!"branch_weights", i32 4001, i32 4000000}
-!67 = !{!68}
-!68 = distinct !{!68, !69, !"sorbet_rb_int_plus: argument 0"}
-!69 = distinct !{!69, !"sorbet_rb_int_plus"}
-!70 = distinct !DISubprogram(name: "AttrReaderNoSig#initialize", linkageName: "func_AttrReaderNoSig#initialize", scope: null, file: !2, line: 8, type: !9, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!71 = !DILocation(line: 8, column: 3, scope: !70)
-!72 = !DILocation(line: 8, column: 18, scope: !70)
-!73 = !DILocation(line: 9, column: 12, scope: !70)
-!74 = !DILocation(line: 9, column: 5, scope: !70)
-!75 = !{!19, !5, i64 24}
-!76 = !DILocation(line: 7, column: 15, scope: !39)
-!77 = !DILocation(line: 7, column: 3, scope: !39)
-!78 = distinct !DISubprogram(name: "func_AttrReaderNoSig#initialize.cold.1", linkageName: "func_AttrReaderNoSig#initialize.cold.1", scope: null, file: !2, type: !79, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!79 = !DISubroutineType(types: !3)
-!80 = !DILocation(line: 8, column: 18, scope: !78)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "AttrReaderNoSig.<static-init>", linkageName: "func_AttrReaderNoSig.<static-init>L62", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!14 = !{!15, !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !{!17, !15, i64 16}
+!17 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !18, i64 40, !18, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !19, i64 152}
+!18 = !{!"int", !8, i64 0}
+!19 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!20 = !{!21, !15, i64 16}
+!21 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!22 = !{!21, !15, i64 32}
+!23 = !DILocation(line: 0, scope: !10)
+!24 = !DILocation(line: 7, column: 3, scope: !10)
+!25 = !{!17, !18, i64 40}
+!26 = !{!17, !18, i64 44}
+!27 = !{!"branch_weights", i32 2000, i32 1}
+!28 = !{!17, !15, i64 56}
+!29 = !DILocation(line: 6, column: 3, scope: !10)
+!30 = !{!31, !31, i64 0}
+!31 = !{!"long long", !8, i64 0}
+!32 = !{!"branch_weights", i32 1, i32 10000}
+!33 = !DILocation(line: 8, column: 3, scope: !10)
+!34 = !{!35, !18, i64 8}
+!35 = !{!"rb_sorbet_param_struct", !36, i64 0, !18, i64 4, !18, i64 8, !18, i64 12, !18, i64 16, !18, i64 20, !18, i64 24, !18, i64 28, !15, i64 32, !18, i64 40, !18, i64 44, !18, i64 48, !18, i64 52, !15, i64 56}
+!36 = !{!"", !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 1, !18, i64 1}
+!37 = !{!35, !18, i64 4}
+!38 = !{!35, !15, i64 32}
+!39 = !DILocation(line: 13, column: 3, scope: !10)
+!40 = !DILocation(line: 7, column: 8, scope: !41)
+!41 = distinct !DISubprogram(name: "AttrReaderNoSig.<static-init>", linkageName: "func_AttrReaderNoSig.<static-init>L62$block_1", scope: !10, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!42 = !DILocation(line: 16, column: 5, scope: !43)
+!43 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!44 = !DILocation(line: 19, column: 7, scope: !43)
+!45 = !DILocation(line: 21, column: 3, scope: !43)
+!46 = !DILocation(line: 23, column: 3, scope: !43)
+!47 = !DILocation(line: 26, column: 1, scope: !43)
+!48 = !DILocation(line: 27, column: 6, scope: !43)
+!49 = !DILocation(line: 27, column: 1, scope: !43)
+!50 = !{!51, !7, i64 400}
+!51 = !{!"rb_vm_struct", !7, i64 0, !52, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !31, i64 216, !8, i64 224, !53, i64 264, !53, i64 280, !53, i64 296, !53, i64 312, !7, i64 328, !18, i64 336, !18, i64 340, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !55, i64 472, !56, i64 992, !15, i64 1016, !15, i64 1024, !18, i64 1032, !18, i64 1036, !53, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !18, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !18, i64 1192, !57, i64 1200, !8, i64 1232}
+!52 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !53, i64 48, !15, i64 64, !18, i64 72, !8, i64 80, !8, i64 128, !18, i64 176, !18, i64 180}
+!53 = !{!"list_head", !54, i64 0}
+!54 = !{!"list_node", !15, i64 0, !15, i64 8}
+!55 = !{!"", !8, i64 0}
+!56 = !{!"rb_hook_list_struct", !15, i64 0, !18, i64 8, !18, i64 12, !18, i64 16}
+!57 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!58 = !DILocation(line: 0, scope: !43)
+!59 = !DILocation(line: 5, column: 1, scope: !43)
+!60 = !DILocation(line: 18, column: 5, scope: !43)
+!61 = !{!"branch_weights", i32 1, i32 2000}
+!62 = !{!"branch_weights", i32 1073205, i32 2146410443}
+!63 = !{!64, !7, i64 0}
+!64 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!65 = !{!66}
+!66 = distinct !{!66, !67, !"sorbet_rb_int_lt: argument 0"}
+!67 = distinct !{!67, !"sorbet_rb_int_lt"}
+!68 = !{!"branch_weights", i32 4001, i32 4000000}
+!69 = !{!70}
+!70 = distinct !{!70, !71, !"sorbet_rb_int_plus: argument 0"}
+!71 = distinct !{!71, !"sorbet_rb_int_plus"}
+!72 = distinct !DISubprogram(name: "AttrReaderNoSig#initialize", linkageName: "func_AttrReaderNoSig#initialize", scope: null, file: !4, line: 8, type: !11, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!73 = !DILocation(line: 8, column: 3, scope: !72)
+!74 = !DILocation(line: 8, column: 18, scope: !72)
+!75 = !DILocation(line: 9, column: 12, scope: !72)
+!76 = !DILocation(line: 9, column: 5, scope: !72)
+!77 = !{!21, !7, i64 24}
+!78 = !DILocation(line: 7, column: 15, scope: !41)
+!79 = !DILocation(line: 7, column: 3, scope: !41)
+!80 = distinct !DISubprogram(name: "func_AttrReaderNoSig#initialize.cold.1", linkageName: "func_AttrReaderNoSig#initialize.cold.1", scope: null, file: !4, type: !81, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!81 = !DISubroutineType(types: !5)
+!82 = !DILocation(line: 8, column: 18, scope: !80)

--- a/test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.llo.exp
@@ -226,196 +226,196 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #14
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #14
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_AttrReaderSigChecked.<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !8 {
+define internal fastcc void @"func_AttrReaderSigChecked.<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !10 {
 fastSymCallIntrinsic_ResolvedSig_sig:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.<static-init>", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !14
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !18
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !20
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !20
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !22
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #15
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !21, !tbaa !12
-  %rubyId_initialize = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !22
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_initialize), !dbg !22
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_AttrReaderSigChecked.<static-init>L62$block_1"), !dbg !22
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !22, !tbaa !12
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !22
-  %11 = load i32, i32* %10, align 8, !dbg !22, !tbaa !23
-  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !22
-  %13 = load i32, i32* %12, align 4, !dbg !22, !tbaa !24
-  %14 = xor i32 %13, -1, !dbg !22
-  %15 = and i32 %14, %11, !dbg !22
-  %16 = icmp eq i32 %15, 0, !dbg !22
-  br i1 %16, label %fastSymCallIntrinsic_ResolvedSig_sig63, label %17, !dbg !22, !prof !25
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !23, !tbaa !14
+  %rubyId_initialize = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !24
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_initialize), !dbg !24
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_AttrReaderSigChecked.<static-init>L62$block_1"), !dbg !24
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !14
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !24
+  %11 = load i32, i32* %10, align 8, !dbg !24, !tbaa !25
+  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !24
+  %13 = load i32, i32* %12, align 4, !dbg !24, !tbaa !26
+  %14 = xor i32 %13, -1, !dbg !24
+  %15 = and i32 %14, %11, !dbg !24
+  %16 = icmp eq i32 %15, 0, !dbg !24
+  br i1 %16, label %fastSymCallIntrinsic_ResolvedSig_sig63, label %17, !dbg !24, !prof !27
 
 17:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig
-  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !22
-  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !22, !tbaa !26
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !22
-  br label %fastSymCallIntrinsic_ResolvedSig_sig63, !dbg !22
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
+  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !24, !tbaa !28
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !24
+  br label %fastSymCallIntrinsic_ResolvedSig_sig63, !dbg !24
 
 fastSymCallIntrinsic_ResolvedSig_sig63:           ; preds = %fastSymCallIntrinsic_ResolvedSig_sig, %17
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !22, !tbaa !12
-  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !27
-  %rawSym57 = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !27
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym57, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_AttrReaderSigChecked.<static-init>L62$block_2"), !dbg !27
-  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !27, !tbaa !12
-  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !27
-  %23 = load i32, i32* %22, align 8, !dbg !27, !tbaa !23
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 6, !dbg !27
-  %25 = load i32, i32* %24, align 4, !dbg !27, !tbaa !24
-  %26 = xor i32 %25, -1, !dbg !27
-  %27 = and i32 %26, %23, !dbg !27
-  %28 = icmp eq i32 %27, 0, !dbg !27
-  br i1 %28, label %fastSymCallIntrinsic_Static_keep_def, label %29, !dbg !27, !prof !25
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !24, !tbaa !14
+  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !29
+  %rawSym57 = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !29
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym57, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_AttrReaderSigChecked.<static-init>L62$block_2"), !dbg !29
+  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !29
+  %23 = load i32, i32* %22, align 8, !dbg !29, !tbaa !25
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 6, !dbg !29
+  %25 = load i32, i32* %24, align 4, !dbg !29, !tbaa !26
+  %26 = xor i32 %25, -1, !dbg !29
+  %27 = and i32 %26, %23, !dbg !29
+  %28 = icmp eq i32 %27, 0, !dbg !29
+  br i1 %28, label %fastSymCallIntrinsic_Static_keep_def, label %29, !dbg !29, !prof !27
 
 29:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig63
-  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !27
-  %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !27, !tbaa !26
-  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #15, !dbg !27
-  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !27
+  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !29
+  %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !29, !tbaa !28
+  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #15, !dbg !29
+  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !29
 
 fastSymCallIntrinsic_Static_keep_def:             ; preds = %fastSymCallIntrinsic_ResolvedSig_sig63, %29
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !27, !tbaa !12
-  %33 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !28
-  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !28, !tbaa !29
-  %needTakeSlowPath = icmp ne i64 %33, %34, !dbg !28
-  br i1 %needTakeSlowPath, label %35, label %36, !dbg !28, !prof !31
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !29, !tbaa !14
+  %33 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !30
+  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
+  %needTakeSlowPath = icmp ne i64 %33, %34, !dbg !30
+  br i1 %needTakeSlowPath, label %35, label %36, !dbg !30, !prof !33
 
 35:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
-  tail call void @"const_recompute_T::Sig"(), !dbg !28
-  br label %36, !dbg !28
+  tail call void @"const_recompute_T::Sig"(), !dbg !30
+  br label %36, !dbg !30
 
 36:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def, %35
-  %37 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !28
-  %38 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !28
-  %39 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !28, !tbaa !29
-  %guardUpdated = icmp eq i64 %38, %39, !dbg !28
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !28
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !28
-  %41 = load i64*, i64** %40, align 8, !dbg !28
-  store i64 %selfRaw, i64* %41, align 8, !dbg !28, !tbaa !4
-  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !28
-  store i64 %37, i64* %42, align 8, !dbg !28, !tbaa !4
-  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !28
-  store i64* %43, i64** %40, align 8, !dbg !28
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !28
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !28, !tbaa !12
-  %rubyId_initialize79 = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !32
-  %rawSym80 = tail call i64 @rb_id2sym(i64 %rubyId_initialize79), !dbg !32
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !32
-  %rawSym81 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !32
-  %44 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !32
-  %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !32, !tbaa !29
-  %needTakeSlowPath4 = icmp ne i64 %44, %45, !dbg !32
-  br i1 %needTakeSlowPath4, label %46, label %47, !dbg !32, !prof !31
+  %37 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !30
+  %38 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !30
+  %39 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
+  %guardUpdated = icmp eq i64 %38, %39, !dbg !30
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !30
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !30
+  %41 = load i64*, i64** %40, align 8, !dbg !30
+  store i64 %selfRaw, i64* %41, align 8, !dbg !30, !tbaa !6
+  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !30
+  store i64 %37, i64* %42, align 8, !dbg !30, !tbaa !6
+  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !30
+  store i64* %43, i64** %40, align 8, !dbg !30
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !30
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !30, !tbaa !14
+  %rubyId_initialize79 = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !34
+  %rawSym80 = tail call i64 @rb_id2sym(i64 %rubyId_initialize79), !dbg !34
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !34
+  %rawSym81 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !34
+  %44 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !34
+  %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !34, !tbaa !31
+  %needTakeSlowPath4 = icmp ne i64 %44, %45, !dbg !34
+  br i1 %needTakeSlowPath4, label %46, label %47, !dbg !34, !prof !33
 
 46:                                               ; preds = %36
-  tail call void @const_recompute_AttrReaderSigChecked(), !dbg !32
-  br label %47, !dbg !32
+  tail call void @const_recompute_AttrReaderSigChecked(), !dbg !34
+  br label %47, !dbg !34
 
 47:                                               ; preds = %36, %46
-  %48 = load i64, i64* @guarded_const_AttrReaderSigChecked, align 8, !dbg !32
-  %49 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !32
-  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !32, !tbaa !29
-  %guardUpdated5 = icmp eq i64 %49, %50, !dbg !32
-  tail call void @llvm.assume(i1 %guardUpdated5), !dbg !32
-  %stackFrame85 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#initialize", align 8, !dbg !32
-  %51 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !32
-  %52 = bitcast i8* %51 to i16*, !dbg !32
-  %53 = load i16, i16* %52, align 8, !dbg !32
-  %54 = and i16 %53, -384, !dbg !32
-  %55 = or i16 %54, 1, !dbg !32
-  store i16 %55, i16* %52, align 8, !dbg !32
-  %56 = getelementptr inbounds i8, i8* %51, i64 8, !dbg !32
-  %57 = bitcast i8* %56 to i32*, !dbg !32
-  store i32 1, i32* %57, align 8, !dbg !32, !tbaa !33
-  %58 = getelementptr inbounds i8, i8* %51, i64 12, !dbg !32
-  %59 = bitcast i8* %58 to i32*, !dbg !32
-  %60 = getelementptr inbounds i8, i8* %51, i64 4, !dbg !32
-  %61 = bitcast i8* %60 to i32*, !dbg !32
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %58, i8 0, i64 20, i1 false), !dbg !32
-  store i32 1, i32* %61, align 4, !dbg !32, !tbaa !36
-  %positional_table = alloca i64, align 8, !dbg !32
-  %rubyId_foo86 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !32
-  store i64 %rubyId_foo86, i64* %positional_table, align 8, !dbg !32
-  %62 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !32
-  %63 = bitcast i64* %positional_table to i8*, !dbg !32
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %63, i64 noundef 8, i1 noundef false) #15, !dbg !32
-  %64 = getelementptr inbounds i8, i8* %51, i64 32, !dbg !32
-  %65 = bitcast i8* %64 to i8**, !dbg !32
-  store i8* %62, i8** %65, align 8, !dbg !32, !tbaa !37
-  tail call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderSigChecked#initialize", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame85, i1 noundef zeroext false) #15, !dbg !32
-  %66 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !32, !tbaa !12
-  %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 5, !dbg !32
-  %68 = load i32, i32* %67, align 8, !dbg !32, !tbaa !23
-  %69 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 6, !dbg !32
-  %70 = load i32, i32* %69, align 4, !dbg !32, !tbaa !24
-  %71 = xor i32 %70, -1, !dbg !32
-  %72 = and i32 %71, %68, !dbg !32
-  %73 = icmp eq i32 %72, 0, !dbg !32
-  br i1 %73, label %fastSymCallIntrinsic_Static_keep_def100, label %74, !dbg !32, !prof !25
+  %48 = load i64, i64* @guarded_const_AttrReaderSigChecked, align 8, !dbg !34
+  %49 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !34
+  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !34, !tbaa !31
+  %guardUpdated5 = icmp eq i64 %49, %50, !dbg !34
+  tail call void @llvm.assume(i1 %guardUpdated5), !dbg !34
+  %stackFrame85 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#initialize", align 8, !dbg !34
+  %51 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !34
+  %52 = bitcast i8* %51 to i16*, !dbg !34
+  %53 = load i16, i16* %52, align 8, !dbg !34
+  %54 = and i16 %53, -384, !dbg !34
+  %55 = or i16 %54, 1, !dbg !34
+  store i16 %55, i16* %52, align 8, !dbg !34
+  %56 = getelementptr inbounds i8, i8* %51, i64 8, !dbg !34
+  %57 = bitcast i8* %56 to i32*, !dbg !34
+  store i32 1, i32* %57, align 8, !dbg !34, !tbaa !35
+  %58 = getelementptr inbounds i8, i8* %51, i64 12, !dbg !34
+  %59 = bitcast i8* %58 to i32*, !dbg !34
+  %60 = getelementptr inbounds i8, i8* %51, i64 4, !dbg !34
+  %61 = bitcast i8* %60 to i32*, !dbg !34
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %58, i8 0, i64 20, i1 false), !dbg !34
+  store i32 1, i32* %61, align 4, !dbg !34, !tbaa !38
+  %positional_table = alloca i64, align 8, !dbg !34
+  %rubyId_foo86 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !34
+  store i64 %rubyId_foo86, i64* %positional_table, align 8, !dbg !34
+  %62 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !34
+  %63 = bitcast i64* %positional_table to i8*, !dbg !34
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %63, i64 noundef 8, i1 noundef false) #15, !dbg !34
+  %64 = getelementptr inbounds i8, i8* %51, i64 32, !dbg !34
+  %65 = bitcast i8* %64 to i8**, !dbg !34
+  store i8* %62, i8** %65, align 8, !dbg !34, !tbaa !39
+  tail call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderSigChecked#initialize", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame85, i1 noundef zeroext false) #15, !dbg !34
+  %66 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !34, !tbaa !14
+  %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 5, !dbg !34
+  %68 = load i32, i32* %67, align 8, !dbg !34, !tbaa !25
+  %69 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 6, !dbg !34
+  %70 = load i32, i32* %69, align 4, !dbg !34, !tbaa !26
+  %71 = xor i32 %70, -1, !dbg !34
+  %72 = and i32 %71, %68, !dbg !34
+  %73 = icmp eq i32 %72, 0, !dbg !34
+  br i1 %73, label %fastSymCallIntrinsic_Static_keep_def100, label %74, !dbg !34, !prof !27
 
 74:                                               ; preds = %47
-  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 8, !dbg !32
-  %76 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %75, align 8, !dbg !32, !tbaa !26
-  %77 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %76, i32 noundef 0) #15, !dbg !32
-  br label %fastSymCallIntrinsic_Static_keep_def100, !dbg !32
+  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 8, !dbg !34
+  %76 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %75, align 8, !dbg !34, !tbaa !28
+  %77 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %76, i32 noundef 0) #15, !dbg !34
+  br label %fastSymCallIntrinsic_Static_keep_def100, !dbg !34
 
 afterSend97:                                      ; preds = %92, %fastSymCallIntrinsic_Static_keep_def100
   ret void
 
 fastSymCallIntrinsic_Static_keep_def100:          ; preds = %47, %74
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !32, !tbaa !12
-  %rubyId_foo91 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !38
-  %rawSym92 = tail call i64 @rb_id2sym(i64 %rubyId_foo91), !dbg !38
-  %rubyId_normal93 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !38
-  %rawSym94 = tail call i64 @rb_id2sym(i64 %rubyId_normal93), !dbg !38
-  %stackFrame101 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#foo", align 8, !dbg !38
-  %78 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !38
-  %79 = bitcast i8* %78 to i16*, !dbg !38
-  %80 = load i16, i16* %79, align 8, !dbg !38
-  %81 = and i16 %80, -384, !dbg !38
-  store i16 %81, i16* %79, align 8, !dbg !38
-  %82 = getelementptr inbounds i8, i8* %78, i64 4, !dbg !38
-  %83 = bitcast i8* %82 to i32*, !dbg !38
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %82, i8 0, i64 28, i1 false), !dbg !38
-  tail call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderSigChecked#foo", i8* nonnull %78, %struct.rb_iseq_struct* %stackFrame101, i1 noundef zeroext false) #15, !dbg !38
-  %84 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !38, !tbaa !12
-  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 5, !dbg !38
-  %86 = load i32, i32* %85, align 8, !dbg !38, !tbaa !23
-  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 6, !dbg !38
-  %88 = load i32, i32* %87, align 4, !dbg !38, !tbaa !24
-  %89 = xor i32 %88, -1, !dbg !38
-  %90 = and i32 %89, %86, !dbg !38
-  %91 = icmp eq i32 %90, 0, !dbg !38
-  br i1 %91, label %afterSend97, label %92, !dbg !38, !prof !25
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !34, !tbaa !14
+  %rubyId_foo91 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
+  %rawSym92 = tail call i64 @rb_id2sym(i64 %rubyId_foo91), !dbg !40
+  %rubyId_normal93 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !40
+  %rawSym94 = tail call i64 @rb_id2sym(i64 %rubyId_normal93), !dbg !40
+  %stackFrame101 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#foo", align 8, !dbg !40
+  %78 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !40
+  %79 = bitcast i8* %78 to i16*, !dbg !40
+  %80 = load i16, i16* %79, align 8, !dbg !40
+  %81 = and i16 %80, -384, !dbg !40
+  store i16 %81, i16* %79, align 8, !dbg !40
+  %82 = getelementptr inbounds i8, i8* %78, i64 4, !dbg !40
+  %83 = bitcast i8* %82 to i32*, !dbg !40
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %82, i8 0, i64 28, i1 false), !dbg !40
+  tail call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderSigChecked#foo", i8* nonnull %78, %struct.rb_iseq_struct* %stackFrame101, i1 noundef zeroext false) #15, !dbg !40
+  %84 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !14
+  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 5, !dbg !40
+  %86 = load i32, i32* %85, align 8, !dbg !40, !tbaa !25
+  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 6, !dbg !40
+  %88 = load i32, i32* %87, align 4, !dbg !40, !tbaa !26
+  %89 = xor i32 %88, -1, !dbg !40
+  %90 = and i32 %89, %86, !dbg !40
+  %91 = icmp eq i32 %90, 0, !dbg !40
+  br i1 %91, label %afterSend97, label %92, !dbg !40, !prof !27
 
 92:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def100
-  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 8, !dbg !38
-  %94 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %93, align 8, !dbg !38, !tbaa !26
-  %95 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #15, !dbg !38
-  br label %afterSend97, !dbg !38
+  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 8, !dbg !40
+  %94 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %93, align 8, !dbg !40, !tbaa !28
+  %95 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #15, !dbg !40
+  br label %afterSend97, !dbg !40
 }
 
 ; Function Attrs: sspreq
@@ -425,7 +425,7 @@ entry:
   %locals.i28.i = alloca i64, i32 0, align 8
   %locals.i26.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, align 8, !dbg !39
+  %keywords.i = alloca i64, align 8, !dbg !41
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
@@ -475,20 +475,20 @@ entry:
   %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
   %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !41
-  %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_<", i64 %"rubyId_<.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !43
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !44
-  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !45
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
-  %rubyId_foo5.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !47
-  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !43
+  %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_<", i64 %"rubyId_<.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
+  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !46
+  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
+  %rubyId_foo5.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !49
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !49
+  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !50
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
   %21 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
   call void @rb_gc_register_mark_object(i64 %21) #15
   %rubyId_initialize.i.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8
@@ -527,314 +527,314 @@ entry:
   %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i37.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
   %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block for.i36.i", i64 %"rubyId_block for.i35.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i37.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i34.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.<static-init>$block_2", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !22
-  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !39
-  %rubyId_foo12.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !39
-  %31 = call i64 @rb_id2sym(i64 %rubyId_foo12.i) #15, !dbg !39
-  store i64 %31, i64* %keywords.i, align 8, !dbg !39
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !39
-  %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !39
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !39
-  %rubyId_sig15.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !27
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.5, i64 %rubyId_sig15.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !27
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !49
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !28
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !32
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !32
-  %rubyId_keep_def23.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !38
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.6, i64 %rubyId_keep_def23.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !38
+  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
+  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !41
+  %rubyId_foo12.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !41
+  %31 = call i64 @rb_id2sym(i64 %rubyId_foo12.i) #15, !dbg !41
+  store i64 %31, i64* %keywords.i, align 8, !dbg !41
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !41
+  %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !41
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !41
+  %rubyId_sig15.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !29
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.5, i64 %rubyId_sig15.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !29
+  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !51
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !51
+  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !30
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !34
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !34
+  %rubyId_keep_def23.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !40
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.6, i64 %rubyId_keep_def23.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !40
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
-  %32 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !12
+  %32 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %33 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %32, i64 0, i32 18
-  %34 = load i64, i64* %33, align 8, !tbaa !51
-  %35 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %34 = load i64, i64* %33, align 8, !tbaa !53
+  %35 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %35, i64 0, i32 2
-  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %36, align 8, !tbaa !14
+  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %36, align 8, !tbaa !16
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %38, align 8, !tbaa !18
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %38, align 8, !tbaa !20
   %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 4
-  %40 = load i64*, i64** %39, align 8, !tbaa !20
-  %41 = load i64, i64* %40, align 8, !tbaa !4
+  %40 = load i64*, i64** %39, align 8, !tbaa !22
+  %41 = load i64, i64* %40, align 8, !tbaa !6
   %42 = and i64 %41, -33
-  store i64 %42, i64* %40, align 8, !tbaa !4
+  store i64 %42, i64* %40, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %35, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i) #15
   %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %43, align 8, !dbg !59, !tbaa !12
-  %44 = load i64, i64* @rb_cObject, align 8, !dbg !60
-  %45 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @str_AttrReaderSigChecked, i64 0, i64 0), i64 %44) #15, !dbg !60
-  %46 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %45) #15, !dbg !60
-  call fastcc void @"func_AttrReaderSigChecked.<static-init>L62"(i64 %45, %struct.rb_control_frame_struct* %46) #15, !dbg !60
-  call void @sorbet_popFrame() #15, !dbg !60
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %43, align 8, !dbg !60, !tbaa !12
-  %47 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !41
-  %48 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !29
-  %needTakeSlowPath = icmp ne i64 %47, %48, !dbg !41
-  br i1 %needTakeSlowPath, label %49, label %50, !dbg !41, !prof !31
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %43, align 8, !dbg !61, !tbaa !14
+  %44 = load i64, i64* @rb_cObject, align 8, !dbg !62
+  %45 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @str_AttrReaderSigChecked, i64 0, i64 0), i64 %44) #15, !dbg !62
+  %46 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %45) #15, !dbg !62
+  call fastcc void @"func_AttrReaderSigChecked.<static-init>L62"(i64 %45, %struct.rb_control_frame_struct* %46) #15, !dbg !62
+  call void @sorbet_popFrame() #15, !dbg !62
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %43, align 8, !dbg !62, !tbaa !14
+  %47 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !43
+  %48 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !31
+  %needTakeSlowPath = icmp ne i64 %47, %48, !dbg !43
+  br i1 %needTakeSlowPath, label %49, label %50, !dbg !43, !prof !33
 
 49:                                               ; preds = %entry
-  call void @const_recompute_AttrReaderSigChecked(), !dbg !41
-  br label %50, !dbg !41
+  call void @const_recompute_AttrReaderSigChecked(), !dbg !43
+  br label %50, !dbg !43
 
 50:                                               ; preds = %entry, %49
-  %51 = load i64, i64* @guarded_const_AttrReaderSigChecked, align 8, !dbg !41
-  %52 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !41
-  %53 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !29
-  %guardUpdated = icmp eq i64 %52, %53, !dbg !41
-  call void @llvm.assume(i1 %guardUpdated), !dbg !41
-  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !41
-  %55 = load i64*, i64** %54, align 8, !dbg !41
-  store i64 %51, i64* %55, align 8, !dbg !41, !tbaa !4
-  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !41
-  store i64 2497, i64* %56, align 8, !dbg !41, !tbaa !4
-  %57 = getelementptr inbounds i64, i64* %56, i64 1, !dbg !41
-  store i64* %57, i64** %54, align 8, !dbg !41
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !41
-  br label %BB2.i, !dbg !61
+  %51 = load i64, i64* @guarded_const_AttrReaderSigChecked, align 8, !dbg !43
+  %52 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !43
+  %53 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !31
+  %guardUpdated = icmp eq i64 %52, %53, !dbg !43
+  call void @llvm.assume(i1 %guardUpdated), !dbg !43
+  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !43
+  %55 = load i64*, i64** %54, align 8, !dbg !43
+  store i64 %51, i64* %55, align 8, !dbg !43, !tbaa !6
+  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !43
+  store i64 2497, i64* %56, align 8, !dbg !43, !tbaa !6
+  %57 = getelementptr inbounds i64, i64* %56, i64 1, !dbg !43
+  store i64* %57, i64** %54, align 8, !dbg !43
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !43
+  br label %BB2.i, !dbg !63
 
 BB2.i:                                            ; preds = %BB2.i.backedge, %50
-  %i.sroa.0.0.i = phi i64 [ 1, %50 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !59
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %43, align 8, !tbaa !12
-  %58 = and i64 %i.sroa.0.0.i, 1, !dbg !43
-  %59 = icmp eq i64 %58, 0, !dbg !43
-  br i1 %59, label %60, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !43, !prof !62
+  %i.sroa.0.0.i = phi i64 [ 1, %50 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !61
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %43, align 8, !tbaa !14
+  %58 = and i64 %i.sroa.0.0.i, 1, !dbg !45
+  %59 = icmp eq i64 %58, 0, !dbg !45
+  br i1 %59, label %60, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !45, !prof !64
 
 60:                                               ; preds = %BB2.i
-  %61 = and i64 %i.sroa.0.0.i, 7, !dbg !43
-  %62 = icmp ne i64 %61, 0, !dbg !43
-  %63 = and i64 %i.sroa.0.0.i, -9, !dbg !43
-  %64 = icmp eq i64 %63, 0, !dbg !43
-  %65 = or i1 %62, %64, !dbg !43
-  br i1 %65, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !43, !prof !63
+  %61 = and i64 %i.sroa.0.0.i, 7, !dbg !45
+  %62 = icmp ne i64 %61, 0, !dbg !45
+  %63 = and i64 %i.sroa.0.0.i, -9, !dbg !45
+  %64 = icmp eq i64 %63, 0, !dbg !45
+  %65 = or i1 %62, %64, !dbg !45
+  br i1 %65, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !45, !prof !65
 
 sorbet_isa_Integer.exit:                          ; preds = %60
-  %66 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !43
-  %67 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %66, i64 0, i32 0, !dbg !43
-  %68 = load i64, i64* %67, align 8, !dbg !43, !tbaa !64
-  %69 = and i64 %68, 31, !dbg !43
-  %70 = icmp eq i64 %69, 10, !dbg !43
-  br i1 %70, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !43, !prof !25
+  %66 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !45
+  %67 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %66, i64 0, i32 0, !dbg !45
+  %68 = load i64, i64* %67, align 8, !dbg !45, !tbaa !66
+  %69 = and i64 %68, 31, !dbg !45
+  %70 = icmp eq i64 %69, 10, !dbg !45
+  br i1 %70, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !45, !prof !27
 
 BB5.i:                                            ; preds = %afterSend37.i
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %43, align 8, !tbaa !12
-  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !44
-  %72 = load i64*, i64** %71, align 8, !dbg !44
-  store i64 %send, i64* %72, align 8, !dbg !44, !tbaa !4
-  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !44
-  store i64* %73, i64** %71, align 8, !dbg !44
-  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !44
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %43, align 8, !dbg !44, !tbaa !12
-  br i1 %74, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !45
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %43, align 8, !tbaa !14
+  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !46
+  %72 = load i64*, i64** %71, align 8, !dbg !46
+  store i64 %send, i64* %72, align 8, !dbg !46, !tbaa !6
+  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !46
+  store i64* %73, i64** %71, align 8, !dbg !46
+  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !46
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %43, align 8, !dbg !46, !tbaa !14
+  br i1 %74, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !47
 
 afterSend37.i:                                    ; preds = %99, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
   %74 = phi i1 [ %77, %"alternativeCallIntrinsic_Integer_<.i" ], [ %82, %sorbet_rb_int_lt.exit.i ], [ %82, %99 ]
-  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send4, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult89.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult89.i, %99 ], !dbg !43
-  %75 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !43
-  %76 = icmp ne i64 %75, 0, !dbg !43
-  br i1 %76, label %BB5.i, label %"func_<root>.<static-init>$151.exit", !dbg !43
+  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send4, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult89.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult89.i, %99 ], !dbg !45
+  %75 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !45
+  %76 = icmp ne i64 %75, 0, !dbg !45
+  br i1 %76, label %BB5.i, label %"func_<root>.<static-init>$151.exit", !dbg !45
 
 "alternativeCallIntrinsic_Integer_<.i":           ; preds = %60, %sorbet_isa_Integer.exit
   %77 = phi i1 [ %70, %sorbet_isa_Integer.exit ], [ false, %60 ]
-  %78 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !43
-  %79 = load i64*, i64** %78, align 8, !dbg !43
-  store i64 %i.sroa.0.0.i, i64* %79, align 8, !dbg !43, !tbaa !4
-  %80 = getelementptr inbounds i64, i64* %79, i64 1, !dbg !43
-  store i64 20000001, i64* %80, align 8, !dbg !43, !tbaa !4
-  %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !43
-  store i64* %81, i64** %78, align 8, !dbg !43
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !43
-  br label %afterSend37.i, !dbg !43
+  %78 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !45
+  %79 = load i64*, i64** %78, align 8, !dbg !45
+  store i64 %i.sroa.0.0.i, i64* %79, align 8, !dbg !45, !tbaa !6
+  %80 = getelementptr inbounds i64, i64* %79, i64 1, !dbg !45
+  store i64 20000001, i64* %80, align 8, !dbg !45, !tbaa !6
+  %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !45
+  store i64* %81, i64** %78, align 8, !dbg !45
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !45
+  br label %afterSend37.i, !dbg !45
 
 "fastSymCallIntrinsic_Integer_<.i":               ; preds = %BB2.i, %sorbet_isa_Integer.exit
   %82 = phi i1 [ %70, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
-  call void @llvm.experimental.noalias.scope.decl(metadata !66) #15, !dbg !43
-  %83 = and i64 %i.sroa.0.0.i, 1, !dbg !43
-  %84 = icmp eq i64 %83, 0, !dbg !43
-  br i1 %84, label %89, label %85, !dbg !43, !prof !69
+  call void @llvm.experimental.noalias.scope.decl(metadata !68) #15, !dbg !45
+  %83 = and i64 %i.sroa.0.0.i, 1, !dbg !45
+  %84 = icmp eq i64 %83, 0, !dbg !45
+  br i1 %84, label %89, label %85, !dbg !45, !prof !71
 
 85:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %86 = ashr i64 %i.sroa.0.0.i, 1, !dbg !43
-  %87 = icmp slt i64 %86, 10000000, !dbg !43
-  %88 = select i1 %87, i64 20, i64 0, !dbg !43
-  br label %sorbet_rb_int_lt.exit.i, !dbg !43
+  %86 = ashr i64 %i.sroa.0.0.i, 1, !dbg !45
+  %87 = icmp slt i64 %86, 10000000, !dbg !45
+  %88 = select i1 %87, i64 20, i64 0, !dbg !45
+  br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
 89:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %90 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !43, !noalias !66
-  br label %sorbet_rb_int_lt.exit.i, !dbg !43
+  %90 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !45, !noalias !68
+  br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
 sorbet_rb_int_lt.exit.i:                          ; preds = %89, %85
   %rawSendResult89.i = phi i64 [ %88, %85 ], [ %90, %89 ]
-  %91 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !43, !tbaa !12
-  %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %91, i64 0, i32 5, !dbg !43
-  %93 = load i32, i32* %92, align 8, !dbg !43, !tbaa !23
-  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %91, i64 0, i32 6, !dbg !43
-  %95 = load i32, i32* %94, align 4, !dbg !43, !tbaa !24
-  %96 = xor i32 %95, -1, !dbg !43
-  %97 = and i32 %96, %93, !dbg !43
-  %98 = icmp eq i32 %97, 0, !dbg !43
-  br i1 %98, label %afterSend37.i, label %99, !dbg !43, !prof !25
+  %91 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !14
+  %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %91, i64 0, i32 5, !dbg !45
+  %93 = load i32, i32* %92, align 8, !dbg !45, !tbaa !25
+  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %91, i64 0, i32 6, !dbg !45
+  %95 = load i32, i32* %94, align 4, !dbg !45, !tbaa !26
+  %96 = xor i32 %95, -1, !dbg !45
+  %97 = and i32 %96, %93, !dbg !45
+  %98 = icmp eq i32 %97, 0, !dbg !45
+  br i1 %98, label %afterSend37.i, label %99, !dbg !45, !prof !27
 
 99:                                               ; preds = %sorbet_rb_int_lt.exit.i
-  %100 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %91, i64 0, i32 8, !dbg !43
-  %101 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %100, align 8, !dbg !43, !tbaa !26
-  %102 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %101, i32 noundef 0) #15, !dbg !43
-  br label %afterSend37.i, !dbg !43
+  %100 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %91, i64 0, i32 8, !dbg !45
+  %101 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %100, align 8, !dbg !45, !tbaa !28
+  %102 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %101, i32 noundef 0) #15, !dbg !45
+  br label %afterSend37.i, !dbg !45
 
 "alternativeCallIntrinsic_Integer_+.i":           ; preds = %BB5.i
-  %103 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !45
-  %104 = load i64*, i64** %103, align 8, !dbg !45
-  store i64 %i.sroa.0.0.i, i64* %104, align 8, !dbg !45, !tbaa !4
-  %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !45
-  store i64 3, i64* %105, align 8, !dbg !45, !tbaa !4
-  %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !45
-  store i64* %106, i64** %103, align 8, !dbg !45
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !45
-  br label %BB2.i.backedge, !dbg !45
+  %103 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !47
+  %104 = load i64*, i64** %103, align 8, !dbg !47
+  store i64 %i.sroa.0.0.i, i64* %104, align 8, !dbg !47, !tbaa !6
+  %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !47
+  store i64 3, i64* %105, align 8, !dbg !47, !tbaa !6
+  %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !47
+  store i64* %106, i64** %103, align 8, !dbg !47
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !47
+  br label %BB2.i.backedge, !dbg !47
 
 "fastSymCallIntrinsic_Integer_+.i":               ; preds = %BB5.i
-  call void @llvm.experimental.noalias.scope.decl(metadata !70) #15, !dbg !45
-  %107 = and i64 %i.sroa.0.0.i, 1, !dbg !45
-  %108 = icmp eq i64 %107, 0, !dbg !45
-  br i1 %108, label %117, label %109, !dbg !45, !prof !69
+  call void @llvm.experimental.noalias.scope.decl(metadata !72) #15, !dbg !47
+  %107 = and i64 %i.sroa.0.0.i, 1, !dbg !47
+  %108 = icmp eq i64 %107, 0, !dbg !47
+  br i1 %108, label %117, label %109, !dbg !47, !prof !71
 
 109:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %110 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !45
-  %111 = extractvalue { i64, i1 } %110, 1, !dbg !45
-  %112 = extractvalue { i64, i1 } %110, 0, !dbg !45
-  br i1 %111, label %113, label %sorbet_rb_int_plus.exit.i, !dbg !45
+  %110 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !47
+  %111 = extractvalue { i64, i1 } %110, 1, !dbg !47
+  %112 = extractvalue { i64, i1 } %110, 0, !dbg !47
+  br i1 %111, label %113, label %sorbet_rb_int_plus.exit.i, !dbg !47
 
 113:                                              ; preds = %109
-  %114 = ashr i64 %112, 1, !dbg !45
-  %115 = xor i64 %114, -9223372036854775808, !dbg !45
-  %116 = call i64 @rb_int2big(i64 %115) #15, !dbg !45
-  br label %sorbet_rb_int_plus.exit.i, !dbg !45
+  %114 = ashr i64 %112, 1, !dbg !47
+  %115 = xor i64 %114, -9223372036854775808, !dbg !47
+  %116 = call i64 @rb_int2big(i64 %115) #15, !dbg !47
+  br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
 117:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %118 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !45, !noalias !70
-  br label %sorbet_rb_int_plus.exit.i, !dbg !45
+  %118 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !47, !noalias !72
+  br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
 sorbet_rb_int_plus.exit.i:                        ; preds = %117, %113, %109
-  %119 = phi i64 [ %118, %117 ], [ %116, %113 ], [ %112, %109 ], !dbg !45
-  %120 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !12
-  %121 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 5, !dbg !45
-  %122 = load i32, i32* %121, align 8, !dbg !45, !tbaa !23
-  %123 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 6, !dbg !45
-  %124 = load i32, i32* %123, align 4, !dbg !45, !tbaa !24
-  %125 = xor i32 %124, -1, !dbg !45
-  %126 = and i32 %125, %122, !dbg !45
-  %127 = icmp eq i32 %126, 0, !dbg !45
-  br i1 %127, label %BB2.i.backedge, label %128, !dbg !45, !prof !25
+  %119 = phi i64 [ %118, %117 ], [ %116, %113 ], [ %112, %109 ], !dbg !47
+  %120 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !14
+  %121 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 5, !dbg !47
+  %122 = load i32, i32* %121, align 8, !dbg !47, !tbaa !25
+  %123 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 6, !dbg !47
+  %124 = load i32, i32* %123, align 4, !dbg !47, !tbaa !26
+  %125 = xor i32 %124, -1, !dbg !47
+  %126 = and i32 %125, %122, !dbg !47
+  %127 = icmp eq i32 %126, 0, !dbg !47
+  br i1 %127, label %BB2.i.backedge, label %128, !dbg !47, !prof !27
 
 128:                                              ; preds = %sorbet_rb_int_plus.exit.i
-  %129 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 8, !dbg !45
-  %130 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %129, align 8, !dbg !45, !tbaa !26
-  %131 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %130, i32 noundef 0) #15, !dbg !45
-  br label %BB2.i.backedge, !dbg !45
+  %129 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 8, !dbg !47
+  %130 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %129, align 8, !dbg !47, !tbaa !28
+  %131 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %130, i32 noundef 0) #15, !dbg !47
+  br label %BB2.i.backedge, !dbg !47
 
 BB2.i.backedge:                                   ; preds = %128, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
   %i.sroa.0.0.i.be = phi i64 [ %send6, %"alternativeCallIntrinsic_Integer_+.i" ], [ %119, %sorbet_rb_int_plus.exit.i ], [ %119, %128 ]
   br label %BB2.i
 
 "func_<root>.<static-init>$151.exit":             ; preds = %afterSend37.i
-  %i.sroa.0.0.i.lcssa = phi i64 [ %i.sroa.0.0.i, %afterSend37.i ], !dbg !59
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %43, align 8, !tbaa !12
-  %132 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !46
-  %133 = load i64*, i64** %132, align 8, !dbg !46
-  store i64 %34, i64* %133, align 8, !dbg !46, !tbaa !4
-  %134 = getelementptr inbounds i64, i64* %133, i64 1, !dbg !46
-  store i64 %i.sroa.0.0.i.lcssa, i64* %134, align 8, !dbg !46, !tbaa !4
-  %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !46
-  store i64* %135, i64** %132, align 8, !dbg !46
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !46
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %43, align 8, !dbg !46, !tbaa !12
-  %136 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !47
-  %137 = load i64*, i64** %136, align 8, !dbg !47
-  store i64 %send, i64* %137, align 8, !dbg !47, !tbaa !4
-  %138 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !47
-  store i64* %138, i64** %136, align 8, !dbg !47
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !47
-  %139 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !48
-  %140 = load i64*, i64** %139, align 8, !dbg !48
-  store i64 %34, i64* %140, align 8, !dbg !48, !tbaa !4
-  %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !48
-  store i64 %send10, i64* %141, align 8, !dbg !48, !tbaa !4
-  %142 = getelementptr inbounds i64, i64* %141, i64 1, !dbg !48
-  store i64* %142, i64** %139, align 8, !dbg !48
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !48
+  %i.sroa.0.0.i.lcssa = phi i64 [ %i.sroa.0.0.i, %afterSend37.i ], !dbg !61
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %43, align 8, !tbaa !14
+  %132 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !48
+  %133 = load i64*, i64** %132, align 8, !dbg !48
+  store i64 %34, i64* %133, align 8, !dbg !48, !tbaa !6
+  %134 = getelementptr inbounds i64, i64* %133, i64 1, !dbg !48
+  store i64 %i.sroa.0.0.i.lcssa, i64* %134, align 8, !dbg !48, !tbaa !6
+  %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !48
+  store i64* %135, i64** %132, align 8, !dbg !48
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !48
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %43, align 8, !dbg !48, !tbaa !14
+  %136 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !49
+  %137 = load i64*, i64** %136, align 8, !dbg !49
+  store i64 %send, i64* %137, align 8, !dbg !49, !tbaa !6
+  %138 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !49
+  store i64* %138, i64** %136, align 8, !dbg !49
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !49
+  %139 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !50
+  %140 = load i64*, i64** %139, align 8, !dbg !50
+  store i64 %34, i64* %140, align 8, !dbg !50, !tbaa !6
+  %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !50
+  store i64 %send10, i64* %141, align 8, !dbg !50, !tbaa !6
+  %142 = getelementptr inbounds i64, i64* %141, i64 1, !dbg !50
+  store i64* %142, i64** %139, align 8, !dbg !50
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !50
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_AttrReaderSigChecked#initialize"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #7 !dbg !73 {
+define i64 @"func_AttrReaderSigChecked#initialize"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #7 !dbg !75 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !74
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !74
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !74
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !74, !prof !69
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !76
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !76
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !76
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !76, !prof !71
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #18, !dbg !74
-  unreachable, !dbg !74
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #18, !dbg !76
+  unreachable, !dbg !76
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_foo = load i64, i64* %argArray, align 8, !dbg !74
-  %1 = and i64 %rawArg_foo, 1, !dbg !75
-  %2 = icmp eq i64 %1, 0, !dbg !75
-  br i1 %2, label %3, label %typeTestSuccess, !dbg !75, !prof !62
+  %rawArg_foo = load i64, i64* %argArray, align 8, !dbg !76
+  %1 = and i64 %rawArg_foo, 1, !dbg !77
+  %2 = icmp eq i64 %1, 0, !dbg !77
+  br i1 %2, label %3, label %typeTestSuccess, !dbg !77, !prof !64
 
 3:                                                ; preds = %fillRequiredArgs
-  %4 = and i64 %rawArg_foo, 7, !dbg !75
-  %5 = icmp ne i64 %4, 0, !dbg !75
-  %6 = and i64 %rawArg_foo, -9, !dbg !75
-  %7 = icmp eq i64 %6, 0, !dbg !75
-  %8 = or i1 %5, %7, !dbg !75
-  br i1 %8, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !75
+  %4 = and i64 %rawArg_foo, 7, !dbg !77
+  %5 = icmp ne i64 %4, 0, !dbg !77
+  %6 = and i64 %rawArg_foo, -9, !dbg !77
+  %7 = icmp eq i64 %6, 0, !dbg !77
+  %8 = or i1 %5, %7, !dbg !77
+  br i1 %8, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !77
 
 sorbet_isa_Integer.exit:                          ; preds = %3
-  %9 = inttoptr i64 %rawArg_foo to %struct.iseq_inline_iv_cache_entry*, !dbg !75
-  %10 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %9, i64 0, i32 0, !dbg !75
-  %11 = load i64, i64* %10, align 8, !dbg !75, !tbaa !64
-  %12 = and i64 %11, 31, !dbg !75
-  %13 = icmp eq i64 %12, 10, !dbg !75
-  br i1 %13, label %typeTestSuccess, label %codeRepl, !dbg !75, !prof !25
+  %9 = inttoptr i64 %rawArg_foo to %struct.iseq_inline_iv_cache_entry*, !dbg !77
+  %10 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %9, i64 0, i32 0, !dbg !77
+  %11 = load i64, i64* %10, align 8, !dbg !77, !tbaa !66
+  %12 = and i64 %11, 31, !dbg !77
+  %13 = icmp eq i64 %12, 10, !dbg !77
+  br i1 %13, label %typeTestSuccess, label %codeRepl, !dbg !77, !prof !27
 
 typeTestSuccess:                                  ; preds = %fillRequiredArgs, %sorbet_isa_Integer.exit
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !75, !tbaa !12
-  %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !76
-  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %rawArg_foo, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #15, !dbg !76
-  %"rubyId_@foo13" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !77
-  %14 = tail call i64 @sorbet_vm_getivar(i64 %selfRaw, i64 %"rubyId_@foo13", %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo.3") #15, !dbg !77
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !77, !tbaa !14
+  %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !78
+  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %rawArg_foo, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #15, !dbg !78
+  %"rubyId_@foo13" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !79
+  %14 = tail call i64 @sorbet_vm_getivar(i64 %selfRaw, i64 %"rubyId_@foo13", %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo.3") #15, !dbg !79
   %"<void-singleton>" = load i64, i64* @"<void-singleton>", align 8
   ret i64 %"<void-singleton>"
 
 codeRepl:                                         ; preds = %3, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_AttrReaderSigChecked#initialize.cold.1"(i64 %rawArg_foo) #19, !dbg !75
+  tail call fastcc void @"func_AttrReaderSigChecked#initialize.cold.1"(i64 %rawArg_foo) #19, !dbg !77
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_AttrReaderSigChecked#foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #7 !dbg !78 {
+define i64 @"func_AttrReaderSigChecked#foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #7 !dbg !80 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !12
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !79
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !79, !prof !62
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !14
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !81
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !81, !prof !64
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #18, !dbg !79
-  unreachable, !dbg !79
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #18, !dbg !81
+  unreachable, !dbg !81
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !80
-  %1 = tail call i64 @sorbet_vm_getivar(i64 %selfRaw, i64 %"rubyId_@foo", %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo.4") #15, !dbg !80
+  %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !82
+  %1 = tail call i64 @sorbet_vm_getivar(i64 %selfRaw, i64 %"rubyId_@foo", %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo.4") #15, !dbg !82
   %2 = and i64 %1, 1
   %3 = icmp eq i64 %2, 0
-  br i1 %3, label %4, label %typeTestSuccess, !prof !62
+  br i1 %3, label %4, label %typeTestSuccess, !prof !64
 
 4:                                                ; preds = %fillRequiredArgs
   %5 = and i64 %1, 7
@@ -847,85 +847,85 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
 sorbet_isa_Integer.exit:                          ; preds = %4
   %10 = inttoptr i64 %1 to %struct.iseq_inline_iv_cache_entry*
   %11 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %10, i64 0, i32 0
-  %12 = load i64, i64* %11, align 8, !tbaa !64
+  %12 = load i64, i64* %11, align 8, !tbaa !66
   %13 = and i64 %12, 31
   %14 = icmp eq i64 %13, 10
-  br i1 %14, label %typeTestSuccess, label %codeRepl, !prof !25
+  br i1 %14, label %typeTestSuccess, label %codeRepl, !prof !27
 
 typeTestSuccess:                                  ; preds = %fillRequiredArgs, %sorbet_isa_Integer.exit
   ret i64 %1
 
 codeRepl:                                         ; preds = %4, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_AttrReaderSigChecked#foo.cold.1"(i64 %1) #19, !dbg !81
+  tail call fastcc void @"func_AttrReaderSigChecked#foo.cold.1"(i64 %1) #19, !dbg !83
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_AttrReaderSigChecked.<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #9 !dbg !40 {
+define internal i64 @"func_AttrReaderSigChecked.<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #9 !dbg !42 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !14
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !82
+  %4 = load i64, i64* %3, align 8, !tbaa !84
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.<static-init>$block_1", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !18
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !20
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !20
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !22
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !12
-  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !83
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !83
-  %11 = load i64, i64* @rb_cInteger, align 8, !dbg !39
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !39
-  %13 = load i64*, i64** %12, align 8, !dbg !39
-  store i64 %4, i64* %13, align 8, !dbg !39, !tbaa !4
-  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !39
-  store i64 %11, i64* %14, align 8, !dbg !39, !tbaa !4
-  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !39
-  store i64* %15, i64** %12, align 8, !dbg !39
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !39
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !39
-  %17 = load i64*, i64** %16, align 8, !dbg !39
-  store i64 %send, i64* %17, align 8, !dbg !39, !tbaa !4
-  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !39
-  store i64* %18, i64** %16, align 8, !dbg !39
-  %send16 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_void, i64 0), !dbg !39
-  ret i64 %send16, !dbg !84
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !14
+  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !85
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !85
+  %11 = load i64, i64* @rb_cInteger, align 8, !dbg !41
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !41
+  %13 = load i64*, i64** %12, align 8, !dbg !41
+  store i64 %4, i64* %13, align 8, !dbg !41, !tbaa !6
+  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !41
+  store i64 %11, i64* %14, align 8, !dbg !41, !tbaa !6
+  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !41
+  store i64* %15, i64** %12, align 8, !dbg !41
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !41
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !41
+  %17 = load i64*, i64** %16, align 8, !dbg !41
+  store i64 %send, i64* %17, align 8, !dbg !41, !tbaa !6
+  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !41
+  store i64* %18, i64** %16, align 8, !dbg !41
+  %send16 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_void, i64 0), !dbg !41
+  ret i64 %send16, !dbg !86
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_AttrReaderSigChecked.<static-init>L62$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #9 !dbg !50 {
+define internal i64 @"func_AttrReaderSigChecked.<static-init>L62$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #9 !dbg !52 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !14
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !82
+  %4 = load i64, i64* %3, align 8, !tbaa !84
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.<static-init>$block_2", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !18
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !20
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !20
-  %8 = load i64, i64* %7, align 8, !tbaa !4
+  %7 = load i64*, i64** %6, align 8, !tbaa !22
+  %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
-  store i64 %9, i64* %7, align 8, !tbaa !4
+  store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %10, align 8, !tbaa !12
-  %11 = load i64, i64* @rb_cInteger, align 8, !dbg !49
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !49
-  %13 = load i64*, i64** %12, align 8, !dbg !49
-  store i64 %4, i64* %13, align 8, !dbg !49, !tbaa !4
-  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !49
-  store i64 %11, i64* %14, align 8, !dbg !49, !tbaa !4
-  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !49
-  store i64* %15, i64** %12, align 8, !dbg !49
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !49
-  ret i64 %send, !dbg !85
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %10, align 8, !tbaa !14
+  %11 = load i64, i64* @rb_cInteger, align 8, !dbg !51
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !51
+  %13 = load i64*, i64** %12, align 8, !dbg !51
+  store i64 %4, i64* %13, align 8, !dbg !51, !tbaa !6
+  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !51
+  store i64 %11, i64* %14, align 8, !dbg !51, !tbaa !6
+  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !51
+  store i64* %15, i64** %12, align 8, !dbg !51
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !51
+  ret i64 %send, !dbg !87
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
@@ -941,14 +941,14 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #11
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_AttrReaderSigChecked#initialize.cold.1"(i64 %rawArg_foo) unnamed_addr #12 !dbg !86 {
+define internal fastcc void @"func_AttrReaderSigChecked#initialize.cold.1"(i64 %rawArg_foo) unnamed_addr #12 !dbg !88 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_foo, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !88
-  unreachable, !dbg !88
+  tail call void @sorbet_cast_failure(i64 %rawArg_foo, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !90
+  unreachable, !dbg !90
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_AttrReaderSigChecked#foo.cold.1"(i64 %0) unnamed_addr #12 !dbg !89 {
+define internal fastcc void @"func_AttrReaderSigChecked#foo.cold.1"(i64 %0) unnamed_addr #12 !dbg !91 {
 newFuncRoot:
   tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18
   unreachable
@@ -961,7 +961,7 @@ declare void @llvm.assume(i1 noundef) #13
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !29
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !31
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
@@ -970,7 +970,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #9 {
 define linkonce void @const_recompute_AttrReaderSigChecked() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([21 x i8], [21 x i8]* @str_AttrReaderSigChecked, i64 0, i64 0), i64 20)
   store i64 %1, i64* @guarded_const_AttrReaderSigChecked, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !29
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !31
   store i64 %2, i64* @guard_epoch_AttrReaderSigChecked, align 8
   ret void
 }
@@ -996,96 +996,98 @@ attributes #17 = { nounwind willreturn }
 attributes #18 = { noreturn }
 attributes #19 = { noinline }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "AttrReaderSigChecked.<static-init>", linkageName: "func_AttrReaderSigChecked.<static-init>L62", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = !DISubroutineType(types: !10)
-!10 = !{!11}
-!11 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!12 = !{!13, !13, i64 0}
-!13 = !{!"any pointer", !6, i64 0}
-!14 = !{!15, !13, i64 16}
-!15 = !{!"rb_execution_context_struct", !13, i64 0, !5, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !16, i64 40, !16, i64 44, !13, i64 48, !13, i64 56, !13, i64 64, !5, i64 72, !5, i64 80, !13, i64 88, !5, i64 96, !13, i64 104, !13, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !17, i64 152}
-!16 = !{!"int", !6, i64 0}
-!17 = !{!"", !13, i64 0, !13, i64 8, !5, i64 16, !6, i64 24}
-!18 = !{!19, !13, i64 16}
-!19 = !{!"rb_control_frame_struct", !13, i64 0, !13, i64 8, !13, i64 16, !5, i64 24, !13, i64 32, !13, i64 40, !13, i64 48}
-!20 = !{!19, !13, i64 32}
-!21 = !DILocation(line: 0, scope: !8)
-!22 = !DILocation(line: 7, column: 3, scope: !8)
-!23 = !{!15, !16, i64 40}
-!24 = !{!15, !16, i64 44}
-!25 = !{!"branch_weights", i32 2000, i32 1}
-!26 = !{!15, !13, i64 56}
-!27 = !DILocation(line: 12, column: 3, scope: !8)
-!28 = !DILocation(line: 6, column: 3, scope: !8)
-!29 = !{!30, !30, i64 0}
-!30 = !{!"long long", !6, i64 0}
-!31 = !{!"branch_weights", i32 1, i32 10000}
-!32 = !DILocation(line: 8, column: 3, scope: !8)
-!33 = !{!34, !16, i64 8}
-!34 = !{!"rb_sorbet_param_struct", !35, i64 0, !16, i64 4, !16, i64 8, !16, i64 12, !16, i64 16, !16, i64 20, !16, i64 24, !16, i64 28, !13, i64 32, !16, i64 40, !16, i64 44, !16, i64 48, !16, i64 52, !13, i64 56}
-!35 = !{!"", !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 1, !16, i64 1}
-!36 = !{!34, !16, i64 4}
-!37 = !{!34, !13, i64 32}
-!38 = !DILocation(line: 13, column: 3, scope: !8)
-!39 = !DILocation(line: 7, column: 8, scope: !40)
-!40 = distinct !DISubprogram(name: "AttrReaderSigChecked.<static-init>", linkageName: "func_AttrReaderSigChecked.<static-init>L62$block_1", scope: !8, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!41 = !DILocation(line: 16, column: 5, scope: !42)
-!42 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!43 = !DILocation(line: 19, column: 7, scope: !42)
-!44 = !DILocation(line: 21, column: 3, scope: !42)
-!45 = !DILocation(line: 23, column: 3, scope: !42)
-!46 = !DILocation(line: 26, column: 1, scope: !42)
-!47 = !DILocation(line: 27, column: 6, scope: !42)
-!48 = !DILocation(line: 27, column: 1, scope: !42)
-!49 = !DILocation(line: 12, column: 8, scope: !50)
-!50 = distinct !DISubprogram(name: "AttrReaderSigChecked.<static-init>", linkageName: "func_AttrReaderSigChecked.<static-init>L62$block_2", scope: !8, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!51 = !{!52, !5, i64 400}
-!52 = !{!"rb_vm_struct", !5, i64 0, !53, i64 8, !13, i64 192, !13, i64 200, !13, i64 208, !30, i64 216, !6, i64 224, !54, i64 264, !54, i64 280, !54, i64 296, !54, i64 312, !5, i64 328, !16, i64 336, !16, i64 340, !16, i64 344, !16, i64 344, !16, i64 344, !16, i64 344, !16, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !13, i64 456, !13, i64 464, !56, i64 472, !57, i64 992, !13, i64 1016, !13, i64 1024, !16, i64 1032, !16, i64 1036, !54, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !16, i64 1136, !13, i64 1144, !13, i64 1152, !13, i64 1160, !13, i64 1168, !13, i64 1176, !13, i64 1184, !16, i64 1192, !58, i64 1200, !6, i64 1232}
-!53 = !{!"rb_global_vm_lock_struct", !13, i64 0, !6, i64 8, !54, i64 48, !13, i64 64, !16, i64 72, !6, i64 80, !6, i64 128, !16, i64 176, !16, i64 180}
-!54 = !{!"list_head", !55, i64 0}
-!55 = !{!"list_node", !13, i64 0, !13, i64 8}
-!56 = !{!"", !6, i64 0}
-!57 = !{!"rb_hook_list_struct", !13, i64 0, !16, i64 8, !16, i64 12, !16, i64 16}
-!58 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!59 = !DILocation(line: 0, scope: !42)
-!60 = !DILocation(line: 5, column: 1, scope: !42)
-!61 = !DILocation(line: 18, column: 5, scope: !42)
-!62 = !{!"branch_weights", i32 1, i32 2000}
-!63 = !{!"branch_weights", i32 1073205, i32 2146410443}
-!64 = !{!65, !5, i64 0}
-!65 = !{!"RBasic", !5, i64 0, !5, i64 8}
-!66 = !{!67}
-!67 = distinct !{!67, !68, !"sorbet_rb_int_lt: argument 0"}
-!68 = distinct !{!68, !"sorbet_rb_int_lt"}
-!69 = !{!"branch_weights", i32 4001, i32 4000000}
-!70 = !{!71}
-!71 = distinct !{!71, !72, !"sorbet_rb_int_plus: argument 0"}
-!72 = distinct !{!72, !"sorbet_rb_int_plus"}
-!73 = distinct !DISubprogram(name: "AttrReaderSigChecked#initialize", linkageName: "func_AttrReaderSigChecked#initialize", scope: null, file: !2, line: 8, type: !9, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!74 = !DILocation(line: 8, column: 3, scope: !73)
-!75 = !DILocation(line: 8, column: 18, scope: !73)
-!76 = !DILocation(line: 9, column: 12, scope: !73)
-!77 = !DILocation(line: 9, column: 5, scope: !73)
-!78 = distinct !DISubprogram(name: "AttrReaderSigChecked#foo", linkageName: "func_AttrReaderSigChecked#foo", scope: null, file: !2, line: 13, type: !9, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!79 = !DILocation(line: 13, column: 3, scope: !78)
-!80 = !DILocation(line: 13, column: 16, scope: !78)
-!81 = !DILocation(line: 0, scope: !78)
-!82 = !{!19, !5, i64 24}
-!83 = !DILocation(line: 7, column: 15, scope: !40)
-!84 = !DILocation(line: 7, column: 3, scope: !40)
-!85 = !DILocation(line: 12, column: 3, scope: !50)
-!86 = distinct !DISubprogram(name: "func_AttrReaderSigChecked#initialize.cold.1", linkageName: "func_AttrReaderSigChecked#initialize.cold.1", scope: null, file: !2, type: !87, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!87 = !DISubroutineType(types: !3)
-!88 = !DILocation(line: 8, column: 18, scope: !86)
-!89 = distinct !DISubprogram(name: "func_AttrReaderSigChecked#foo.cold.1", linkageName: "func_AttrReaderSigChecked#foo.cold.1", scope: null, file: !2, type: !87, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "AttrReaderSigChecked.<static-init>", linkageName: "func_AttrReaderSigChecked.<static-init>L62", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!14 = !{!15, !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !{!17, !15, i64 16}
+!17 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !18, i64 40, !18, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !19, i64 152}
+!18 = !{!"int", !8, i64 0}
+!19 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!20 = !{!21, !15, i64 16}
+!21 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!22 = !{!21, !15, i64 32}
+!23 = !DILocation(line: 0, scope: !10)
+!24 = !DILocation(line: 7, column: 3, scope: !10)
+!25 = !{!17, !18, i64 40}
+!26 = !{!17, !18, i64 44}
+!27 = !{!"branch_weights", i32 2000, i32 1}
+!28 = !{!17, !15, i64 56}
+!29 = !DILocation(line: 12, column: 3, scope: !10)
+!30 = !DILocation(line: 6, column: 3, scope: !10)
+!31 = !{!32, !32, i64 0}
+!32 = !{!"long long", !8, i64 0}
+!33 = !{!"branch_weights", i32 1, i32 10000}
+!34 = !DILocation(line: 8, column: 3, scope: !10)
+!35 = !{!36, !18, i64 8}
+!36 = !{!"rb_sorbet_param_struct", !37, i64 0, !18, i64 4, !18, i64 8, !18, i64 12, !18, i64 16, !18, i64 20, !18, i64 24, !18, i64 28, !15, i64 32, !18, i64 40, !18, i64 44, !18, i64 48, !18, i64 52, !15, i64 56}
+!37 = !{!"", !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 1, !18, i64 1}
+!38 = !{!36, !18, i64 4}
+!39 = !{!36, !15, i64 32}
+!40 = !DILocation(line: 13, column: 3, scope: !10)
+!41 = !DILocation(line: 7, column: 8, scope: !42)
+!42 = distinct !DISubprogram(name: "AttrReaderSigChecked.<static-init>", linkageName: "func_AttrReaderSigChecked.<static-init>L62$block_1", scope: !10, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!43 = !DILocation(line: 16, column: 5, scope: !44)
+!44 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!45 = !DILocation(line: 19, column: 7, scope: !44)
+!46 = !DILocation(line: 21, column: 3, scope: !44)
+!47 = !DILocation(line: 23, column: 3, scope: !44)
+!48 = !DILocation(line: 26, column: 1, scope: !44)
+!49 = !DILocation(line: 27, column: 6, scope: !44)
+!50 = !DILocation(line: 27, column: 1, scope: !44)
+!51 = !DILocation(line: 12, column: 8, scope: !52)
+!52 = distinct !DISubprogram(name: "AttrReaderSigChecked.<static-init>", linkageName: "func_AttrReaderSigChecked.<static-init>L62$block_2", scope: !10, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!53 = !{!54, !7, i64 400}
+!54 = !{!"rb_vm_struct", !7, i64 0, !55, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !32, i64 216, !8, i64 224, !56, i64 264, !56, i64 280, !56, i64 296, !56, i64 312, !7, i64 328, !18, i64 336, !18, i64 340, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !58, i64 472, !59, i64 992, !15, i64 1016, !15, i64 1024, !18, i64 1032, !18, i64 1036, !56, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !18, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !18, i64 1192, !60, i64 1200, !8, i64 1232}
+!55 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !56, i64 48, !15, i64 64, !18, i64 72, !8, i64 80, !8, i64 128, !18, i64 176, !18, i64 180}
+!56 = !{!"list_head", !57, i64 0}
+!57 = !{!"list_node", !15, i64 0, !15, i64 8}
+!58 = !{!"", !8, i64 0}
+!59 = !{!"rb_hook_list_struct", !15, i64 0, !18, i64 8, !18, i64 12, !18, i64 16}
+!60 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!61 = !DILocation(line: 0, scope: !44)
+!62 = !DILocation(line: 5, column: 1, scope: !44)
+!63 = !DILocation(line: 18, column: 5, scope: !44)
+!64 = !{!"branch_weights", i32 1, i32 2000}
+!65 = !{!"branch_weights", i32 1073205, i32 2146410443}
+!66 = !{!67, !7, i64 0}
+!67 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!68 = !{!69}
+!69 = distinct !{!69, !70, !"sorbet_rb_int_lt: argument 0"}
+!70 = distinct !{!70, !"sorbet_rb_int_lt"}
+!71 = !{!"branch_weights", i32 4001, i32 4000000}
+!72 = !{!73}
+!73 = distinct !{!73, !74, !"sorbet_rb_int_plus: argument 0"}
+!74 = distinct !{!74, !"sorbet_rb_int_plus"}
+!75 = distinct !DISubprogram(name: "AttrReaderSigChecked#initialize", linkageName: "func_AttrReaderSigChecked#initialize", scope: null, file: !4, line: 8, type: !11, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!76 = !DILocation(line: 8, column: 3, scope: !75)
+!77 = !DILocation(line: 8, column: 18, scope: !75)
+!78 = !DILocation(line: 9, column: 12, scope: !75)
+!79 = !DILocation(line: 9, column: 5, scope: !75)
+!80 = distinct !DISubprogram(name: "AttrReaderSigChecked#foo", linkageName: "func_AttrReaderSigChecked#foo", scope: null, file: !4, line: 13, type: !11, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!81 = !DILocation(line: 13, column: 3, scope: !80)
+!82 = !DILocation(line: 13, column: 16, scope: !80)
+!83 = !DILocation(line: 0, scope: !80)
+!84 = !{!21, !7, i64 24}
+!85 = !DILocation(line: 7, column: 15, scope: !42)
+!86 = !DILocation(line: 7, column: 3, scope: !42)
+!87 = !DILocation(line: 12, column: 3, scope: !52)
+!88 = distinct !DISubprogram(name: "func_AttrReaderSigChecked#initialize.cold.1", linkageName: "func_AttrReaderSigChecked#initialize.cold.1", scope: null, file: !4, type: !89, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!89 = !DISubroutineType(types: !5)
+!90 = !DILocation(line: 8, column: 18, scope: !88)
+!91 = distinct !DISubprogram(name: "func_AttrReaderSigChecked#foo.cold.1", linkageName: "func_AttrReaderSigChecked#foo.cold.1", scope: null, file: !4, type: !89, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)

--- a/test/testdata/ruby_benchmark/stripe/prop_const_getter.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/prop_const_getter.llo.exp
@@ -255,185 +255,185 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #14
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
-  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !4
+  %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
   tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #14
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_MyStruct.<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !8 {
+define internal fastcc void @"func_MyStruct.<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !10 {
 fastSymCallIntrinsic_Static_sig:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.<static-init>", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !14
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !18
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !20
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !20
-  %6 = load i64, i64* %5, align 8, !tbaa !4
+  %5 = load i64*, i64** %4, align 8, !tbaa !22
+  %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !4
+  store i64 %7, i64* %5, align 8, !tbaa !6
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #15
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !21, !tbaa !12
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !22, !tbaa !12
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !22
-  %11 = load i32, i32* %10, align 8, !dbg !22, !tbaa !23
-  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !22
-  %13 = load i32, i32* %12, align 4, !dbg !22, !tbaa !24
-  %14 = xor i32 %13, -1, !dbg !22
-  %15 = and i32 %14, %11, !dbg !22
-  %16 = icmp eq i32 %15, 0, !dbg !22
-  br i1 %16, label %fastSymCallIntrinsic_Static_sig53, label %17, !dbg !22, !prof !25
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !23, !tbaa !14
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !14
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !24
+  %11 = load i32, i32* %10, align 8, !dbg !24, !tbaa !25
+  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !24
+  %13 = load i32, i32* %12, align 4, !dbg !24, !tbaa !26
+  %14 = xor i32 %13, -1, !dbg !24
+  %15 = and i32 %14, %11, !dbg !24
+  %16 = icmp eq i32 %15, 0, !dbg !24
+  br i1 %16, label %fastSymCallIntrinsic_Static_sig53, label %17, !dbg !24, !prof !27
 
 17:                                               ; preds = %fastSymCallIntrinsic_Static_sig
-  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !22
-  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !22, !tbaa !26
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !22
-  br label %fastSymCallIntrinsic_Static_sig53, !dbg !22
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
+  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !24, !tbaa !28
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !24
+  br label %fastSymCallIntrinsic_Static_sig53, !dbg !24
 
 fastSymCallIntrinsic_Static_sig53:                ; preds = %fastSymCallIntrinsic_Static_sig, %17
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !22, !tbaa !12
-  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !27, !tbaa !12
-  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !27
-  %23 = load i32, i32* %22, align 8, !dbg !27, !tbaa !23
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 6, !dbg !27
-  %25 = load i32, i32* %24, align 4, !dbg !27, !tbaa !24
-  %26 = xor i32 %25, -1, !dbg !27
-  %27 = and i32 %26, %23, !dbg !27
-  %28 = icmp eq i32 %27, 0, !dbg !27
-  br i1 %28, label %sorbet_setupParamKeywords.exit, label %29, !dbg !27, !prof !25
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !24, !tbaa !14
+  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !29
+  %23 = load i32, i32* %22, align 8, !dbg !29, !tbaa !25
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 6, !dbg !29
+  %25 = load i32, i32* %24, align 4, !dbg !29, !tbaa !26
+  %26 = xor i32 %25, -1, !dbg !29
+  %27 = and i32 %26, %23, !dbg !29
+  %28 = icmp eq i32 %27, 0, !dbg !29
+  br i1 %28, label %sorbet_setupParamKeywords.exit, label %29, !dbg !29, !prof !27
 
 29:                                               ; preds = %fastSymCallIntrinsic_Static_sig53
-  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !27
-  %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !27, !tbaa !26
-  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #15, !dbg !27
-  br label %sorbet_setupParamKeywords.exit, !dbg !27
+  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !29
+  %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !29, !tbaa !28
+  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #15, !dbg !29
+  br label %sorbet_setupParamKeywords.exit, !dbg !29
 
 sorbet_setupParamKeywords.exit:                   ; preds = %29, %fastSymCallIntrinsic_Static_sig53
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !27, !tbaa !12
-  %rubyId_initialize = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !22
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_initialize), !dbg !22
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !22
-  %rawSym58 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !22
-  %33 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !22
-  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !28
-  %needTakeSlowPath = icmp ne i64 %33, %34, !dbg !22
-  br i1 %needTakeSlowPath, label %35, label %36, !dbg !22, !prof !30
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !29, !tbaa !14
+  %rubyId_initialize = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !24
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_initialize), !dbg !24
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !24
+  %rawSym58 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !24
+  %33 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !24
+  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !30
+  %needTakeSlowPath = icmp ne i64 %33, %34, !dbg !24
+  br i1 %needTakeSlowPath, label %35, label %36, !dbg !24, !prof !32
 
 35:                                               ; preds = %sorbet_setupParamKeywords.exit
-  tail call void @const_recompute_MyStruct(), !dbg !22
-  br label %36, !dbg !22
+  tail call void @const_recompute_MyStruct(), !dbg !24
+  br label %36, !dbg !24
 
 36:                                               ; preds = %sorbet_setupParamKeywords.exit, %35
-  %37 = load i64, i64* @guarded_const_MyStruct, align 8, !dbg !22
-  %38 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !22
-  %39 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !28
-  %guardUpdated = icmp eq i64 %38, %39, !dbg !22
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !22
-  %stackFrame62 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct#initialize", align 8, !dbg !22
-  %40 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !22
-  %41 = bitcast i8* %40 to i16*, !dbg !22
-  %42 = load i16, i16* %41, align 8, !dbg !22
-  %43 = and i16 %42, -384, !dbg !22
-  %44 = or i16 %43, 16, !dbg !22
-  store i16 %44, i16* %41, align 8, !dbg !22
-  %45 = getelementptr inbounds i8, i8* %40, i64 8, !dbg !22
-  %46 = bitcast i8* %45 to i32*, !dbg !22
-  %47 = getelementptr inbounds i8, i8* %40, i64 4, !dbg !22
-  %48 = bitcast i8* %47 to i32*, !dbg !22
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %45, i8 0, i64 24, i1 false), !dbg !22
-  store i32 1, i32* %48, align 4, !dbg !22, !tbaa !31
-  %keyword_table = alloca i64, align 8, !dbg !22
-  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !22
-  store i64 %rubyId_foo, i64* %keyword_table, align 8, !dbg !22
-  %49 = getelementptr inbounds i8, i8* %40, i64 40, !dbg !22
-  %50 = bitcast i8* %49 to i32*, !dbg !22
-  store i32 1, i32* %50, align 8, !dbg !22, !tbaa !34
-  %51 = getelementptr inbounds i8, i8* %40, i64 44, !dbg !22
-  %52 = bitcast i8* %51 to i32*, !dbg !22
-  store i32 1, i32* %52, align 4, !dbg !22, !tbaa !35
-  %53 = getelementptr inbounds i8, i8* %40, i64 48, !dbg !22
-  %54 = bitcast i8* %53 to i32*, !dbg !22
-  store i32 1, i32* %54, align 8, !dbg !22, !tbaa !36
-  %55 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !22
-  %56 = bitcast i64* %keyword_table to i8*, !dbg !22
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %55, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %56, i64 noundef 8, i1 noundef false) #15, !dbg !22
-  %57 = getelementptr inbounds i8, i8* %40, i64 56, !dbg !22
-  %58 = bitcast i8* %57 to i8**, !dbg !22
-  store i8* %55, i8** %58, align 8, !dbg !22, !tbaa !37
-  tail call void @sorbet_vm_define_method(i64 %37, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_MyStruct#initialize", i8* nonnull %40, %struct.rb_iseq_struct* %stackFrame62, i1 noundef zeroext false) #15, !dbg !22
-  %59 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !22, !tbaa !12
-  %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 5, !dbg !22
-  %61 = load i32, i32* %60, align 8, !dbg !22, !tbaa !23
-  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 6, !dbg !22
-  %63 = load i32, i32* %62, align 4, !dbg !22, !tbaa !24
-  %64 = xor i32 %63, -1, !dbg !22
-  %65 = and i32 %64, %61, !dbg !22
-  %66 = icmp eq i32 %65, 0, !dbg !22
-  br i1 %66, label %fastSymCallIntrinsic_Static_keep_def84, label %67, !dbg !22, !prof !25
+  %37 = load i64, i64* @guarded_const_MyStruct, align 8, !dbg !24
+  %38 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !24
+  %39 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !30
+  %guardUpdated = icmp eq i64 %38, %39, !dbg !24
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !24
+  %stackFrame62 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct#initialize", align 8, !dbg !24
+  %40 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !24
+  %41 = bitcast i8* %40 to i16*, !dbg !24
+  %42 = load i16, i16* %41, align 8, !dbg !24
+  %43 = and i16 %42, -384, !dbg !24
+  %44 = or i16 %43, 16, !dbg !24
+  store i16 %44, i16* %41, align 8, !dbg !24
+  %45 = getelementptr inbounds i8, i8* %40, i64 8, !dbg !24
+  %46 = bitcast i8* %45 to i32*, !dbg !24
+  %47 = getelementptr inbounds i8, i8* %40, i64 4, !dbg !24
+  %48 = bitcast i8* %47 to i32*, !dbg !24
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %45, i8 0, i64 24, i1 false), !dbg !24
+  store i32 1, i32* %48, align 4, !dbg !24, !tbaa !33
+  %keyword_table = alloca i64, align 8, !dbg !24
+  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !24
+  store i64 %rubyId_foo, i64* %keyword_table, align 8, !dbg !24
+  %49 = getelementptr inbounds i8, i8* %40, i64 40, !dbg !24
+  %50 = bitcast i8* %49 to i32*, !dbg !24
+  store i32 1, i32* %50, align 8, !dbg !24, !tbaa !36
+  %51 = getelementptr inbounds i8, i8* %40, i64 44, !dbg !24
+  %52 = bitcast i8* %51 to i32*, !dbg !24
+  store i32 1, i32* %52, align 4, !dbg !24, !tbaa !37
+  %53 = getelementptr inbounds i8, i8* %40, i64 48, !dbg !24
+  %54 = bitcast i8* %53 to i32*, !dbg !24
+  store i32 1, i32* %54, align 8, !dbg !24, !tbaa !38
+  %55 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !24
+  %56 = bitcast i64* %keyword_table to i8*, !dbg !24
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %55, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %56, i64 noundef 8, i1 noundef false) #15, !dbg !24
+  %57 = getelementptr inbounds i8, i8* %40, i64 56, !dbg !24
+  %58 = bitcast i8* %57 to i8**, !dbg !24
+  store i8* %55, i8** %58, align 8, !dbg !24, !tbaa !39
+  tail call void @sorbet_vm_define_method(i64 %37, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_MyStruct#initialize", i8* nonnull %40, %struct.rb_iseq_struct* %stackFrame62, i1 noundef zeroext false) #15, !dbg !24
+  %59 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !14
+  %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 5, !dbg !24
+  %61 = load i32, i32* %60, align 8, !dbg !24, !tbaa !25
+  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 6, !dbg !24
+  %63 = load i32, i32* %62, align 4, !dbg !24, !tbaa !26
+  %64 = xor i32 %63, -1, !dbg !24
+  %65 = and i32 %64, %61, !dbg !24
+  %66 = icmp eq i32 %65, 0, !dbg !24
+  br i1 %66, label %fastSymCallIntrinsic_Static_keep_def84, label %67, !dbg !24, !prof !27
 
 67:                                               ; preds = %36
-  %68 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 8, !dbg !22
-  %69 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %68, align 8, !dbg !22, !tbaa !26
-  %70 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %69, i32 noundef 0) #15, !dbg !22
-  br label %fastSymCallIntrinsic_Static_keep_def84, !dbg !22
+  %68 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 8, !dbg !24
+  %69 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %68, align 8, !dbg !24, !tbaa !28
+  %70 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %69, i32 noundef 0) #15, !dbg !24
+  br label %fastSymCallIntrinsic_Static_keep_def84, !dbg !24
 
 afterSend81:                                      ; preds = %91, %fastSymCallIntrinsic_Static_keep_def84
   ret void
 
 fastSymCallIntrinsic_Static_keep_def84:           ; preds = %36, %67
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !22, !tbaa !12
-  %rubyId_foo67 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !38
-  %rawSym68 = tail call i64 @rb_id2sym(i64 %rubyId_foo67), !dbg !38
-  %rubyId_without_accessors = load i64, i64* @rubyIdPrecomputed_without_accessors, align 8, !dbg !27
-  %rawSym69 = tail call i64 @rb_id2sym(i64 %rubyId_without_accessors), !dbg !27
-  %71 = load i64, i64* @rb_cInteger, align 8, !dbg !27
-  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !27
-  %73 = load i64*, i64** %72, align 8, !dbg !27
-  store i64 %selfRaw, i64* %73, align 8, !dbg !27, !tbaa !4
-  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !27
-  store i64 %rawSym68, i64* %74, align 8, !dbg !27, !tbaa !4
-  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !27
-  store i64 %71, i64* %75, align 8, !dbg !27, !tbaa !4
-  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !27
-  store i64 20, i64* %76, align 8, !dbg !27, !tbaa !4
-  %77 = getelementptr inbounds i64, i64* %76, i64 1, !dbg !27
-  store i64* %77, i64** %72, align 8, !dbg !27
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_const, i64 0), !dbg !27
-  %rubyId_foo76 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !27
-  %rawSym77 = tail call i64 @rb_id2sym(i64 %rubyId_foo76), !dbg !27
-  %rubyId_attr_reader = load i64, i64* @rubyIdPrecomputed_attr_reader, align 8, !dbg !27
-  %rawSym78 = tail call i64 @rb_id2sym(i64 %rubyId_attr_reader), !dbg !27
-  %78 = tail call i64 @rb_intern(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0)) #15, !dbg !27
-  %79 = tail call i64 @rb_id2str(i64 %78) #15, !dbg !27
-  %80 = tail call i64 (i8*, ...) @rb_sprintf(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i64 %79) #15, !dbg !27
-  %81 = tail call i64 @rb_intern_str(i64 %80) #15, !dbg !27
-  %82 = inttoptr i64 %81 to i8*, !dbg !27
-  tail call void @rb_add_method(i64 %37, i64 %78, i32 noundef 4, i8* %82, i32 noundef 1) #15, !dbg !27
-  %83 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !27, !tbaa !12
-  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 5, !dbg !27
-  %85 = load i32, i32* %84, align 8, !dbg !27, !tbaa !23
-  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 6, !dbg !27
-  %87 = load i32, i32* %86, align 4, !dbg !27, !tbaa !24
-  %88 = xor i32 %87, -1, !dbg !27
-  %89 = and i32 %88, %85, !dbg !27
-  %90 = icmp eq i32 %89, 0, !dbg !27
-  br i1 %90, label %afterSend81, label %91, !dbg !27, !prof !25
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !24, !tbaa !14
+  %rubyId_foo67 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
+  %rawSym68 = tail call i64 @rb_id2sym(i64 %rubyId_foo67), !dbg !40
+  %rubyId_without_accessors = load i64, i64* @rubyIdPrecomputed_without_accessors, align 8, !dbg !29
+  %rawSym69 = tail call i64 @rb_id2sym(i64 %rubyId_without_accessors), !dbg !29
+  %71 = load i64, i64* @rb_cInteger, align 8, !dbg !29
+  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !29
+  %73 = load i64*, i64** %72, align 8, !dbg !29
+  store i64 %selfRaw, i64* %73, align 8, !dbg !29, !tbaa !6
+  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !29
+  store i64 %rawSym68, i64* %74, align 8, !dbg !29, !tbaa !6
+  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !29
+  store i64 %71, i64* %75, align 8, !dbg !29, !tbaa !6
+  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !29
+  store i64 20, i64* %76, align 8, !dbg !29, !tbaa !6
+  %77 = getelementptr inbounds i64, i64* %76, i64 1, !dbg !29
+  store i64* %77, i64** %72, align 8, !dbg !29
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_const, i64 0), !dbg !29
+  %rubyId_foo76 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !29
+  %rawSym77 = tail call i64 @rb_id2sym(i64 %rubyId_foo76), !dbg !29
+  %rubyId_attr_reader = load i64, i64* @rubyIdPrecomputed_attr_reader, align 8, !dbg !29
+  %rawSym78 = tail call i64 @rb_id2sym(i64 %rubyId_attr_reader), !dbg !29
+  %78 = tail call i64 @rb_intern(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0)) #15, !dbg !29
+  %79 = tail call i64 @rb_id2str(i64 %78) #15, !dbg !29
+  %80 = tail call i64 (i8*, ...) @rb_sprintf(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i64 %79) #15, !dbg !29
+  %81 = tail call i64 @rb_intern_str(i64 %80) #15, !dbg !29
+  %82 = inttoptr i64 %81 to i8*, !dbg !29
+  tail call void @rb_add_method(i64 %37, i64 %78, i32 noundef 4, i8* %82, i32 noundef 1) #15, !dbg !29
+  %83 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
+  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 5, !dbg !29
+  %85 = load i32, i32* %84, align 8, !dbg !29, !tbaa !25
+  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 6, !dbg !29
+  %87 = load i32, i32* %86, align 4, !dbg !29, !tbaa !26
+  %88 = xor i32 %87, -1, !dbg !29
+  %89 = and i32 %88, %85, !dbg !29
+  %90 = icmp eq i32 %89, 0, !dbg !29
+  br i1 %90, label %afterSend81, label %91, !dbg !29, !prof !27
 
 91:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def84
-  %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 8, !dbg !27
-  %93 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %92, align 8, !dbg !27, !tbaa !26
-  %94 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %93, i32 noundef 0) #15, !dbg !27
-  br label %afterSend81, !dbg !27
+  %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 8, !dbg !29
+  %93 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %92, align 8, !dbg !29, !tbaa !28
+  %94 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %93, i32 noundef 0) #15, !dbg !29
+  br label %afterSend81, !dbg !29
 }
 
 ; Function Attrs: sspreq
@@ -442,9 +442,9 @@ entry:
   %locals.i31.i = alloca i64, align 8
   %locals.i27.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, align 8, !dbg !39
-  %keywords11.i = alloca i64, align 8, !dbg !41
-  %keywords20.i = alloca i64, align 8, !dbg !27
+  %keywords.i = alloca i64, align 8, !dbg !41
+  %keywords11.i = alloca i64, align 8, !dbg !43
+  %keywords20.i = alloca i64, align 8, !dbg !29
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
@@ -502,23 +502,23 @@ entry:
   %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
   %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !39
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !39
-  %25 = call i64 @rb_id2sym(i64 %rubyId_foo.i) #15, !dbg !39
-  store i64 %25, i64* %keywords.i, align 8, !dbg !39
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 64, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !39
-  %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_<", i64 %"rubyId_<.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !43
-  %rubyId_foo1.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo1.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !44
-  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !45
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
-  %rubyId_foo5.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !47
-  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !41
+  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !41
+  %25 = call i64 @rb_id2sym(i64 %rubyId_foo.i) #15, !dbg !41
+  store i64 %25, i64* %keywords.i, align 8, !dbg !41
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 64, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !41
+  %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_<", i64 %"rubyId_<.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
+  %rubyId_foo1.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo1.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !46
+  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
+  %rubyId_foo5.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !49
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !49
+  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !50
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
   %26 = call i64 @rb_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
   call void @rb_gc_register_mark_object(i64 %26) #15
   %rubyId_initialize.i.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8
@@ -551,428 +551,428 @@ entry:
   %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i36.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
   %33 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block for.i35.i", i64 %"rubyId_block for.i34.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i36.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i33.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %33, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.<static-init>$block_2", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
-  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !41
-  %rubyId_foo12.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !41
-  %34 = call i64 @rb_id2sym(i64 %rubyId_foo12.i) #15, !dbg !41
-  store i64 %34, i64* %keywords11.i, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 64, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords11.i), !dbg !41
-  %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !41
-  %rubyId_sig16.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !27
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.3, i64 %rubyId_sig16.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !27
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !49
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !22
-  %rubyId_const.i = load i64, i64* @rubyIdPrecomputed_const, align 8, !dbg !27
-  %rubyId_without_accessors.i = load i64, i64* @rubyIdPrecomputed_without_accessors, align 8, !dbg !27
-  %35 = call i64 @rb_id2sym(i64 %rubyId_without_accessors.i) #15, !dbg !27
-  store i64 %35, i64* %keywords20.i, align 8, !dbg !27
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_const, i64 %rubyId_const.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull %keywords20.i), !dbg !27
-  %rubyId_keep_def24.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !27
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def24.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !27
+  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
+  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !43
+  %rubyId_foo12.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !43
+  %34 = call i64 @rb_id2sym(i64 %rubyId_foo12.i) #15, !dbg !43
+  store i64 %34, i64* %keywords11.i, align 8, !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 64, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords11.i), !dbg !43
+  %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !43
+  %rubyId_sig16.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !29
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.3, i64 %rubyId_sig16.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
+  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !51
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !51
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
+  %rubyId_const.i = load i64, i64* @rubyIdPrecomputed_const, align 8, !dbg !29
+  %rubyId_without_accessors.i = load i64, i64* @rubyIdPrecomputed_without_accessors, align 8, !dbg !29
+  %35 = call i64 @rb_id2sym(i64 %rubyId_without_accessors.i) #15, !dbg !29
+  store i64 %35, i64* %keywords20.i, align 8, !dbg !29
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_const, i64 %rubyId_const.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull %keywords20.i), !dbg !29
+  %rubyId_keep_def24.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !29
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def24.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !29
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %2)
-  %36 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !12
+  %36 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %37 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %36, i64 0, i32 18
-  %38 = load i64, i64* %37, align 8, !tbaa !51
-  %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !12
+  %38 = load i64, i64* %37, align 8, !tbaa !53
+  %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %39, i64 0, i32 2
-  %41 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %40, align 8, !tbaa !14
+  %41 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %40, align 8, !tbaa !16
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$151", align 8
   %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %42, align 8, !tbaa !18
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %42, align 8, !tbaa !20
   %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 4
-  %44 = load i64*, i64** %43, align 8, !tbaa !20
-  %45 = load i64, i64* %44, align 8, !tbaa !4
+  %44 = load i64*, i64** %43, align 8, !tbaa !22
+  %45 = load i64, i64* %44, align 8, !tbaa !6
   %46 = and i64 %45, -33
-  store i64 %46, i64* %44, align 8, !tbaa !4
+  store i64 %46, i64* %44, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %39, %struct.rb_control_frame_struct* %41, %struct.rb_iseq_struct* %stackFrame.i) #15
   %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 0
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %47, align 8, !dbg !59, !tbaa !12
-  %48 = load i64, i64* @"guard_epoch_T::Struct", align 8, !dbg !60
-  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !60, !tbaa !28
-  %needTakeSlowPath = icmp ne i64 %48, %49, !dbg !60
-  br i1 %needTakeSlowPath, label %50, label %51, !dbg !60, !prof !30
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %47, align 8, !dbg !61, !tbaa !14
+  %48 = load i64, i64* @"guard_epoch_T::Struct", align 8, !dbg !62
+  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !62, !tbaa !30
+  %needTakeSlowPath = icmp ne i64 %48, %49, !dbg !62
+  br i1 %needTakeSlowPath, label %50, label %51, !dbg !62, !prof !32
 
 50:                                               ; preds = %entry
-  call void @"const_recompute_T::Struct"(), !dbg !60
-  br label %51, !dbg !60
+  call void @"const_recompute_T::Struct"(), !dbg !62
+  br label %51, !dbg !62
 
 51:                                               ; preds = %entry, %50
-  %52 = load i64, i64* @"guarded_const_T::Struct", align 8, !dbg !60
-  %53 = load i64, i64* @"guard_epoch_T::Struct", align 8, !dbg !60
-  %54 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !60, !tbaa !28
-  %guardUpdated = icmp eq i64 %53, %54, !dbg !60
-  call void @llvm.assume(i1 %guardUpdated), !dbg !60
-  %55 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_MyStruct, i64 0, i64 0), i64 %52) #15, !dbg !60
-  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #15, !dbg !60
-  call fastcc void @"func_MyStruct.<static-init>L62"(i64 %55, %struct.rb_control_frame_struct* %56) #15, !dbg !60
-  call void @sorbet_popFrame() #15, !dbg !60
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %47, align 8, !dbg !61, !tbaa !12
-  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !62
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #15, !dbg !62
-  %57 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !39
-  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !39, !tbaa !28
-  %needTakeSlowPath2 = icmp ne i64 %57, %58, !dbg !39
-  br i1 %needTakeSlowPath2, label %59, label %60, !dbg !39, !prof !30
+  %52 = load i64, i64* @"guarded_const_T::Struct", align 8, !dbg !62
+  %53 = load i64, i64* @"guard_epoch_T::Struct", align 8, !dbg !62
+  %54 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !62, !tbaa !30
+  %guardUpdated = icmp eq i64 %53, %54, !dbg !62
+  call void @llvm.assume(i1 %guardUpdated), !dbg !62
+  %55 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_MyStruct, i64 0, i64 0), i64 %52) #15, !dbg !62
+  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #15, !dbg !62
+  call fastcc void @"func_MyStruct.<static-init>L62"(i64 %55, %struct.rb_control_frame_struct* %56) #15, !dbg !62
+  call void @sorbet_popFrame() #15, !dbg !62
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %47, align 8, !dbg !63, !tbaa !14
+  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !64
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #15, !dbg !64
+  %57 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !41
+  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !30
+  %needTakeSlowPath2 = icmp ne i64 %57, %58, !dbg !41
+  br i1 %needTakeSlowPath2, label %59, label %60, !dbg !41, !prof !32
 
 59:                                               ; preds = %51
-  call void @const_recompute_MyStruct(), !dbg !39
-  br label %60, !dbg !39
+  call void @const_recompute_MyStruct(), !dbg !41
+  br label %60, !dbg !41
 
 60:                                               ; preds = %51, %59
-  %61 = load i64, i64* @guarded_const_MyStruct, align 8, !dbg !39
-  %62 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !39
-  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !39, !tbaa !28
-  %guardUpdated3 = icmp eq i64 %62, %63, !dbg !39
-  call void @llvm.assume(i1 %guardUpdated3), !dbg !39
-  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !39
-  %65 = load i64*, i64** %64, align 8, !dbg !39
-  store i64 %61, i64* %65, align 8, !dbg !39, !tbaa !4
-  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !39
-  store i64 861, i64* %66, align 8, !dbg !39, !tbaa !4
-  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !39
-  store i64* %67, i64** %64, align 8, !dbg !39
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !39
-  br label %BB2.i, !dbg !63
+  %61 = load i64, i64* @guarded_const_MyStruct, align 8, !dbg !41
+  %62 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !41
+  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !30
+  %guardUpdated3 = icmp eq i64 %62, %63, !dbg !41
+  call void @llvm.assume(i1 %guardUpdated3), !dbg !41
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !41
+  %65 = load i64*, i64** %64, align 8, !dbg !41
+  store i64 %61, i64* %65, align 8, !dbg !41, !tbaa !6
+  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !41
+  store i64 861, i64* %66, align 8, !dbg !41, !tbaa !6
+  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !41
+  store i64* %67, i64** %64, align 8, !dbg !41
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !41
+  br label %BB2.i, !dbg !65
 
 BB2.i:                                            ; preds = %BB2.i.backedge, %60
-  %i.sroa.0.0.i = phi i64 [ 1, %60 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !59
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %47, align 8, !tbaa !12
-  %68 = and i64 %i.sroa.0.0.i, 1, !dbg !43
-  %69 = icmp eq i64 %68, 0, !dbg !43
-  br i1 %69, label %70, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !43, !prof !64
+  %i.sroa.0.0.i = phi i64 [ 1, %60 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !61
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %47, align 8, !tbaa !14
+  %68 = and i64 %i.sroa.0.0.i, 1, !dbg !45
+  %69 = icmp eq i64 %68, 0, !dbg !45
+  br i1 %69, label %70, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !45, !prof !66
 
 70:                                               ; preds = %BB2.i
-  %71 = and i64 %i.sroa.0.0.i, 7, !dbg !43
-  %72 = icmp ne i64 %71, 0, !dbg !43
-  %73 = and i64 %i.sroa.0.0.i, -9, !dbg !43
-  %74 = icmp eq i64 %73, 0, !dbg !43
-  %75 = or i1 %72, %74, !dbg !43
-  br i1 %75, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !43, !prof !65
+  %71 = and i64 %i.sroa.0.0.i, 7, !dbg !45
+  %72 = icmp ne i64 %71, 0, !dbg !45
+  %73 = and i64 %i.sroa.0.0.i, -9, !dbg !45
+  %74 = icmp eq i64 %73, 0, !dbg !45
+  %75 = or i1 %72, %74, !dbg !45
+  br i1 %75, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !45, !prof !67
 
 sorbet_isa_Integer.exit:                          ; preds = %70
-  %76 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !43
-  %77 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %76, i64 0, i32 0, !dbg !43
-  %78 = load i64, i64* %77, align 8, !dbg !43, !tbaa !66
-  %79 = and i64 %78, 31, !dbg !43
-  %80 = icmp eq i64 %79, 10, !dbg !43
-  br i1 %80, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !43, !prof !25
+  %76 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !45
+  %77 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %76, i64 0, i32 0, !dbg !45
+  %78 = load i64, i64* %77, align 8, !dbg !45, !tbaa !68
+  %79 = and i64 %78, 31, !dbg !45
+  %80 = icmp eq i64 %79, 10, !dbg !45
+  br i1 %80, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !45, !prof !27
 
 BB5.i:                                            ; preds = %afterSend40.i
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %47, align 8, !tbaa !12
-  %81 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !44
-  %82 = load i64*, i64** %81, align 8, !dbg !44
-  store i64 %send, i64* %82, align 8, !dbg !44, !tbaa !4
-  %83 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !44
-  store i64* %83, i64** %81, align 8, !dbg !44
-  %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !44
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %47, align 8, !dbg !44, !tbaa !12
-  br i1 %84, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !45
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %47, align 8, !tbaa !14
+  %81 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !46
+  %82 = load i64*, i64** %81, align 8, !dbg !46
+  store i64 %send, i64* %82, align 8, !dbg !46, !tbaa !6
+  %83 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !46
+  store i64* %83, i64** %81, align 8, !dbg !46
+  %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !46
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %47, align 8, !dbg !46, !tbaa !14
+  br i1 %84, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !47
 
 afterSend40.i:                                    ; preds = %109, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
   %84 = phi i1 [ %87, %"alternativeCallIntrinsic_Integer_<.i" ], [ %92, %sorbet_rb_int_lt.exit.i ], [ %92, %109 ]
-  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send7, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult92.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult92.i, %109 ], !dbg !43
-  %85 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !43
-  %86 = icmp ne i64 %85, 0, !dbg !43
-  br i1 %86, label %BB5.i, label %"func_<root>.<static-init>$151.exit", !dbg !43
+  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send7, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult92.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult92.i, %109 ], !dbg !45
+  %85 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !45
+  %86 = icmp ne i64 %85, 0, !dbg !45
+  br i1 %86, label %BB5.i, label %"func_<root>.<static-init>$151.exit", !dbg !45
 
 "alternativeCallIntrinsic_Integer_<.i":           ; preds = %70, %sorbet_isa_Integer.exit
   %87 = phi i1 [ %80, %sorbet_isa_Integer.exit ], [ false, %70 ]
-  %88 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !43
-  %89 = load i64*, i64** %88, align 8, !dbg !43
-  store i64 %i.sroa.0.0.i, i64* %89, align 8, !dbg !43, !tbaa !4
-  %90 = getelementptr inbounds i64, i64* %89, i64 1, !dbg !43
-  store i64 20000001, i64* %90, align 8, !dbg !43, !tbaa !4
-  %91 = getelementptr inbounds i64, i64* %90, i64 1, !dbg !43
-  store i64* %91, i64** %88, align 8, !dbg !43
-  %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !43
-  br label %afterSend40.i, !dbg !43
+  %88 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !45
+  %89 = load i64*, i64** %88, align 8, !dbg !45
+  store i64 %i.sroa.0.0.i, i64* %89, align 8, !dbg !45, !tbaa !6
+  %90 = getelementptr inbounds i64, i64* %89, i64 1, !dbg !45
+  store i64 20000001, i64* %90, align 8, !dbg !45, !tbaa !6
+  %91 = getelementptr inbounds i64, i64* %90, i64 1, !dbg !45
+  store i64* %91, i64** %88, align 8, !dbg !45
+  %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !45
+  br label %afterSend40.i, !dbg !45
 
 "fastSymCallIntrinsic_Integer_<.i":               ; preds = %BB2.i, %sorbet_isa_Integer.exit
   %92 = phi i1 [ %80, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
-  call void @llvm.experimental.noalias.scope.decl(metadata !68) #15, !dbg !43
-  %93 = and i64 %i.sroa.0.0.i, 1, !dbg !43
-  %94 = icmp eq i64 %93, 0, !dbg !43
-  br i1 %94, label %99, label %95, !dbg !43, !prof !71
+  call void @llvm.experimental.noalias.scope.decl(metadata !70) #15, !dbg !45
+  %93 = and i64 %i.sroa.0.0.i, 1, !dbg !45
+  %94 = icmp eq i64 %93, 0, !dbg !45
+  br i1 %94, label %99, label %95, !dbg !45, !prof !73
 
 95:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %96 = ashr i64 %i.sroa.0.0.i, 1, !dbg !43
-  %97 = icmp slt i64 %96, 10000000, !dbg !43
-  %98 = select i1 %97, i64 20, i64 0, !dbg !43
-  br label %sorbet_rb_int_lt.exit.i, !dbg !43
+  %96 = ashr i64 %i.sroa.0.0.i, 1, !dbg !45
+  %97 = icmp slt i64 %96, 10000000, !dbg !45
+  %98 = select i1 %97, i64 20, i64 0, !dbg !45
+  br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
 99:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %100 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !43, !noalias !68
-  br label %sorbet_rb_int_lt.exit.i, !dbg !43
+  %100 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !45, !noalias !70
+  br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
 sorbet_rb_int_lt.exit.i:                          ; preds = %99, %95
   %rawSendResult92.i = phi i64 [ %98, %95 ], [ %100, %99 ]
-  %101 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !43, !tbaa !12
-  %102 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 5, !dbg !43
-  %103 = load i32, i32* %102, align 8, !dbg !43, !tbaa !23
-  %104 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 6, !dbg !43
-  %105 = load i32, i32* %104, align 4, !dbg !43, !tbaa !24
-  %106 = xor i32 %105, -1, !dbg !43
-  %107 = and i32 %106, %103, !dbg !43
-  %108 = icmp eq i32 %107, 0, !dbg !43
-  br i1 %108, label %afterSend40.i, label %109, !dbg !43, !prof !25
+  %101 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !14
+  %102 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 5, !dbg !45
+  %103 = load i32, i32* %102, align 8, !dbg !45, !tbaa !25
+  %104 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 6, !dbg !45
+  %105 = load i32, i32* %104, align 4, !dbg !45, !tbaa !26
+  %106 = xor i32 %105, -1, !dbg !45
+  %107 = and i32 %106, %103, !dbg !45
+  %108 = icmp eq i32 %107, 0, !dbg !45
+  br i1 %108, label %afterSend40.i, label %109, !dbg !45, !prof !27
 
 109:                                              ; preds = %sorbet_rb_int_lt.exit.i
-  %110 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 8, !dbg !43
-  %111 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %110, align 8, !dbg !43, !tbaa !26
-  %112 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %111, i32 noundef 0) #15, !dbg !43
-  br label %afterSend40.i, !dbg !43
+  %110 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 8, !dbg !45
+  %111 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %110, align 8, !dbg !45, !tbaa !28
+  %112 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %111, i32 noundef 0) #15, !dbg !45
+  br label %afterSend40.i, !dbg !45
 
 "alternativeCallIntrinsic_Integer_+.i":           ; preds = %BB5.i
-  %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !45
-  %114 = load i64*, i64** %113, align 8, !dbg !45
-  store i64 %i.sroa.0.0.i, i64* %114, align 8, !dbg !45, !tbaa !4
-  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !45
-  store i64 3, i64* %115, align 8, !dbg !45, !tbaa !4
-  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !45
-  store i64* %116, i64** %113, align 8, !dbg !45
-  %send9 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !45
-  br label %BB2.i.backedge, !dbg !45
+  %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !47
+  %114 = load i64*, i64** %113, align 8, !dbg !47
+  store i64 %i.sroa.0.0.i, i64* %114, align 8, !dbg !47, !tbaa !6
+  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !47
+  store i64 3, i64* %115, align 8, !dbg !47, !tbaa !6
+  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !47
+  store i64* %116, i64** %113, align 8, !dbg !47
+  %send9 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !47
+  br label %BB2.i.backedge, !dbg !47
 
 "fastSymCallIntrinsic_Integer_+.i":               ; preds = %BB5.i
-  call void @llvm.experimental.noalias.scope.decl(metadata !72) #15, !dbg !45
-  %117 = and i64 %i.sroa.0.0.i, 1, !dbg !45
-  %118 = icmp eq i64 %117, 0, !dbg !45
-  br i1 %118, label %127, label %119, !dbg !45, !prof !71
+  call void @llvm.experimental.noalias.scope.decl(metadata !74) #15, !dbg !47
+  %117 = and i64 %i.sroa.0.0.i, 1, !dbg !47
+  %118 = icmp eq i64 %117, 0, !dbg !47
+  br i1 %118, label %127, label %119, !dbg !47, !prof !73
 
 119:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %120 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !45
-  %121 = extractvalue { i64, i1 } %120, 1, !dbg !45
-  %122 = extractvalue { i64, i1 } %120, 0, !dbg !45
-  br i1 %121, label %123, label %sorbet_rb_int_plus.exit.i, !dbg !45
+  %120 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !47
+  %121 = extractvalue { i64, i1 } %120, 1, !dbg !47
+  %122 = extractvalue { i64, i1 } %120, 0, !dbg !47
+  br i1 %121, label %123, label %sorbet_rb_int_plus.exit.i, !dbg !47
 
 123:                                              ; preds = %119
-  %124 = ashr i64 %122, 1, !dbg !45
-  %125 = xor i64 %124, -9223372036854775808, !dbg !45
-  %126 = call i64 @rb_int2big(i64 %125) #15, !dbg !45
-  br label %sorbet_rb_int_plus.exit.i, !dbg !45
+  %124 = ashr i64 %122, 1, !dbg !47
+  %125 = xor i64 %124, -9223372036854775808, !dbg !47
+  %126 = call i64 @rb_int2big(i64 %125) #15, !dbg !47
+  br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
 127:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %128 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !45, !noalias !72
-  br label %sorbet_rb_int_plus.exit.i, !dbg !45
+  %128 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !47, !noalias !74
+  br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
 sorbet_rb_int_plus.exit.i:                        ; preds = %127, %123, %119
-  %129 = phi i64 [ %128, %127 ], [ %126, %123 ], [ %122, %119 ], !dbg !45
-  %130 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !12
-  %131 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %130, i64 0, i32 5, !dbg !45
-  %132 = load i32, i32* %131, align 8, !dbg !45, !tbaa !23
-  %133 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %130, i64 0, i32 6, !dbg !45
-  %134 = load i32, i32* %133, align 4, !dbg !45, !tbaa !24
-  %135 = xor i32 %134, -1, !dbg !45
-  %136 = and i32 %135, %132, !dbg !45
-  %137 = icmp eq i32 %136, 0, !dbg !45
-  br i1 %137, label %BB2.i.backedge, label %138, !dbg !45, !prof !25
+  %129 = phi i64 [ %128, %127 ], [ %126, %123 ], [ %122, %119 ], !dbg !47
+  %130 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !14
+  %131 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %130, i64 0, i32 5, !dbg !47
+  %132 = load i32, i32* %131, align 8, !dbg !47, !tbaa !25
+  %133 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %130, i64 0, i32 6, !dbg !47
+  %134 = load i32, i32* %133, align 4, !dbg !47, !tbaa !26
+  %135 = xor i32 %134, -1, !dbg !47
+  %136 = and i32 %135, %132, !dbg !47
+  %137 = icmp eq i32 %136, 0, !dbg !47
+  br i1 %137, label %BB2.i.backedge, label %138, !dbg !47, !prof !27
 
 138:                                              ; preds = %sorbet_rb_int_plus.exit.i
-  %139 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %130, i64 0, i32 8, !dbg !45
-  %140 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %139, align 8, !dbg !45, !tbaa !26
-  %141 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %140, i32 noundef 0) #15, !dbg !45
-  br label %BB2.i.backedge, !dbg !45
+  %139 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %130, i64 0, i32 8, !dbg !47
+  %140 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %139, align 8, !dbg !47, !tbaa !28
+  %141 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %140, i32 noundef 0) #15, !dbg !47
+  br label %BB2.i.backedge, !dbg !47
 
 BB2.i.backedge:                                   ; preds = %138, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
   %i.sroa.0.0.i.be = phi i64 [ %send9, %"alternativeCallIntrinsic_Integer_+.i" ], [ %129, %sorbet_rb_int_plus.exit.i ], [ %129, %138 ]
   br label %BB2.i
 
 "func_<root>.<static-init>$151.exit":             ; preds = %afterSend40.i
-  %i.sroa.0.0.i.lcssa = phi i64 [ %i.sroa.0.0.i, %afterSend40.i ], !dbg !59
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %47, align 8, !tbaa !12
-  %142 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !46
-  %143 = load i64*, i64** %142, align 8, !dbg !46
-  store i64 %38, i64* %143, align 8, !dbg !46, !tbaa !4
-  %144 = getelementptr inbounds i64, i64* %143, i64 1, !dbg !46
-  store i64 %i.sroa.0.0.i.lcssa, i64* %144, align 8, !dbg !46, !tbaa !4
-  %145 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !46
-  store i64* %145, i64** %142, align 8, !dbg !46
-  %send11 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !46
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %47, align 8, !dbg !46, !tbaa !12
-  %146 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !47
-  %147 = load i64*, i64** %146, align 8, !dbg !47
-  store i64 %send, i64* %147, align 8, !dbg !47, !tbaa !4
-  %148 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !47
-  store i64* %148, i64** %146, align 8, !dbg !47
-  %send13 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !47
-  %149 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !48
-  %150 = load i64*, i64** %149, align 8, !dbg !48
-  store i64 %38, i64* %150, align 8, !dbg !48, !tbaa !4
-  %151 = getelementptr inbounds i64, i64* %150, i64 1, !dbg !48
-  store i64 %send13, i64* %151, align 8, !dbg !48, !tbaa !4
-  %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !48
-  store i64* %152, i64** %149, align 8, !dbg !48
-  %send15 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !48
+  %i.sroa.0.0.i.lcssa = phi i64 [ %i.sroa.0.0.i, %afterSend40.i ], !dbg !61
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %47, align 8, !tbaa !14
+  %142 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !48
+  %143 = load i64*, i64** %142, align 8, !dbg !48
+  store i64 %38, i64* %143, align 8, !dbg !48, !tbaa !6
+  %144 = getelementptr inbounds i64, i64* %143, i64 1, !dbg !48
+  store i64 %i.sroa.0.0.i.lcssa, i64* %144, align 8, !dbg !48, !tbaa !6
+  %145 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !48
+  store i64* %145, i64** %142, align 8, !dbg !48
+  %send11 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !48
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %47, align 8, !dbg !48, !tbaa !14
+  %146 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !49
+  %147 = load i64*, i64** %146, align 8, !dbg !49
+  store i64 %send, i64* %147, align 8, !dbg !49, !tbaa !6
+  %148 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !49
+  store i64* %148, i64** %146, align 8, !dbg !49
+  %send13 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !49
+  %149 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !50
+  %150 = load i64*, i64** %149, align 8, !dbg !50
+  store i64 %38, i64* %150, align 8, !dbg !50, !tbaa !6
+  %151 = getelementptr inbounds i64, i64* %150, i64 1, !dbg !50
+  store i64 %send13, i64* %151, align 8, !dbg !50, !tbaa !6
+  %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !50
+  store i64* %152, i64** %149, align 8, !dbg !50
+  %send15 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !50
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_MyStruct#initialize"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #7 !dbg !75 {
+define i64 @"func_MyStruct#initialize"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #7 !dbg !77 {
 functionEntryInitializers:
   %callArgs = alloca [2 x i64], align 8
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !tbaa !12
-  %hashAttemptReadGuard = icmp ult i32 0, %argc, !dbg !76
-  br i1 %hashAttemptReadGuard, label %readKWHashArgCountSuccess, label %fillRequiredArgs.thread, !dbg !76
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !tbaa !14
+  %hashAttemptReadGuard = icmp ult i32 0, %argc, !dbg !78
+  br i1 %hashAttemptReadGuard, label %readKWHashArgCountSuccess, label %fillRequiredArgs.thread, !dbg !78
 
 fillRequiredArgs.thread:                          ; preds = %functionEntryInitializers
-  %rubyId_foo39 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !76
-  %rawSym40 = tail call i64 @rb_id2sym(i64 %rubyId_foo39), !dbg !76
-  br label %sorbet_assertNoExtraKWArg.exit.thread, !dbg !76
+  %rubyId_foo39 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !78
+  %rawSym40 = tail call i64 @rb_id2sym(i64 %rubyId_foo39), !dbg !78
+  br label %sorbet_assertNoExtraKWArg.exit.thread, !dbg !78
 
 readKWHashArgCountSuccess:                        ; preds = %functionEntryInitializers
-  %argsWithoutHashCount = sub nuw i32 %argc, 1, !dbg !76
-  %1 = getelementptr i64, i64* %argArray, i32 %argsWithoutHashCount, !dbg !76
-  %KWArgHash = load i64, i64* %1, align 8, !dbg !76
-  %2 = and i64 %KWArgHash, 7, !dbg !76
-  %3 = icmp ne i64 %2, 0, !dbg !76
-  %4 = and i64 %KWArgHash, -9, !dbg !76
-  %5 = icmp eq i64 %4, 0, !dbg !76
-  %6 = or i1 %3, %5, !dbg !76
-  br i1 %6, label %argCountFailBlock, label %sorbet_isa_Hash.exit, !dbg !76
+  %argsWithoutHashCount = sub nuw i32 %argc, 1, !dbg !78
+  %1 = getelementptr i64, i64* %argArray, i32 %argsWithoutHashCount, !dbg !78
+  %KWArgHash = load i64, i64* %1, align 8, !dbg !78
+  %2 = and i64 %KWArgHash, 7, !dbg !78
+  %3 = icmp ne i64 %2, 0, !dbg !78
+  %4 = and i64 %KWArgHash, -9, !dbg !78
+  %5 = icmp eq i64 %4, 0, !dbg !78
+  %6 = or i1 %3, %5, !dbg !78
+  br i1 %6, label %argCountFailBlock, label %sorbet_isa_Hash.exit, !dbg !78
 
 sorbet_isa_Hash.exit:                             ; preds = %readKWHashArgCountSuccess
-  %7 = inttoptr i64 %KWArgHash to %struct.iseq_inline_iv_cache_entry*, !dbg !76
-  %8 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %7, i64 0, i32 0, !dbg !76
-  %9 = load i64, i64* %8, align 8, !dbg !76, !tbaa !66
-  %10 = and i64 %9, 31, !dbg !76
-  %11 = icmp eq i64 %10, 8, !dbg !76
+  %7 = inttoptr i64 %KWArgHash to %struct.iseq_inline_iv_cache_entry*, !dbg !78
+  %8 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %7, i64 0, i32 0, !dbg !78
+  %9 = load i64, i64* %8, align 8, !dbg !78, !tbaa !68
+  %10 = and i64 %9, 31, !dbg !78
+  %11 = icmp eq i64 %10, 8, !dbg !78
   br i1 %11, label %afterKWHash, label %argCountFailBlock
 
 afterKWHash:                                      ; preds = %sorbet_isa_Hash.exit
-  %tooManyArgs = icmp ugt i32 %argsWithoutHashCount, 0, !dbg !76
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !76, !prof !64
+  %tooManyArgs = icmp ugt i32 %argsWithoutHashCount, 0, !dbg !78
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !78, !prof !66
 
 argCountFailBlock:                                ; preds = %readKWHashArgCountSuccess, %sorbet_isa_Hash.exit, %afterKWHash
   %argcPhi32 = phi i32 [ %argsWithoutHashCount, %afterKWHash ], [ %argc, %sorbet_isa_Hash.exit ], [ %argc, %readKWHashArgCountSuccess ]
-  tail call void @sorbet_raiseArity(i32 %argcPhi32, i32 noundef 0, i32 noundef 0) #18, !dbg !76
-  unreachable, !dbg !76
+  tail call void @sorbet_raiseArity(i32 %argcPhi32, i32 noundef 0, i32 noundef 0) #18, !dbg !78
+  unreachable, !dbg !78
 
 fillRequiredArgs:                                 ; preds = %afterKWHash
-  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !76
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !76
-  %12 = icmp eq i64 %KWArgHash, 52, !dbg !76
-  br i1 %12, label %sorbet_assertNoExtraKWArg.exit.thread, label %sorbet_getKWArg.exit, !dbg !76
+  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !78
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !78
+  %12 = icmp eq i64 %KWArgHash, 52, !dbg !78
+  br i1 %12, label %sorbet_assertNoExtraKWArg.exit.thread, label %sorbet_getKWArg.exit, !dbg !78
 
 sorbet_getKWArg.exit:                             ; preds = %fillRequiredArgs
-  %13 = tail call i64 @rb_hash_delete_entry(i64 %KWArgHash, i64 %rawSym) #15, !dbg !76
-  %14 = icmp eq i64 %13, 52, !dbg !76
-  %spec.select48 = select i1 %14, i64 8, i64 %13, !dbg !76
-  %15 = inttoptr i64 %KWArgHash to %struct.iseq_inline_iv_cache_entry*, !dbg !76
-  %16 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %15, i64 0, i32 0, !dbg !76
-  %17 = load i64, i64* %16, align 8, !dbg !76, !tbaa !66
-  %18 = trunc i64 %17 to i16, !dbg !76
-  %19 = icmp sgt i16 %18, -1, !dbg !76
-  br i1 %19, label %20, label %23, !dbg !76
+  %13 = tail call i64 @rb_hash_delete_entry(i64 %KWArgHash, i64 %rawSym) #15, !dbg !78
+  %14 = icmp eq i64 %13, 52, !dbg !78
+  %spec.select48 = select i1 %14, i64 8, i64 %13, !dbg !78
+  %15 = inttoptr i64 %KWArgHash to %struct.iseq_inline_iv_cache_entry*, !dbg !78
+  %16 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %15, i64 0, i32 0, !dbg !78
+  %17 = load i64, i64* %16, align 8, !dbg !78, !tbaa !68
+  %18 = trunc i64 %17 to i16, !dbg !78
+  %19 = icmp sgt i16 %18, -1, !dbg !78
+  br i1 %19, label %20, label %23, !dbg !78
 
 20:                                               ; preds = %sorbet_getKWArg.exit
-  %21 = lshr i64 %17, 16, !dbg !76
-  %22 = and i64 %21, 15, !dbg !76
-  br label %29, !dbg !76
+  %21 = lshr i64 %17, 16, !dbg !78
+  %22 = and i64 %21, 15, !dbg !78
+  br label %29, !dbg !78
 
 23:                                               ; preds = %sorbet_getKWArg.exit
-  %24 = inttoptr i64 %KWArgHash to %struct.RHash*, !dbg !76
-  %25 = getelementptr inbounds %struct.RHash, %struct.RHash* %24, i64 0, i32 1, i32 0, !dbg !76
-  %26 = load %struct.st_table*, %struct.st_table** %25, align 8, !dbg !76, !tbaa !77
-  %27 = getelementptr inbounds %struct.st_table, %struct.st_table* %26, i64 0, i32 5, !dbg !76
-  %28 = load i64, i64* %27, align 8, !dbg !76, !tbaa !78
-  br label %29, !dbg !76
+  %24 = inttoptr i64 %KWArgHash to %struct.RHash*, !dbg !78
+  %25 = getelementptr inbounds %struct.RHash, %struct.RHash* %24, i64 0, i32 1, i32 0, !dbg !78
+  %26 = load %struct.st_table*, %struct.st_table** %25, align 8, !dbg !78, !tbaa !79
+  %27 = getelementptr inbounds %struct.st_table, %struct.st_table* %26, i64 0, i32 5, !dbg !78
+  %28 = load i64, i64* %27, align 8, !dbg !78, !tbaa !80
+  br label %29, !dbg !78
 
 29:                                               ; preds = %23, %20
-  %30 = phi i64 [ %22, %20 ], [ %28, %23 ], !dbg !76
-  %31 = icmp eq i64 %30, 0, !dbg !76
-  br i1 %31, label %sorbet_assertNoExtraKWArg.exit, label %32, !dbg !76
+  %30 = phi i64 [ %22, %20 ], [ %28, %23 ], !dbg !78
+  %31 = icmp eq i64 %30, 0, !dbg !78
+  br i1 %31, label %sorbet_assertNoExtraKWArg.exit, label %32, !dbg !78
 
 32:                                               ; preds = %29
-  tail call void @sorbet_raiseExtraKeywords(i64 %KWArgHash) #14, !dbg !76
-  unreachable, !dbg !76
+  tail call void @sorbet_raiseExtraKeywords(i64 %KWArgHash) #14, !dbg !78
+  unreachable, !dbg !78
 
 sorbet_assertNoExtraKWArg.exit.thread:            ; preds = %fillRequiredArgs.thread, %fillRequiredArgs
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !80, !tbaa !12
-  br label %36, !dbg !81
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !82, !tbaa !14
+  br label %36, !dbg !83
 
 sorbet_assertNoExtraKWArg.exit:                   ; preds = %29
   %33 = phi i64 [ %spec.select48, %29 ]
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !80, !tbaa !12
-  %34 = and i64 %33, 1, !dbg !81
-  %35 = icmp eq i64 %34, 0, !dbg !81
-  br i1 %35, label %36, label %typeTestSuccess10, !dbg !81, !prof !64
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !82, !tbaa !14
+  %34 = and i64 %33, 1, !dbg !83
+  %35 = icmp eq i64 %34, 0, !dbg !83
+  br i1 %35, label %36, label %typeTestSuccess10, !dbg !83, !prof !66
 
 36:                                               ; preds = %sorbet_assertNoExtraKWArg.exit.thread, %sorbet_assertNoExtraKWArg.exit
   %37 = phi i64 [ 8, %sorbet_assertNoExtraKWArg.exit.thread ], [ %33, %sorbet_assertNoExtraKWArg.exit ]
-  %38 = and i64 %37, 7, !dbg !81
-  %39 = icmp ne i64 %38, 0, !dbg !81
-  %40 = and i64 %37, -9, !dbg !81
-  %41 = icmp eq i64 %40, 0, !dbg !81
-  %42 = or i1 %39, %41, !dbg !81
-  br i1 %42, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !81
+  %38 = and i64 %37, 7, !dbg !83
+  %39 = icmp ne i64 %38, 0, !dbg !83
+  %40 = and i64 %37, -9, !dbg !83
+  %41 = icmp eq i64 %40, 0, !dbg !83
+  %42 = or i1 %39, %41, !dbg !83
+  br i1 %42, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !83
 
 sorbet_isa_Integer.exit:                          ; preds = %36
-  %43 = inttoptr i64 %37 to %struct.iseq_inline_iv_cache_entry*, !dbg !81
-  %44 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %43, i64 0, i32 0, !dbg !81
-  %45 = load i64, i64* %44, align 8, !dbg !81, !tbaa !66
-  %46 = and i64 %45, 31, !dbg !81
-  %47 = icmp eq i64 %46, 10, !dbg !81
-  br i1 %47, label %typeTestSuccess10, label %codeRepl, !dbg !81, !prof !25
+  %43 = inttoptr i64 %37 to %struct.iseq_inline_iv_cache_entry*, !dbg !83
+  %44 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %43, i64 0, i32 0, !dbg !83
+  %45 = load i64, i64* %44, align 8, !dbg !83, !tbaa !68
+  %46 = and i64 %45, 31, !dbg !83
+  %47 = icmp eq i64 %46, 10, !dbg !83
+  br i1 %47, label %typeTestSuccess10, label %codeRepl, !dbg !83, !prof !27
 
 codeRepl:                                         ; preds = %36, %sorbet_isa_Integer.exit
   %48 = phi i64 [ %37, %36 ], [ %37, %sorbet_isa_Integer.exit ]
-  tail call fastcc void @"func_MyStruct#initialize.cold.1"(i64 %48) #19, !dbg !81
+  tail call fastcc void @"func_MyStruct#initialize.cold.1"(i64 %48) #19, !dbg !83
   unreachable
 
 typeTestSuccess10:                                ; preds = %sorbet_assertNoExtraKWArg.exit, %sorbet_isa_Integer.exit
   %49 = phi i64 [ %33, %sorbet_assertNoExtraKWArg.exit ], [ %37, %sorbet_isa_Integer.exit ]
-  %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !82
-  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %49, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #15, !dbg !82
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !82, !tbaa !12
-  %rubyId_foo13 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !76
-  %rawSym14 = tail call i64 @rb_id2sym(i64 %rubyId_foo13), !dbg !76
-  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !76
-  store i64 %rawSym14, i64* %callArgs0Addr, align 8, !dbg !76
-  %callArgs1Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 1, !dbg !76
-  store i64 %49, i64* %callArgs1Addr, align 8, !dbg !76
-  %50 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !76
-  %51 = tail call i64 @rb_hash_new_with_size(i64 noundef 1) #15, !dbg !76
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %50, i64 %51) #15, !dbg !76
-  store i64 %51, i64* %callArgs0Addr, align 8, !dbg !76
-  call void @llvm.experimental.noalias.scope.decl(metadata !83), !dbg !76
-  %52 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !76, !tbaa !12, !noalias !83
-  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 2, !dbg !76
-  %54 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %53, align 8, !dbg !76, !tbaa !14, !noalias !83
-  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %54, i64 0, i32 3, !dbg !76
-  %56 = load i64, i64* %55, align 8, !dbg !76, !tbaa !86, !noalias !83
-  %57 = call %struct.rb_callable_method_entry_struct* @rb_vm_frame_method_entry(%struct.rb_control_frame_struct* %54) #15, !dbg !76, !noalias !83
-  %58 = getelementptr inbounds %struct.rb_callable_method_entry_struct, %struct.rb_callable_method_entry_struct* %57, i64 0, i32 1, !dbg !76
-  %59 = load i64, i64* %58, align 8, !dbg !76, !tbaa !87, !noalias !83
-  %60 = inttoptr i64 %59 to %struct.RClass*, !dbg !76
-  %61 = getelementptr inbounds %struct.RClass, %struct.RClass* %60, i64 0, i32 2, !dbg !76
-  %62 = load %struct.rb_classext_struct*, %struct.rb_classext_struct** %61, align 8, !dbg !76, !tbaa !89, !noalias !83
-  %63 = getelementptr inbounds %struct.rb_classext_struct, %struct.rb_classext_struct* %62, i64 0, i32 8, !dbg !76
-  %64 = load i64, i64* %63, align 8, !dbg !76, !tbaa !91, !noalias !83
-  %65 = inttoptr i64 %64 to %struct.RClass*, !dbg !76
-  %66 = getelementptr inbounds %struct.RClass, %struct.RClass* %65, i64 0, i32 1, !dbg !76
-  %67 = load i64, i64* %66, align 8, !dbg !76, !tbaa !93, !noalias !83
-  %68 = getelementptr inbounds %struct.rb_callable_method_entry_struct, %struct.rb_callable_method_entry_struct* %57, i64 0, i32 2, !dbg !76
-  %69 = load %struct.rb_method_definition_struct*, %struct.rb_method_definition_struct** %68, align 8, !dbg !76, !tbaa !94, !noalias !83
-  %70 = getelementptr inbounds %struct.rb_method_definition_struct, %struct.rb_method_definition_struct* %69, i64 0, i32 2, !dbg !76
-  %71 = load i64, i64* %70, align 8, !dbg !76, !tbaa !95, !noalias !83
-  %72 = call %struct.rb_callable_method_entry_struct* @rb_callable_method_entry(i64 %67, i64 %71) #15, !dbg !76, !noalias !83
-  %73 = icmp eq %struct.rb_callable_method_entry_struct* %72, null, !dbg !76
-  br i1 %73, label %74, label %sorbet_callSuper.exit, !dbg !76
+  %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !84
+  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %49, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #15, !dbg !84
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !84, !tbaa !14
+  %rubyId_foo13 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !78
+  %rawSym14 = tail call i64 @rb_id2sym(i64 %rubyId_foo13), !dbg !78
+  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !78
+  store i64 %rawSym14, i64* %callArgs0Addr, align 8, !dbg !78
+  %callArgs1Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 1, !dbg !78
+  store i64 %49, i64* %callArgs1Addr, align 8, !dbg !78
+  %50 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !78
+  %51 = tail call i64 @rb_hash_new_with_size(i64 noundef 1) #15, !dbg !78
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %50, i64 %51) #15, !dbg !78
+  store i64 %51, i64* %callArgs0Addr, align 8, !dbg !78
+  call void @llvm.experimental.noalias.scope.decl(metadata !85), !dbg !78
+  %52 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !14, !noalias !85
+  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 2, !dbg !78
+  %54 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %53, align 8, !dbg !78, !tbaa !16, !noalias !85
+  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %54, i64 0, i32 3, !dbg !78
+  %56 = load i64, i64* %55, align 8, !dbg !78, !tbaa !88, !noalias !85
+  %57 = call %struct.rb_callable_method_entry_struct* @rb_vm_frame_method_entry(%struct.rb_control_frame_struct* %54) #15, !dbg !78, !noalias !85
+  %58 = getelementptr inbounds %struct.rb_callable_method_entry_struct, %struct.rb_callable_method_entry_struct* %57, i64 0, i32 1, !dbg !78
+  %59 = load i64, i64* %58, align 8, !dbg !78, !tbaa !89, !noalias !85
+  %60 = inttoptr i64 %59 to %struct.RClass*, !dbg !78
+  %61 = getelementptr inbounds %struct.RClass, %struct.RClass* %60, i64 0, i32 2, !dbg !78
+  %62 = load %struct.rb_classext_struct*, %struct.rb_classext_struct** %61, align 8, !dbg !78, !tbaa !91, !noalias !85
+  %63 = getelementptr inbounds %struct.rb_classext_struct, %struct.rb_classext_struct* %62, i64 0, i32 8, !dbg !78
+  %64 = load i64, i64* %63, align 8, !dbg !78, !tbaa !93, !noalias !85
+  %65 = inttoptr i64 %64 to %struct.RClass*, !dbg !78
+  %66 = getelementptr inbounds %struct.RClass, %struct.RClass* %65, i64 0, i32 1, !dbg !78
+  %67 = load i64, i64* %66, align 8, !dbg !78, !tbaa !95, !noalias !85
+  %68 = getelementptr inbounds %struct.rb_callable_method_entry_struct, %struct.rb_callable_method_entry_struct* %57, i64 0, i32 2, !dbg !78
+  %69 = load %struct.rb_method_definition_struct*, %struct.rb_method_definition_struct** %68, align 8, !dbg !78, !tbaa !96, !noalias !85
+  %70 = getelementptr inbounds %struct.rb_method_definition_struct, %struct.rb_method_definition_struct* %69, i64 0, i32 2, !dbg !78
+  %71 = load i64, i64* %70, align 8, !dbg !78, !tbaa !97, !noalias !85
+  %72 = call %struct.rb_callable_method_entry_struct* @rb_callable_method_entry(i64 %67, i64 %71) #15, !dbg !78, !noalias !85
+  %73 = icmp eq %struct.rb_callable_method_entry_struct* %72, null, !dbg !78
+  br i1 %73, label %74, label %sorbet_callSuper.exit, !dbg !78
 
 74:                                               ; preds = %typeTestSuccess10
-  %75 = load i64, i64* @rb_eRuntimeError, align 8, !dbg !76, !tbaa !4
-  call void (i64, i8*, ...) @rb_raise(i64 %75, i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @.str.7, i64 0, i64 0)) #14, !dbg !76
-  unreachable, !dbg !76
+  %75 = load i64, i64* @rb_eRuntimeError, align 8, !dbg !78, !tbaa !6
+  call void (i64, i8*, ...) @rb_raise(i64 %75, i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @.str.7, i64 0, i64 0)) #14, !dbg !78
+  unreachable, !dbg !78
 
 sorbet_callSuper.exit:                            ; preds = %typeTestSuccess10
-  %76 = call i64 @rb_vm_call_kw(%struct.rb_execution_context_struct* nonnull %52, i64 %56, i64 %71, i32 noundef 1, i64* noundef nonnull %50, %struct.rb_callable_method_entry_struct* nonnull %72, i32 noundef 1) #15, !dbg !76
+  %76 = call i64 @rb_vm_call_kw(%struct.rb_execution_context_struct* nonnull %52, i64 %56, i64 %71, i32 noundef 1, i64* noundef nonnull %50, %struct.rb_callable_method_entry_struct* nonnull %72, i32 noundef 1) #15, !dbg !78
   %"<void-singleton>" = load i64, i64* @"<void-singleton>", align 8
   ret i64 %"<void-singleton>"
 }
@@ -990,10 +990,10 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #10
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_MyStruct#initialize.cold.1"(i64 %0) unnamed_addr #11 !dbg !97 {
+define internal fastcc void @"func_MyStruct#initialize.cold.1"(i64 %0) unnamed_addr #11 !dbg !99 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !99
-  unreachable, !dbg !99
+  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !101
+  unreachable, !dbg !101
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
@@ -1003,7 +1003,7 @@ declare void @llvm.assume(i1 noundef) #12
 define linkonce void @const_recompute_MyStruct() local_unnamed_addr #13 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @str_MyStruct, i64 0, i64 0), i64 8)
   store i64 %1, i64* @guarded_const_MyStruct, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !28
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !30
   store i64 %2, i64* @guard_epoch_MyStruct, align 8
   ret void
 }
@@ -1012,7 +1012,7 @@ define linkonce void @const_recompute_MyStruct() local_unnamed_addr #13 {
 define linkonce void @"const_recompute_T::Struct"() local_unnamed_addr #13 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([10 x i8], [10 x i8]* @"str_T::Struct", i64 0, i64 0), i64 9)
   store i64 %1, i64* @"guarded_const_T::Struct", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !28
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !30
   store i64 %2, i64* @"guard_epoch_T::Struct", align 8
   ret void
 }
@@ -1038,106 +1038,108 @@ attributes #17 = { nounwind willreturn }
 attributes #18 = { noreturn }
 attributes #19 = { noinline }
 
-!llvm.module.flags = !{!0}
-!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
-!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3)
-!2 = !DIFile(filename: "test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", directory: ".")
-!3 = !{}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !DISubprogram(name: "MyStruct.<static-init>", linkageName: "func_MyStruct.<static-init>L62", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!9 = !DISubroutineType(types: !10)
-!10 = !{!11}
-!11 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!12 = !{!13, !13, i64 0}
-!13 = !{!"any pointer", !6, i64 0}
-!14 = !{!15, !13, i64 16}
-!15 = !{!"rb_execution_context_struct", !13, i64 0, !5, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !16, i64 40, !16, i64 44, !13, i64 48, !13, i64 56, !13, i64 64, !5, i64 72, !5, i64 80, !13, i64 88, !5, i64 96, !13, i64 104, !13, i64 112, !5, i64 120, !5, i64 128, !6, i64 136, !6, i64 137, !5, i64 144, !17, i64 152}
-!16 = !{!"int", !6, i64 0}
-!17 = !{!"", !13, i64 0, !13, i64 8, !5, i64 16, !6, i64 24}
-!18 = !{!19, !13, i64 16}
-!19 = !{!"rb_control_frame_struct", !13, i64 0, !13, i64 8, !13, i64 16, !5, i64 24, !13, i64 32, !13, i64 40, !13, i64 48}
-!20 = !{!19, !13, i64 32}
-!21 = !DILocation(line: 0, scope: !8)
-!22 = !DILocation(line: 5, column: 1, scope: !8)
-!23 = !{!15, !16, i64 40}
-!24 = !{!15, !16, i64 44}
-!25 = !{!"branch_weights", i32 2000, i32 1}
-!26 = !{!15, !13, i64 56}
-!27 = !DILocation(line: 6, column: 3, scope: !8)
-!28 = !{!29, !29, i64 0}
-!29 = !{!"long long", !6, i64 0}
-!30 = !{!"branch_weights", i32 1, i32 10000}
-!31 = !{!32, !16, i64 4}
-!32 = !{!"rb_sorbet_param_struct", !33, i64 0, !16, i64 4, !16, i64 8, !16, i64 12, !16, i64 16, !16, i64 20, !16, i64 24, !16, i64 28, !13, i64 32, !16, i64 40, !16, i64 44, !16, i64 48, !16, i64 52, !13, i64 56}
-!33 = !{!"", !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 0, !16, i64 1, !16, i64 1}
-!34 = !{!32, !16, i64 40}
-!35 = !{!32, !16, i64 44}
-!36 = !{!32, !16, i64 48}
-!37 = !{!32, !13, i64 56}
-!38 = !DILocation(line: 6, column: 9, scope: !8)
-!39 = !DILocation(line: 9, column: 13, scope: !40)
-!40 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!41 = !DILocation(line: 5, column: 1, scope: !42)
-!42 = distinct !DISubprogram(name: "MyStruct.<static-init>", linkageName: "func_MyStruct.<static-init>L62$block_1", scope: !8, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!43 = !DILocation(line: 12, column: 7, scope: !40)
-!44 = !DILocation(line: 14, column: 3, scope: !40)
-!45 = !DILocation(line: 16, column: 3, scope: !40)
-!46 = !DILocation(line: 19, column: 1, scope: !40)
-!47 = !DILocation(line: 20, column: 6, scope: !40)
-!48 = !DILocation(line: 20, column: 1, scope: !40)
-!49 = !DILocation(line: 6, column: 3, scope: !50)
-!50 = distinct !DISubprogram(name: "MyStruct.<static-init>", linkageName: "func_MyStruct.<static-init>L62$block_2", scope: !8, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!51 = !{!52, !5, i64 400}
-!52 = !{!"rb_vm_struct", !5, i64 0, !53, i64 8, !13, i64 192, !13, i64 200, !13, i64 208, !29, i64 216, !6, i64 224, !54, i64 264, !54, i64 280, !54, i64 296, !54, i64 312, !5, i64 328, !16, i64 336, !16, i64 340, !16, i64 344, !16, i64 344, !16, i64 344, !16, i64 344, !16, i64 348, !5, i64 352, !6, i64 360, !5, i64 400, !5, i64 408, !5, i64 416, !5, i64 424, !5, i64 432, !5, i64 440, !5, i64 448, !13, i64 456, !13, i64 464, !56, i64 472, !57, i64 992, !13, i64 1016, !13, i64 1024, !16, i64 1032, !16, i64 1036, !54, i64 1040, !6, i64 1056, !5, i64 1096, !5, i64 1104, !5, i64 1112, !5, i64 1120, !5, i64 1128, !16, i64 1136, !13, i64 1144, !13, i64 1152, !13, i64 1160, !13, i64 1168, !13, i64 1176, !13, i64 1184, !16, i64 1192, !58, i64 1200, !6, i64 1232}
-!53 = !{!"rb_global_vm_lock_struct", !13, i64 0, !6, i64 8, !54, i64 48, !13, i64 64, !16, i64 72, !6, i64 80, !6, i64 128, !16, i64 176, !16, i64 180}
-!54 = !{!"list_head", !55, i64 0}
-!55 = !{!"list_node", !13, i64 0, !13, i64 8}
-!56 = !{!"", !6, i64 0}
-!57 = !{!"rb_hook_list_struct", !13, i64 0, !16, i64 8, !16, i64 12, !16, i64 16}
-!58 = !{!"", !5, i64 0, !5, i64 8, !5, i64 16, !5, i64 24}
-!59 = !DILocation(line: 0, scope: !40)
-!60 = !DILocation(line: 5, column: 1, scope: !40)
-!61 = !DILocation(line: 5, column: 18, scope: !40)
-!62 = !DILocation(line: 9, column: 26, scope: !40)
-!63 = !DILocation(line: 11, column: 5, scope: !40)
-!64 = !{!"branch_weights", i32 1, i32 2000}
-!65 = !{!"branch_weights", i32 1073205, i32 2146410443}
-!66 = !{!67, !5, i64 0}
-!67 = !{!"RBasic", !5, i64 0, !5, i64 8}
-!68 = !{!69}
-!69 = distinct !{!69, !70, !"sorbet_rb_int_lt: argument 0"}
-!70 = distinct !{!70, !"sorbet_rb_int_lt"}
-!71 = !{!"branch_weights", i32 4001, i32 4000000}
-!72 = !{!73}
-!73 = distinct !{!73, !74, !"sorbet_rb_int_plus: argument 0"}
-!74 = distinct !{!74, !"sorbet_rb_int_plus"}
-!75 = distinct !DISubprogram(name: "MyStruct#initialize", linkageName: "func_MyStruct#initialize", scope: null, file: !2, line: 5, type: !9, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !3)
-!76 = !DILocation(line: 5, column: 1, scope: !75)
-!77 = !{!6, !6, i64 0}
-!78 = !{!79, !5, i64 16}
-!79 = !{!"st_table", !6, i64 0, !6, i64 1, !6, i64 2, !16, i64 4, !13, i64 8, !5, i64 16, !13, i64 24, !5, i64 32, !5, i64 40, !13, i64 48}
-!80 = !DILocation(line: 0, scope: !75)
-!81 = !DILocation(line: 6, column: 3, scope: !75)
-!82 = !DILocation(line: 6, column: 10, scope: !75)
-!83 = !{!84}
-!84 = distinct !{!84, !85, !"sorbet_callSuper: argument 0"}
-!85 = distinct !{!85, !"sorbet_callSuper"}
-!86 = !{!19, !5, i64 24}
-!87 = !{!88, !5, i64 8}
-!88 = !{!"rb_callable_method_entry_struct", !5, i64 0, !5, i64 8, !13, i64 16, !5, i64 24, !5, i64 32}
-!89 = !{!90, !13, i64 24}
-!90 = !{!"RClass", !67, i64 0, !5, i64 16, !13, i64 24, !29, i64 32}
-!91 = !{!92, !5, i64 64}
-!92 = !{!"rb_classext_struct", !13, i64 0, !13, i64 8, !13, i64 16, !13, i64 24, !13, i64 32, !13, i64 40, !13, i64 48, !13, i64 56, !5, i64 64, !5, i64 72, !13, i64 80, !5, i64 88}
-!93 = !{!90, !5, i64 16}
-!94 = !{!88, !13, i64 16}
-!95 = !{!96, !5, i64 32}
-!96 = !{!"rb_method_definition_struct", !6, i64 0, !16, i64 0, !16, i64 4, !6, i64 8, !5, i64 32, !5, i64 40}
-!97 = distinct !DISubprogram(name: "func_MyStruct#initialize.cold.1", linkageName: "func_MyStruct#initialize.cold.1", scope: null, file: !2, type: !98, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !1, retainedNodes: !3)
-!98 = !DISubroutineType(types: !3)
-!99 = !DILocation(line: 6, column: 3, scope: !97)
+!1 = !{i32 4, !"cf-protection-return", i32 1}
+!2 = !{i32 4, !"cf-protection-branch", i32 1}
+!3 = distinct !DICompileUnit(language: DW_LANG_C, file: !4, producer: "Sorbet LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", directory: ".")
+!5 = !{}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"long", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = distinct !DISubprogram(name: "MyStruct.<static-init>", linkageName: "func_MyStruct.<static-init>L62", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!14 = !{!15, !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !{!17, !15, i64 16}
+!17 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !18, i64 40, !18, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !19, i64 152}
+!18 = !{!"int", !8, i64 0}
+!19 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!20 = !{!21, !15, i64 16}
+!21 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!22 = !{!21, !15, i64 32}
+!23 = !DILocation(line: 0, scope: !10)
+!24 = !DILocation(line: 5, column: 1, scope: !10)
+!25 = !{!17, !18, i64 40}
+!26 = !{!17, !18, i64 44}
+!27 = !{!"branch_weights", i32 2000, i32 1}
+!28 = !{!17, !15, i64 56}
+!29 = !DILocation(line: 6, column: 3, scope: !10)
+!30 = !{!31, !31, i64 0}
+!31 = !{!"long long", !8, i64 0}
+!32 = !{!"branch_weights", i32 1, i32 10000}
+!33 = !{!34, !18, i64 4}
+!34 = !{!"rb_sorbet_param_struct", !35, i64 0, !18, i64 4, !18, i64 8, !18, i64 12, !18, i64 16, !18, i64 20, !18, i64 24, !18, i64 28, !15, i64 32, !18, i64 40, !18, i64 44, !18, i64 48, !18, i64 52, !15, i64 56}
+!35 = !{!"", !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 1, !18, i64 1}
+!36 = !{!34, !18, i64 40}
+!37 = !{!34, !18, i64 44}
+!38 = !{!34, !18, i64 48}
+!39 = !{!34, !15, i64 56}
+!40 = !DILocation(line: 6, column: 9, scope: !10)
+!41 = !DILocation(line: 9, column: 13, scope: !42)
+!42 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$151", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!43 = !DILocation(line: 5, column: 1, scope: !44)
+!44 = distinct !DISubprogram(name: "MyStruct.<static-init>", linkageName: "func_MyStruct.<static-init>L62$block_1", scope: !10, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!45 = !DILocation(line: 12, column: 7, scope: !42)
+!46 = !DILocation(line: 14, column: 3, scope: !42)
+!47 = !DILocation(line: 16, column: 3, scope: !42)
+!48 = !DILocation(line: 19, column: 1, scope: !42)
+!49 = !DILocation(line: 20, column: 6, scope: !42)
+!50 = !DILocation(line: 20, column: 1, scope: !42)
+!51 = !DILocation(line: 6, column: 3, scope: !52)
+!52 = distinct !DISubprogram(name: "MyStruct.<static-init>", linkageName: "func_MyStruct.<static-init>L62$block_2", scope: !10, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!53 = !{!54, !7, i64 400}
+!54 = !{!"rb_vm_struct", !7, i64 0, !55, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !31, i64 216, !8, i64 224, !56, i64 264, !56, i64 280, !56, i64 296, !56, i64 312, !7, i64 328, !18, i64 336, !18, i64 340, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !58, i64 472, !59, i64 992, !15, i64 1016, !15, i64 1024, !18, i64 1032, !18, i64 1036, !56, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !18, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !18, i64 1192, !60, i64 1200, !8, i64 1232}
+!55 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !56, i64 48, !15, i64 64, !18, i64 72, !8, i64 80, !8, i64 128, !18, i64 176, !18, i64 180}
+!56 = !{!"list_head", !57, i64 0}
+!57 = !{!"list_node", !15, i64 0, !15, i64 8}
+!58 = !{!"", !8, i64 0}
+!59 = !{!"rb_hook_list_struct", !15, i64 0, !18, i64 8, !18, i64 12, !18, i64 16}
+!60 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!61 = !DILocation(line: 0, scope: !42)
+!62 = !DILocation(line: 5, column: 1, scope: !42)
+!63 = !DILocation(line: 5, column: 18, scope: !42)
+!64 = !DILocation(line: 9, column: 26, scope: !42)
+!65 = !DILocation(line: 11, column: 5, scope: !42)
+!66 = !{!"branch_weights", i32 1, i32 2000}
+!67 = !{!"branch_weights", i32 1073205, i32 2146410443}
+!68 = !{!69, !7, i64 0}
+!69 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!70 = !{!71}
+!71 = distinct !{!71, !72, !"sorbet_rb_int_lt: argument 0"}
+!72 = distinct !{!72, !"sorbet_rb_int_lt"}
+!73 = !{!"branch_weights", i32 4001, i32 4000000}
+!74 = !{!75}
+!75 = distinct !{!75, !76, !"sorbet_rb_int_plus: argument 0"}
+!76 = distinct !{!76, !"sorbet_rb_int_plus"}
+!77 = distinct !DISubprogram(name: "MyStruct#initialize", linkageName: "func_MyStruct#initialize", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!78 = !DILocation(line: 5, column: 1, scope: !77)
+!79 = !{!8, !8, i64 0}
+!80 = !{!81, !7, i64 16}
+!81 = !{!"st_table", !8, i64 0, !8, i64 1, !8, i64 2, !18, i64 4, !15, i64 8, !7, i64 16, !15, i64 24, !7, i64 32, !7, i64 40, !15, i64 48}
+!82 = !DILocation(line: 0, scope: !77)
+!83 = !DILocation(line: 6, column: 3, scope: !77)
+!84 = !DILocation(line: 6, column: 10, scope: !77)
+!85 = !{!86}
+!86 = distinct !{!86, !87, !"sorbet_callSuper: argument 0"}
+!87 = distinct !{!87, !"sorbet_callSuper"}
+!88 = !{!21, !7, i64 24}
+!89 = !{!90, !7, i64 8}
+!90 = !{!"rb_callable_method_entry_struct", !7, i64 0, !7, i64 8, !15, i64 16, !7, i64 24, !7, i64 32}
+!91 = !{!92, !15, i64 24}
+!92 = !{!"RClass", !69, i64 0, !7, i64 16, !15, i64 24, !31, i64 32}
+!93 = !{!94, !7, i64 64}
+!94 = !{!"rb_classext_struct", !15, i64 0, !15, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !15, i64 40, !15, i64 48, !15, i64 56, !7, i64 64, !7, i64 72, !15, i64 80, !7, i64 88}
+!95 = !{!92, !7, i64 16}
+!96 = !{!90, !15, i64 16}
+!97 = !{!98, !7, i64 32}
+!98 = !{!"rb_method_definition_struct", !8, i64 0, !18, i64 0, !18, i64 4, !8, i64 8, !7, i64 32, !7, i64 40}
+!99 = distinct !DISubprogram(name: "func_MyStruct#initialize.cold.1", linkageName: "func_MyStruct#initialize.cold.1", scope: null, file: !4, type: !100, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!100 = !DISubroutineType(types: !5)
+!101 = !DILocation(line: 6, column: 3, scope: !99)


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This mechanism is a defense-in-depth switch for compiled code; on x86-ish machines, these annotations on the module instructs the code generator to emit instructions for [Intel's Control-flow Enforcement Technology](https://software.intel.com/content/www/us/en/develop/articles/technical-look-control-flow-enforcement-technology.html).  Adding these annotations is, as far as I can tell, a no-op on targets that don't have similar mechanisms (not that the Sorbet compiler supports anything but x86-64 at the moment anyway).

Code compiled with this option interoperates just fine with code compiled without this option.  My system libraries are not compiled with `-fcf-protection` (the corresponding option for C/C++ compilers), nor does my computer have a processor that is CET-capable.  But I can run tests with this PR just fine, and I have verified that the appropriate instructions (which are NOPs on machines that don't support CET) exist in the compiled artifacts.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
