### PR TITLE
properly initialize variable when building IREmitterContext

### DIFF
--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -590,7 +590,7 @@ IREmitterContext IREmitterContext::getSorbetBlocks2LLVMBlockMapping(CompilerStat
     vector<llvm::BasicBlock *> userEntryBlockByFunction(rubyBlock2Function.size());
     vector<llvm::AllocaInst *> sendArgArrayByBlock;
     vector<llvm::AllocaInst *> lineNumberPtrsByFunction;
-    bool hasReturnFromBlock;
+    bool hasReturnFromBlock = false;
     UnorderedMap<int, llvm::AllocaInst *> blockControlFramePtrs;
 
     int i = 0;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We weren't properly initializing this variable along all paths.  Luckily (?), not initializing this variable only made the compiler's output less deterministic and also simply made us do a little extra work at runtime.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
