### PR TITLE
Improve typing of Enumerable#to_h; fixes #3368

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3134,6 +3134,11 @@ class Enumerable_toH : public IntrinsicMethod {
 public:
     // Forward Enumerable.to_h to RubyType.enumerable_to_h[self]
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        // Exit early when this is the case that's handled by the enumerable.rbi sig
+        if (args.args.empty() && args.block != nullptr) {
+            return;
+        }
+
         auto hash = make_type<ClassType>(core::Symbols::Sorbet_Private_Static().data(gs)->lookupSingletonClass(gs));
         InlinedVector<LocOffsets, 2> argLocs{args.locs.receiver};
         CallLocs locs{

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3135,6 +3135,7 @@ public:
     // Forward Enumerable.to_h to RubyType.enumerable_to_h[self]
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         // Exit early when this is the case that's handled by the enumerable.rbi sig
+        // The result type will already have been populated by dispatchCall using the sig.
         if (args.args.empty() && args.block != nullptr) {
             return;
         }

--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -1699,7 +1699,11 @@ module Enumerable
   # (1..5).to_h {|x| [x, x ** 2]}
   #   #=> {1=>1, 2=>4, 3=>9, 4=>16, 5=>25}
   # ```
-  sig {params(blk: T.nilable(T.proc.params(arg0: Elem).returns([T.untyped, T.untyped]))).returns(T::Hash[T.untyped, T.untyped])}
+  sig do
+    type_parameters(:U, :V).params(
+      blk: T.nilable(T.proc.params(arg0: Elem).returns([T.type_parameter(:U), T.type_parameter(:V)])))
+      .returns(T::Hash[T.type_parameter(:U), T.type_parameter(:V)])
+  end
   def to_h(&blk); end
 
   # Returns a new array by removing duplicate values in `self`.

--- a/test/testdata/rbi/enumerable.rb
+++ b/test/testdata/rbi/enumerable.rb
@@ -37,6 +37,13 @@ a.one?
 a.one?(1)
 a.one? { |i| i }
 
+# There are two ways to call to_h:
+#   1) no arguments where the argument must be enumerable with tuple elements
+#   2) a block argument, where the block must return tuples
+[1,2,3].to_h # error: Expected `T::Enumerable[[T.type_parameter(:U), T.type_parameter(:V)]]`
+T.reveal_type([[:a, 1], [:b, 2], [:c, 3]].to_h) # error: Revealed type: `T::Hash[Symbol, Integer]`
+T.reveal_type([1,2,3].to_h {|i| [i.to_s, i] }) # error: Revealed type: `T::Hash[String, Integer]`
+
 # detect
 p = T.let(->{ 1 }, T.proc.returns(Integer))
 T.reveal_type([1,2].detect) # error: Revealed type: `T::Enumerator[Integer]`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
When no arguments are present and a block is passed to `Enumerable#to_h`, skip dispatching to the internal `Sorbet::Private::Static.enumerable_to_h` method. Also improve the signature for `Enumerable#to_h` when a block is passed to return a typed hash.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #3368

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
