### PR TITLE
use RAII cleanup rather than catch and rethrow in the plugin injector

### DIFF
--- a/plugin_injector/BUILD
+++ b/plugin_injector/BUILD
@@ -13,7 +13,7 @@ cc_library(
         "//compiler/IREmitter",
         "//compiler/Names",
         "//compiler/ObjectFileEmitter",
-        "@com_google_absl//absl/cleanup:cleanup",
+        "@com_google_absl//absl/cleanup",
         "@com_stripe_ruby_typer//ast",
         "@com_stripe_ruby_typer//cfg",
         "@com_stripe_ruby_typer//common",

--- a/plugin_injector/BUILD
+++ b/plugin_injector/BUILD
@@ -13,6 +13,7 @@ cc_library(
         "//compiler/IREmitter",
         "//compiler/Names",
         "//compiler/ObjectFileEmitter",
+        "@com_google_absl//absl/cleanup:cleanup",
         "@com_stripe_ruby_typer//ast",
         "@com_stripe_ruby_typer//cfg",
         "@com_stripe_ruby_typer//common",


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The plugin injector currently catches all non-specific exceptions, nulls out some state, and rethrows.  This rethrowing hides the original context of the exception.  An example error from some WIP-patch:

```
froydnj@pyro:~/src/sorbet$  ./bazel-bin/compiler/sorbet --compiled-out-dir=. --llvm-ir-dir=. test/testdata/compiler/negate.rb
Backtrace:
  #3 0x64bd1d6
  #4 0x64bd170 __cxxabiv1::exception_cleanup_func()
  #5 0x304b00e sorbet::pipeline::semantic_extension::LLVMSemanticExtension::typecheck()
  #6 0x2822c53 sorbet::realmain::pipeline::CFGCollectorAndTyper::preTransformMethodDef()
  [...extra frames elided...]

libc++abi: terminate_handler unexpectedly returned
Aborted
```

"There was an error somewhere underneath `typecheck`, how useful."

One can workaround this in the debugger by breaking on `__cxa_throw` to see the original `throw` location.  But it would sometimes be more useful to get the original error in the backtrace; a debugger is not always readily available and the original backtrace can be highly illuminating in any event.

This PR moves the cleanup code to be done via C++ RAII and `absl::Cleanup` so that we don't have to catch the original error.  It's a bit gnarly because it attempts to preserve the current behavior of the `AbortCompilation` and `OptimizerException` errors.

Backtrace from the same error as above, but with the current PR applied to the build:

```
froydnj@pyro:~/src/sorbet$  ./bazel-bin/compiler/sorbet --compiled-out-dir=. --llvm-ir-dir=. test/testdata/compiler/negate.rb
Backtrace:
  #3 0x64bd6b6
  #4 0x64bd650 __cxxabiv1::exception_cleanup_func()
  #5 0x254e589
  #6 0x3091c76 std::__1::optional<>::value()
  #7 0x307fd6a sorbet::compiler::(anonymous namespace)::TrackCaptures::trackBlockUsage()
  #8 0x3079519 sorbet::compiler::(anonymous namespace)::findCaptures()
  #9 0x3073046 sorbet::compiler::IREmitterContext::getSorbetBlocks2LLVMBlockMapping()
  #10 0x305c58d sorbet::compiler::IREmitter::run()
  #11 0x304af2a sorbet::pipeline::semantic_extension::LLVMSemanticExtension::typecheck()
  #12 0x2822fb3 sorbet::realmain::pipeline::CFGCollectorAndTyper::preTransformMethodDef()
  [...extra frames elided...]

libc++abi: terminate_handler unexpectedly returned
Aborted
```

We can more easily see that we're throwing an exception in `std::optional::value()`; it's `bad_optional_access` because we're accessing `nullopt`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
