### PR TITLE
add a test for rescuing a superclass of the raised error

### DIFF
--- a/test/testdata/compiler/exceptions/raise_subclass.rb
+++ b/test/testdata/compiler/exceptions/raise_subclass.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+begin
+  p 'running begin'
+  raise KeyError, 'wrong key'
+rescue IndexError
+  p "found it!"
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I don't think we have a test for this, and this seems like a good test to have.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
