### PR TITLE
Put package definitions into top-level namespaces

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -411,6 +411,7 @@ NameDef names[] = {
     {"PackageSpec", "PackageSpec", true},
     {"PackageRegistry", "<PackageRegistry>", true},
     {"PackageMethods", "<PackageMethods>", true},
+    {"PackageDefs", "<PackageDefs>", true},
 
     // Compiler
     {"runningCompiled_p", "running_compiled?"},

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -774,6 +774,25 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
         return file;
     }
 
+    auto &rootKlass = ast::cast_tree_nonnull<ast::ClassDef>(file.tree);
+
+    // put our class definition into a non-writeable scope, because
+    // otherwise our package definitions can conflict with top-level
+    // names. (e.g. if we have a package named `Foo`, it'll conflict
+    // with `::Foo`.)
+    auto *scope = ast::cast_tree<ast::UnresolvedConstantLit>(rootKlass.name);
+    // if scope here is `nullptr`, it means the class definition isn't
+    // well-formed and doesn't have an `UnresolvedConstantLit` as its
+    // name
+    if (scope != nullptr) {
+        // keep going until we find the root scope
+        while (auto cnst = ast::cast_tree<ast::UnresolvedConstantLit>(scope->scope)) {
+            scope = cnst;
+        }
+        // and prepend our internal non-writeable name here
+        scope->scope = name2Expr(core::Names::Constants::PackageDefs());
+    }
+
     // Sanity check: __package.rb files _must_ be typed: strict
     if (file.file.data(ctx).originalSigil < core::StrictLevel::Strict) {
         if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::PackageFileMustBeStrict)) {
@@ -811,8 +830,8 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
         ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),
                         name2Expr(core::Names::Constants::PackageRegistry()), {}, std::move(importedPackages));
 
-    auto &rootKlass = ast::cast_tree_nonnull<ast::ClassDef>(file.tree);
     rootKlass.rhs.emplace_back(move(packageNamespace));
+
     return file;
 }
 

--- a/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(<emptyTree>::<C Package>::<C Subpackage>)
+  class <emptyTree>::<C <PackageDefs>>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C Package>::<C Subpackage>)
 
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>)
 
@@ -37,8 +37,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Package>::<C Subpackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(<emptyTree>::<C Package>)
+  class <emptyTree>::<C <PackageDefs>>::<C Package>::<C Subpackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C Package>)
 
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>)
   end

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C A><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(<emptyTree>::<C B>)
+  class <emptyTree>::<C <PackageDefs>>::<C A><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C B>)
 
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C B>::<C BClass>)
   end
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C <PackageDefs>>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>)
   end
 

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -1,8 +1,8 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(<emptyTree>::<C Project>::<C Foo>)
+  class <emptyTree>::<C <PackageDefs>>::<C Project>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C Project>::<C Foo>)
 
-    <self>.import(<emptyTree>::<C Project>::<C Baz>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C Project>::<C Baz>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
@@ -43,7 +43,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Baz><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C <PackageDefs>>::<C Project>::<C Baz><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1>::<C Project>::<C Baz>::<C C>)
   end
 
@@ -51,41 +51,37 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1><<C <todo sym>>> < ()
-    class <emptyTree>::<C Project>::<C Baz>::<C C><<C <todo sym>>> < (::<todo sym>)
-      ::Sorbet::Private::Static.sig(<self>) do ||
-        <self>.void()
-      end
-
-      def self.c<<todo method>>(&<blk>)
-        <emptyTree>
-      end
-
-      <self>.extend(<emptyTree>::<C T>::<C Sig>)
-
-      ::Sorbet::Private::Static.keep_self_def(<self>, :c, :normal)
+  class <emptyTree>::<C Project>::<C Baz>::<C C><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
     end
+
+    def self.c<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :c, :normal)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1><<C <todo sym>>> < ()
-    class <emptyTree>::<C Project>::<C Foo>::<C B><<C <todo sym>>> < (::<todo sym>)
-      ::Sorbet::Private::Static.sig(<self>) do ||
-        <self>.void()
-      end
-
-      def self.b<<todo method>>(&<blk>)
-        <emptyTree>
-      end
-
-      <self>.extend(<emptyTree>::<C T>::<C Sig>)
-
-      ::Sorbet::Private::Static.keep_self_def(<self>, :b, :normal)
+  class <emptyTree>::<C Project>::<C Foo>::<C B><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
     end
+
+    def self.b<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :b, :normal)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C <PackageDefs>>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C B>)
   end
 

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -51,33 +51,37 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Baz>::<C C><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(<self>) do ||
-      <self>.void()
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Project>::<C Baz>::<C C><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
+      def self.c<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_self_def(<self>, :c, :normal)
     end
-
-    def self.c<<todo method>>(&<blk>)
-      <emptyTree>
-    end
-
-    <self>.extend(<emptyTree>::<C T>::<C Sig>)
-
-    ::Sorbet::Private::Static.keep_self_def(<self>, :c, :normal)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Foo>::<C B><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(<self>) do ||
-      <self>.void()
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Project>::<C Foo>::<C B><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
+      def self.b<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_self_def(<self>, :b, :normal)
     end
-
-    def self.b<<todo method>>(&<blk>)
-      <emptyTree>
-    end
-
-    <self>.extend(<emptyTree>::<C T>::<C Sig>)
-
-    ::Sorbet::Private::Static.keep_self_def(<self>, :b, :normal)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -51,37 +51,33 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1><<C <todo sym>>> < ()
-    class <emptyTree>::<C Project>::<C Baz>::<C C><<C <todo sym>>> < (::<todo sym>)
-      ::Sorbet::Private::Static.sig(<self>) do ||
-        <self>.void()
-      end
-
-      def self.c<<todo method>>(&<blk>)
-        <emptyTree>
-      end
-
-      <self>.extend(<emptyTree>::<C T>::<C Sig>)
-
-      ::Sorbet::Private::Static.keep_self_def(<self>, :c, :normal)
+  class <emptyTree>::<C Project>::<C Baz>::<C C><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
     end
+
+    def self.c<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :c, :normal)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1><<C <todo sym>>> < ()
-    class <emptyTree>::<C Project>::<C Foo>::<C B><<C <todo sym>>> < (::<todo sym>)
-      ::Sorbet::Private::Static.sig(<self>) do ||
-        <self>.void()
-      end
-
-      def self.b<<todo method>>(&<blk>)
-        <emptyTree>
-      end
-
-      <self>.extend(<emptyTree>::<C T>::<C Sig>)
-
-      ::Sorbet::Private::Static.keep_self_def(<self>, :b, :normal)
+  class <emptyTree>::<C Project>::<C Foo>::<C B><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
     end
+
+    def self.b<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :b, :normal)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -1,16 +1,16 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C A><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C <PackageDefs>>::<C A><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(123)
 
     <self>.import("hello")
 
     <self>.import(<self>.method())
 
-    <self>.import(<emptyTree>::<C REFERENCE>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C REFERENCE>)
 
-    <self>.import(<emptyTree>::<C B>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C B>)
 
-    <self>.import(<emptyTree>::<C B>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C B>)
 
     <self>.export(123)
 
@@ -74,8 +74,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(<emptyTree>::<C A>)
+  class <emptyTree>::<C <PackageDefs>>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C A>)
 
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>)
 

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -1,7 +1,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C SomeConstant> = <emptyTree>::<C PackageSpec>
 
-  class <emptyTree>::<C MyPackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C <PackageDefs>>::<C MyPackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.void()
     end

--- a/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C RootPackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(<emptyTree>::<C RootPackage>::<C Foo>)
+  class <emptyTree>::<C <PackageDefs>>::<C RootPackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C RootPackage>::<C Foo>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
@@ -43,7 +43,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C RootPackage>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C <PackageDefs>>::<C RootPackage>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Constant>)
 
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>)

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(<emptyTree>::<C Package>::<C Subpackage>)
+  class <emptyTree>::<C <PackageDefs>>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C Package>::<C Subpackage>)
 
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>)
   end
@@ -29,8 +29,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Package>::<C Subpackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(<emptyTree>::<C Package>)
+  class <emptyTree>::<C <PackageDefs>>::<C Package>::<C Subpackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C Package>)
 
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>)
   end

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(<emptyTree>::<C Project>::<C Foo>)
+  class <emptyTree>::<C <PackageDefs>>::<C Project>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C Project>::<C Foo>)
 
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C Bar>)
 
@@ -62,8 +62,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(<emptyTree>::<C Project>::<C Bar>)
+  class <emptyTree>::<C <PackageDefs>>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C Project>::<C Bar>)
 
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C Foo>)
 

--- a/test/testdata/packager/top-level/pass.package-tree.exp
+++ b/test/testdata/packager/top-level/pass.package-tree.exp
@@ -1,6 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Toplevel><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Toplevel_Package$1>::<C Toplevel>)
+  class <emptyTree>::<C <PackageDefs>>::<C Toplevel><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
@@ -31,14 +30,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C User><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(<emptyTree>::<C Toplevel>)
+  class <emptyTree>::<C <PackageDefs>>::<C Project>::<C User><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C <PackageDefs>>::<C Toplevel>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Package>::<C User><<C <todo sym>>> < ()
-    module <emptyTree>::<C Thing><<C <todo sym>>> < ()
-      ::<root>::<C Toplevel>.hello()
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_User_Package$1><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project>::<C User><<C <todo sym>>> < ()
+      module <emptyTree>::<C Thing><<C <todo sym>>> < ()
+        ::<root>::<C Toplevel>.hello()
+      end
     end
   end
 end

--- a/test/testdata/packager/top-level/pass.package-tree.exp
+++ b/test/testdata/packager/top-level/pass.package-tree.exp
@@ -1,0 +1,44 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Toplevel><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Toplevel_Package$1>::<C Toplevel>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Toplevel_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Toplevel><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+      <self>.export(<emptyTree>::<C Toplevel>)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Toplevel_Package$1><<C <todo sym>>> < ()
+    module ::<root>::<C Toplevel><<C <todo sym>>> < ()
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
+      def self.hello<<todo method>>(&<blk>)
+        <self>.puts("hello")
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      ::Sorbet::Private::Static.keep_self_def(<self>, :hello, :normal)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Project>::<C User><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Toplevel>)
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C Package>::<C User><<C <todo sym>>> < ()
+    module <emptyTree>::<C Thing><<C <todo sym>>> < ()
+      ::<root>::<C Toplevel>.hello()
+    end
+  end
+end

--- a/test/testdata/packager/top-level/toplevel/__package.rb
+++ b/test/testdata/packager/top-level/toplevel/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Toplevel < PackageSpec
+  export Toplevel
+end

--- a/test/testdata/packager/top-level/toplevel/__package.rb
+++ b/test/testdata/packager/top-level/toplevel/__package.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # typed: strict
+# enable-packager: true
 
 class Toplevel < PackageSpec
-  export Toplevel
 end

--- a/test/testdata/packager/top-level/toplevel/__package.rb~
+++ b/test/testdata/packager/top-level/toplevel/__package.rb~
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Toplevel < PackageSpec
+  export Toplevel
+end

--- a/test/testdata/packager/top-level/toplevel/toplevel.rb
+++ b/test/testdata/packager/top-level/toplevel/toplevel.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+
+module ::Toplevel # error: was previously defined
+  extend T::Sig
+
+  sig {void}
+  def self.hello
+    puts "hello"
+  end
+end

--- a/test/testdata/packager/top-level/toplevel/toplevel.rb
+++ b/test/testdata/packager/top-level/toplevel/toplevel.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # typed: strict
 
-module ::Toplevel # error: was previously defined
+module ::Toplevel
   extend T::Sig
 
   sig {void}

--- a/test/testdata/packager/top-level/toplevel/toplevel.rb
+++ b/test/testdata/packager/top-level/toplevel/toplevel.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 # typed: strict
+# enable-packager: true
 
 module ::Toplevel
   extend T::Sig

--- a/test/testdata/packager/top-level/user/__package.rb
+++ b/test/testdata/packager/top-level/user/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Project::User < PackageSpec
+  import Toplevel
+end

--- a/test/testdata/packager/top-level/user/__packager.rb
+++ b/test/testdata/packager/top-level/user/__packager.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-# typed: strict
-
-class Project::User < PackageSpec
-  import Toplevel
-end

--- a/test/testdata/packager/top-level/user/__packager.rb
+++ b/test/testdata/packager/top-level/user/__packager.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::User < PackageSpec
+  import Toplevel
+end

--- a/test/testdata/packager/top-level/user/use.rb
+++ b/test/testdata/packager/top-level/user/use.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 # typed: strict
+# enable-packager: true
 
-module Package::User
+module Project::User
   module Thing
     ::Toplevel.hello
   end

--- a/test/testdata/packager/top-level/user/use.rb
+++ b/test/testdata/packager/top-level/user/use.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: strict
+
+module Package::User
+  module Thing
+    ::Toplevel.hello
+  end
+end


### PR DESCRIPTION
This fixes an edge case in the packager that's unlikely but possible. All we do here is find the existing package definitions and add an unprintable name (here `<PackageDefs>`) to the front, ensuring that they'll never live in the same namespace as anything else.

### Motivation
If we had a package file
```ruby
# foo/__package.rb
class Foo < PackageSpec
  # et cetera
end
```
and in another file did this
```ruby
# foo/foo.rb
module ::Foo
  # et cetera
end
```

we would get a message like

```
foo/foo.rb:4: Foo was previously defined as a class https://srb.help/4012
     4 |module ::Foo
        ^^^^^^^^^^^^
    foo/__package.rb:4: Previous definition
     4 |class Foo < PackageSpec
        ^^^^^^^^^^^^^^^^^^^^^^^
```

This prevents that from happening by putting the `PackageSpec` definition into a new bespoke namespace.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added a test for this behavior. (We can still package—and therefore control imports for—"packages" whose classes are explicitly defined at the top-level.)
