### PR TITLE
use `uname -m` for platform detection in bazel wrapper script

### DIFF
--- a/bazel
+++ b/bazel
@@ -50,7 +50,7 @@ fi
 echo >&2 "No cached Bazel v$BAZEL_VERSION found, installing..."
 
 kernel_name="$(uname -s | tr 'A-Z' 'a-z')"
-processor_name="$(uname -p)"
+processor_name="$(uname -m)"
 
 bazel_installer_platform="${kernel_name}-${processor_name}"
 case "$bazel_installer_platform" in
@@ -58,10 +58,6 @@ case "$bazel_installer_platform" in
   darwin-x86_64) ;;
   darwin-arm64)
     # Pseudo Apple Silicon support by forcing x86_64 (Rosetta) for now
-    bazel_installer_platform="darwin-x86_64"
-    ;;
-  darwin-i386)
-    # macOS Mojave reports as i386
     bazel_installer_platform="darwin-x86_64"
     ;;
   *)


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I pulled and compiled this morning:

```
froydnj@pyro:~/src/sorbet$ ./bazel build //main:sorbet //compiler:sorbet
No cached Bazel v4.2.1 found, installing...
Building on linux-unknown is not implemented
froydnj@pyro:~/src/sorbet$ uname -p
unknown
```

which seems bad.  The help output for uname says `-p` is "non-portable"; I'm not exactly sure what that means in this context, but there you go.

`uname -m` seems to do the right thing (returns `x86_64`) on that machine, on two different other Linux machines I have at home, on a Stripe devbox, and on my Stripe (x86-64) mac.  As a bonus on the (Big Sur) mac, `uname -m` returns `x86_64` whereas `uname -p` returns `i386`, so I think we can get rid of the gross case in the `bazel` wrapper.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
