### PR TITLE
Make DispatchArgs::suppressErrors required

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -830,7 +830,7 @@ struct DispatchArgs {
     // Do not produce dispatch-related errors while evaluating the call. This is a performance optimization, as there
     // are cases where we call dispatchCall with no intention of showing the errors to the user. Producing those
     // unreported errors is expensive!
-    bool suppressErrors = false;
+    bool suppressErrors;
 
     Loc callLoc() const {
         return core::Loc(locs.file, locs.call);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -771,17 +771,19 @@ core::ClassOrModuleRef Types::getRepresentedClass(const GlobalState &gs, const T
 
 DispatchArgs DispatchArgs::withSelfRef(const TypePtr &newSelfRef) const {
     return DispatchArgs{
-        name, locs, numPosArgs, args, newSelfRef, fullType, newSelfRef, block, originForUninitialized, suppressErrors};
+        name,        locs,          numPosArgs, args, newSelfRef, fullType, newSelfRef, block, originForUninitialized,
+        isPrivateOk, suppressErrors};
 }
 
 DispatchArgs DispatchArgs::withThisRef(const TypePtr &newThisRef) const {
     return DispatchArgs{
-        name, locs, numPosArgs, args, selfType, fullType, newThisRef, block, originForUninitialized, suppressErrors};
+        name,        locs,          numPosArgs, args, selfType, fullType, newThisRef, block, originForUninitialized,
+        isPrivateOk, suppressErrors};
 }
 
 DispatchArgs DispatchArgs::withErrorsSuppressed() const {
-    return DispatchArgs{name, locs, numPosArgs, args, selfType, fullType, thisType, block, originForUninitialized,
-                        true};
+    return DispatchArgs{
+        name, locs, numPosArgs, args, selfType, fullType, thisType, block, originForUninitialized, isPrivateOk, true};
 }
 
 DispatchResult DispatchResult::merge(const GlobalState &gs, DispatchResult::Combinator kind, DispatchResult &&left,

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -123,6 +123,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
     // core::Loc::none() should be okay here.
     auto originForUninitialized = core::Loc::none();
     auto originForFullType = core::Loc::none();
+    auto suppressErrors = true;
     core::DispatchArgs dispatchArgs{snd->fun,
                                     locs,
                                     numPosArgs,
@@ -132,7 +133,8 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
                                     snd->recv.type,
                                     snd->link,
                                     originForUninitialized,
-                                    snd->isPrivateOk};
+                                    snd->isPrivateOk,
+                                    suppressErrors};
     auto dispatchInfo = snd->recv.type.dispatchCall(ctx, dispatchArgs);
 
     // See if we can learn what types should they have

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -961,9 +961,12 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     send->argLocs,
                 };
 
+                // This is the main place where we type check a method, so we default by assuming
+                // that we want to report all errors (supressing nothing).
+                auto suppressErrors = false;
                 core::DispatchArgs dispatchArgs{
-                    send->fun, locs,          send->numPosArgs, args,     recvType.type,
-                    recvType,  recvType.type, send->link,       ownerLoc, send->isPrivateOk};
+                    send->fun,  locs,     send->numPosArgs,  args,          recvType.type, recvType, recvType.type,
+                    send->link, ownerLoc, send->isPrivateOk, suppressErrors};
                 auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
 
                 auto it = &dispatched;

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -1017,6 +1017,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                 recvi->loc,
                 argLocs,
             };
+            auto suppressErrors = false;
             core::DispatchArgs dispatchArgs{core::Names::squareBrackets(),
                                             locs,
                                             s.numPosArgs,
@@ -1026,7 +1027,8 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                                             ctype,
                                             nullptr,
                                             originForUninitialized,
-                                            s.flags.isPrivateOk};
+                                            s.flags.isPrivateOk,
+                                            suppressErrors};
             auto out = core::Types::dispatchCallWithoutBlock(ctx, ctype, dispatchArgs);
 
             if (out.isUntyped()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Errors were not always being suppressed properly, because certain
locations forgot to propagate the old value when constructing a new
`DispatchArgs` struct.

This meant that we were actually doing substantially more work than we
meant to.

This might also fix a source of non-deterministic behavior in Sorbet on
Stripe's codebase (not yet tested) but the performance benefits (not yet
measured) should be justification enough to land this.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.