### PR TITLE
delete outdated explicit instantiations of unique_ptr on trees

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -5,37 +5,6 @@
 #include <sstream>
 #include <utility>
 
-// makes lldb work. Don't remove please
-template class std::unique_ptr<sorbet::ast::ClassDef>;
-template class std::unique_ptr<sorbet::ast::MethodDef>;
-template class std::unique_ptr<sorbet::ast::If>;
-template class std::unique_ptr<sorbet::ast::While>;
-template class std::unique_ptr<sorbet::ast::Break>;
-template class std::unique_ptr<sorbet::ast::Retry>;
-template class std::unique_ptr<sorbet::ast::Next>;
-template class std::unique_ptr<sorbet::ast::Return>;
-template class std::unique_ptr<sorbet::ast::RescueCase>;
-template class std::unique_ptr<sorbet::ast::Rescue>;
-template class std::unique_ptr<sorbet::ast::Local>;
-template class std::unique_ptr<sorbet::ast::UnresolvedIdent>;
-template class std::unique_ptr<sorbet::ast::RestArg>;
-template class std::unique_ptr<sorbet::ast::KeywordArg>;
-template class std::unique_ptr<sorbet::ast::OptionalArg>;
-template class std::unique_ptr<sorbet::ast::BlockArg>;
-template class std::unique_ptr<sorbet::ast::ShadowArg>;
-template class std::unique_ptr<sorbet::ast::Assign>;
-template class std::unique_ptr<sorbet::ast::Send>;
-template class std::unique_ptr<sorbet::ast::Cast>;
-template class std::unique_ptr<sorbet::ast::Hash>;
-template class std::unique_ptr<sorbet::ast::Array>;
-template class std::unique_ptr<sorbet::ast::Literal>;
-template class std::unique_ptr<sorbet::ast::UnresolvedConstantLit>;
-template class std::unique_ptr<sorbet::ast::ZSuperArgs>;
-template class std::unique_ptr<sorbet::ast::Block>;
-template class std::unique_ptr<sorbet::ast::InsSeq>;
-template class std::unique_ptr<sorbet::ast::EmptyTree>;
-template class std::unique_ptr<sorbet::ast::ConstantLit>;
-
 using namespace std;
 
 namespace sorbet::ast {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The comment here says "don't delete", but this dates back to when the AST was managed via `unique_ptr` rather than our custom `ExpressionPtr`.  Seeing as how we no longer use `unique_ptr` in our AST, these explicit instantiations can be deleted.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
