### PR TITLE
delete random type member generated by the Struct.new rewriter

### DIFF
--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -138,16 +138,6 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
                                                     ast::MK::RaiseUnimplemented(loc)));
     }
 
-    // Elem = type_member(fixed: T.untyped)
-    {
-        auto typeMember =
-            ast::MK::Send(loc, ast::MK::Self(loc), core::Names::typeMember(), 0,
-                          ast::MK::SendArgs(ast::MK::Symbol(loc, core::Names::fixed()), ast::MK::Untyped(loc)));
-        body.emplace_back(
-            ast::MK::Assign(loc, ast::MK::UnresolvedConstant(loc, ast::MK::EmptyTree(), core::Names::Constants::Elem()),
-                            std::move(typeMember)));
-    }
-
     if (isMissingInitialize(ctx, send)) {
         body.emplace_back(ast::MK::SigVoid(loc, std::move(sigArgs)));
         body.emplace_back(ast::MK::SyntheticMethod(loc, loc, core::Names::initialize(), std::move(newArgs),

--- a/test/testdata/lsp/struct_fuzz.rb
+++ b/test/testdata/lsp/struct_fuzz.rb
@@ -2,7 +2,6 @@
 # no-stdlib: true
   ::B=Struct.new:x
 # ^^^^^^^^^^^^^^^^ error: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)`
-# ^^^^^^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(B)`
 # ^^^^^^^^^^^^^^^^ error: Method `params` does not exist on `T.class_of(B)`
 # ^^^^^^^^^^^^^^^^ error: Method `unsafe` does not exist on `T.class_of(T)`
 # ^^^^^^^^^^^^^^^^ error: Method `unsafe` does not exist on `T.class_of(T)`

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -46,8 +46,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       ::Sorbet::Private::Static.keep_def(<self>, :bar=, :normal)
 
-      <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())
-
       ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
     end
 
@@ -83,8 +81,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::Sorbet::Private::Static.keep_def(<self>, :bar, :normal)
 
       ::Sorbet::Private::Static.keep_def(<self>, :bar=, :normal)
-
-      <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())
 
       ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
     end
@@ -152,8 +148,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       ::Sorbet::Private::Static.keep_def(<self>, :foo=, :normal)
 
-      <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())
-
       ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
     end
 
@@ -177,8 +171,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::Sorbet::Private::Static.keep_def(<self>, :foo, :normal)
 
       ::Sorbet::Private::Static.keep_def(<self>, :foo=, :normal)
-
-      <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())
 
       ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
     end
@@ -221,8 +213,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       ::Sorbet::Private::Static.keep_def(<self>, :bar=, :normal)
 
-      <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())
-
       ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
     end
   end
@@ -257,8 +247,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       ::Sorbet::Private::Static.keep_def(<self>, :x=, :normal)
 
-      <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())
-
       ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
 
       <self>.include(<emptyTree>::<C MyMixin>)
@@ -288,8 +276,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::Sorbet::Private::Static.keep_def(<self>, :x, :normal)
 
       ::Sorbet::Private::Static.keep_def(<self>, :x=, :normal)
-
-      <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())
 
       ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
 
@@ -371,8 +357,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       ::Sorbet::Private::Static.keep_def(<self>, :a=, :normal)
 
-      <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())
-
       ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
     end
 
@@ -396,8 +380,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::Sorbet::Private::Static.keep_def(<self>, :a, :normal)
 
       ::Sorbet::Private::Static.keep_def(<self>, :a=, :normal)
-
-      <emptyTree>::<C Elem> = <self>.type_member(:fixed, ::T.untyped())
 
       ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
     end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This type member doesn't make any sense: I guess maybe we might have had it in for generating `Struct` declarations with extra type information?  But then I would think we'd want per-field type information, not type information on the structure level.

Deleting it doesn't seem to cause any harm; we'll see what happens with respect to Stripe's codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
