### PR TITLE
Add a failing test for captured kwsplats

### DIFF
--- a/test/testdata/compiler/disabled/kwsplat_argument_capture.rb
+++ b/test/testdata/compiler/disabled/kwsplat_argument_capture.rb
@@ -1,0 +1,57 @@
+# compiled: true
+# typed: true
+# frozen_string_literal: true
+
+# When parsing keyword arguments that have a kwsplat present, the code that we
+# emit will iteratively remove parsed arguments from the kwsplat hash to
+# determine what's left over. The effect of this is that if something else had a
+# reference to the hash that was used for the keyword args, they will see that
+# hash as having fewer elements after the compiled function was called.
+
+class Util
+  extend T::Sig
+
+  sig {params(x: Integer, args: T.untyped).void}
+  def self.main(x:, **args)
+    puts x
+    puts args
+  end
+end
+
+class Inspector
+
+  def self.setup
+    return unless @old.nil?
+
+    @old = Util.method(:main)
+    old = @old
+
+    Util.define_singleton_method(:main) do |args|
+      Inspector.instance_variable_set(:@args, args)
+      old.call(args)
+    end
+  end
+
+  def self.teardown
+    # In the compiled version, this puts will differ as the `@args` hash has
+    # been mutated by the compiled function.
+    puts "args = #{@args}"
+    Util.define_singleton_method(:main, @old)
+  end
+
+end
+
+class Test
+  def self.test_stub
+    args = {msg: 'hi', x: 20}
+    Util.main(x: 10, **args)
+  end
+end
+
+# Matches ruby
+Test.test_stub
+
+# Doesn't match ruby, as the `@args` hash has been mutated
+Inspector.setup
+Test.test_stub
+Inspector.teardown


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Add a disabled test case showing that the behavior of compiled code with a keyword splat differs from the vm when the arguments are captured.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
More tests.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
