### PR TITLE
Avoid adding synthetic `initialize` on Structs if already defined

### DIFF
--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -21,7 +21,7 @@ bool isKeywordInitKey(const core::GlobalState &gs, const ast::ExpressionPtr &nod
     return false;
 }
 
-bool missingInitialize(const core::GlobalState &gs, const ast::Send *send) {
+bool isMissingInitialize(const core::GlobalState &gs, const ast::Send *send) {
     if (send->block == nullptr) {
         return true;
     }
@@ -33,6 +33,14 @@ bool missingInitialize(const core::GlobalState &gs, const ast::Send *send) {
 
         if (methodDef && methodDef->name == core::Names::initialize()) {
             return false;
+        }
+
+        for (auto &&stat : insSeq->stats) {
+            methodDef = ast::cast_tree<ast::MethodDef>(stat);
+
+            if (methodDef && methodDef->name == core::Names::initialize()) {
+                return false;
+            }
         }
     }
 
@@ -140,7 +148,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
                             std::move(typeMember)));
     }
 
-    if (missingInitialize(ctx, send)) {
+    if (isMissingInitialize(ctx, send)) {
         body.emplace_back(ast::MK::SigVoid(loc, std::move(sigArgs)));
         body.emplace_back(ast::MK::SyntheticMethod(loc, loc, core::Names::initialize(), std::move(newArgs),
                                                    ast::MK::RaiseUnimplemented(loc)));

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -21,6 +21,24 @@ bool isKeywordInitKey(const core::GlobalState &gs, const ast::ExpressionPtr &nod
     return false;
 }
 
+bool missingInitialize(const core::GlobalState &gs, const ast::Send *send) {
+    if (send->block == nullptr) {
+        return true;
+    }
+
+    auto &block = ast::cast_tree_nonnull<ast::Block>(send->block);
+
+    if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block.body)) {
+        auto methodDef = ast::cast_tree<ast::MethodDef>(insSeq->expr);
+
+        if (methodDef && methodDef->name == core::Names::initialize()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 } // namespace
 
 vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *asgn) {
@@ -122,9 +140,11 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
                             std::move(typeMember)));
     }
 
-    body.emplace_back(ast::MK::SigVoid(loc, std::move(sigArgs)));
-    body.emplace_back(ast::MK::SyntheticMethod(loc, loc, core::Names::initialize(), std::move(newArgs),
-                                               ast::MK::RaiseUnimplemented(loc)));
+    if (missingInitialize(ctx, send)) {
+        body.emplace_back(ast::MK::SigVoid(loc, std::move(sigArgs)));
+        body.emplace_back(ast::MK::SyntheticMethod(loc, loc, core::Names::initialize(), std::move(newArgs),
+                                                   ast::MK::RaiseUnimplemented(loc)));
+    }
 
     if (send->block != nullptr) {
         auto &block = ast::cast_tree_nonnull<ast::Block>(send->block);

--- a/test/testdata/rewriter/struct_with_initialize.rb
+++ b/test/testdata/rewriter/struct_with_initialize.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+Const = Struct.new(:something, keyword_init: true) do
+  extend T::Sig
+
+  sig { params(something: Integer).void }
+  def initialize(something: 0)
+    T.reveal_type(something) # error: Integer
+  end
+end

--- a/test/testdata/rewriter/struct_with_initialize.rb
+++ b/test/testdata/rewriter/struct_with_initialize.rb
@@ -8,3 +8,30 @@ Const = Struct.new(:something, keyword_init: true) do
     T.reveal_type(something) # error: Integer
   end
 end
+
+AnotherConst = Struct.new(:something, keyword_init: true) do
+  extend T::Sig
+
+  sig { params(something: Integer).void }
+  def initialize(something: 0)
+    T.reveal_type(something) # error: Integer
+  end
+
+  def other_method
+    "more statements".upcase
+  end
+end
+
+ConstWithSomethingBeforeInit = Struct.new(:something, keyword_init: true) do
+  extend T::Sig
+
+  sig { returns(String) }
+  def other_method
+    "more statements".upcase
+  end
+
+  sig { params(something: Integer).void }
+  def initialize(something: 0)
+    T.reveal_type(something) # error: Integer
+  end
+end


### PR DESCRIPTION
Avoid adding a synthetic `initialize` on the struct rewriter if we can find an occurrence of `initialize` inside the given block.

### Motivation

Closes #4289

Avoid adding a synthetic `initialize` method with corresponding signature if a struct is already defining one on its own. If one is being manually defined, we might end up causing a conflict of expected types, as described in the linked issue.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.