### PR TITLE
keep the original send around when rewriting DSLBuilder

### DIFF
--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -82,8 +82,10 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
     ast::MethodDef::Flags flags;
     flags.discardDef = true;
 
-    stats.emplace_back(ast::MK::Send(loc, move(send->recv), sendFun, send->numPosArgs, std::move(send->args),
-                                     send->flags, move(send->block)));
+    if (!skipSetter && !skipGetter) {
+        stats.emplace_back(ast::MK::Send(loc, ast::MK::Unsafe(loc, move(send->recv)), sendFun, send->numPosArgs,
+                                         std::move(send->args), send->flags, move(send->block)));
+    }
 
     // def self.<prop>
     if (!skipSetter) {

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -31,10 +31,11 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
     bool skipSetter = false;
     ast::ExpressionPtr type;
     core::NameRef name;
+    core::NameRef sendFun = send->fun;
 
-    if (send->fun == core::Names::dslOptional()) {
+    if (sendFun == core::Names::dslOptional()) {
         nilable = true;
-    } else if (send->fun == core::Names::dslRequired()) {
+    } else if (sendFun == core::Names::dslRequired()) {
     } else {
         return empty;
     }
@@ -78,6 +79,12 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
 
     vector<ast::ExpressionPtr> stats;
 
+    ast::MethodDef::Flags flags;
+    flags.discardDef = true;
+
+    stats.emplace_back(ast::MK::Send(loc, move(send->recv), sendFun, send->numPosArgs, std::move(send->args),
+                                     send->flags, move(send->block)));
+
     // def self.<prop>
     if (!skipSetter) {
         stats.emplace_back(ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, name), ASTUtil::dupType(type),
@@ -87,7 +94,7 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
             auto default_ = ast::MK::UntypedNil(loc);
             arg = ast::MK::OptionalArg(loc, move(arg), move(default_));
         }
-        auto defSelfProp = ast::MK::SyntheticMethod1(loc, loc, name, move(arg), ast::MK::EmptyTree());
+        auto defSelfProp = ast::MK::SyntheticMethod1(loc, loc, name, move(arg), ast::MK::EmptyTree(), flags);
         ast::cast_tree<ast::MethodDef>(defSelfProp)->flags.isSelfMethod = true;
         stats.emplace_back(move(defSelfProp));
     }
@@ -100,13 +107,13 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
         // def self.get_<prop>
         core::NameRef getName = ctx.state.enterNameUTF8("get_" + name.show(ctx));
         stats.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(type)));
-        auto defSelfGetProp = ast::MK::SyntheticMethod(loc, loc, getName, {}, ast::MK::RaiseUnimplemented(loc));
+        auto defSelfGetProp = ast::MK::SyntheticMethod(loc, loc, getName, {}, ast::MK::RaiseUnimplemented(loc), flags);
         ast::cast_tree<ast::MethodDef>(defSelfGetProp)->flags.isSelfMethod = true;
         stats.emplace_back(move(defSelfGetProp));
 
         // def <prop>()
         stats.emplace_back(ast::MK::Sig0(loc, ASTUtil::dupType(type)));
-        stats.emplace_back(ast::MK::SyntheticMethod(loc, loc, name, {}, ast::MK::RaiseUnimplemented(loc)));
+        stats.emplace_back(ast::MK::SyntheticMethod(loc, loc, name, {}, ast::MK::RaiseUnimplemented(loc), flags));
     }
 
     return stats;

--- a/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
@@ -168,49 +168,23 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
-    ::Sorbet::Private::Static.keep_self_def(<self>, :opt_string, :normal)
+    <self>.dsl_optional(:opt_string, <emptyTree>::<C String>)
 
-    ::Sorbet::Private::Static.keep_self_def(<self>, :get_opt_string, :normal)
+    <self>.dsl_optional(:opt_int_defaulted, <emptyTree>::<C Integer>, :default, 0)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :opt_string, :normal)
+    <self>.dsl_required(:req_string, <emptyTree>::<C String>)
 
-    ::Sorbet::Private::Static.keep_self_def(<self>, :opt_int_defaulted, :normal)
+    <self>.dsl_required(:implied_string, <emptyTree>::<C String>, :implied, "foo")
 
-    ::Sorbet::Private::Static.keep_self_def(<self>, :get_opt_int_defaulted, :normal)
+    <self>.dsl_optional(:no_getter, <emptyTree>::<C String>, :skip_getter, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :opt_int_defaulted, :normal)
-
-    ::Sorbet::Private::Static.keep_self_def(<self>, :req_string, :normal)
-
-    ::Sorbet::Private::Static.keep_self_def(<self>, :get_req_string, :normal)
-
-    ::Sorbet::Private::Static.keep_def(<self>, :req_string, :normal)
-
-    ::Sorbet::Private::Static.keep_self_def(<self>, :implied_string, :normal)
-
-    ::Sorbet::Private::Static.keep_self_def(<self>, :get_implied_string, :normal)
-
-    ::Sorbet::Private::Static.keep_def(<self>, :implied_string, :normal)
-
-    ::Sorbet::Private::Static.keep_self_def(<self>, :no_getter, :normal)
-
-    ::Sorbet::Private::Static.keep_self_def(<self>, :get_no_setter, :normal)
-
-    ::Sorbet::Private::Static.keep_def(<self>, :no_setter, :normal)
+    <self>.dsl_optional(:no_setter, <emptyTree>::<C String>, :skip_setter, true)
 
     <self>.dsl_optional(:no_getter_or_setter, <emptyTree>::<C String>, :skip_getter, true, :skip_setter, true)
 
-    ::Sorbet::Private::Static.keep_self_def(<self>, :class_of, :normal)
+    <self>.dsl_optional(:class_of, <emptyTree>::<C T>.class_of(<emptyTree>::<C Integer>))
 
-    ::Sorbet::Private::Static.keep_self_def(<self>, :get_class_of, :normal)
-
-    ::Sorbet::Private::Static.keep_def(<self>, :class_of, :normal)
-
-    ::Sorbet::Private::Static.keep_self_def(<self>, :root_const, :normal)
-
-    ::Sorbet::Private::Static.keep_self_def(<self>, :get_root_const, :normal)
-
-    ::Sorbet::Private::Static.keep_def(<self>, :root_const, :normal)
+    <self>.dsl_optional(:root_const, ::<root>::<C Integer>)
   end
 
   class <emptyTree>::<C TestChild><<C <todo sym>>> < (<emptyTree>::<C TestDSLBuilder>)

--- a/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
@@ -168,23 +168,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
-    <self>.dsl_optional(:opt_string, <emptyTree>::<C String>)
+    ::T.unsafe(<self>).dsl_optional(:opt_string, <emptyTree>::<C String>)
 
-    <self>.dsl_optional(:opt_int_defaulted, <emptyTree>::<C Integer>, :default, 0)
+    ::T.unsafe(<self>).dsl_optional(:opt_int_defaulted, <emptyTree>::<C Integer>, :default, 0)
 
-    <self>.dsl_required(:req_string, <emptyTree>::<C String>)
+    ::T.unsafe(<self>).dsl_required(:req_string, <emptyTree>::<C String>)
 
-    <self>.dsl_required(:implied_string, <emptyTree>::<C String>, :implied, "foo")
-
-    <self>.dsl_optional(:no_getter, <emptyTree>::<C String>, :skip_getter, true)
-
-    <self>.dsl_optional(:no_setter, <emptyTree>::<C String>, :skip_setter, true)
+    ::T.unsafe(<self>).dsl_required(:implied_string, <emptyTree>::<C String>, :implied, "foo")
 
     <self>.dsl_optional(:no_getter_or_setter, <emptyTree>::<C String>, :skip_getter, true, :skip_setter, true)
 
-    <self>.dsl_optional(:class_of, <emptyTree>::<C T>.class_of(<emptyTree>::<C Integer>))
+    ::T.unsafe(<self>).dsl_optional(:class_of, <emptyTree>::<C T>.class_of(<emptyTree>::<C Integer>))
 
-    <self>.dsl_optional(:root_const, ::<root>::<C Integer>)
+    ::T.unsafe(<self>).dsl_optional(:root_const, ::<root>::<C Integer>)
   end
 
   class <emptyTree>::<C TestChild><<C <todo sym>>> < (<emptyTree>::<C TestDSLBuilder>)


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Compiling files that use the `DSLBuilder` dsl doesn't work so well, because the synthesized methods aren't actually implemented.

Rather than trying to implement them, it's simpler to mark them as discardable so the compiler won't try to install them as methods.  But then we also need to keep around the original `Send` so that the `dsl_required`/`dsl_optional` call happens at runtime and installs the necessary methods.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
