### PR TITLE
[LSP] Tests for Go to Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,33 @@ class Project::Foo
 end
 ```
 
+#### Testing "Go to Implementation"
+
+Testing the "Go to Implementation" feature is really similar to the testing techniques of the "Go to Type Definition".
+
+```ruby
+module A
+#      ^ find-implementation: A
+  extend T::Sig
+  extend T::Helpers
+  interface!
+end
+
+ class B
+#^^^^^^^ implementation: A
+  extend T::Sig
+  include A
+#         ^ find-implementation: A
+end
+```
+
+There are two types of assertions:
+
+1. `find-implementation: <symbol>` means make a "Go to Implementation" request here. `<symbol>` marks the symbol name we are looking for.
+2. `implementation: <symbol>` marks the location which should be returned for the "Go to Implementation" call for a given `<symbol>`
+
+If the request returns multiple locations, you should mark all of them with `implementation: <symbol>`
+
 #### Testing rename constant
 
 To write a test for renaming constants, you need to make at least two files:

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -1796,11 +1796,13 @@ void SymbolSearchAssertion::checkAll(const vector<shared_ptr<RangeAssertion>> &a
     }
 }
 
-ImplementationAssertion::ImplementationAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine, string_view symbol)
+ImplementationAssertion::ImplementationAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine,
+                                                 string_view symbol)
     : RangeAssertion(filename, range, assertionLine), symbol(symbol) {}
 
-shared_ptr<ImplementationAssertion> ImplementationAssertion::make(string_view filename, unique_ptr<Range> &range, int assertionLine,
-                                                string_view assertionContents, string_view assertionType) {
+shared_ptr<ImplementationAssertion> ImplementationAssertion::make(string_view filename, unique_ptr<Range> &range,
+                                                                  int assertionLine, string_view assertionContents,
+                                                                  string_view assertionType) {
     auto [symbol, _, __] = getSymbolVersionAndOption(assertionContents);
     return make_shared<ImplementationAssertion>(filename, range, assertionLine, symbol);
 }
@@ -1809,11 +1811,14 @@ string ImplementationAssertion::toString() const {
     return fmt::format("implementation: {}", symbol);
 }
 
-FindImplementationAssertion::FindImplementationAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine, string_view symbol)
+FindImplementationAssertion::FindImplementationAssertion(string_view filename, unique_ptr<Range> &range,
+                                                         int assertionLine, string_view symbol)
     : RangeAssertion(filename, range, assertionLine), symbol(symbol) {}
 
-shared_ptr<FindImplementationAssertion> FindImplementationAssertion::make(string_view filename, unique_ptr<Range> &range, int assertionLine,
-                                                string_view assertionContents, string_view assertionType) {
+shared_ptr<FindImplementationAssertion> FindImplementationAssertion::make(string_view filename,
+                                                                          unique_ptr<Range> &range, int assertionLine,
+                                                                          string_view assertionContents,
+                                                                          string_view assertionType) {
     auto [symbol, _, __] = getSymbolVersionAndOption(assertionContents);
     return make_shared<FindImplementationAssertion>(filename, range, assertionLine, symbol);
 }
@@ -1822,9 +1827,10 @@ string FindImplementationAssertion::toString() const {
     return fmt::format("find-implementation: {}", symbol);
 }
 
-void FindImplementationAssertion::check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
-                      LSPWrapper &wrapper, int &nextId, std::string_view symbol, const Location &queryLoc,
-                      const std::vector<std::shared_ptr<ImplementationAssertion>> &allImpls) {
+void FindImplementationAssertion::check(
+    const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents, LSPWrapper &wrapper, int &nextId,
+    std::string_view symbol, const Location &queryLoc,
+    const std::vector<std::shared_ptr<ImplementationAssertion>> &allImpls) {
     const int line = queryLoc.range->start->line;
     // Can only query with one character, so just use the first one.
     const int character = queryLoc.range->start->character;
@@ -1836,7 +1842,7 @@ void FindImplementationAssertion::check(const UnorderedMap<std::string, std::sha
     auto request = make_unique<LSPMessage>(make_unique<RequestMessage>(
         "2.0", id, LSPMethod::TextDocumentImplementation,
         make_unique<ImplementationParams>(make_unique<TextDocumentIdentifier>(string(queryLoc.uri)),
-                                                make_unique<Position>(line, character))));
+                                          make_unique<Position>(line, character))));
     auto responses = getLSPResponsesFor(wrapper, move(request));
     REQUIRE_EQ(1, responses.size());
     assertResponseMessage(id, *responses.at(0));
@@ -1848,10 +1854,9 @@ void FindImplementationAssertion::check(const UnorderedMap<std::string, std::sha
     auto &locations = extractLocations(respMsg);
 
     // casting from ImplementationAssertion to RangeAssertion
-    std::vector<std::shared_ptr<RangeAssertion>> allLocs (allImpls.begin(), allImpls.end());
+    std::vector<std::shared_ptr<RangeAssertion>> allLocs(allImpls.begin(), allImpls.end());
     assertLocationsMatch(config, sourceFileContents, symbol, allLocs, line, character, locSourceLine, locFilename,
                          locations, "find implementation");
 };
-
 
 } // namespace sorbet::test

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -393,22 +393,24 @@ public:
 
 // # ^^^ implementation: symbol
 class ImplementationAssertion final : public RangeAssertion {
-    public:
-
-    ImplementationAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine, std::string_view symbol);
-    static std::shared_ptr<ImplementationAssertion> make(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
-                                                std::string_view assertionContents, std::string_view assertionType);
+public:
+    ImplementationAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
+                            std::string_view symbol);
+    static std::shared_ptr<ImplementationAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
+                                                         int assertionLine, std::string_view assertionContents,
+                                                         std::string_view assertionType);
     const std::string symbol;
     std::string toString() const override;
 };
 
 // # ^^^ find-implementation: symbol
 class FindImplementationAssertion final : public RangeAssertion {
-    public:
-
-    FindImplementationAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine, std::string_view symbol);
-    static std::shared_ptr<FindImplementationAssertion> make(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
-                                                std::string_view assertionContents, std::string_view assertionType);
+public:
+    FindImplementationAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
+                                std::string_view symbol);
+    static std::shared_ptr<FindImplementationAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
+                                                             int assertionLine, std::string_view assertionContents,
+                                                             std::string_view assertionType);
 
     static void check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
                       LSPWrapper &wrapper, int &nextId, std::string_view symbol, const Location &queryLoc,

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -391,5 +391,32 @@ public:
     std::string toString() const override;
 };
 
+// # ^^^ implementation: symbol
+class ImplementationAssertion final : public RangeAssertion {
+    public:
+
+    ImplementationAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine, std::string_view symbol);
+    static std::shared_ptr<ImplementationAssertion> make(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
+                                                std::string_view assertionContents, std::string_view assertionType);
+    const std::string symbol;
+    std::string toString() const override;
+};
+
+// # ^^^ find-implementation: symbol
+class FindImplementationAssertion final : public RangeAssertion {
+    public:
+
+    FindImplementationAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine, std::string_view symbol);
+    static std::shared_ptr<FindImplementationAssertion> make(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
+                                                std::string_view assertionContents, std::string_view assertionType);
+
+    static void check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
+                      LSPWrapper &wrapper, int &nextId, std::string_view symbol, const Location &queryLoc,
+                      const std::vector<std::shared_ptr<ImplementationAssertion>> &allLocs);
+
+    const std::string symbol;
+    std::string toString() const override;
+};
+
 } // namespace sorbet::test
 #endif // TEST_HELPERS_POSITION_ASSERTIONS_H

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -434,9 +434,10 @@ TEST_CASE("LSPTest") {
         // RangeAssertions, so rather than fiddle with up casting, we'll just make the whole vector RangeAssertions)
         UnorderedMap<string, pair<vector<shared_ptr<RangeAssertion>>, vector<shared_ptr<TypeAssertion>>>> typeDefMap;
 
-
         // symbol => [ ImplementationAssertion[], FindImplementationAssertion[] ]
-        UnorderedMap<string, pair<vector<shared_ptr<ImplementationAssertion>>, vector<shared_ptr<FindImplementationAssertion>>>> implementationMap;
+        UnorderedMap<string,
+                     pair<vector<shared_ptr<ImplementationAssertion>>, vector<shared_ptr<FindImplementationAssertion>>>>
+            implementationMap;
         for (auto &assertion : assertions) {
             fmt::print("*** assertion: {}", assertion->toString());
             if (auto defAssertion = dynamic_pointer_cast<DefAssertion>(assertion)) {
@@ -552,7 +553,8 @@ TEST_CASE("LSPTest") {
             auto &[impls, implAssertions] = implsAndAssertions;
             for (auto &implAssertion : implAssertions) {
                 auto queryLoc = implAssertion->getLocation(config);
-                FindImplementationAssertion::check(test.sourceFileContents, *lspWrapper, nextId, symbol, *queryLoc, impls);
+                FindImplementationAssertion::check(test.sourceFileContents, *lspWrapper, nextId, symbol, *queryLoc,
+                                                   impls);
             }
         }
     }

--- a/test/testdata/lsp/find_implementation.rb
+++ b/test/testdata/lsp/find_implementation.rb
@@ -1,0 +1,61 @@
+# typed: true
+
+module Runnable
+#      ^^^^^^^^ find-implementation: Runnable
+  extend T::Sig
+  extend T::Helpers
+  interface!
+
+  sig { abstract.params(args: T::Array[String]).void }
+  def run(args); end
+#     ^^^ find-implementation: run
+end
+
+ class HelloWorld
+#^^^^^^^^^^^^^^^^ implementation: Runnable
+  extend T::Sig
+  include Runnable
+#         ^^^^^^^^ find-implementation: Runnable
+  sig { override.params(args: T::Array[String]).void }
+  def run(args)
+# ^^^^^^^^^^^^^ implementation: run
+#     ^^^ find-implementation: run
+    puts 'Hello World!'
+  end
+end
+
+ class ByeByeWorld
+#^^^^^^^^^^^^^^^^^ implementation: Runnable
+  extend T::Sig
+  include Runnable
+#         ^^^^^^^^ find-implementation: Runnable
+  sig { override.params(args: T::Array[String]).void }
+  def run(args)
+# ^^^^^^^^^^^^^ implementation: run
+#     ^^^ find-implementation: run
+    puts 'Farewell World!'
+  end
+end
+
+class Main
+    extend T::Sig
+  
+    sig {params(x: String).void}
+    def self.main(x)
+        hello = T.let(HelloWorld.new, Runnable)
+#                                     ^^^^^^^^ find-implementation: Runnable
+        byebye = T.let(ByeByeWorld.new, Runnable)
+#                                       ^^^^^^^^ find-implementation: Runnable
+        hello.run([])
+#             ^^^ find-implementation: run
+        HelloWorld.new.run([])
+#                      ^^^ find-implementation: run
+    end
+
+    sig {params(runnable: Runnable).void}
+#                         ^^^^^^^^ find-implementation: Runnable
+    def self.run(runnable)
+        runnable.run([])
+#                ^^^ find-implementation: run
+    end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This is the stacked PR on top of https://github.com/sorbet/sorbet/pull/4598


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The PR adds LSP tests for "Go to Implementations" feature. I took my inspiration from the tests for "Go to Type Definition".

The PR introduces two new annotation types: `implementation` and `find-implementation`. First one marks the locations which LSP should return, and the second one marks the code point for the request. The test compares expected locations to the locations actually returned by the LSP 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
