### PR TITLE
strengthen the tests in ivar_cvar_oror_eq.rb to cover more cases

### DIFF
--- a/test/testdata/infer/ivar_cvar_oror_eq.rb
+++ b/test/testdata/infer/ivar_cvar_oror_eq.rb
@@ -1,23 +1,56 @@
 # typed: true
 
-# Test that Sorbet correctly infers the types of @@var in f and @ivar in g.
+# Test that Sorbet correctly infers the types of class variables and instance
+# variables when they are used as the LHS of ||=.
 
 class C
   extend T::Sig
 
-  @@var = T.let(nil, T.nilable(Integer))
+  @@nilable_var = T.let(nil, T.nilable(Integer))
+  @@falsy_var = T.let(false, T.any(FalseClass, Integer))
+  @@nevernil = T.let(81, Integer)
 
+  sig {void}
   def initialize
     @ivar = T.let(nil, T.nilable(String))
+    @ivar
   end
 
   sig {params(x: Integer).returns(Integer)}
-  def self.f(x)
-    @@var ||= x
+  def self.f1(x)
+    @@nilable_var ||= x
+  end
+
+  sig {params(x: Integer).returns(Integer)}
+  def self.f2(x)
+    @@nevernil ||= x # error: This code is unreachable
+  end
+
+  sig {params(x: Integer).returns(Integer)}
+  def self.f3(x)
+    @@nilable_var ||= x
+    @@nilable_var
+  end
+
+  sig {params(x: Integer).returns(Integer)}
+  def self.f4(x)
+    @@falsy_var ||= x
+    @@falsy_var
+  end
+
+  sig {params(x: Integer).returns(Integer)}
+  def self.f5(x)
+    @@falsy_var ||= x
   end
 
   sig {params(x: String).returns(String)}
-  def g(x)
+  def g1(x)
     @ivar ||= x
+  end
+
+  sig {params(x: String).returns(String)}
+  def g2(x)
+    @ivar ||= x
+    @ivar
   end
 end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I thought I was done with #4558 until jez mentioned another test I should try, which led to more tests being added here.  The `@@falsy_var` tests are to explicitly test that inference drops `FalseClass` in the true branches of the desugaring of `||=`.  This property is trivially true now, but #4558 brings some changes that make it not trivially true.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
