### PR TITLE
add a test for inferring types of {,@}@var ||= ...

### DIFF
--- a/test/testdata/infer/ivar_cvar_oror_eq.rb
+++ b/test/testdata/infer/ivar_cvar_oror_eq.rb
@@ -1,0 +1,23 @@
+# typed: true
+
+# Test that Sorbet correctly infers the types of @@var in f and @ivar in g.
+
+class C
+  extend T::Sig
+
+  @@var = T.let(nil, T.nilable(Integer))
+
+  def initialize
+    @ivar = T.let(nil, T.nilable(String))
+  end
+
+  sig {params(x: Integer).returns(Integer)}
+  def self.f(x)
+    @@var ||= x
+  end
+
+  sig {params(x: String).returns(String)}
+  def g(x)
+    @ivar ||= x
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I ran into test failures in Stripe's codebase with the current iteration of #4558, and we didn't have any tests for this, AFAICT.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
