### PR TITLE
Better error messages for `FixedHash`

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
@@ -51,7 +51,7 @@ module T::Types
     # @override Base
     def describe_obj(obj)
       if obj.is_a?(Hash)
-        "type {#{obj.map {|(k, v)| "#{k}: #{v.class}"}.join(', ')}}"
+        "type #{serialize_hash(obj.transform_values(&:class))}"
       else
         super
       end

--- a/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
@@ -13,15 +13,7 @@ module T::Types
 
     # @override Base
     def name
-      entries = @types.map do |(k, v)|
-        if Symbol === k && ":#{k}" == k.inspect
-          "#{k}: #{v}"
-        else
-          "#{k.inspect} => #{v}"
-        end
-      end
-
-      "{#{entries.join(', ')}}"
+      serialize_hash(@types)
     end
 
     # @override Base
@@ -63,6 +55,20 @@ module T::Types
       else
         super
       end
+    end
+
+    private
+
+    def serialize_hash(hash)
+      entries = hash.map do |(k, v)|
+        if Symbol === k && ":#{k}" == k.inspect
+          "#{k}: #{v}"
+        else
+          "#{k.inspect} => #{v}"
+        end
+      end
+
+      "{#{entries.join(', ')}}"
     end
   end
 end

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -291,6 +291,11 @@ module Opus::Types::Test
         assert_equal("Expected type {a: String, b: T::Boolean, c: T.nilable(Numeric)}, got type {a: TrueClass, b: TrueClass, c: Integer}", msg)
       end
 
+      it "fails validation with a hash of wrong typed keys" do
+        msg = check_error_message_for_obj(@type, {"a" => true, :"foo bar" => true, :"foo" => 3})
+        assert_equal("Expected type {a: String, b: T::Boolean, c: T.nilable(Numeric)}, got type {\"a\" => TrueClass, :\"foo bar\" => TrueClass, foo: Integer}", msg)
+      end
+
       it "fails validation if a field is missing" do
         msg = check_error_message_for_obj(@type, {b: true, c: 3})
         assert_equal("Expected type {a: String, b: T::Boolean, c: T.nilable(Numeric)}, got type {b: TrueClass, c: Integer}", msg)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The error message printed when a `FixedHash` type is not valid for a given hash object was assuming that the hash would always have `Symbol` keys. Thus, it was always printing the object description with the `k: v` syntax, which could lead to confusing error messages.

This PR reuses the same hash serialization logic implemented in #4223 to print the hash object description. In order to do this, I extracted the hash serialization to a private method on the `FixedHash` class and reused it for doing hash object serialization.

The only downside of this approach is that hash object serialization wants to print not the values in the hash but their classes, instead. For simplicity of implementation, I decided to create a temporary key to class of value hash using `Hash#transform_values`, which has been available in Ruby since 2.4. This solution implies two traversals over the hash and an extra temporary hash instance, so it is wasteful. However, since this printing should only be done during error conditions, I think that is a fair tradeoff.

Please let me know if you would like me to implement this in a different way.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We got a report of a runtime error saying:
```
Expected type {shop_id: Integer, model_ids: Array}, got type {shop_id: Integer, model_ids: Array}
```
which was super confusing. We later on identified that the actual code was declaring the expected shape with `Symbol` keys, but the input had `String` keys.

A small repro of the (confusing) error message is the following:
```ruby
require "sorbet-runtime"

type = T::Utils.coerce({shop_id: Integer, model_ids: Array})

# This input shows an error
args = {"shop_id" => 1, "model_ids" => [2, 3]}
type.error_message_for_obj(args)
# => "Expected type {shop_id: Integer, model_ids: Array}, got type {shop_id: Integer, model_ids: Array}"

# This input has no errors
args = {shop_id: 1, model_ids: [2, 3]}
type.error_message_for_obj(args)
# => nil
```

After this change the same code becomes:
```ruby
require "sorbet-runtime"

type = T::Utils.coerce({shop_id: Integer, model_ids: Array})

# This input shows an error
args = {"shop_id" => 1, "model_ids" => [2, 3]}
type.error_message_for_obj(args)
# => "Expected type {shop_id: Integer, model_ids: Array}, got type {\"shop_id\" => Integer, \"model_ids\" => Array}"

# This input has no errors
args = {shop_id: 1, model_ids: [2, 3]}
type.error_message_for_obj(args)
# => nil
```
which makes the error much more obvious.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
