### PR TITLE
Some easy Rubocop cleanup

### DIFF
--- a/gems/sorbet-runtime/.rubocop.yml
+++ b/gems/sorbet-runtime/.rubocop.yml
@@ -28,6 +28,8 @@ Style/TrivialAccessors:
   IgnoreClassMethods: true
 Style/EmptyElse:
   EnforcedStyle: empty
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
 
 # This doesn't play very well with implementations of Sorbet abstract methods
 Lint/UnusedMethodArgument:

--- a/gems/sorbet-runtime/.rubocop_todo.yml
+++ b/gems/sorbet-runtime/.rubocop_todo.yml
@@ -22,12 +22,6 @@ Layout/CaseIndentation:
     - 'lib/types/props/utils.rb'
     - 'test/types/enum.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/ElseAlignment:
-  Exclude:
-    - 'lib/types/types/self_type.rb'
-
 # Offense count: 51
 # Cop supports --auto-correct.
 Layout/EmptyLineAfterGuardClause:

--- a/gems/sorbet-runtime/.rubocop_todo.yml
+++ b/gems/sorbet-runtime/.rubocop_todo.yml
@@ -174,13 +174,6 @@ Layout/MultilineOperationIndentation:
     - 'lib/types/props/weak_constructor.rb'
     - 'lib/types/types/base.rb'
 
-# Offense count: 3
-Lint/UselessAssignment:
-  Exclude:
-    - 'test/types/final_method.rb'
-    - 'test/types/props/serializable.rb'
-    - 'test/types/types.rb'
-
 # Offense count: 97
 # Configuration parameters: IgnoredMethods.
 Metrics/AbcSize:

--- a/gems/sorbet-runtime/.rubocop_todo.yml
+++ b/gems/sorbet-runtime/.rubocop_todo.yml
@@ -195,7 +195,7 @@ Metrics/BlockLength:
 # Offense count: 23
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 1094
+  Max: 1098
 
 # Offense count: 38
 # Configuration parameters: IgnoredMethods.
@@ -423,24 +423,6 @@ Style/Semicolon:
     - 'test/types/casts.rb'
     - 'test/types/configuration.rb'
     - 'test/types/types.rb'
-
-# Offense count: 33
-# Cop supports --auto-correct.
-# Configuration parameters: AllowIfMethodIsEmpty.
-Style/SingleLineMethods:
-  Exclude:
-    - 'lib/types/private/methods/modes.rb'
-    - 'lib/types/props/_props.rb'
-    - 'lib/types/props/decorator.rb'
-    - 'lib/types/props/optional.rb'
-    - 'lib/types/props/serializable.rb'
-    - 'test/types/abstract_validation.rb'
-    - 'test/types/builder_syntax.rb'
-    - 'test/types/edge_cases.rb'
-    - 'test/types/interface_validation.rb'
-    - 'test/types/method_modes.rb'
-    - 'test/types/types.rb'
-    - 'test/types/validate_override_types.rb'
 
 # Offense count: 734
 # Cop supports --auto-correct.

--- a/gems/sorbet-runtime/.rubocop_todo.yml
+++ b/gems/sorbet-runtime/.rubocop_todo.yml
@@ -115,13 +115,6 @@ Layout/EmptyLinesAroundModuleBody:
     - 'lib/types/props/private/deserializer_generator.rb'
     - 'lib/types/props/private/serializer_generator.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment, AllowBeforeTrailingComments, ForceEqualSignAlignment.
-Layout/ExtraSpacing:
-  Exclude:
-    - 'lib/types/props/generated_code_validation.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: IndentationWidth.
@@ -180,68 +173,6 @@ Layout/MultilineOperationIndentation:
     - 'lib/types/private/methods/signature_validation.rb'
     - 'lib/types/props/weak_constructor.rb'
     - 'lib/types/types/base.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/SpaceAroundEqualsInParameterDefault:
-  Exclude:
-    - 'test/types/method_patches.rb'
-
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment, EnforcedStyleForExponentOperator.
-# SupportedStylesForExponentOperator: space, no_space
-Layout/SpaceAroundOperators:
-  Exclude:
-    - 'lib/types/props/generated_code_validation.rb'
-    - 'lib/types/props/serializable.rb'
-
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: require_no_space, require_space
-Layout/SpaceInLambdaLiteral:
-  Exclude:
-    - 'test/types/props/private/setter_factory.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.
-# SupportedStyles: space, no_space
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceInsideBlockBraces:
-  Exclude:
-    - 'bench/getters.rb'
-
-# Offense count: 8
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/SpaceInsideParens:
-  Exclude:
-    - 'test/types/method_validation.rb'
-
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: final_newline, final_blank_line
-Layout/TrailingEmptyLines:
-  Exclude:
-    - 'bench/constructor.rb'
-    - 'bench/prop_definition.rb'
-    - 'bench/setters.rb'
-    - 'lib/types/props/private/serializer_generator.rb'
-
-# Offense count: 8
-# Cop supports --auto-correct.
-Lint/RedundantCopDisableDirective:
-  Exclude:
-    - 'lib/types/props/serializable.rb'
-    - 'test/types/enum.rb'
-    - 'test/types/method_validation.rb'
-    - 'test/types/types.rb'
 
 # Offense count: 3
 Lint/UselessAssignment:

--- a/gems/sorbet-runtime/.rubocop_todo.yml
+++ b/gems/sorbet-runtime/.rubocop_todo.yml
@@ -273,13 +273,6 @@ Naming/PredicateName:
     - 'lib/types/props/optional.rb'
     - 'lib/types/utils.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AutoCorrect.
-Security/JSONLoad:
-  Exclude:
-    - 'test/types/props/serializable.rb'
-
 # Offense count: 53
 # Configuration parameters: EnforcedStyle, AllowModifiersOnSymbols.
 # SupportedStyles: inline, group

--- a/gems/sorbet-runtime/.rubocop_todo.yml
+++ b/gems/sorbet-runtime/.rubocop_todo.yml
@@ -115,13 +115,6 @@ Layout/EmptyLinesAroundModuleBody:
     - 'lib/types/props/private/deserializer_generator.rb'
     - 'lib/types/props/private/serializer_generator.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: IndentationWidth.
-# SupportedStyles: special_inside_parentheses, consistent, align_brackets
-Layout/FirstArrayElementIndentation:
-  EnforcedStyle: consistent
-
 # Offense count: 20
 # Cop supports --auto-correct.
 # Configuration parameters: Width, IgnoredPatterns.

--- a/gems/sorbet-runtime/.rubocop_todo.yml
+++ b/gems/sorbet-runtime/.rubocop_todo.yml
@@ -109,15 +109,6 @@ Layout/EmptyLinesAroundModuleBody:
     - 'lib/types/props/private/deserializer_generator.rb'
     - 'lib/types/props/private/serializer_generator.rb'
 
-# Offense count: 20
-# Cop supports --auto-correct.
-# Configuration parameters: Width, IgnoredPatterns.
-Layout/IndentationWidth:
-  Exclude:
-    - 'lib/types/props/serializable.rb'
-    - 'lib/types/types/self_type.rb'
-    - 'test/types/abstract_validation.rb'
-
 # Offense count: 11
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/gems/sorbet-runtime/.rubocop_todo.yml
+++ b/gems/sorbet-runtime/.rubocop_todo.yml
@@ -280,11 +280,6 @@ Security/JSONLoad:
   Exclude:
     - 'test/types/props/serializable.rb'
 
-# Offense count: 1
-Security/MarshalLoad:
-  Exclude:
-    - 'lib/types/enum.rb'
-
 # Offense count: 53
 # Configuration parameters: EnforcedStyle, AllowModifiersOnSymbols.
 # SupportedStyles: inline, group

--- a/gems/sorbet-runtime/bench/constructor.rb
+++ b/gems/sorbet-runtime/bench/constructor.rb
@@ -74,4 +74,3 @@ module SorbetBenchmarks
     end
   end
 end
-

--- a/gems/sorbet-runtime/bench/getters.rb
+++ b/gems/sorbet-runtime/bench/getters.rb
@@ -21,7 +21,7 @@ module SorbetBenchmarks
     def self.run
       poro = ExamplePoro.new
       poro.attr = 0
-      10_000.times { poro.attr }
+      10_000.times {poro.attr}
       result = Benchmark.measure do
         100_000.times do
           poro.attr
@@ -40,7 +40,7 @@ module SorbetBenchmarks
       puts result
 
       struct = ExampleStruct.new(prop: 0)
-      10_000.times { struct.prop }
+      10_000.times {struct.prop}
       result = Benchmark.measure do
         100_000.times do
           struct.prop
@@ -59,7 +59,7 @@ module SorbetBenchmarks
       puts result
 
       struct = ExampleStruct.new(prop: 0)
-      10_000.times { struct.ifunset }
+      10_000.times {struct.ifunset}
       result = Benchmark.measure do
         100_000.times do
           struct.ifunset

--- a/gems/sorbet-runtime/bench/prop_definition.rb
+++ b/gems/sorbet-runtime/bench/prop_definition.rb
@@ -71,4 +71,3 @@ module SorbetBenchmarks
     end
   end
 end
-

--- a/gems/sorbet-runtime/bench/setters.rb
+++ b/gems/sorbet-runtime/bench/setters.rb
@@ -127,4 +127,3 @@ module SorbetBenchmarks
     end
   end
 end
-

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -361,6 +361,6 @@ class T::Enum
 
   sig {params(args: String).returns(T.attached_class)}
   def self._load(args)
-    deserialize(Marshal.load(args))
+    deserialize(Marshal.load(args)) # rubocop:disable Security/MarshalLoad
   end
 end

--- a/gems/sorbet-runtime/lib/types/private/methods/modes.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/modes.rb
@@ -2,12 +2,24 @@
 # typed: true
 
 module T::Private::Methods::Modes
-  def self.standard; 'standard'; end
-  def self.abstract; 'abstract'; end
-  def self.overridable; 'overridable'; end
-  def self.override; 'override'; end
-  def self.overridable_override; 'overridable_override'; end
-  def self.untyped; 'untyped'; end
+  def self.standard
+    'standard'
+  end
+  def self.abstract
+    'abstract'
+  end
+  def self.overridable
+    'overridable'
+  end
+  def self.override
+    'override'
+  end
+  def self.overridable_override
+    'overridable_override'
+  end
+  def self.untyped
+    'untyped'
+  end
   MODES = [self.standard, self.abstract, self.overridable, self.override, self.overridable_override, self.untyped].freeze
 
   OVERRIDABLE_MODES = [self.override, self.overridable, self.overridable_override, self.untyped, self.abstract].freeze

--- a/gems/sorbet-runtime/lib/types/props/_props.rb
+++ b/gems/sorbet-runtime/lib/types/props/_props.rb
@@ -20,13 +20,23 @@ module T::Props
     extend T::Sig
     extend T::Helpers
 
-    def props; decorator.props; end
-    def plugins; @plugins ||= []; end
+    def props
+      decorator.props
+    end
+    def plugins
+      @plugins ||= []
+    end
 
-    def decorator_class; Decorator; end
+    def decorator_class
+      Decorator
+    end
 
-    def decorator; @decorator ||= decorator_class.new(self); end
-    def reload_decorator!; @decorator = decorator_class.new(self); end
+    def decorator
+      @decorator ||= decorator_class.new(self)
+    end
+    def reload_decorator!
+      @decorator = decorator_class.new(self)
+    end
 
     # @!method self.prop(name, type, opts={})
     #

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -34,11 +34,15 @@ class T::Props::Decorator
   attr_reader :props
 
   sig {returns(T::Array[Symbol])}
-  def all_props; props.keys; end
+  def all_props
+    props.keys
+  end
 
   # checked(:never) - O(prop accesses)
   sig {params(prop: T.any(Symbol, String)).returns(Rules).checked(:never)}
-  def prop_rules(prop); props[prop.to_sym] || raise("No such prop: #{prop.inspect}"); end
+  def prop_rules(prop)
+    props[prop.to_sym] || raise("No such prop: #{prop.inspect}")
+  end
 
   # checked(:never) - Rules hash is expensive to check
   sig {params(prop: Symbol, rules: Rules).void.checked(:never)}
@@ -78,7 +82,9 @@ class T::Props::Decorator
 
   # checked(:never) - O(prop accesses)
   sig {returns(T.all(Module, T::Props::ClassMethods)).checked(:never)}
-  def decorated_class; @class; end
+  def decorated_class
+    @class
+  end
 
   # Accessors
 

--- a/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
@@ -157,7 +157,7 @@ module T::Props
         validate_lack_of_side_effects(try, whitelisted_methods_for_deserialize)
 
         assert_equal(:resbody, rescue_body.type)
-        exceptions, assignment, handler =  rescue_body.children
+        exceptions, assignment, handler = rescue_body.children
         assert_equal(:array, exceptions.type)
         exceptions.children.each {|c| assert_equal(:const, c.type)}
         assert_equal(:lvasgn, assignment.type)

--- a/gems/sorbet-runtime/lib/types/props/optional.rb
+++ b/gems/sorbet-runtime/lib/types/props/optional.rb
@@ -25,7 +25,9 @@ module T::Props::Optional::DecoratorMethods
     super || VALID_RULE_KEYS[key]
   end
 
-  def prop_optional?(prop); prop_rules(prop)[:fully_optional]; end
+  def prop_optional?(prop)
+    prop_rules(prop)[:fully_optional]
+  end
 
   def compute_derived_rules(rules)
     rules[:fully_optional] = !T::Props::Utils.need_nil_write_check?(rules)

--- a/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
@@ -74,4 +74,3 @@ module T::Props
     end
   end
 end
-

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -15,7 +15,7 @@ module T::Props::Serializable
   #   exception if this object has mandatory props with missing
   #   values.
   # @return [Hash] A serialization of this object.
-  def serialize(strict=true) # rubocop:disable Style/OptionalBooleanParameter (changing this API is unfortunately not feasible)
+  def serialize(strict=true)
     begin
       h = __t_props_generated_serialize(strict)
     rescue => e
@@ -56,7 +56,7 @@ module T::Props::Serializable
   #  the hash contains keys that do not correspond to any known
   #  props on this instance.
   # @return [void]
-  def deserialize(hash, strict=false) # rubocop:disable Style/OptionalBooleanParameter (changing this API is unfortunately not feasible)
+  def deserialize(hash, strict=false)
     begin
       hash_keys_matching_props = __t_props_generated_deserialize(hash)
     rescue => e
@@ -192,7 +192,7 @@ module T::Props::Serializable::DecoratorMethods
   def prop_dont_store?(prop); prop_rules(prop)[:dont_store]; end
   def prop_by_serialized_forms; @class.prop_by_serialized_forms; end
 
-  def from_hash(hash, strict=false) # rubocop:disable Style/OptionalBooleanParameter (changing this API is unfortunately not feasible)
+  def from_hash(hash, strict=false)
     raise ArgumentError.new("#{hash.inspect} provided to from_hash") if !(hash && hash.is_a?(Hash))
 
     i = @class.allocate
@@ -259,7 +259,7 @@ module T::Props::Serializable::DecoratorMethods
     context = "  #{source_lines[(previous_blank + 1)...next_blank].join("\n  ")}"
     <<~MSG
       Error in #{decorated_class.name}##{generated_method}: #{error.message}
-      at line #{line_num-previous_blank-1} in:
+      at line #{line_num - previous_blank - 1} in:
       #{context}
     MSG
   end
@@ -345,7 +345,7 @@ module T::Props::Serializable::ClassMethods
   # Allocate a new instance and call {#deserialize} to load a new
   # object from a hash.
   # @return [Serializable]
-  def from_hash(hash, strict=false) # rubocop:disable Style/OptionalBooleanParameter (changing this API is unfortunately not feasible)
+  def from_hash(hash, strict=false)
     self.decorator.from_hash(hash, strict)
   end
 

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -303,7 +303,7 @@ module T::Props::Serializable::DecoratorMethods
     end
 
     if !rules[:raise_on_nil_write].nil? && rules[:raise_on_nil_write] != true
-        raise ArgumentError.new("The value of `raise_on_nil_write` if specified must be `true` (given: #{rules[:raise_on_nil_write]}).")
+      raise ArgumentError.new("The value of `raise_on_nil_write` if specified must be `true` (given: #{rules[:raise_on_nil_write]}).")
     end
 
     result

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -189,8 +189,12 @@ module T::Props::Serializable::DecoratorMethods
     @class.props.select {|_, v| T::Props::Utils.required_prop?(v)}.keys
   end
 
-  def prop_dont_store?(prop); prop_rules(prop)[:dont_store]; end
-  def prop_by_serialized_forms; @class.prop_by_serialized_forms; end
+  def prop_dont_store?(prop)
+    prop_rules(prop)[:dont_store]
+  end
+  def prop_by_serialized_forms
+    @class.prop_by_serialized_forms
+  end
 
   def from_hash(hash, strict=false)
     raise ArgumentError.new("#{hash.inspect} provided to from_hash") if !(hash && hash.is_a?(Hash))
@@ -338,7 +342,9 @@ end
 # NB: This must stay in the same file where T::Props::Serializable is defined due to
 # T::Props::Decorator#apply_plugin; see https://git.corp.stripe.com/stripe-internal/pay-server/blob/fc7f15593b49875f2d0499ffecfd19798bac05b3/chalk/odm/lib/chalk-odm/document_decorator.rb#L716-L717
 module T::Props::Serializable::ClassMethods
-  def prop_by_serialized_forms; @prop_by_serialized_forms ||= {}; end
+  def prop_by_serialized_forms
+    @prop_by_serialized_forms ||= {}
+  end
 
   # @!method self.from_hash(hash, strict)
   #

--- a/gems/sorbet-runtime/lib/types/types/self_type.rb
+++ b/gems/sorbet-runtime/lib/types/types/self_type.rb
@@ -23,7 +23,7 @@ module T::Types
       case other
       when SelfType
           true
-        else
+      else
           false
       end
     end

--- a/gems/sorbet-runtime/lib/types/types/self_type.rb
+++ b/gems/sorbet-runtime/lib/types/types/self_type.rb
@@ -22,9 +22,9 @@ module T::Types
     private def subtype_of_single?(other)
       case other
       when SelfType
-          true
+        true
       else
-          false
+        false
       end
     end
 

--- a/gems/sorbet-runtime/test/types/abstract_validation.rb
+++ b/gems/sorbet-runtime/test/types/abstract_validation.rb
@@ -374,7 +374,9 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
         def self.foo; end
 
         sig {override.returns(Object)}
-        def bar; "baz"; end
+        def bar
+          "baz"
+        end
       end
       assert_equal("baz", klass.new.bar)
     end

--- a/gems/sorbet-runtime/test/types/abstract_validation.rb
+++ b/gems/sorbet-runtime/test/types/abstract_validation.rb
@@ -7,32 +7,32 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
   end
 
   module AbstractMixin
-  extend T::Sig
-  extend T::Helpers
-  abstract!
+    extend T::Sig
+    extend T::Helpers
+    abstract!
 
-  sig {abstract.returns(Object)}
-  def foo; end
+    sig {abstract.returns(Object)}
+    def foo; end
 
-  sig {abstract.returns(Object)}
-  def bar; end
+    sig {abstract.returns(Object)}
+    def bar; end
 
-  sig {returns(Object)}
-  def concrete_standard; end
+    sig {returns(Object)}
+    def concrete_standard; end
 
-  def concrete_no_signature; end
+    def concrete_no_signature; end
   end
 
   class AbstractClass
-  extend T::Sig
-  extend T::Helpers
-  abstract!
+    extend T::Sig
+    extend T::Helpers
+    abstract!
 
-  sig {abstract.returns(Object)}
-  def self.foo; end
+    sig {abstract.returns(Object)}
+    def self.foo; end
 
-  sig {abstract.returns(Object)}
-  def bar; end
+    sig {abstract.returns(Object)}
+    def bar; end
   end
 
   it "raises an error when defining an abstract class method on a module" do

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -16,7 +16,9 @@ module Opus::Types::Test
         sig do
           builder = params(x: Integer).returns(String)
         end
-        def self.fn(x); x.to_s; end
+        def self.fn(x);
+          x.to_s;
+        end
       end
       mod.fn(1) # executes the sig block
 

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -731,7 +731,9 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     c1 = Class.new do
       extend T::Sig
       sig {returns(Integer)}
-      def foo; 1; end
+      def foo
+        1
+      end
       def self.method_added(method)
         super(method)
       end
@@ -739,7 +741,9 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         super(method)
       end
       sig {returns(Integer)}
-      def bar; "bad"; end
+      def bar
+        "bad"
+      end
     end
     assert_equal(1, c1.new.foo)
     assert_raises(TypeError) {c1.new.bar}

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -361,7 +361,7 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
 
     it 'raises an assertion if to_str is called (implicitly) and also returns the serialized value' do
       ex = assert_raises(NoMethodError) do
-        'foo ' + CardSuit::HEART # rubocop:disable Style/StringConcatenation
+        'foo ' + CardSuit::HEART
       end
       assert_equal(ENUM_CONVERSION_MSG, ex.message)
     end
@@ -385,7 +385,7 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
     end
 
     it 'raises an assertion if to_str is called (implicitly) and also returns the serialized value' do
-      assert_equal('foo heart', 'foo ' + CardSuit::HEART) # rubocop:disable Style/StringConcatenation
+      assert_equal('foo heart', 'foo ' + CardSuit::HEART)
     end
   end
 

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -398,7 +398,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   end
 
   it "forbids redefinition with .checked(:never)" do
-    err = assert_raises(RuntimeError) do
+    assert_raises(RuntimeError) do
       c = Class.new do
         extend T::Sig
         sig(:final) {void.checked(:never)}

--- a/gems/sorbet-runtime/test/types/interface_validation.rb
+++ b/gems/sorbet-runtime/test/types/interface_validation.rb
@@ -160,7 +160,9 @@ class Opus::Types::Test::InterfacesTest < Critic::Unit::UnitTest
       include base
 
       sig {override.returns(Integer)}
-      def foo; 1; end
+      def foo
+        1
+      end
     end
 
     klass = Class.new do

--- a/gems/sorbet-runtime/test/types/method_modes.rb
+++ b/gems/sorbet-runtime/test/types/method_modes.rb
@@ -36,7 +36,9 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
         extend T::Sig
         extend T::Helpers
         sig {override.returns(Object)}
-        def self.name; 'foo'; end
+        def self.name
+          'foo'
+        end
       end
 
       mod = Module.new do
@@ -44,7 +46,9 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
         extend T::Helpers
         extend mixin
         sig {override.returns(Object)}
-        def self.name; 'bar'; end
+        def self.name
+          'bar'
+        end
       end
 
       mod.name
@@ -215,7 +219,9 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
             .params(blk: T.proc.params(arg0: Elem).returns(BasicObject))
             .returns(T.untyped)
         end
-        def each(&blk); yield; end
+        def each(&blk)
+          yield
+        end
       end
 
       called = false

--- a/gems/sorbet-runtime/test/types/method_patches.rb
+++ b/gems/sorbet-runtime/test/types/method_patches.rb
@@ -62,12 +62,12 @@ module Opus::Types::Test
     end
 
     it "return the same result for complex methods with and without signature" do
-      def @mod.no_sig(a, b = nil, *c, d:, e: nil, **f, &blk)
+      def @mod.no_sig(a, b=nil, *c, d:, e: nil, **f, &blk)
         :foo
       end
 
       @mod.sig {params(a: T.untyped, b: T.untyped, c: T.untyped, d: T.untyped, e: T.untyped, f: T.untyped, blk: T.untyped).void}
-      def @mod.with_sig(a, b = nil, *c, d:, e: nil, **f, &blk)
+      def @mod.with_sig(a, b=nil, *c, d:, e: nil, **f, &blk)
         :foo
       end
 

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -116,7 +116,7 @@ module Opus::Types::Test
           mod = Module.new do
             extend T::Sig
             sig {params(a: Integer, b: Integer).returns(Integer)}
-            def self.foo(a: 1, b:) # rubocop:disable Style/KeywordParametersOrder
+            def self.foo(a: 1, b:)
               a + b
             end
           end
@@ -372,7 +372,7 @@ module Opus::Types::Test
               (1...10)
             end
 
-            assert_equal((1...10), @mod.foo )
+            assert_equal((1...10), @mod.foo)
           end
 
           it 'permits a range that has an integer start and no end' do
@@ -381,7 +381,7 @@ module Opus::Types::Test
               (1...nil)
             end
 
-            assert_equal((1...nil), @mod.foo )
+            assert_equal((1...nil), @mod.foo)
           end
 
           # Ruby 2.6 does not support ranges with boundless starts
@@ -392,7 +392,7 @@ module Opus::Types::Test
                 (nil...10)
               end
 
-              assert_equal((nil...10), @mod.foo )
+              assert_equal((nil...10), @mod.foo)
             end
           end
 
@@ -402,7 +402,7 @@ module Opus::Types::Test
               (nil...nil)
             end
 
-            assert_equal((nil...nil), @mod.foo )
+            assert_equal((nil...nil), @mod.foo)
           end
         end
       end

--- a/gems/sorbet-runtime/test/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/test/types/props/private/setter_factory.rb
@@ -6,9 +6,9 @@ class Opus::Types::Test::Props::Private::SetterFactoryTest < Critic::Unit::UnitT
     include T::Props
     include T::Props::WeakConstructor
 
-    prop :validated, T.untyped, setter_validate: -> (_prop, _value) {raise Error.new 'invalid'}
-    prop :nilable_validated, T.nilable(Integer), setter_validate: -> (_prop, _value) {raise Error.new 'invalid'}
-    prop :unvalidated, T.untyped, setter_validate: -> (prop, _value) {raise Error.new 'bad prop' unless prop == :unvalidated}
+    prop :validated, T.untyped, setter_validate: ->(_prop, _value) {raise Error.new 'invalid'}
+    prop :nilable_validated, T.nilable(Integer), setter_validate: ->(_prop, _value) {raise Error.new 'invalid'}
+    prop :unvalidated, T.untyped, setter_validate: ->(prop, _value) {raise Error.new 'bad prop' unless prop == :unvalidated}
 
   end
 

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -1281,7 +1281,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
 
     assert_equal('{"my_float":1}', json)
 
-    deserialized_hash = JSON.load(json)
+    deserialized_hash = JSON.parse(json)
 
     assert_instance_of(Integer, deserialized_hash['my_float'])
     assert_equal(1, deserialized_hash['my_float'])

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -908,7 +908,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
 
       obj = CustomType.new
       e = assert_raises(TypeError) do
-        result = CustomSetPropStruct.from_hash({'set' => obj})
+        CustomSetPropStruct.from_hash({'set' => obj})
       end
 
       assert_includes(e.message, "value must be enumerable")

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -325,7 +325,9 @@ module Opus::Types::Test
       class TestEnumerable
         include Enumerable
 
-        def each; yield "something"; end
+        def each;
+          yield "something";
+        end
       end
 
       it 'fails if value is not an array' do
@@ -958,10 +960,14 @@ module Opus::Types::Test
         c = Class.new do
           extend T::Sig
           sig {returns(MyEnum::A)}
-          def self.good_return; MyEnum::A; end
+          def self.good_return;
+            MyEnum::A;
+          end
 
           sig {returns(MyEnum::B)}
-          def self.bad_return; MyEnum::C; end
+          def self.bad_return;
+            MyEnum::C;
+          end
         end
 
         assert_equal(c.good_return, MyEnum::A)

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -827,7 +827,7 @@ module Opus::Types::Test
       it 'delegates equality' do
         assert(T.any(Integer, String) == make_type_alias {T.any(Integer, String)})
         assert(make_type_alias {T.any(Integer, String)} == T.any(Integer, String))
-        assert(make_type_alias {T.any(Integer, String)} == make_type_alias {T.any(Integer, String)}) # rubocop:disable Lint/BinaryOperatorWithIdenticalOperands
+        assert(make_type_alias {T.any(Integer, String)} == make_type_alias {T.any(Integer, String)})
 
         refute(make_type_alias {T.any(Integer, Float)} == make_type_alias {T.any(Integer, String)})
       end

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -98,7 +98,7 @@ module Opus::Types::Test
         m = Module.new
         ivars = m.instance_variables
 
-        x = T::Types::Simple::Private::Pool.type_for_module(m)
+        _ = T::Types::Simple::Private::Pool.type_for_module(m)
         assert_equal(ivars, m.instance_variables)
       end
     end

--- a/gems/sorbet-runtime/test/types/validate_override_types.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_types.rb
@@ -26,7 +26,9 @@ module Opus::Types::Test
       klass = Class.new(SuccessBase) do
         extend T::Sig
         sig {override.params(pos: SubFoo1, kw: SubFoo2).returns(BaseFoo3)}
-        def foo(pos, kw:); BaseFoo3.new; end
+        def foo(pos, kw:)
+          BaseFoo3.new
+        end
       end
       klass.new.foo(SubFoo1.new, kw: SubFoo2.new)
     end
@@ -35,7 +37,9 @@ module Opus::Types::Test
       klass = Class.new(SuccessBase) do
         extend T::Sig
         sig {override.params(pos: BaseFoo1, kw: SubFoo2).returns(BaseFoo3)}
-        def foo(pos, kw:); BaseFoo3.new; end
+        def foo(pos, kw:)
+          BaseFoo3.new
+        end
       end
       klass.new.foo(SubFoo1.new, kw: SubFoo2.new)
     end
@@ -44,7 +48,9 @@ module Opus::Types::Test
       klass = Class.new(SuccessBase) do
         extend T::Sig
         sig {override.params(pos: SubFoo1, kw: BaseFoo2).returns(BaseFoo3)}
-        def foo(pos, kw:); BaseFoo3.new; end
+        def foo(pos, kw:)
+          BaseFoo3.new
+        end
       end
       klass.new.foo(SubFoo1.new, kw: SubFoo2.new)
     end
@@ -53,7 +59,9 @@ module Opus::Types::Test
       klass = Class.new(SuccessBase) do
         extend T::Sig
         sig {override.params(pos: SubFoo1, kw: SubFoo2).returns(SubFoo3)}
-        def foo(pos, kw:); SubFoo3.new; end
+        def foo(pos, kw:)
+          SubFoo3.new
+        end
       end
       klass.new.foo(SubFoo1.new, kw: SubFoo2.new)
     end


### PR DESCRIPTION
Autocorrect various cops without too high of an offense count; move some configuration we likely want to keep indefinitely out of rubocop_todo and into either rubocop.yml or inline; fix a couple of easy things manually.

### Motivation
Cleanup, boredom. Probably done with Rubocop stuff for now though.

### Test plan
`bundle exec rake` passes
