### PR TITLE
Add a test for missing errors with keyword args splats

### DIFF
--- a/test/testdata/compiler/disabled/kwarg_splat_missing_required.rb
+++ b/test/testdata/compiler/disabled/kwarg_splat_missing_required.rb
@@ -1,0 +1,14 @@
+# typed: true
+# compiled: true
+# frozen_string_literal: true
+
+class Test
+  extend T::Sig
+
+  def self.main(x:, **args)
+    p x
+    p args
+  end
+end
+
+Test.main(**T.unsafe({}))


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
We're not checking that required keyword arguments are provided. When a signature is present we'll throw a type error if the signature was for a non-nil type, but when the signature is missing the body will execute with the value of the required parameter as `nil`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
More tests.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
