### PR TITLE
return the correct type for new(*[])

### DIFF
--- a/rewriter/SelfNew.cc
+++ b/rewriter/SelfNew.cc
@@ -5,11 +5,8 @@
 
 namespace sorbet::rewriter {
 
-ast::ExpressionPtr SelfNew::run(core::MutableContext ctx, ast::Send *send) {
-    if (send->fun != core::Names::new_() || !send->recv.isSelfReference()) {
-        return nullptr;
-    }
-
+namespace {
+ast::ExpressionPtr convertSelfNew(core::MutableContext ctx, ast::Send *send) {
     ast::Send::ARGS_store args;
 
     args.emplace_back(std::move(send->recv));
@@ -20,6 +17,64 @@ ast::ExpressionPtr SelfNew::run(core::MutableContext ctx, ast::Send *send) {
 
     auto numPosArgs = send->numPosArgs + 1;
     return ast::MK::SelfNew(send->loc, numPosArgs, std::move(args), send->flags, std::move(send->block));
+}
+
+bool isSelfNewCallWithSplat(core::MutableContext ctx, ast::Send *send) {
+    if (send->fun != core::Names::callWithSplat()) {
+        return false;
+    }
+
+    if (!send->args[0].isSelfReference()) {
+        return false;
+    }
+
+    auto *lit = ast::cast_tree<ast::Literal>(send->args[1]);
+    if (lit == nullptr) {
+        return false;
+    }
+
+    if (!core::isa_type<core::LiteralType>(lit->value)) {
+        return false;
+    }
+
+    const auto &litType = core::cast_type_nonnull<core::LiteralType>(lit->value);
+    if (litType.literalKind != core::LiteralType::LiteralTypeKind::Symbol) {
+        return false;
+    }
+
+    if (litType.asName(ctx) != core::Names::new_()) {
+        return false;
+    }
+
+    return true;
+}
+
+ast::ExpressionPtr convertSelfNewCallWithSplat(core::MutableContext ctx, ast::Send *send) {
+    ast::Send::ARGS_store args;
+
+    for (auto &arg : send->args) {
+        args.emplace_back(std::move(arg));
+    }
+
+    auto magic = ast::MK::Constant(send->loc, core::Symbols::Magic());
+    args[0] = std::move(magic);
+    args[1] = ast::MK::Symbol(send->loc, core::Names::selfNew());
+
+    return ast::MK::Send(send->loc, std::move(send->recv), send->fun, send->numPosArgs, std::move(args), send->flags,
+                         std::move(send->block));
+}
+} // namespace
+
+ast::ExpressionPtr SelfNew::run(core::MutableContext ctx, ast::Send *send) {
+    if (send->fun == core::Names::new_() && send->recv.isSelfReference()) {
+        return convertSelfNew(ctx, send);
+    }
+
+    if (isSelfNewCallWithSplat(ctx, send)) {
+        return convertSelfNewCallWithSplat(ctx, send);
+    }
+
+    return nullptr;
 }
 
 } // namespace sorbet::rewriter

--- a/test/testdata/infer/self_new_with_splat.rb
+++ b/test/testdata/infer/self_new_with_splat.rb
@@ -1,0 +1,21 @@
+# typed: strict
+class Foo
+  extend T::Sig
+
+  sig {returns(T.attached_class)}
+  def self.works_correctly
+    new
+  end
+
+  sig {returns(T.attached_class)}
+  def self.also_works
+    new(*[])
+  end
+
+  sig {returns(T.attached_class)}
+  def self.also_works_with_block
+    new(*[]) do
+      1
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #4613.  jez's suggestion worked perfectly.

I guess we should also add a test for passing through `&blk`?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
