### PR TITLE
Packager bug: ignore multi-def error in <PackageTests>

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -433,6 +433,8 @@ void GlobalState::initEmpty() {
 
     id = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageRegistry());
     ENFORCE(id == Symbols::PackageRegistry());
+    id = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageTests());
+    ENFORCE(id == Symbols::PackageTests());
 
     // PackageSpec is a class that can be subclassed.
     id = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageSpec());

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -813,12 +813,16 @@ public:
         return ClassOrModuleRef::fromRaw(78);
     }
 
-    static ClassOrModuleRef PackageSpec() {
+    static ClassOrModuleRef PackageTests() {
         return ClassOrModuleRef::fromRaw(79);
     }
 
-    static ClassOrModuleRef PackageSpecSingleton() {
+    static ClassOrModuleRef PackageSpec() {
         return ClassOrModuleRef::fromRaw(80);
+    }
+
+    static ClassOrModuleRef PackageSpecSingleton() {
+        return ClassOrModuleRef::fromRaw(81);
     }
 
     static MethodRef PackageSpec_import() {
@@ -834,11 +838,11 @@ public:
     }
 
     static ClassOrModuleRef Encoding() {
-        return ClassOrModuleRef::fromRaw(81);
+        return ClassOrModuleRef::fromRaw(82);
     }
 
     static ClassOrModuleRef Thread() {
-        return ClassOrModuleRef::fromRaw(82);
+        return ClassOrModuleRef::fromRaw(83);
     }
 
     static MethodRef Class_new() {
@@ -850,19 +854,19 @@ public:
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
-        return ClassOrModuleRef::fromRaw(83);
-    }
-
-    static ClassOrModuleRef Sorbet_Private_Static_ResolvedSigSingleton() {
         return ClassOrModuleRef::fromRaw(84);
     }
 
-    static ClassOrModuleRef T_Private_Compiler() {
+    static ClassOrModuleRef Sorbet_Private_Static_ResolvedSigSingleton() {
         return ClassOrModuleRef::fromRaw(85);
     }
 
-    static ClassOrModuleRef T_Private_CompilerSingleton() {
+    static ClassOrModuleRef T_Private_Compiler() {
         return ClassOrModuleRef::fromRaw(86);
+    }
+
+    static ClassOrModuleRef T_Private_CompilerSingleton() {
+        return ClassOrModuleRef::fromRaw(87);
     }
 
     static constexpr int MAX_PROC_ARITY = 10;
@@ -891,7 +895,7 @@ public:
     static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 40;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 3;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
-    static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 98;
+    static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 99;
 };
 
 template <typename H> H AbslHashValue(H h, const SymbolRef &m) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1635,7 +1635,8 @@ public:
                 classBehaviorLocs[klass.symbol] = core::Loc(ctx.file, klass.declLoc);
             } else if (prevLoc->second.file() != ctx.file &&
                        // Ignore packages, which have 'behavior defined in multiple files'.
-                       klass.symbol.data(ctx)->owner != core::Symbols::PackageRegistry()) {
+                       klass.symbol.data(ctx)->owner != core::Symbols::PackageRegistry() &&
+                       klass.symbol.data(ctx)->owner != core::Symbols::PackageTests()) {
                 if (auto e = ctx.state.beginError(core::Loc(ctx.file, klass.declLoc),
                                                   core::errors::Namer::MultipleBehaviorDefs)) {
                     e.setHeader("`{}` has behavior defined in multiple files", klass.symbol.show(ctx));

--- a/test/cli/package-test-simple/main_lib/lib.test.rb
+++ b/test/cli/package-test-simple/main_lib/lib.test.rb
@@ -11,3 +11,7 @@ class Test::Project::MainLib::LibTest
 
  Project::TestOnly::SomeHelper.new # access via test_import
 end
+
+# Add "behavior" to this file. When enforcing `MultipleBehaviorDefs` in
+# `--stripe-mode` the top-level of <PackageTests> should be ignored.
+1 + 1

--- a/test/cli/package-test-simple/main_lib/other.test.rb
+++ b/test/cli/package-test-simple/main_lib/other.test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Test::Project::MainLib::OtherTest
+end
+
+# Add "behavior" to this file. When enforcing `MultipleBehaviorDefs` in
+# `--stripe-mode` the top-level of <PackageTests> should be ignored.
+1 + 1

--- a/test/cli/package-test-simple/package-test-simple.sh
+++ b/test/cli/package-test-simple/package-test-simple.sh
@@ -1,3 +1,3 @@
 cd test/cli/package-test-simple || exit 1
 
-../../../main/sorbet --silence-dev-message --stripe-packages . 2>&1
+../../../main/sorbet --silence-dev-message --stripe-packages --stripe-mode . 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fix a bug in the interaction between `--stripe-mode` and `--stripe-packages` involving top-level behavior in test code. This mirrors a rule already applied for the non-test package registry.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
