### PR TITLE
Disabled test for compiler assert when a block has both splat and block args

### DIFF
--- a/test/testdata/compiler/disabled/splat_and_block_args_to_block.rb
+++ b/test/testdata/compiler/disabled/splat_and_block_args_to_block.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+def f(&blk)
+  blk.call(42, &blk)
+end
+
+f { |*args, &blk| puts "hi" }


### PR DESCRIPTION
### Motivation
More tests! (This came up while trying to compile some new files in Stripe's codebase.)

### Test plan
See included automated tests.
