### PR TITLE
Disabled test for a new return-from-block issue

### DIFF
--- a/test/testdata/compiler/disabled/return_across_exception_and_block_consumer.rb
+++ b/test/testdata/compiler/disabled/return_across_exception_and_block_consumer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+def justyield
+  yield
+end
+
+def f
+  puts (justyield do
+          begin
+            return 444
+          rescue
+            nil
+          end
+        end)
+  555
+end
+
+puts "Here is f: #{f}"


### PR DESCRIPTION
### Motivation
Found a new test case that fails when compiling. I think the issue is that we're `return`ing from inside a `begin` that is itself inside a `do`, and misidentifying the function that is the target for the `return`.

### Test plan
Ran this by hand, verified that it compiled but gives different output from the interpreter.