### PR TITLE
Return richer data to `inline_type_error_handler`

### DIFF
--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -214,7 +214,7 @@ module T
     begin
       raise TypeError.new("Passed `nil` into T.must")
     rescue TypeError => e # raise into rescue to ensure e.backtrace is populated
-      T::Configuration.inline_type_error_handler(e)
+      T::Configuration.inline_type_error_handler(e, kind: 'T.must', value: arg, type: nil)
     end
   end
 
@@ -239,7 +239,7 @@ module T
     begin
       raise TypeError.new(msg)
     rescue TypeError => e # raise into rescue to ensure e.backtrace is populated
-      T::Configuration.inline_type_error_handler(e)
+      T::Configuration.inline_type_error_handler(e, kind: 'T.absurd', value: value, type: nil)
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -214,7 +214,7 @@ module T
     begin
       raise TypeError.new("Passed `nil` into T.must")
     rescue TypeError => e # raise into rescue to ensure e.backtrace is populated
-      T::Configuration.inline_type_error_handler(e, kind: 'T.must', value: arg, type: nil)
+      T::Configuration.inline_type_error_handler(e, {kind: 'T.must', value: arg, type: nil})
     end
   end
 
@@ -239,7 +239,7 @@ module T
     begin
       raise TypeError.new(msg)
     rescue TypeError => e # raise into rescue to ensure e.backtrace is populated
-      T::Configuration.inline_type_error_handler(e, kind: 'T.absurd', value: value, type: nil)
+      T::Configuration.inline_type_error_handler(e, {kind: 'T.absurd', value: value, type: nil})
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -152,7 +152,12 @@ module T::Configuration
 
   def self.inline_type_error_handler(error, opts={})
     if @inline_type_error_handler
-      @inline_type_error_handler.call(error, opts)
+      # Backwards compatibility before `inline_type_error_handler` took a second arg
+      if @inline_type_error_handler.arity == 1
+        @inline_type_error_handler.call(error)
+      else
+        @inline_type_error_handler.call(error, opts)
+      end
     else
       inline_type_error_handler_default(error, opts)
     end

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -138,7 +138,7 @@ module T::Configuration
   # @option opts [Object] :value Actual param/return value
   #
   # @example
-  #   T::Configuration.inline_type_error_handler = lambda do |error|
+  #   T::Configuration.inline_type_error_handler = lambda do |error, opts|
   #     puts error.message
   #   end
   def self.inline_type_error_handler=(value)

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -131,6 +131,11 @@ module T::Configuration
   # Parameters passed to value.call:
   #
   # @param [TypeError] error TypeError that was raised
+  # @param [Hash] opts A hash containing contextual information on the error:
+  # @option opts [String] :kind One of:
+  #   ['T.cast', 'T.let', 'T.bind', 'T.assert_type!', 'T.must', 'T.absurd']
+  # @option opts [Object, nil] :type Expected param/return value type
+  # @option opts [Object] :value Actual param/return value
   #
   # @example
   #   T::Configuration.inline_type_error_handler = lambda do |error|
@@ -141,15 +146,15 @@ module T::Configuration
     @inline_type_error_handler = value
   end
 
-  private_class_method def self.inline_type_error_handler_default(error)
+  private_class_method def self.inline_type_error_handler_default(error, opts)
     raise error
   end
 
-  def self.inline_type_error_handler(error)
+  def self.inline_type_error_handler(error, opts={})
     if @inline_type_error_handler
-      @inline_type_error_handler.call(error)
+      @inline_type_error_handler.call(error, opts)
     else
-      inline_type_error_handler_default(error)
+      inline_type_error_handler_default(error, opts)
     end
     nil
   end

--- a/gems/sorbet-runtime/lib/types/private/casts.rb
+++ b/gems/sorbet-runtime/lib/types/private/casts.rb
@@ -14,7 +14,7 @@ module T::Private
 
         raise TypeError.new("#{cast_method}: #{error}\n#{suffix}")
       rescue TypeError => e # raise into rescue to ensure e.backtrace is populated
-        T::Configuration.inline_type_error_handler(e)
+        T::Configuration.inline_type_error_handler(e, kind: cast_method, value: value, type: type)
         value
       end
     end
@@ -33,7 +33,7 @@ module T::Private
 
         raise TypeError.new("#{cast_method}: #{error}\n#{suffix}")
       rescue TypeError => e # raise into rescue to ensure e.backtrace is populated
-        T::Configuration.inline_type_error_handler(e)
+        T::Configuration.inline_type_error_handler(e, kind: cast_method, value: value, type: type)
         value
       end
     end

--- a/gems/sorbet-runtime/lib/types/private/casts.rb
+++ b/gems/sorbet-runtime/lib/types/private/casts.rb
@@ -14,7 +14,7 @@ module T::Private
 
         raise TypeError.new("#{cast_method}: #{error}\n#{suffix}")
       rescue TypeError => e # raise into rescue to ensure e.backtrace is populated
-        T::Configuration.inline_type_error_handler(e, kind: cast_method, value: value, type: type)
+        T::Configuration.inline_type_error_handler(e, {kind: cast_method, value: value, type: type})
         value
       end
     end
@@ -33,7 +33,7 @@ module T::Private
 
         raise TypeError.new("#{cast_method}: #{error}\n#{suffix}")
       rescue TypeError => e # raise into rescue to ensure e.backtrace is populated
-        T::Configuration.inline_type_error_handler(e, kind: cast_method, value: value, type: type)
+        T::Configuration.inline_type_error_handler(e, {kind: cast_method, value: value, type: type})
         value
       end
     end

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -100,6 +100,9 @@ module Opus::Types::Test
         end
       end
 
+      # `inline_type_error_handler` historically took only a single arg, but now takes two. This
+      # test ensures backwards compatibility with any consumers still using a single argument. It
+      # can/should be removed whenever we're comfortable breaking this compatibility.
       describe 'when overridden with a single arg' do
         before do
           T::Configuration.inline_type_error_handler = lambda do |single_arg|

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -93,7 +93,7 @@ module Opus::Types::Test
             error.is_a?(TypeError) &&
               opts.is_a?(Hash) &&
               opts[:kind] == 'T.let' &&
-              opts[:type] == String &&
+              opts[:type].name == 'String' &&
               opts[:value] == 1
           end
           assert_equal(1, T.let(1, String))

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -151,7 +151,7 @@ module T::Configuration
   def self.disable_vm_prop_serde; end
   def self.hard_assert_handler(str, extra); end
   def self.hard_assert_handler=(value); end
-  def self.inline_type_error_handler(error); end
+  def self.inline_type_error_handler(error, opts); end
   def self.inline_type_error_handler=(value); end
   def self.log_info_handler(str, extra); end
   def self.log_info_handler=(value); end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -132,7 +132,7 @@ end
 T::Boolean = T.type_alias {T.any(TrueClass, FalseClass)}
 
 module T::Configuration
-  def self.call_validation_error_handler(signature, opts); end
+  def self.call_validation_error_handler(signature, opts={}); end
   def self.call_validation_error_handler=(value); end
   def self.default_checked_level=(default_checked_level); end
   def self.enable_checking_for_sigs_marked_checked_tests; end
@@ -151,7 +151,7 @@ module T::Configuration
   def self.disable_vm_prop_serde; end
   def self.hard_assert_handler(str, extra); end
   def self.hard_assert_handler=(value); end
-  def self.inline_type_error_handler(error, opts); end
+  def self.inline_type_error_handler(error, opts={}); end
   def self.inline_type_error_handler=(value); end
   def self.log_info_handler(str, extra); end
   def self.log_info_handler=(value); end
@@ -163,7 +163,7 @@ module T::Configuration
   def self.sealed_violation_whitelist=(sealed_violation_whitelist); end
   def self.sig_builder_error_handler(error, location); end
   def self.sig_builder_error_handler=(value); end
-  def self.sig_validation_error_handler(error, opts); end
+  def self.sig_validation_error_handler(error, opts={}); end
   def self.sig_validation_error_handler=(value); end
   def self.soft_assert_handler(str, extra); end
   def self.soft_assert_handler=(value); end

--- a/website/docs/tconfiguration.md
+++ b/website/docs/tconfiguration.md
@@ -33,7 +33,7 @@ There are four kinds of [inline type assertions](type-assertions.md):
 To customize the behavior when one of these assertions fails:
 
 ```ruby
-T::Configuration.inline_type_error_handler = lambda do |error|
+T::Configuration.inline_type_error_handler = lambda do |error, opts|
   puts error.message
 end
 ```


### PR DESCRIPTION
Enable `inline_type_error_handler` to take a second argument which has more data about the type error.

### Motivation

We ran into an issue trying to programmatically customize the handling of inline type errors. The argument passed to `inline_type_error_handler` is a simple `TypeError` whose message is [potentially truncated](https://github.com/sorbet/sorbet/blob/d9591b81594d4d096cfbe16cc469492ebc16db2c/gems/sorbet-runtime/lib/types/types/base.rb#L123) which makes it difficult or impossible to programmatically operate on the given value or expected type.

By contrast, the second argument passed to `call_validation_error_handler` is an object with a lot of detail: https://github.com/sorbet/sorbet/blob/061809c551ff62c546a8f9181a27b30906c8b89d/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb#L191-L200

This PR updates `inline_type_error_handler` to take a second argument that's a hash with the failed value and (optionally) the expected type and caller location. We check the arity of the configured proc to keep backwards compatibility for existing handlers.

### Test plan

Will add some tests if this is something you're open to merging.

<!-- See included automated tests. -->
