### PR TITLE
Allow fundamental types to be passed by value to ConcurrentQueue::push

### DIFF
--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -38,7 +38,7 @@ public:
     AbstractConcurrentBoundedQueue(const AbstractConcurrentBoundedQueue &other) = delete;
     AbstractConcurrentBoundedQueue(AbstractConcurrentBoundedQueue &&other) = delete;
 
-    // When `Elem` is a fundamental type (int, bool, etc) push takes a value, but if it's anythign else it expects an
+    // When `Elem` is a fundamental type (int, bool, etc) push takes a value, but if it's anything else it expects an
     // rvalue reference so that we don't forget to move the argument.
     // TODO: is it valuable to make this check use `std::is_trivially_copyable` instead?
     inline void push(typename std::conditional<std::is_fundamental<Elem>::value, Elem, Elem &&>::type elem,

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -74,8 +74,7 @@ void Hashing::computeFileHashes(const vector<shared_ptr<core::File>> &files, spd
     Timer timeit(logger, "computeFileHashes");
     auto fileq = make_shared<ConcurrentBoundedQueue<size_t>>(files.size());
     for (size_t i = 0; i < files.size(); i++) {
-        auto copy = i;
-        fileq->push(move(copy), 1);
+        fileq->push(i, 1);
     }
 
     logger.debug("Computing state hashes for {} files", files.size());
@@ -129,8 +128,7 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::Glob
     // Below, we rewrite ASTs to an empty GlobalState and use them for hashing.
     auto fileq = make_shared<ConcurrentBoundedQueue<size_t>>(asts.size());
     for (size_t i = 0; i < asts.size(); i++) {
-        auto copy = i;
-        fileq->push(move(copy), 1);
+        fileq->push(i, 1);
     }
 
     logger.debug("Computing state hashes for {} files", asts.size());

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -453,7 +453,7 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
     auto inputq = make_shared<ConcurrentBoundedQueue<int>>(tasks.size());
     auto outputq = make_shared<BlockingBoundedQueue<CounterState>>(tasks.size());
     for (int i = 0; i < tasks.size(); ++i) {
-        inputq->push(move(i), 1);
+        inputq->push(i, 1);
     }
 
     workers.multiplexJob("runAutogenWriteAutoloads", [&gs, &tasks, &alCfg, inputq, outputq]() {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -281,8 +281,7 @@ bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &i
     Timer timeit(logger, "slow_path.copy_indexes");
     shared_ptr<ConcurrentBoundedQueue<int>> fileq = make_shared<ConcurrentBoundedQueue<int>>(indexed.size());
     for (int i = 0; i < indexed.size(); i++) {
-        auto copy = i;
-        fileq->push(move(copy), 1);
+        fileq->push(i, 1);
     }
 
     const auto &epochManager = *gs->epochManager;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1096,8 +1096,7 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, vector
     // Compress files in parallel.
     auto fileq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile *>>(parsedFiles.size());
     for (auto &parsedFile : parsedFiles) {
-        auto ptr = &parsedFile;
-        fileq->push(move(ptr), 1);
+        fileq->push(&parsedFile, 1);
     }
 
     auto resultq = make_shared<BlockingBoundedQueue<vector<pair<string, vector<u1>>>>>(parsedFiles.size());

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -216,7 +216,7 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
     auto fileq = make_shared<ConcurrentBoundedQueue<int>>(indexed.size());
     vector<AutogenResult::Serialized> merged(indexed.size());
     for (int i = 0; i < indexed.size(); ++i) {
-        fileq->push(move(i), 1);
+        fileq->push(i, 1);
     }
     auto crcBuilder = autogen::CRCBuilder::create();
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
There are a number of places in the codebase where we use `ConcurrentQueue<int>` and other similar instantiations. The current behavior of `ConcurrentQueue::push` is that the element argument must be an rvalue reference, which yields loops that look like: https://github.com/sorbet/sorbet/blob/4a5cbc15d277cbc1cf7f5c3c6fa55ccb86c04cf2/hashing/hashing.cc#L76-L79

While requiring that non-fundamental types are moved into the queue is good, it's not as nice to have to move `int` elements in. This PR adds a little bit of template hackery to the argument to `push`, requiring that it's passed by value when it's a fundamental type and an rvalue reference otherwise.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Less surprising use of `ConcurrentQueue::push`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
