### PR TITLE
--stripe-packages: do not consider top-level test dir a test

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -21,8 +21,8 @@ namespace {
 constexpr string_view PACKAGE_FILE_NAME = "__package.rb"sv;
 constexpr core::NameRef TEST_NAME = core::Names::Constants::Test();
 
-bool isTestFile(core::File &file) {
-    return absl::EndsWith(file.path(), ".test.rb") || absl::StrContains(file.path(), "/test/");
+bool isTestFile(const core::GlobalState &gs, core::File &file) {
+    return absl::EndsWith(file.path(), ".test.rb") || absl::StrContains(gs.getPrintablePath(file.path()), "/test/");
 }
 
 struct FullyQualifiedName {
@@ -1047,7 +1047,7 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
                     if (file.sourceType == core::File::Type::Normal) {
                         core::Context ctx(gs, core::Symbols::root(), job.file);
                         if (auto pkg = constPkgDB.getPackageForContext(ctx)) {
-                            job = rewritePackagedFile(ctx, move(job), pkg->name.mangledName, pkg, isTestFile(file));
+                            job = rewritePackagedFile(ctx, move(job), pkg->name.mangledName, pkg, isTestFile(gs, file));
                         } else {
                             // Don't transform, but raise an error on the first line.
                             if (auto e =

--- a/test/cli/package-test-simple/test/__package.rb
+++ b/test/cli/package-test-simple/test/__package.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Critic < PackageSpec
+end

--- a/test/cli/package-test-simple/test/harness.rb
+++ b/test/cli/package-test-simple/test/harness.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+# We do not consider files in the top-level test/ dir of project to be test-files.
+class Critic::TestHarness
+end

--- a/test/cli/package-test-simple/test/test/harness_test.rb
+++ b/test/cli/package-test-simple/test/test/harness_test.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Test::Critic::TestHarness::HarnessTest
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fix a stripe-specific edge case where the top-level `test/` dir also contains the test-harness and runtime support for tests that isn't actually a test itself. The original intent of this function was to _not_ classify these files as tests for the purposes of packages, however the path's actually contain a `./` prefix which defeated this logic.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
