### PR TITLE
be sure to test both sides of @@var ||= ... in the compiler

### DIFF
--- a/test/testdata/compiler/disabled/uninitialized_class_variable.rb
+++ b/test/testdata/compiler/disabled/uninitialized_class_variable.rb
@@ -14,4 +14,6 @@ class A
 end
 
 A.init_change('constant')
+A.init_change('other')
 p A.get_change('constant')
+p A.get_change('other')


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This test is disabled, but I discovered that it doesn't provide good coverage of whatever AST we provide because we're not testing both cases of `||=`. :man_facepalming:  This PR fixes that.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
