### PR TITLE
Add disabled test for forwarding block to super

### DIFF
--- a/test/testdata/compiler/disabled/super_forward_block.rb
+++ b/test/testdata/compiler/disabled/super_forward_block.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+class C
+  def f(&blk)
+    yield "hi"
+    yield "hi"
+  end
+end
+
+class D < C
+  def f(&blk)
+    puts "in D"
+    super
+  end
+end
+
+D.new.f { |x| puts "in block: #{x}" }


### PR DESCRIPTION
### Motivation
Came across this while trying to compile some more files: looks like we don't forward the `&blk` to `super`.

I'm not sure if we already have a test for this case specifically, but I couldn't find one with some quick grepping; if you know of one, gentle reviewer, please let me know.

### Test plan
See included automated tests.
