### PR TITLE
make update_testdata_exp.sh aware of the extra-package-files-directory-prefix directive

### DIFF
--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -81,6 +81,15 @@ for this_src in "${rb_src[@]}" DUMMY; do
       fi
       if [ "$pass" = "package-tree" ]; then
         args=("--stripe-packages")
+        extra_prefixes=()
+        while IFS='' read -r prefix; do
+          extra_prefixes+=("$prefix")
+        done < <(grep '# extra-package-files-directory-prefix: ' "${srcs[@]}" | sort | awk -F': ' '{print $2}')
+        if [ "${#extra_prefixes[@]}" -gt 0 ]; then
+          for prefix in "${extra_prefixes[@]}"; do
+            args+=("--extra-package-files-directory-prefix" "${prefix}")
+          done
+        fi
       fi
       if ! [ -e "$candidate" ]; then
         continue


### PR DESCRIPTION
cc @aadi-stripe @nroman-stripe 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`update_testdata_exp.sh` was giving spurious changes to `test/testdata/packager/extra_package_paths/pass.package-tree.exp` because the former was not aware of the extra directives the latter was (apparently) regenerated with.  This PR fixes that to take the necessary directives into account.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Running `tools/scripts/update_testdata_exp.sh` now gives no changes, as expected.
