### PR TITLE
preallocate methodHashes in GlobalState::hash

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1949,6 +1949,7 @@ unique_ptr<GlobalStateHash> GlobalState::hash() const {
     }
 
     unique_ptr<GlobalStateHash> result = make_unique<GlobalStateHash>();
+    result->methodHashes.reserve(methodHashes.size());
     for (const auto &e : methodHashes) {
         result->methodHashes.emplace_back(e.first, patchHash(e.second));
     }


### PR DESCRIPTION
### Motivation

A little preallocation is a good thing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
