### PR TITLE
Update return type for Regexp#match to be nilable

### DIFF
--- a/rbi/core/regexp.rbi
+++ b/rbi/core/regexp.rbi
@@ -1146,7 +1146,7 @@ class Regexp < Object
         arg1: Integer,
         blk: T.proc.params(arg0: MatchData).returns(T.type_parameter(:U))
     )
-    .returns(T.type_parameter(:U))
+    .returns(T.nilable(T.type_parameter(:U)))
   end
   def match(arg0, arg1=T.unsafe(nil), &blk); end
 


### PR DESCRIPTION
`Regexp#match` returns `nil` when there is no match.

### Motivation
More precise stdlib rbi. Original motivation was this example reported by an engineer at Stripe:

[View on Sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Asig%20%7Bparams%28s%3A%20String%29.returns%28String%29%7D%0Adef%20foo%28s%29%0A%20%20%2F%5CAFoo%5Cz%2F.match%28s%29%20do%0A%20%20%20%20return%20s.downcase%0A%20%20end%0A%20%20%2F%5CAbar%5Cz%2F.match%28s%29%20do%0A%20%20%20%20return%20s.upcase%0A%20%20end%0A%20%20s%0Aend%0A%0Afoo%28%22bar%22%29)
```ruby
# typed: true
extend T::Sig

sig {params(s: String).returns(String)}
def foo(s)
  /\AFoo\z/.match(s) do
    return s.downcase
  end
  /\Abar\z/.match(s) do
    return s.upcase
  end
  s
end

foo("bar")
```

### Test plan
See included automated tests. Also tests pass on Stripe codebase, and I verified that the above linked example now typechecks as it should.