### PR TITLE
Fix disabled rescue_splat test

### DIFF
--- a/test/testdata/compiler/disabled/rescue_splat.rb
+++ b/test/testdata/compiler/disabled/rescue_splat.rb
@@ -6,22 +6,27 @@ def rescue_ok?(cases, &blk)
   begin
     blk.call
   rescue *cases
-    :ok
+    :rescued_from_splat
+  rescue
+    :rescued_from_catch_all
   else
-    :ko
+    :no_exception
   end
 end
 
-cases = [ArgumentError, RegexpError]
-p rescue_ok?(cases) do
-  Regexp.new("?")
-end
-p rescue_ok?(cases) do
-  1.to_a
-end
-p rescue_ok?(cases) do
-  raise "Uncaught"
-end
-p rescue_ok?(cases) do
-  [1, 2, 3].first(4, 5)
-end
+cases = [ArgumentError, TypeError]
+p (rescue_ok?(cases) do
+     T.unsafe(3.0) + "aha"
+   end)
+p (rescue_ok?(cases) do
+     T.unsafe(1).to_a
+   end)
+p (rescue_ok?(cases) do
+     raise "Uncaught"
+   end)
+p (rescue_ok?(cases) do
+     T.unsafe([1, 2, 3]).first(4, 5)
+   end)
+p (rescue_ok?(cases) do
+     2+2
+   end)


### PR DESCRIPTION
### Motivation
This test is currently failing due to typechecking errors, which I don't think was the intent. I think it was also expecting `else` to do the job of a bare `rescue`.

After the change, output from the interpreter is:

```
:rescued_from_splat
:rescued_from_catch_all
:rescued_from_catch_all
:rescued_from_splat
:no_exception
```

while output from compiled is:

```
Traceback (most recent call last):
...
test/testdata/compiler/disabled/rescue_splat.rb:8:in `is_a?': class or module required (TypeError)
```

### Test plan
See included automated tests.
