### PR TITLE
Add -p compilied-files-json

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -70,6 +70,7 @@ const vector<PrintOptions> print_options({
     {"autogen-autoloader", &Printers::AutogenAutoloader, true, false},
     {"autogen-subclasses", &Printers::AutogenSubclasses, true},
     {"package-tree", &Printers::Packager},
+    {"compiled-files-json", &Printers::CompiledFilesJson},
 });
 
 PrinterConfig::PrinterConfig() : state(make_shared<GuardedState>()){};
@@ -135,6 +136,7 @@ vector<reference_wrapper<PrinterConfig>> Printers::printers() {
         AutogenAutoloader,
         AutogenSubclasses,
         Packager,
+        CompiledFilesJson,
     });
 }
 

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -80,6 +80,7 @@ struct Printers {
     PrinterConfig AutogenAutoloader;
     PrinterConfig AutogenSubclasses;
     PrinterConfig Packager;
+    PrinterConfig CompiledFilesJson;
     // Ensure everything here is in PrinterConfig::printers().
 
     std::vector<std::reference_wrapper<PrinterConfig>> printers();

--- a/test/cli/compiled-files-json/compiled-false.rb
+++ b/test/cli/compiled-files-json/compiled-false.rb
@@ -1,0 +1,1 @@
+# compiled: false

--- a/test/cli/compiled-files-json/compiled-files-json.out
+++ b/test/cli/compiled-files-json/compiled-files-json.out
@@ -1,0 +1,2 @@
+No errors! Great job.
+[{"file":"./compiled-false.rb","compiled":"false"},{"file":"./compiled-none.rb","compiled":"none"},{"file":"./compiled-true.rb","compiled":"true"}]

--- a/test/cli/compiled-files-json/compiled-files-json.sh
+++ b/test/cli/compiled-files-json/compiled-files-json.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+sorbet="$PWD/main/sorbet"
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+"$sorbet" --silence-dev-message --print compiled-files-json ./*.rb 2>&1

--- a/test/cli/compiled-files-json/compiled-true.rb
+++ b/test/cli/compiled-files-json/compiled-true.rb
@@ -1,0 +1,3 @@
+# compiled: true
+# typed: true
+# frozen_string_literal: true

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -196,7 +196,7 @@ Usage:
                                 file-table-proto, file-table-messagepack,
                                 missing-constants, autogen, autogen-msgpack,
                                 autogen-classlist, autogen-autoloader, autogen-subclasses,
-                                package-tree]
+                                package-tree, compiled-files-json]
       --autogen-subclasses-parent string
                                 Parent classes for which generate a list of
                                 subclasses. This option must be used in


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Add the `compiled-files-json` print option, which prints out a json array that contains objects describing the compiled status of each file processed. Example output looks like:

```[{"file":"compiled-false.rb","compiled":"false"},{"file":"compiled-none.rb","compiled":"none"},{"file":"compiled-true.rb","compiled":"true"}]```

And pretty-printed:

```
[
  {
    "file": "compiled-false.rb",
    "compiled": "false"
  },
  {
    "file": "compiled-none.rb",
    "compiled": "none"
  },
  {
    "file": "compiled-true.rb",
    "compiled": "true"
  }
]
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Collecting stats on the number of files that are compiled.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
