### PR TITLE
Fix reserved numparam usage in hidden definition names

### DIFF
--- a/gems/sorbet/lib/serialize.rb
+++ b/gems/sorbet/lib/serialize.rb
@@ -346,7 +346,7 @@ class Sorbet::Private::Serialize
       # generate. (Coincidentally, that is why Ruby 2.7+ uses those names,
       # so that user code cannot mess with the forwarded arguments)
       if ["*", "**", "&"].include?(name.to_s)
-        name = '_' + (uniq == 0 ? '' : uniq.to_s)
+        name = 'arg' + (uniq == 0 ? '' : uniq.to_s)
         uniq += 1
       end
 


### PR DESCRIPTION
Closes #4541

We missed a spot in #4344 where hidden definitions was still using names reserved for numparams.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.