### PR TITLE
refactor SymbolBasedIntrinsic applicability checks

### DIFF
--- a/compiler/IREmitter/sends.cc
+++ b/compiler/IREmitter/sends.cc
@@ -167,6 +167,46 @@ llvm::Value *tryNameBasedIntrinsic(MethodCallContext &mcctx) {
     return tryFinalMethodCall(mcctx);
 }
 
+// We want at least inline storage for one intrinsic so we don't allocate during
+// the search process.  Two intrinsics are reasonably common (e.g. .length) and
+// three could come up quite a bit in numeric code.
+const size_t NUM_INTRINSICS = 3;
+
+struct ApplicableIntrinsic {
+  ApplicableIntrinsic(const SymbolBasedIntrinsicMethod *method, core::ClassOrModuleRef klass)
+    : method(method), klass(klass) {}
+  const SymbolBasedIntrinsicMethod *method;
+  core::ClassOrModuleRef klass;
+};
+
+InlinedVector<ApplicableIntrinsic, NUM_INTRINSICS> applicableIntrinsics(MethodCallContext &mcctx) {
+  InlinedVector<ApplicableIntrinsic, NUM_INTRINSICS> intrinsics;
+  auto remainingType = mcctx.send->recv.type;
+  for (auto symbolBasedIntrinsic : SymbolBasedIntrinsicMethod::definedIntrinsics(mcctx.cs)) {
+    if (!absl::c_linear_search(symbolBasedIntrinsic->applicableMethods(mcctx.cs), mcctx.send->fun)) {
+      continue;
+    }
+
+    if (mcctx.blk.has_value() && symbolBasedIntrinsic->blockHandled == Intrinsics::HandleBlock::Unhandled) {
+      continue;
+    }
+
+    auto potentialClasses = symbolBasedIntrinsic->applicableClasses(mcctx.cs);
+    for (auto &c : potentialClasses) {
+      auto leftType = core::Types::dropSubtypesOf(mcctx.cs, remainingType, c);
+
+      if (leftType == remainingType) {
+        continue;
+      }
+
+      remainingType = leftType;
+      intrinsics.emplace_back(symbolBasedIntrinsic, c);
+    }
+  }
+
+  return intrinsics;
+}
+
 llvm::Value *trySymbolBasedIntrinsic(MethodCallContext &mcctx) {
     auto &cs = mcctx.cs;
     auto *send = mcctx.send;
@@ -180,46 +220,28 @@ llvm::Value *trySymbolBasedIntrinsic(MethodCallContext &mcctx) {
     auto phi = builder.CreatePHI(builder.getInt64Ty(), 2, llvm::Twine("symIntrinsicRawPhi_") + methodNameRef);
     builder.SetInsertPoint(rememberStart);
     if (!remainingType.isUntyped()) {
-        for (auto symbolBasedIntrinsic : SymbolBasedIntrinsicMethod::definedIntrinsics(mcctx.cs)) {
-            if (!absl::c_linear_search(symbolBasedIntrinsic->applicableMethods(cs), send->fun)) {
-                continue;
-            }
+      auto intrinsics = applicableIntrinsics(mcctx);
+      for (auto &intrinsic : intrinsics) {
+        auto clazName = intrinsic.klass.data(cs)->name.shortName(cs);
+        llvm::StringRef clazNameRef(clazName.data(), clazName.size());
 
-            if (mcctx.blk.has_value() && symbolBasedIntrinsic->blockHandled == Intrinsics::HandleBlock::Unhandled) {
-                continue;
-            }
+        auto alternative = llvm::BasicBlock::Create(
+            cs, llvm::Twine("alternativeCallIntrinsic_") + clazNameRef + "_" + methodNameRef,
+            builder.GetInsertBlock()->getParent());
+        auto fastPath = llvm::BasicBlock::Create(
+            cs, llvm::Twine("fastSymCallIntrinsic_") + clazNameRef + "_" + methodNameRef,
+            builder.GetInsertBlock()->getParent());
 
-            auto potentialClasses = symbolBasedIntrinsic->applicableClasses(cs);
-            for (auto &c : potentialClasses) {
-                auto leftType = core::Types::dropSubtypesOf(cs, remainingType, c);
-
-                if (leftType == remainingType) {
-                    continue;
-                }
-
-                remainingType = leftType;
-
-                auto clazName = c.data(cs)->name.shortName(cs);
-                llvm::StringRef clazNameRef(clazName.data(), clazName.size());
-
-                auto alternative = llvm::BasicBlock::Create(
-                    cs, llvm::Twine("alternativeCallIntrinsic_") + clazNameRef + "_" + methodNameRef,
-                    builder.GetInsertBlock()->getParent());
-                auto fastPath = llvm::BasicBlock::Create(
-                    cs, llvm::Twine("fastSymCallIntrinsic_") + clazNameRef + "_" + methodNameRef,
-                    builder.GetInsertBlock()->getParent());
-
-                auto *typeTest = symbolBasedIntrinsic->receiverFastPathTest(mcctx, c);
-                builder.CreateCondBr(Payload::setExpectedBool(cs, builder, typeTest, true), fastPath, alternative);
-                builder.SetInsertPoint(fastPath);
-                auto fastPathRes = symbolBasedIntrinsic->makeCall(mcctx);
-                Payload::afterIntrinsic(cs, builder);
-                auto fastPathEnd = builder.GetInsertBlock();
-                builder.CreateBr(afterSend);
-                phi->addIncoming(fastPathRes, fastPathEnd);
-                builder.SetInsertPoint(alternative);
-            }
-        }
+        auto *typeTest = intrinsic.method->receiverFastPathTest(mcctx, intrinsic.klass);
+        builder.CreateCondBr(Payload::setExpectedBool(cs, builder, typeTest, true), fastPath, alternative);
+        builder.SetInsertPoint(fastPath);
+        auto fastPathRes = intrinsic.method->makeCall(mcctx);
+        Payload::afterIntrinsic(cs, builder);
+        auto fastPathEnd = builder.GetInsertBlock();
+        builder.CreateBr(afterSend);
+        phi->addIncoming(fastPathRes, fastPathEnd);
+        builder.SetInsertPoint(alternative);
+      }
     }
     auto slowPathRes = tryNameBasedIntrinsic(mcctx);
     auto slowPathEnd = builder.GetInsertBlock();


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I found this code confusing the first time I looked through it; I think refactoring it to separate out the "determine applicable intrinsics" from the "generate code for runtime type testing + execution" makes it clearer.

I have a secondary goal here: we'd like to change things such that intrinsics on `Sorbet::Private::Static` and `<Magic>` that don't get translated throw errors at compile time, rather than runtime.  `<Magic>` has already been (mostly) done as #4591, but `Sorbet::Private::Static` is a little harder.  Why?  Because a lot of `Sorbet::Private::Static` intrinsics are implemented as symbol-based intrinsics and so we wind up generating code like:

```
if receiver is Sorbet::Private::Static
  do the intrinsic thing
else
  do runtime dispatch to Sorbet::Private::Static
end
```

The `else` path winds up getting optimized out by LLVM, but as we're generating code for it, we'd error under a scheme where we checked for unimplemented intrinsics on `Sorbet::Private::Static`.

So I'd like to change things such that we always only generate the intrinsic path for `Sorbet::Private::Static` intrinsics and that's easier to do if we see the full list up front.  (I'd also like to change things so that for e.g. `Thread.current`, we generate better code, and this PR is helpful for eventually doing that.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
