### PR TITLE
Add missing RBI for method REXML::XPath.match

### DIFF
--- a/rbi/stdlib/rexml.rbi
+++ b/rbi/stdlib/rexml.rbi
@@ -3412,6 +3412,10 @@ class REXML::XPath
   #   {|el| ... }
   # ```
   def self.each(element, path = nil, namespaces = nil, variables = {}, options = {}, &block); end
+
+  # Returns an array of nodes matching a given
+  # [`XPath`](https://docs.ruby-lang.org/en/2.7.0/REXML/XPath.html).
+  def self.match(element, path = nil, namespaces = nil, variables = {}, options = {}); end
 end
 
 # You don't want to use this class. Really. Use XPath, which is a wrapper for

--- a/rbi/stdlib/rexml.rbi
+++ b/rbi/stdlib/rexml.rbi
@@ -3386,7 +3386,7 @@ class REXML::XPath
   # XPath.first( node, "a/x:b", { "x"=>"http://doofus" } )
   # XPath.first( node, '/book/publisher/text()=$publisher', {}, {"publisher"=>"O'Reilly"})
   # ```
-  def self.first(element, path = _, namespaces = _, variables = _, options = _, &block); end
+  def self.first(element, path = nil, namespaces = nil, variables = {}, options = {}, &block); end
 
   # Iterates over nodes that match the given path, calling the supplied block
   # with the match.
@@ -3411,7 +3411,7 @@ class REXML::XPath
   # XPath.each( node, '/book/publisher/text()=$publisher', {}, {"publisher"=>"O'Reilly"}) \
   #   {|el| ... }
   # ```
-  def self.each(element, path = _, namespaces = _, variables = _, options = _, &block); end
+  def self.each(element, path = nil, namespaces = nil, variables = {}, options = {}, &block); end
 end
 
 # You don't want to use this class. Really. Use XPath, which is a wrapper for


### PR DESCRIPTION
Documentation can be found here: https://ruby-doc.org/stdlib-2.6.1/libdoc/rexml/rdoc/REXML/XPath.html#method-c-match

Also fixed the default values for:
* https://ruby-doc.org/stdlib-2.6.1/libdoc/rexml/rdoc/REXML/XPath.html#method-c-each
* https://ruby-doc.org/stdlib-2.6.1/libdoc/rexml/rdoc/REXML/XPath.html#method-c-first