### PR TITLE
Populate the isBlock flag in CFG construction

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -426,6 +426,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                         target.isRepeated = e.flags.isRepeated;
                         target.isDefault = e.flags.isDefault;
                         target.isShadow = e.flags.isShadow;
+                        target.isBlock = e.flags.isBlock;
                     }
                     auto link = make_shared<core::SendAndBlockLink>(s.fun, move(argFlags), newRubyBlockId);
                     auto send = make_unique<Send>(recv, s.fun, s.recv.loc(), s.numPosArgs, args, argLocs,

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -421,12 +421,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     vector<ast::ParsedArg> blockArgFlags = ast::ArgParsing::parseArgs(blockArgs);
                     vector<core::ArgInfo::ArgFlags> argFlags;
                     for (auto &e : blockArgFlags) {
-                        auto &target = argFlags.emplace_back();
-                        target.isKeyword = e.flags.isKeyword;
-                        target.isRepeated = e.flags.isRepeated;
-                        target.isDefault = e.flags.isDefault;
-                        target.isShadow = e.flags.isShadow;
-                        target.isBlock = e.flags.isBlock;
+                        argFlags.emplace_back(e.flags);
                     }
                     auto link = make_shared<core::SendAndBlockLink>(s.fun, move(argFlags), newRubyBlockId);
                     auto send = make_unique<Send>(recv, s.fun, s.recv.loc(), s.numPosArgs, args, argLocs,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
We weren't setting the `isBlock` flag for the argument info during CFG construction. This turns out to be required for correctly supporting `Proc#arity`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Suporting the implementation of `Proc#arity`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.