### PR TITLE
Auto correct initialize sigs not returning void

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -13,5 +13,6 @@ constexpr ErrorClass TEnumConstNotEnumValue{3506, StrictLevel::False};
 constexpr ErrorClass BadTestEach{3507, StrictLevel::True};
 constexpr ErrorClass PropForeignStrict{3508, StrictLevel::False};
 constexpr ErrorClass ComputedBySymbol{3509, StrictLevel::False};
+constexpr ErrorClass InitializeReturnType{3510, StrictLevel::False};
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/rbi/core/file.rbi
+++ b/rbi/core/file.rbi
@@ -1721,7 +1721,7 @@ class File::Stat < Object
     params(
         file: String,
     )
-    .returns(Object)
+    .void
   end
   def initialize(file); end
 

--- a/rbi/core/thread.rbi
+++ b/rbi/core/thread.rbi
@@ -414,7 +414,7 @@ class Thread < Object
   sig {returns(T.nilable(ThreadGroup))}
   def group; end
 
-  sig {params(args: T.untyped, blk: T.untyped).returns(Thread)}
+  sig {params(args: T.untyped, blk: T.untyped).void}
   def initialize(*args, &blk); end
 
   # The calling thread will suspend execution and run this `thr`.
@@ -1602,7 +1602,7 @@ class Thread::SizedQueue < Thread::Queue
   sig {params(args: T.untyped).returns(T.untyped)}
   def enq(*args); end
 
-  sig {params(max: T.untyped).returns(SizedQueue)}
+  sig {params(max: T.untyped).void}
   def initialize(max); end
 
   # Returns the maximum size of the queue.

--- a/rbi/gems/didyoumean.rbi
+++ b/rbi/gems/didyoumean.rbi
@@ -44,7 +44,7 @@ class DidYouMean::NullChecker < Object
 end
 
 class DidYouMean::SpellChecker < Object
-  sig {params(dictionary: T::Enumerable[T.any(String, Symbol)]).returns(DidYouMean::SpellChecker)}
+  sig {params(dictionary: T::Enumerable[T.any(String, Symbol)]).void}
   def initialize(dictionary:)
   end
 

--- a/rbi/gems/msgpack.rbi
+++ b/rbi/gems/msgpack.rbi
@@ -66,7 +66,7 @@ class MessagePack::Buffer
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -204,7 +204,7 @@ class MessagePack::Factory
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -303,7 +303,7 @@ class MessagePack::Packer
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -510,7 +510,7 @@ class MessagePack::Unpacker
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 

--- a/rbi/stdlib/bundler.rbi
+++ b/rbi/stdlib/bundler.rbi
@@ -935,7 +935,7 @@ class Bundler::Definition
       optional_groups: T.untyped,
       gemfiles: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(lockfile, dependencies, sources, unlock, ruby_version=T.unsafe(nil), optional_groups=T.unsafe(nil), gemfiles=T.unsafe(nil)); end
 
@@ -1114,7 +1114,7 @@ class Bundler::DepProxy
       dep: T.untyped,
       platform: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(dep, platform); end
 
@@ -1167,7 +1167,7 @@ class Bundler::Dependency < Gem::Dependency
       options: T.untyped,
       blk: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(name, version, options=T.unsafe(nil), &blk); end
 
@@ -1279,7 +1279,7 @@ class Bundler::Dsl
   end
   def group(*args, &blk); end
 
-  sig {returns(T.untyped)}
+  sig {void}
   def initialize(); end
 
   sig do
@@ -1399,7 +1399,7 @@ class Bundler::Dsl::DSLError < Bundler::GemfileError
       backtrace: T.untyped,
       contents: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(description, dsl_path, backtrace, contents=T.unsafe(nil)); end
 
@@ -1483,7 +1483,7 @@ class Bundler::EndpointSpecification < Gem::Specification
       dependencies: T.untyped,
       metadata: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(name, version, platform, dependencies, metadata=T.unsafe(nil)); end
 
@@ -1552,7 +1552,7 @@ class Bundler::EnvironmentPreserver
       env: T.untyped,
       keys: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(env, keys); end
 
@@ -1641,7 +1641,7 @@ class Bundler::FeatureFlag
     params(
       bundler_version: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(bundler_version); end
 
@@ -3225,7 +3225,7 @@ class Bundler::FileUtils::Entry_
       b: T.untyped,
       deref: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(a, b=T.unsafe(nil), deref=T.unsafe(nil)); end
 
@@ -4234,7 +4234,7 @@ class Bundler::GemRequireError < Bundler::BundlerError
       orig_exception: T.untyped,
       msg: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(orig_exception, msg); end
 
@@ -4274,7 +4274,7 @@ class Bundler::GenericSystemCallError < Bundler::BundlerError
       underlying_error: T.untyped,
       message: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(underlying_error, message); end
 
@@ -4405,7 +4405,7 @@ class Bundler::Index
   sig {returns(T.untyped)}
   def empty?(); end
 
-  sig {returns(T.untyped)}
+  sig {void}
   def initialize(); end
 
   sig {returns(T.untyped)}
@@ -4544,7 +4544,7 @@ class Bundler::LazySpecification
       platform: T.untyped,
       source: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(name, version, platform, source=T.unsafe(nil)); end
 
@@ -4727,7 +4727,7 @@ class Bundler::LockfileParser
     params(
       lockfile: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(lockfile); end
 
@@ -4821,7 +4821,7 @@ class Bundler::Molinillo::CircularDependencyError < Bundler::Molinillo::Resolver
     params(
       vertices: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(vertices); end
 end
@@ -5052,7 +5052,7 @@ class Bundler::Molinillo::DependencyGraph
   end
   def each(&blk); end
 
-  sig {returns(T.untyped)}
+  sig {void}
   def initialize(); end
 
   # @return [String] a string suitable for debugging
@@ -5240,7 +5240,7 @@ class Bundler::Molinillo::DependencyGraph::AddEdgeNoCircular < Bundler::Molinill
       destination: T.untyped,
       requirement: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(origin, destination, requirement); end
 
@@ -5291,7 +5291,7 @@ class Bundler::Molinillo::DependencyGraph::AddVertex < Bundler::Molinillo::Depen
       payload: T.untyped,
       root: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(name, payload, root); end
 
@@ -5338,7 +5338,7 @@ class Bundler::Molinillo::DependencyGraph::DeleteEdge < Bundler::Molinillo::Depe
       destination_name: T.untyped,
       requirement: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(origin_name, destination_name, requirement); end
 
@@ -5390,7 +5390,7 @@ class Bundler::Molinillo::DependencyGraph::DetachVertexNamed < Bundler::Molinill
     params(
       name: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(name); end
 
@@ -5536,7 +5536,7 @@ class Bundler::Molinillo::DependencyGraph::Log
   end
   def each(&blk); end
 
-  sig {returns(T.untyped)}
+  sig {void}
   def initialize(); end
 
   # Pops the most recent action from the log and undoes the action @param
@@ -5601,7 +5601,7 @@ class Bundler::Molinillo::DependencyGraph::SetPayload < Bundler::Molinillo::Depe
       name: T.untyped,
       payload: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(name, payload); end
 
@@ -5639,7 +5639,7 @@ class Bundler::Molinillo::DependencyGraph::Tag < Bundler::Molinillo::DependencyG
     params(
       tag: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(tag); end
 
@@ -5763,7 +5763,7 @@ class Bundler::Molinillo::DependencyGraph::Vertex
       name: T.untyped,
       payload: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(name, payload); end
 
@@ -5950,7 +5950,7 @@ class Bundler::Molinillo::NoSuchDependencyError < Bundler::Molinillo::ResolverEr
       dependency: T.untyped,
       required_by: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(dependency, required_by=T.unsafe(nil)); end
 
@@ -6105,7 +6105,7 @@ class Bundler::Molinillo::Resolver
       specification_provider: T.untyped,
       resolver_ui: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(specification_provider, resolver_ui); end
 
@@ -6167,7 +6167,7 @@ class Bundler::Molinillo::Resolver::Resolution
       requested: T.untyped,
       base: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(specification_provider, resolver_ui, requested, base); end
 
@@ -6784,7 +6784,7 @@ class Bundler::Molinillo::VersionConflict < Bundler::Molinillo::ResolverError
       conflicts: T.untyped,
       specification_provider: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(conflicts, specification_provider); end
 
@@ -6859,7 +6859,7 @@ class Bundler::PermissionError < Bundler::BundlerError
       path: T.untyped,
       permission_type: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(path, permission_type=T.unsafe(nil)); end
 
@@ -7265,7 +7265,7 @@ class Bundler::RemoteSpecification
       platform: T.untyped,
       spec_fetcher: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(name, version, platform, spec_fetcher); end
 
@@ -7380,7 +7380,7 @@ class Bundler::Resolver
       additional_base_requirements: T.untyped,
       platforms: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(index, source_requirements, base, gem_version_promoter, additional_base_requirements, platforms); end
 
@@ -7545,7 +7545,7 @@ class Bundler::Resolver::SpecGroup
     params(
       all_specs: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(all_specs); end
 
@@ -7653,7 +7653,7 @@ class Bundler::RubyVersion
       engine: T.untyped,
       engine_version: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(versions, patchlevel, engine, engine_version); end
 
@@ -7851,7 +7851,7 @@ class Bundler::RubygemsIntegration
   end
   def inflate(obj); end
 
-  sig {returns(T.untyped)}
+  sig {void}
   def initialize(); end
 
   sig do
@@ -8156,7 +8156,7 @@ end
 
 # RubyGems versions 1.3.6 and 1.3.7
 class Bundler::RubygemsIntegration::Ancient < Bundler::RubygemsIntegration::Legacy
-  sig {returns(T.untyped)}
+  sig {void}
   def initialize(); end
 end
 
@@ -8258,7 +8258,7 @@ class Bundler::RubygemsIntegration::Legacy < Bundler::RubygemsIntegration
   end
   def find_name(name); end
 
-  sig {returns(T.untyped)}
+  sig {void}
   def initialize(); end
 
   sig {returns(T.untyped)}
@@ -8324,7 +8324,7 @@ class Bundler::RubygemsIntegration::MoreFuture < Bundler::RubygemsIntegration::F
   end
   def find_name(name); end
 
-  sig {returns(T.untyped)}
+  sig {void}
   def initialize(); end
 
   # only 2.5.2+ has all of the stub methods we want to use, and since this is a
@@ -8409,7 +8409,7 @@ class Bundler::Runtime
       root: T.untyped,
       definition: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(root, definition); end
 
@@ -8504,7 +8504,7 @@ class Bundler::Settings
     params(
       root: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(root=T.unsafe(nil)); end
 
@@ -8932,7 +8932,7 @@ class Bundler::Source::Gemspec < Bundler::Source::Path
     params(
       options: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(options); end
 end
@@ -8992,7 +8992,7 @@ class Bundler::Source::Git < Bundler::Source::Path
     params(
       options: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(options); end
 
@@ -9080,7 +9080,7 @@ class Bundler::Source::Git::GitCommandError < Bundler::GitError
       path: T.untyped,
       extra_info: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(command, path=T.unsafe(nil), extra_info=T.unsafe(nil)); end
 end
@@ -9090,13 +9090,13 @@ class Bundler::Source::Git::GitNotAllowedError < Bundler::GitError
     params(
       command: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(command); end
 end
 
 class Bundler::Source::Git::GitNotInstalledError < Bundler::GitError
-  sig {returns(T.untyped)}
+  sig {void}
   def initialize(); end
 end
 
@@ -9140,7 +9140,7 @@ class Bundler::Source::Git::GitProxy
       revision: T.untyped,
       git: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(path, uri, ref, revision=T.unsafe(nil), git=T.unsafe(nil)); end
 
@@ -9198,7 +9198,7 @@ class Bundler::Source::Git::MissingGitRevisionError < Bundler::GitError
       ref: T.untyped,
       repo: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(ref, repo); end
 end
@@ -9308,7 +9308,7 @@ class Bundler::Source::Path < Bundler::Source
     params(
       options: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(options); end
 
@@ -9544,7 +9544,7 @@ class Bundler::Source::Rubygems < Bundler::Source
     params(
       options: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(options=T.unsafe(nil)); end
 
@@ -9736,7 +9736,7 @@ class Bundler::SourceList
   end
   def global_rubygems_source=(uri); end
 
-  sig {returns(T.untyped)}
+  sig {void}
   def initialize(); end
 
   sig {returns(T.untyped)}
@@ -9858,7 +9858,7 @@ class Bundler::SpecSet
     params(
       specs: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(specs); end
 
@@ -10052,7 +10052,7 @@ class Bundler::UI::RGProxy < Gem::SilentUI
     params(
       ui: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(ui); end
 
@@ -10122,7 +10122,7 @@ class Bundler::UI::Silent
   end
   def info(message, newline=T.unsafe(nil)); end
 
-  sig {returns(T.untyped)}
+  sig {void}
   def initialize(); end
 
   sig do
@@ -10218,7 +10218,7 @@ class Bundler::VersionConflict < Bundler::BundlerError
       conflicts: T.untyped,
       msg: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(conflicts, msg=T.unsafe(nil)); end
 
@@ -10262,7 +10262,7 @@ class Bundler::YamlSyntaxError < Bundler::BundlerError
       orig_exception: T.untyped,
       msg: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(orig_exception, msg); end
 

--- a/rbi/stdlib/cgi.rbi
+++ b/rbi/stdlib/cgi.rbi
@@ -510,7 +510,7 @@ class CGI
       options: ::T.untyped,
       block: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(options=T.unsafe(nil), &block); end
 
@@ -730,7 +730,7 @@ class CGI::Cookie < Array
       name: ::T.untyped,
       value: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(name=T.unsafe(nil), *value); end
 

--- a/rbi/stdlib/digest.rbi
+++ b/rbi/stdlib/digest.rbi
@@ -175,7 +175,7 @@ end
 # This module stands as a base class for digest implementation classes.
 class Digest::Class
   include ::Digest::Instance
-  sig {returns(::T.untyped)}
+  sig {void}
   def initialize(); end
 
   # Returns the base64 encoded hash value of a given *string*. The return value
@@ -457,7 +457,7 @@ class Digest::SHA2 < Digest::Class
     params(
       bitlen: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(bitlen=T.unsafe(nil)); end
 

--- a/rbi/stdlib/erb.rbi
+++ b/rbi/stdlib/erb.rbi
@@ -341,7 +341,7 @@ class ERB
       trim_mode: ::T.untyped,
       eoutvar: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(str, safe_level=T.unsafe(nil), trim_mode=T.unsafe(nil), eoutvar=T.unsafe(nil)); end
 
@@ -521,7 +521,7 @@ class ERB::Compiler
     params(
       trim_mode: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(trim_mode); end
 
@@ -605,7 +605,7 @@ class ERB::Compiler::Buffer
       enc: ::T.untyped,
       frozen: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(compiler, enc=T.unsafe(nil), frozen=T.unsafe(nil)); end
 
@@ -634,7 +634,7 @@ class ERB::Compiler::PercentLine
     params(
       str: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(str); end
 
@@ -655,7 +655,7 @@ class ERB::Compiler::Scanner
       trim_mode: ::T.untyped,
       percent: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(src, trim_mode, percent); end
 
@@ -737,7 +737,7 @@ class ERB::Compiler::TrimScanner < ERB::Compiler::Scanner
       trim_mode: ::T.untyped,
       percent: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(src, trim_mode, percent); end
 

--- a/rbi/stdlib/fileutils.rbi
+++ b/rbi/stdlib/fileutils.rbi
@@ -1013,7 +1013,7 @@ class FileUtils::Entry_ < Object
   sig {returns(T::Boolean)}
   def file?; end
 
-  sig {params(a: T.untyped, b: T.untyped, deref: T::Boolean).returns(T.untyped)}
+  sig {params(a: T.untyped, b: T.untyped, deref: T::Boolean).void}
   def initialize(a, b = nil, deref = false); end
 
   sig {params(dest: T.untyped).returns(T.untyped)}

--- a/rbi/stdlib/open_struct.rbi
+++ b/rbi/stdlib/open_struct.rbi
@@ -237,7 +237,7 @@ class OpenStruct
     params(
       hash: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(hash=T.unsafe(nil)); end
 

--- a/rbi/stdlib/openssl.rbi
+++ b/rbi/stdlib/openssl.rbi
@@ -1214,7 +1214,7 @@ class OpenSSL::ASN1::ASN1Data
       arg1: ::T.untyped,
       arg2: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(arg0, arg1, arg2); end
 
@@ -1362,7 +1362,7 @@ class OpenSSL::ASN1::Constructive < OpenSSL::ASN1::ASN1Data
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -1391,7 +1391,7 @@ class OpenSSL::ASN1::Constructive < OpenSSL::ASN1::ASN1Data
 end
 
 class OpenSSL::ASN1::EndOfContent < OpenSSL::ASN1::ASN1Data
-  sig {returns(::T.untyped)}
+  sig {void}
   def initialize(); end
 end
 
@@ -1580,7 +1580,7 @@ class OpenSSL::ASN1::Primitive < OpenSSL::ASN1::ASN1Data
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -1800,7 +1800,7 @@ class OpenSSL::BN
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -2143,7 +2143,7 @@ module OpenSSL::Buffering
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -2823,7 +2823,7 @@ class OpenSSL::Cipher
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(arg0); end
 
@@ -3014,7 +3014,7 @@ class OpenSSL::Cipher::AES < OpenSSL::Cipher
     params(
       args: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*args); end
 end
@@ -3024,7 +3024,7 @@ class OpenSSL::Cipher::AES128 < OpenSSL::Cipher
     params(
       mode: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(mode=T.unsafe(nil)); end
 end
@@ -3034,7 +3034,7 @@ class OpenSSL::Cipher::AES192 < OpenSSL::Cipher
     params(
       mode: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(mode=T.unsafe(nil)); end
 end
@@ -3044,7 +3044,7 @@ class OpenSSL::Cipher::AES256 < OpenSSL::Cipher
     params(
       mode: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(mode=T.unsafe(nil)); end
 end
@@ -3054,7 +3054,7 @@ class OpenSSL::Cipher::BF < OpenSSL::Cipher
     params(
       args: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*args); end
 end
@@ -3064,7 +3064,7 @@ class OpenSSL::Cipher::CAST5 < OpenSSL::Cipher
     params(
       args: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*args); end
 end
@@ -3077,7 +3077,7 @@ class OpenSSL::Cipher::DES < OpenSSL::Cipher
     params(
       args: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*args); end
 end
@@ -3087,7 +3087,7 @@ class OpenSSL::Cipher::IDEA < OpenSSL::Cipher
     params(
       args: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*args); end
 end
@@ -3097,7 +3097,7 @@ class OpenSSL::Cipher::RC2 < OpenSSL::Cipher
     params(
       args: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*args); end
 end
@@ -3107,7 +3107,7 @@ class OpenSSL::Cipher::RC4 < OpenSSL::Cipher
     params(
       args: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*args); end
 end
@@ -3117,7 +3117,7 @@ class OpenSSL::Cipher::RC5 < OpenSSL::Cipher
     params(
       args: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*args); end
 end
@@ -3280,7 +3280,7 @@ class OpenSSL::Config
     params(
       filename: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(filename=T.unsafe(nil)); end
 
@@ -3556,7 +3556,7 @@ class OpenSSL::Digest < Digest::Class
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -3633,7 +3633,7 @@ class OpenSSL::Digest::DSS < OpenSSL::Digest
     params(
       data: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(data=T.unsafe(nil)); end
 
@@ -3659,7 +3659,7 @@ class OpenSSL::Digest::DSS1 < OpenSSL::Digest
     params(
       data: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(data=T.unsafe(nil)); end
 
@@ -3691,7 +3691,7 @@ class OpenSSL::Digest::MD2 < OpenSSL::Digest
     params(
       data: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(data=T.unsafe(nil)); end
 
@@ -3717,7 +3717,7 @@ class OpenSSL::Digest::MD4 < OpenSSL::Digest
     params(
       data: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(data=T.unsafe(nil)); end
 
@@ -3743,7 +3743,7 @@ class OpenSSL::Digest::MD5 < OpenSSL::Digest
     params(
       data: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(data=T.unsafe(nil)); end
 
@@ -3769,7 +3769,7 @@ class OpenSSL::Digest::MDC2 < OpenSSL::Digest
     params(
       data: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(data=T.unsafe(nil)); end
 
@@ -3795,7 +3795,7 @@ class OpenSSL::Digest::RIPEMD160 < OpenSSL::Digest
     params(
       data: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(data=T.unsafe(nil)); end
 
@@ -3821,7 +3821,7 @@ class OpenSSL::Digest::SHA < OpenSSL::Digest
     params(
       data: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(data=T.unsafe(nil)); end
 
@@ -3847,7 +3847,7 @@ class OpenSSL::Digest::SHA1 < OpenSSL::Digest
     params(
       data: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(data=T.unsafe(nil)); end
 
@@ -3873,7 +3873,7 @@ class OpenSSL::Digest::SHA224 < OpenSSL::Digest
     params(
       data: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(data=T.unsafe(nil)); end
 
@@ -3899,7 +3899,7 @@ class OpenSSL::Digest::SHA256 < OpenSSL::Digest
     params(
       data: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(data=T.unsafe(nil)); end
 
@@ -3925,7 +3925,7 @@ class OpenSSL::Digest::SHA384 < OpenSSL::Digest
     params(
       data: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(data=T.unsafe(nil)); end
 
@@ -3951,7 +3951,7 @@ class OpenSSL::Digest::SHA512 < OpenSSL::Digest
     params(
       data: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(data=T.unsafe(nil)); end
 
@@ -4259,7 +4259,7 @@ class OpenSSL::HMAC
       arg0: ::T.untyped,
       arg1: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(arg0, arg1); end
 
@@ -4483,7 +4483,7 @@ class OpenSSL::Netscape::SPKI
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -4876,7 +4876,7 @@ class OpenSSL::OCSP::BasicResponse
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -4970,7 +4970,7 @@ class OpenSSL::OCSP::CertificateId
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -5063,7 +5063,7 @@ class OpenSSL::OCSP::Request
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -5123,7 +5123,7 @@ class OpenSSL::OCSP::Response
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -5207,7 +5207,7 @@ class OpenSSL::OCSP::SingleResponse
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(arg0); end
 
@@ -5248,7 +5248,7 @@ class OpenSSL::PKCS12
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -5454,7 +5454,7 @@ class OpenSSL::PKCS7
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -5540,7 +5540,7 @@ class OpenSSL::PKCS7::RecipientInfo
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(arg0); end
 
@@ -5558,7 +5558,7 @@ class OpenSSL::PKCS7::SignerInfo
       arg1: ::T.untyped,
       arg2: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(arg0, arg1, arg2); end
 
@@ -5763,7 +5763,7 @@ class OpenSSL::PKey::DH < OpenSSL::PKey::PKey
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -5981,7 +5981,7 @@ class OpenSSL::PKey::DSA < OpenSSL::PKey::PKey
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -6320,7 +6320,7 @@ class OpenSSL::PKey::EC < OpenSSL::PKey::PKey
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -6507,7 +6507,7 @@ class OpenSSL::PKey::EC::Group
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -6634,7 +6634,7 @@ class OpenSSL::PKey::EC::Point
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -6707,7 +6707,7 @@ end
 # *   [`OpenSSL::PKey::DSA`](https://docs.ruby-lang.org/en/2.7.0/OpenSSL/PKey/DSA.html)
 # *   [`OpenSSL::PKey::EC`](https://docs.ruby-lang.org/en/2.7.0/OpenSSL/PKey/EC.html)
 class OpenSSL::PKey::PKey
-  sig {returns(::T.untyped)}
+  sig {void}
   def initialize(); end
 
   # To sign the [`String`](https://docs.ruby-lang.org/en/2.7.0/String.html)
@@ -6853,7 +6853,7 @@ class OpenSSL::PKey::RSA < OpenSSL::PKey::PKey
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -7623,7 +7623,7 @@ class OpenSSL::SSL::SSLContext
     params(
       version: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(version=T.unsafe(nil)); end
 
@@ -8294,7 +8294,7 @@ class OpenSSL::SSL::SSLServer
       svr: ::T.untyped,
       ctx: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(svr, ctx); end
 
@@ -8467,7 +8467,7 @@ class OpenSSL::SSL::SSLSocket
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -8615,7 +8615,7 @@ class OpenSSL::SSL::Session
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(arg0); end
 
@@ -8799,7 +8799,7 @@ class OpenSSL::X509::Attribute
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -8866,7 +8866,7 @@ class OpenSSL::X509::CRL
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -9101,7 +9101,7 @@ class OpenSSL::X509::Certificate
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -9252,7 +9252,7 @@ class OpenSSL::X509::Extension
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -9364,7 +9364,7 @@ class OpenSSL::X509::ExtensionFactory
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -9529,7 +9529,7 @@ class OpenSSL::X509::Name
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -9679,7 +9679,7 @@ class OpenSSL::X509::Request
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -9783,7 +9783,7 @@ class OpenSSL::X509::Revoked
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -9925,7 +9925,7 @@ class OpenSSL::X509::Store
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -10070,7 +10070,7 @@ class OpenSSL::X509::StoreContext
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 

--- a/rbi/stdlib/socket.rbi
+++ b/rbi/stdlib/socket.rbi
@@ -182,7 +182,7 @@ class Addrinfo < Data
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -2469,7 +2469,7 @@ class Socket < BasicSocket
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -3618,7 +3618,7 @@ class Socket::AncillaryData
       arg2: ::T.untyped,
       arg3: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(arg0, arg1, arg2, arg3); end
 
@@ -4540,7 +4540,7 @@ class Socket::Option
       arg2: ::T.untyped,
       arg3: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(arg0, arg1, arg2, arg3); end
 
@@ -4779,7 +4779,7 @@ class Socket::UDPSource
       local_address: ::T.untyped,
       reply_proc: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(remote_address, local_address, &reply_proc); end
 
@@ -4913,7 +4913,7 @@ class TCPServer < TCPSocket
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -5040,7 +5040,7 @@ class TCPSocket < IPSocket
       local_host: ::T.untyped,
       local_port: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(host=T.unsafe(nil), port=T.unsafe(nil), local_host=T.unsafe(nil), local_port=T.unsafe(nil)); end
 
@@ -5211,7 +5211,7 @@ class UDPSocket < IPSocket
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(*arg0); end
 
@@ -5393,7 +5393,7 @@ class UNIXServer < UNIXSocket
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(arg0); end
 
@@ -5519,7 +5519,7 @@ class UNIXSocket < BasicSocket
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
   def initialize(arg0); end
 

--- a/rbi/stdlib/webrick.rbi
+++ b/rbi/stdlib/webrick.rbi
@@ -604,7 +604,7 @@ class WEBrick::Cookie
       name: T.untyped,
       value: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(name, value); end
 
@@ -742,7 +742,7 @@ class WEBrick::GenericServer
       config: T.untyped,
       default: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(config=T.unsafe(nil), default=T.unsafe(nil)); end
 
@@ -993,7 +993,7 @@ class WEBrick::HTTPAuth::BasicAuth
       config: T.untyped,
       default: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(config, default=T.unsafe(nil)); end
 
@@ -1084,7 +1084,7 @@ class WEBrick::HTTPAuth::DigestAuth
       config: T.untyped,
       default: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(config, default=T.unsafe(nil)); end
 
@@ -1217,7 +1217,7 @@ class WEBrick::HTTPAuth::Htdigest
     params(
       path: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(path); end
 
@@ -1281,7 +1281,7 @@ class WEBrick::HTTPAuth::Htgroup
     params(
       path: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(path); end
 
@@ -1360,7 +1360,7 @@ class WEBrick::HTTPAuth::Htpasswd
       path: T.untyped,
       password_hash: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(path, password_hash: T.unsafe(nil)); end
 
@@ -1555,7 +1555,7 @@ class WEBrick::HTTPRequest
     params(
       config: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(config); end
 
@@ -1855,7 +1855,7 @@ class WEBrick::HTTPResponse
     params(
       config: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(config); end
 
@@ -2042,7 +2042,7 @@ class WEBrick::HTTPServer < WEBrick::GenericServer
       config: T.untyped,
       default: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(config=T.unsafe(nil), default=T.unsafe(nil)); end
 
@@ -2165,7 +2165,7 @@ class WEBrick::HTTPServer::MountTable
   end
   def delete(dir); end
 
-  sig {returns(T.untyped)}
+  sig {void}
   def initialize(); end
 
   sig do
@@ -2284,7 +2284,7 @@ class WEBrick::HTTPServlet::AbstractServlet
       server: T.untyped,
       options: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(server, *options); end
 
@@ -2349,7 +2349,7 @@ class WEBrick::HTTPServlet::CGIHandler < WEBrick::HTTPServlet::AbstractServlet
       server: T.untyped,
       name: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(server, name); end
 end
@@ -2381,7 +2381,7 @@ class WEBrick::HTTPServlet::DefaultFileHandler < WEBrick::HTTPServlet::AbstractS
       server: T.untyped,
       local_path: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(server, local_path); end
 
@@ -2471,7 +2471,7 @@ class WEBrick::HTTPServlet::ERBHandler < WEBrick::HTTPServlet::AbstractServlet
       server: T.untyped,
       name: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(server, name); end
 end
@@ -2521,7 +2521,7 @@ class WEBrick::HTTPServlet::FileHandler < WEBrick::HTTPServlet::AbstractServlet
       options: T.untyped,
       default: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(server, root, options=T.unsafe(nil), default=T.unsafe(nil)); end
 
@@ -2599,7 +2599,7 @@ class WEBrick::HTTPServlet::ProcHandler < WEBrick::HTTPServlet::AbstractServlet
     params(
       proc: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(proc); end
 end
@@ -3224,7 +3224,7 @@ class WEBrick::HTTPUtils::FormData < String
     params(
       args: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(*args); end
 
@@ -3293,7 +3293,7 @@ class WEBrick::HTTPVersion
     params(
       version: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(version); end
 
@@ -3346,7 +3346,7 @@ class WEBrick::Log < WEBrick::BasicLog
       log_file: T.untyped,
       level: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
   def initialize(log_file=T.unsafe(nil), level=T.unsafe(nil)); end
 
@@ -3503,7 +3503,7 @@ class WEBrick::Utils::TimeoutHandler
   end
   def cancel(thread, id); end
 
-  sig {returns(T.untyped)}
+  sig {void}
   def initialize(); end
 
   sig do

--- a/test/cli/suggest_initialize_sig/suggest_initialize_sig.out
+++ b/test/cli/suggest_initialize_sig/suggest_initialize_sig.out
@@ -51,4 +51,67 @@ test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:52: The initialize met
     test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:52: Replace with `params(x: T.any(Integer, String)).void`
     52 |  sig {params(x: T.any(Integer, String)).returns(T.any(Integer, String))}
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 5
+
+test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:71: The initialize method should always return void https://srb.help/3510
+    71 |    params(
+    72 |      path: String,
+    73 |      key: String
+    74 |    )
+    75 |    .returns(T.self_type)
+    76 |    .checked(:tests)
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:71: Replace with `params(
+      path: String,
+      key: String
+    )
+    .void
+    .checked(:tests)`
+    71 |    params(
+    72 |      path: String,
+    73 |      key: String
+    74 |    )
+    75 |    .returns(T.self_type)
+    76 |    .checked(:tests)
+
+test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:86: The initialize method should always return void https://srb.help/3510
+    86 |    params(
+    87 |      path: String,
+    88 |      key: String
+    89 |    )
+    90 |    .returns(T.self_type).checked(:tests)
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:86: Replace with `params(
+      path: String,
+      key: String
+    )
+    .void.checked(:tests)`
+    86 |    params(
+    87 |      path: String,
+    88 |      key: String
+    89 |    )
+    90 |    .returns(T.self_type).checked(:tests)
+
+test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:79: Expected `LineBreakAfterReturns` but found `NilClass` for method result type https://srb.help/7005
+    79 |  end
+          ^^^
+  Expected `LineBreakAfterReturns` for result type of method `initialize`:
+    test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:78:
+    78 |  def initialize(path, key)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `NilClass` originating from:
+    test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:78: Possibly uninitialized (`NilClass`) in:
+    78 |  def initialize(path, key)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:93: Expected `LineBreakOnlyAtEnd` but found `NilClass` for method result type https://srb.help/7005
+    93 |  end
+          ^^^
+  Expected `LineBreakOnlyAtEnd` for result type of method `initialize`:
+    test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:92:
+    92 |  def initialize(path, key)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `NilClass` originating from:
+    test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:92: Possibly uninitialized (`NilClass`) in:
+    92 |  def initialize(path, key)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 9

--- a/test/cli/suggest_initialize_sig/suggest_initialize_sig.out
+++ b/test/cli/suggest_initialize_sig/suggest_initialize_sig.out
@@ -5,4 +5,50 @@ test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:6: The initialize meth
     test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:6: Replace with `params(x: Integer).void.on_failure(:soft, notify: 'sorbet')`
      6 |  sig {params(x: Integer).returns(Integer).on_failure(:soft, notify: 'sorbet')}
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 1
+
+test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:16: The initialize method should always return void https://srb.help/3510
+    16 |    params(
+    17 |      x: Integer
+    18 |    )
+    19 |    .returns(Integer)
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:16: Replace with `params(
+      x: Integer
+    )
+    .void`
+    16 |    params(
+    17 |      x: Integer
+    18 |    )
+    19 |    .returns(Integer)
+
+test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:30: The initialize method should always return void https://srb.help/3510
+    30 |    params(
+    31 |      x: T::Array[T.any(String, T::Enum)]
+    32 |    )
+    33 |    .returns(T::Array[T.any(String, T::Enum)])
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:30: Replace with `params(
+      x: T::Array[T.any(String, T::Enum)]
+    )
+    .void`
+    30 |    params(
+    31 |      x: T::Array[T.any(String, T::Enum)]
+    32 |    )
+    33 |    .returns(T::Array[T.any(String, T::Enum)])
+
+test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:43: The initialize method should always return void https://srb.help/3510
+    43 |  sig {params(x: T.nilable(Integer)).returns(T.nilable(Integer)).on_failure(:soft, notify: 'sorbet')}
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:43: Replace with `params(x: T.nilable(Integer)).void.on_failure(:soft, notify: 'sorbet')`
+    43 |  sig {params(x: T.nilable(Integer)).returns(T.nilable(Integer)).on_failure(:soft, notify: 'sorbet')}
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:52: The initialize method should always return void https://srb.help/3510
+    52 |  sig {params(x: T.any(Integer, String)).returns(T.any(Integer, String))}
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:52: Replace with `params(x: T.any(Integer, String)).void`
+    52 |  sig {params(x: T.any(Integer, String)).returns(T.any(Integer, String))}
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 5

--- a/test/cli/suggest_initialize_sig/suggest_initialize_sig.out
+++ b/test/cli/suggest_initialize_sig/suggest_initialize_sig.out
@@ -1,0 +1,8 @@
+test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:6: The initialize method should always return void https://srb.help/3510
+     6 |  sig {params(x: Integer).returns(Integer).on_failure(:soft, notify: 'sorbet')}
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:6: Replace with `params(x: Integer).void.on_failure(:soft, notify: 'sorbet')`
+     6 |  sig {params(x: Integer).returns(Integer).on_failure(:soft, notify: 'sorbet')}
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 1

--- a/test/cli/suggest_initialize_sig/suggest_initialize_sig.rb
+++ b/test/cli/suggest_initialize_sig/suggest_initialize_sig.rb
@@ -1,9 +1,55 @@
 # typed: true
 
-class Foo
+class SimpleReturns
   extend T::Sig
 
   sig {params(x: Integer).returns(Integer).on_failure(:soft, notify: 'sorbet')}
+  def initialize(x)
+    @x = x
+  end
+end
+
+class SimpleMultiLineReturns
+  extend T::Sig
+
+  sig do
+    params(
+      x: Integer
+    )
+    .returns(Integer)
+  end
+  def initialize(x)
+    @x = x
+  end
+end
+
+class MultiLineReturnsWithCombinators
+  extend T::Sig
+
+  sig do
+    params(
+      x: T::Array[T.any(String, T::Enum)]
+    )
+    .returns(T::Array[T.any(String, T::Enum)])
+  end
+  def initialize(x)
+    @x = x
+  end
+end
+
+class SingleLineReturnsWithCombinators
+  extend T::Sig
+
+  sig {params(x: T.nilable(Integer)).returns(T.nilable(Integer)).on_failure(:soft, notify: 'sorbet')}
+  def initialize(x)
+    @x = x
+  end
+end
+
+class SingleLineNoAfterStatements
+  extend T::Sig
+
+  sig {params(x: T.any(Integer, String)).returns(T.any(Integer, String))}
   def initialize(x)
     @x = x
   end

--- a/test/cli/suggest_initialize_sig/suggest_initialize_sig.rb
+++ b/test/cli/suggest_initialize_sig/suggest_initialize_sig.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+class Foo
+  extend T::Sig
+
+  sig {params(x: Integer).returns(Integer).on_failure(:soft, notify: 'sorbet')}
+  def initialize(x)
+    @x = x
+  end
+end

--- a/test/cli/suggest_initialize_sig/suggest_initialize_sig.rb
+++ b/test/cli/suggest_initialize_sig/suggest_initialize_sig.rb
@@ -54,3 +54,41 @@ class SingleLineNoAfterStatements
     @x = x
   end
 end
+
+class ClassMethodInitializeIsIgnored
+  extend T::Sig
+
+  sig {returns(ClassMethodInitializeIsIgnored)}
+  def self.initialize
+    new
+  end
+end
+
+class LineBreakAfterReturns
+  extend T::Sig
+
+  sig do
+    params(
+      path: String,
+      key: String
+    )
+    .returns(T.self_type)
+    .checked(:tests)
+  end
+  def initialize(path, key)
+  end
+end
+
+class LineBreakOnlyAtEnd
+  extend T::Sig
+
+  sig do
+    params(
+      path: String,
+      key: String
+    )
+    .returns(T.self_type).checked(:tests)
+  end
+  def initialize(path, key)
+  end
+end

--- a/test/cli/suggest_initialize_sig/suggest_initialize_sig.sh
+++ b/test/cli/suggest_initialize_sig/suggest_initialize_sig.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+main/sorbet --silence-dev-message test/cli/suggest_initialize_sig/suggest_initialize_sig.rb 2>&1

--- a/test/testdata/infer/block_arg.rb
+++ b/test/testdata/infer/block_arg.rb
@@ -49,7 +49,7 @@ class A
   class ConstructorBlock
     extend T::Sig
 
-    sig {params(blk: T.proc.params(s: Symbol).returns(String)).returns(NilClass)}
+    sig {params(blk: T.proc.params(s: Symbol).returns(String)).void}
     def initialize(&blk)
     end
   end

--- a/test/testdata/infer/constructor_return.rb
+++ b/test/testdata/infer/constructor_return.rb
@@ -2,7 +2,7 @@
 class A
   extend T::Sig
 
-  sig {returns(Integer)}
+  sig {void}
   def initialize()
     yield
     1

--- a/test/testdata/rewriter/initializer.rb
+++ b/test/testdata/rewriter/initializer.rb
@@ -156,3 +156,21 @@ class OnFailure
     T.reveal_type(@x) # error: Revealed type: `Integer`
   end
 end
+
+class BadSigReturn
+  extend T::Sig
+
+  sig {params(x: Integer).returns(Integer)} # error: The initialize method should always return void
+  def initialize(x)
+    @x = x
+  end
+end
+
+class BadSigReturnNotLastStatement
+  extend T::Sig
+
+  sig {params(x: Integer).returns(Integer).on_failure(:soft, notify: 'sorbet')} # error: The initialize method should always return void
+  def initialize(x)
+    @x = x
+  end
+end


### PR DESCRIPTION
Closes #2929

Add an error and auto-correct for `initialize` signatures that don't return `void`.

The first commit contains the entire implementation. The second one is just fixing internal RBIs that weren't returning `void` for initializers.

### Motivation

The recommendation is to have all initializers return `void`, so we should help enforce the correct behaviour.

### Test plan

See included automated tests.