### PR TITLE
(runtime) Add fast-path Union subclass for unions of two simple types

### DIFF
--- a/gems/sorbet-runtime/.rubocop_todo.yml
+++ b/gems/sorbet-runtime/.rubocop_todo.yml
@@ -167,6 +167,8 @@ Metrics/BlockLength:
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
   Max: 1098
+  Exclude:
+    - 'test/types/types.rb'
 
 # Offense count: 38
 # Configuration parameters: IgnoredMethods.

--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -72,17 +72,21 @@ module SorbetBenchmarks
       end
 
       type = T::Utils.coerce(T.nilable(Integer))
-      time_block("T::Types::Union#valid?", iterations_in_block: 10) do
+      time_block("T.nilable(Integer).valid?", iterations_in_block: 5) do
         type.valid?(0)
         type.valid?(1)
         type.valid?(2)
         type.valid?(nil)
         type.valid?(false)
+      end
+
+      type = T::Utils.coerce(T.any(Integer, Float, T::Boolean))
+      time_block("T.any(Integer, Float, T::Boolean).valid?", iterations_in_block: 5) do
         type.valid?(0)
         type.valid?(1)
         type.valid?(2)
         type.valid?(nil)
-        type.valid?(false)
+        type.valid?('hi')
       end
 
       time_block("T.let(..., Integer)") do
@@ -128,26 +132,6 @@ module SorbetBenchmarks
       time_block("sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs)") do
         arg_plus_kwargs(:foo, x: 1, y: 2)
         arg_plus_kwargs(:bar, x: 1)
-      end
-
-      time_block(".bind(example).call") do
-        Object.instance_method(:class).bind(example).call
-      end
-
-      if T::Configuration::AT_LEAST_RUBY_2_7
-        time_block(".bind_call(example)") do
-          Object.instance_method(:class).bind_call(example)
-        end
-
-        time_block("if AT_LEAST_RUBY_2_7; .bind_call(example); end") do
-          if T::Configuration::AT_LEAST_RUBY_2_7
-            Object.instance_method(:class).bind_call(example)
-          else
-            raise "must be run on 2.7"
-          end
-        end
-      else
-        puts 'skipping UnboundMethod#bind_call tests (re-run on Ruby 2.7+)'
       end
     end
 

--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -54,6 +54,7 @@ require_relative 'types/private/types/not_typed'
 require_relative 'types/private/types/void'
 require_relative 'types/private/types/string_holder'
 require_relative 'types/private/types/type_alias'
+require_relative 'types/private/types/simple_pair_union'
 
 require_relative 'types/types/type_variable'
 require_relative 'types/types/type_member'

--- a/gems/sorbet-runtime/lib/types/private/types/simple_pair_union.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/simple_pair_union.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# typed: true
+
+# Specialization of Union for the common case of the union of two simple types.
+#
+# This covers e.g. T.nilable(SomeModule), T.any(Integer, Float), and T::Boolean.
+class T::Private::Types::SimplePairUnion < T::Types::Union
+  class DuplicateType < RuntimeError; end
+
+  # @param type_a [T::Types::Simple]
+  # @param type_b [T::Types::Simple]
+  def initialize(type_a, type_b)
+    if type_a == type_b
+      raise DuplicateType.new("#{type_a} == #{type_b}")
+    end
+
+    @raw_a = type_a.raw_type
+    @raw_b = type_b.raw_type
+  end
+
+  # @override Union
+  def recursively_valid?(obj)
+    obj.is_a?(@raw_a) || obj.is_a?(@raw_b)
+  end
+
+  # @override Union
+  def valid?(obj)
+    obj.is_a?(@raw_a) || obj.is_a?(@raw_b)
+  end
+
+  # @override Union
+  def types
+    # We reconstruct the simple types rather than just storing them because
+    # (1) this is normally not a hot path and (2) we want to keep the instance
+    # variable count <= 3 so that we can fit in a 40 byte heap entry along
+    # with object headers.
+    @types ||= [
+      T::Types::Simple::Private::Pool.type_for_module(@raw_a),
+      T::Types::Simple::Private::Pool.type_for_module(@raw_b),
+    ]
+  end
+end

--- a/gems/sorbet-runtime/lib/types/types/base.rb
+++ b/gems/sorbet-runtime/lib/types/types/base.rb
@@ -161,8 +161,12 @@ module T::Types
     end
 
     def ==(other)
-      (T::Utils.resolve_alias(other).class == T::Utils.resolve_alias(self).class) &&
+      case other
+      when T::Types::Base
         other.name == self.name
+      else
+        false
+      end
     end
 
     alias_method :eql?, :==

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -52,7 +52,10 @@ module T::Types
     end
 
     def to_nilable
-      @nilable ||= T::Types::Union.new([self, T::Utils::Nilable::NIL_TYPE])
+      @nilable ||= T::Private::Types::SimplePairUnion.new(
+        self,
+        T::Utils::Nilable::NIL_TYPE,
+      )
     end
 
     module Private

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -224,6 +224,29 @@ module Opus::Types::Test
         assert_equal(x.hash, y.hash)
       end
 
+      it 'pools correctly for simple nilable types' do
+        x = T::Types::Union::Private::Pool.union_of_types(
+          T::Utils.coerce(String),
+          T::Utils.coerce(NilClass),
+        )
+        y = T::Types::Union::Private::Pool.union_of_types(
+          T::Utils.coerce(String),
+          T::Utils.coerce(NilClass),
+        )
+        assert_equal(x.object_id, y.object_id)
+        assert_equal(
+          T::Private::Types::SimplePairUnion,
+          x.class,
+        )
+      end
+
+      it 'uses fast path for T::Boolean' do
+        assert_equal(
+          T::Private::Types::SimplePairUnion,
+          T::Boolean.aliased_type.class,
+        )
+      end
+
       it 'deduplicates type, fast path' do
         assert_equal(
           'Integer',

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -224,6 +224,16 @@ module Opus::Types::Test
         assert_equal(x.hash, y.hash)
       end
 
+      it 'handles equality between simple pair and complex unions' do
+        x = T::Types::Union.new([String, NilClass])
+        y = T::Private::Types::SimplePairUnion.new(
+          T::Utils.coerce(String),
+          T::Utils.coerce(NilClass),
+        )
+        assert_equal(x, y)
+        assert_equal(x.hash, y.hash)
+      end
+
       it 'pools correctly for simple nilable types' do
         x = T::Types::Union::Private::Pool.union_of_types(
           T::Utils.coerce(String),


### PR DESCRIPTION
This covers, e.g., `T::Boolean` and `T.nilable(Example)`.

Probably best reviewed commit-by-commit: first two are prep, final commit makes the change.

### Motivation
Duration of a simple `valid?` check for a `T.nilable(Integer)` is cut by almost 2/3rds; the effect is smaller but still noticeable with actual `sig` and `T.let` uses.

Before (updated 2021-11-06):
```
$ bundle exec rake bench:typecheck
...
T.nilable(Integer).valid?: 100.384 ns
T.any(Integer, Float, T::Boolean).valid?: 140.021 ns
T.let(..., T.nilable(Integer)): 633.98 ns
sig {params(x: T.nilable(Integer)).void}: 232.429 ns
T.let(..., T.nilable(Example)): 633.894 ns
sig {params(x: T.nilable(Example)).void}: 233.363 ns
```

After:
```
$ bundle exec rake bench:typecheck
...
T.nilable(Integer).valid?: 38.858 ns
T.any(Integer, Float, T::Boolean).valid?: 140.908 ns
T.let(..., T.nilable(Integer)): 601.688 ns
sig {params(x: T.nilable(Integer)).void}: 164.325 ns
T.let(..., T.nilable(Example)): 606.617 ns
sig {params(x: T.nilable(Example)).void}: 164.904 ns
```

### Test plan
Made sure existing Union tests covered both fast-path and normal cases, where relevant. Added tests for handling duplicate types passed to a `T.any`, which broke in a previous version of this PR.