### PR TITLE
Fix desugaring to call-with-splat-and-block

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -659,7 +659,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         send->args.pop_back();
                     }
 
-                    // Deconstruct the kwargs hash in if it's present.
+                    // Deconstruct the kwargs hash if it's present.
                     if (!send->args.empty()) {
                         if (auto *hash = parser::cast_node<parser::Hash>(send->args.back().get())) {
                             if (hash->kwargs) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -649,8 +649,18 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     // Build up an array that represents the keyword args for the send. When there is a Kwsplat, treat
                     // all keyword arguments as a single argument.
                     unique_ptr<parser::Node> kwArray;
+
+                    // If there's a &blk node in the last position, pop that off (we'll put it back later, but
+                    // subsequent logic for dealing with the kwargs hash is simpler this way).
+                    unique_ptr<parser::Node> savedBlockPass = nullptr;
+
+                    if (!send->args.empty() && parser::isa_node<parser::BlockPass>(send->args.back().get())) {
+                        savedBlockPass = std::move(send->args.back());
+                        send->args.pop_back();
+                    }
+
+                    // Deconstruct the kwargs hash in if it's present.
                     if (!send->args.empty()) {
-                        // Deconstruct the kwargs hash in the last argument if it's present.
                         if (auto *hash = parser::cast_node<parser::Hash>(send->args.back().get())) {
                             if (hash->kwargs) {
                                 // hold a reference to the node, and remove it from the back of the send list
@@ -684,6 +694,11 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                                 kwArray = make_unique<parser::Array>(loc, std::move(elts));
                             }
                         }
+                    }
+
+                    // Put the &blk arg back, if present.
+                    if (savedBlockPass) {
+                        send->args.emplace_back(std::move(savedBlockPass));
                     }
 
                     // If the kwargs hash is not present, make a `nil` to put in the place of that argument. This

--- a/test/testdata/desugar/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forward_args.rb.desugar-tree.exp
@@ -9,10 +9,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo2<<todo method>>(*args, *kwargs:, &block)
-      ::<Magic>.<call-with-splat-and-block>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>(args).concat([begin
-              <hashTemp>$2 = ::<Magic>.<to-hash-dup>(kwargs)
-              <hashTemp>$2
-            end]), nil, block)
+      ::<Magic>.<call-with-splat-and-block>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>(args), [begin
+            <hashTemp>$2 = ::<Magic>.<to-hash-dup>(kwargs)
+            <hashTemp>$2
+          end], block)
     end
 
     def foo3<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
@@ -20,10 +20,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo4<<todo method>>(*args, *kwargs:, &block)
-      ::<Magic>.<call-with-splat-and-block>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>([1, 2, 3]).concat(::<Magic>.<splat>(args)).concat([begin
-              <hashTemp>$2 = ::<Magic>.<to-hash-dup>(kwargs)
-              <hashTemp>$2
-            end]), nil, block)
+      ::<Magic>.<call-with-splat-and-block>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>([1, 2, 3]).concat(::<Magic>.<splat>(args)), [begin
+            <hashTemp>$2 = ::<Magic>.<to-hash-dup>(kwargs)
+            <hashTemp>$2
+          end], block)
     end
   end
 


### PR DESCRIPTION
This fixes a bug in desugaring sends to `call-with-splat-and-block`. The trouble seemed to be that, when looking for the kwarg hash to deconstruct it, we assumed it would always be in the last position, which isn't true when a final `&blk` is present. Since that check fails, the kwarg hash winds up getting treated like an ordinary positional argument.

Example:

```ruby
def f(&blk)
  g(1, 2, *[3,4,5], 6, **{j: 99}, &blk)
end
```

Output of `-p desugar-tree` before change (note that the `begin...end` is inside the args to `concat` and the penultimate arg to call-with-splat-and-block is `nil`):

```
class <emptyTree><<C <root>>> < (::<todo sym>)
  def f<<todo method>>(&blk)
    ::<Magic>.<call-with-splat-and-block>(<self>, :g, [1, 2].concat(::<Magic>.<splat>([3, 4, 5])).concat([6, begin
            <hashTemp>$2 = ::<Magic>.<to-hash-dup>({:j => 99})
            <hashTemp>$2
          end]), nil, blk)
  end
end
```

Output of `-p desugar-tree` after change (the `begin...end` is now the penultimate arg to call-with-splat-and-block):

```
class <emptyTree><<C <root>>> < (::<todo sym>)
  def f<<todo method>>(&blk)
    ::<Magic>.<call-with-splat-and-block>(<self>, :g, [1, 2].concat(::<Magic>.<splat>([3, 4, 5])).concat([6]), [begin
          <hashTemp>$2 = ::<Magic>.<to-hash-dup>({:j => 99})
          <hashTemp>$2
        end], blk)
  end
end
```

### Motivation
I'm working on a separate change to support forwarding of splat and block args to "zsuper" in the compiler, which works by synthesizing `call-with-splat-and-block` calls, and as I was throwing things at the desugarer to double check my understanding of the semantics I came across this. Wanted to make sure it worked when synthesized as intended by the desugarer, before moving on to synthesizing it in novel contexts.


### Test plan
I think the change to `forward_args.rb.desugar-tree.exp` implies that this change is covered well by existing tests.