### PR TITLE
Add disabled test for Regexp.new being evaluated too eagerly(?)

### DIFF
--- a/test/testdata/compiler/disabled/regexp_error_too_eager.rb
+++ b/test/testdata/compiler/disabled/regexp_error_too_eager.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+puts "hi"
+if T.unsafe(false)
+  Regexp.new("?")
+end


### PR DESCRIPTION
### Motivation
It looks like maybe we are somehow evaluating `Regexp.new` too eagerly (maybe as a result of some rewrite?) which causes problems when `Regexp.new` throws an exception.

Interpreter output of this test case is just `hi`, compiled output is a `RegexpError` stack trace before `hi` even gets printed.

### Test plan
See included automated tests.
