### PR TITLE
Track the compiled status in File

### DIFF
--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -428,8 +428,11 @@ IREmitterHelpers::isFinalMethod(const core::GlobalState &gs, core::TypePtr recvT
     }
 
     auto file = funSym.data(gs)->loc().file();
-    bool isCompiled = file.data(gs).compiledLevel == core::CompiledLevel::True;
-    return IREmitterHelpers::FinalMethodInfo{recvSym, funSym, file, isCompiled};
+    if (file.data(gs).compiledLevel != core::CompiledLevel::True) {
+        return std::nullopt;
+    }
+
+    return IREmitterHelpers::FinalMethodInfo{recvSym, funSym, file};
 }
 
 llvm::Value *IREmitterHelpers::receiverFastPathTestWithCache(MethodCallContext &mcctx,

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -428,7 +428,7 @@ IREmitterHelpers::isFinalMethod(const core::GlobalState &gs, core::TypePtr recvT
     }
 
     auto file = funSym.data(gs)->loc().file();
-    bool isCompiled = file.data(gs).source().find("# compiled: true\n") != string_view::npos;
+    bool isCompiled = file.data(gs).compiledLevel == core::CompiledLevel::True;
     return IREmitterHelpers::FinalMethodInfo{recvSym, funSym, file, isCompiled};
 }
 

--- a/compiler/IREmitter/IREmitterHelpers.h
+++ b/compiler/IREmitter/IREmitterHelpers.h
@@ -155,7 +155,6 @@ public:
         core::ClassOrModuleRef recv;
         core::SymbolRef method;
         core::FileRef file;
-        bool isCompiled{false};
     };
 
     // Return true when the symbol is a final method

--- a/compiler/IREmitter/sends.cc
+++ b/compiler/IREmitter/sends.cc
@@ -86,7 +86,7 @@ llvm::Value *tryFinalMethodCall(MethodCallContext &mcctx) {
     auto &cs = mcctx.cs;
     auto recvType = mcctx.send->recv.type;
     auto finalInfo = IREmitterHelpers::isFinalMethod(cs, recvType, mcctx.send->fun);
-    if (!finalInfo.has_value() || !finalInfo->isCompiled) {
+    if (!finalInfo.has_value()) {
         return IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
     }
 

--- a/core/CompiledLevel.h
+++ b/core/CompiledLevel.h
@@ -1,0 +1,19 @@
+#ifndef SORBET_CORE_COMPILED_LEVEL_H
+#define SORBET_CORE_COMPILED_LEVEL_H
+
+namespace sorbet::core {
+enum class CompiledLevel {
+
+    // This file has no compiled sigil present. The behavior here is the same as for `# compiled: false`, but it's
+    // useful to distinguish files that have no sigil present for stats.
+    None = 0,
+
+    // This file is explicitly opted-out of compilation.
+    False = 1,
+
+    // This file should be compiled.
+    True = 1,
+};
+}
+
+#endif

--- a/core/CompiledLevel.h
+++ b/core/CompiledLevel.h
@@ -12,7 +12,7 @@ enum class CompiledLevel {
     False = 1,
 
     // This file should be compiled.
-    True = 1,
+    True = 2,
 };
 }
 

--- a/core/Files.h
+++ b/core/Files.h
@@ -1,6 +1,7 @@
 #ifndef SORBET_AST_FILES_H
 #define SORBET_AST_FILES_H
 
+#include "core/CompiledLevel.h"
 #include "core/Names.h"
 #include "core/StrictLevel.h"
 #include <string>
@@ -80,7 +81,8 @@ public:
     friend class GlobalState;
     friend class ::sorbet::core::serialize::SerializerImpl;
 
-    static StrictLevel fileSigil(std::string_view source);
+    static StrictLevel fileStrictSigil(std::string_view source);
+    static CompiledLevel fileCompiledSigil(std::string_view source);
 
     std::string_view path() const;
     std::string_view source() const;
@@ -119,6 +121,8 @@ private:
 public:
     const StrictLevel originalSigil;
     StrictLevel strictLevel;
+
+    const CompiledLevel compiledLevel;
 };
 
 template <typename H> H AbslHashValue(H h, const FileRef &m) {

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -99,7 +99,7 @@ TEST_CASE("FileIsTyped") { // NOLINT
         {"\n# @typed\n", StrictLevel::None},
     };
     for (auto &tc : cases) {
-        CHECK_EQ(tc.strict, File::fileSigil(tc.src));
+        CHECK_EQ(tc.strict, File::fileStrictSigil(tc.src));
     }
 }
 

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -103,6 +103,26 @@ TEST_CASE("FileIsTyped") { // NOLINT
     }
 }
 
+struct FileIsCompiledCase {
+    string_view src;
+    CompiledLevel compiled;
+};
+
+TEST_CASE("FileIsCompiled") { // NOLINT
+    vector<FileIsCompiledCase> cases = {
+        {"", CompiledLevel::None},
+        {"# compiled: true", CompiledLevel::True},
+        {"\n# compiled: true\n", CompiledLevel::True},
+        {"\n# compiled: false\n", CompiledLevel::False},
+        {"not a compiled: sigil\n# compiled: true\n", CompiledLevel::True},
+        {"compiled:\n# compiled: nonsense\n", CompiledLevel::None},
+        {"compiled: true\n", CompiledLevel::None},
+    };
+    for (auto &tc : cases) {
+        CHECK_EQ(tc.compiled, File::fileCompiledSigil(tc.src));
+    }
+}
+
 TEST_CASE("Substitute") { // NOLINT
     GlobalState gs1(errorQueue);
     gs1.initEmpty();

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -536,7 +536,7 @@ int realmain(int argc, char *argv[]) {
                 prodCounterInc("types.input.lines");
                 prodCounterInc("types.input.files");
                 auto input = opts.inlineInput;
-                if (core::File::fileSigil(opts.inlineInput) == core::StrictLevel::None) {
+                if (core::File::fileStrictSigil(opts.inlineInput) == core::StrictLevel::None) {
                     // put it at the end so as to not upset line numbers
                     input += "\n# typed: true";
                 }

--- a/plugin_injector/plugin_injector.cc
+++ b/plugin_injector/plugin_injector.cc
@@ -130,8 +130,7 @@ class LLVMSemanticExtension : public SemanticExtension {
     }
 
     bool isCompiledTrue(const core::GlobalState &gs, const core::FileRef &f) const {
-        // TODO parse this the same way as `typed:`
-        return f.data(gs).source().find("# compiled: true\n") != string_view::npos;
+        return f.data(gs).compiledLevel == core::CompiledLevel::True;
     }
 
     // There are a certain class of method calls that sorbet generates for auxiliary


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Track the compiled level for a file in the same way that we do the typed level. This avoids re-parsing the file in multiple places in the compiler, and opens the door to tracking the compiled status of files more generally.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Avoiding duplicating work, pre-work for tracking the compiled status of files.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
