### PR TITLE
cfg-view: Open SVGs with default browser

### DIFF
--- a/tools/scripts/cfg-view.sh
+++ b/tools/scripts/cfg-view.sh
@@ -32,7 +32,7 @@ fi
 "${sorbet_exe[@]}" --silence-dev-message --suppress-non-critical --typed=true --print "$print" "$@" > "$dot"
 dot -Tsvg "$dot" > "$svg"
 if command -v open &> /dev/null && test "$sys" != Linux; then
-  open -a "Google Chrome" "$svg"
+  open "$svg"
 elif command -v sensible-browser &> /dev/null; then
   sensible-browser "$svg"
 elif command -v xdg-open &> /dev/null; then


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Open SVGs with user's default SVG program.

I prefer using Firefox on my personal laptop. I think this script should respect
whichever program people prefer to open SVGs with.

To get the old behavior, change the default program for opening SVGs:

<https://www.imore.com/how-set-mac-app-default-when-opening-file>

(alternatively: we could add a command-line flag for this if people feel
strongly)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a