### PR TITLE
redo format_cxx.sh to accept a list of files to format

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -159,7 +159,9 @@ SORBET_ALIVE(VALUE, sorbet_vm_fstring_new, (const char *ptr, long len));
 
 extern void sorbet_throwReturn(rb_execution_context_t *ec, VALUE retval) __attribute__((noreturn));
 KEEP_ALIVE(sorbet_throwReturn);
-SORBET_ALIVE(VALUE, sorbet_vm_callBlock, (rb_control_frame_t *cfp, int argc, SORBET_ATTRIBUTE(noescape) const VALUE *const restrict argv, int kw_splat));
+SORBET_ALIVE(VALUE, sorbet_vm_callBlock,
+             (rb_control_frame_t * cfp, int argc, SORBET_ATTRIBUTE(noescape) const VALUE *const restrict argv,
+              int kw_splat));
 
 SORBET_ALIVE(int, rb_cvar_lookup, (VALUE klass, ID id, VALUE *v));
 
@@ -170,14 +172,12 @@ struct rfb_status {
     // Whether the value was returned via return-from-block.
     bool was_thrown;
 };
-SORBET_ALIVE(struct rfb_status, sorbet_vm_return_from_block_wrapper, (int argc, VALUE *argv, VALUE recv, rb_control_frame_t *cfp, rb_sorbet_func_t wrapped));
+SORBET_ALIVE(struct rfb_status, sorbet_vm_return_from_block_wrapper,
+             (int argc, VALUE *argv, VALUE recv, rb_control_frame_t *cfp, rb_sorbet_func_t wrapped));
 SORBET_ALIVE(VALUE, sorbet_run_exception_handling,
-             (rb_execution_context_t *ec,
-              ExceptionFFIType body,
-              VALUE ** volatile pc,
+             (rb_execution_context_t * ec, ExceptionFFIType body, VALUE **volatile pc,
               // The locals offset for the body.
-              VALUE methodClosure,
-              rb_control_frame_t * volatile cfp,
+              VALUE methodClosure, rb_control_frame_t *volatile cfp,
               // May be nullptr.
               ExceptionFFIType handlers,
               // May be nullptr.
@@ -185,9 +185,7 @@ SORBET_ALIVE(VALUE, sorbet_run_exception_handling,
               // May be nullptr.
               ExceptionFFIType ensureClause,
               // The special value indicating that we need to retry.
-              VALUE retrySingleton,
-              long exceptionValueIndex,
-              long exceptionValueLevel));
+              VALUE retrySingleton, long exceptionValueIndex, long exceptionValueLevel));
 
 // The next several functions exist to convert Ruby definitions into LLVM IR, and
 // are always inlined as a consequence.
@@ -1773,7 +1771,6 @@ VALUE sorbet_removeKWArg(VALUE maybeHash, VALUE key) {
     if (maybeHash == RUBY_Qundef) {
         return RUBY_Qundef;
     }
-
 
     return rb_hash_delete_entry(maybeHash, key);
 }

--- a/compiler/IREmitter/Payload/patches/vm_insnhelper.c
+++ b/compiler/IREmitter/Payload/patches/vm_insnhelper.c
@@ -492,9 +492,10 @@ struct rfb_status {
     bool was_thrown;
 };
 
-struct rfb_status sorbet_vm_return_from_block_wrapper(int argc, VALUE *argv, VALUE recv, rb_control_frame_t * volatile cfp, rb_sorbet_func_t wrapped) {
+struct rfb_status sorbet_vm_return_from_block_wrapper(int argc, VALUE *argv, VALUE recv,
+                                                      rb_control_frame_t *volatile cfp, rb_sorbet_func_t wrapped) {
     enum ruby_tag_type state;
-    rb_execution_context_t * volatile ec = GET_EC();
+    rb_execution_context_t *volatile ec = GET_EC();
     struct rfb_status status;
     status.return_value = Qundef;
     status.was_thrown = false;
@@ -562,12 +563,10 @@ static void sorbet_raiseIfNotNil(VALUE exception) {
 
     rb_exc_raise(exception);
 }
-VALUE sorbet_run_exception_handling(rb_execution_context_t * volatile ec,
-                                    volatile ExceptionFFIType body,
-                                    VALUE ** volatile pc,
+VALUE sorbet_run_exception_handling(rb_execution_context_t *volatile ec, volatile ExceptionFFIType body,
+                                    VALUE **volatile pc,
                                     // The locals offset for the body.
-                                    volatile VALUE methodClosure,
-                                    rb_control_frame_t * volatile cfp,
+                                    volatile VALUE methodClosure, rb_control_frame_t *volatile cfp,
                                     // May be nullptr.
                                     volatile ExceptionFFIType handlers,
                                     // May be nullptr.
@@ -575,8 +574,7 @@ VALUE sorbet_run_exception_handling(rb_execution_context_t * volatile ec,
                                     // May be nullptr.
                                     volatile ExceptionFFIType ensureClause,
                                     // The special value indicating that we need to retry.
-                                    volatile VALUE retrySingleton,
-                                    volatile long exceptionValueIndex,
+                                    volatile VALUE retrySingleton, volatile long exceptionValueIndex,
                                     volatile long exceptionValueLevel) {
     // `volatile` is not used in polite C programming, but here it's very important:
     // it ensures that the requisite variables are stored in memory across the setjmp
@@ -722,7 +720,7 @@ VALUE sorbet_run_exception_handling(rb_execution_context_t * volatile ec,
         rb_set_errinfo(postRescueExceptionContext);
     }
 
- execute_ensure:
+execute_ensure:
     // However we arrived at this state, we are done with our entry on the tag stack.
     EC_POP_TAG();
 


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I wanted to be able to run `./tools/scripts/remote-script ./tools/script/format_cxx.sh`, but there's no `.git` on a Stripe devbox. The next best thing is providing a list of files to format. (It might be even better to setup editor auto-format on save, but I am a curmudgeon.)

(A very similar change landed when we had a separate compiler repo, but the change did not get carried over from the compiler repo.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
