### PR TITLE
fix sorbet_magic_mergeHashHelper prototype

### DIFF
--- a/compiler/IREmitter/Payload/patches/hash.c
+++ b/compiler/IREmitter/Payload/patches/hash.c
@@ -1,6 +1,6 @@
 
 // A faster version of merge!, under the assumption that we don't pass blocks, and only pass a single arg.
-VALUE sorbet_magic_mergeHashHelper(self, hash) {
+VALUE sorbet_magic_mergeHashHelper(VALUE self, VALUE hash) {
     rb_hash_foreach(hash, rb_hash_update_i, self);
     return self;
 }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The legacy of a 40-year-old language rears its ugly head.  I'm reasonably certain that the previous definition is going to do bad things to pointers at runtime.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
