### PR TITLE
Fix signatures in vm-payload.c

### DIFF
--- a/compiler/IREmitter/Payload/vm-payload.c
+++ b/compiler/IREmitter/Payload/vm-payload.c
@@ -141,7 +141,10 @@ VALUE sorbet_addMissingKWArg(VALUE missing, VALUE sym) {
     return missing;
 }
 
-__attribute__((__noreturn)) void sorbet_raiseMissingKeywords(VALUE missing) {
+// from class.c
+VALUE rb_keyword_error_new(const char *error, VALUE keys);
+
+__attribute__((__noreturn__)) void sorbet_raiseMissingKeywords(VALUE missing) {
     rb_exc_raise(rb_keyword_error_new("missing", missing));
 }
 


### PR DESCRIPTION
I was seeing build failures with `./bazel test //...` as follows:

```
ERROR: /home/aprocter/stripe/sorbet/compiler/IREmitter/Payload/BUILD:65:12: Compiling compiler/IREmitter/Payload/vm-payload.c failed: (Exit 1): clang failed: error executing command /home/aprocter/.cache/bazel/_bazel_aprocter/0fa27aedae0428666dbd1b3b122d50e7/external/llvm_toolchain_12_0_0/bin/clang -U_FORTIFY_SOURCE -fstack-protector -fno-omit-frame-pointer -fcolor-diagnostics ... (remaining 39 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
compiler/IREmitter/Payload/vm-payload.c:144:16: error: unknown attribute '__noreturn' ignored [-Werror,-Wunknown-attributes]
__attribute__((__noreturn)) void sorbet_raiseMissingKeywords(VALUE missing) {
               ^~~~~~~~~~
compiler/IREmitter/Payload/vm-payload.c:145:18: error: implicit declaration of function 'rb_keyword_error_new' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    rb_exc_raise(rb_keyword_error_new("missing", missing));
                 ^
compiler/IREmitter/Payload/vm-payload.c:145:18: note: did you mean 'rb_key_err_new'?
bazel-out/k8-fastbuild/bin/external/sorbet_ruby_2_7/toolchain/internal_include/internal.h:1580:7: note: 'rb_key_err_new' declared here
VALUE rb_key_err_new(VALUE mesg, VALUE recv, VALUE name);
      ^
2 errors generated.
```

Not sure why we haven't been seeing this in CI or elsewhere, but maybe there's something subtly different about my environment. In any case, the fix here seems reasonable.

### Motivation
Fix the build.


### Test plan
Tested that it builds for me locally, so if it also builds in CI I think we should be good.