### PR TITLE
Add `T::Props::ValueObject` for `T::Struct` comparisons

### DIFF
--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -105,6 +105,7 @@ require_relative 'types/props/serializable'
 require_relative 'types/props/type_validation'
 require_relative 'types/props/private/parser'
 require_relative 'types/props/generated_code_validation'
+require_relative 'types/props/value_object'
 
 require_relative 'types/struct'
 require_relative 'types/non_forcing_constants'

--- a/gems/sorbet-runtime/lib/types/props/value_object.rb
+++ b/gems/sorbet-runtime/lib/types/props/value_object.rb
@@ -1,0 +1,32 @@
+# typed: strict
+# frozen_string_literal: true
+
+module T::Props::ValueObject
+  extend T::Sig
+
+  # A struct is equal to another if the classes and all prop definitions (attributes) and values are the same
+  sig {params(other: Object).returns(T::Boolean)}
+  def ==(other)
+    return false unless self.class == other.class
+
+    other_prop = T.cast(other, T::Props::ValueObject)
+    decorator = self.class.decorator
+    other_decorator = other_prop.class.decorator
+    return false unless decorator.all_props == other_decorator.all_props
+
+    decorator.all_props.all? do |prop|
+      decorator.get(self, prop) == other_decorator.get(other_prop, prop)
+    end
+  end
+
+  alias eql? ==
+
+  # Match Struct#hash by using both the class and all prop definitions (attributes) and values to calculate the hash
+  sig {returns(Integer)}
+  def hash
+    decorator = self.class.decorator
+    prop_values = decorator.all_props.map {|prop| decorator.get(self, prop)}
+
+    [self.class, decorator.all_props, prop_values].hash
+  end
+end

--- a/gems/sorbet-runtime/test/types/props/value_object.rb
+++ b/gems/sorbet-runtime/test/types/props/value_object.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class Opus::Types::Test::Props::ValueObjectTest < Critic::Unit::UnitTest
+  class MyStruct < T::Struct
+    include T::Props::ValueObject
+
+    prop :a, String
+    const :b, Integer
+  end
+
+  class Circular < T::Struct
+    include T::Props::ValueObject
+
+    prop :danger, T.nilable(Circular)
+  end
+
+  class IncludesProps
+    include T::Props
+    include T::Props::ValueObject
+
+    prop :a, String
+  end
+
+  class Child < IncludesProps; end
+
+  it "compares T::Structs based on their classes and props" do
+    first = MyStruct.new(a: "hello", b: 5)
+    second = MyStruct.new(a: "hello", b: 5)
+
+    assert_equal(first, second)
+
+    first.a = "bye"
+    refute_equal(first, second)
+  end
+
+  it "takes class and props into account for calculating the object's hash" do
+    first = MyStruct.new(a: "hello", b: 5)
+    hash = [MyStruct, %i[a b], ["hello", 5]].hash
+
+    assert_equal(hash, first.hash)
+  end
+
+  it "matches regular struct behavior for comparions" do
+    first = MyStruct.new(a: "hello", b: 5)
+    second = MyStruct.new(a: "hello", b: 5)
+
+    assert_equal(0, first <=> second)
+
+    first.a = "blop"
+    assert_nil(first <=> second)
+  end
+
+  # If we have a circular dependency between two structs, we want to create an infinite loop as it happens in other
+  # typed languages. The current implementation does result in an infinite loop, but Ruby eventually raises a
+  # SystemStackError because the stack level is too deep.
+  # See https://github.com/sorbet/sorbet/issues/1540#issuecomment-525978986
+  it "creates an infinite loop if we have a circular reference" do
+    first = Circular.new
+    second = Circular.new(danger: first)
+    first.danger = second
+
+    assert_raises(SystemStackError, "stack level too deep") do
+      first == second
+    end
+  end
+
+  it "implements equality for objects that are not structs but include props" do
+    first = IncludesProps.new
+    second = IncludesProps.new
+    first.a = "Parent"
+    second.a = "Parent"
+
+    assert_equal(first, second)
+  end
+
+  it "does not consider objects to be equal if their classes are different" do
+    child = Child.new
+    child.a = "secret"
+    parent = IncludesProps.new
+    parent.a = "secret"
+
+    refute_equal(child, parent)
+  end
+
+  it "compares classes that inherit from value objects properly" do
+    first = Child.new
+    first.a = "secret"
+    second = Child.new
+    second.a = "secret"
+
+    assert_equal(first, second)
+
+    second.a = "different secret"
+    refute_equal(first, second)
+  end
+
+  it "can be used as hash keys" do
+    first = MyStruct.new(a: "hello", b: 5)
+    second = MyStruct.new(a: "hello", b: 5)
+
+    hash = {}
+    hash[first] = "You found me!"
+
+    assert_equal("You found me!", hash[second])
+  end
+end

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -207,3 +207,8 @@ module T::Props::GeneratedCodeValidation
   def self.validate_deserialize(source); end
   def self.validate_serialize(source); end
 end
+
+module T::Props::ValueObject
+  include T::Props
+  include Kernel
+end

--- a/website/docs/tstruct.md
+++ b/website/docs/tstruct.md
@@ -68,3 +68,37 @@ my_struct.serialize # => { "foo": 4, "quz": 0.5 }
 ```
 
 Note that `bar` is skipped because it is `nil`.
+
+## Using T::Struct as value objects
+
+Regular Ruby structs work as value objects. An instance of a struct is
+considered to be equal to another if they have the same class and the same
+attributes.
+
+The same behavior can be achieved for `T::Struct` or any class using `T::Props`
+by including the `T::Props::ValueObject` module.
+
+```ruby
+class MyValueObject < T::Struct
+  include T::Props::ValueObject
+
+  prop :a, Integer
+end
+
+first = MyValueObject.new(a: 50)
+second = MyValueObject.new(a: 50)
+
+first == second # true because classes, prop definitions and values are the same
+
+class AnotherValueObject
+  include T::Props
+  include T::Props::ValueObject
+
+  prop :a, Integer
+end
+
+first = AnotherValueObject.new(a: 50)
+second = AnotherValueObject.new(a: 50)
+
+first == second # true. Same behavior as T::Struct
+```


### PR DESCRIPTION
Implement equality and `hash` for prop objects in an optional module.

### Motivation

Closes #1540

Ruby structs implement equality by comparing the classes and attributes of the two instances. The fact that `T::Struct` does not do the same is often surprising or confusing to developers. However, it's likely that at this point a lot of code depends on the old behavior, which does not match regular structs.

So, we are suggesting adding an optional module that can be included in any class that includes `T::Props` to then implement equality like Ruby structs. This approach allows devs to have more control as they migrate to use the new equality.

### Test plan

See included automated tests.

cc/ @elliottt 