### PR TITLE
Start emitting defaults for block args

### DIFF
--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -193,6 +193,14 @@ string LoadYieldParams::showRaw(const core::GlobalState &gs, const CFG &cfg, int
     return fmt::format("LoadYieldParams {{ link = {0} }}", this->link->fun.showRaw(gs));
 }
 
+string YieldParamPresent::toString(const core::GlobalState &gs, const CFG &cfg) const {
+    return fmt::format("yield_param_present({})", this->argId);
+}
+
+string YieldParamPresent::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
+    return fmt::format("YieldParamPresent {{ argId = {} }}", this->argId);
+}
+
 string GetCurrentException::toString(const core::GlobalState &gs, const CFG &cfg) const {
     return "<get-current-exception>";
 }

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -196,6 +196,18 @@ public:
 };
 CheckSize(LoadYieldParams, 32, 8);
 
+class YieldParamPresent final : public Instruction {
+public:
+    u2 argId;
+
+    YieldParamPresent(u2 argId) : argId{argId} {
+        categoryCounterInc("cfg", "argpresent");
+    };
+    virtual std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    virtual std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+};
+CheckSize(YieldParamPresent, 16, 8);
+
 class Cast final : public Instruction {
 public:
     core::NameRef cast;

--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -663,8 +663,8 @@ void emitUserBody(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &ir
                     /* intentionally omitted, it's part of method preambula */
                 },
                 [&](cfg::YieldParamPresent *i) {
-                    failCompilation(cs, core::Loc(cfg.file, bind.loc),
-                                    "Unable to compile blocks with default arguments!");
+                    auto *val = Payload::rubyTrue(cs, builder);
+                    Payload::varSet(cs, bind.bind.variable, val, builder, irctx, bb->rubyBlockId);
                 },
                 [&](cfg::Cast *i) {
                     auto val = Payload::varGet(cs, i->value.variable, builder, irctx, bb->rubyBlockId);

--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -662,6 +662,10 @@ void emitUserBody(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &ir
                     loadYieldParamsResults.insert(bind.bind.variable);
                     /* intentionally omitted, it's part of method preambula */
                 },
+                [&](cfg::YieldParamPresent *i) {
+                    failCompilation(cs, core::Loc(cfg.file, bind.loc),
+                                    "Unable to compile blocks with default arguments!");
+                },
                 [&](cfg::Cast *i) {
                     auto val = Payload::varGet(cs, i->value.variable, builder, irctx, bb->rubyBlockId);
 

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -662,6 +662,44 @@ vector<optional<string>> getBlockLocationNames(CompilerState &cs, cfg::CFG &cfg,
     return blockLocationNames;
 }
 
+void collectRubyBlockArgs(const cfg::CFG &cfg, const cfg::BasicBlock *b, vector<cfg::LocalRef> &blockArgs) {
+    bool insideThenBlock = false;
+
+    while (true) {
+        for (auto &maybeCallOnLoadYieldArg : b->exprs) {
+            auto maybeCast = cfg::cast_instruction<cfg::Send>(maybeCallOnLoadYieldArg.value.get());
+            if (maybeCast == nullptr || maybeCast->recv.variable.data(cfg)._name != core::Names::blkArg() ||
+                maybeCast->fun != core::Names::squareBrackets() || maybeCast->args.size() != 1) {
+                continue;
+            }
+            if (!core::isa_type<core::LiteralType>(maybeCast->args[0].type)) {
+                continue;
+            }
+            auto litType = core::cast_type_nonnull<core::LiteralType>(maybeCast->args[0].type);
+            blockArgs[litType.asInteger()] = maybeCallOnLoadYieldArg.bind.variable;
+        }
+
+        // When the exit condition for this block is constructed through `argPresent`, continue down the `then` branch
+        // to collect more block arg definitions.
+        if (b->bexit.cond.variable.data(cfg)._name == core::Names::argPresent()) {
+            insideThenBlock = true;
+            b = b->bexit.thenb;
+            continue;
+        }
+
+        // The blocks emitted when optional arguments are present end in an unconditional jump to join with the path
+        // that would populate the arg with the default value.
+        if (insideThenBlock) {
+            insideThenBlock = false;
+            b = b->bexit.thenb;
+            continue;
+        }
+
+        // We've reaced the end of argument handling entry blocks in the ruby block CFG.
+        return;
+    }
+}
+
 } // namespace
 
 IREmitterContext IREmitterContext::getSorbetBlocks2LLVMBlockMapping(CompilerState &cs, cfg::CFG &cfg,
@@ -806,19 +844,9 @@ IREmitterContext IREmitterContext::getSorbetBlocks2LLVMBlockMapping(CompilerStat
             ENFORCE(expectedSend->link);
             blockLinks[b->rubyBlockId] = expectedSend->link;
 
-            rubyBlockArgs[b->rubyBlockId].resize(expectedSend->link->argFlags.size(), cfg::LocalRef::noVariable());
-            for (auto &maybeCallOnLoadYieldArg : b->bexit.thenb->exprs) {
-                auto maybeCast = cfg::cast_instruction<cfg::Send>(maybeCallOnLoadYieldArg.value.get());
-                if (maybeCast == nullptr || maybeCast->recv.variable.data(cfg)._name != core::Names::blkArg() ||
-                    maybeCast->fun != core::Names::squareBrackets() || maybeCast->args.size() != 1) {
-                    continue;
-                }
-                if (!core::isa_type<core::LiteralType>(maybeCast->args[0].type)) {
-                    continue;
-                }
-                auto litType = core::cast_type_nonnull<core::LiteralType>(maybeCast->args[0].type);
-                rubyBlockArgs[b->rubyBlockId][litType.asInteger()] = maybeCallOnLoadYieldArg.bind.variable;
-            }
+            auto &blockArgs = rubyBlockArgs[b->rubyBlockId];
+            blockArgs.resize(expectedSend->link->argFlags.size(), cfg::LocalRef::noVariable());
+            collectRubyBlockArgs(cfg, b->bexit.thenb, blockArgs);
         } else if (b->bexit.cond.variable.data(cfg)._name == core::Names::exceptionValue()) {
             if (exceptionHandlingBlockHeaders[b->id] == 0) {
                 continue;
@@ -844,6 +872,11 @@ IREmitterContext IREmitterContext::getSorbetBlocks2LLVMBlockMapping(CompilerStat
                 userEntryBlockByFunction[ensureBlockId] = llvmBlocks[ensureBlock->id];
             }
         } else if (b->bexit.cond.variable.data(cfg)._name == core::Names::argPresent()) {
+            // TODO(trevor) we don't currently handle argPresent decisions in ruby-Argblocks, only for the method entry.
+            if (b->rubyBlockId > 0) {
+                continue;
+            }
+
             // the ArgPresent instruction is always the last one generated in the block
             int argId = -1;
             auto &bind = b->exprs.back();

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -262,6 +262,7 @@ findCaptures(CompilerState &cs, const ast::MethodDef &mdef, cfg::CFG &cfg,
                 [&](cfg::LoadSelf *i) { /*nothing*/ /*todo: how does instance exec pass self?*/ },
                 [&](cfg::Literal *i) { /* nothing*/ }, [&](cfg::ArgPresent *i) { /*nothing*/ },
                 [&](cfg::LoadArg *i) { /*nothing*/ }, [&](cfg::LoadYieldParams *i) { /*nothing*/ },
+                [&](cfg::YieldParamPresent *i) { /* nothing */ },
                 [&](cfg::Cast *i) { usage.trackBlockUsage(bb.get(), i->value.variable); },
                 [&](cfg::TAbsurd *i) { usage.trackBlockUsage(bb.get(), i->what.variable); });
         }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1163,6 +1163,12 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 }
                 tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
             },
+            [&](cfg::YieldParamPresent *i) {
+                // Return an unanalyzable boolean value that indicates whether or not arg was provided
+                // It's unanalyzable because it varies by each individual call site.
+                tp.type = core::Types::Boolean();
+                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+            },
             [&](cfg::Return *i) {
                 tp.type = core::Types::bottom();
                 tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));

--- a/test/testdata/compiler/block_arg_expand.llo.exp
+++ b/test/testdata/compiler/block_arg_expand.llo.exp
@@ -117,7 +117,10 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_p = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_p = internal unnamed_addr global i64 0, align 8
 @str_p = private unnamed_addr constant [2 x i8] c"p\00", align 1
+@str_x = private unnamed_addr constant [2 x i8] c"x\00", align 1
 @ic_p.5 = internal global %struct.FunctionInlineCache zeroinitializer
+@str_default = private unnamed_addr constant [8 x i8] c"default\00", align 1
+@str_something = private unnamed_addr constant [10 x i8] c"something\00", align 1
 @ic_p.8 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.9 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.12 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -452,22 +455,22 @@ fillFromArgBlock0:                                ; preds = %functionEntryInitia
   br label %fillFromDefaultBlockDone1, !dbg !48
 
 fillFromDefaultBlockDone1:                        ; preds = %functionEntryInitializers, %fillFromArgBlock0
-  %array.sroa.0.0 = phi i64 [ %rawArg_array, %fillFromArgBlock0 ], [ 8, %functionEntryInitializers ], !dbg !48
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %10, align 8, !dbg !49, !tbaa !15
-  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !50
-  %12 = load i64*, i64** %11, align 8, !dbg !50
-  store i64 %4, i64* %12, align 8, !dbg !50, !tbaa !6
-  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !50
-  store i64 %array.sroa.0.0, i64* %13, align 8, !dbg !50, !tbaa !6
-  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !50
-  store i64* %14, i64** %11, align 8, !dbg !50
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.5, i64 0), !dbg !50
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %10, align 8, !dbg !50, !tbaa !15
-  ret i64 %send, !dbg !51
+  %array.sroa.0.1 = phi i64 [ %rawArg_array, %fillFromArgBlock0 ], [ 8, %functionEntryInitializers ], !dbg !48
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %10, align 8, !tbaa !15
+  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !49
+  %12 = load i64*, i64** %11, align 8, !dbg !49
+  store i64 %4, i64* %12, align 8, !dbg !49, !tbaa !6
+  %13 = getelementptr inbounds i64, i64* %12, i64 1, !dbg !49
+  store i64 %array.sroa.0.1, i64* %13, align 8, !dbg !49, !tbaa !6
+  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !49
+  store i64* %14, i64** %11, align 8, !dbg !49
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.5, i64 0), !dbg !49
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %10, align 8, !dbg !49, !tbaa !15
+  ret i64 %send, !dbg !50
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$152$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !52 {
+define internal i64 @"func_<root>.<static-init>$152$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !51 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -484,107 +487,107 @@ functionEntryInitializers:
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %10, align 8, !tbaa !15
-  %arrayExpansionSizeGuard = icmp eq i32 %argc, 1, !dbg !53
-  br i1 %arrayExpansionSizeGuard, label %argArrayExpandArrayTest, label %fillRequiredArgs, !dbg !53
+  %arrayExpansionSizeGuard = icmp eq i32 %argc, 1, !dbg !52
+  br i1 %arrayExpansionSizeGuard, label %argArrayExpandArrayTest, label %fillRequiredArgs, !dbg !52
 
 argArrayExpandArrayTest:                          ; preds = %functionEntryInitializers
-  %arg1_maybeExpandToFullArgs = load i64, i64* %argArray, align 8, !dbg !53
-  %11 = and i64 %arg1_maybeExpandToFullArgs, 7, !dbg !53
-  %12 = icmp ne i64 %11, 0, !dbg !53
-  %13 = and i64 %arg1_maybeExpandToFullArgs, -9, !dbg !53
-  %14 = icmp eq i64 %13, 0, !dbg !53
-  %15 = or i1 %12, %14, !dbg !53
-  br i1 %15, label %fillFromDefaultBlockDone2, label %sorbet_isa_Array.exit, !dbg !53
+  %arg1_maybeExpandToFullArgs = load i64, i64* %argArray, align 8, !dbg !52
+  %11 = and i64 %arg1_maybeExpandToFullArgs, 7, !dbg !52
+  %12 = icmp ne i64 %11, 0, !dbg !52
+  %13 = and i64 %arg1_maybeExpandToFullArgs, -9, !dbg !52
+  %14 = icmp eq i64 %13, 0, !dbg !52
+  %15 = or i1 %12, %14, !dbg !52
+  br i1 %15, label %fillFromDefaultBlockDone2, label %sorbet_isa_Array.exit, !dbg !52
 
 sorbet_isa_Array.exit:                            ; preds = %argArrayExpandArrayTest
-  %16 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !53
-  %17 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %16, i64 0, i32 0, !dbg !53
-  %18 = load i64, i64* %17, align 8, !dbg !53, !tbaa !25
-  %19 = and i64 %18, 31, !dbg !53
-  %20 = icmp eq i64 %19, 7, !dbg !53
-  br i1 %20, label %argArrayExpand, label %fillFromDefaultBlockDone2, !dbg !53
+  %16 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !52
+  %17 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %16, i64 0, i32 0, !dbg !52
+  %18 = load i64, i64* %17, align 8, !dbg !52, !tbaa !25
+  %19 = and i64 %18, 31, !dbg !52
+  %20 = icmp eq i64 %19, 7, !dbg !52
+  br i1 %20, label %argArrayExpand, label %fillFromDefaultBlockDone2, !dbg !52
 
 argArrayExpand:                                   ; preds = %sorbet_isa_Array.exit
-  %21 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !53
-  %22 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %21, i64 0, i32 0, !dbg !53
-  %23 = load i64, i64* %22, align 8, !dbg !53, !tbaa !25
-  %24 = and i64 %23, 33554432, !dbg !53
-  %25 = icmp eq i64 %24, 0, !dbg !53
-  br i1 %25, label %27, label %26, !dbg !53
+  %21 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !52
+  %22 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %21, i64 0, i32 0, !dbg !52
+  %23 = load i64, i64* %22, align 8, !dbg !52, !tbaa !25
+  %24 = and i64 %23, 33554432, !dbg !52
+  %25 = icmp eq i64 %24, 0, !dbg !52
+  br i1 %25, label %27, label %26, !dbg !52
 
 26:                                               ; preds = %argArrayExpand
-  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #12, !dbg !53
-  br label %27, !dbg !53
+  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #12, !dbg !52
+  br label %27, !dbg !52
 
 27:                                               ; preds = %26, %argArrayExpand
-  %28 = load i64, i64* %22, align 8, !dbg !53, !tbaa !25
-  %29 = and i64 %28, 8192, !dbg !53
-  %30 = icmp eq i64 %29, 0, !dbg !53
-  %31 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.RArray*, !dbg !53
-  br i1 %30, label %36, label %32, !dbg !53
+  %28 = load i64, i64* %22, align 8, !dbg !52, !tbaa !25
+  %29 = and i64 %28, 8192, !dbg !52
+  %30 = icmp eq i64 %29, 0, !dbg !52
+  %31 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.RArray*, !dbg !52
+  br i1 %30, label %36, label %32, !dbg !52
 
 32:                                               ; preds = %27
-  %33 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !53
-  %34 = lshr i64 %28, 15, !dbg !53
-  %35 = and i64 %34, 3, !dbg !53
-  br label %rb_array_len.exit, !dbg !53
+  %33 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !52
+  %34 = lshr i64 %28, 15, !dbg !52
+  %35 = and i64 %34, 3, !dbg !52
+  br label %rb_array_len.exit, !dbg !52
 
 36:                                               ; preds = %27
-  %37 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 2, !dbg !53
-  %38 = load i64*, i64** %37, align 8, !dbg !53, !tbaa !27
-  %39 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !53
-  %40 = load i64, i64* %39, align 8, !dbg !53, !tbaa !27
-  br label %rb_array_len.exit, !dbg !53
+  %37 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 2, !dbg !52
+  %38 = load i64*, i64** %37, align 8, !dbg !52, !tbaa !27
+  %39 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !52
+  %40 = load i64, i64* %39, align 8, !dbg !52, !tbaa !27
+  br label %rb_array_len.exit, !dbg !52
 
 rb_array_len.exit:                                ; preds = %32, %36
   %41 = phi i64* [ %33, %32 ], [ %38, %36 ]
-  %42 = phi i64 [ %35, %32 ], [ %40, %36 ], !dbg !53
-  %43 = trunc i64 %42 to i32, !dbg !53
-  br label %fillRequiredArgs, !dbg !53
+  %42 = phi i64 [ %35, %32 ], [ %40, %36 ], !dbg !52
+  %43 = trunc i64 %42 to i32, !dbg !52
+  br label %fillRequiredArgs, !dbg !52
 
 fillFromArgBlock0:                                ; preds = %fillRequiredArgs
-  %rawArg_x = load i64, i64* %argArrayPhi, align 8, !dbg !53
-  %default1 = icmp eq i32 %argcPhi, 1, !dbg !53
-  br i1 %default1, label %fillFromDefaultBlockDone2, label %fillFromArgBlock1, !dbg !53, !prof !28
+  %rawArg_x = load i64, i64* %argArrayPhi, align 8, !dbg !52
+  %default1 = icmp eq i32 %argcPhi, 1, !dbg !52
+  br i1 %default1, label %fillFromDefaultBlockDone2, label %fillFromArgBlock1, !dbg !52, !prof !28
 
 fillFromArgBlock1:                                ; preds = %fillFromArgBlock0
-  %44 = getelementptr i64, i64* %argArrayPhi, i32 1, !dbg !53
-  %rawArg_y = load i64, i64* %44, align 8, !dbg !53
-  br label %fillFromDefaultBlockDone2, !dbg !53
+  %44 = getelementptr i64, i64* %argArrayPhi, i32 1, !dbg !52
+  %rawArg_y = load i64, i64* %44, align 8, !dbg !52
+  br label %fillFromDefaultBlockDone2, !dbg !52
 
 fillFromDefaultBlockDone2:                        ; preds = %argArrayExpandArrayTest, %sorbet_isa_Array.exit, %fillFromArgBlock0, %fillRequiredArgs, %fillFromArgBlock1
-  %y.sroa.0.0 = phi i64 [ %rawArg_y, %fillFromArgBlock1 ], [ 8, %fillRequiredArgs ], [ 8, %fillFromArgBlock0 ], [ 8, %sorbet_isa_Array.exit ], [ 8, %argArrayExpandArrayTest ], !dbg !53
-  %x.sroa.0.1 = phi i64 [ %rawArg_x, %fillFromArgBlock1 ], [ %rawArg_x, %fillFromArgBlock0 ], [ 8, %fillRequiredArgs ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ], !dbg !53
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %10, align 8, !dbg !54, !tbaa !15
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !55
-  %46 = load i64*, i64** %45, align 8, !dbg !55
-  store i64 %4, i64* %46, align 8, !dbg !55, !tbaa !6
-  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !55
-  store i64 %x.sroa.0.1, i64* %47, align 8, !dbg !55, !tbaa !6
-  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !55
-  store i64* %48, i64** %45, align 8, !dbg !55
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.8, i64 0), !dbg !55
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %10, align 8, !dbg !55, !tbaa !15
-  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !56
-  %50 = load i64*, i64** %49, align 8, !dbg !56
-  store i64 %4, i64* %50, align 8, !dbg !56, !tbaa !6
-  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !56
-  store i64 %y.sroa.0.0, i64* %51, align 8, !dbg !56, !tbaa !6
-  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !56
-  store i64* %52, i64** %49, align 8, !dbg !56
-  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.9, i64 0), !dbg !56
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %10, align 8, !dbg !56, !tbaa !15
-  ret i64 %send38, !dbg !57
+  %y.sroa.0.1 = phi i64 [ %rawArg_y, %fillFromArgBlock1 ], [ 8, %fillRequiredArgs ], [ 8, %fillFromArgBlock0 ], [ 8, %sorbet_isa_Array.exit ], [ 8, %argArrayExpandArrayTest ], !dbg !52
+  %x.sroa.0.2 = phi i64 [ %rawArg_x, %fillFromArgBlock1 ], [ %rawArg_x, %fillFromArgBlock0 ], [ 8, %fillRequiredArgs ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ], !dbg !52
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %10, align 8, !tbaa !15
+  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !53
+  %46 = load i64*, i64** %45, align 8, !dbg !53
+  store i64 %4, i64* %46, align 8, !dbg !53, !tbaa !6
+  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !53
+  store i64 %x.sroa.0.2, i64* %47, align 8, !dbg !53, !tbaa !6
+  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !53
+  store i64* %48, i64** %45, align 8, !dbg !53
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.8, i64 0), !dbg !53
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %10, align 8, !dbg !53, !tbaa !15
+  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !54
+  %50 = load i64*, i64** %49, align 8, !dbg !54
+  store i64 %4, i64* %50, align 8, !dbg !54, !tbaa !6
+  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !54
+  store i64 %y.sroa.0.1, i64* %51, align 8, !dbg !54, !tbaa !6
+  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !54
+  store i64* %52, i64** %49, align 8, !dbg !54
+  %send51 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.9, i64 0), !dbg !54
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %10, align 8, !dbg !54, !tbaa !15
+  ret i64 %send51, !dbg !55
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers, %rb_array_len.exit
-  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %43, %rb_array_len.exit ], !dbg !53
-  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %41, %rb_array_len.exit ], !dbg !53
-  %default0 = icmp eq i32 %argcPhi, 0, !dbg !53
-  br i1 %default0, label %fillFromDefaultBlockDone2, label %fillFromArgBlock0, !dbg !53, !prof !28
+  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %43, %rb_array_len.exit ], !dbg !52
+  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %41, %rb_array_len.exit ], !dbg !52
+  %default0 = icmp eq i32 %argcPhi, 0, !dbg !52
+  br i1 %default0, label %fillFromDefaultBlockDone2, label %fillFromArgBlock0, !dbg !52, !prof !28
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.<static-init>$152$block_5"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !58 {
+define internal i64 @"func_<root>.<static-init>$152$block_5"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !56 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -601,103 +604,103 @@ functionEntryInitializers:
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %10, align 8, !tbaa !15
-  %arrayExpansionSizeGuard = icmp eq i32 %argc, 1, !dbg !59
-  br i1 %arrayExpansionSizeGuard, label %argArrayExpandArrayTest, label %fillRequiredArgs, !dbg !59
+  %arrayExpansionSizeGuard = icmp eq i32 %argc, 1, !dbg !57
+  br i1 %arrayExpansionSizeGuard, label %argArrayExpandArrayTest, label %fillRequiredArgs, !dbg !57
 
 argArrayExpandArrayTest:                          ; preds = %functionEntryInitializers
-  %arg1_maybeExpandToFullArgs = load i64, i64* %argArray, align 8, !dbg !59
-  %11 = and i64 %arg1_maybeExpandToFullArgs, 7, !dbg !59
-  %12 = icmp ne i64 %11, 0, !dbg !59
-  %13 = and i64 %arg1_maybeExpandToFullArgs, -9, !dbg !59
-  %14 = icmp eq i64 %13, 0, !dbg !59
-  %15 = or i1 %12, %14, !dbg !59
-  br i1 %15, label %fillFromDefaultBlockDone2, label %sorbet_isa_Array.exit, !dbg !59
+  %arg1_maybeExpandToFullArgs = load i64, i64* %argArray, align 8, !dbg !57
+  %11 = and i64 %arg1_maybeExpandToFullArgs, 7, !dbg !57
+  %12 = icmp ne i64 %11, 0, !dbg !57
+  %13 = and i64 %arg1_maybeExpandToFullArgs, -9, !dbg !57
+  %14 = icmp eq i64 %13, 0, !dbg !57
+  %15 = or i1 %12, %14, !dbg !57
+  br i1 %15, label %fillFromDefaultBlockDone2, label %sorbet_isa_Array.exit, !dbg !57
 
 sorbet_isa_Array.exit:                            ; preds = %argArrayExpandArrayTest
-  %16 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !59
-  %17 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %16, i64 0, i32 0, !dbg !59
-  %18 = load i64, i64* %17, align 8, !dbg !59, !tbaa !25
-  %19 = and i64 %18, 31, !dbg !59
-  %20 = icmp eq i64 %19, 7, !dbg !59
-  br i1 %20, label %argArrayExpand, label %fillFromDefaultBlockDone2, !dbg !59
+  %16 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !57
+  %17 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %16, i64 0, i32 0, !dbg !57
+  %18 = load i64, i64* %17, align 8, !dbg !57, !tbaa !25
+  %19 = and i64 %18, 31, !dbg !57
+  %20 = icmp eq i64 %19, 7, !dbg !57
+  br i1 %20, label %argArrayExpand, label %fillFromDefaultBlockDone2, !dbg !57
 
 argArrayExpand:                                   ; preds = %sorbet_isa_Array.exit
-  %21 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !59
-  %22 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %21, i64 0, i32 0, !dbg !59
-  %23 = load i64, i64* %22, align 8, !dbg !59, !tbaa !25
-  %24 = and i64 %23, 33554432, !dbg !59
-  %25 = icmp eq i64 %24, 0, !dbg !59
-  br i1 %25, label %27, label %26, !dbg !59
+  %21 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !57
+  %22 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %21, i64 0, i32 0, !dbg !57
+  %23 = load i64, i64* %22, align 8, !dbg !57, !tbaa !25
+  %24 = and i64 %23, 33554432, !dbg !57
+  %25 = icmp eq i64 %24, 0, !dbg !57
+  br i1 %25, label %27, label %26, !dbg !57
 
 26:                                               ; preds = %argArrayExpand
-  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #12, !dbg !59
-  br label %27, !dbg !59
+  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #12, !dbg !57
+  br label %27, !dbg !57
 
 27:                                               ; preds = %26, %argArrayExpand
-  %28 = load i64, i64* %22, align 8, !dbg !59, !tbaa !25
-  %29 = and i64 %28, 8192, !dbg !59
-  %30 = icmp eq i64 %29, 0, !dbg !59
-  %31 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.RArray*, !dbg !59
-  br i1 %30, label %36, label %32, !dbg !59
+  %28 = load i64, i64* %22, align 8, !dbg !57, !tbaa !25
+  %29 = and i64 %28, 8192, !dbg !57
+  %30 = icmp eq i64 %29, 0, !dbg !57
+  %31 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.RArray*, !dbg !57
+  br i1 %30, label %36, label %32, !dbg !57
 
 32:                                               ; preds = %27
-  %33 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !59
-  %34 = lshr i64 %28, 15, !dbg !59
-  %35 = and i64 %34, 3, !dbg !59
-  br label %rb_array_len.exit, !dbg !59
+  %33 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !57
+  %34 = lshr i64 %28, 15, !dbg !57
+  %35 = and i64 %34, 3, !dbg !57
+  br label %rb_array_len.exit, !dbg !57
 
 36:                                               ; preds = %27
-  %37 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 2, !dbg !59
-  %38 = load i64*, i64** %37, align 8, !dbg !59, !tbaa !27
-  %39 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !59
-  %40 = load i64, i64* %39, align 8, !dbg !59, !tbaa !27
-  br label %rb_array_len.exit, !dbg !59
+  %37 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 2, !dbg !57
+  %38 = load i64*, i64** %37, align 8, !dbg !57, !tbaa !27
+  %39 = getelementptr inbounds %struct.RArray, %struct.RArray* %31, i64 0, i32 1, i32 0, i32 0, !dbg !57
+  %40 = load i64, i64* %39, align 8, !dbg !57, !tbaa !27
+  br label %rb_array_len.exit, !dbg !57
 
 rb_array_len.exit:                                ; preds = %32, %36
   %41 = phi i64* [ %33, %32 ], [ %38, %36 ]
-  %42 = phi i64 [ %35, %32 ], [ %40, %36 ], !dbg !59
-  %43 = trunc i64 %42 to i32, !dbg !59
-  br label %fillRequiredArgs, !dbg !59
+  %42 = phi i64 [ %35, %32 ], [ %40, %36 ], !dbg !57
+  %43 = trunc i64 %42 to i32, !dbg !57
+  br label %fillRequiredArgs, !dbg !57
 
 fillFromArgBlock0:                                ; preds = %fillRequiredArgs
-  %rawArg_x = load i64, i64* %argArrayPhi, align 8, !dbg !59
-  %default1 = icmp eq i32 %argcPhi, 1, !dbg !59
-  br i1 %default1, label %fillFromDefaultBlockDone2, label %fillFromArgBlock1, !dbg !59, !prof !28
+  %rawArg_x = load i64, i64* %argArrayPhi, align 8, !dbg !57
+  %default1 = icmp eq i32 %argcPhi, 1, !dbg !57
+  br i1 %default1, label %fillFromDefaultBlockDone2, label %fillFromArgBlock1, !dbg !57, !prof !28
 
 fillFromArgBlock1:                                ; preds = %fillFromArgBlock0
-  %44 = getelementptr i64, i64* %argArrayPhi, i32 1, !dbg !59
-  %rawArg_y = load i64, i64* %44, align 8, !dbg !59
-  br label %fillFromDefaultBlockDone2, !dbg !59
+  %44 = getelementptr i64, i64* %argArrayPhi, i32 1, !dbg !57
+  %rawArg_y = load i64, i64* %44, align 8, !dbg !57
+  br label %fillFromDefaultBlockDone2, !dbg !57
 
 fillFromDefaultBlockDone2:                        ; preds = %argArrayExpandArrayTest, %sorbet_isa_Array.exit, %fillFromArgBlock0, %fillRequiredArgs, %fillFromArgBlock1
-  %y.sroa.0.0 = phi i64 [ %rawArg_y, %fillFromArgBlock1 ], [ 8, %fillRequiredArgs ], [ 8, %fillFromArgBlock0 ], [ 8, %sorbet_isa_Array.exit ], [ 8, %argArrayExpandArrayTest ], !dbg !59
-  %x.sroa.0.1 = phi i64 [ %rawArg_x, %fillFromArgBlock1 ], [ %rawArg_x, %fillFromArgBlock0 ], [ 8, %fillRequiredArgs ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ], !dbg !59
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %10, align 8, !dbg !60, !tbaa !15
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !61
-  %46 = load i64*, i64** %45, align 8, !dbg !61
-  store i64 %4, i64* %46, align 8, !dbg !61, !tbaa !6
-  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !61
-  store i64 %x.sroa.0.1, i64* %47, align 8, !dbg !61, !tbaa !6
-  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !61
-  store i64* %48, i64** %45, align 8, !dbg !61
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.12, i64 0), !dbg !61
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %10, align 8, !dbg !61, !tbaa !15
-  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !62
-  %50 = load i64*, i64** %49, align 8, !dbg !62
-  store i64 %4, i64* %50, align 8, !dbg !62, !tbaa !6
-  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !62
-  store i64 %y.sroa.0.0, i64* %51, align 8, !dbg !62, !tbaa !6
-  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !62
-  store i64* %52, i64** %49, align 8, !dbg !62
-  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.13, i64 0), !dbg !62
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %10, align 8, !dbg !62, !tbaa !15
-  ret i64 %send38, !dbg !63
+  %y.sroa.0.1 = phi i64 [ %rawArg_y, %fillFromArgBlock1 ], [ 8, %fillRequiredArgs ], [ 8, %fillFromArgBlock0 ], [ 8, %sorbet_isa_Array.exit ], [ 8, %argArrayExpandArrayTest ], !dbg !57
+  %x.sroa.0.1 = phi i64 [ %rawArg_x, %fillFromArgBlock1 ], [ %rawArg_x, %fillFromArgBlock0 ], [ 8, %fillRequiredArgs ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ], !dbg !57
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %10, align 8, !tbaa !15
+  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !58
+  %46 = load i64*, i64** %45, align 8, !dbg !58
+  store i64 %4, i64* %46, align 8, !dbg !58, !tbaa !6
+  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !58
+  store i64 %x.sroa.0.1, i64* %47, align 8, !dbg !58, !tbaa !6
+  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !58
+  store i64* %48, i64** %45, align 8, !dbg !58
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.12, i64 0), !dbg !58
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %10, align 8, !dbg !58, !tbaa !15
+  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !59
+  %50 = load i64*, i64** %49, align 8, !dbg !59
+  store i64 %4, i64* %50, align 8, !dbg !59, !tbaa !6
+  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !59
+  store i64 %y.sroa.0.1, i64* %51, align 8, !dbg !59, !tbaa !6
+  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !59
+  store i64* %52, i64** %49, align 8, !dbg !59
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.13, i64 0), !dbg !59
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %10, align 8, !dbg !59, !tbaa !15
+  ret i64 %send42, !dbg !60
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers, %rb_array_len.exit
-  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %43, %rb_array_len.exit ], !dbg !59
-  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %41, %rb_array_len.exit ], !dbg !59
-  %default0 = icmp eq i32 %argcPhi, 0, !dbg !59
-  br i1 %default0, label %fillFromDefaultBlockDone2, label %fillFromArgBlock0, !dbg !59, !prof !28
+  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %43, %rb_array_len.exit ], !dbg !57
+  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %41, %rb_array_len.exit ], !dbg !57
+  %default0 = icmp eq i32 %argcPhi, 0, !dbg !57
+  br i1 %default0, label %fillFromDefaultBlockDone2, label %fillFromArgBlock0, !dbg !57, !prof !28
 }
 
 ; Function Attrs: sspreq
@@ -727,749 +730,752 @@ entry:
   store i64 %13, i64* @"rubyIdPrecomputed_+", align 8
   %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #12
   store i64 %14, i64* @rubyIdPrecomputed_p, align 8
-  %15 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
-  tail call void @rb_gc_register_mark_object(i64 %15) #12
-  store i64 %15, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %16 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/block_arg_expand.rb", i64 0, i64 0), i64 noundef 42) #12
-  tail call void @rb_gc_register_mark_object(i64 %16) #12
-  store i64 %16, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #12
+  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_default, i64 0, i64 0), i64 noundef 7) #12
+  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @str_something, i64 0, i64 0), i64 noundef 9) #12
+  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
+  tail call void @rb_gc_register_mark_object(i64 %18) #12
+  store i64 %18, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/block_arg_expand.rb", i64 0, i64 0), i64 noundef 42) #12
+  tail call void @rb_gc_register_mark_object(i64 %19) #12
+  store i64 %19, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 32)
-  %17 = bitcast i64* %locals.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %17)
+  %20 = bitcast i64* %locals.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %20)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
   %"rubyId_<block-call>.i.i" = load i64, i64* @"rubyIdPrecomputed_<block-call>", align 8
   store i64 %"rubyId_<block-call>.i.i", i64* %locals.i.i, align 8
-  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 3)
-  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %17)
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #12
-  call void @rb_gc_register_mark_object(i64 %19) #12
-  store i64 %19, i64* @"rubyStrFrozen_block in <top (required)>", align 8
+  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 3)
+  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %20)
+  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #12
+  call void @rb_gc_register_mark_object(i64 %22) #12
+  store i64 %22, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_1", align 8
+  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_1", align 8
   %stackFrame.i27.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i28.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_block in <top (required)>.i29.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i29.i", i64 %"rubyId_block in <top (required)>.i28.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i27.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_2", align 8
+  %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i29.i", i64 %"rubyId_block in <top (required)>.i28.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i27.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_2", align 8
   %stackFrame.i31.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i32.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_block in <top (required)>.i33.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i34.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %22 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i33.i", i64 %"rubyId_block in <top (required)>.i32.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i34.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i31.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %22, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_3", align 8
+  %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i33.i", i64 %"rubyId_block in <top (required)>.i32.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i34.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i31.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_3", align 8
   %stackFrame.i35.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i36.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_block in <top (required)>.i37.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i38.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i37.i", i64 %"rubyId_block in <top (required)>.i36.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i38.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i35.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_4", align 8
+  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i37.i", i64 %"rubyId_block in <top (required)>.i36.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i38.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i35.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_4", align 8
   %stackFrame.i39.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i40.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_block in <top (required)>.i41.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i42.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i41.i", i64 %"rubyId_block in <top (required)>.i40.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i42.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i39.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_5", align 8
+  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i41.i", i64 %"rubyId_block in <top (required)>.i40.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i42.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i39.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_5", align 8
   %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !30
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
   %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !45
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
-  %rubyId_p7.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !50
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.5, i64 %rubyId_p7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
-  %rubyId_p12.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !55
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.8, i64 %rubyId_p12.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !55
-  %rubyId_p15.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !56
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.9, i64 %rubyId_p15.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !56
-  %rubyId_p20.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !61
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p20.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !61
-  %rubyId_p23.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !62
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p23.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !62
-  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 2
-  %27 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !17
-  %28 = bitcast [3 x i64]* %callArgs.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %28)
+  %rubyId_p7.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !49
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.5, i64 %rubyId_p7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
+  %rubyId_p12.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !53
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.8, i64 %rubyId_p12.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !53
+  %rubyId_p15.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !54
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.9, i64 %rubyId_p15.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !54
+  %rubyId_p20.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !58
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p20.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !58
+  %rubyId_p23.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !59
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p23.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !59
+  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 2
+  %30 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %29, align 8, !tbaa !17
+  %31 = bitcast [3 x i64]* %callArgs.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %31)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152", align 8
-  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !17
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %30, align 8, !tbaa !21
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4
-  %32 = load i64*, i64** %31, align 8, !tbaa !23
-  %33 = load i64, i64* %32, align 8, !tbaa !6
-  %34 = and i64 %33, -33
-  store i64 %34, i64* %32, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %25, %struct.rb_control_frame_struct* %29, %struct.rb_iseq_struct* %stackFrame.i) #12
-  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %35, align 8, !dbg !64, !tbaa !15
-  %callArgs0Addr.i = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i32 0, i64 0, !dbg !65
-  %36 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !65
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %36, align 8, !dbg !65
-  %37 = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i64 0, i64 0, !dbg !65
-  call void @llvm.experimental.noalias.scope.decl(metadata !66) #12, !dbg !65
-  %38 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %37) #12, !dbg !65
-  store i64 %38, i64* %callArgs0Addr.i, align 8, !dbg !69
-  call void @llvm.experimental.noalias.scope.decl(metadata !70) #12, !dbg !69
-  %39 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %37) #12, !dbg !69
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %35, align 8, !dbg !69, !tbaa !15
-  %rubyId_each.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !73
-  %40 = bitcast %struct.sorbet_inlineIntrinsicEnv* %6 to i8*, !dbg !73
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %40) #12, !dbg !73
-  %41 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 0, !dbg !73
-  store i64 %39, i64* %41, align 8, !dbg !73, !tbaa !74
-  %42 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 1, !dbg !73
-  store i64 %rubyId_each.i, i64* %42, align 8, !dbg !73, !tbaa !76
-  %43 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 2, !dbg !73
-  store i32 0, i32* %43, align 8, !dbg !73, !tbaa !77
-  %44 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 3, !dbg !73
-  %45 = bitcast i64** %44 to i8*, !dbg !73
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %45, i8 0, i64 16, i1 false) #12, !dbg !73
-  %46 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !73, !tbaa !15
-  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2, !dbg !73
-  %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !dbg !73, !tbaa !17
-  call void @llvm.experimental.noalias.scope.decl(metadata !78) #12, !dbg !73
-  %49 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$152$block_1", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !73
-  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 3, !dbg !73
-  %51 = bitcast i64* %50 to %struct.rb_captured_block*, !dbg !73
-  %52 = getelementptr inbounds i64, i64* %50, i64 2, !dbg !73
-  %53 = bitcast i64* %52 to %struct.vm_ifunc**, !dbg !73
-  store %struct.vm_ifunc* %49, %struct.vm_ifunc** %53, align 8, !dbg !73, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !81) #12, !dbg !73
-  %54 = ptrtoint %struct.rb_captured_block* %51 to i64, !dbg !73
-  %55 = or i64 %54, 3, !dbg !73
-  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 17, !dbg !73
-  store i64 %55, i64* %56, align 8, !dbg !73, !tbaa !84
-  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !85, !tbaa !15
-  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 17, !dbg !85
-  %59 = load i64, i64* %58, align 8, !dbg !85, !tbaa !84
-  %60 = and i64 %59, -4, !dbg !85
-  %61 = inttoptr i64 %60 to %struct.rb_captured_block*, !dbg !85
-  store i64 0, i64* %58, align 8, !dbg !85, !tbaa !84
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %61) #12, !dbg !85
-  %62 = inttoptr i64 %39 to %struct.iseq_inline_iv_cache_entry*, !dbg !85
-  %63 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %62, i64 0, i32 0, !dbg !85
-  %64 = load i64, i64* %63, align 8, !dbg !85, !tbaa !25
-  %65 = and i64 %64, 8192, !dbg !85
-  %66 = icmp eq i64 %65, 0, !dbg !85
-  br i1 %66, label %70, label %67, !dbg !85
-
-67:                                               ; preds = %entry
-  %68 = lshr i64 %64, 15, !dbg !85
-  %69 = and i64 %68, 3, !dbg !85
-  br label %rb_array_len.exit1.i3.i, !dbg !85
+  %32 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %29, align 8, !tbaa !17
+  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %33, align 8, !tbaa !21
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 4
+  %35 = load i64*, i64** %34, align 8, !tbaa !23
+  %36 = load i64, i64* %35, align 8, !tbaa !6
+  %37 = and i64 %36, -33
+  store i64 %37, i64* %35, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %28, %struct.rb_control_frame_struct* %32, %struct.rb_iseq_struct* %stackFrame.i) #12
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 0
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %38, align 8, !dbg !61, !tbaa !15
+  %callArgs0Addr.i = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i32 0, i64 0, !dbg !62
+  %39 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !62
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %39, align 8, !dbg !62
+  %40 = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i64 0, i64 0, !dbg !62
+  call void @llvm.experimental.noalias.scope.decl(metadata !63) #12, !dbg !62
+  %41 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %40) #12, !dbg !62
+  store i64 %41, i64* %callArgs0Addr.i, align 8, !dbg !66
+  call void @llvm.experimental.noalias.scope.decl(metadata !67) #12, !dbg !66
+  %42 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %40) #12, !dbg !66
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %38, align 8, !dbg !66, !tbaa !15
+  %rubyId_each.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !70
+  %43 = bitcast %struct.sorbet_inlineIntrinsicEnv* %6 to i8*, !dbg !70
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %43) #12, !dbg !70
+  %44 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 0, !dbg !70
+  store i64 %42, i64* %44, align 8, !dbg !70, !tbaa !71
+  %45 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 1, !dbg !70
+  store i64 %rubyId_each.i, i64* %45, align 8, !dbg !70, !tbaa !73
+  %46 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 2, !dbg !70
+  store i32 0, i32* %46, align 8, !dbg !70, !tbaa !74
+  %47 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 3, !dbg !70
+  %48 = bitcast i64** %47 to i8*, !dbg !70
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %48, i8 0, i64 16, i1 false) #12, !dbg !70
+  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !70, !tbaa !15
+  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 2, !dbg !70
+  %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !70, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !75) #12, !dbg !70
+  %52 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$152$block_1", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !70
+  %53 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 3, !dbg !70
+  %54 = bitcast i64* %53 to %struct.rb_captured_block*, !dbg !70
+  %55 = getelementptr inbounds i64, i64* %53, i64 2, !dbg !70
+  %56 = bitcast i64* %55 to %struct.vm_ifunc**, !dbg !70
+  store %struct.vm_ifunc* %52, %struct.vm_ifunc** %56, align 8, !dbg !70, !tbaa !27
+  call void @llvm.experimental.noalias.scope.decl(metadata !78) #12, !dbg !70
+  %57 = ptrtoint %struct.rb_captured_block* %54 to i64, !dbg !70
+  %58 = or i64 %57, 3, !dbg !70
+  %59 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 17, !dbg !70
+  store i64 %58, i64* %59, align 8, !dbg !70, !tbaa !81
+  %60 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !82, !tbaa !15
+  %61 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %60, i64 0, i32 17, !dbg !82
+  %62 = load i64, i64* %61, align 8, !dbg !82, !tbaa !81
+  %63 = and i64 %62, -4, !dbg !82
+  %64 = inttoptr i64 %63 to %struct.rb_captured_block*, !dbg !82
+  store i64 0, i64* %61, align 8, !dbg !82, !tbaa !81
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %64) #12, !dbg !82
+  %65 = inttoptr i64 %42 to %struct.iseq_inline_iv_cache_entry*, !dbg !82
+  %66 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %65, i64 0, i32 0, !dbg !82
+  %67 = load i64, i64* %66, align 8, !dbg !82, !tbaa !25
+  %68 = and i64 %67, 8192, !dbg !82
+  %69 = icmp eq i64 %68, 0, !dbg !82
+  br i1 %69, label %73, label %70, !dbg !82
 
 70:                                               ; preds = %entry
-  %71 = inttoptr i64 %39 to %struct.RArray*, !dbg !85
-  %72 = getelementptr inbounds %struct.RArray, %struct.RArray* %71, i64 0, i32 1, i32 0, i32 0, !dbg !85
-  %73 = load i64, i64* %72, align 8, !dbg !85, !tbaa !27
-  br label %rb_array_len.exit1.i3.i, !dbg !85
+  %71 = lshr i64 %67, 15, !dbg !82
+  %72 = and i64 %71, 3, !dbg !82
+  br label %rb_array_len.exit1.i3.i, !dbg !82
 
-rb_array_len.exit1.i3.i:                          ; preds = %70, %67
-  %74 = phi i64 [ %69, %67 ], [ %73, %70 ], !dbg !85
-  %75 = icmp sgt i64 %74, 0, !dbg !85
-  br i1 %75, label %76, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !85
+73:                                               ; preds = %entry
+  %74 = inttoptr i64 %42 to %struct.RArray*, !dbg !82
+  %75 = getelementptr inbounds %struct.RArray, %struct.RArray* %74, i64 0, i32 1, i32 0, i32 0, !dbg !82
+  %76 = load i64, i64* %75, align 8, !dbg !82, !tbaa !27
+  br label %rb_array_len.exit1.i3.i, !dbg !82
 
-76:                                               ; preds = %rb_array_len.exit1.i3.i
-  %77 = bitcast i64* %1 to i8*, !dbg !85
-  %78 = inttoptr i64 %39 to %struct.RArray*, !dbg !73
-  %79 = getelementptr inbounds %struct.RArray, %struct.RArray* %78, i64 0, i32 1, i32 0, i32 0, !dbg !73
-  %80 = getelementptr inbounds %struct.RArray, %struct.RArray* %78, i64 0, i32 1, i32 0, i32 2, !dbg !73
-  br label %81, !dbg !85
+rb_array_len.exit1.i3.i:                          ; preds = %73, %70
+  %77 = phi i64 [ %72, %70 ], [ %76, %73 ], !dbg !82
+  %78 = icmp sgt i64 %77, 0, !dbg !82
+  br i1 %78, label %79, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !82
 
-81:                                               ; preds = %rb_array_len.exit.i5.i, %76
-  %82 = phi i64 [ 0, %76 ], [ %92, %rb_array_len.exit.i5.i ], !dbg !85
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %77) #12, !dbg !85
-  %83 = load i64, i64* %63, align 8, !dbg !85, !tbaa !25
-  %84 = and i64 %83, 8192, !dbg !85
-  %85 = icmp eq i64 %84, 0, !dbg !85
-  br i1 %85, label %86, label %rb_array_const_ptr_transient.exit.i4.i, !dbg !85
+79:                                               ; preds = %rb_array_len.exit1.i3.i
+  %80 = bitcast i64* %1 to i8*, !dbg !82
+  %81 = inttoptr i64 %42 to %struct.RArray*, !dbg !70
+  %82 = getelementptr inbounds %struct.RArray, %struct.RArray* %81, i64 0, i32 1, i32 0, i32 0, !dbg !70
+  %83 = getelementptr inbounds %struct.RArray, %struct.RArray* %81, i64 0, i32 1, i32 0, i32 2, !dbg !70
+  br label %84, !dbg !82
 
-86:                                               ; preds = %81
-  %87 = load i64*, i64** %80, align 8, !dbg !85, !tbaa !27
-  br label %rb_array_const_ptr_transient.exit.i4.i, !dbg !85
+84:                                               ; preds = %rb_array_len.exit.i5.i, %79
+  %85 = phi i64 [ 0, %79 ], [ %95, %rb_array_len.exit.i5.i ], !dbg !82
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %80) #12, !dbg !82
+  %86 = load i64, i64* %66, align 8, !dbg !82, !tbaa !25
+  %87 = and i64 %86, 8192, !dbg !82
+  %88 = icmp eq i64 %87, 0, !dbg !82
+  br i1 %88, label %89, label %rb_array_const_ptr_transient.exit.i4.i, !dbg !82
 
-rb_array_const_ptr_transient.exit.i4.i:           ; preds = %86, %81
-  %88 = phi i64* [ %87, %86 ], [ %79, %81 ], !dbg !85
-  %89 = getelementptr inbounds i64, i64* %88, i64 %82, !dbg !85
-  %90 = load i64, i64* %89, align 8, !dbg !85, !tbaa !6
-  store i64 %90, i64* %1, align 8, !dbg !85, !tbaa !6
-  %91 = call i64 @"func_<root>.<static-init>$152$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %1, i64 undef) #12, !dbg !85
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %77) #12, !dbg !85
-  %92 = add nuw nsw i64 %82, 1, !dbg !85
-  %93 = load i64, i64* %63, align 8, !dbg !85, !tbaa !25
-  %94 = and i64 %93, 8192, !dbg !85
-  %95 = icmp eq i64 %94, 0, !dbg !85
-  br i1 %95, label %99, label %96, !dbg !85
+89:                                               ; preds = %84
+  %90 = load i64*, i64** %83, align 8, !dbg !82, !tbaa !27
+  br label %rb_array_const_ptr_transient.exit.i4.i, !dbg !82
 
-96:                                               ; preds = %rb_array_const_ptr_transient.exit.i4.i
-  %97 = lshr i64 %93, 15, !dbg !85
-  %98 = and i64 %97, 3, !dbg !85
-  br label %rb_array_len.exit.i5.i, !dbg !85
+rb_array_const_ptr_transient.exit.i4.i:           ; preds = %89, %84
+  %91 = phi i64* [ %90, %89 ], [ %82, %84 ], !dbg !82
+  %92 = getelementptr inbounds i64, i64* %91, i64 %85, !dbg !82
+  %93 = load i64, i64* %92, align 8, !dbg !82, !tbaa !6
+  store i64 %93, i64* %1, align 8, !dbg !82, !tbaa !6
+  %94 = call i64 @"func_<root>.<static-init>$152$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %1, i64 undef) #12, !dbg !82
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %80) #12, !dbg !82
+  %95 = add nuw nsw i64 %85, 1, !dbg !82
+  %96 = load i64, i64* %66, align 8, !dbg !82, !tbaa !25
+  %97 = and i64 %96, 8192, !dbg !82
+  %98 = icmp eq i64 %97, 0, !dbg !82
+  br i1 %98, label %102, label %99, !dbg !82
 
 99:                                               ; preds = %rb_array_const_ptr_transient.exit.i4.i
-  %100 = load i64, i64* %79, align 8, !dbg !85, !tbaa !27
-  br label %rb_array_len.exit.i5.i, !dbg !85
+  %100 = lshr i64 %96, 15, !dbg !82
+  %101 = and i64 %100, 3, !dbg !82
+  br label %rb_array_len.exit.i5.i, !dbg !82
 
-rb_array_len.exit.i5.i:                           ; preds = %99, %96
-  %101 = phi i64 [ %98, %96 ], [ %100, %99 ], !dbg !85
-  %102 = icmp sgt i64 %101, %92, !dbg !85
-  br i1 %102, label %81, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !85, !llvm.loop !87
+102:                                              ; preds = %rb_array_const_ptr_transient.exit.i4.i
+  %103 = load i64, i64* %82, align 8, !dbg !82, !tbaa !27
+  br label %rb_array_len.exit.i5.i, !dbg !82
+
+rb_array_len.exit.i5.i:                           ; preds = %102, %99
+  %104 = phi i64 [ %101, %99 ], [ %103, %102 ], !dbg !82
+  %105 = icmp sgt i64 %104, %95, !dbg !82
+  br i1 %105, label %84, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !82, !llvm.loop !84
 
 forward_sorbet_rb_array_each_withBlock.exit.i:    ; preds = %rb_array_len.exit.i5.i, %rb_array_len.exit1.i3.i
-  call void @sorbet_popFrame() #12, !dbg !85
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %40) #12, !dbg !73
-  %103 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !73, !tbaa !15
-  %104 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 5, !dbg !73
-  %105 = load i32, i32* %104, align 8, !dbg !73, !tbaa !37
-  %106 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 6, !dbg !73
-  %107 = load i32, i32* %106, align 4, !dbg !73, !tbaa !38
-  %108 = xor i32 %107, -1, !dbg !73
-  %109 = and i32 %108, %105, !dbg !73
-  %110 = icmp eq i32 %109, 0, !dbg !73
-  br i1 %110, label %rb_check_arity.1.exit.i8.i, label %111, !dbg !73, !prof !31
+  call void @sorbet_popFrame() #12, !dbg !82
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %43) #12, !dbg !70
+  %106 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !70, !tbaa !15
+  %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 5, !dbg !70
+  %108 = load i32, i32* %107, align 8, !dbg !70, !tbaa !37
+  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 6, !dbg !70
+  %110 = load i32, i32* %109, align 4, !dbg !70, !tbaa !38
+  %111 = xor i32 %110, -1, !dbg !70
+  %112 = and i32 %111, %108, !dbg !70
+  %113 = icmp eq i32 %112, 0, !dbg !70
+  br i1 %113, label %rb_check_arity.1.exit.i8.i, label %114, !dbg !70, !prof !31
 
-111:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.exit.i
-  %112 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 8, !dbg !73
-  %113 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %112, align 8, !dbg !73, !tbaa !39
-  %114 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %113, i32 noundef 0) #12, !dbg !73
-  br label %rb_check_arity.1.exit.i8.i, !dbg !73
+114:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.exit.i
+  %115 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 8, !dbg !70
+  %116 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %115, align 8, !dbg !70, !tbaa !39
+  %117 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %116, i32 noundef 0) #12, !dbg !70
+  br label %rb_check_arity.1.exit.i8.i, !dbg !70
 
-rb_check_arity.1.exit.i8.i:                       ; preds = %111, %forward_sorbet_rb_array_each_withBlock.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %35, align 8, !dbg !73, !tbaa !15
-  %rubyId_each66.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !89
-  %115 = bitcast %struct.sorbet_inlineIntrinsicEnv* %5 to i8*, !dbg !89
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %115) #12, !dbg !89
-  %116 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 0, !dbg !89
-  store i64 %39, i64* %116, align 8, !dbg !89, !tbaa !74
-  %117 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 1, !dbg !89
-  store i64 %rubyId_each66.i, i64* %117, align 8, !dbg !89, !tbaa !76
-  %118 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 2, !dbg !89
-  store i32 0, i32* %118, align 8, !dbg !89, !tbaa !77
-  %119 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 3, !dbg !89
-  %120 = bitcast i64** %119 to i8*, !dbg !89
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %120, i8 0, i64 16, i1 false) #12, !dbg !89
-  %121 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !89, !tbaa !15
-  %122 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %121, i64 0, i32 2, !dbg !89
-  %123 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %122, align 8, !dbg !89, !tbaa !17
-  call void @llvm.experimental.noalias.scope.decl(metadata !90) #12, !dbg !89
-  %124 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$152$block_2", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !89
-  %125 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %123, i64 0, i32 3, !dbg !89
-  %126 = bitcast i64* %125 to %struct.rb_captured_block*, !dbg !89
-  %127 = getelementptr inbounds i64, i64* %125, i64 2, !dbg !89
-  %128 = bitcast i64* %127 to %struct.vm_ifunc**, !dbg !89
-  store %struct.vm_ifunc* %124, %struct.vm_ifunc** %128, align 8, !dbg !89, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !93) #12, !dbg !89
-  %129 = ptrtoint %struct.rb_captured_block* %126 to i64, !dbg !89
-  %130 = or i64 %129, 3, !dbg !89
-  %131 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %121, i64 0, i32 17, !dbg !89
-  store i64 %130, i64* %131, align 8, !dbg !89, !tbaa !84
-  %132 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !96, !tbaa !15
-  %133 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %132, i64 0, i32 17, !dbg !96
-  %134 = load i64, i64* %133, align 8, !dbg !96, !tbaa !84
-  %135 = and i64 %134, -4, !dbg !96
-  %136 = inttoptr i64 %135 to %struct.rb_captured_block*, !dbg !96
-  store i64 0, i64* %133, align 8, !dbg !96, !tbaa !84
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %136) #12, !dbg !96
-  %137 = load i64, i64* %63, align 8, !dbg !96, !tbaa !25
-  %138 = and i64 %137, 8192, !dbg !96
-  %139 = icmp eq i64 %138, 0, !dbg !96
-  br i1 %139, label %143, label %140, !dbg !96
-
-140:                                              ; preds = %rb_check_arity.1.exit.i8.i
-  %141 = lshr i64 %137, 15, !dbg !96
-  %142 = and i64 %141, 3, !dbg !96
-  br label %rb_array_len.exit1.i9.i, !dbg !96
+rb_check_arity.1.exit.i8.i:                       ; preds = %114, %forward_sorbet_rb_array_each_withBlock.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %38, align 8, !dbg !70, !tbaa !15
+  %rubyId_each66.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !86
+  %118 = bitcast %struct.sorbet_inlineIntrinsicEnv* %5 to i8*, !dbg !86
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %118) #12, !dbg !86
+  %119 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 0, !dbg !86
+  store i64 %42, i64* %119, align 8, !dbg !86, !tbaa !71
+  %120 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 1, !dbg !86
+  store i64 %rubyId_each66.i, i64* %120, align 8, !dbg !86, !tbaa !73
+  %121 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 2, !dbg !86
+  store i32 0, i32* %121, align 8, !dbg !86, !tbaa !74
+  %122 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 3, !dbg !86
+  %123 = bitcast i64** %122 to i8*, !dbg !86
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %123, i8 0, i64 16, i1 false) #12, !dbg !86
+  %124 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !15
+  %125 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %124, i64 0, i32 2, !dbg !86
+  %126 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %125, align 8, !dbg !86, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !87) #12, !dbg !86
+  %127 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$152$block_2", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !86
+  %128 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %126, i64 0, i32 3, !dbg !86
+  %129 = bitcast i64* %128 to %struct.rb_captured_block*, !dbg !86
+  %130 = getelementptr inbounds i64, i64* %128, i64 2, !dbg !86
+  %131 = bitcast i64* %130 to %struct.vm_ifunc**, !dbg !86
+  store %struct.vm_ifunc* %127, %struct.vm_ifunc** %131, align 8, !dbg !86, !tbaa !27
+  call void @llvm.experimental.noalias.scope.decl(metadata !90) #12, !dbg !86
+  %132 = ptrtoint %struct.rb_captured_block* %129 to i64, !dbg !86
+  %133 = or i64 %132, 3, !dbg !86
+  %134 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %124, i64 0, i32 17, !dbg !86
+  store i64 %133, i64* %134, align 8, !dbg !86, !tbaa !81
+  %135 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15
+  %136 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %135, i64 0, i32 17, !dbg !93
+  %137 = load i64, i64* %136, align 8, !dbg !93, !tbaa !81
+  %138 = and i64 %137, -4, !dbg !93
+  %139 = inttoptr i64 %138 to %struct.rb_captured_block*, !dbg !93
+  store i64 0, i64* %136, align 8, !dbg !93, !tbaa !81
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %139) #12, !dbg !93
+  %140 = load i64, i64* %66, align 8, !dbg !93, !tbaa !25
+  %141 = and i64 %140, 8192, !dbg !93
+  %142 = icmp eq i64 %141, 0, !dbg !93
+  br i1 %142, label %146, label %143, !dbg !93
 
 143:                                              ; preds = %rb_check_arity.1.exit.i8.i
-  %144 = inttoptr i64 %39 to %struct.RArray*, !dbg !96
-  %145 = getelementptr inbounds %struct.RArray, %struct.RArray* %144, i64 0, i32 1, i32 0, i32 0, !dbg !96
-  %146 = load i64, i64* %145, align 8, !dbg !96, !tbaa !27
-  br label %rb_array_len.exit1.i9.i, !dbg !96
+  %144 = lshr i64 %140, 15, !dbg !93
+  %145 = and i64 %144, 3, !dbg !93
+  br label %rb_array_len.exit1.i9.i, !dbg !93
 
-rb_array_len.exit1.i9.i:                          ; preds = %143, %140
-  %147 = phi i64 [ %142, %140 ], [ %146, %143 ], !dbg !96
-  %148 = icmp sgt i64 %147, 0, !dbg !96
-  br i1 %148, label %149, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !96
+146:                                              ; preds = %rb_check_arity.1.exit.i8.i
+  %147 = inttoptr i64 %42 to %struct.RArray*, !dbg !93
+  %148 = getelementptr inbounds %struct.RArray, %struct.RArray* %147, i64 0, i32 1, i32 0, i32 0, !dbg !93
+  %149 = load i64, i64* %148, align 8, !dbg !93, !tbaa !27
+  br label %rb_array_len.exit1.i9.i, !dbg !93
 
-149:                                              ; preds = %rb_array_len.exit1.i9.i
-  %150 = inttoptr i64 %39 to %struct.RArray*, !dbg !89
-  %151 = getelementptr inbounds %struct.RArray, %struct.RArray* %150, i64 0, i32 1, i32 0, i32 0, !dbg !89
-  %152 = getelementptr inbounds %struct.RArray, %struct.RArray* %150, i64 0, i32 1, i32 0, i32 2, !dbg !89
-  br label %153, !dbg !96
+rb_array_len.exit1.i9.i:                          ; preds = %146, %143
+  %150 = phi i64 [ %145, %143 ], [ %149, %146 ], !dbg !93
+  %151 = icmp sgt i64 %150, 0, !dbg !93
+  br i1 %151, label %152, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !93
 
-153:                                              ; preds = %rb_array_len.exit.i11.i, %149
-  %154 = phi i64 [ 0, %149 ], [ %178, %rb_array_len.exit.i11.i ], !dbg !96
-  %155 = load i64, i64* %63, align 8, !dbg !96, !tbaa !25
-  %156 = and i64 %155, 8192, !dbg !96
-  %157 = icmp eq i64 %156, 0, !dbg !96
-  br i1 %157, label %158, label %rb_array_const_ptr_transient.exit.i10.i, !dbg !96
+152:                                              ; preds = %rb_array_len.exit1.i9.i
+  %153 = inttoptr i64 %42 to %struct.RArray*, !dbg !86
+  %154 = getelementptr inbounds %struct.RArray, %struct.RArray* %153, i64 0, i32 1, i32 0, i32 0, !dbg !86
+  %155 = getelementptr inbounds %struct.RArray, %struct.RArray* %153, i64 0, i32 1, i32 0, i32 2, !dbg !86
+  br label %156, !dbg !93
 
-158:                                              ; preds = %153
-  %159 = load i64*, i64** %152, align 8, !dbg !96, !tbaa !27
-  br label %rb_array_const_ptr_transient.exit.i10.i, !dbg !96
+156:                                              ; preds = %rb_array_len.exit.i11.i, %152
+  %157 = phi i64 [ 0, %152 ], [ %181, %rb_array_len.exit.i11.i ], !dbg !93
+  %158 = load i64, i64* %66, align 8, !dbg !93, !tbaa !25
+  %159 = and i64 %158, 8192, !dbg !93
+  %160 = icmp eq i64 %159, 0, !dbg !93
+  br i1 %160, label %161, label %rb_array_const_ptr_transient.exit.i10.i, !dbg !93
 
-rb_array_const_ptr_transient.exit.i10.i:          ; preds = %158, %153
-  %160 = phi i64* [ %159, %158 ], [ %151, %153 ], !dbg !96
-  %161 = getelementptr inbounds i64, i64* %160, i64 %154, !dbg !96
-  %162 = load i64, i64* %161, align 8, !dbg !96, !tbaa !6
-  call void @llvm.experimental.noalias.scope.decl(metadata !98) #12, !dbg !96
-  %163 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !89, !tbaa !15, !noalias !98
-  %164 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %163, i64 0, i32 2, !dbg !89
-  %165 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %164, align 8, !dbg !89, !tbaa !17, !noalias !98
-  %166 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 3, !dbg !89
-  %167 = load i64, i64* %166, align 8, !dbg !89, !tbaa !42, !noalias !98
-  %stackFrame.i.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_2", align 8, !dbg !89, !noalias !98
-  %168 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 2, !dbg !89
-  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %168, align 8, !dbg !89, !tbaa !21, !noalias !98
-  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 4, !dbg !89
-  %170 = load i64*, i64** %169, align 8, !dbg !89, !tbaa !23, !noalias !98
-  %171 = load i64, i64* %170, align 8, !dbg !89, !tbaa !6, !noalias !98
-  %172 = and i64 %171, -129, !dbg !89
-  store i64 %172, i64* %170, align 8, !dbg !89, !tbaa !6, !noalias !98
-  %173 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 0, !dbg !89
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %173, align 8, !dbg !101, !tbaa !15, !noalias !98
-  %174 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 1, !dbg !103
-  %175 = load i64*, i64** %174, align 8, !dbg !103
-  store i64 %167, i64* %175, align 8, !dbg !103, !tbaa !6
-  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !103
-  store i64 %162, i64* %176, align 8, !dbg !103, !tbaa !6
-  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !103
-  store i64* %177, i64** %174, align 8, !dbg !103
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !103
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %173, align 8, !dbg !103, !tbaa !15, !noalias !98
-  %178 = add nuw nsw i64 %154, 1, !dbg !96
-  %179 = load i64, i64* %63, align 8, !dbg !96, !tbaa !25
-  %180 = and i64 %179, 8192, !dbg !96
-  %181 = icmp eq i64 %180, 0, !dbg !96
-  br i1 %181, label %185, label %182, !dbg !96
+161:                                              ; preds = %156
+  %162 = load i64*, i64** %155, align 8, !dbg !93, !tbaa !27
+  br label %rb_array_const_ptr_transient.exit.i10.i, !dbg !93
 
-182:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
-  %183 = lshr i64 %179, 15, !dbg !96
-  %184 = and i64 %183, 3, !dbg !96
-  br label %rb_array_len.exit.i11.i, !dbg !96
+rb_array_const_ptr_transient.exit.i10.i:          ; preds = %161, %156
+  %163 = phi i64* [ %162, %161 ], [ %154, %156 ], !dbg !93
+  %164 = getelementptr inbounds i64, i64* %163, i64 %157, !dbg !93
+  %165 = load i64, i64* %164, align 8, !dbg !93, !tbaa !6
+  call void @llvm.experimental.noalias.scope.decl(metadata !95) #12, !dbg !93
+  %166 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !15, !noalias !95
+  %167 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 2, !dbg !86
+  %168 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %167, align 8, !dbg !86, !tbaa !17, !noalias !95
+  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 3, !dbg !86
+  %170 = load i64, i64* %169, align 8, !dbg !86, !tbaa !42, !noalias !95
+  %stackFrame.i.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_2", align 8, !dbg !86, !noalias !95
+  %171 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 2, !dbg !86
+  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %171, align 8, !dbg !86, !tbaa !21, !noalias !95
+  %172 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 4, !dbg !86
+  %173 = load i64*, i64** %172, align 8, !dbg !86, !tbaa !23, !noalias !95
+  %174 = load i64, i64* %173, align 8, !dbg !86, !tbaa !6, !noalias !95
+  %175 = and i64 %174, -129, !dbg !86
+  store i64 %175, i64* %173, align 8, !dbg !86, !tbaa !6, !noalias !95
+  %176 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 0, !dbg !86
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %176, align 8, !dbg !98, !tbaa !15, !noalias !95
+  %177 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 1, !dbg !100
+  %178 = load i64*, i64** %177, align 8, !dbg !100
+  store i64 %170, i64* %178, align 8, !dbg !100, !tbaa !6
+  %179 = getelementptr inbounds i64, i64* %178, i64 1, !dbg !100
+  store i64 %165, i64* %179, align 8, !dbg !100, !tbaa !6
+  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !100
+  store i64* %180, i64** %177, align 8, !dbg !100
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !100
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %176, align 8, !dbg !100, !tbaa !15, !noalias !95
+  %181 = add nuw nsw i64 %157, 1, !dbg !93
+  %182 = load i64, i64* %66, align 8, !dbg !93, !tbaa !25
+  %183 = and i64 %182, 8192, !dbg !93
+  %184 = icmp eq i64 %183, 0, !dbg !93
+  br i1 %184, label %188, label %185, !dbg !93
 
 185:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
-  %186 = load i64, i64* %151, align 8, !dbg !96, !tbaa !27
-  br label %rb_array_len.exit.i11.i, !dbg !96
+  %186 = lshr i64 %182, 15, !dbg !93
+  %187 = and i64 %186, 3, !dbg !93
+  br label %rb_array_len.exit.i11.i, !dbg !93
 
-rb_array_len.exit.i11.i:                          ; preds = %185, %182
-  %187 = phi i64 [ %184, %182 ], [ %186, %185 ], !dbg !96
-  %188 = icmp sgt i64 %187, %178, !dbg !96
-  br i1 %188, label %153, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !96, !llvm.loop !104
+188:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
+  %189 = load i64, i64* %154, align 8, !dbg !93, !tbaa !27
+  br label %rb_array_len.exit.i11.i, !dbg !93
+
+rb_array_len.exit.i11.i:                          ; preds = %188, %185
+  %190 = phi i64 [ %187, %185 ], [ %189, %188 ], !dbg !93
+  %191 = icmp sgt i64 %190, %181, !dbg !93
+  br i1 %191, label %156, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !93, !llvm.loop !101
 
 forward_sorbet_rb_array_each_withBlock.1.exit.i:  ; preds = %rb_array_len.exit.i11.i, %rb_array_len.exit1.i9.i
-  call void @sorbet_popFrame() #12, !dbg !96
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %115) #12, !dbg !89
-  %189 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !89, !tbaa !15
-  %190 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %189, i64 0, i32 5, !dbg !89
-  %191 = load i32, i32* %190, align 8, !dbg !89, !tbaa !37
-  %192 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %189, i64 0, i32 6, !dbg !89
-  %193 = load i32, i32* %192, align 4, !dbg !89, !tbaa !38
-  %194 = xor i32 %193, -1, !dbg !89
-  %195 = and i32 %194, %191, !dbg !89
-  %196 = icmp eq i32 %195, 0, !dbg !89
-  br i1 %196, label %rb_check_arity.1.exit.i14.i, label %197, !dbg !89, !prof !31
+  call void @sorbet_popFrame() #12, !dbg !93
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %118) #12, !dbg !86
+  %192 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !15
+  %193 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %192, i64 0, i32 5, !dbg !86
+  %194 = load i32, i32* %193, align 8, !dbg !86, !tbaa !37
+  %195 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %192, i64 0, i32 6, !dbg !86
+  %196 = load i32, i32* %195, align 4, !dbg !86, !tbaa !38
+  %197 = xor i32 %196, -1, !dbg !86
+  %198 = and i32 %197, %194, !dbg !86
+  %199 = icmp eq i32 %198, 0, !dbg !86
+  br i1 %199, label %rb_check_arity.1.exit.i14.i, label %200, !dbg !86, !prof !31
 
-197:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.1.exit.i
-  %198 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %189, i64 0, i32 8, !dbg !89
-  %199 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %198, align 8, !dbg !89, !tbaa !39
-  %200 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %199, i32 noundef 0) #12, !dbg !89
-  br label %rb_check_arity.1.exit.i14.i, !dbg !89
+200:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.1.exit.i
+  %201 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %192, i64 0, i32 8, !dbg !86
+  %202 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %201, align 8, !dbg !86, !tbaa !39
+  %203 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %202, i32 noundef 0) #12, !dbg !86
+  br label %rb_check_arity.1.exit.i14.i, !dbg !86
 
-rb_check_arity.1.exit.i14.i:                      ; preds = %197, %forward_sorbet_rb_array_each_withBlock.1.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %35, align 8, !dbg !89, !tbaa !15
-  %rubyId_each78.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !105
-  %201 = bitcast %struct.sorbet_inlineIntrinsicEnv* %4 to i8*, !dbg !105
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %201) #12, !dbg !105
-  %202 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 0, !dbg !105
-  store i64 %39, i64* %202, align 8, !dbg !105, !tbaa !74
-  %203 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 1, !dbg !105
-  store i64 %rubyId_each78.i, i64* %203, align 8, !dbg !105, !tbaa !76
-  %204 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 2, !dbg !105
-  store i32 0, i32* %204, align 8, !dbg !105, !tbaa !77
-  %205 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 3, !dbg !105
-  %206 = bitcast i64** %205 to i8*, !dbg !105
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %206, i8 0, i64 16, i1 false) #12, !dbg !105
-  %207 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !105, !tbaa !15
-  %208 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %207, i64 0, i32 2, !dbg !105
-  %209 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %208, align 8, !dbg !105, !tbaa !17
-  call void @llvm.experimental.noalias.scope.decl(metadata !106) #12, !dbg !105
-  %210 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$152$block_3", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !105
-  %211 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %209, i64 0, i32 3, !dbg !105
-  %212 = bitcast i64* %211 to %struct.rb_captured_block*, !dbg !105
-  %213 = getelementptr inbounds i64, i64* %211, i64 2, !dbg !105
-  %214 = bitcast i64* %213 to %struct.vm_ifunc**, !dbg !105
-  store %struct.vm_ifunc* %210, %struct.vm_ifunc** %214, align 8, !dbg !105, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !109) #12, !dbg !105
-  %215 = ptrtoint %struct.rb_captured_block* %212 to i64, !dbg !105
-  %216 = or i64 %215, 3, !dbg !105
-  %217 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %207, i64 0, i32 17, !dbg !105
-  store i64 %216, i64* %217, align 8, !dbg !105, !tbaa !84
-  %218 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !112, !tbaa !15
-  %219 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %218, i64 0, i32 17, !dbg !112
-  %220 = load i64, i64* %219, align 8, !dbg !112, !tbaa !84
-  %221 = and i64 %220, -4, !dbg !112
-  %222 = inttoptr i64 %221 to %struct.rb_captured_block*, !dbg !112
-  store i64 0, i64* %219, align 8, !dbg !112, !tbaa !84
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %222) #12, !dbg !112
-  %223 = load i64, i64* %63, align 8, !dbg !112, !tbaa !25
-  %224 = and i64 %223, 8192, !dbg !112
-  %225 = icmp eq i64 %224, 0, !dbg !112
-  br i1 %225, label %229, label %226, !dbg !112
-
-226:                                              ; preds = %rb_check_arity.1.exit.i14.i
-  %227 = lshr i64 %223, 15, !dbg !112
-  %228 = and i64 %227, 3, !dbg !112
-  br label %rb_array_len.exit1.i15.i, !dbg !112
+rb_check_arity.1.exit.i14.i:                      ; preds = %200, %forward_sorbet_rb_array_each_withBlock.1.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %38, align 8, !dbg !86, !tbaa !15
+  %rubyId_each78.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !102
+  %204 = bitcast %struct.sorbet_inlineIntrinsicEnv* %4 to i8*, !dbg !102
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %204) #12, !dbg !102
+  %205 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 0, !dbg !102
+  store i64 %42, i64* %205, align 8, !dbg !102, !tbaa !71
+  %206 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 1, !dbg !102
+  store i64 %rubyId_each78.i, i64* %206, align 8, !dbg !102, !tbaa !73
+  %207 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 2, !dbg !102
+  store i32 0, i32* %207, align 8, !dbg !102, !tbaa !74
+  %208 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 3, !dbg !102
+  %209 = bitcast i64** %208 to i8*, !dbg !102
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %209, i8 0, i64 16, i1 false) #12, !dbg !102
+  %210 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !102, !tbaa !15
+  %211 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %210, i64 0, i32 2, !dbg !102
+  %212 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %211, align 8, !dbg !102, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !103) #12, !dbg !102
+  %213 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$152$block_3", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !102
+  %214 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %212, i64 0, i32 3, !dbg !102
+  %215 = bitcast i64* %214 to %struct.rb_captured_block*, !dbg !102
+  %216 = getelementptr inbounds i64, i64* %214, i64 2, !dbg !102
+  %217 = bitcast i64* %216 to %struct.vm_ifunc**, !dbg !102
+  store %struct.vm_ifunc* %213, %struct.vm_ifunc** %217, align 8, !dbg !102, !tbaa !27
+  call void @llvm.experimental.noalias.scope.decl(metadata !106) #12, !dbg !102
+  %218 = ptrtoint %struct.rb_captured_block* %215 to i64, !dbg !102
+  %219 = or i64 %218, 3, !dbg !102
+  %220 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %210, i64 0, i32 17, !dbg !102
+  store i64 %219, i64* %220, align 8, !dbg !102, !tbaa !81
+  %221 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !109, !tbaa !15
+  %222 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %221, i64 0, i32 17, !dbg !109
+  %223 = load i64, i64* %222, align 8, !dbg !109, !tbaa !81
+  %224 = and i64 %223, -4, !dbg !109
+  %225 = inttoptr i64 %224 to %struct.rb_captured_block*, !dbg !109
+  store i64 0, i64* %222, align 8, !dbg !109, !tbaa !81
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %225) #12, !dbg !109
+  %226 = load i64, i64* %66, align 8, !dbg !109, !tbaa !25
+  %227 = and i64 %226, 8192, !dbg !109
+  %228 = icmp eq i64 %227, 0, !dbg !109
+  br i1 %228, label %232, label %229, !dbg !109
 
 229:                                              ; preds = %rb_check_arity.1.exit.i14.i
-  %230 = inttoptr i64 %39 to %struct.RArray*, !dbg !112
-  %231 = getelementptr inbounds %struct.RArray, %struct.RArray* %230, i64 0, i32 1, i32 0, i32 0, !dbg !112
-  %232 = load i64, i64* %231, align 8, !dbg !112, !tbaa !27
-  br label %rb_array_len.exit1.i15.i, !dbg !112
+  %230 = lshr i64 %226, 15, !dbg !109
+  %231 = and i64 %230, 3, !dbg !109
+  br label %rb_array_len.exit1.i15.i, !dbg !109
 
-rb_array_len.exit1.i15.i:                         ; preds = %229, %226
-  %233 = phi i64 [ %228, %226 ], [ %232, %229 ], !dbg !112
-  %234 = icmp sgt i64 %233, 0, !dbg !112
-  br i1 %234, label %235, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !112
+232:                                              ; preds = %rb_check_arity.1.exit.i14.i
+  %233 = inttoptr i64 %42 to %struct.RArray*, !dbg !109
+  %234 = getelementptr inbounds %struct.RArray, %struct.RArray* %233, i64 0, i32 1, i32 0, i32 0, !dbg !109
+  %235 = load i64, i64* %234, align 8, !dbg !109, !tbaa !27
+  br label %rb_array_len.exit1.i15.i, !dbg !109
 
-235:                                              ; preds = %rb_array_len.exit1.i15.i
-  %236 = inttoptr i64 %39 to %struct.RArray*, !dbg !105
-  %237 = getelementptr inbounds %struct.RArray, %struct.RArray* %236, i64 0, i32 1, i32 0, i32 0, !dbg !105
-  %238 = getelementptr inbounds %struct.RArray, %struct.RArray* %236, i64 0, i32 1, i32 0, i32 2, !dbg !105
-  br label %239, !dbg !112
+rb_array_len.exit1.i15.i:                         ; preds = %232, %229
+  %236 = phi i64 [ %231, %229 ], [ %235, %232 ], !dbg !109
+  %237 = icmp sgt i64 %236, 0, !dbg !109
+  br i1 %237, label %238, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !109
 
-239:                                              ; preds = %rb_array_len.exit.i18.i, %235
-  %240 = phi i64 [ 0, %235 ], [ %264, %rb_array_len.exit.i18.i ], !dbg !112
-  %241 = load i64, i64* %63, align 8, !dbg !112, !tbaa !25
-  %242 = and i64 %241, 8192, !dbg !112
-  %243 = icmp eq i64 %242, 0, !dbg !112
-  br i1 %243, label %244, label %rb_array_const_ptr_transient.exit.i17.i, !dbg !112
+238:                                              ; preds = %rb_array_len.exit1.i15.i
+  %239 = inttoptr i64 %42 to %struct.RArray*, !dbg !102
+  %240 = getelementptr inbounds %struct.RArray, %struct.RArray* %239, i64 0, i32 1, i32 0, i32 0, !dbg !102
+  %241 = getelementptr inbounds %struct.RArray, %struct.RArray* %239, i64 0, i32 1, i32 0, i32 2, !dbg !102
+  br label %242, !dbg !109
 
-244:                                              ; preds = %239
-  %245 = load i64*, i64** %238, align 8, !dbg !112, !tbaa !27
-  br label %rb_array_const_ptr_transient.exit.i17.i, !dbg !112
+242:                                              ; preds = %rb_array_len.exit.i18.i, %238
+  %243 = phi i64 [ 0, %238 ], [ %267, %rb_array_len.exit.i18.i ], !dbg !109
+  %244 = load i64, i64* %66, align 8, !dbg !109, !tbaa !25
+  %245 = and i64 %244, 8192, !dbg !109
+  %246 = icmp eq i64 %245, 0, !dbg !109
+  br i1 %246, label %247, label %rb_array_const_ptr_transient.exit.i17.i, !dbg !109
 
-rb_array_const_ptr_transient.exit.i17.i:          ; preds = %244, %239
-  %246 = phi i64* [ %245, %244 ], [ %237, %239 ], !dbg !112
-  %247 = getelementptr inbounds i64, i64* %246, i64 %240, !dbg !112
-  %248 = load i64, i64* %247, align 8, !dbg !112, !tbaa !6
-  call void @llvm.experimental.noalias.scope.decl(metadata !114) #12, !dbg !112
-  %249 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !105, !tbaa !15, !noalias !114
-  %250 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %249, i64 0, i32 2, !dbg !105
-  %251 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %250, align 8, !dbg !105, !tbaa !17, !noalias !114
-  %252 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 3, !dbg !105
-  %253 = load i64, i64* %252, align 8, !dbg !105, !tbaa !42, !noalias !114
-  %stackFrame.i.i16.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_3", align 8, !dbg !105, !noalias !114
-  %254 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 2, !dbg !105
-  store %struct.rb_iseq_struct* %stackFrame.i.i16.i, %struct.rb_iseq_struct** %254, align 8, !dbg !105, !tbaa !21, !noalias !114
-  %255 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 4, !dbg !105
-  %256 = load i64*, i64** %255, align 8, !dbg !105, !tbaa !23, !noalias !114
-  %257 = load i64, i64* %256, align 8, !dbg !105, !tbaa !6, !noalias !114
-  %258 = and i64 %257, -129, !dbg !105
-  store i64 %258, i64* %256, align 8, !dbg !105, !tbaa !6, !noalias !114
-  %259 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 0, !dbg !105
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %259, align 8, !dbg !117, !tbaa !15, !noalias !114
-  %260 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %251, i64 0, i32 1, !dbg !119
-  %261 = load i64*, i64** %260, align 8, !dbg !119
-  store i64 %253, i64* %261, align 8, !dbg !119, !tbaa !6
-  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !119
-  store i64 %248, i64* %262, align 8, !dbg !119, !tbaa !6
-  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !119
-  store i64* %263, i64** %260, align 8, !dbg !119
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.5, i64 0), !dbg !119
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %259, align 8, !dbg !119, !tbaa !15, !noalias !114
-  %264 = add nuw nsw i64 %240, 1, !dbg !112
-  %265 = load i64, i64* %63, align 8, !dbg !112, !tbaa !25
-  %266 = and i64 %265, 8192, !dbg !112
-  %267 = icmp eq i64 %266, 0, !dbg !112
-  br i1 %267, label %271, label %268, !dbg !112
+247:                                              ; preds = %242
+  %248 = load i64*, i64** %241, align 8, !dbg !109, !tbaa !27
+  br label %rb_array_const_ptr_transient.exit.i17.i, !dbg !109
 
-268:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
-  %269 = lshr i64 %265, 15, !dbg !112
-  %270 = and i64 %269, 3, !dbg !112
-  br label %rb_array_len.exit.i18.i, !dbg !112
+rb_array_const_ptr_transient.exit.i17.i:          ; preds = %247, %242
+  %249 = phi i64* [ %248, %247 ], [ %240, %242 ], !dbg !109
+  %250 = getelementptr inbounds i64, i64* %249, i64 %243, !dbg !109
+  %251 = load i64, i64* %250, align 8, !dbg !109, !tbaa !6
+  call void @llvm.experimental.noalias.scope.decl(metadata !111) #12, !dbg !109
+  %252 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !102, !tbaa !15, !noalias !111
+  %253 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %252, i64 0, i32 2, !dbg !102
+  %254 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %253, align 8, !dbg !102, !tbaa !17, !noalias !111
+  %255 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %254, i64 0, i32 3, !dbg !102
+  %256 = load i64, i64* %255, align 8, !dbg !102, !tbaa !42, !noalias !111
+  %stackFrame.i.i16.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.<static-init>$152$block_3", align 8, !dbg !102, !noalias !111
+  %257 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %254, i64 0, i32 2, !dbg !102
+  store %struct.rb_iseq_struct* %stackFrame.i.i16.i, %struct.rb_iseq_struct** %257, align 8, !dbg !102, !tbaa !21, !noalias !111
+  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %254, i64 0, i32 4, !dbg !102
+  %259 = load i64*, i64** %258, align 8, !dbg !102, !tbaa !23, !noalias !111
+  %260 = load i64, i64* %259, align 8, !dbg !102, !tbaa !6, !noalias !111
+  %261 = and i64 %260, -129, !dbg !102
+  store i64 %261, i64* %259, align 8, !dbg !102, !tbaa !6, !noalias !111
+  %262 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %254, i64 0, i32 0, !dbg !102
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %262, align 8, !dbg !102, !tbaa !15, !noalias !111
+  %263 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %254, i64 0, i32 1, !dbg !114
+  %264 = load i64*, i64** %263, align 8, !dbg !114
+  store i64 %256, i64* %264, align 8, !dbg !114, !tbaa !6
+  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !114
+  store i64 %251, i64* %265, align 8, !dbg !114, !tbaa !6
+  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !114
+  store i64* %266, i64** %263, align 8, !dbg !114
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.5, i64 0), !dbg !114
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %262, align 8, !dbg !114, !tbaa !15, !noalias !111
+  %267 = add nuw nsw i64 %243, 1, !dbg !109
+  %268 = load i64, i64* %66, align 8, !dbg !109, !tbaa !25
+  %269 = and i64 %268, 8192, !dbg !109
+  %270 = icmp eq i64 %269, 0, !dbg !109
+  br i1 %270, label %274, label %271, !dbg !109
 
 271:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
-  %272 = load i64, i64* %237, align 8, !dbg !112, !tbaa !27
-  br label %rb_array_len.exit.i18.i, !dbg !112
+  %272 = lshr i64 %268, 15, !dbg !109
+  %273 = and i64 %272, 3, !dbg !109
+  br label %rb_array_len.exit.i18.i, !dbg !109
 
-rb_array_len.exit.i18.i:                          ; preds = %271, %268
-  %273 = phi i64 [ %270, %268 ], [ %272, %271 ], !dbg !112
-  %274 = icmp sgt i64 %273, %264, !dbg !112
-  br i1 %274, label %239, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !112, !llvm.loop !120
+274:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
+  %275 = load i64, i64* %240, align 8, !dbg !109, !tbaa !27
+  br label %rb_array_len.exit.i18.i, !dbg !109
+
+rb_array_len.exit.i18.i:                          ; preds = %274, %271
+  %276 = phi i64 [ %273, %271 ], [ %275, %274 ], !dbg !109
+  %277 = icmp sgt i64 %276, %267, !dbg !109
+  br i1 %277, label %242, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !109, !llvm.loop !116
 
 forward_sorbet_rb_array_each_withBlock.3.exit.i:  ; preds = %rb_array_len.exit.i18.i, %rb_array_len.exit1.i15.i
-  call void @sorbet_popFrame() #12, !dbg !112
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %201) #12, !dbg !105
-  %275 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !105, !tbaa !15
-  %276 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %275, i64 0, i32 5, !dbg !105
-  %277 = load i32, i32* %276, align 8, !dbg !105, !tbaa !37
-  %278 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %275, i64 0, i32 6, !dbg !105
-  %279 = load i32, i32* %278, align 4, !dbg !105, !tbaa !38
-  %280 = xor i32 %279, -1, !dbg !105
-  %281 = and i32 %280, %277, !dbg !105
-  %282 = icmp eq i32 %281, 0, !dbg !105
-  br i1 %282, label %rb_check_arity.1.exit.i21.i, label %283, !dbg !105, !prof !31
+  call void @sorbet_popFrame() #12, !dbg !109
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %204) #12, !dbg !102
+  %278 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !102, !tbaa !15
+  %279 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %278, i64 0, i32 5, !dbg !102
+  %280 = load i32, i32* %279, align 8, !dbg !102, !tbaa !37
+  %281 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %278, i64 0, i32 6, !dbg !102
+  %282 = load i32, i32* %281, align 4, !dbg !102, !tbaa !38
+  %283 = xor i32 %282, -1, !dbg !102
+  %284 = and i32 %283, %280, !dbg !102
+  %285 = icmp eq i32 %284, 0, !dbg !102
+  br i1 %285, label %rb_check_arity.1.exit.i21.i, label %286, !dbg !102, !prof !31
 
-283:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.3.exit.i
-  %284 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %275, i64 0, i32 8, !dbg !105
-  %285 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %284, align 8, !dbg !105, !tbaa !39
-  %286 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %285, i32 noundef 0) #12, !dbg !105
-  br label %rb_check_arity.1.exit.i21.i, !dbg !105
+286:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.3.exit.i
+  %287 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %278, i64 0, i32 8, !dbg !102
+  %288 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %287, align 8, !dbg !102, !tbaa !39
+  %289 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %288, i32 noundef 0) #12, !dbg !102
+  br label %rb_check_arity.1.exit.i21.i, !dbg !102
 
-rb_check_arity.1.exit.i21.i:                      ; preds = %283, %forward_sorbet_rb_array_each_withBlock.3.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %35, align 8, !dbg !105, !tbaa !15
-  %rubyId_each90.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !121
-  %287 = bitcast %struct.sorbet_inlineIntrinsicEnv* %3 to i8*, !dbg !121
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %287) #12, !dbg !121
-  %288 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 0, !dbg !121
-  store i64 %39, i64* %288, align 8, !dbg !121, !tbaa !74
-  %289 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 1, !dbg !121
-  store i64 %rubyId_each90.i, i64* %289, align 8, !dbg !121, !tbaa !76
-  %290 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 2, !dbg !121
-  store i32 0, i32* %290, align 8, !dbg !121, !tbaa !77
-  %291 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 3, !dbg !121
-  %292 = bitcast i64** %291 to i8*, !dbg !121
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %292, i8 0, i64 16, i1 false) #12, !dbg !121
-  %293 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !121, !tbaa !15
-  %294 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %293, i64 0, i32 2, !dbg !121
-  %295 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %294, align 8, !dbg !121, !tbaa !17
-  call void @llvm.experimental.noalias.scope.decl(metadata !122) #12, !dbg !121
-  %296 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$152$block_4", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !121
-  %297 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %295, i64 0, i32 3, !dbg !121
-  %298 = bitcast i64* %297 to %struct.rb_captured_block*, !dbg !121
-  %299 = getelementptr inbounds i64, i64* %297, i64 2, !dbg !121
-  %300 = bitcast i64* %299 to %struct.vm_ifunc**, !dbg !121
-  store %struct.vm_ifunc* %296, %struct.vm_ifunc** %300, align 8, !dbg !121, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !125) #12, !dbg !121
-  %301 = ptrtoint %struct.rb_captured_block* %298 to i64, !dbg !121
-  %302 = or i64 %301, 3, !dbg !121
-  %303 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %293, i64 0, i32 17, !dbg !121
-  store i64 %302, i64* %303, align 8, !dbg !121, !tbaa !84
-  %304 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !128, !tbaa !15
-  %305 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %304, i64 0, i32 17, !dbg !128
-  %306 = load i64, i64* %305, align 8, !dbg !128, !tbaa !84
-  %307 = and i64 %306, -4, !dbg !128
-  %308 = inttoptr i64 %307 to %struct.rb_captured_block*, !dbg !128
-  store i64 0, i64* %305, align 8, !dbg !128, !tbaa !84
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %308) #12, !dbg !128
-  %309 = load i64, i64* %63, align 8, !dbg !128, !tbaa !25
-  %310 = and i64 %309, 8192, !dbg !128
-  %311 = icmp eq i64 %310, 0, !dbg !128
-  br i1 %311, label %315, label %312, !dbg !128
-
-312:                                              ; preds = %rb_check_arity.1.exit.i21.i
-  %313 = lshr i64 %309, 15, !dbg !128
-  %314 = and i64 %313, 3, !dbg !128
-  br label %rb_array_len.exit1.i22.i, !dbg !128
+rb_check_arity.1.exit.i21.i:                      ; preds = %286, %forward_sorbet_rb_array_each_withBlock.3.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %38, align 8, !dbg !102, !tbaa !15
+  %rubyId_each90.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !117
+  %290 = bitcast %struct.sorbet_inlineIntrinsicEnv* %3 to i8*, !dbg !117
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %290) #12, !dbg !117
+  %291 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 0, !dbg !117
+  store i64 %42, i64* %291, align 8, !dbg !117, !tbaa !71
+  %292 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 1, !dbg !117
+  store i64 %rubyId_each90.i, i64* %292, align 8, !dbg !117, !tbaa !73
+  %293 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 2, !dbg !117
+  store i32 0, i32* %293, align 8, !dbg !117, !tbaa !74
+  %294 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 3, !dbg !117
+  %295 = bitcast i64** %294 to i8*, !dbg !117
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %295, i8 0, i64 16, i1 false) #12, !dbg !117
+  %296 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !117, !tbaa !15
+  %297 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %296, i64 0, i32 2, !dbg !117
+  %298 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %297, align 8, !dbg !117, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !118) #12, !dbg !117
+  %299 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$152$block_4", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !117
+  %300 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %298, i64 0, i32 3, !dbg !117
+  %301 = bitcast i64* %300 to %struct.rb_captured_block*, !dbg !117
+  %302 = getelementptr inbounds i64, i64* %300, i64 2, !dbg !117
+  %303 = bitcast i64* %302 to %struct.vm_ifunc**, !dbg !117
+  store %struct.vm_ifunc* %299, %struct.vm_ifunc** %303, align 8, !dbg !117, !tbaa !27
+  call void @llvm.experimental.noalias.scope.decl(metadata !121) #12, !dbg !117
+  %304 = ptrtoint %struct.rb_captured_block* %301 to i64, !dbg !117
+  %305 = or i64 %304, 3, !dbg !117
+  %306 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %296, i64 0, i32 17, !dbg !117
+  store i64 %305, i64* %306, align 8, !dbg !117, !tbaa !81
+  %307 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !124, !tbaa !15
+  %308 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %307, i64 0, i32 17, !dbg !124
+  %309 = load i64, i64* %308, align 8, !dbg !124, !tbaa !81
+  %310 = and i64 %309, -4, !dbg !124
+  %311 = inttoptr i64 %310 to %struct.rb_captured_block*, !dbg !124
+  store i64 0, i64* %308, align 8, !dbg !124, !tbaa !81
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %311) #12, !dbg !124
+  %312 = load i64, i64* %66, align 8, !dbg !124, !tbaa !25
+  %313 = and i64 %312, 8192, !dbg !124
+  %314 = icmp eq i64 %313, 0, !dbg !124
+  br i1 %314, label %318, label %315, !dbg !124
 
 315:                                              ; preds = %rb_check_arity.1.exit.i21.i
-  %316 = inttoptr i64 %39 to %struct.RArray*, !dbg !128
-  %317 = getelementptr inbounds %struct.RArray, %struct.RArray* %316, i64 0, i32 1, i32 0, i32 0, !dbg !128
-  %318 = load i64, i64* %317, align 8, !dbg !128, !tbaa !27
-  br label %rb_array_len.exit1.i22.i, !dbg !128
+  %316 = lshr i64 %312, 15, !dbg !124
+  %317 = and i64 %316, 3, !dbg !124
+  br label %rb_array_len.exit1.i22.i, !dbg !124
 
-rb_array_len.exit1.i22.i:                         ; preds = %315, %312
-  %319 = phi i64 [ %314, %312 ], [ %318, %315 ], !dbg !128
-  %320 = icmp sgt i64 %319, 0, !dbg !128
-  br i1 %320, label %321, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !128
+318:                                              ; preds = %rb_check_arity.1.exit.i21.i
+  %319 = inttoptr i64 %42 to %struct.RArray*, !dbg !124
+  %320 = getelementptr inbounds %struct.RArray, %struct.RArray* %319, i64 0, i32 1, i32 0, i32 0, !dbg !124
+  %321 = load i64, i64* %320, align 8, !dbg !124, !tbaa !27
+  br label %rb_array_len.exit1.i22.i, !dbg !124
 
-321:                                              ; preds = %rb_array_len.exit1.i22.i
-  %322 = bitcast i64* %0 to i8*, !dbg !128
-  %323 = inttoptr i64 %39 to %struct.RArray*, !dbg !121
-  %324 = getelementptr inbounds %struct.RArray, %struct.RArray* %323, i64 0, i32 1, i32 0, i32 0, !dbg !121
-  %325 = getelementptr inbounds %struct.RArray, %struct.RArray* %323, i64 0, i32 1, i32 0, i32 2, !dbg !121
-  br label %326, !dbg !128
+rb_array_len.exit1.i22.i:                         ; preds = %318, %315
+  %322 = phi i64 [ %317, %315 ], [ %321, %318 ], !dbg !124
+  %323 = icmp sgt i64 %322, 0, !dbg !124
+  br i1 %323, label %324, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !124
 
-326:                                              ; preds = %rb_array_len.exit.i24.i, %321
-  %327 = phi i64 [ 0, %321 ], [ %337, %rb_array_len.exit.i24.i ], !dbg !128
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %322) #12, !dbg !128
-  %328 = load i64, i64* %63, align 8, !dbg !128, !tbaa !25
-  %329 = and i64 %328, 8192, !dbg !128
-  %330 = icmp eq i64 %329, 0, !dbg !128
-  br i1 %330, label %331, label %rb_array_const_ptr_transient.exit.i23.i, !dbg !128
+324:                                              ; preds = %rb_array_len.exit1.i22.i
+  %325 = bitcast i64* %0 to i8*, !dbg !124
+  %326 = inttoptr i64 %42 to %struct.RArray*, !dbg !117
+  %327 = getelementptr inbounds %struct.RArray, %struct.RArray* %326, i64 0, i32 1, i32 0, i32 0, !dbg !117
+  %328 = getelementptr inbounds %struct.RArray, %struct.RArray* %326, i64 0, i32 1, i32 0, i32 2, !dbg !117
+  br label %329, !dbg !124
 
-331:                                              ; preds = %326
-  %332 = load i64*, i64** %325, align 8, !dbg !128, !tbaa !27
-  br label %rb_array_const_ptr_transient.exit.i23.i, !dbg !128
+329:                                              ; preds = %rb_array_len.exit.i24.i, %324
+  %330 = phi i64 [ 0, %324 ], [ %340, %rb_array_len.exit.i24.i ], !dbg !124
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %325) #12, !dbg !124
+  %331 = load i64, i64* %66, align 8, !dbg !124, !tbaa !25
+  %332 = and i64 %331, 8192, !dbg !124
+  %333 = icmp eq i64 %332, 0, !dbg !124
+  br i1 %333, label %334, label %rb_array_const_ptr_transient.exit.i23.i, !dbg !124
 
-rb_array_const_ptr_transient.exit.i23.i:          ; preds = %331, %326
-  %333 = phi i64* [ %332, %331 ], [ %324, %326 ], !dbg !128
-  %334 = getelementptr inbounds i64, i64* %333, i64 %327, !dbg !128
-  %335 = load i64, i64* %334, align 8, !dbg !128, !tbaa !6
-  store i64 %335, i64* %0, align 8, !dbg !128, !tbaa !6
-  %336 = call i64 @"func_<root>.<static-init>$152$block_4"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #12, !dbg !128
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %322) #12, !dbg !128
-  %337 = add nuw nsw i64 %327, 1, !dbg !128
-  %338 = load i64, i64* %63, align 8, !dbg !128, !tbaa !25
-  %339 = and i64 %338, 8192, !dbg !128
-  %340 = icmp eq i64 %339, 0, !dbg !128
-  br i1 %340, label %344, label %341, !dbg !128
+334:                                              ; preds = %329
+  %335 = load i64*, i64** %328, align 8, !dbg !124, !tbaa !27
+  br label %rb_array_const_ptr_transient.exit.i23.i, !dbg !124
 
-341:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
-  %342 = lshr i64 %338, 15, !dbg !128
-  %343 = and i64 %342, 3, !dbg !128
-  br label %rb_array_len.exit.i24.i, !dbg !128
+rb_array_const_ptr_transient.exit.i23.i:          ; preds = %334, %329
+  %336 = phi i64* [ %335, %334 ], [ %327, %329 ], !dbg !124
+  %337 = getelementptr inbounds i64, i64* %336, i64 %330, !dbg !124
+  %338 = load i64, i64* %337, align 8, !dbg !124, !tbaa !6
+  store i64 %338, i64* %0, align 8, !dbg !124, !tbaa !6
+  %339 = call i64 @"func_<root>.<static-init>$152$block_4"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #12, !dbg !124
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %325) #12, !dbg !124
+  %340 = add nuw nsw i64 %330, 1, !dbg !124
+  %341 = load i64, i64* %66, align 8, !dbg !124, !tbaa !25
+  %342 = and i64 %341, 8192, !dbg !124
+  %343 = icmp eq i64 %342, 0, !dbg !124
+  br i1 %343, label %347, label %344, !dbg !124
 
 344:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
-  %345 = load i64, i64* %324, align 8, !dbg !128, !tbaa !27
-  br label %rb_array_len.exit.i24.i, !dbg !128
+  %345 = lshr i64 %341, 15, !dbg !124
+  %346 = and i64 %345, 3, !dbg !124
+  br label %rb_array_len.exit.i24.i, !dbg !124
 
-rb_array_len.exit.i24.i:                          ; preds = %344, %341
-  %346 = phi i64 [ %343, %341 ], [ %345, %344 ], !dbg !128
-  %347 = icmp sgt i64 %346, %337, !dbg !128
-  br i1 %347, label %326, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !128, !llvm.loop !130
+347:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
+  %348 = load i64, i64* %327, align 8, !dbg !124, !tbaa !27
+  br label %rb_array_len.exit.i24.i, !dbg !124
+
+rb_array_len.exit.i24.i:                          ; preds = %347, %344
+  %349 = phi i64 [ %346, %344 ], [ %348, %347 ], !dbg !124
+  %350 = icmp sgt i64 %349, %340, !dbg !124
+  br i1 %350, label %329, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !124, !llvm.loop !126
 
 forward_sorbet_rb_array_each_withBlock.6.exit.i:  ; preds = %rb_array_len.exit.i24.i, %rb_array_len.exit1.i22.i
-  call void @sorbet_popFrame() #12, !dbg !128
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %287) #12, !dbg !121
-  %348 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !121, !tbaa !15
-  %349 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %348, i64 0, i32 5, !dbg !121
-  %350 = load i32, i32* %349, align 8, !dbg !121, !tbaa !37
-  %351 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %348, i64 0, i32 6, !dbg !121
-  %352 = load i32, i32* %351, align 4, !dbg !121, !tbaa !38
-  %353 = xor i32 %352, -1, !dbg !121
-  %354 = and i32 %353, %350, !dbg !121
-  %355 = icmp eq i32 %354, 0, !dbg !121
-  br i1 %355, label %rb_check_arity.1.exit.i.i, label %356, !dbg !121, !prof !31
+  call void @sorbet_popFrame() #12, !dbg !124
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %290) #12, !dbg !117
+  %351 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !117, !tbaa !15
+  %352 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %351, i64 0, i32 5, !dbg !117
+  %353 = load i32, i32* %352, align 8, !dbg !117, !tbaa !37
+  %354 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %351, i64 0, i32 6, !dbg !117
+  %355 = load i32, i32* %354, align 4, !dbg !117, !tbaa !38
+  %356 = xor i32 %355, -1, !dbg !117
+  %357 = and i32 %356, %353, !dbg !117
+  %358 = icmp eq i32 %357, 0, !dbg !117
+  br i1 %358, label %rb_check_arity.1.exit.i.i, label %359, !dbg !117, !prof !31
 
-356:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.6.exit.i
-  %357 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %348, i64 0, i32 8, !dbg !121
-  %358 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %357, align 8, !dbg !121, !tbaa !39
-  %359 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %358, i32 noundef 0) #12, !dbg !121
-  br label %rb_check_arity.1.exit.i.i, !dbg !121
+359:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.6.exit.i
+  %360 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %351, i64 0, i32 8, !dbg !117
+  %361 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %360, align 8, !dbg !117, !tbaa !39
+  %362 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %361, i32 noundef 0) #12, !dbg !117
+  br label %rb_check_arity.1.exit.i.i, !dbg !117
 
-rb_check_arity.1.exit.i.i:                        ; preds = %356, %forward_sorbet_rb_array_each_withBlock.6.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %35, align 8, !dbg !121, !tbaa !15
-  %rubyId_each102.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !131
-  %360 = bitcast %struct.sorbet_inlineIntrinsicEnv* %7 to i8*, !dbg !131
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %360) #12, !dbg !131
-  %361 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 0, !dbg !131
-  store i64 %39, i64* %361, align 8, !dbg !131, !tbaa !74
-  %362 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 1, !dbg !131
-  store i64 %rubyId_each102.i, i64* %362, align 8, !dbg !131, !tbaa !76
-  %363 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 2, !dbg !131
-  store i32 0, i32* %363, align 8, !dbg !131, !tbaa !77
-  %364 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 3, !dbg !131
-  %365 = bitcast i64** %364 to i8*, !dbg !131
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %365, i8 0, i64 16, i1 false) #12, !dbg !131
-  %366 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !131, !tbaa !15
-  %367 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %366, i64 0, i32 2, !dbg !131
-  %368 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %367, align 8, !dbg !131, !tbaa !17
-  call void @llvm.experimental.noalias.scope.decl(metadata !132) #12, !dbg !131
-  %369 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$152$block_5", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !131
-  %370 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %368, i64 0, i32 3, !dbg !131
-  %371 = bitcast i64* %370 to %struct.rb_captured_block*, !dbg !131
-  %372 = getelementptr inbounds i64, i64* %370, i64 2, !dbg !131
-  %373 = bitcast i64* %372 to %struct.vm_ifunc**, !dbg !131
-  store %struct.vm_ifunc* %369, %struct.vm_ifunc** %373, align 8, !dbg !131, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !135) #12, !dbg !131
-  %374 = ptrtoint %struct.rb_captured_block* %371 to i64, !dbg !131
-  %375 = or i64 %374, 3, !dbg !131
-  %376 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %366, i64 0, i32 17, !dbg !131
-  store i64 %375, i64* %376, align 8, !dbg !131, !tbaa !84
-  %377 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !138, !tbaa !15
-  %378 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %377, i64 0, i32 17, !dbg !138
-  %379 = load i64, i64* %378, align 8, !dbg !138, !tbaa !84
-  %380 = and i64 %379, -4, !dbg !138
-  %381 = inttoptr i64 %380 to %struct.rb_captured_block*, !dbg !138
-  store i64 0, i64* %378, align 8, !dbg !138, !tbaa !84
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %381) #12, !dbg !138
-  %382 = load i64, i64* %63, align 8, !dbg !138, !tbaa !25
-  %383 = and i64 %382, 8192, !dbg !138
-  %384 = icmp eq i64 %383, 0, !dbg !138
-  br i1 %384, label %388, label %385, !dbg !138
-
-385:                                              ; preds = %rb_check_arity.1.exit.i.i
-  %386 = lshr i64 %382, 15, !dbg !138
-  %387 = and i64 %386, 3, !dbg !138
-  br label %rb_array_len.exit1.i.i, !dbg !138
+rb_check_arity.1.exit.i.i:                        ; preds = %359, %forward_sorbet_rb_array_each_withBlock.6.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %38, align 8, !dbg !117, !tbaa !15
+  %rubyId_each102.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !127
+  %363 = bitcast %struct.sorbet_inlineIntrinsicEnv* %7 to i8*, !dbg !127
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %363) #12, !dbg !127
+  %364 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 0, !dbg !127
+  store i64 %42, i64* %364, align 8, !dbg !127, !tbaa !71
+  %365 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 1, !dbg !127
+  store i64 %rubyId_each102.i, i64* %365, align 8, !dbg !127, !tbaa !73
+  %366 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 2, !dbg !127
+  store i32 0, i32* %366, align 8, !dbg !127, !tbaa !74
+  %367 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 3, !dbg !127
+  %368 = bitcast i64** %367 to i8*, !dbg !127
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %368, i8 0, i64 16, i1 false) #12, !dbg !127
+  %369 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !127, !tbaa !15
+  %370 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %369, i64 0, i32 2, !dbg !127
+  %371 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %370, align 8, !dbg !127, !tbaa !17
+  call void @llvm.experimental.noalias.scope.decl(metadata !128) #12, !dbg !127
+  %372 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.<static-init>$152$block_5", i8* null, i32 noundef 0, i32 noundef -1) #12, !dbg !127
+  %373 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %371, i64 0, i32 3, !dbg !127
+  %374 = bitcast i64* %373 to %struct.rb_captured_block*, !dbg !127
+  %375 = getelementptr inbounds i64, i64* %373, i64 2, !dbg !127
+  %376 = bitcast i64* %375 to %struct.vm_ifunc**, !dbg !127
+  store %struct.vm_ifunc* %372, %struct.vm_ifunc** %376, align 8, !dbg !127, !tbaa !27
+  call void @llvm.experimental.noalias.scope.decl(metadata !131) #12, !dbg !127
+  %377 = ptrtoint %struct.rb_captured_block* %374 to i64, !dbg !127
+  %378 = or i64 %377, 3, !dbg !127
+  %379 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %369, i64 0, i32 17, !dbg !127
+  store i64 %378, i64* %379, align 8, !dbg !127, !tbaa !81
+  %380 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !134, !tbaa !15
+  %381 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %380, i64 0, i32 17, !dbg !134
+  %382 = load i64, i64* %381, align 8, !dbg !134, !tbaa !81
+  %383 = and i64 %382, -4, !dbg !134
+  %384 = inttoptr i64 %383 to %struct.rb_captured_block*, !dbg !134
+  store i64 0, i64* %381, align 8, !dbg !134, !tbaa !81
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %384) #12, !dbg !134
+  %385 = load i64, i64* %66, align 8, !dbg !134, !tbaa !25
+  %386 = and i64 %385, 8192, !dbg !134
+  %387 = icmp eq i64 %386, 0, !dbg !134
+  br i1 %387, label %391, label %388, !dbg !134
 
 388:                                              ; preds = %rb_check_arity.1.exit.i.i
-  %389 = inttoptr i64 %39 to %struct.RArray*, !dbg !138
-  %390 = getelementptr inbounds %struct.RArray, %struct.RArray* %389, i64 0, i32 1, i32 0, i32 0, !dbg !138
-  %391 = load i64, i64* %390, align 8, !dbg !138, !tbaa !27
-  br label %rb_array_len.exit1.i.i, !dbg !138
+  %389 = lshr i64 %385, 15, !dbg !134
+  %390 = and i64 %389, 3, !dbg !134
+  br label %rb_array_len.exit1.i.i, !dbg !134
 
-rb_array_len.exit1.i.i:                           ; preds = %388, %385
-  %392 = phi i64 [ %387, %385 ], [ %391, %388 ], !dbg !138
-  %393 = icmp sgt i64 %392, 0, !dbg !138
-  br i1 %393, label %394, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !138
+391:                                              ; preds = %rb_check_arity.1.exit.i.i
+  %392 = inttoptr i64 %42 to %struct.RArray*, !dbg !134
+  %393 = getelementptr inbounds %struct.RArray, %struct.RArray* %392, i64 0, i32 1, i32 0, i32 0, !dbg !134
+  %394 = load i64, i64* %393, align 8, !dbg !134, !tbaa !27
+  br label %rb_array_len.exit1.i.i, !dbg !134
 
-394:                                              ; preds = %rb_array_len.exit1.i.i
-  %395 = bitcast i64* %2 to i8*, !dbg !138
-  %396 = inttoptr i64 %39 to %struct.RArray*, !dbg !131
-  %397 = getelementptr inbounds %struct.RArray, %struct.RArray* %396, i64 0, i32 1, i32 0, i32 0, !dbg !131
-  %398 = getelementptr inbounds %struct.RArray, %struct.RArray* %396, i64 0, i32 1, i32 0, i32 2, !dbg !131
-  br label %399, !dbg !138
+rb_array_len.exit1.i.i:                           ; preds = %391, %388
+  %395 = phi i64 [ %390, %388 ], [ %394, %391 ], !dbg !134
+  %396 = icmp sgt i64 %395, 0, !dbg !134
+  br i1 %396, label %397, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !134
 
-399:                                              ; preds = %rb_array_len.exit.i.i, %394
-  %400 = phi i64 [ 0, %394 ], [ %410, %rb_array_len.exit.i.i ], !dbg !138
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %395) #12, !dbg !138
-  %401 = load i64, i64* %63, align 8, !dbg !138, !tbaa !25
-  %402 = and i64 %401, 8192, !dbg !138
-  %403 = icmp eq i64 %402, 0, !dbg !138
-  br i1 %403, label %404, label %rb_array_const_ptr_transient.exit.i.i, !dbg !138
+397:                                              ; preds = %rb_array_len.exit1.i.i
+  %398 = bitcast i64* %2 to i8*, !dbg !134
+  %399 = inttoptr i64 %42 to %struct.RArray*, !dbg !127
+  %400 = getelementptr inbounds %struct.RArray, %struct.RArray* %399, i64 0, i32 1, i32 0, i32 0, !dbg !127
+  %401 = getelementptr inbounds %struct.RArray, %struct.RArray* %399, i64 0, i32 1, i32 0, i32 2, !dbg !127
+  br label %402, !dbg !134
 
-404:                                              ; preds = %399
-  %405 = load i64*, i64** %398, align 8, !dbg !138, !tbaa !27
-  br label %rb_array_const_ptr_transient.exit.i.i, !dbg !138
+402:                                              ; preds = %rb_array_len.exit.i.i, %397
+  %403 = phi i64 [ 0, %397 ], [ %413, %rb_array_len.exit.i.i ], !dbg !134
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %398) #12, !dbg !134
+  %404 = load i64, i64* %66, align 8, !dbg !134, !tbaa !25
+  %405 = and i64 %404, 8192, !dbg !134
+  %406 = icmp eq i64 %405, 0, !dbg !134
+  br i1 %406, label %407, label %rb_array_const_ptr_transient.exit.i.i, !dbg !134
 
-rb_array_const_ptr_transient.exit.i.i:            ; preds = %404, %399
-  %406 = phi i64* [ %405, %404 ], [ %397, %399 ], !dbg !138
-  %407 = getelementptr inbounds i64, i64* %406, i64 %400, !dbg !138
-  %408 = load i64, i64* %407, align 8, !dbg !138, !tbaa !6
-  store i64 %408, i64* %2, align 8, !dbg !138, !tbaa !6
-  %409 = call i64 @"func_<root>.<static-init>$152$block_5"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %2, i64 undef) #12, !dbg !138
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %395) #12, !dbg !138
-  %410 = add nuw nsw i64 %400, 1, !dbg !138
-  %411 = load i64, i64* %63, align 8, !dbg !138, !tbaa !25
-  %412 = and i64 %411, 8192, !dbg !138
-  %413 = icmp eq i64 %412, 0, !dbg !138
-  br i1 %413, label %417, label %414, !dbg !138
+407:                                              ; preds = %402
+  %408 = load i64*, i64** %401, align 8, !dbg !134, !tbaa !27
+  br label %rb_array_const_ptr_transient.exit.i.i, !dbg !134
 
-414:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %415 = lshr i64 %411, 15, !dbg !138
-  %416 = and i64 %415, 3, !dbg !138
-  br label %rb_array_len.exit.i.i, !dbg !138
+rb_array_const_ptr_transient.exit.i.i:            ; preds = %407, %402
+  %409 = phi i64* [ %408, %407 ], [ %400, %402 ], !dbg !134
+  %410 = getelementptr inbounds i64, i64* %409, i64 %403, !dbg !134
+  %411 = load i64, i64* %410, align 8, !dbg !134, !tbaa !6
+  store i64 %411, i64* %2, align 8, !dbg !134, !tbaa !6
+  %412 = call i64 @"func_<root>.<static-init>$152$block_5"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %2, i64 undef) #12, !dbg !134
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %398) #12, !dbg !134
+  %413 = add nuw nsw i64 %403, 1, !dbg !134
+  %414 = load i64, i64* %66, align 8, !dbg !134, !tbaa !25
+  %415 = and i64 %414, 8192, !dbg !134
+  %416 = icmp eq i64 %415, 0, !dbg !134
+  br i1 %416, label %420, label %417, !dbg !134
 
 417:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %418 = load i64, i64* %397, align 8, !dbg !138, !tbaa !27
-  br label %rb_array_len.exit.i.i, !dbg !138
+  %418 = lshr i64 %414, 15, !dbg !134
+  %419 = and i64 %418, 3, !dbg !134
+  br label %rb_array_len.exit.i.i, !dbg !134
 
-rb_array_len.exit.i.i:                            ; preds = %417, %414
-  %419 = phi i64 [ %416, %414 ], [ %418, %417 ], !dbg !138
-  %420 = icmp sgt i64 %419, %410, !dbg !138
-  br i1 %420, label %399, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !138, !llvm.loop !140
+420:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
+  %421 = load i64, i64* %400, align 8, !dbg !134, !tbaa !27
+  br label %rb_array_len.exit.i.i, !dbg !134
+
+rb_array_len.exit.i.i:                            ; preds = %420, %417
+  %422 = phi i64 [ %419, %417 ], [ %421, %420 ], !dbg !134
+  %423 = icmp sgt i64 %422, %413, !dbg !134
+  br i1 %423, label %402, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !134, !llvm.loop !136
 
 forward_sorbet_rb_array_each_withBlock.10.exit.i: ; preds = %rb_array_len.exit.i.i, %rb_array_len.exit1.i.i
-  call void @sorbet_popFrame() #12, !dbg !138
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %360) #12, !dbg !131
-  %421 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !131, !tbaa !15
-  %422 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %421, i64 0, i32 5, !dbg !131
-  %423 = load i32, i32* %422, align 8, !dbg !131, !tbaa !37
-  %424 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %421, i64 0, i32 6, !dbg !131
-  %425 = load i32, i32* %424, align 4, !dbg !131, !tbaa !38
-  %426 = xor i32 %425, -1, !dbg !131
-  %427 = and i32 %426, %423, !dbg !131
-  %428 = icmp eq i32 %427, 0, !dbg !131
-  br i1 %428, label %"func_<root>.<static-init>$152.exit", label %429, !dbg !131, !prof !31
+  call void @sorbet_popFrame() #12, !dbg !134
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %363) #12, !dbg !127
+  %424 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !127, !tbaa !15
+  %425 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %424, i64 0, i32 5, !dbg !127
+  %426 = load i32, i32* %425, align 8, !dbg !127, !tbaa !37
+  %427 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %424, i64 0, i32 6, !dbg !127
+  %428 = load i32, i32* %427, align 4, !dbg !127, !tbaa !38
+  %429 = xor i32 %428, -1, !dbg !127
+  %430 = and i32 %429, %426, !dbg !127
+  %431 = icmp eq i32 %430, 0, !dbg !127
+  br i1 %431, label %"func_<root>.<static-init>$152.exit", label %432, !dbg !127, !prof !31
 
-429:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i
-  %430 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %421, i64 0, i32 8, !dbg !131
-  %431 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %430, align 8, !dbg !131, !tbaa !39
-  %432 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %431, i32 noundef 0) #12, !dbg !131
-  br label %"func_<root>.<static-init>$152.exit", !dbg !131
+432:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i
+  %433 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %424, i64 0, i32 8, !dbg !127
+  %434 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %433, align 8, !dbg !127, !tbaa !39
+  %435 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %434, i32 noundef 0) #12, !dbg !127
+  br label %"func_<root>.<static-init>$152.exit", !dbg !127
 
-"func_<root>.<static-init>$152.exit":             ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i, %429
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %35, align 8, !tbaa !15
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %28)
+"func_<root>.<static-init>$152.exit":             ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i, %432
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %38, align 8, !tbaa !15
+  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %31)
   ret void
 }
 
@@ -1480,10 +1486,10 @@ declare void @llvm.experimental.noalias.scope.decl(metadata) #8
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #9
 
 ; Function Attrs: cold minsize noreturn ssp
-define internal fastcc void @"func_<root>.<static-init>$152$block_1.cold.1"(i64 %el2.sroa.0.0) unnamed_addr #10 !dbg !141 {
+define internal fastcc void @"func_<root>.<static-init>$152$block_1.cold.1"(i64 %el2.sroa.0.0) unnamed_addr #10 !dbg !137 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %el2.sroa.0.0, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_T.let, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #15, !dbg !143
-  unreachable, !dbg !143
+  tail call void @sorbet_cast_failure(i64 %el2.sroa.0.0, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_T.let, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #15, !dbg !139
+  unreachable, !dbg !139
 }
 
 attributes #0 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
@@ -1555,98 +1561,94 @@ attributes #15 = { noreturn }
 !46 = !DILocation(line: 13, column: 1, scope: !41)
 !47 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$152$block_3", scope: !11, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !48 = !DILocation(line: 5, column: 1, scope: !47)
-!49 = !DILocation(line: 18, column: 12, scope: !47)
-!50 = !DILocation(line: 19, column: 3, scope: !47)
-!51 = !DILocation(line: 18, column: 1, scope: !47)
-!52 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$152$block_4", scope: !11, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!53 = !DILocation(line: 5, column: 1, scope: !52)
-!54 = !DILocation(line: 23, column: 24, scope: !52)
-!55 = !DILocation(line: 24, column: 3, scope: !52)
-!56 = !DILocation(line: 25, column: 3, scope: !52)
-!57 = !DILocation(line: 23, column: 1, scope: !52)
-!58 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$152$block_5", scope: !11, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!59 = !DILocation(line: 5, column: 1, scope: !58)
-!60 = !DILocation(line: 28, column: 15, scope: !58)
-!61 = !DILocation(line: 29, column: 3, scope: !58)
-!62 = !DILocation(line: 30, column: 3, scope: !58)
-!63 = !DILocation(line: 28, column: 1, scope: !58)
-!64 = !DILocation(line: 0, scope: !11)
-!65 = !DILocation(line: 5, column: 6, scope: !11)
-!66 = !{!67}
-!67 = distinct !{!67, !68, !"sorbet_buildArrayIntrinsic: argument 0"}
-!68 = distinct !{!68, !"sorbet_buildArrayIntrinsic"}
-!69 = !DILocation(line: 5, column: 5, scope: !11)
-!70 = !{!71}
-!71 = distinct !{!71, !72, !"sorbet_buildArrayIntrinsic: argument 0"}
-!72 = distinct !{!72, !"sorbet_buildArrayIntrinsic"}
-!73 = !DILocation(line: 8, column: 1, scope: !11)
-!74 = !{!75, !7, i64 0}
-!75 = !{!"sorbet_inlineIntrinsicEnv", !7, i64 0, !7, i64 8, !19, i64 16, !16, i64 24, !7, i64 32}
-!76 = !{!75, !7, i64 8}
-!77 = !{!75, !19, i64 16}
+!49 = !DILocation(line: 19, column: 3, scope: !47)
+!50 = !DILocation(line: 18, column: 1, scope: !47)
+!51 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$152$block_4", scope: !11, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!52 = !DILocation(line: 5, column: 1, scope: !51)
+!53 = !DILocation(line: 24, column: 3, scope: !51)
+!54 = !DILocation(line: 25, column: 3, scope: !51)
+!55 = !DILocation(line: 23, column: 1, scope: !51)
+!56 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.<static-init>$152$block_5", scope: !11, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!57 = !DILocation(line: 5, column: 1, scope: !56)
+!58 = !DILocation(line: 29, column: 3, scope: !56)
+!59 = !DILocation(line: 30, column: 3, scope: !56)
+!60 = !DILocation(line: 28, column: 1, scope: !56)
+!61 = !DILocation(line: 0, scope: !11)
+!62 = !DILocation(line: 5, column: 6, scope: !11)
+!63 = !{!64}
+!64 = distinct !{!64, !65, !"sorbet_buildArrayIntrinsic: argument 0"}
+!65 = distinct !{!65, !"sorbet_buildArrayIntrinsic"}
+!66 = !DILocation(line: 5, column: 5, scope: !11)
+!67 = !{!68}
+!68 = distinct !{!68, !69, !"sorbet_buildArrayIntrinsic: argument 0"}
+!69 = distinct !{!69, !"sorbet_buildArrayIntrinsic"}
+!70 = !DILocation(line: 8, column: 1, scope: !11)
+!71 = !{!72, !7, i64 0}
+!72 = !{!"sorbet_inlineIntrinsicEnv", !7, i64 0, !7, i64 8, !19, i64 16, !16, i64 24, !7, i64 32}
+!73 = !{!72, !7, i64 8}
+!74 = !{!72, !19, i64 16}
+!75 = !{!76}
+!76 = distinct !{!76, !77, !"rb_vm_ifunc_proc_new: argument 0"}
+!77 = distinct !{!77, !"rb_vm_ifunc_proc_new"}
 !78 = !{!79}
-!79 = distinct !{!79, !80, !"rb_vm_ifunc_proc_new: argument 0"}
-!80 = distinct !{!80, !"rb_vm_ifunc_proc_new"}
-!81 = !{!82}
-!82 = distinct !{!82, !83, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!83 = distinct !{!83, !"VM_BH_FROM_IFUNC_BLOCK"}
-!84 = !{!18, !7, i64 128}
-!85 = !DILocation(line: 8, column: 1, scope: !11, inlinedAt: !86)
-!86 = distinct !DILocation(line: 8, column: 1, scope: !11)
-!87 = distinct !{!87, !88}
-!88 = !{!"llvm.loop.unroll.disable"}
-!89 = !DILocation(line: 13, column: 1, scope: !11)
+!79 = distinct !{!79, !80, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!80 = distinct !{!80, !"VM_BH_FROM_IFUNC_BLOCK"}
+!81 = !{!18, !7, i64 128}
+!82 = !DILocation(line: 8, column: 1, scope: !11, inlinedAt: !83)
+!83 = distinct !DILocation(line: 8, column: 1, scope: !11)
+!84 = distinct !{!84, !85}
+!85 = !{!"llvm.loop.unroll.disable"}
+!86 = !DILocation(line: 13, column: 1, scope: !11)
+!87 = !{!88}
+!88 = distinct !{!88, !89, !"rb_vm_ifunc_proc_new: argument 0"}
+!89 = distinct !{!89, !"rb_vm_ifunc_proc_new"}
 !90 = !{!91}
-!91 = distinct !{!91, !92, !"rb_vm_ifunc_proc_new: argument 0"}
-!92 = distinct !{!92, !"rb_vm_ifunc_proc_new"}
-!93 = !{!94}
-!94 = distinct !{!94, !95, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!95 = distinct !{!95, !"VM_BH_FROM_IFUNC_BLOCK"}
-!96 = !DILocation(line: 13, column: 1, scope: !11, inlinedAt: !97)
-!97 = distinct !DILocation(line: 13, column: 1, scope: !11)
-!98 = !{!99}
-!99 = distinct !{!99, !100, !"func_<root>.<static-init>$152$block_2: %argArray"}
-!100 = distinct !{!100, !"func_<root>.<static-init>$152$block_2"}
-!101 = !DILocation(line: 13, column: 12, scope: !41, inlinedAt: !102)
-!102 = distinct !DILocation(line: 13, column: 1, scope: !11, inlinedAt: !97)
-!103 = !DILocation(line: 14, column: 3, scope: !41, inlinedAt: !102)
-!104 = distinct !{!104, !88}
-!105 = !DILocation(line: 18, column: 1, scope: !11)
+!91 = distinct !{!91, !92, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!92 = distinct !{!92, !"VM_BH_FROM_IFUNC_BLOCK"}
+!93 = !DILocation(line: 13, column: 1, scope: !11, inlinedAt: !94)
+!94 = distinct !DILocation(line: 13, column: 1, scope: !11)
+!95 = !{!96}
+!96 = distinct !{!96, !97, !"func_<root>.<static-init>$152$block_2: %argArray"}
+!97 = distinct !{!97, !"func_<root>.<static-init>$152$block_2"}
+!98 = !DILocation(line: 13, column: 12, scope: !41, inlinedAt: !99)
+!99 = distinct !DILocation(line: 13, column: 1, scope: !11, inlinedAt: !94)
+!100 = !DILocation(line: 14, column: 3, scope: !41, inlinedAt: !99)
+!101 = distinct !{!101, !85}
+!102 = !DILocation(line: 18, column: 1, scope: !11)
+!103 = !{!104}
+!104 = distinct !{!104, !105, !"rb_vm_ifunc_proc_new: argument 0"}
+!105 = distinct !{!105, !"rb_vm_ifunc_proc_new"}
 !106 = !{!107}
-!107 = distinct !{!107, !108, !"rb_vm_ifunc_proc_new: argument 0"}
-!108 = distinct !{!108, !"rb_vm_ifunc_proc_new"}
-!109 = !{!110}
-!110 = distinct !{!110, !111, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!111 = distinct !{!111, !"VM_BH_FROM_IFUNC_BLOCK"}
-!112 = !DILocation(line: 18, column: 1, scope: !11, inlinedAt: !113)
-!113 = distinct !DILocation(line: 18, column: 1, scope: !11)
-!114 = !{!115}
-!115 = distinct !{!115, !116, !"func_<root>.<static-init>$152$block_3: %argArray"}
-!116 = distinct !{!116, !"func_<root>.<static-init>$152$block_3"}
-!117 = !DILocation(line: 18, column: 12, scope: !47, inlinedAt: !118)
-!118 = distinct !DILocation(line: 18, column: 1, scope: !11, inlinedAt: !113)
-!119 = !DILocation(line: 19, column: 3, scope: !47, inlinedAt: !118)
-!120 = distinct !{!120, !88}
-!121 = !DILocation(line: 23, column: 1, scope: !11)
-!122 = !{!123}
-!123 = distinct !{!123, !124, !"rb_vm_ifunc_proc_new: argument 0"}
-!124 = distinct !{!124, !"rb_vm_ifunc_proc_new"}
-!125 = !{!126}
-!126 = distinct !{!126, !127, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!127 = distinct !{!127, !"VM_BH_FROM_IFUNC_BLOCK"}
-!128 = !DILocation(line: 23, column: 1, scope: !11, inlinedAt: !129)
-!129 = distinct !DILocation(line: 23, column: 1, scope: !11)
-!130 = distinct !{!130, !88}
-!131 = !DILocation(line: 28, column: 1, scope: !11)
-!132 = !{!133}
-!133 = distinct !{!133, !134, !"rb_vm_ifunc_proc_new: argument 0"}
-!134 = distinct !{!134, !"rb_vm_ifunc_proc_new"}
-!135 = !{!136}
-!136 = distinct !{!136, !137, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!137 = distinct !{!137, !"VM_BH_FROM_IFUNC_BLOCK"}
-!138 = !DILocation(line: 28, column: 1, scope: !11, inlinedAt: !139)
-!139 = distinct !DILocation(line: 28, column: 1, scope: !11)
-!140 = distinct !{!140, !88}
-!141 = distinct !DISubprogram(name: "func_<root>.<static-init>$152$block_1.cold.1", linkageName: "func_<root>.<static-init>$152$block_1.cold.1", scope: null, file: !4, type: !142, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!142 = !DISubroutineType(types: !5)
-!143 = !DILocation(line: 9, column: 25, scope: !141)
+!107 = distinct !{!107, !108, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!108 = distinct !{!108, !"VM_BH_FROM_IFUNC_BLOCK"}
+!109 = !DILocation(line: 18, column: 1, scope: !11, inlinedAt: !110)
+!110 = distinct !DILocation(line: 18, column: 1, scope: !11)
+!111 = !{!112}
+!112 = distinct !{!112, !113, !"func_<root>.<static-init>$152$block_3: %argArray"}
+!113 = distinct !{!113, !"func_<root>.<static-init>$152$block_3"}
+!114 = !DILocation(line: 19, column: 3, scope: !47, inlinedAt: !115)
+!115 = distinct !DILocation(line: 18, column: 1, scope: !11, inlinedAt: !110)
+!116 = distinct !{!116, !85}
+!117 = !DILocation(line: 23, column: 1, scope: !11)
+!118 = !{!119}
+!119 = distinct !{!119, !120, !"rb_vm_ifunc_proc_new: argument 0"}
+!120 = distinct !{!120, !"rb_vm_ifunc_proc_new"}
+!121 = !{!122}
+!122 = distinct !{!122, !123, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!123 = distinct !{!123, !"VM_BH_FROM_IFUNC_BLOCK"}
+!124 = !DILocation(line: 23, column: 1, scope: !11, inlinedAt: !125)
+!125 = distinct !DILocation(line: 23, column: 1, scope: !11)
+!126 = distinct !{!126, !85}
+!127 = !DILocation(line: 28, column: 1, scope: !11)
+!128 = !{!129}
+!129 = distinct !{!129, !130, !"rb_vm_ifunc_proc_new: argument 0"}
+!130 = distinct !{!130, !"rb_vm_ifunc_proc_new"}
+!131 = !{!132}
+!132 = distinct !{!132, !133, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!133 = distinct !{!133, !"VM_BH_FROM_IFUNC_BLOCK"}
+!134 = !DILocation(line: 28, column: 1, scope: !11, inlinedAt: !135)
+!135 = distinct !DILocation(line: 28, column: 1, scope: !11)
+!136 = distinct !{!136, !85}
+!137 = distinct !DISubprogram(name: "func_<root>.<static-init>$152$block_1.cold.1", linkageName: "func_<root>.<static-init>$152$block_1.cold.1", scope: null, file: !4, type: !138, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!138 = !DISubroutineType(types: !5)
+!139 = !DILocation(line: 9, column: 25, scope: !137)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Begin emitting logic for setting defaults in block arguments. Currently the defaults are ignored and block args will always be initialized as `nil`. This shows up in the disabled test [test/testdata/compiler/disabled/block_with_defaults.rb](https://github.com/sorbet/sorbet/blob/cb55f38db4906c593445ff66d182fd0fc82ff920/test/testdata/compiler/disabled/block_with_defaults.rb), which will produce the wrong value when compiled.

The change is to emit similar logic to the method entry for handling default arguments, guarding them with a new instruction `YieldParamPresent` (similar behavior to `ArgPresent`, but specific to yield parameters in blocks). That instruction returns a boolean result, indicating whether or not the argument was present in the array of arguments given to the block.
![Screen Shot 2021-09-08 at 2 00 45 PM](https://user-images.githubusercontent.com/22708/132586498-bdf7ec4c-83e7-4926-a39e-a6eadbb8dc08.png)

This PR adds the new instruction, and hard-codes its compiled behavior to return `true` which preserves the current behavior. The next step will be to unify the handling of defaults for block and method parameters in `setupArguments`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Prework for handling block argument defaults.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
