### PR TITLE
Stop mutating the kwargs hash, always check for required kwargs

### DIFF
--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -433,7 +433,14 @@ void setupArguments(CompilerState &base, cfg::CFG &cfg, const ast::MethodDef &md
                             auto rawRubySym = builder.CreateCall(cs.getFunction("rb_id2sym"), {rawId}, "rawSym");
 
                             auto argPresent = irctx.argPresentVariables[argId];
-                            auto passedValue = Payload::getKWArg(cs, builder, hashArgs, rawRubySym);
+
+                            llvm::Value *passedValue;
+                            if (hasKWRestArgs) {
+                                passedValue = Payload::removeKWArg(cs, builder, hashArgs, rawRubySym);
+                            } else {
+                                passedValue = Payload::getKWArg(cs, builder, hashArgs, rawRubySym);
+                            }
+
                             auto isItUndef = Payload::testIsUndef(cs, builder, passedValue);
 
                             auto kwArgSet = llvm::BasicBlock::Create(cs, "kwArgSet", func);

--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -454,26 +454,28 @@ void setupArguments(CompilerState &base, cfg::CFG &cfg, const ast::MethodDef &md
                                                 rubyBlockId);
                             }
 
+                            auto *updatedMissingKwargs = missingKwargs;
                             if (!argsFlags[argId].isDefault) {
-                                missingKwargs = Payload::addMissingKWArg(cs, builder, missingKwargs, rawRubySym);
+                                updatedMissingKwargs = Payload::addMissingKWArg(cs, builder, missingKwargs, rawRubySym);
                             }
 
                             optionalPhi->addIncoming(optionalKwargs, builder.GetInsertBlock());
-                            missingPhi->addIncoming(missingKwargs, builder.GetInsertBlock());
+                            missingPhi->addIncoming(updatedMissingKwargs, builder.GetInsertBlock());
                             builder.CreateBr(kwArgContinue);
 
                             builder.SetInsertPoint(kwArgSet);
+                            auto *updatedOptionalKwargs = optionalKwargs;
                             if (!isBlock && argPresent.exists()) {
                                 if (argsFlags[argId].isDefault) {
-                                    optionalKwargs = builder.CreateBinOp(llvm::Instruction::Add, optionalKwargs,
-                                                                         IREmitterHelpers::buildS4(cs, 1));
+                                    updatedOptionalKwargs = builder.CreateBinOp(llvm::Instruction::Add, optionalKwargs,
+                                                                                IREmitterHelpers::buildS4(cs, 1));
                                 }
 
                                 Payload::varSet(cs, argPresent, Payload::rubyTrue(cs, builder), builder, irctx,
                                                 rubyBlockId);
                             }
                             Payload::varSet(cs, name, passedValue, builder, irctx, rubyBlockId);
-                            optionalPhi->addIncoming(optionalKwargs, builder.GetInsertBlock());
+                            optionalPhi->addIncoming(updatedOptionalKwargs, builder.GetInsertBlock());
                             missingPhi->addIncoming(missingKwargs, builder.GetInsertBlock());
                             builder.CreateBr(kwArgContinue);
 

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -920,9 +920,11 @@ llvm::Value *Payload::readKWRestArg(CompilerState &cs, llvm::IRBuilderBase &buil
     return builder.CreateCall(cs.getFunction("sorbet_readKWRestArgs"), {maybeHash});
 }
 
-llvm::Value *Payload::assertNoExtraKWArg(CompilerState &cs, llvm::IRBuilderBase &build, llvm::Value *maybeHash) {
+llvm::Value *Payload::assertNoExtraKWArg(CompilerState &cs, llvm::IRBuilderBase &build, llvm::Value *maybeHash,
+                                         llvm::Value *numRequired, llvm::Value *requiredRemaining, llvm::Value *optionalParsed) {
     auto &builder = builderCast(build);
-    return builder.CreateCall(cs.getFunction("sorbet_assertNoExtraKWArg"), {maybeHash});
+    return builder.CreateCall(cs.getFunction("sorbet_assertNoExtraKWArg"),
+                              {maybeHash, numRequired, requiredRemaining, optionalParsed});
 }
 
 llvm::Value *Payload::getKWArg(CompilerState &cs, llvm::IRBuilderBase &build, llvm::Value *maybeHash,

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -943,6 +943,12 @@ llvm::Value *Payload::getKWArg(CompilerState &cs, llvm::IRBuilderBase &build, ll
     return builder.CreateCall(cs.getFunction("sorbet_getKWArg"), {maybeHash, rubySym});
 }
 
+llvm::Value *Payload::removeKWArg(CompilerState &cs, llvm::IRBuilderBase &build, llvm::Value *maybeHash,
+                                  llvm::Value *rubySym) {
+    auto &builder = builderCast(build);
+    return builder.CreateCall(cs.getFunction("sorbet_removeKWArg"), {maybeHash, rubySym});
+}
+
 llvm::Value *Payload::readRestArgs(CompilerState &cs, llvm::IRBuilderBase &build, int maxPositionalArgCount,
                                    llvm::Value *argCountRaw, llvm::Value *argArrayRaw) {
     auto &builder = builderCast(build);

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -920,11 +920,21 @@ llvm::Value *Payload::readKWRestArg(CompilerState &cs, llvm::IRBuilderBase &buil
     return builder.CreateCall(cs.getFunction("sorbet_readKWRestArgs"), {maybeHash});
 }
 
-llvm::Value *Payload::assertNoExtraKWArg(CompilerState &cs, llvm::IRBuilderBase &build, llvm::Value *maybeHash,
-                                         llvm::Value *numRequired, llvm::Value *requiredRemaining, llvm::Value *optionalParsed) {
+llvm::Value *Payload::addMissingKWArg(CompilerState &cs, llvm::IRBuilderBase &build, llvm::Value *missing,
+                                      llvm::Value *sym) {
     auto &builder = builderCast(build);
-    return builder.CreateCall(cs.getFunction("sorbet_assertNoExtraKWArg"),
-                              {maybeHash, numRequired, requiredRemaining, optionalParsed});
+    return builder.CreateCall(cs.getFunction("sorbet_addMissingKWArg"), {missing, sym});
+}
+
+llvm::Value *Payload::assertAllRequiredKWArgs(CompilerState &cs, llvm::IRBuilderBase &build, llvm::Value *missing) {
+    auto &builder = builderCast(build);
+    return builder.CreateCall(cs.getFunction("sorbet_assertAllRequiredKWArgs"), {missing});
+}
+
+llvm::Value *Payload::assertNoExtraKWArg(CompilerState &cs, llvm::IRBuilderBase &build, llvm::Value *maybeHash,
+                                         llvm::Value *numRequired, llvm::Value *optionalParsed) {
+    auto &builder = builderCast(build);
+    return builder.CreateCall(cs.getFunction("sorbet_assertNoExtraKWArg"), {maybeHash, numRequired, optionalParsed});
 }
 
 llvm::Value *Payload::getKWArg(CompilerState &cs, llvm::IRBuilderBase &build, llvm::Value *maybeHash,

--- a/compiler/IREmitter/Payload.h
+++ b/compiler/IREmitter/Payload.h
@@ -58,7 +58,9 @@ public:
                                           const IREmitterContext &irctx, const ast::MethodDef &md, int rubyBlockId);
 
     static llvm::Value *readKWRestArg(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *maybeHash);
-    static llvm::Value *assertNoExtraKWArg(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *maybeHash);
+    static llvm::Value *assertNoExtraKWArg(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *maybeHash,
+                                           llvm::Value *numRequired, llvm::Value *requiredRemaining,
+                                           llvm::Value *optionalParsed);
     static llvm::Value *getKWArg(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *maybeHash,
                                  llvm::Value *rubySym);
     static llvm::Value *readRestArgs(CompilerState &cs, llvm::IRBuilderBase &builder, int maxPositionalArgCount,

--- a/compiler/IREmitter/Payload.h
+++ b/compiler/IREmitter/Payload.h
@@ -66,6 +66,8 @@ public:
 
     static llvm::Value *getKWArg(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *maybeHash,
                                  llvm::Value *rubySym);
+    static llvm::Value *removeKWArg(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *maybeHash,
+                                    llvm::Value *rubySym);
     static llvm::Value *readRestArgs(CompilerState &cs, llvm::IRBuilderBase &builder, int maxPositionalArgCount,
                                      llvm::Value *argCountRaw, llvm::Value *argArrayRaw);
     static core::Loc setLineNumber(CompilerState &cs, llvm::IRBuilderBase &builder, core::Loc loc,

--- a/compiler/IREmitter/Payload.h
+++ b/compiler/IREmitter/Payload.h
@@ -59,8 +59,11 @@ public:
 
     static llvm::Value *readKWRestArg(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *maybeHash);
     static llvm::Value *assertNoExtraKWArg(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *maybeHash,
-                                           llvm::Value *numRequired, llvm::Value *requiredRemaining,
-                                           llvm::Value *optionalParsed);
+                                           llvm::Value *numRequired, llvm::Value *optionalParsed);
+    static llvm::Value *assertAllRequiredKWArgs(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *missing);
+    static llvm::Value *addMissingKWArg(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *missing,
+                                        llvm::Value *sym);
+
     static llvm::Value *getKWArg(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *maybeHash,
                                  llvm::Value *rubySym);
     static llvm::Value *readRestArgs(CompilerState &cs, llvm::IRBuilderBase &builder, int maxPositionalArgCount,

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -1730,15 +1730,26 @@ VALUE sorbet_selfNew(VALUE recv, ID fun, int argc, VALUE *argv, BlockFFIType blk
 // ****                       Calls
 // ****
 
+// When no double-splat is present, only lookup entries in the keyword argument hash, don't delete them.
 SORBET_INLINE
 VALUE sorbet_getKWArg(VALUE maybeHash, VALUE key) {
     if (maybeHash == RUBY_Qundef) {
         return RUBY_Qundef;
     }
 
-    // TODO: ruby seems to do something smarter here:
-    //  https://github.com/ruby/ruby/blob/5aa0e6bee916f454ecf886252e1b025d824f7bd8/class.c#L1901
     return rb_hash_lookup2(maybeHash, key, RUBY_Qundef);
+}
+
+// When building up a double-splat, reuse the original hash for the double-splat arg by deleting the entries that we
+// parse out of it.
+SORBET_INLINE
+VALUE sorbet_removeKWArg(VALUE maybeHash, VALUE key) {
+    if (maybeHash == RUBY_Qundef) {
+        return RUBY_Qundef;
+    }
+
+
+    return rb_hash_delete_entry(maybeHash, key);
 }
 
 SORBET_INLINE

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -1735,18 +1735,21 @@ VALUE sorbet_getKWArg(VALUE maybeHash, VALUE key) {
 
     // TODO: ruby seems to do something smarter here:
     //  https://github.com/ruby/ruby/blob/5aa0e6bee916f454ecf886252e1b025d824f7bd8/class.c#L1901
-    //
-    return rb_hash_delete_entry(maybeHash, key);
+    return rb_hash_lookup2(maybeHash, key, RUBY_Qundef);
 }
 
 SORBET_INLINE
-VALUE sorbet_assertNoExtraKWArg(VALUE maybeHash) {
+VALUE sorbet_assertNoExtraKWArg(VALUE maybeHash, int requiredKwargs, int remainingRequired, int optionalParsed) {
     if (maybeHash == RUBY_Qundef) {
         return RUBY_Qundef;
     }
-    if (RHASH_EMPTY_P(maybeHash)) {
+
+    int size = rb_hash_size_num(maybeHash);
+    if (remainingRequired == 0 && (size - requiredKwargs) == optionalParsed) {
         return RUBY_Qundef;
     }
+
+    sorbet_stopInDebugger();
 
     sorbet_raiseExtraKeywords(maybeHash);
 }

--- a/compiler/IREmitter/Payload/vm-payload.c
+++ b/compiler/IREmitter/Payload/vm-payload.c
@@ -132,6 +132,19 @@ __attribute__((__noreturn__)) void sorbet_raiseArity(int argc, int min, int max)
     rb_exc_raise(sorbet_rb_arity_error_new(argc, min, max));
 }
 
+VALUE sorbet_addMissingKWArg(VALUE missing, VALUE sym) {
+    if (UNLIKELY(missing == RUBY_Qundef)) {
+        missing = rb_ary_new();
+    }
+
+    rb_ary_push(missing, sym);
+    return missing;
+}
+
+__attribute__((__noreturn)) void sorbet_raiseMissingKeywords(VALUE missing) {
+    rb_exc_raise(rb_keyword_error_new("missing", missing));
+}
+
 __attribute__((__noreturn__)) void sorbet_raiseExtraKeywords(VALUE hash) {
     VALUE err_mess = rb_sprintf("unknown keywords: %" PRIsVALUE, rb_hash_keys(hash));
     rb_exc_raise(rb_exc_new3(rb_eArgError, err_mess));

--- a/test/testdata/compiler/all_arguments.llo.exp
+++ b/test/testdata/compiler/all_arguments.llo.exp
@@ -149,6 +149,11 @@ declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 ; Function Attrs: noreturn
 declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #1
 
+; Function Attrs: noreturn
+declare void @sorbet_raiseMissingKeywords(i64) local_unnamed_addr #1
+
+declare i64 @sorbet_addMissingKWArg(i64, i64) local_unnamed_addr #0
+
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
 declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
@@ -253,152 +258,170 @@ argCountSecondCheckBlock:                         ; preds = %functionEntryInitia
 fillFromDefaultBlockDone1:                        ; preds = %sorbet_getMethodBlockAsProc.exit
   %12 = getelementptr i64, i64* %argArray, i32 1, !dbg !16
   %rawArg_b = load i64, i64* %12, align 8, !dbg !16
-  %13 = icmp sgt i32 %argcPhi84, 2, !dbg !16
+  %13 = icmp sgt i32 %argcPhi87, 2, !dbg !16
   br i1 %13, label %15, label %fillFromDefaultBlockDone1.thread, !dbg !16
 
 fillFromDefaultBlockDone1.thread:                 ; preds = %sorbet_getMethodBlockAsProc.exit, %fillFromDefaultBlockDone1
-  %"<argPresent>.sroa.0.090" = phi i64 [ 20, %fillFromDefaultBlockDone1 ], [ 0, %sorbet_getMethodBlockAsProc.exit ]
-  %b.sroa.0.188 = phi i64 [ %rawArg_b, %fillFromDefaultBlockDone1 ], [ 8, %sorbet_getMethodBlockAsProc.exit ]
+  %"<argPresent>.sroa.0.093" = phi i64 [ 20, %fillFromDefaultBlockDone1 ], [ 0, %sorbet_getMethodBlockAsProc.exit ]
+  %b.sroa.0.191 = phi i64 [ %rawArg_b, %fillFromDefaultBlockDone1 ], [ 8, %sorbet_getMethodBlockAsProc.exit ]
   %14 = tail call i64 @rb_ary_new() #10, !dbg !16
   br label %sorbet_readRestArgs.exit, !dbg !16
 
 15:                                               ; preds = %fillFromDefaultBlockDone1
-  %16 = sub nuw nsw i32 %argcPhi84, 2, !dbg !16
+  %16 = sub nuw nsw i32 %argcPhi87, 2, !dbg !16
   %17 = zext i32 %16 to i64
   %18 = getelementptr inbounds i64, i64* %argArray, i64 2, !dbg !16
   %19 = tail call i64 @rb_ary_new_from_values(i64 %17, i64* nonnull %18) #10, !dbg !16
   br label %sorbet_readRestArgs.exit, !dbg !16
 
 sorbet_readRestArgs.exit:                         ; preds = %fillFromDefaultBlockDone1.thread, %15
-  %"<argPresent>.sroa.0.089" = phi i64 [ %"<argPresent>.sroa.0.090", %fillFromDefaultBlockDone1.thread ], [ 20, %15 ]
-  %b.sroa.0.187 = phi i64 [ %b.sroa.0.188, %fillFromDefaultBlockDone1.thread ], [ %rawArg_b, %15 ]
+  %"<argPresent>.sroa.0.092" = phi i64 [ %"<argPresent>.sroa.0.093", %fillFromDefaultBlockDone1.thread ], [ 20, %15 ]
+  %b.sroa.0.190 = phi i64 [ %b.sroa.0.191, %fillFromDefaultBlockDone1.thread ], [ %rawArg_b, %15 ]
   %20 = phi i64 [ %14, %fillFromDefaultBlockDone1.thread ], [ %19, %15 ], !dbg !16
   %rubyId_d = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !16
   %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_d), !dbg !16
-  %21 = icmp eq i64 %hashArgsPhi81, 52, !dbg !16
-  br i1 %21, label %33, label %sorbet_getKWArg.exit77, !dbg !16
+  %21 = icmp eq i64 %hashArgsPhi84, 52, !dbg !16
+  br i1 %21, label %kwArgContinue, label %sorbet_removeKWArg.exit79, !dbg !16
 
-sorbet_getKWArg.exit77:                           ; preds = %sorbet_readRestArgs.exit
-  %22 = tail call i64 @rb_hash_delete_entry(i64 %hashArgsPhi81, i64 %rawSym) #10, !dbg !16
+sorbet_removeKWArg.exit79:                        ; preds = %sorbet_readRestArgs.exit
+  %22 = tail call i64 @rb_hash_delete_entry(i64 %hashArgsPhi84, i64 %rawSym) #10, !dbg !16
   %23 = icmp eq i64 %22, 52, !dbg !16
-  %24 = select i1 %23, i64 8, i64 %22, !dbg !16
-  %rubyId_e = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !16
-  %rawSym20 = tail call i64 @rb_id2sym(i64 %rubyId_e), !dbg !16
-  %25 = tail call i64 @rb_hash_delete_entry(i64 %hashArgsPhi81, i64 %rawSym20) #10, !dbg !16
-  %26 = icmp eq i64 %25, 52, !dbg !16
-  %e.sroa.0.1 = select i1 %26, i64 8, i64 %25, !dbg !16
-  %27 = tail call i64 @rb_hash_dup(i64 %hashArgsPhi81) #10, !dbg !16
-  br i1 %26, label %sorbet_readKWRestArgs.exit.thread, label %37
+  br i1 %23, label %kwArgContinue, label %kwArgContinue.thread, !dbg !16
+
+kwArgContinue.thread:                             ; preds = %sorbet_removeKWArg.exit79
+  %rubyId_e100 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !16
+  %rawSym21101 = tail call i64 @rb_id2sym(i64 %rubyId_e100), !dbg !16
+  br label %sorbet_removeKWArg.exit.thread, !dbg !16
 
 fillRequiredArgs:                                 ; preds = %.thread, %sorbet_isa_Hash.exit, %argCountSecondCheckBlock
-  %argcPhi84 = phi i32 [ 1, %argCountSecondCheckBlock ], [ %argc, %.thread ], [ %argsWithoutHashCount, %sorbet_isa_Hash.exit ]
-  %hashArgsPhi81 = phi i64 [ 52, %argCountSecondCheckBlock ], [ 52, %.thread ], [ %KWArgHash, %sorbet_isa_Hash.exit ]
+  %argcPhi87 = phi i32 [ 1, %argCountSecondCheckBlock ], [ %argc, %.thread ], [ %argsWithoutHashCount, %sorbet_isa_Hash.exit ]
+  %hashArgsPhi84 = phi i64 [ 52, %argCountSecondCheckBlock ], [ 52, %.thread ], [ %KWArgHash, %sorbet_isa_Hash.exit ]
   %rawArg_a = load i64, i64* %argArray, align 8, !dbg !16
-  %28 = tail call i32 @rb_block_given_p() #10, !dbg !16
-  %29 = icmp eq i32 %28, 0, !dbg !16
-  br i1 %29, label %sorbet_getMethodBlockAsProc.exit, label %30, !dbg !16
+  %24 = tail call i32 @rb_block_given_p() #10, !dbg !16
+  %25 = icmp eq i32 %24, 0, !dbg !16
+  br i1 %25, label %sorbet_getMethodBlockAsProc.exit, label %26, !dbg !16
 
-30:                                               ; preds = %fillRequiredArgs
-  %31 = tail call i64 @rb_block_proc() #10, !dbg !16
+26:                                               ; preds = %fillRequiredArgs
+  %27 = tail call i64 @rb_block_proc() #10, !dbg !16
   br label %sorbet_getMethodBlockAsProc.exit, !dbg !16
 
-sorbet_getMethodBlockAsProc.exit:                 ; preds = %fillRequiredArgs, %30
-  %32 = phi i64 [ %31, %30 ], [ 8, %fillRequiredArgs ], !dbg !16
-  %default0 = icmp eq i32 %argcPhi84, 1, !dbg !16
+sorbet_getMethodBlockAsProc.exit:                 ; preds = %fillRequiredArgs, %26
+  %28 = phi i64 [ %27, %26 ], [ 8, %fillRequiredArgs ], !dbg !16
+  %default0 = icmp eq i32 %argcPhi87, 1, !dbg !16
   br i1 %default0, label %fillFromDefaultBlockDone1.thread, label %fillFromDefaultBlockDone1, !dbg !16, !prof !19
 
-33:                                               ; preds = %sorbet_readRestArgs.exit
-  %rubyId_e101 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !16
-  %rawSym20102 = tail call i64 @rb_id2sym(i64 %rubyId_e101), !dbg !16
-  %34 = tail call i64 @rb_hash_new() #10, !dbg !16
-  br label %sorbet_readKWRestArgs.exit.thread, !dbg !16
+kwArgContinue:                                    ; preds = %sorbet_readRestArgs.exit, %sorbet_removeKWArg.exit79
+  %29 = tail call i64 @sorbet_addMissingKWArg(i64 noundef 52, i64 %rawSym), !dbg !16
+  %rubyId_e = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !16
+  %rawSym21 = tail call i64 @rb_id2sym(i64 %rubyId_e), !dbg !16
+  br i1 %21, label %sorbet_removeKWArg.exit, label %sorbet_removeKWArg.exit.thread, !dbg !16
 
-sorbet_readKWRestArgs.exit.thread:                ; preds = %33, %sorbet_getKWArg.exit77
-  %.ph = phi i64 [ 8, %33 ], [ %24, %sorbet_getKWArg.exit77 ]
-  %.ph113 = phi i64 [ %34, %33 ], [ %27, %sorbet_getKWArg.exit77 ]
-  %35 = and i64 %"<argPresent>.sroa.0.089", -9, !dbg !20
-  %36 = icmp ne i64 %35, 0, !dbg !20
-  %b.sroa.0.0116 = select i1 %36, i64 %b.sroa.0.187, i64 3, !dbg !20
-  br label %42, !dbg !21
+sorbet_removeKWArg.exit:                          ; preds = %kwArgContinue
+  %30 = icmp eq i64 %29, 52, !dbg !16
+  br i1 %30, label %sorbet_readKWRestArgs.exit.thread, label %34, !dbg !16, !prof !20
 
-37:                                               ; preds = %sorbet_getKWArg.exit77
-  %"<argPresent>9.sroa.0.0108" = phi i64 [ 20, %sorbet_getKWArg.exit77 ]
-  %e.sroa.0.1106 = phi i64 [ %e.sroa.0.1, %sorbet_getKWArg.exit77 ]
-  %38 = phi i64 [ %24, %sorbet_getKWArg.exit77 ]
-  %39 = phi i64 [ %27, %sorbet_getKWArg.exit77 ], !dbg !16
-  %40 = and i64 %"<argPresent>.sroa.0.089", -9, !dbg !20
-  %41 = icmp ne i64 %40, 0, !dbg !20
-  %b.sroa.0.0 = select i1 %41, i64 %b.sroa.0.187, i64 3, !dbg !20
-  br label %42, !dbg !21
+sorbet_removeKWArg.exit.thread:                   ; preds = %kwArgContinue, %kwArgContinue.thread
+  %rawSym21107 = phi i64 [ %rawSym21101, %kwArgContinue.thread ], [ %rawSym21, %kwArgContinue ]
+  %missingArgsPhi105 = phi i64 [ 52, %kwArgContinue.thread ], [ %29, %kwArgContinue ]
+  %d.sroa.0.0103 = phi i64 [ %22, %kwArgContinue.thread ], [ 8, %kwArgContinue ]
+  %31 = tail call i64 @rb_hash_delete_entry(i64 %hashArgsPhi84, i64 %rawSym21107) #10, !dbg !16
+  %32 = icmp eq i64 %31, 52, !dbg !16
+  %e.sroa.0.1111 = select i1 %32, i64 8, i64 %31, !dbg !16
+  %"<argPresent>9.sroa.0.0112" = select i1 %32, i64 0, i64 20, !dbg !16
+  %33 = icmp eq i64 %missingArgsPhi105, 52, !dbg !16
+  br i1 %33, label %sorbet_readKWRestArgs.exit, label %34, !dbg !16, !prof !20
 
-42:                                               ; preds = %sorbet_readKWRestArgs.exit.thread, %37
-  %b.sroa.0.0117 = phi i64 [ %b.sroa.0.0, %37 ], [ %b.sroa.0.0116, %sorbet_readKWRestArgs.exit.thread ]
-  %43 = phi i64 [ %39, %37 ], [ %.ph113, %sorbet_readKWRestArgs.exit.thread ]
-  %44 = phi i64 [ %38, %37 ], [ %.ph, %sorbet_readKWRestArgs.exit.thread ]
-  %45 = phi i64 [ %e.sroa.0.1106, %37 ], [ 5, %sorbet_readKWRestArgs.exit.thread ]
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !22, !tbaa !14
-  %callArgs0Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 0, !dbg !23
-  store i64 %rawArg_a, i64* %callArgs0Addr, align 8, !dbg !23
-  %callArgs1Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 1, !dbg !23
-  store i64 %b.sroa.0.0117, i64* %callArgs1Addr, align 8, !dbg !23
-  %callArgs2Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 2, !dbg !23
-  store i64 %20, i64* %callArgs2Addr, align 8, !dbg !23
-  %callArgs3Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 3, !dbg !23
-  store i64 %44, i64* %callArgs3Addr, align 8, !dbg !23
-  %callArgs4Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 4, !dbg !23
-  store i64 %45, i64* %callArgs4Addr, align 8, !dbg !23
-  %callArgs5Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 5, !dbg !23
-  store i64 %43, i64* %callArgs5Addr, align 8, !dbg !23
-  %callArgs6Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 6, !dbg !23
-  store i64 %32, i64* %callArgs6Addr, align 8, !dbg !23
-  %46 = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 0, !dbg !23
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !24) #11, !dbg !23
-  %47 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull %46) #10, !dbg !23
-  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !23
-  %49 = load i64*, i64** %48, align 8, !dbg !23
-  store i64 %47, i64* %49, align 8, !dbg !23, !tbaa !6
-  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !23
-  store i64* %50, i64** %48, align 8, !dbg !23
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_inspect, i64 0), !dbg !23
-  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !27
-  %52 = load i64*, i64** %51, align 8, !dbg !27
-  store i64 %selfRaw, i64* %52, align 8, !dbg !27, !tbaa !6
-  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !27
-  store i64 %send, i64* %53, align 8, !dbg !27, !tbaa !6
-  %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !27
-  store i64* %54, i64** %51, align 8, !dbg !27
-  %send112 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !27
-  ret i64 %send112
+34:                                               ; preds = %sorbet_removeKWArg.exit.thread, %sorbet_removeKWArg.exit
+  %missingArgsPhi106113 = phi i64 [ %missingArgsPhi105, %sorbet_removeKWArg.exit.thread ], [ %29, %sorbet_removeKWArg.exit ]
+  tail call void @sorbet_raiseMissingKeywords(i64 %missingArgsPhi106113) #8, !dbg !16
+  unreachable, !dbg !16
+
+sorbet_readKWRestArgs.exit.thread:                ; preds = %sorbet_removeKWArg.exit
+  %35 = tail call i64 @rb_hash_new() #10, !dbg !16
+  %36 = and i64 %"<argPresent>.sroa.0.092", -9, !dbg !21
+  %37 = icmp ne i64 %36, 0, !dbg !21
+  %b.sroa.0.0138 = select i1 %37, i64 %b.sroa.0.190, i64 3, !dbg !21
+  br label %43, !dbg !22
+
+sorbet_readKWRestArgs.exit:                       ; preds = %sorbet_removeKWArg.exit.thread
+  %38 = tail call i64 @rb_hash_dup(i64 %hashArgsPhi84) #10, !dbg !16
+  %39 = and i64 %"<argPresent>.sroa.0.092", -9, !dbg !21
+  %40 = icmp ne i64 %39, 0, !dbg !21
+  %b.sroa.0.0 = select i1 %40, i64 %b.sroa.0.190, i64 3, !dbg !21
+  %41 = icmp ne i64 %"<argPresent>9.sroa.0.0112", 0, !dbg !22
+  br i1 %41, label %42, label %43, !dbg !22
+
+42:                                               ; preds = %sorbet_readKWRestArgs.exit
+  br label %43, !dbg !22
+
+43:                                               ; preds = %sorbet_readKWRestArgs.exit.thread, %sorbet_readKWRestArgs.exit, %42
+  %b.sroa.0.0140 = phi i64 [ %b.sroa.0.0, %42 ], [ %b.sroa.0.0, %sorbet_readKWRestArgs.exit ], [ %b.sroa.0.0138, %sorbet_readKWRestArgs.exit.thread ]
+  %44 = phi i64 [ %38, %42 ], [ %38, %sorbet_readKWRestArgs.exit ], [ %35, %sorbet_readKWRestArgs.exit.thread ]
+  %d.sroa.0.0104114127139 = phi i64 [ %d.sroa.0.0103, %42 ], [ %d.sroa.0.0103, %sorbet_readKWRestArgs.exit ], [ 8, %sorbet_readKWRestArgs.exit.thread ]
+  %45 = phi i64 [ %e.sroa.0.1111, %42 ], [ 5, %sorbet_readKWRestArgs.exit ], [ 5, %sorbet_readKWRestArgs.exit.thread ]
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !23, !tbaa !14
+  %callArgs0Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 0, !dbg !24
+  store i64 %rawArg_a, i64* %callArgs0Addr, align 8, !dbg !24
+  %callArgs1Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 1, !dbg !24
+  store i64 %b.sroa.0.0140, i64* %callArgs1Addr, align 8, !dbg !24
+  %callArgs2Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 2, !dbg !24
+  store i64 %20, i64* %callArgs2Addr, align 8, !dbg !24
+  %callArgs3Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 3, !dbg !24
+  store i64 %d.sroa.0.0104114127139, i64* %callArgs3Addr, align 8, !dbg !24
+  %callArgs4Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 4, !dbg !24
+  store i64 %45, i64* %callArgs4Addr, align 8, !dbg !24
+  %callArgs5Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 5, !dbg !24
+  store i64 %44, i64* %callArgs5Addr, align 8, !dbg !24
+  %callArgs6Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 6, !dbg !24
+  store i64 %28, i64* %callArgs6Addr, align 8, !dbg !24
+  %46 = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 0, !dbg !24
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !25) #11, !dbg !24
+  %47 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull %46) #10, !dbg !24
+  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !24
+  %49 = load i64*, i64** %48, align 8, !dbg !24
+  store i64 %47, i64* %49, align 8, !dbg !24, !tbaa !6
+  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !24
+  store i64* %50, i64** %48, align 8, !dbg !24
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_inspect, i64 0), !dbg !24
+  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !28
+  %52 = load i64*, i64** %51, align 8, !dbg !28
+  store i64 %selfRaw, i64* %52, align 8, !dbg !28, !tbaa !6
+  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !28
+  store i64 %send, i64* %53, align 8, !dbg !28, !tbaa !6
+  %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !28
+  store i64* %54, i64** %51, align 8, !dbg !28
+  %send134 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !28
+  ret i64 %send134
 }
 
 ; Function Attrs: sspreq
 define void @Init_all_arguments() local_unnamed_addr #6 {
 entry:
-  %positional_table.i = alloca i64, i32 4, align 8, !dbg !28
-  %keyword_table.i = alloca i64, i32 3, align 8, !dbg !28
+  %positional_table.i = alloca i64, i32 4, align 8, !dbg !29
+  %keyword_table.i = alloca i64, i32 3, align 8, !dbg !29
   %locals.i165.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, align 8, !dbg !30
-  %keywords5.i = alloca i64, align 8, !dbg !31
-  %keywords11.i = alloca i64, align 8, !dbg !32
-  %keywords17.i = alloca i64, align 8, !dbg !33
-  %keywords23.i = alloca i64, align 8, !dbg !34
-  %keywords29.i = alloca i64, align 8, !dbg !35
-  %keywords35.i = alloca i64, align 8, !dbg !36
-  %keywords41.i = alloca i64, i32 2, align 8, !dbg !37
-  %keywords48.i = alloca i64, i32 2, align 8, !dbg !38
-  %keywords56.i = alloca i64, i32 2, align 8, !dbg !39
-  %keywords64.i = alloca i64, i32 2, align 8, !dbg !40
-  %keywords72.i = alloca i64, i32 2, align 8, !dbg !41
-  %keywords80.i = alloca i64, i32 2, align 8, !dbg !42
-  %keywords88.i = alloca i64, i32 2, align 8, !dbg !43
-  %keywords96.i = alloca i64, i32 3, align 8, !dbg !44
-  %keywords105.i = alloca i64, i32 3, align 8, !dbg !45
-  %keywords115.i = alloca i64, i32 3, align 8, !dbg !46
-  %keywords125.i = alloca i64, i32 3, align 8, !dbg !47
-  %keywords135.i = alloca i64, i32 3, align 8, !dbg !48
-  %keywords145.i = alloca i64, i32 3, align 8, !dbg !49
-  %keywords155.i = alloca i64, i32 3, align 8, !dbg !50
+  %keywords.i = alloca i64, align 8, !dbg !31
+  %keywords5.i = alloca i64, align 8, !dbg !32
+  %keywords11.i = alloca i64, align 8, !dbg !33
+  %keywords17.i = alloca i64, align 8, !dbg !34
+  %keywords23.i = alloca i64, align 8, !dbg !35
+  %keywords29.i = alloca i64, align 8, !dbg !36
+  %keywords35.i = alloca i64, align 8, !dbg !37
+  %keywords41.i = alloca i64, i32 2, align 8, !dbg !38
+  %keywords48.i = alloca i64, i32 2, align 8, !dbg !39
+  %keywords56.i = alloca i64, i32 2, align 8, !dbg !40
+  %keywords64.i = alloca i64, i32 2, align 8, !dbg !41
+  %keywords72.i = alloca i64, i32 2, align 8, !dbg !42
+  %keywords80.i = alloca i64, i32 2, align 8, !dbg !43
+  %keywords88.i = alloca i64, i32 2, align 8, !dbg !44
+  %keywords96.i = alloca i64, i32 3, align 8, !dbg !45
+  %keywords105.i = alloca i64, i32 3, align 8, !dbg !46
+  %keywords115.i = alloca i64, i32 3, align 8, !dbg !47
+  %keywords125.i = alloca i64, i32 3, align 8, !dbg !48
+  %keywords135.i = alloca i64, i32 3, align 8, !dbg !49
+  %keywords145.i = alloca i64, i32 3, align 8, !dbg !50
+  %keywords155.i = alloca i64, i32 3, align 8, !dbg !51
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
@@ -483,207 +506,207 @@ entry:
   %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
   %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_take_arguments.i.i, i64 %rubyId_take_arguments.i.i, i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 8)
   store %struct.rb_iseq_struct* %38, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#take_arguments", align 8
-  %rubyId_inspect.i = load i64, i64* @rubyIdPrecomputed_inspect, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_inspect, i64 %rubyId_inspect.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !23
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !27
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !27
+  %rubyId_inspect.i = load i64, i64* @rubyIdPrecomputed_inspect, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_inspect, i64 %rubyId_inspect.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !28
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
   %39 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
   call void @rb_gc_register_mark_object(i64 %39) #10
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/all_arguments.rb.i164.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
   %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %39, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i164.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i165.i, i32 noundef 0, i32 noundef 11)
   store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !28
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !28
-  %rubyId_take_arguments.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !30
-  %rubyId_d.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !30
-  %41 = call i64 @rb_id2sym(i64 %rubyId_d.i) #10, !dbg !30
-  store i64 %41, i64* %keywords.i, align 8, !dbg !30
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments.i, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !30
-  %rubyId_take_arguments4.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !31
-  %rubyId_d6.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !31
-  %42 = call i64 @rb_id2sym(i64 %rubyId_d6.i) #10, !dbg !31
-  store i64 %42, i64* %keywords5.i, align 8, !dbg !31
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments4.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull %keywords5.i), !dbg !31
-  %rubyId_take_arguments10.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !32
-  %rubyId_d12.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !32
-  %43 = call i64 @rb_id2sym(i64 %rubyId_d12.i) #10, !dbg !32
-  store i64 %43, i64* %keywords11.i, align 8, !dbg !32
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments10.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull %keywords11.i), !dbg !32
-  %rubyId_take_arguments16.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !33
-  %rubyId_d18.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !33
-  %44 = call i64 @rb_id2sym(i64 %rubyId_d18.i) #10, !dbg !33
-  store i64 %44, i64* %keywords17.i, align 8, !dbg !33
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments16.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull %keywords17.i), !dbg !33
-  %rubyId_take_arguments22.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !34
-  %rubyId_d24.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !34
-  %45 = call i64 @rb_id2sym(i64 %rubyId_d24.i) #10, !dbg !34
-  store i64 %45, i64* %keywords23.i, align 8, !dbg !34
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments22.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull %keywords23.i), !dbg !34
-  %rubyId_take_arguments28.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !35
-  %rubyId_d30.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !35
-  %46 = call i64 @rb_id2sym(i64 %rubyId_d30.i) #10, !dbg !35
-  store i64 %46, i64* %keywords29.i, align 8, !dbg !35
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments28.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull %keywords29.i), !dbg !35
-  %rubyId_take_arguments34.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !36
-  %rubyId_d36.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !36
-  %47 = call i64 @rb_id2sym(i64 %rubyId_d36.i) #10, !dbg !36
-  store i64 %47, i64* %keywords35.i, align 8, !dbg !36
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments34.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull %keywords35.i), !dbg !36
-  %rubyId_take_arguments40.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !37
-  %rubyId_d42.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !37
-  %48 = call i64 @rb_id2sym(i64 %rubyId_d42.i) #10, !dbg !37
-  store i64 %48, i64* %keywords41.i, align 8, !dbg !37
-  %rubyId_e.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !37
-  %49 = call i64 @rb_id2sym(i64 %rubyId_e.i) #10, !dbg !37
-  %50 = getelementptr i64, i64* %keywords41.i, i32 1, !dbg !37
-  store i64 %49, i64* %50, align 8, !dbg !37
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments40.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull %keywords41.i), !dbg !37
-  %rubyId_take_arguments47.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !38
-  %rubyId_d49.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !38
-  %51 = call i64 @rb_id2sym(i64 %rubyId_d49.i) #10, !dbg !38
-  store i64 %51, i64* %keywords48.i, align 8, !dbg !38
-  %rubyId_e51.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !38
-  %52 = call i64 @rb_id2sym(i64 %rubyId_e51.i) #10, !dbg !38
-  %53 = getelementptr i64, i64* %keywords48.i, i32 1, !dbg !38
-  store i64 %52, i64* %53, align 8, !dbg !38
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments47.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull %keywords48.i), !dbg !38
-  %rubyId_take_arguments55.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !39
-  %rubyId_d57.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !39
-  %54 = call i64 @rb_id2sym(i64 %rubyId_d57.i) #10, !dbg !39
-  store i64 %54, i64* %keywords56.i, align 8, !dbg !39
-  %rubyId_e59.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !39
-  %55 = call i64 @rb_id2sym(i64 %rubyId_e59.i) #10, !dbg !39
-  %56 = getelementptr i64, i64* %keywords56.i, i32 1, !dbg !39
-  store i64 %55, i64* %56, align 8, !dbg !39
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments55.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull %keywords56.i), !dbg !39
-  %rubyId_take_arguments63.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !40
-  %rubyId_d65.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !40
-  %57 = call i64 @rb_id2sym(i64 %rubyId_d65.i) #10, !dbg !40
-  store i64 %57, i64* %keywords64.i, align 8, !dbg !40
-  %rubyId_e67.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !40
-  %58 = call i64 @rb_id2sym(i64 %rubyId_e67.i) #10, !dbg !40
-  %59 = getelementptr i64, i64* %keywords64.i, i32 1, !dbg !40
-  store i64 %58, i64* %59, align 8, !dbg !40
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments63.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull %keywords64.i), !dbg !40
-  %rubyId_take_arguments71.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !41
-  %rubyId_d73.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !41
-  %60 = call i64 @rb_id2sym(i64 %rubyId_d73.i) #10, !dbg !41
-  store i64 %60, i64* %keywords72.i, align 8, !dbg !41
-  %rubyId_e75.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !41
-  %61 = call i64 @rb_id2sym(i64 %rubyId_e75.i) #10, !dbg !41
-  %62 = getelementptr i64, i64* %keywords72.i, i32 1, !dbg !41
-  store i64 %61, i64* %62, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments71.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull %keywords72.i), !dbg !41
-  %rubyId_take_arguments79.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !42
-  %rubyId_d81.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !42
-  %63 = call i64 @rb_id2sym(i64 %rubyId_d81.i) #10, !dbg !42
-  store i64 %63, i64* %keywords80.i, align 8, !dbg !42
-  %rubyId_e83.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !42
-  %64 = call i64 @rb_id2sym(i64 %rubyId_e83.i) #10, !dbg !42
-  %65 = getelementptr i64, i64* %keywords80.i, i32 1, !dbg !42
-  store i64 %64, i64* %65, align 8, !dbg !42
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments79.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull %keywords80.i), !dbg !42
-  %rubyId_take_arguments87.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !43
-  %rubyId_d89.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !43
-  %66 = call i64 @rb_id2sym(i64 %rubyId_d89.i) #10, !dbg !43
-  store i64 %66, i64* %keywords88.i, align 8, !dbg !43
-  %rubyId_e91.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !43
-  %67 = call i64 @rb_id2sym(i64 %rubyId_e91.i) #10, !dbg !43
-  %68 = getelementptr i64, i64* %keywords88.i, i32 1, !dbg !43
-  store i64 %67, i64* %68, align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments87.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull %keywords88.i), !dbg !43
-  %rubyId_take_arguments95.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !44
-  %rubyId_d97.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !44
-  %69 = call i64 @rb_id2sym(i64 %rubyId_d97.i) #10, !dbg !44
-  store i64 %69, i64* %keywords96.i, align 8, !dbg !44
-  %rubyId_e99.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !44
-  %70 = call i64 @rb_id2sym(i64 %rubyId_e99.i) #10, !dbg !44
-  %71 = getelementptr i64, i64* %keywords96.i, i32 1, !dbg !44
-  store i64 %70, i64* %71, align 8, !dbg !44
-  %rubyId_baz.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !44
-  %72 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #10, !dbg !44
-  %73 = getelementptr i64, i64* %keywords96.i, i32 2, !dbg !44
-  store i64 %72, i64* %73, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments95.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull %keywords96.i), !dbg !44
-  %rubyId_take_arguments104.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !45
-  %rubyId_d106.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !45
-  %74 = call i64 @rb_id2sym(i64 %rubyId_d106.i) #10, !dbg !45
-  store i64 %74, i64* %keywords105.i, align 8, !dbg !45
-  %rubyId_e108.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !45
-  %75 = call i64 @rb_id2sym(i64 %rubyId_e108.i) #10, !dbg !45
-  %76 = getelementptr i64, i64* %keywords105.i, i32 1, !dbg !45
-  store i64 %75, i64* %76, align 8, !dbg !45
-  %rubyId_baz110.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !45
-  %77 = call i64 @rb_id2sym(i64 %rubyId_baz110.i) #10, !dbg !45
-  %78 = getelementptr i64, i64* %keywords105.i, i32 2, !dbg !45
-  store i64 %77, i64* %78, align 8, !dbg !45
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments104.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull %keywords105.i), !dbg !45
-  %rubyId_take_arguments114.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !46
-  %rubyId_d116.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !46
-  %79 = call i64 @rb_id2sym(i64 %rubyId_d116.i) #10, !dbg !46
-  store i64 %79, i64* %keywords115.i, align 8, !dbg !46
-  %rubyId_e118.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !46
-  %80 = call i64 @rb_id2sym(i64 %rubyId_e118.i) #10, !dbg !46
-  %81 = getelementptr i64, i64* %keywords115.i, i32 1, !dbg !46
-  store i64 %80, i64* %81, align 8, !dbg !46
-  %rubyId_baz120.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !46
-  %82 = call i64 @rb_id2sym(i64 %rubyId_baz120.i) #10, !dbg !46
-  %83 = getelementptr i64, i64* %keywords115.i, i32 2, !dbg !46
-  store i64 %82, i64* %83, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments114.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull %keywords115.i), !dbg !46
-  %rubyId_take_arguments124.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !47
-  %rubyId_d126.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !47
-  %84 = call i64 @rb_id2sym(i64 %rubyId_d126.i) #10, !dbg !47
-  store i64 %84, i64* %keywords125.i, align 8, !dbg !47
-  %rubyId_e128.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !47
-  %85 = call i64 @rb_id2sym(i64 %rubyId_e128.i) #10, !dbg !47
-  %86 = getelementptr i64, i64* %keywords125.i, i32 1, !dbg !47
-  store i64 %85, i64* %86, align 8, !dbg !47
-  %rubyId_baz130.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !47
-  %87 = call i64 @rb_id2sym(i64 %rubyId_baz130.i) #10, !dbg !47
-  %88 = getelementptr i64, i64* %keywords125.i, i32 2, !dbg !47
-  store i64 %87, i64* %88, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments124.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull %keywords125.i), !dbg !47
-  %rubyId_take_arguments134.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !48
-  %rubyId_d136.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !48
-  %89 = call i64 @rb_id2sym(i64 %rubyId_d136.i) #10, !dbg !48
-  store i64 %89, i64* %keywords135.i, align 8, !dbg !48
-  %rubyId_e138.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !48
-  %90 = call i64 @rb_id2sym(i64 %rubyId_e138.i) #10, !dbg !48
-  %91 = getelementptr i64, i64* %keywords135.i, i32 1, !dbg !48
-  store i64 %90, i64* %91, align 8, !dbg !48
-  %rubyId_baz140.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !48
-  %92 = call i64 @rb_id2sym(i64 %rubyId_baz140.i) #10, !dbg !48
-  %93 = getelementptr i64, i64* %keywords135.i, i32 2, !dbg !48
-  store i64 %92, i64* %93, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments134.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull %keywords135.i), !dbg !48
-  %rubyId_take_arguments144.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !49
-  %rubyId_d146.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !49
-  %94 = call i64 @rb_id2sym(i64 %rubyId_d146.i) #10, !dbg !49
-  store i64 %94, i64* %keywords145.i, align 8, !dbg !49
-  %rubyId_e148.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !49
-  %95 = call i64 @rb_id2sym(i64 %rubyId_e148.i) #10, !dbg !49
-  %96 = getelementptr i64, i64* %keywords145.i, i32 1, !dbg !49
-  store i64 %95, i64* %96, align 8, !dbg !49
-  %rubyId_baz150.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !49
-  %97 = call i64 @rb_id2sym(i64 %rubyId_baz150.i) #10, !dbg !49
-  %98 = getelementptr i64, i64* %keywords145.i, i32 2, !dbg !49
-  store i64 %97, i64* %98, align 8, !dbg !49
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments144.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull %keywords145.i), !dbg !49
-  %rubyId_take_arguments154.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !50
-  %rubyId_d156.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !50
-  %99 = call i64 @rb_id2sym(i64 %rubyId_d156.i) #10, !dbg !50
-  store i64 %99, i64* %keywords155.i, align 8, !dbg !50
-  %rubyId_e158.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !50
-  %100 = call i64 @rb_id2sym(i64 %rubyId_e158.i) #10, !dbg !50
-  %101 = getelementptr i64, i64* %keywords155.i, i32 1, !dbg !50
-  store i64 %100, i64* %101, align 8, !dbg !50
-  %rubyId_baz160.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !50
-  %102 = call i64 @rb_id2sym(i64 %rubyId_baz160.i) #10, !dbg !50
-  %103 = getelementptr i64, i64* %keywords155.i, i32 2, !dbg !50
-  store i64 %102, i64* %103, align 8, !dbg !50
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments154.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull %keywords155.i), !dbg !50
+  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !29
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !29
+  %rubyId_take_arguments.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !31
+  %rubyId_d.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !31
+  %41 = call i64 @rb_id2sym(i64 %rubyId_d.i) #10, !dbg !31
+  store i64 %41, i64* %keywords.i, align 8, !dbg !31
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments.i, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !31
+  %rubyId_take_arguments4.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !32
+  %rubyId_d6.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !32
+  %42 = call i64 @rb_id2sym(i64 %rubyId_d6.i) #10, !dbg !32
+  store i64 %42, i64* %keywords5.i, align 8, !dbg !32
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments4.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull %keywords5.i), !dbg !32
+  %rubyId_take_arguments10.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !33
+  %rubyId_d12.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !33
+  %43 = call i64 @rb_id2sym(i64 %rubyId_d12.i) #10, !dbg !33
+  store i64 %43, i64* %keywords11.i, align 8, !dbg !33
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments10.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull %keywords11.i), !dbg !33
+  %rubyId_take_arguments16.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !34
+  %rubyId_d18.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !34
+  %44 = call i64 @rb_id2sym(i64 %rubyId_d18.i) #10, !dbg !34
+  store i64 %44, i64* %keywords17.i, align 8, !dbg !34
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments16.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull %keywords17.i), !dbg !34
+  %rubyId_take_arguments22.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !35
+  %rubyId_d24.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !35
+  %45 = call i64 @rb_id2sym(i64 %rubyId_d24.i) #10, !dbg !35
+  store i64 %45, i64* %keywords23.i, align 8, !dbg !35
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments22.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull %keywords23.i), !dbg !35
+  %rubyId_take_arguments28.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !36
+  %rubyId_d30.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !36
+  %46 = call i64 @rb_id2sym(i64 %rubyId_d30.i) #10, !dbg !36
+  store i64 %46, i64* %keywords29.i, align 8, !dbg !36
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments28.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull %keywords29.i), !dbg !36
+  %rubyId_take_arguments34.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !37
+  %rubyId_d36.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !37
+  %47 = call i64 @rb_id2sym(i64 %rubyId_d36.i) #10, !dbg !37
+  store i64 %47, i64* %keywords35.i, align 8, !dbg !37
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments34.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull %keywords35.i), !dbg !37
+  %rubyId_take_arguments40.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !38
+  %rubyId_d42.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !38
+  %48 = call i64 @rb_id2sym(i64 %rubyId_d42.i) #10, !dbg !38
+  store i64 %48, i64* %keywords41.i, align 8, !dbg !38
+  %rubyId_e.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !38
+  %49 = call i64 @rb_id2sym(i64 %rubyId_e.i) #10, !dbg !38
+  %50 = getelementptr i64, i64* %keywords41.i, i32 1, !dbg !38
+  store i64 %49, i64* %50, align 8, !dbg !38
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments40.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull %keywords41.i), !dbg !38
+  %rubyId_take_arguments47.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !39
+  %rubyId_d49.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !39
+  %51 = call i64 @rb_id2sym(i64 %rubyId_d49.i) #10, !dbg !39
+  store i64 %51, i64* %keywords48.i, align 8, !dbg !39
+  %rubyId_e51.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !39
+  %52 = call i64 @rb_id2sym(i64 %rubyId_e51.i) #10, !dbg !39
+  %53 = getelementptr i64, i64* %keywords48.i, i32 1, !dbg !39
+  store i64 %52, i64* %53, align 8, !dbg !39
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments47.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull %keywords48.i), !dbg !39
+  %rubyId_take_arguments55.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !40
+  %rubyId_d57.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !40
+  %54 = call i64 @rb_id2sym(i64 %rubyId_d57.i) #10, !dbg !40
+  store i64 %54, i64* %keywords56.i, align 8, !dbg !40
+  %rubyId_e59.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !40
+  %55 = call i64 @rb_id2sym(i64 %rubyId_e59.i) #10, !dbg !40
+  %56 = getelementptr i64, i64* %keywords56.i, i32 1, !dbg !40
+  store i64 %55, i64* %56, align 8, !dbg !40
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments55.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull %keywords56.i), !dbg !40
+  %rubyId_take_arguments63.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !41
+  %rubyId_d65.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !41
+  %57 = call i64 @rb_id2sym(i64 %rubyId_d65.i) #10, !dbg !41
+  store i64 %57, i64* %keywords64.i, align 8, !dbg !41
+  %rubyId_e67.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !41
+  %58 = call i64 @rb_id2sym(i64 %rubyId_e67.i) #10, !dbg !41
+  %59 = getelementptr i64, i64* %keywords64.i, i32 1, !dbg !41
+  store i64 %58, i64* %59, align 8, !dbg !41
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments63.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull %keywords64.i), !dbg !41
+  %rubyId_take_arguments71.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !42
+  %rubyId_d73.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !42
+  %60 = call i64 @rb_id2sym(i64 %rubyId_d73.i) #10, !dbg !42
+  store i64 %60, i64* %keywords72.i, align 8, !dbg !42
+  %rubyId_e75.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !42
+  %61 = call i64 @rb_id2sym(i64 %rubyId_e75.i) #10, !dbg !42
+  %62 = getelementptr i64, i64* %keywords72.i, i32 1, !dbg !42
+  store i64 %61, i64* %62, align 8, !dbg !42
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments71.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull %keywords72.i), !dbg !42
+  %rubyId_take_arguments79.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !43
+  %rubyId_d81.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !43
+  %63 = call i64 @rb_id2sym(i64 %rubyId_d81.i) #10, !dbg !43
+  store i64 %63, i64* %keywords80.i, align 8, !dbg !43
+  %rubyId_e83.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !43
+  %64 = call i64 @rb_id2sym(i64 %rubyId_e83.i) #10, !dbg !43
+  %65 = getelementptr i64, i64* %keywords80.i, i32 1, !dbg !43
+  store i64 %64, i64* %65, align 8, !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments79.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull %keywords80.i), !dbg !43
+  %rubyId_take_arguments87.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !44
+  %rubyId_d89.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !44
+  %66 = call i64 @rb_id2sym(i64 %rubyId_d89.i) #10, !dbg !44
+  store i64 %66, i64* %keywords88.i, align 8, !dbg !44
+  %rubyId_e91.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !44
+  %67 = call i64 @rb_id2sym(i64 %rubyId_e91.i) #10, !dbg !44
+  %68 = getelementptr i64, i64* %keywords88.i, i32 1, !dbg !44
+  store i64 %67, i64* %68, align 8, !dbg !44
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments87.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull %keywords88.i), !dbg !44
+  %rubyId_take_arguments95.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !45
+  %rubyId_d97.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !45
+  %69 = call i64 @rb_id2sym(i64 %rubyId_d97.i) #10, !dbg !45
+  store i64 %69, i64* %keywords96.i, align 8, !dbg !45
+  %rubyId_e99.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !45
+  %70 = call i64 @rb_id2sym(i64 %rubyId_e99.i) #10, !dbg !45
+  %71 = getelementptr i64, i64* %keywords96.i, i32 1, !dbg !45
+  store i64 %70, i64* %71, align 8, !dbg !45
+  %rubyId_baz.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !45
+  %72 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #10, !dbg !45
+  %73 = getelementptr i64, i64* %keywords96.i, i32 2, !dbg !45
+  store i64 %72, i64* %73, align 8, !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments95.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull %keywords96.i), !dbg !45
+  %rubyId_take_arguments104.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !46
+  %rubyId_d106.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !46
+  %74 = call i64 @rb_id2sym(i64 %rubyId_d106.i) #10, !dbg !46
+  store i64 %74, i64* %keywords105.i, align 8, !dbg !46
+  %rubyId_e108.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !46
+  %75 = call i64 @rb_id2sym(i64 %rubyId_e108.i) #10, !dbg !46
+  %76 = getelementptr i64, i64* %keywords105.i, i32 1, !dbg !46
+  store i64 %75, i64* %76, align 8, !dbg !46
+  %rubyId_baz110.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !46
+  %77 = call i64 @rb_id2sym(i64 %rubyId_baz110.i) #10, !dbg !46
+  %78 = getelementptr i64, i64* %keywords105.i, i32 2, !dbg !46
+  store i64 %77, i64* %78, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments104.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull %keywords105.i), !dbg !46
+  %rubyId_take_arguments114.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !47
+  %rubyId_d116.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !47
+  %79 = call i64 @rb_id2sym(i64 %rubyId_d116.i) #10, !dbg !47
+  store i64 %79, i64* %keywords115.i, align 8, !dbg !47
+  %rubyId_e118.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !47
+  %80 = call i64 @rb_id2sym(i64 %rubyId_e118.i) #10, !dbg !47
+  %81 = getelementptr i64, i64* %keywords115.i, i32 1, !dbg !47
+  store i64 %80, i64* %81, align 8, !dbg !47
+  %rubyId_baz120.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !47
+  %82 = call i64 @rb_id2sym(i64 %rubyId_baz120.i) #10, !dbg !47
+  %83 = getelementptr i64, i64* %keywords115.i, i32 2, !dbg !47
+  store i64 %82, i64* %83, align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments114.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull %keywords115.i), !dbg !47
+  %rubyId_take_arguments124.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !48
+  %rubyId_d126.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !48
+  %84 = call i64 @rb_id2sym(i64 %rubyId_d126.i) #10, !dbg !48
+  store i64 %84, i64* %keywords125.i, align 8, !dbg !48
+  %rubyId_e128.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !48
+  %85 = call i64 @rb_id2sym(i64 %rubyId_e128.i) #10, !dbg !48
+  %86 = getelementptr i64, i64* %keywords125.i, i32 1, !dbg !48
+  store i64 %85, i64* %86, align 8, !dbg !48
+  %rubyId_baz130.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !48
+  %87 = call i64 @rb_id2sym(i64 %rubyId_baz130.i) #10, !dbg !48
+  %88 = getelementptr i64, i64* %keywords125.i, i32 2, !dbg !48
+  store i64 %87, i64* %88, align 8, !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments124.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull %keywords125.i), !dbg !48
+  %rubyId_take_arguments134.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !49
+  %rubyId_d136.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !49
+  %89 = call i64 @rb_id2sym(i64 %rubyId_d136.i) #10, !dbg !49
+  store i64 %89, i64* %keywords135.i, align 8, !dbg !49
+  %rubyId_e138.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !49
+  %90 = call i64 @rb_id2sym(i64 %rubyId_e138.i) #10, !dbg !49
+  %91 = getelementptr i64, i64* %keywords135.i, i32 1, !dbg !49
+  store i64 %90, i64* %91, align 8, !dbg !49
+  %rubyId_baz140.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !49
+  %92 = call i64 @rb_id2sym(i64 %rubyId_baz140.i) #10, !dbg !49
+  %93 = getelementptr i64, i64* %keywords135.i, i32 2, !dbg !49
+  store i64 %92, i64* %93, align 8, !dbg !49
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments134.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull %keywords135.i), !dbg !49
+  %rubyId_take_arguments144.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !50
+  %rubyId_d146.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !50
+  %94 = call i64 @rb_id2sym(i64 %rubyId_d146.i) #10, !dbg !50
+  store i64 %94, i64* %keywords145.i, align 8, !dbg !50
+  %rubyId_e148.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !50
+  %95 = call i64 @rb_id2sym(i64 %rubyId_e148.i) #10, !dbg !50
+  %96 = getelementptr i64, i64* %keywords145.i, i32 1, !dbg !50
+  store i64 %95, i64* %96, align 8, !dbg !50
+  %rubyId_baz150.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !50
+  %97 = call i64 @rb_id2sym(i64 %rubyId_baz150.i) #10, !dbg !50
+  %98 = getelementptr i64, i64* %keywords145.i, i32 2, !dbg !50
+  store i64 %97, i64* %98, align 8, !dbg !50
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments144.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull %keywords145.i), !dbg !50
+  %rubyId_take_arguments154.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !51
+  %rubyId_d156.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !51
+  %99 = call i64 @rb_id2sym(i64 %rubyId_d156.i) #10, !dbg !51
+  store i64 %99, i64* %keywords155.i, align 8, !dbg !51
+  %rubyId_e158.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !51
+  %100 = call i64 @rb_id2sym(i64 %rubyId_e158.i) #10, !dbg !51
+  %101 = getelementptr i64, i64* %keywords155.i, i32 1, !dbg !51
+  store i64 %100, i64* %101, align 8, !dbg !51
+  %rubyId_baz160.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !51
+  %102 = call i64 @rb_id2sym(i64 %rubyId_baz160.i) #10, !dbg !51
+  %103 = getelementptr i64, i64* %keywords155.i, i32 2, !dbg !51
+  store i64 %102, i64* %103, align 8, !dbg !51
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments154.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull %keywords155.i), !dbg !51
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %2)
@@ -707,575 +730,575 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %20)
   %104 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %105 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %104, i64 0, i32 18
-  %106 = load i64, i64* %105, align 8, !tbaa !51
+  %106 = load i64, i64* %105, align 8, !tbaa !52
   %107 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %108 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %107, i64 0, i32 2
-  %109 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %108, align 8, !tbaa !61
+  %109 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %108, align 8, !tbaa !62
   %110 = bitcast i64* %positional_table.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %110)
   %111 = bitcast i64* %keyword_table.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %111)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152", align 8
   %112 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %112, align 8, !tbaa !64
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %112, align 8, !tbaa !65
   %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 4
-  %114 = load i64*, i64** %113, align 8, !tbaa !66
+  %114 = load i64*, i64** %113, align 8, !tbaa !67
   %115 = load i64, i64* %114, align 8, !tbaa !6
   %116 = and i64 %115, -33
   store i64 %116, i64* %114, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %107, %struct.rb_control_frame_struct* %109, %struct.rb_iseq_struct* %stackFrame.i) #10
   %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %117, align 8, !dbg !67, !tbaa !14
-  %rubyId_take_arguments.i1 = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !28
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_take_arguments.i1) #10, !dbg !28
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !28
-  %rawSym386.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #10, !dbg !28
-  %118 = load i64, i64* @rb_cObject, align 8, !dbg !28
-  %stackFrame387.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#take_arguments", align 8, !dbg !28
-  %119 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !28
-  %120 = bitcast i8* %119 to i16*, !dbg !28
-  %121 = load i16, i16* %120, align 8, !dbg !28
-  %122 = and i16 %121, -384, !dbg !28
-  %123 = or i16 %122, 119, !dbg !28
-  store i16 %123, i16* %120, align 8, !dbg !28
-  %124 = getelementptr inbounds i8, i8* %119, i64 8, !dbg !28
-  %125 = bitcast i8* %124 to i32*, !dbg !28
-  %126 = getelementptr inbounds i8, i8* %119, i64 12, !dbg !28
-  %127 = bitcast i8* %126 to i32*, !dbg !28
-  %128 = getelementptr inbounds i8, i8* %119, i64 16, !dbg !28
-  %129 = getelementptr inbounds i8, i8* %119, i64 20, !dbg !28
-  %130 = bitcast i8* %129 to i32*, !dbg !28
-  store i32 0, i32* %130, align 4, !dbg !28, !tbaa !68
-  %131 = getelementptr inbounds i8, i8* %119, i64 24, !dbg !28
-  %132 = bitcast i8* %131 to i32*, !dbg !28
-  store i32 0, i32* %132, align 8, !dbg !28, !tbaa !71
-  %133 = getelementptr inbounds i8, i8* %119, i64 28, !dbg !28
-  %134 = bitcast i8* %133 to i32*, !dbg !28
-  store i32 3, i32* %134, align 4, !dbg !28, !tbaa !72
-  %135 = getelementptr inbounds i8, i8* %119, i64 4, !dbg !28
-  %136 = bitcast i8* %135 to i32*, !dbg !28
-  %137 = bitcast i32* %136 to <4 x i32>*, !dbg !28
-  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %137, align 4, !dbg !28, !tbaa !73
-  %rubyId_a.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !28
-  store i64 %rubyId_a.i, i64* %positional_table.i, align 8, !dbg !28
-  %rubyId_b.i = load i64, i64* @rubyIdPrecomputed_b, align 8, !dbg !28
-  %138 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !28
-  store i64 %rubyId_b.i, i64* %138, align 8, !dbg !28
-  %rubyId_c.i = load i64, i64* @rubyIdPrecomputed_c, align 8, !dbg !28
-  %139 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !28
-  store i64 %rubyId_c.i, i64* %139, align 8, !dbg !28
-  %rubyId_g.i = load i64, i64* @rubyIdPrecomputed_g, align 8, !dbg !28
-  %140 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !28
-  store i64 %rubyId_g.i, i64* %140, align 8, !dbg !28
-  %141 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #12, !dbg !28
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %141, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %110, i64 noundef 32, i1 noundef false) #10, !dbg !28
-  %142 = getelementptr inbounds i8, i8* %119, i64 32, !dbg !28
-  %143 = bitcast i8* %142 to i8**, !dbg !28
-  store i8* %141, i8** %143, align 8, !dbg !28, !tbaa !74
-  %rubyId_d.i2 = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !28
-  store i64 %rubyId_d.i2, i64* %keyword_table.i, align 8, !dbg !28
-  %rubyId_e.i3 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !28
-  %144 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !28
-  store i64 %rubyId_e.i3, i64* %144, align 8, !dbg !28
-  %rubyId_f.i = load i64, i64* @rubyIdPrecomputed_f, align 8, !dbg !28
-  %145 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !28
-  store i64 %rubyId_f.i, i64* %145, align 8, !dbg !28
-  %146 = getelementptr inbounds i8, i8* %119, i64 40, !dbg !28
-  %147 = bitcast i8* %146 to i32*, !dbg !28
-  store i32 2, i32* %147, align 8, !dbg !28, !tbaa !75
-  %148 = getelementptr inbounds i8, i8* %119, i64 44, !dbg !28
-  %149 = bitcast i8* %148 to i32*, !dbg !28
-  store i32 1, i32* %149, align 4, !dbg !28, !tbaa !76
-  %150 = load i32, i32* %125, align 8, !dbg !28, !tbaa !77
-  %151 = load i32, i32* %127, align 4, !dbg !28, !tbaa !78
-  %152 = add i32 %150, 2, !dbg !28
-  %153 = add i32 %152, %151, !dbg !28
-  %154 = getelementptr inbounds i8, i8* %119, i64 48, !dbg !28
-  %155 = bitcast i8* %154 to i32*, !dbg !28
-  store i32 %153, i32* %155, align 8, !dbg !28, !tbaa !79
-  %156 = load i16, i16* %120, align 8, !dbg !28
-  %157 = and i16 %156, 32, !dbg !28
-  %158 = icmp eq i16 %157, 0, !dbg !28
-  br i1 %158, label %sorbet_setupParamKeywords.exit.i, label %159, !dbg !28
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %117, align 8, !dbg !68, !tbaa !14
+  %rubyId_take_arguments.i1 = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !29
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_take_arguments.i1) #10, !dbg !29
+  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !29
+  %rawSym386.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #10, !dbg !29
+  %118 = load i64, i64* @rb_cObject, align 8, !dbg !29
+  %stackFrame387.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#take_arguments", align 8, !dbg !29
+  %119 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !29
+  %120 = bitcast i8* %119 to i16*, !dbg !29
+  %121 = load i16, i16* %120, align 8, !dbg !29
+  %122 = and i16 %121, -384, !dbg !29
+  %123 = or i16 %122, 119, !dbg !29
+  store i16 %123, i16* %120, align 8, !dbg !29
+  %124 = getelementptr inbounds i8, i8* %119, i64 8, !dbg !29
+  %125 = bitcast i8* %124 to i32*, !dbg !29
+  %126 = getelementptr inbounds i8, i8* %119, i64 12, !dbg !29
+  %127 = bitcast i8* %126 to i32*, !dbg !29
+  %128 = getelementptr inbounds i8, i8* %119, i64 16, !dbg !29
+  %129 = getelementptr inbounds i8, i8* %119, i64 20, !dbg !29
+  %130 = bitcast i8* %129 to i32*, !dbg !29
+  store i32 0, i32* %130, align 4, !dbg !29, !tbaa !69
+  %131 = getelementptr inbounds i8, i8* %119, i64 24, !dbg !29
+  %132 = bitcast i8* %131 to i32*, !dbg !29
+  store i32 0, i32* %132, align 8, !dbg !29, !tbaa !72
+  %133 = getelementptr inbounds i8, i8* %119, i64 28, !dbg !29
+  %134 = bitcast i8* %133 to i32*, !dbg !29
+  store i32 3, i32* %134, align 4, !dbg !29, !tbaa !73
+  %135 = getelementptr inbounds i8, i8* %119, i64 4, !dbg !29
+  %136 = bitcast i8* %135 to i32*, !dbg !29
+  %137 = bitcast i32* %136 to <4 x i32>*, !dbg !29
+  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %137, align 4, !dbg !29, !tbaa !74
+  %rubyId_a.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !29
+  store i64 %rubyId_a.i, i64* %positional_table.i, align 8, !dbg !29
+  %rubyId_b.i = load i64, i64* @rubyIdPrecomputed_b, align 8, !dbg !29
+  %138 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !29
+  store i64 %rubyId_b.i, i64* %138, align 8, !dbg !29
+  %rubyId_c.i = load i64, i64* @rubyIdPrecomputed_c, align 8, !dbg !29
+  %139 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !29
+  store i64 %rubyId_c.i, i64* %139, align 8, !dbg !29
+  %rubyId_g.i = load i64, i64* @rubyIdPrecomputed_g, align 8, !dbg !29
+  %140 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !29
+  store i64 %rubyId_g.i, i64* %140, align 8, !dbg !29
+  %141 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #12, !dbg !29
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %141, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %110, i64 noundef 32, i1 noundef false) #10, !dbg !29
+  %142 = getelementptr inbounds i8, i8* %119, i64 32, !dbg !29
+  %143 = bitcast i8* %142 to i8**, !dbg !29
+  store i8* %141, i8** %143, align 8, !dbg !29, !tbaa !75
+  %rubyId_d.i2 = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !29
+  store i64 %rubyId_d.i2, i64* %keyword_table.i, align 8, !dbg !29
+  %rubyId_e.i3 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !29
+  %144 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !29
+  store i64 %rubyId_e.i3, i64* %144, align 8, !dbg !29
+  %rubyId_f.i = load i64, i64* @rubyIdPrecomputed_f, align 8, !dbg !29
+  %145 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !29
+  store i64 %rubyId_f.i, i64* %145, align 8, !dbg !29
+  %146 = getelementptr inbounds i8, i8* %119, i64 40, !dbg !29
+  %147 = bitcast i8* %146 to i32*, !dbg !29
+  store i32 2, i32* %147, align 8, !dbg !29, !tbaa !76
+  %148 = getelementptr inbounds i8, i8* %119, i64 44, !dbg !29
+  %149 = bitcast i8* %148 to i32*, !dbg !29
+  store i32 1, i32* %149, align 4, !dbg !29, !tbaa !77
+  %150 = load i32, i32* %125, align 8, !dbg !29, !tbaa !78
+  %151 = load i32, i32* %127, align 4, !dbg !29, !tbaa !79
+  %152 = add i32 %150, 2, !dbg !29
+  %153 = add i32 %152, %151, !dbg !29
+  %154 = getelementptr inbounds i8, i8* %119, i64 48, !dbg !29
+  %155 = bitcast i8* %154 to i32*, !dbg !29
+  store i32 %153, i32* %155, align 8, !dbg !29, !tbaa !80
+  %156 = load i16, i16* %120, align 8, !dbg !29
+  %157 = and i16 %156, 32, !dbg !29
+  %158 = icmp eq i16 %157, 0, !dbg !29
+  br i1 %158, label %sorbet_setupParamKeywords.exit.i, label %159, !dbg !29
 
 159:                                              ; preds = %entry
-  %160 = add nsw i32 %153, 1, !dbg !28
-  %161 = getelementptr inbounds i8, i8* %119, i64 52, !dbg !28
-  %162 = bitcast i8* %161 to i32*, !dbg !28
-  store i32 %160, i32* %162, align 4, !dbg !28, !tbaa !80
-  br label %sorbet_setupParamKeywords.exit.i, !dbg !28
+  %160 = add nsw i32 %153, 1, !dbg !29
+  %161 = getelementptr inbounds i8, i8* %119, i64 52, !dbg !29
+  %162 = bitcast i8* %161 to i32*, !dbg !29
+  store i32 %160, i32* %162, align 4, !dbg !29, !tbaa !81
+  br label %sorbet_setupParamKeywords.exit.i, !dbg !29
 
 sorbet_setupParamKeywords.exit.i:                 ; preds = %159, %entry
-  %163 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #12, !dbg !28
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %163, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %111, i64 noundef 24, i1 noundef false) #10, !dbg !28
-  %164 = getelementptr inbounds i8, i8* %119, i64 56, !dbg !28
-  %165 = bitcast i8* %164 to i8**, !dbg !28
-  store i8* %163, i8** %165, align 8, !dbg !28, !tbaa !81
-  call void @sorbet_vm_define_method(i64 %118, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#take_arguments", i8* nonnull %119, %struct.rb_iseq_struct* %stackFrame387.i, i1 noundef zeroext false) #10, !dbg !28
-  %166 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !14
-  %167 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 5, !dbg !28
-  %168 = load i32, i32* %167, align 8, !dbg !28, !tbaa !82
-  %169 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 6, !dbg !28
-  %170 = load i32, i32* %169, align 4, !dbg !28, !tbaa !83
-  %171 = xor i32 %170, -1, !dbg !28
-  %172 = and i32 %171, %168, !dbg !28
-  %173 = icmp eq i32 %172, 0, !dbg !28
-  br i1 %173, label %"func_<root>.<static-init>$152.exit", label %174, !dbg !28, !prof !84
+  %163 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #12, !dbg !29
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %163, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %111, i64 noundef 24, i1 noundef false) #10, !dbg !29
+  %164 = getelementptr inbounds i8, i8* %119, i64 56, !dbg !29
+  %165 = bitcast i8* %164 to i8**, !dbg !29
+  store i8* %163, i8** %165, align 8, !dbg !29, !tbaa !82
+  call void @sorbet_vm_define_method(i64 %118, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#take_arguments", i8* nonnull %119, %struct.rb_iseq_struct* %stackFrame387.i, i1 noundef zeroext false) #10, !dbg !29
+  %166 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
+  %167 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 5, !dbg !29
+  %168 = load i32, i32* %167, align 8, !dbg !29, !tbaa !83
+  %169 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 6, !dbg !29
+  %170 = load i32, i32* %169, align 4, !dbg !29, !tbaa !84
+  %171 = xor i32 %170, -1, !dbg !29
+  %172 = and i32 %171, %168, !dbg !29
+  %173 = icmp eq i32 %172, 0, !dbg !29
+  br i1 %173, label %"func_<root>.<static-init>$152.exit", label %174, !dbg !29, !prof !20
 
 174:                                              ; preds = %sorbet_setupParamKeywords.exit.i
-  %175 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 8, !dbg !28
-  %176 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %175, align 8, !dbg !28, !tbaa !85
-  %177 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %176, i32 noundef 0) #10, !dbg !28
-  br label %"func_<root>.<static-init>$152.exit", !dbg !28
+  %175 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 8, !dbg !29
+  %176 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %175, align 8, !dbg !29, !tbaa !85
+  %177 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %176, i32 noundef 0) #10, !dbg !29
+  br label %"func_<root>.<static-init>$152.exit", !dbg !29
 
 "func_<root>.<static-init>$152.exit":             ; preds = %sorbet_setupParamKeywords.exit.i, %174
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %117, align 8, !dbg !28, !tbaa !14
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %117, align 8, !dbg !29, !tbaa !14
   %rubyId_d398.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !86
   %rawSym399.i = call i64 @rb_id2sym(i64 %rubyId_d398.i) #10, !dbg !86
-  %178 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !30
-  %179 = load i64*, i64** %178, align 8, !dbg !30
-  store i64 %106, i64* %179, align 8, !dbg !30, !tbaa !6
-  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !30
-  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !30
-  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !30
-  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !30
-  %184 = bitcast i64* %180 to <4 x i64>*, !dbg !30
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %184, align 8, !dbg !30, !tbaa !6
-  %185 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !30
-  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !30
-  %187 = bitcast i64* %185 to <2 x i64>*, !dbg !30
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %187, align 8, !dbg !30, !tbaa !6
-  %188 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !30
-  store i64 -13, i64* %188, align 8, !dbg !30, !tbaa !6
-  %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !30
-  store i64 -15, i64* %189, align 8, !dbg !30, !tbaa !6
-  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !30
-  store i64* %190, i64** %178, align 8, !dbg !30
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments, i64 0), !dbg !30
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %117, align 8, !dbg !30, !tbaa !14
+  %178 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !31
+  %179 = load i64*, i64** %178, align 8, !dbg !31
+  store i64 %106, i64* %179, align 8, !dbg !31, !tbaa !6
+  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !31
+  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !31
+  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !31
+  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !31
+  %184 = bitcast i64* %180 to <4 x i64>*, !dbg !31
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %184, align 8, !dbg !31, !tbaa !6
+  %185 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !31
+  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !31
+  %187 = bitcast i64* %185 to <2 x i64>*, !dbg !31
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %187, align 8, !dbg !31, !tbaa !6
+  %188 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !31
+  store i64 -13, i64* %188, align 8, !dbg !31, !tbaa !6
+  %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !31
+  store i64 -15, i64* %189, align 8, !dbg !31, !tbaa !6
+  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !31
+  store i64* %190, i64** %178, align 8, !dbg !31
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments, i64 0), !dbg !31
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %117, align 8, !dbg !31, !tbaa !14
   %rubyId_d419.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !87
   %rawSym420.i = call i64 @rb_id2sym(i64 %rubyId_d419.i) #10, !dbg !87
-  %191 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !31
-  %192 = load i64*, i64** %191, align 8, !dbg !31
-  store i64 %106, i64* %192, align 8, !dbg !31, !tbaa !6
-  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !31
-  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !31
-  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !31
-  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !31
-  %197 = bitcast i64* %193 to <4 x i64>*, !dbg !31
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %197, align 8, !dbg !31, !tbaa !6
-  %198 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !31
-  %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !31
-  %200 = bitcast i64* %198 to <2 x i64>*, !dbg !31
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %200, align 8, !dbg !31, !tbaa !6
-  %201 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !31
-  store i64 -15, i64* %201, align 8, !dbg !31, !tbaa !6
-  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !31
-  store i64* %202, i64** %191, align 8, !dbg !31
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !31
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %117, align 8, !dbg !31, !tbaa !14
+  %191 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !32
+  %192 = load i64*, i64** %191, align 8, !dbg !32
+  store i64 %106, i64* %192, align 8, !dbg !32, !tbaa !6
+  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !32
+  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !32
+  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !32
+  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !32
+  %197 = bitcast i64* %193 to <4 x i64>*, !dbg !32
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %197, align 8, !dbg !32, !tbaa !6
+  %198 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !32
+  %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !32
+  %200 = bitcast i64* %198 to <2 x i64>*, !dbg !32
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %200, align 8, !dbg !32, !tbaa !6
+  %201 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !32
+  store i64 -15, i64* %201, align 8, !dbg !32, !tbaa !6
+  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !32
+  store i64* %202, i64** %191, align 8, !dbg !32
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !32
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %117, align 8, !dbg !32, !tbaa !14
   %rubyId_d439.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !88
   %rawSym440.i = call i64 @rb_id2sym(i64 %rubyId_d439.i) #10, !dbg !88
-  %203 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !32
-  %204 = load i64*, i64** %203, align 8, !dbg !32
-  store i64 %106, i64* %204, align 8, !dbg !32, !tbaa !6
-  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !32
-  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !32
-  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !32
-  %208 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !32
-  %209 = bitcast i64* %205 to <4 x i64>*, !dbg !32
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %209, align 8, !dbg !32, !tbaa !6
-  %210 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !32
-  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !32
-  %212 = bitcast i64* %210 to <2 x i64>*, !dbg !32
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %212, align 8, !dbg !32, !tbaa !6
-  %213 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !32
-  store i64* %213, i64** %203, align 8, !dbg !32
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !32
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %117, align 8, !dbg !32, !tbaa !14
+  %203 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !33
+  %204 = load i64*, i64** %203, align 8, !dbg !33
+  store i64 %106, i64* %204, align 8, !dbg !33, !tbaa !6
+  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !33
+  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !33
+  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !33
+  %208 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !33
+  %209 = bitcast i64* %205 to <4 x i64>*, !dbg !33
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %209, align 8, !dbg !33, !tbaa !6
+  %210 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !33
+  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !33
+  %212 = bitcast i64* %210 to <2 x i64>*, !dbg !33
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %212, align 8, !dbg !33, !tbaa !6
+  %213 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !33
+  store i64* %213, i64** %203, align 8, !dbg !33
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !33
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %117, align 8, !dbg !33, !tbaa !14
   %rubyId_d457.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !89
   %rawSym458.i = call i64 @rb_id2sym(i64 %rubyId_d457.i) #10, !dbg !89
-  %214 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !33
-  %215 = load i64*, i64** %214, align 8, !dbg !33
-  store i64 %106, i64* %215, align 8, !dbg !33, !tbaa !6
-  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !33
-  %217 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !33
-  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !33
-  %219 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !33
-  %220 = bitcast i64* %216 to <4 x i64>*, !dbg !33
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %220, align 8, !dbg !33, !tbaa !6
-  %221 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !33
-  store i64 -15, i64* %221, align 8, !dbg !33, !tbaa !6
-  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !33
-  store i64* %222, i64** %214, align 8, !dbg !33
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !33
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %117, align 8, !dbg !33, !tbaa !14
+  %214 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !34
+  %215 = load i64*, i64** %214, align 8, !dbg !34
+  store i64 %106, i64* %215, align 8, !dbg !34, !tbaa !6
+  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !34
+  %217 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !34
+  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !34
+  %219 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !34
+  %220 = bitcast i64* %216 to <4 x i64>*, !dbg !34
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %220, align 8, !dbg !34, !tbaa !6
+  %221 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !34
+  store i64 -15, i64* %221, align 8, !dbg !34, !tbaa !6
+  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !34
+  store i64* %222, i64** %214, align 8, !dbg !34
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !34
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %117, align 8, !dbg !34, !tbaa !14
   %rubyId_d473.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !90
   %rawSym474.i = call i64 @rb_id2sym(i64 %rubyId_d473.i) #10, !dbg !90
-  %223 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !34
-  %224 = load i64*, i64** %223, align 8, !dbg !34
-  store i64 %106, i64* %224, align 8, !dbg !34, !tbaa !6
-  %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !34
-  %226 = getelementptr inbounds i64, i64* %225, i64 1, !dbg !34
-  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !34
-  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !34
-  %229 = bitcast i64* %225 to <4 x i64>*, !dbg !34
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %229, align 8, !dbg !34, !tbaa !6
-  %230 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !34
-  store i64* %230, i64** %223, align 8, !dbg !34
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !34
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %117, align 8, !dbg !34, !tbaa !14
+  %223 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !35
+  %224 = load i64*, i64** %223, align 8, !dbg !35
+  store i64 %106, i64* %224, align 8, !dbg !35, !tbaa !6
+  %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !35
+  %226 = getelementptr inbounds i64, i64* %225, i64 1, !dbg !35
+  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !35
+  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !35
+  %229 = bitcast i64* %225 to <4 x i64>*, !dbg !35
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %229, align 8, !dbg !35, !tbaa !6
+  %230 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !35
+  store i64* %230, i64** %223, align 8, !dbg !35
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !35
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %117, align 8, !dbg !35, !tbaa !14
   %rubyId_d487.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !91
   %rawSym488.i = call i64 @rb_id2sym(i64 %rubyId_d487.i) #10, !dbg !91
-  %231 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !35
-  %232 = load i64*, i64** %231, align 8, !dbg !35
-  store i64 %106, i64* %232, align 8, !dbg !35, !tbaa !6
-  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !35
-  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !35
-  %235 = bitcast i64* %233 to <2 x i64>*, !dbg !35
-  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %235, align 8, !dbg !35, !tbaa !6
-  %236 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !35
-  store i64 -15, i64* %236, align 8, !dbg !35, !tbaa !6
-  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !35
-  store i64* %237, i64** %231, align 8, !dbg !35
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !35
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %117, align 8, !dbg !35, !tbaa !14
+  %231 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !36
+  %232 = load i64*, i64** %231, align 8, !dbg !36
+  store i64 %106, i64* %232, align 8, !dbg !36, !tbaa !6
+  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !36
+  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !36
+  %235 = bitcast i64* %233 to <2 x i64>*, !dbg !36
+  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %235, align 8, !dbg !36, !tbaa !6
+  %236 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !36
+  store i64 -15, i64* %236, align 8, !dbg !36, !tbaa !6
+  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !36
+  store i64* %237, i64** %231, align 8, !dbg !36
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !36
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %117, align 8, !dbg !36, !tbaa !14
   %rubyId_d499.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !92
   %rawSym500.i = call i64 @rb_id2sym(i64 %rubyId_d499.i) #10, !dbg !92
-  %238 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !36
-  %239 = load i64*, i64** %238, align 8, !dbg !36
-  store i64 %106, i64* %239, align 8, !dbg !36, !tbaa !6
-  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !36
-  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !36
-  %242 = bitcast i64* %240 to <2 x i64>*, !dbg !36
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %242, align 8, !dbg !36, !tbaa !6
-  %243 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !36
-  store i64* %243, i64** %238, align 8, !dbg !36
-  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !36
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %117, align 8, !dbg !36, !tbaa !14
+  %238 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !37
+  %239 = load i64*, i64** %238, align 8, !dbg !37
+  store i64 %106, i64* %239, align 8, !dbg !37, !tbaa !6
+  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !37
+  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !37
+  %242 = bitcast i64* %240 to <2 x i64>*, !dbg !37
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %242, align 8, !dbg !37, !tbaa !6
+  %243 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !37
+  store i64* %243, i64** %238, align 8, !dbg !37
+  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !37
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %117, align 8, !dbg !37, !tbaa !14
   %rubyId_d516.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !93
   %rawSym517.i = call i64 @rb_id2sym(i64 %rubyId_d516.i) #10, !dbg !93
   %rubyId_e519.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !94
   %rawSym520.i = call i64 @rb_id2sym(i64 %rubyId_e519.i) #10, !dbg !94
-  %244 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !37
-  %245 = load i64*, i64** %244, align 8, !dbg !37
-  store i64 %106, i64* %245, align 8, !dbg !37, !tbaa !6
-  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !37
-  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !37
-  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !37
-  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !37
-  %250 = bitcast i64* %246 to <4 x i64>*, !dbg !37
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %250, align 8, !dbg !37, !tbaa !6
-  %251 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !37
-  %252 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !37
-  %253 = bitcast i64* %251 to <2 x i64>*, !dbg !37
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %253, align 8, !dbg !37, !tbaa !6
-  %254 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !37
-  store i64 -13, i64* %254, align 8, !dbg !37, !tbaa !6
-  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !37
-  store i64 -15, i64* %255, align 8, !dbg !37, !tbaa !6
-  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !37
-  store i64 -17, i64* %256, align 8, !dbg !37, !tbaa !6
-  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !37
-  store i64* %257, i64** %244, align 8, !dbg !37
-  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !37
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %117, align 8, !dbg !37, !tbaa !14
+  %244 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !38
+  %245 = load i64*, i64** %244, align 8, !dbg !38
+  store i64 %106, i64* %245, align 8, !dbg !38, !tbaa !6
+  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !38
+  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !38
+  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !38
+  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !38
+  %250 = bitcast i64* %246 to <4 x i64>*, !dbg !38
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %250, align 8, !dbg !38, !tbaa !6
+  %251 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !38
+  %252 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !38
+  %253 = bitcast i64* %251 to <2 x i64>*, !dbg !38
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %253, align 8, !dbg !38, !tbaa !6
+  %254 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !38
+  store i64 -13, i64* %254, align 8, !dbg !38, !tbaa !6
+  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !38
+  store i64 -15, i64* %255, align 8, !dbg !38, !tbaa !6
+  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !38
+  store i64 -17, i64* %256, align 8, !dbg !38, !tbaa !6
+  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !38
+  store i64* %257, i64** %244, align 8, !dbg !38
+  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !38
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %117, align 8, !dbg !38, !tbaa !14
   %rubyId_d542.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !95
   %rawSym543.i = call i64 @rb_id2sym(i64 %rubyId_d542.i) #10, !dbg !95
   %rubyId_e545.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !96
   %rawSym546.i = call i64 @rb_id2sym(i64 %rubyId_e545.i) #10, !dbg !96
-  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !38
-  %259 = load i64*, i64** %258, align 8, !dbg !38
-  store i64 %106, i64* %259, align 8, !dbg !38, !tbaa !6
-  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !38
-  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !38
-  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !38
-  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !38
-  %264 = bitcast i64* %260 to <4 x i64>*, !dbg !38
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %264, align 8, !dbg !38, !tbaa !6
-  %265 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !38
-  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !38
-  %267 = bitcast i64* %265 to <2 x i64>*, !dbg !38
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %267, align 8, !dbg !38, !tbaa !6
-  %268 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !38
-  store i64 -15, i64* %268, align 8, !dbg !38, !tbaa !6
-  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !38
-  store i64 -17, i64* %269, align 8, !dbg !38, !tbaa !6
-  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !38
-  store i64* %270, i64** %258, align 8, !dbg !38
-  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !38
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %117, align 8, !dbg !38, !tbaa !14
+  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !39
+  %259 = load i64*, i64** %258, align 8, !dbg !39
+  store i64 %106, i64* %259, align 8, !dbg !39, !tbaa !6
+  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !39
+  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !39
+  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !39
+  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !39
+  %264 = bitcast i64* %260 to <4 x i64>*, !dbg !39
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %264, align 8, !dbg !39, !tbaa !6
+  %265 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !39
+  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !39
+  %267 = bitcast i64* %265 to <2 x i64>*, !dbg !39
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %267, align 8, !dbg !39, !tbaa !6
+  %268 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !39
+  store i64 -15, i64* %268, align 8, !dbg !39, !tbaa !6
+  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !39
+  store i64 -17, i64* %269, align 8, !dbg !39, !tbaa !6
+  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !39
+  store i64* %270, i64** %258, align 8, !dbg !39
+  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !39
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %117, align 8, !dbg !39, !tbaa !14
   %rubyId_d566.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !97
   %rawSym567.i = call i64 @rb_id2sym(i64 %rubyId_d566.i) #10, !dbg !97
   %rubyId_e569.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !98
   %rawSym570.i = call i64 @rb_id2sym(i64 %rubyId_e569.i) #10, !dbg !98
-  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !39
-  %272 = load i64*, i64** %271, align 8, !dbg !39
-  store i64 %106, i64* %272, align 8, !dbg !39, !tbaa !6
-  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !39
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !39
-  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !39
-  %276 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !39
-  %277 = bitcast i64* %273 to <4 x i64>*, !dbg !39
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %277, align 8, !dbg !39, !tbaa !6
-  %278 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !39
-  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !39
-  %280 = bitcast i64* %278 to <2 x i64>*, !dbg !39
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %280, align 8, !dbg !39, !tbaa !6
-  %281 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !39
-  store i64 -17, i64* %281, align 8, !dbg !39, !tbaa !6
-  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !39
-  store i64* %282, i64** %271, align 8, !dbg !39
-  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !39
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %117, align 8, !dbg !39, !tbaa !14
+  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !40
+  %272 = load i64*, i64** %271, align 8, !dbg !40
+  store i64 %106, i64* %272, align 8, !dbg !40, !tbaa !6
+  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !40
+  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !40
+  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !40
+  %276 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !40
+  %277 = bitcast i64* %273 to <4 x i64>*, !dbg !40
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %277, align 8, !dbg !40, !tbaa !6
+  %278 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !40
+  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !40
+  %280 = bitcast i64* %278 to <2 x i64>*, !dbg !40
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %280, align 8, !dbg !40, !tbaa !6
+  %281 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !40
+  store i64 -17, i64* %281, align 8, !dbg !40, !tbaa !6
+  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !40
+  store i64* %282, i64** %271, align 8, !dbg !40
+  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !40
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %117, align 8, !dbg !40, !tbaa !14
   %rubyId_d588.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !99
   %rawSym589.i = call i64 @rb_id2sym(i64 %rubyId_d588.i) #10, !dbg !99
   %rubyId_e591.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !100
   %rawSym592.i = call i64 @rb_id2sym(i64 %rubyId_e591.i) #10, !dbg !100
-  %283 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !40
-  %284 = load i64*, i64** %283, align 8, !dbg !40
-  store i64 %106, i64* %284, align 8, !dbg !40, !tbaa !6
-  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !40
-  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !40
-  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !40
-  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !40
-  %289 = bitcast i64* %285 to <4 x i64>*, !dbg !40
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %289, align 8, !dbg !40, !tbaa !6
-  %290 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !40
-  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !40
-  %292 = bitcast i64* %290 to <2 x i64>*, !dbg !40
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %292, align 8, !dbg !40, !tbaa !6
-  %293 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !40
-  store i64* %293, i64** %283, align 8, !dbg !40
-  %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !40
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %117, align 8, !dbg !40, !tbaa !14
+  %283 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !41
+  %284 = load i64*, i64** %283, align 8, !dbg !41
+  store i64 %106, i64* %284, align 8, !dbg !41, !tbaa !6
+  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !41
+  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !41
+  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !41
+  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !41
+  %289 = bitcast i64* %285 to <4 x i64>*, !dbg !41
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %289, align 8, !dbg !41, !tbaa !6
+  %290 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !41
+  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !41
+  %292 = bitcast i64* %290 to <2 x i64>*, !dbg !41
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %292, align 8, !dbg !41, !tbaa !6
+  %293 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !41
+  store i64* %293, i64** %283, align 8, !dbg !41
+  %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !41
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %117, align 8, !dbg !41, !tbaa !14
   %rubyId_d608.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !101
   %rawSym609.i = call i64 @rb_id2sym(i64 %rubyId_d608.i) #10, !dbg !101
   %rubyId_e611.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !102
   %rawSym612.i = call i64 @rb_id2sym(i64 %rubyId_e611.i) #10, !dbg !102
-  %294 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !41
-  %295 = load i64*, i64** %294, align 8, !dbg !41
-  store i64 %106, i64* %295, align 8, !dbg !41, !tbaa !6
-  %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !41
-  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !41
-  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !41
-  %299 = getelementptr inbounds i64, i64* %298, i64 1, !dbg !41
-  %300 = bitcast i64* %296 to <4 x i64>*, !dbg !41
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %300, align 8, !dbg !41, !tbaa !6
-  %301 = getelementptr inbounds i64, i64* %299, i64 1, !dbg !41
-  store i64 -17, i64* %301, align 8, !dbg !41, !tbaa !6
-  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !41
-  store i64* %302, i64** %294, align 8, !dbg !41
-  %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !41
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %117, align 8, !dbg !41, !tbaa !14
+  %294 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !42
+  %295 = load i64*, i64** %294, align 8, !dbg !42
+  store i64 %106, i64* %295, align 8, !dbg !42, !tbaa !6
+  %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !42
+  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !42
+  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !42
+  %299 = getelementptr inbounds i64, i64* %298, i64 1, !dbg !42
+  %300 = bitcast i64* %296 to <4 x i64>*, !dbg !42
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %300, align 8, !dbg !42, !tbaa !6
+  %301 = getelementptr inbounds i64, i64* %299, i64 1, !dbg !42
+  store i64 -17, i64* %301, align 8, !dbg !42, !tbaa !6
+  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !42
+  store i64* %302, i64** %294, align 8, !dbg !42
+  %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !42
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %117, align 8, !dbg !42, !tbaa !14
   %rubyId_d626.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !103
   %rawSym627.i = call i64 @rb_id2sym(i64 %rubyId_d626.i) #10, !dbg !103
   %rubyId_e629.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !104
   %rawSym630.i = call i64 @rb_id2sym(i64 %rubyId_e629.i) #10, !dbg !104
-  %303 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !42
-  %304 = load i64*, i64** %303, align 8, !dbg !42
-  store i64 %106, i64* %304, align 8, !dbg !42, !tbaa !6
-  %305 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !42
-  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !42
-  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !42
-  %308 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !42
-  %309 = bitcast i64* %305 to <4 x i64>*, !dbg !42
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %309, align 8, !dbg !42, !tbaa !6
-  %310 = getelementptr inbounds i64, i64* %308, i64 1, !dbg !42
-  store i64* %310, i64** %303, align 8, !dbg !42
-  %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !42
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %117, align 8, !dbg !42, !tbaa !14
+  %303 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !43
+  %304 = load i64*, i64** %303, align 8, !dbg !43
+  store i64 %106, i64* %304, align 8, !dbg !43, !tbaa !6
+  %305 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !43
+  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !43
+  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !43
+  %308 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !43
+  %309 = bitcast i64* %305 to <4 x i64>*, !dbg !43
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %309, align 8, !dbg !43, !tbaa !6
+  %310 = getelementptr inbounds i64, i64* %308, i64 1, !dbg !43
+  store i64* %310, i64** %303, align 8, !dbg !43
+  %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !43
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %117, align 8, !dbg !43, !tbaa !14
   %rubyId_d642.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !105
   %rawSym643.i = call i64 @rb_id2sym(i64 %rubyId_d642.i) #10, !dbg !105
   %rubyId_e645.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !106
   %rawSym646.i = call i64 @rb_id2sym(i64 %rubyId_e645.i) #10, !dbg !106
-  %311 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !43
-  %312 = load i64*, i64** %311, align 8, !dbg !43
-  store i64 %106, i64* %312, align 8, !dbg !43, !tbaa !6
-  %313 = getelementptr inbounds i64, i64* %312, i64 1, !dbg !43
-  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !43
-  %315 = bitcast i64* %313 to <2 x i64>*, !dbg !43
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %315, align 8, !dbg !43, !tbaa !6
-  %316 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !43
-  store i64 -17, i64* %316, align 8, !dbg !43, !tbaa !6
-  %317 = getelementptr inbounds i64, i64* %316, i64 1, !dbg !43
-  store i64* %317, i64** %311, align 8, !dbg !43
-  %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %117, align 8, !dbg !43, !tbaa !14
+  %311 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !44
+  %312 = load i64*, i64** %311, align 8, !dbg !44
+  store i64 %106, i64* %312, align 8, !dbg !44, !tbaa !6
+  %313 = getelementptr inbounds i64, i64* %312, i64 1, !dbg !44
+  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !44
+  %315 = bitcast i64* %313 to <2 x i64>*, !dbg !44
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %315, align 8, !dbg !44, !tbaa !6
+  %316 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !44
+  store i64 -17, i64* %316, align 8, !dbg !44, !tbaa !6
+  %317 = getelementptr inbounds i64, i64* %316, i64 1, !dbg !44
+  store i64* %317, i64** %311, align 8, !dbg !44
+  %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !44
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %117, align 8, !dbg !44, !tbaa !14
   %rubyId_d663.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !107
   %rawSym664.i = call i64 @rb_id2sym(i64 %rubyId_d663.i) #10, !dbg !107
   %rubyId_e666.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !108
   %rawSym667.i = call i64 @rb_id2sym(i64 %rubyId_e666.i) #10, !dbg !108
   %rubyId_baz.i4 = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !109
   %rawSym669.i = call i64 @rb_id2sym(i64 %rubyId_baz.i4) #10, !dbg !109
-  %318 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !44
-  %319 = load i64*, i64** %318, align 8, !dbg !44
-  store i64 %106, i64* %319, align 8, !dbg !44, !tbaa !6
-  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !44
-  %321 = getelementptr inbounds i64, i64* %320, i64 1, !dbg !44
-  %322 = getelementptr inbounds i64, i64* %321, i64 1, !dbg !44
-  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !44
-  %324 = bitcast i64* %320 to <4 x i64>*, !dbg !44
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %324, align 8, !dbg !44, !tbaa !6
-  %325 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !44
-  %326 = getelementptr inbounds i64, i64* %325, i64 1, !dbg !44
-  %327 = bitcast i64* %325 to <2 x i64>*, !dbg !44
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %327, align 8, !dbg !44, !tbaa !6
-  %328 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !44
-  store i64 -13, i64* %328, align 8, !dbg !44, !tbaa !6
-  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !44
-  store i64 -15, i64* %329, align 8, !dbg !44, !tbaa !6
-  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !44
-  store i64 -17, i64* %330, align 8, !dbg !44, !tbaa !6
-  %331 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !44
-  store i64 -19, i64* %331, align 8, !dbg !44, !tbaa !6
-  %332 = getelementptr inbounds i64, i64* %331, i64 1, !dbg !44
-  store i64* %332, i64** %318, align 8, !dbg !44
-  %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !44
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %117, align 8, !dbg !44, !tbaa !14
+  %318 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !45
+  %319 = load i64*, i64** %318, align 8, !dbg !45
+  store i64 %106, i64* %319, align 8, !dbg !45, !tbaa !6
+  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !45
+  %321 = getelementptr inbounds i64, i64* %320, i64 1, !dbg !45
+  %322 = getelementptr inbounds i64, i64* %321, i64 1, !dbg !45
+  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !45
+  %324 = bitcast i64* %320 to <4 x i64>*, !dbg !45
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %324, align 8, !dbg !45, !tbaa !6
+  %325 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !45
+  %326 = getelementptr inbounds i64, i64* %325, i64 1, !dbg !45
+  %327 = bitcast i64* %325 to <2 x i64>*, !dbg !45
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %327, align 8, !dbg !45, !tbaa !6
+  %328 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !45
+  store i64 -13, i64* %328, align 8, !dbg !45, !tbaa !6
+  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !45
+  store i64 -15, i64* %329, align 8, !dbg !45, !tbaa !6
+  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !45
+  store i64 -17, i64* %330, align 8, !dbg !45, !tbaa !6
+  %331 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !45
+  store i64 -19, i64* %331, align 8, !dbg !45, !tbaa !6
+  %332 = getelementptr inbounds i64, i64* %331, i64 1, !dbg !45
+  store i64* %332, i64** %318, align 8, !dbg !45
+  %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !45
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %117, align 8, !dbg !45, !tbaa !14
   %rubyId_d692.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !110
   %rawSym693.i = call i64 @rb_id2sym(i64 %rubyId_d692.i) #10, !dbg !110
   %rubyId_e695.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !111
   %rawSym696.i = call i64 @rb_id2sym(i64 %rubyId_e695.i) #10, !dbg !111
   %rubyId_baz698.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !112
   %rawSym699.i = call i64 @rb_id2sym(i64 %rubyId_baz698.i) #10, !dbg !112
-  %333 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !45
-  %334 = load i64*, i64** %333, align 8, !dbg !45
-  store i64 %106, i64* %334, align 8, !dbg !45, !tbaa !6
-  %335 = getelementptr inbounds i64, i64* %334, i64 1, !dbg !45
-  %336 = getelementptr inbounds i64, i64* %335, i64 1, !dbg !45
-  %337 = getelementptr inbounds i64, i64* %336, i64 1, !dbg !45
-  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !45
-  %339 = bitcast i64* %335 to <4 x i64>*, !dbg !45
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %339, align 8, !dbg !45, !tbaa !6
-  %340 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !45
-  %341 = getelementptr inbounds i64, i64* %340, i64 1, !dbg !45
-  %342 = bitcast i64* %340 to <2 x i64>*, !dbg !45
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %342, align 8, !dbg !45, !tbaa !6
-  %343 = getelementptr inbounds i64, i64* %341, i64 1, !dbg !45
-  store i64 -15, i64* %343, align 8, !dbg !45, !tbaa !6
-  %344 = getelementptr inbounds i64, i64* %343, i64 1, !dbg !45
-  store i64 -17, i64* %344, align 8, !dbg !45, !tbaa !6
-  %345 = getelementptr inbounds i64, i64* %344, i64 1, !dbg !45
-  store i64 -19, i64* %345, align 8, !dbg !45, !tbaa !6
-  %346 = getelementptr inbounds i64, i64* %345, i64 1, !dbg !45
-  store i64* %346, i64** %333, align 8, !dbg !45
-  %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !45
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %117, align 8, !dbg !45, !tbaa !14
+  %333 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !46
+  %334 = load i64*, i64** %333, align 8, !dbg !46
+  store i64 %106, i64* %334, align 8, !dbg !46, !tbaa !6
+  %335 = getelementptr inbounds i64, i64* %334, i64 1, !dbg !46
+  %336 = getelementptr inbounds i64, i64* %335, i64 1, !dbg !46
+  %337 = getelementptr inbounds i64, i64* %336, i64 1, !dbg !46
+  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !46
+  %339 = bitcast i64* %335 to <4 x i64>*, !dbg !46
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %339, align 8, !dbg !46, !tbaa !6
+  %340 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !46
+  %341 = getelementptr inbounds i64, i64* %340, i64 1, !dbg !46
+  %342 = bitcast i64* %340 to <2 x i64>*, !dbg !46
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %342, align 8, !dbg !46, !tbaa !6
+  %343 = getelementptr inbounds i64, i64* %341, i64 1, !dbg !46
+  store i64 -15, i64* %343, align 8, !dbg !46, !tbaa !6
+  %344 = getelementptr inbounds i64, i64* %343, i64 1, !dbg !46
+  store i64 -17, i64* %344, align 8, !dbg !46, !tbaa !6
+  %345 = getelementptr inbounds i64, i64* %344, i64 1, !dbg !46
+  store i64 -19, i64* %345, align 8, !dbg !46, !tbaa !6
+  %346 = getelementptr inbounds i64, i64* %345, i64 1, !dbg !46
+  store i64* %346, i64** %333, align 8, !dbg !46
+  %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !46
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %117, align 8, !dbg !46, !tbaa !14
   %rubyId_d720.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !113
   %rawSym721.i = call i64 @rb_id2sym(i64 %rubyId_d720.i) #10, !dbg !113
   %rubyId_e723.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !114
   %rawSym724.i = call i64 @rb_id2sym(i64 %rubyId_e723.i) #10, !dbg !114
   %rubyId_baz726.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !115
   %rawSym727.i = call i64 @rb_id2sym(i64 %rubyId_baz726.i) #10, !dbg !115
-  %347 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !46
-  %348 = load i64*, i64** %347, align 8, !dbg !46
-  store i64 %106, i64* %348, align 8, !dbg !46, !tbaa !6
-  %349 = getelementptr inbounds i64, i64* %348, i64 1, !dbg !46
-  %350 = getelementptr inbounds i64, i64* %349, i64 1, !dbg !46
-  %351 = getelementptr inbounds i64, i64* %350, i64 1, !dbg !46
-  %352 = getelementptr inbounds i64, i64* %351, i64 1, !dbg !46
-  %353 = bitcast i64* %349 to <4 x i64>*, !dbg !46
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %353, align 8, !dbg !46, !tbaa !6
-  %354 = getelementptr inbounds i64, i64* %352, i64 1, !dbg !46
-  %355 = getelementptr inbounds i64, i64* %354, i64 1, !dbg !46
-  %356 = bitcast i64* %354 to <2 x i64>*, !dbg !46
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %356, align 8, !dbg !46, !tbaa !6
-  %357 = getelementptr inbounds i64, i64* %355, i64 1, !dbg !46
-  store i64 -17, i64* %357, align 8, !dbg !46, !tbaa !6
-  %358 = getelementptr inbounds i64, i64* %357, i64 1, !dbg !46
-  store i64 -19, i64* %358, align 8, !dbg !46, !tbaa !6
-  %359 = getelementptr inbounds i64, i64* %358, i64 1, !dbg !46
-  store i64* %359, i64** %347, align 8, !dbg !46
-  %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !46
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %117, align 8, !dbg !46, !tbaa !14
+  %347 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !47
+  %348 = load i64*, i64** %347, align 8, !dbg !47
+  store i64 %106, i64* %348, align 8, !dbg !47, !tbaa !6
+  %349 = getelementptr inbounds i64, i64* %348, i64 1, !dbg !47
+  %350 = getelementptr inbounds i64, i64* %349, i64 1, !dbg !47
+  %351 = getelementptr inbounds i64, i64* %350, i64 1, !dbg !47
+  %352 = getelementptr inbounds i64, i64* %351, i64 1, !dbg !47
+  %353 = bitcast i64* %349 to <4 x i64>*, !dbg !47
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %353, align 8, !dbg !47, !tbaa !6
+  %354 = getelementptr inbounds i64, i64* %352, i64 1, !dbg !47
+  %355 = getelementptr inbounds i64, i64* %354, i64 1, !dbg !47
+  %356 = bitcast i64* %354 to <2 x i64>*, !dbg !47
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %356, align 8, !dbg !47, !tbaa !6
+  %357 = getelementptr inbounds i64, i64* %355, i64 1, !dbg !47
+  store i64 -17, i64* %357, align 8, !dbg !47, !tbaa !6
+  %358 = getelementptr inbounds i64, i64* %357, i64 1, !dbg !47
+  store i64 -19, i64* %358, align 8, !dbg !47, !tbaa !6
+  %359 = getelementptr inbounds i64, i64* %358, i64 1, !dbg !47
+  store i64* %359, i64** %347, align 8, !dbg !47
+  %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !47
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %117, align 8, !dbg !47, !tbaa !14
   %rubyId_d746.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !116
   %rawSym747.i = call i64 @rb_id2sym(i64 %rubyId_d746.i) #10, !dbg !116
   %rubyId_e749.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !117
   %rawSym750.i = call i64 @rb_id2sym(i64 %rubyId_e749.i) #10, !dbg !117
   %rubyId_baz752.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !118
   %rawSym753.i = call i64 @rb_id2sym(i64 %rubyId_baz752.i) #10, !dbg !118
-  %360 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !47
-  %361 = load i64*, i64** %360, align 8, !dbg !47
-  store i64 %106, i64* %361, align 8, !dbg !47, !tbaa !6
-  %362 = getelementptr inbounds i64, i64* %361, i64 1, !dbg !47
-  %363 = getelementptr inbounds i64, i64* %362, i64 1, !dbg !47
-  %364 = getelementptr inbounds i64, i64* %363, i64 1, !dbg !47
-  %365 = getelementptr inbounds i64, i64* %364, i64 1, !dbg !47
-  %366 = bitcast i64* %362 to <4 x i64>*, !dbg !47
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %366, align 8, !dbg !47, !tbaa !6
-  %367 = getelementptr inbounds i64, i64* %365, i64 1, !dbg !47
-  %368 = getelementptr inbounds i64, i64* %367, i64 1, !dbg !47
-  %369 = bitcast i64* %367 to <2 x i64>*, !dbg !47
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %369, align 8, !dbg !47, !tbaa !6
-  %370 = getelementptr inbounds i64, i64* %368, i64 1, !dbg !47
-  store i64 -19, i64* %370, align 8, !dbg !47, !tbaa !6
-  %371 = getelementptr inbounds i64, i64* %370, i64 1, !dbg !47
-  store i64* %371, i64** %360, align 8, !dbg !47
-  %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !47
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %117, align 8, !dbg !47, !tbaa !14
+  %360 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !48
+  %361 = load i64*, i64** %360, align 8, !dbg !48
+  store i64 %106, i64* %361, align 8, !dbg !48, !tbaa !6
+  %362 = getelementptr inbounds i64, i64* %361, i64 1, !dbg !48
+  %363 = getelementptr inbounds i64, i64* %362, i64 1, !dbg !48
+  %364 = getelementptr inbounds i64, i64* %363, i64 1, !dbg !48
+  %365 = getelementptr inbounds i64, i64* %364, i64 1, !dbg !48
+  %366 = bitcast i64* %362 to <4 x i64>*, !dbg !48
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %366, align 8, !dbg !48, !tbaa !6
+  %367 = getelementptr inbounds i64, i64* %365, i64 1, !dbg !48
+  %368 = getelementptr inbounds i64, i64* %367, i64 1, !dbg !48
+  %369 = bitcast i64* %367 to <2 x i64>*, !dbg !48
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %369, align 8, !dbg !48, !tbaa !6
+  %370 = getelementptr inbounds i64, i64* %368, i64 1, !dbg !48
+  store i64 -19, i64* %370, align 8, !dbg !48, !tbaa !6
+  %371 = getelementptr inbounds i64, i64* %370, i64 1, !dbg !48
+  store i64* %371, i64** %360, align 8, !dbg !48
+  %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !48
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %117, align 8, !dbg !48, !tbaa !14
   %rubyId_d770.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !119
   %rawSym771.i = call i64 @rb_id2sym(i64 %rubyId_d770.i) #10, !dbg !119
   %rubyId_e773.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !120
   %rawSym774.i = call i64 @rb_id2sym(i64 %rubyId_e773.i) #10, !dbg !120
   %rubyId_baz776.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !121
   %rawSym777.i = call i64 @rb_id2sym(i64 %rubyId_baz776.i) #10, !dbg !121
-  %372 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !48
-  %373 = load i64*, i64** %372, align 8, !dbg !48
-  store i64 %106, i64* %373, align 8, !dbg !48, !tbaa !6
-  %374 = getelementptr inbounds i64, i64* %373, i64 1, !dbg !48
-  %375 = getelementptr inbounds i64, i64* %374, i64 1, !dbg !48
-  %376 = getelementptr inbounds i64, i64* %375, i64 1, !dbg !48
-  %377 = getelementptr inbounds i64, i64* %376, i64 1, !dbg !48
-  %378 = bitcast i64* %374 to <4 x i64>*, !dbg !48
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %378, align 8, !dbg !48, !tbaa !6
-  %379 = getelementptr inbounds i64, i64* %377, i64 1, !dbg !48
-  %380 = getelementptr inbounds i64, i64* %379, i64 1, !dbg !48
-  %381 = bitcast i64* %379 to <2 x i64>*, !dbg !48
-  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %381, align 8, !dbg !48, !tbaa !6
-  %382 = getelementptr inbounds i64, i64* %380, i64 1, !dbg !48
-  store i64* %382, i64** %372, align 8, !dbg !48
-  %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !48
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %117, align 8, !dbg !48, !tbaa !14
+  %372 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !49
+  %373 = load i64*, i64** %372, align 8, !dbg !49
+  store i64 %106, i64* %373, align 8, !dbg !49, !tbaa !6
+  %374 = getelementptr inbounds i64, i64* %373, i64 1, !dbg !49
+  %375 = getelementptr inbounds i64, i64* %374, i64 1, !dbg !49
+  %376 = getelementptr inbounds i64, i64* %375, i64 1, !dbg !49
+  %377 = getelementptr inbounds i64, i64* %376, i64 1, !dbg !49
+  %378 = bitcast i64* %374 to <4 x i64>*, !dbg !49
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %378, align 8, !dbg !49, !tbaa !6
+  %379 = getelementptr inbounds i64, i64* %377, i64 1, !dbg !49
+  %380 = getelementptr inbounds i64, i64* %379, i64 1, !dbg !49
+  %381 = bitcast i64* %379 to <2 x i64>*, !dbg !49
+  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %381, align 8, !dbg !49, !tbaa !6
+  %382 = getelementptr inbounds i64, i64* %380, i64 1, !dbg !49
+  store i64* %382, i64** %372, align 8, !dbg !49
+  %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !49
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %117, align 8, !dbg !49, !tbaa !14
   %rubyId_d792.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !122
   %rawSym793.i = call i64 @rb_id2sym(i64 %rubyId_d792.i) #10, !dbg !122
   %rubyId_e795.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !123
   %rawSym796.i = call i64 @rb_id2sym(i64 %rubyId_e795.i) #10, !dbg !123
   %rubyId_baz798.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !124
   %rawSym799.i = call i64 @rb_id2sym(i64 %rubyId_baz798.i) #10, !dbg !124
-  %383 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !49
-  %384 = load i64*, i64** %383, align 8, !dbg !49
-  store i64 %106, i64* %384, align 8, !dbg !49, !tbaa !6
-  %385 = getelementptr inbounds i64, i64* %384, i64 1, !dbg !49
-  %386 = getelementptr inbounds i64, i64* %385, i64 1, !dbg !49
-  %387 = getelementptr inbounds i64, i64* %386, i64 1, !dbg !49
-  %388 = getelementptr inbounds i64, i64* %387, i64 1, !dbg !49
-  %389 = bitcast i64* %385 to <4 x i64>*, !dbg !49
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %389, align 8, !dbg !49, !tbaa !6
-  %390 = getelementptr inbounds i64, i64* %388, i64 1, !dbg !49
-  store i64 -19, i64* %390, align 8, !dbg !49, !tbaa !6
-  %391 = getelementptr inbounds i64, i64* %390, i64 1, !dbg !49
-  store i64* %391, i64** %383, align 8, !dbg !49
-  %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !49
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %117, align 8, !dbg !49, !tbaa !14
+  %383 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !50
+  %384 = load i64*, i64** %383, align 8, !dbg !50
+  store i64 %106, i64* %384, align 8, !dbg !50, !tbaa !6
+  %385 = getelementptr inbounds i64, i64* %384, i64 1, !dbg !50
+  %386 = getelementptr inbounds i64, i64* %385, i64 1, !dbg !50
+  %387 = getelementptr inbounds i64, i64* %386, i64 1, !dbg !50
+  %388 = getelementptr inbounds i64, i64* %387, i64 1, !dbg !50
+  %389 = bitcast i64* %385 to <4 x i64>*, !dbg !50
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %389, align 8, !dbg !50, !tbaa !6
+  %390 = getelementptr inbounds i64, i64* %388, i64 1, !dbg !50
+  store i64 -19, i64* %390, align 8, !dbg !50, !tbaa !6
+  %391 = getelementptr inbounds i64, i64* %390, i64 1, !dbg !50
+  store i64* %391, i64** %383, align 8, !dbg !50
+  %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !50
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %117, align 8, !dbg !50, !tbaa !14
   %rubyId_d812.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !125
   %rawSym813.i = call i64 @rb_id2sym(i64 %rubyId_d812.i) #10, !dbg !125
   %rubyId_e815.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !126
   %rawSym816.i = call i64 @rb_id2sym(i64 %rubyId_e815.i) #10, !dbg !126
   %rubyId_baz818.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !127
   %rawSym819.i = call i64 @rb_id2sym(i64 %rubyId_baz818.i) #10, !dbg !127
-  %392 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !50
-  %393 = load i64*, i64** %392, align 8, !dbg !50
-  store i64 %106, i64* %393, align 8, !dbg !50, !tbaa !6
-  %394 = getelementptr inbounds i64, i64* %393, i64 1, !dbg !50
-  %395 = getelementptr inbounds i64, i64* %394, i64 1, !dbg !50
-  %396 = getelementptr inbounds i64, i64* %395, i64 1, !dbg !50
-  %397 = getelementptr inbounds i64, i64* %396, i64 1, !dbg !50
-  %398 = bitcast i64* %394 to <4 x i64>*, !dbg !50
-  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %398, align 8, !dbg !50, !tbaa !6
-  %399 = getelementptr inbounds i64, i64* %397, i64 1, !dbg !50
-  store i64* %399, i64** %392, align 8, !dbg !50
-  %send44 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !50
+  %392 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !51
+  %393 = load i64*, i64** %392, align 8, !dbg !51
+  store i64 %106, i64* %393, align 8, !dbg !51, !tbaa !6
+  %394 = getelementptr inbounds i64, i64* %393, i64 1, !dbg !51
+  %395 = getelementptr inbounds i64, i64* %394, i64 1, !dbg !51
+  %396 = getelementptr inbounds i64, i64* %395, i64 1, !dbg !51
+  %397 = getelementptr inbounds i64, i64* %396, i64 1, !dbg !51
+  %398 = bitcast i64* %394 to <4 x i64>*, !dbg !51
+  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %398, align 8, !dbg !51, !tbaa !6
+  %399 = getelementptr inbounds i64, i64* %397, i64 1, !dbg !51
+  store i64* %399, i64** %392, align 8, !dbg !51
+  %send44 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !51
   call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %110)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %111)
   ret void
@@ -1327,111 +1350,111 @@ attributes #12 = { nounwind allocsize(0,1) }
 !17 = !{!18, !7, i64 0}
 !18 = !{!"RBasic", !7, i64 0, !7, i64 8}
 !19 = !{!"branch_weights", i32 1, i32 2000}
-!20 = !DILocation(line: 4, column: 23, scope: !10)
-!21 = !DILocation(line: 4, column: 36, scope: !10)
-!22 = !DILocation(line: 0, scope: !10)
-!23 = !DILocation(line: 5, column: 10, scope: !10)
-!24 = !{!25}
-!25 = distinct !{!25, !26, !"sorbet_buildArrayIntrinsic: argument 0"}
-!26 = distinct !{!26, !"sorbet_buildArrayIntrinsic"}
-!27 = !DILocation(line: 5, column: 5, scope: !10)
-!28 = !DILocation(line: 4, column: 1, scope: !29)
-!29 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$152", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!30 = !DILocation(line: 8, column: 1, scope: !29)
-!31 = !DILocation(line: 9, column: 1, scope: !29)
-!32 = !DILocation(line: 10, column: 1, scope: !29)
-!33 = !DILocation(line: 11, column: 1, scope: !29)
-!34 = !DILocation(line: 12, column: 1, scope: !29)
-!35 = !DILocation(line: 13, column: 1, scope: !29)
-!36 = !DILocation(line: 14, column: 1, scope: !29)
-!37 = !DILocation(line: 16, column: 1, scope: !29)
-!38 = !DILocation(line: 17, column: 1, scope: !29)
-!39 = !DILocation(line: 18, column: 1, scope: !29)
-!40 = !DILocation(line: 19, column: 1, scope: !29)
-!41 = !DILocation(line: 20, column: 1, scope: !29)
-!42 = !DILocation(line: 21, column: 1, scope: !29)
-!43 = !DILocation(line: 22, column: 1, scope: !29)
-!44 = !DILocation(line: 24, column: 1, scope: !29)
-!45 = !DILocation(line: 25, column: 1, scope: !29)
-!46 = !DILocation(line: 26, column: 1, scope: !29)
-!47 = !DILocation(line: 27, column: 1, scope: !29)
-!48 = !DILocation(line: 28, column: 1, scope: !29)
-!49 = !DILocation(line: 29, column: 1, scope: !29)
-!50 = !DILocation(line: 30, column: 1, scope: !29)
-!51 = !{!52, !7, i64 400}
-!52 = !{!"rb_vm_struct", !7, i64 0, !53, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !57, i64 216, !8, i64 224, !54, i64 264, !54, i64 280, !54, i64 296, !54, i64 312, !7, i64 328, !56, i64 336, !56, i64 340, !56, i64 344, !56, i64 344, !56, i64 344, !56, i64 344, !56, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !58, i64 472, !59, i64 992, !15, i64 1016, !15, i64 1024, !56, i64 1032, !56, i64 1036, !54, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !56, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !56, i64 1192, !60, i64 1200, !8, i64 1232}
-!53 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !54, i64 48, !15, i64 64, !56, i64 72, !8, i64 80, !8, i64 128, !56, i64 176, !56, i64 180}
-!54 = !{!"list_head", !55, i64 0}
-!55 = !{!"list_node", !15, i64 0, !15, i64 8}
-!56 = !{!"int", !8, i64 0}
-!57 = !{!"long long", !8, i64 0}
-!58 = !{!"", !8, i64 0}
-!59 = !{!"rb_hook_list_struct", !15, i64 0, !56, i64 8, !56, i64 12, !56, i64 16}
-!60 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!61 = !{!62, !15, i64 16}
-!62 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !56, i64 40, !56, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !63, i64 152}
-!63 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
-!64 = !{!65, !15, i64 16}
-!65 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
-!66 = !{!65, !15, i64 32}
-!67 = !DILocation(line: 0, scope: !29)
-!68 = !{!69, !56, i64 20}
-!69 = !{!"rb_sorbet_param_struct", !70, i64 0, !56, i64 4, !56, i64 8, !56, i64 12, !56, i64 16, !56, i64 20, !56, i64 24, !56, i64 28, !15, i64 32, !56, i64 40, !56, i64 44, !56, i64 48, !56, i64 52, !15, i64 56}
-!70 = !{!"", !56, i64 0, !56, i64 0, !56, i64 0, !56, i64 0, !56, i64 0, !56, i64 0, !56, i64 0, !56, i64 0, !56, i64 1, !56, i64 1}
-!71 = !{!69, !56, i64 24}
-!72 = !{!69, !56, i64 28}
-!73 = !{!56, !56, i64 0}
-!74 = !{!69, !15, i64 32}
-!75 = !{!69, !56, i64 40}
-!76 = !{!69, !56, i64 44}
-!77 = !{!69, !56, i64 8}
-!78 = !{!69, !56, i64 12}
-!79 = !{!69, !56, i64 48}
-!80 = !{!69, !56, i64 52}
-!81 = !{!69, !15, i64 56}
-!82 = !{!62, !56, i64 40}
-!83 = !{!62, !56, i64 44}
-!84 = !{!"branch_weights", i32 2000, i32 1}
-!85 = !{!62, !15, i64 56}
-!86 = !DILocation(line: 8, column: 44, scope: !29)
-!87 = !DILocation(line: 9, column: 40, scope: !29)
-!88 = !DILocation(line: 10, column: 36, scope: !29)
-!89 = !DILocation(line: 11, column: 32, scope: !29)
-!90 = !DILocation(line: 12, column: 28, scope: !29)
-!91 = !DILocation(line: 13, column: 24, scope: !29)
-!92 = !DILocation(line: 14, column: 20, scope: !29)
-!93 = !DILocation(line: 16, column: 44, scope: !29)
-!94 = !DILocation(line: 16, column: 51, scope: !29)
-!95 = !DILocation(line: 17, column: 40, scope: !29)
-!96 = !DILocation(line: 17, column: 47, scope: !29)
-!97 = !DILocation(line: 18, column: 36, scope: !29)
-!98 = !DILocation(line: 18, column: 43, scope: !29)
-!99 = !DILocation(line: 19, column: 32, scope: !29)
-!100 = !DILocation(line: 19, column: 39, scope: !29)
-!101 = !DILocation(line: 20, column: 28, scope: !29)
-!102 = !DILocation(line: 20, column: 35, scope: !29)
-!103 = !DILocation(line: 21, column: 24, scope: !29)
-!104 = !DILocation(line: 21, column: 31, scope: !29)
-!105 = !DILocation(line: 22, column: 20, scope: !29)
-!106 = !DILocation(line: 22, column: 27, scope: !29)
-!107 = !DILocation(line: 24, column: 44, scope: !29)
-!108 = !DILocation(line: 24, column: 51, scope: !29)
-!109 = !DILocation(line: 24, column: 58, scope: !29)
-!110 = !DILocation(line: 25, column: 40, scope: !29)
-!111 = !DILocation(line: 25, column: 47, scope: !29)
-!112 = !DILocation(line: 25, column: 54, scope: !29)
-!113 = !DILocation(line: 26, column: 36, scope: !29)
-!114 = !DILocation(line: 26, column: 43, scope: !29)
-!115 = !DILocation(line: 26, column: 50, scope: !29)
-!116 = !DILocation(line: 27, column: 32, scope: !29)
-!117 = !DILocation(line: 27, column: 39, scope: !29)
-!118 = !DILocation(line: 27, column: 46, scope: !29)
-!119 = !DILocation(line: 28, column: 28, scope: !29)
-!120 = !DILocation(line: 28, column: 35, scope: !29)
-!121 = !DILocation(line: 28, column: 42, scope: !29)
-!122 = !DILocation(line: 29, column: 24, scope: !29)
-!123 = !DILocation(line: 29, column: 31, scope: !29)
-!124 = !DILocation(line: 29, column: 38, scope: !29)
-!125 = !DILocation(line: 30, column: 20, scope: !29)
-!126 = !DILocation(line: 30, column: 27, scope: !29)
-!127 = !DILocation(line: 30, column: 34, scope: !29)
+!20 = !{!"branch_weights", i32 2000, i32 1}
+!21 = !DILocation(line: 4, column: 23, scope: !10)
+!22 = !DILocation(line: 4, column: 36, scope: !10)
+!23 = !DILocation(line: 0, scope: !10)
+!24 = !DILocation(line: 5, column: 10, scope: !10)
+!25 = !{!26}
+!26 = distinct !{!26, !27, !"sorbet_buildArrayIntrinsic: argument 0"}
+!27 = distinct !{!27, !"sorbet_buildArrayIntrinsic"}
+!28 = !DILocation(line: 5, column: 5, scope: !10)
+!29 = !DILocation(line: 4, column: 1, scope: !30)
+!30 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$152", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!31 = !DILocation(line: 8, column: 1, scope: !30)
+!32 = !DILocation(line: 9, column: 1, scope: !30)
+!33 = !DILocation(line: 10, column: 1, scope: !30)
+!34 = !DILocation(line: 11, column: 1, scope: !30)
+!35 = !DILocation(line: 12, column: 1, scope: !30)
+!36 = !DILocation(line: 13, column: 1, scope: !30)
+!37 = !DILocation(line: 14, column: 1, scope: !30)
+!38 = !DILocation(line: 16, column: 1, scope: !30)
+!39 = !DILocation(line: 17, column: 1, scope: !30)
+!40 = !DILocation(line: 18, column: 1, scope: !30)
+!41 = !DILocation(line: 19, column: 1, scope: !30)
+!42 = !DILocation(line: 20, column: 1, scope: !30)
+!43 = !DILocation(line: 21, column: 1, scope: !30)
+!44 = !DILocation(line: 22, column: 1, scope: !30)
+!45 = !DILocation(line: 24, column: 1, scope: !30)
+!46 = !DILocation(line: 25, column: 1, scope: !30)
+!47 = !DILocation(line: 26, column: 1, scope: !30)
+!48 = !DILocation(line: 27, column: 1, scope: !30)
+!49 = !DILocation(line: 28, column: 1, scope: !30)
+!50 = !DILocation(line: 29, column: 1, scope: !30)
+!51 = !DILocation(line: 30, column: 1, scope: !30)
+!52 = !{!53, !7, i64 400}
+!53 = !{!"rb_vm_struct", !7, i64 0, !54, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !58, i64 216, !8, i64 224, !55, i64 264, !55, i64 280, !55, i64 296, !55, i64 312, !7, i64 328, !57, i64 336, !57, i64 340, !57, i64 344, !57, i64 344, !57, i64 344, !57, i64 344, !57, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !59, i64 472, !60, i64 992, !15, i64 1016, !15, i64 1024, !57, i64 1032, !57, i64 1036, !55, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !57, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !57, i64 1192, !61, i64 1200, !8, i64 1232}
+!54 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !55, i64 48, !15, i64 64, !57, i64 72, !8, i64 80, !8, i64 128, !57, i64 176, !57, i64 180}
+!55 = !{!"list_head", !56, i64 0}
+!56 = !{!"list_node", !15, i64 0, !15, i64 8}
+!57 = !{!"int", !8, i64 0}
+!58 = !{!"long long", !8, i64 0}
+!59 = !{!"", !8, i64 0}
+!60 = !{!"rb_hook_list_struct", !15, i64 0, !57, i64 8, !57, i64 12, !57, i64 16}
+!61 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!62 = !{!63, !15, i64 16}
+!63 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !57, i64 40, !57, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !64, i64 152}
+!64 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!65 = !{!66, !15, i64 16}
+!66 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!67 = !{!66, !15, i64 32}
+!68 = !DILocation(line: 0, scope: !30)
+!69 = !{!70, !57, i64 20}
+!70 = !{!"rb_sorbet_param_struct", !71, i64 0, !57, i64 4, !57, i64 8, !57, i64 12, !57, i64 16, !57, i64 20, !57, i64 24, !57, i64 28, !15, i64 32, !57, i64 40, !57, i64 44, !57, i64 48, !57, i64 52, !15, i64 56}
+!71 = !{!"", !57, i64 0, !57, i64 0, !57, i64 0, !57, i64 0, !57, i64 0, !57, i64 0, !57, i64 0, !57, i64 0, !57, i64 1, !57, i64 1}
+!72 = !{!70, !57, i64 24}
+!73 = !{!70, !57, i64 28}
+!74 = !{!57, !57, i64 0}
+!75 = !{!70, !15, i64 32}
+!76 = !{!70, !57, i64 40}
+!77 = !{!70, !57, i64 44}
+!78 = !{!70, !57, i64 8}
+!79 = !{!70, !57, i64 12}
+!80 = !{!70, !57, i64 48}
+!81 = !{!70, !57, i64 52}
+!82 = !{!70, !15, i64 56}
+!83 = !{!63, !57, i64 40}
+!84 = !{!63, !57, i64 44}
+!85 = !{!63, !15, i64 56}
+!86 = !DILocation(line: 8, column: 44, scope: !30)
+!87 = !DILocation(line: 9, column: 40, scope: !30)
+!88 = !DILocation(line: 10, column: 36, scope: !30)
+!89 = !DILocation(line: 11, column: 32, scope: !30)
+!90 = !DILocation(line: 12, column: 28, scope: !30)
+!91 = !DILocation(line: 13, column: 24, scope: !30)
+!92 = !DILocation(line: 14, column: 20, scope: !30)
+!93 = !DILocation(line: 16, column: 44, scope: !30)
+!94 = !DILocation(line: 16, column: 51, scope: !30)
+!95 = !DILocation(line: 17, column: 40, scope: !30)
+!96 = !DILocation(line: 17, column: 47, scope: !30)
+!97 = !DILocation(line: 18, column: 36, scope: !30)
+!98 = !DILocation(line: 18, column: 43, scope: !30)
+!99 = !DILocation(line: 19, column: 32, scope: !30)
+!100 = !DILocation(line: 19, column: 39, scope: !30)
+!101 = !DILocation(line: 20, column: 28, scope: !30)
+!102 = !DILocation(line: 20, column: 35, scope: !30)
+!103 = !DILocation(line: 21, column: 24, scope: !30)
+!104 = !DILocation(line: 21, column: 31, scope: !30)
+!105 = !DILocation(line: 22, column: 20, scope: !30)
+!106 = !DILocation(line: 22, column: 27, scope: !30)
+!107 = !DILocation(line: 24, column: 44, scope: !30)
+!108 = !DILocation(line: 24, column: 51, scope: !30)
+!109 = !DILocation(line: 24, column: 58, scope: !30)
+!110 = !DILocation(line: 25, column: 40, scope: !30)
+!111 = !DILocation(line: 25, column: 47, scope: !30)
+!112 = !DILocation(line: 25, column: 54, scope: !30)
+!113 = !DILocation(line: 26, column: 36, scope: !30)
+!114 = !DILocation(line: 26, column: 43, scope: !30)
+!115 = !DILocation(line: 26, column: 50, scope: !30)
+!116 = !DILocation(line: 27, column: 32, scope: !30)
+!117 = !DILocation(line: 27, column: 39, scope: !30)
+!118 = !DILocation(line: 27, column: 46, scope: !30)
+!119 = !DILocation(line: 28, column: 28, scope: !30)
+!120 = !DILocation(line: 28, column: 35, scope: !30)
+!121 = !DILocation(line: 28, column: 42, scope: !30)
+!122 = !DILocation(line: 29, column: 24, scope: !30)
+!123 = !DILocation(line: 29, column: 31, scope: !30)
+!124 = !DILocation(line: 29, column: 38, scope: !30)
+!125 = !DILocation(line: 30, column: 20, scope: !30)
+!126 = !DILocation(line: 30, column: 27, scope: !30)
+!127 = !DILocation(line: 30, column: 34, scope: !30)

--- a/test/testdata/compiler/kwarg_splat_missing_required.rb
+++ b/test/testdata/compiler/kwarg_splat_missing_required.rb
@@ -11,4 +11,8 @@ class Test
   end
 end
 
-Test.main(**T.unsafe({}))
+begin
+  Test.main(**T.unsafe({}))
+rescue
+  puts $!.message
+end

--- a/test/testdata/ruby_benchmark/stripe/prop_const_getter.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/prop_const_getter.llo.exp
@@ -76,8 +76,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 %struct.iseq_inline_iv_cache_entry = type { i64, i64 }
-%struct.RHash = type { %struct.iseq_inline_iv_cache_entry, %union.anon.24, i64, %union.anon }
-%union.anon.24 = type { %struct.st_table* }
 %struct.RClass = type { %struct.iseq_inline_iv_cache_entry, i64, %struct.rb_classext_struct*, i64 }
 %struct.rb_classext_struct = type { %struct.st_table*, %struct.st_table*, %struct.rb_id_table*, %struct.rb_id_table*, %struct.rb_id_table*, %struct.rb_subclass_entry*, %struct.rb_subclass_entry**, %struct.rb_subclass_entry**, i64, i64, i64 (i64)*, i64 }
 %struct.rb_id_table = type opaque
@@ -178,7 +176,12 @@ declare void @sorbet_cast_failure(i64, i8*, i8*) local_unnamed_addr #1
 declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #2
 
 ; Function Attrs: noreturn
+declare void @sorbet_raiseMissingKeywords(i64) local_unnamed_addr #2
+
+; Function Attrs: noreturn
 declare void @sorbet_raiseExtraKeywords(i64) local_unnamed_addr #2
+
+declare i64 @sorbet_addMissingKWArg(i64, i64) local_unnamed_addr #0
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -236,7 +239,9 @@ declare i64 @rb_int2big(i64) local_unnamed_addr #0
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
 declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #3
 
-declare i64 @rb_hash_delete_entry(i64, i64) local_unnamed_addr #0
+declare i64 @rb_hash_lookup2(i64, i64, i64) local_unnamed_addr #0
+
+declare i64 @rb_hash_size_num(i64) local_unnamed_addr #0
 
 declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
 
@@ -829,7 +834,7 @@ functionEntryInitializers:
 fillRequiredArgs.thread:                          ; preds = %functionEntryInitializers
   %rubyId_foo39 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !78
   %rawSym40 = tail call i64 @rb_id2sym(i64 %rubyId_foo39), !dbg !78
-  br label %sorbet_assertNoExtraKWArg.exit.thread, !dbg !78
+  br label %kwArgContinue, !dbg !78
 
 readKWHashArgCountSuccess:                        ; preds = %functionEntryInitializers
   %argsWithoutHashCount = sub nuw i32 %argc, 1, !dbg !78
@@ -863,121 +868,121 @@ fillRequiredArgs:                                 ; preds = %afterKWHash
   %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !78
   %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !78
   %12 = icmp eq i64 %KWArgHash, 52, !dbg !78
-  br i1 %12, label %sorbet_assertNoExtraKWArg.exit.thread, label %sorbet_getKWArg.exit, !dbg !78
+  br i1 %12, label %kwArgContinue, label %sorbet_getKWArg.exit, !dbg !78
 
 sorbet_getKWArg.exit:                             ; preds = %fillRequiredArgs
-  %13 = tail call i64 @rb_hash_delete_entry(i64 %KWArgHash, i64 %rawSym) #15, !dbg !78
+  %13 = tail call i64 @rb_hash_lookup2(i64 %KWArgHash, i64 %rawSym, i64 noundef 52) #15, !dbg !78
   %14 = icmp eq i64 %13, 52, !dbg !78
-  %spec.select48 = select i1 %14, i64 8, i64 %13, !dbg !78
-  %15 = inttoptr i64 %KWArgHash to %struct.iseq_inline_iv_cache_entry*, !dbg !78
-  %16 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %15, i64 0, i32 0, !dbg !78
-  %17 = load i64, i64* %16, align 8, !dbg !78, !tbaa !68
-  %18 = trunc i64 %17 to i16, !dbg !78
-  %19 = icmp sgt i16 %18, -1, !dbg !78
-  br i1 %19, label %20, label %23, !dbg !78
+  br i1 %14, label %kwArgContinue.thread, label %sorbet_assertAllRequiredKWArgs.exit.thread, !dbg !78
 
-20:                                               ; preds = %sorbet_getKWArg.exit
-  %21 = lshr i64 %17, 16, !dbg !78
-  %22 = and i64 %21, 15, !dbg !78
-  br label %29, !dbg !78
+kwArgContinue:                                    ; preds = %fillRequiredArgs.thread, %fillRequiredArgs
+  %rawSym4144 = phi i64 [ %rawSym40, %fillRequiredArgs.thread ], [ %rawSym, %fillRequiredArgs ]
+  %15 = tail call i64 @sorbet_addMissingKWArg(i64 noundef 52, i64 %rawSym4144), !dbg !78
+  %16 = icmp eq i64 %15, 52, !dbg !78
+  br i1 %16, label %sorbet_assertNoExtraKWArg.exit.thread, label %19, !dbg !78, !prof !27
 
-23:                                               ; preds = %sorbet_getKWArg.exit
-  %24 = inttoptr i64 %KWArgHash to %struct.RHash*, !dbg !78
-  %25 = getelementptr inbounds %struct.RHash, %struct.RHash* %24, i64 0, i32 1, i32 0, !dbg !78
-  %26 = load %struct.st_table*, %struct.st_table** %25, align 8, !dbg !78, !tbaa !79
-  %27 = getelementptr inbounds %struct.st_table, %struct.st_table* %26, i64 0, i32 5, !dbg !78
-  %28 = load i64, i64* %27, align 8, !dbg !78, !tbaa !80
-  br label %29, !dbg !78
+sorbet_assertNoExtraKWArg.exit.thread:            ; preds = %kwArgContinue
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !79, !tbaa !14
+  br label %28, !dbg !80
 
-29:                                               ; preds = %23, %20
-  %30 = phi i64 [ %22, %20 ], [ %28, %23 ], !dbg !78
-  %31 = icmp eq i64 %30, 0, !dbg !78
-  br i1 %31, label %sorbet_assertNoExtraKWArg.exit, label %32, !dbg !78
+kwArgContinue.thread:                             ; preds = %sorbet_getKWArg.exit
+  %17 = tail call i64 @sorbet_addMissingKWArg(i64 noundef 52, i64 %rawSym), !dbg !78
+  %18 = icmp eq i64 %17, 52, !dbg !78
+  br i1 %18, label %sorbet_assertAllRequiredKWArgs.exit.thread, label %19, !dbg !78, !prof !27
 
-32:                                               ; preds = %29
+19:                                               ; preds = %kwArgContinue.thread, %kwArgContinue
+  %20 = phi i64 [ %17, %kwArgContinue.thread ], [ %15, %kwArgContinue ]
+  tail call void @sorbet_raiseMissingKeywords(i64 %20) #14, !dbg !78
+  unreachable, !dbg !78
+
+sorbet_assertAllRequiredKWArgs.exit.thread:       ; preds = %kwArgContinue.thread, %sorbet_getKWArg.exit
+  %foo.sroa.0.05154 = phi i64 [ %13, %sorbet_getKWArg.exit ], [ 8, %kwArgContinue.thread ]
+  %21 = tail call i64 @rb_hash_size_num(i64 %KWArgHash) #15, !dbg !78
+  %22 = trunc i64 %21 to i32, !dbg !78
+  %23 = sub nsw i32 %22, 1, !dbg !78
+  %24 = icmp eq i32 %23, 0, !dbg !78
+  br i1 %24, label %sorbet_assertNoExtraKWArg.exit, label %25, !dbg !78, !prof !27
+
+25:                                               ; preds = %sorbet_assertAllRequiredKWArgs.exit.thread
   tail call void @sorbet_raiseExtraKeywords(i64 %KWArgHash) #14, !dbg !78
   unreachable, !dbg !78
 
-sorbet_assertNoExtraKWArg.exit.thread:            ; preds = %fillRequiredArgs.thread, %fillRequiredArgs
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !82, !tbaa !14
-  br label %36, !dbg !83
+sorbet_assertNoExtraKWArg.exit:                   ; preds = %sorbet_assertAllRequiredKWArgs.exit.thread
+  %foo.sroa.0.05155 = phi i64 [ %foo.sroa.0.05154, %sorbet_assertAllRequiredKWArgs.exit.thread ]
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !79, !tbaa !14
+  %26 = and i64 %foo.sroa.0.05155, 1, !dbg !80
+  %27 = icmp eq i64 %26, 0, !dbg !80
+  br i1 %27, label %28, label %typeTestSuccess11, !dbg !80, !prof !66
 
-sorbet_assertNoExtraKWArg.exit:                   ; preds = %29
-  %33 = phi i64 [ %spec.select48, %29 ]
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !82, !tbaa !14
-  %34 = and i64 %33, 1, !dbg !83
-  %35 = icmp eq i64 %34, 0, !dbg !83
-  br i1 %35, label %36, label %typeTestSuccess10, !dbg !83, !prof !66
+28:                                               ; preds = %sorbet_assertNoExtraKWArg.exit.thread, %sorbet_assertNoExtraKWArg.exit
+  %foo.sroa.0.0515572 = phi i64 [ 8, %sorbet_assertNoExtraKWArg.exit.thread ], [ %foo.sroa.0.05155, %sorbet_assertNoExtraKWArg.exit ]
+  %29 = and i64 %foo.sroa.0.0515572, 7, !dbg !80
+  %30 = icmp ne i64 %29, 0, !dbg !80
+  %31 = and i64 %foo.sroa.0.0515572, -9, !dbg !80
+  %32 = icmp eq i64 %31, 0, !dbg !80
+  %33 = or i1 %30, %32, !dbg !80
+  br i1 %33, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !80
 
-36:                                               ; preds = %sorbet_assertNoExtraKWArg.exit.thread, %sorbet_assertNoExtraKWArg.exit
-  %37 = phi i64 [ 8, %sorbet_assertNoExtraKWArg.exit.thread ], [ %33, %sorbet_assertNoExtraKWArg.exit ]
-  %38 = and i64 %37, 7, !dbg !83
-  %39 = icmp ne i64 %38, 0, !dbg !83
-  %40 = and i64 %37, -9, !dbg !83
-  %41 = icmp eq i64 %40, 0, !dbg !83
-  %42 = or i1 %39, %41, !dbg !83
-  br i1 %42, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !83
+sorbet_isa_Integer.exit:                          ; preds = %28
+  %34 = inttoptr i64 %foo.sroa.0.0515572 to %struct.iseq_inline_iv_cache_entry*, !dbg !80
+  %35 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %34, i64 0, i32 0, !dbg !80
+  %36 = load i64, i64* %35, align 8, !dbg !80, !tbaa !68
+  %37 = and i64 %36, 31, !dbg !80
+  %38 = icmp eq i64 %37, 10, !dbg !80
+  br i1 %38, label %typeTestSuccess11, label %codeRepl, !dbg !80, !prof !27
 
-sorbet_isa_Integer.exit:                          ; preds = %36
-  %43 = inttoptr i64 %37 to %struct.iseq_inline_iv_cache_entry*, !dbg !83
-  %44 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %43, i64 0, i32 0, !dbg !83
-  %45 = load i64, i64* %44, align 8, !dbg !83, !tbaa !68
-  %46 = and i64 %45, 31, !dbg !83
-  %47 = icmp eq i64 %46, 10, !dbg !83
-  br i1 %47, label %typeTestSuccess10, label %codeRepl, !dbg !83, !prof !27
-
-codeRepl:                                         ; preds = %36, %sorbet_isa_Integer.exit
-  %48 = phi i64 [ %37, %36 ], [ %37, %sorbet_isa_Integer.exit ]
-  tail call fastcc void @"func_MyStruct#initialize.cold.1"(i64 %48) #19, !dbg !83
+codeRepl:                                         ; preds = %28, %sorbet_isa_Integer.exit
+  %foo.sroa.0.0515573 = phi i64 [ %foo.sroa.0.0515572, %28 ], [ %foo.sroa.0.0515572, %sorbet_isa_Integer.exit ]
+  tail call fastcc void @"func_MyStruct#initialize.cold.1"(i64 %foo.sroa.0.0515573) #19, !dbg !80
   unreachable
 
-typeTestSuccess10:                                ; preds = %sorbet_assertNoExtraKWArg.exit, %sorbet_isa_Integer.exit
-  %49 = phi i64 [ %33, %sorbet_assertNoExtraKWArg.exit ], [ %37, %sorbet_isa_Integer.exit ]
-  %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !84
-  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %49, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #15, !dbg !84
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !84, !tbaa !14
-  %rubyId_foo13 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !78
-  %rawSym14 = tail call i64 @rb_id2sym(i64 %rubyId_foo13), !dbg !78
+typeTestSuccess11:                                ; preds = %sorbet_assertNoExtraKWArg.exit, %sorbet_isa_Integer.exit
+  %foo.sroa.0.0515571 = phi i64 [ %foo.sroa.0.05155, %sorbet_assertNoExtraKWArg.exit ], [ %foo.sroa.0.0515572, %sorbet_isa_Integer.exit ]
+  %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !81
+  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %foo.sroa.0.0515571, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #15, !dbg !81
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !81, !tbaa !14
+  %rubyId_foo14 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !78
+  %rawSym15 = tail call i64 @rb_id2sym(i64 %rubyId_foo14), !dbg !78
   %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !78
-  store i64 %rawSym14, i64* %callArgs0Addr, align 8, !dbg !78
+  store i64 %rawSym15, i64* %callArgs0Addr, align 8, !dbg !78
   %callArgs1Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 1, !dbg !78
-  store i64 %49, i64* %callArgs1Addr, align 8, !dbg !78
-  %50 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !78
-  %51 = tail call i64 @rb_hash_new_with_size(i64 noundef 1) #15, !dbg !78
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %50, i64 %51) #15, !dbg !78
-  store i64 %51, i64* %callArgs0Addr, align 8, !dbg !78
-  call void @llvm.experimental.noalias.scope.decl(metadata !85), !dbg !78
-  %52 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !14, !noalias !85
-  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 2, !dbg !78
-  %54 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %53, align 8, !dbg !78, !tbaa !16, !noalias !85
-  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %54, i64 0, i32 3, !dbg !78
-  %56 = load i64, i64* %55, align 8, !dbg !78, !tbaa !88, !noalias !85
-  %57 = call %struct.rb_callable_method_entry_struct* @rb_vm_frame_method_entry(%struct.rb_control_frame_struct* %54) #15, !dbg !78, !noalias !85
-  %58 = getelementptr inbounds %struct.rb_callable_method_entry_struct, %struct.rb_callable_method_entry_struct* %57, i64 0, i32 1, !dbg !78
-  %59 = load i64, i64* %58, align 8, !dbg !78, !tbaa !89, !noalias !85
-  %60 = inttoptr i64 %59 to %struct.RClass*, !dbg !78
-  %61 = getelementptr inbounds %struct.RClass, %struct.RClass* %60, i64 0, i32 2, !dbg !78
-  %62 = load %struct.rb_classext_struct*, %struct.rb_classext_struct** %61, align 8, !dbg !78, !tbaa !91, !noalias !85
-  %63 = getelementptr inbounds %struct.rb_classext_struct, %struct.rb_classext_struct* %62, i64 0, i32 8, !dbg !78
-  %64 = load i64, i64* %63, align 8, !dbg !78, !tbaa !93, !noalias !85
-  %65 = inttoptr i64 %64 to %struct.RClass*, !dbg !78
-  %66 = getelementptr inbounds %struct.RClass, %struct.RClass* %65, i64 0, i32 1, !dbg !78
-  %67 = load i64, i64* %66, align 8, !dbg !78, !tbaa !95, !noalias !85
-  %68 = getelementptr inbounds %struct.rb_callable_method_entry_struct, %struct.rb_callable_method_entry_struct* %57, i64 0, i32 2, !dbg !78
-  %69 = load %struct.rb_method_definition_struct*, %struct.rb_method_definition_struct** %68, align 8, !dbg !78, !tbaa !96, !noalias !85
-  %70 = getelementptr inbounds %struct.rb_method_definition_struct, %struct.rb_method_definition_struct* %69, i64 0, i32 2, !dbg !78
-  %71 = load i64, i64* %70, align 8, !dbg !78, !tbaa !97, !noalias !85
-  %72 = call %struct.rb_callable_method_entry_struct* @rb_callable_method_entry(i64 %67, i64 %71) #15, !dbg !78, !noalias !85
-  %73 = icmp eq %struct.rb_callable_method_entry_struct* %72, null, !dbg !78
-  br i1 %73, label %74, label %sorbet_callSuper.exit, !dbg !78
+  store i64 %foo.sroa.0.0515571, i64* %callArgs1Addr, align 8, !dbg !78
+  %39 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !78
+  %40 = tail call i64 @rb_hash_new_with_size(i64 noundef 1) #15, !dbg !78
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %39, i64 %40) #15, !dbg !78
+  store i64 %40, i64* %callArgs0Addr, align 8, !dbg !78
+  call void @llvm.experimental.noalias.scope.decl(metadata !82), !dbg !78
+  %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !14, !noalias !82
+  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 2, !dbg !78
+  %43 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %42, align 8, !dbg !78, !tbaa !16, !noalias !82
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 3, !dbg !78
+  %45 = load i64, i64* %44, align 8, !dbg !78, !tbaa !85, !noalias !82
+  %46 = call %struct.rb_callable_method_entry_struct* @rb_vm_frame_method_entry(%struct.rb_control_frame_struct* %43) #15, !dbg !78, !noalias !82
+  %47 = getelementptr inbounds %struct.rb_callable_method_entry_struct, %struct.rb_callable_method_entry_struct* %46, i64 0, i32 1, !dbg !78
+  %48 = load i64, i64* %47, align 8, !dbg !78, !tbaa !86, !noalias !82
+  %49 = inttoptr i64 %48 to %struct.RClass*, !dbg !78
+  %50 = getelementptr inbounds %struct.RClass, %struct.RClass* %49, i64 0, i32 2, !dbg !78
+  %51 = load %struct.rb_classext_struct*, %struct.rb_classext_struct** %50, align 8, !dbg !78, !tbaa !88, !noalias !82
+  %52 = getelementptr inbounds %struct.rb_classext_struct, %struct.rb_classext_struct* %51, i64 0, i32 8, !dbg !78
+  %53 = load i64, i64* %52, align 8, !dbg !78, !tbaa !90, !noalias !82
+  %54 = inttoptr i64 %53 to %struct.RClass*, !dbg !78
+  %55 = getelementptr inbounds %struct.RClass, %struct.RClass* %54, i64 0, i32 1, !dbg !78
+  %56 = load i64, i64* %55, align 8, !dbg !78, !tbaa !92, !noalias !82
+  %57 = getelementptr inbounds %struct.rb_callable_method_entry_struct, %struct.rb_callable_method_entry_struct* %46, i64 0, i32 2, !dbg !78
+  %58 = load %struct.rb_method_definition_struct*, %struct.rb_method_definition_struct** %57, align 8, !dbg !78, !tbaa !93, !noalias !82
+  %59 = getelementptr inbounds %struct.rb_method_definition_struct, %struct.rb_method_definition_struct* %58, i64 0, i32 2, !dbg !78
+  %60 = load i64, i64* %59, align 8, !dbg !78, !tbaa !94, !noalias !82
+  %61 = call %struct.rb_callable_method_entry_struct* @rb_callable_method_entry(i64 %56, i64 %60) #15, !dbg !78, !noalias !82
+  %62 = icmp eq %struct.rb_callable_method_entry_struct* %61, null, !dbg !78
+  br i1 %62, label %63, label %sorbet_callSuper.exit, !dbg !78
 
-74:                                               ; preds = %typeTestSuccess10
-  %75 = load i64, i64* @rb_eRuntimeError, align 8, !dbg !78, !tbaa !6
-  call void (i64, i8*, ...) @rb_raise(i64 %75, i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @.str.7, i64 0, i64 0)) #14, !dbg !78
+63:                                               ; preds = %typeTestSuccess11
+  %64 = load i64, i64* @rb_eRuntimeError, align 8, !dbg !78, !tbaa !6
+  call void (i64, i8*, ...) @rb_raise(i64 %64, i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @.str.7, i64 0, i64 0)) #14, !dbg !78
   unreachable, !dbg !78
 
-sorbet_callSuper.exit:                            ; preds = %typeTestSuccess10
-  %76 = call i64 @rb_vm_call_kw(%struct.rb_execution_context_struct* nonnull %52, i64 %56, i64 %71, i32 noundef 1, i64* noundef nonnull %50, %struct.rb_callable_method_entry_struct* nonnull %72, i32 noundef 1) #15, !dbg !78
+sorbet_callSuper.exit:                            ; preds = %typeTestSuccess11
+  %65 = call i64 @rb_vm_call_kw(%struct.rb_execution_context_struct* nonnull %41, i64 %45, i64 %60, i32 noundef 1, i64* noundef nonnull %39, %struct.rb_callable_method_entry_struct* nonnull %61, i32 noundef 1) #15, !dbg !78
   %"<void-singleton>" = load i64, i64* @"<void-singleton>", align 8
   ret i64 %"<void-singleton>"
 }
@@ -995,10 +1000,10 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #10
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_MyStruct#initialize.cold.1"(i64 %0) unnamed_addr #11 !dbg !99 {
+define internal fastcc void @"func_MyStruct#initialize.cold.1"(i64 %foo.sroa.0.05155) unnamed_addr #11 !dbg !96 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !101
-  unreachable, !dbg !101
+  tail call void @sorbet_cast_failure(i64 %foo.sroa.0.05155, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !98
+  unreachable, !dbg !98
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
@@ -1125,26 +1130,23 @@ attributes #19 = { noinline }
 !76 = distinct !{!76, !"sorbet_rb_int_plus"}
 !77 = distinct !DISubprogram(name: "MyStruct#initialize", linkageName: "func_MyStruct#initialize", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !78 = !DILocation(line: 5, column: 1, scope: !77)
-!79 = !{!8, !8, i64 0}
-!80 = !{!81, !7, i64 16}
-!81 = !{!"st_table", !8, i64 0, !8, i64 1, !8, i64 2, !18, i64 4, !15, i64 8, !7, i64 16, !15, i64 24, !7, i64 32, !7, i64 40, !15, i64 48}
-!82 = !DILocation(line: 0, scope: !77)
-!83 = !DILocation(line: 6, column: 3, scope: !77)
-!84 = !DILocation(line: 6, column: 10, scope: !77)
-!85 = !{!86}
-!86 = distinct !{!86, !87, !"sorbet_callSuper: argument 0"}
-!87 = distinct !{!87, !"sorbet_callSuper"}
-!88 = !{!21, !7, i64 24}
-!89 = !{!90, !7, i64 8}
-!90 = !{!"rb_callable_method_entry_struct", !7, i64 0, !7, i64 8, !15, i64 16, !7, i64 24, !7, i64 32}
-!91 = !{!92, !15, i64 24}
-!92 = !{!"RClass", !69, i64 0, !7, i64 16, !15, i64 24, !31, i64 32}
-!93 = !{!94, !7, i64 64}
-!94 = !{!"rb_classext_struct", !15, i64 0, !15, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !15, i64 40, !15, i64 48, !15, i64 56, !7, i64 64, !7, i64 72, !15, i64 80, !7, i64 88}
-!95 = !{!92, !7, i64 16}
-!96 = !{!90, !15, i64 16}
-!97 = !{!98, !7, i64 32}
-!98 = !{!"rb_method_definition_struct", !8, i64 0, !18, i64 0, !18, i64 4, !8, i64 8, !7, i64 32, !7, i64 40}
-!99 = distinct !DISubprogram(name: "func_MyStruct#initialize.cold.1", linkageName: "func_MyStruct#initialize.cold.1", scope: null, file: !4, type: !100, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!100 = !DISubroutineType(types: !5)
-!101 = !DILocation(line: 6, column: 3, scope: !99)
+!79 = !DILocation(line: 0, scope: !77)
+!80 = !DILocation(line: 6, column: 3, scope: !77)
+!81 = !DILocation(line: 6, column: 10, scope: !77)
+!82 = !{!83}
+!83 = distinct !{!83, !84, !"sorbet_callSuper: argument 0"}
+!84 = distinct !{!84, !"sorbet_callSuper"}
+!85 = !{!21, !7, i64 24}
+!86 = !{!87, !7, i64 8}
+!87 = !{!"rb_callable_method_entry_struct", !7, i64 0, !7, i64 8, !15, i64 16, !7, i64 24, !7, i64 32}
+!88 = !{!89, !15, i64 24}
+!89 = !{!"RClass", !69, i64 0, !7, i64 16, !15, i64 24, !31, i64 32}
+!90 = !{!91, !7, i64 64}
+!91 = !{!"rb_classext_struct", !15, i64 0, !15, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !15, i64 40, !15, i64 48, !15, i64 56, !7, i64 64, !7, i64 72, !15, i64 80, !7, i64 88}
+!92 = !{!89, !7, i64 16}
+!93 = !{!87, !15, i64 16}
+!94 = !{!95, !7, i64 32}
+!95 = !{!"rb_method_definition_struct", !8, i64 0, !18, i64 0, !18, i64 4, !8, i64 8, !7, i64 32, !7, i64 40}
+!96 = distinct !DISubprogram(name: "func_MyStruct#initialize.cold.1", linkageName: "func_MyStruct#initialize.cold.1", scope: null, file: !4, type: !97, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!97 = !DISubroutineType(types: !5)
+!98 = !DILocation(line: 6, column: 3, scope: !96)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
We're currently removing entries from the keyword args hash as we parse it, which is causing test failures for some internal tests that use meta-programming to intercept arguments before they're given to the compiled function. The VM does this as well, but only in the event that there is a double-splat in the arguments list; when there is no double splat in the args list the vm will only read elements out of the hash that contains the keyword args. We now match that behavior, and only mutate the keyword args hash when pruning out required and optional args from the hash that will be used as the double splat.

While I was modifying keyword argument parsing, I improved handling of missing keyword arguments by following the lead from the VM and threading through an array that contains the missing keyword args. The array is initialized the first time we encounter a missing arg, so we only pay the cost for it when we would raise an error anyway. Improving the handling of missing required keyword args fixes a disabled test, and brings us more in line with the behavior of the VM.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixing bugs

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
