### PR TITLE
Fix package prefix enforcement bug with top-level casgns

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -392,12 +392,19 @@ public:
         auto *lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn.lhs);
         if (lhs != nullptr) {
             auto &pkgName = requiredNamespace();
+            bool needsLitPush = nameParts.size() < pkgName.size() && rootConsts == 0;
+            if (needsLitPush) {
+                pushConstantLit(lhs);
+            }
             if (rootConsts == 0 && !isPrefix(pkgName, nameParts)) {
                 if (auto e = ctx.beginError(lhs->loc, core::errors::Packager::DefinitionPackageMismatch)) {
                     e.setHeader("Constants may not be defined outside of the enclosing package namespace `{}`",
                                 fmt::map_join(pkgName.begin(), pkgName.end(),
                                               "::", [&](const auto &nr) { return nr.show(ctx); }));
                 }
+            }
+            if (needsLitPush) {
+                popConstantLit(lhs);
             }
         }
         return original;

--- a/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
+++ b/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
@@ -8,6 +8,12 @@ module Wrong
       # ^^^^^^ error: Class or method definition must match enclosing package namespace `Root::Nested`
 end
 
+Root::Nested::Foo::Bar = nil
+::Allowed::TopLevel = nil
+
+  NotAllowed::Foo::Bar = nil
+# ^^^^^^^^^^^^^^^^^^^^ error: Constants may not be defined outside of the enclosing package namespace `Root::Nested`
+
 module Root::Nested
 
   ALLOWED_CONST = T.let(1, Integer)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
A bug in package mode's prefix enforcement only considered the scope a constant was defined in when determining if nesting was correct. This simple fix also considers the LHS of the constant assignment as part of the name.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
