### PR TITLE
add a disabled test for uninitialized class variables

### DIFF
--- a/test/testdata/compiler/disabled/uninitialized_class_variable.rb
+++ b/test/testdata/compiler/disabled/uninitialized_class_variable.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# compiled: true
+# typed: true
+
+class A
+  def self.init_change(change)
+    @@changes ||= {}
+    @@changes[change] = :done
+  end
+
+  def self.get_change(change)
+    @@changes[change]
+  end
+end
+
+A.init_change('constant')
+p A.get_change('constant')


### PR DESCRIPTION
### Motivation

The semantics for `@@var ||= ...` are apparently slightly different from `@var ||= ...`; Ruby is happy to deal with the latter without an explicit `defined` check, but not so much the former.  The error in the former case is:

```
       │SorbetLLVM using compiled: /home/froydnj/.cache/bazel/bazel/.../com_stripe_ruby_typer/test/testdata/compiler/uninitialized_class_variable.sorbet.build/test/testdata/compiler/uninitialized_class_variable.rb.so for /home/froydnj/src/sorbet/test/testdata/compiler/uninitialized_class_variable.rb
       │test/testdata/compiler/uninitialized_class_variable.rb:6:in `init_change': uninitialized class variable @@changes in A (NameError)
       │        from test/testdata/compiler/uninitialized_class_variable.rb:16:in `<top (required)>'
       │        from /home/froydnj/.cache/bazel/bazel/.../com_stripe_ruby_typer/bazel-out/k8-fastbuild/bin/external/sorbet_ruby_2_7/toolchain/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
       │        from /home/froydnj/.cache/bazel/bazel/.../com_stripe_ruby_typer/bazel-out/k8-fastbuild/bin/external/sorbet_ruby_2_7/toolchain/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
       │        from /home/froydnj/.cache/bazel/bazel/.../com_stripe_ruby_typer/test/patch_require.rb:33:in `require'
       │        from /tmp/tmp.Y2EWRvORZz:1:in `<main>'
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
