### PR TITLE
enforce that we don't make VM calls to Sorbet::Private::Static methods

### DIFF
--- a/compiler/IREmitter/SymbolBasedIntrinsicMethod.h
+++ b/compiler/IREmitter/SymbolBasedIntrinsicMethod.h
@@ -30,6 +30,16 @@ public:
     // Ruby VM.
     virtual llvm::Value *receiverFastPathTest(MethodCallContext &mcctx, core::ClassOrModuleRef potentialClass) const;
 
+    // The above is a runtime test, since it returns an llvm::Value (which might be `true`).
+    // This method is a compile test for instances where we statically know the compile-time
+    // test would succeed.  This might be done for intrinsics which we know don't have
+    // a slow path through the VM (e.g. calls on Sorbet::Private::Static) or where having
+    // a slow path through the VM would hinder optimizations like having an assumption
+    // about the return type of the method.
+    //
+    // You should not typically be returning true from this.
+    virtual bool skipFastPathTest(MethodCallContext &mcctx, core::ClassOrModuleRef potentialClass) const;
+
     SymbolBasedIntrinsicMethod(Intrinsics::HandleBlock blockHandled) : blockHandled(blockHandled){};
     virtual ~SymbolBasedIntrinsicMethod() = default;
     static std::vector<const SymbolBasedIntrinsicMethod *> &definedIntrinsics(const core::GlobalState &gs);

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -487,6 +487,9 @@ public:
         return Payload::varGet(cs, send->args[1].variable, builder, mcctx.irctx, mcctx.rubyBlockId);
     }
 
+    virtual bool skipFastPathTest(MethodCallContext &mcctx, core::ClassOrModuleRef potentialClass) const override {
+        return true;
+    }
     virtual InlinedVector<core::ClassOrModuleRef, 2> applicableClasses(const core::GlobalState &gs) const override {
         return {core::Symbols::Sorbet_Private_Static().data(gs)->lookupSingletonClass(gs)};
     };
@@ -549,6 +552,9 @@ public:
         return Payload::rubyNil(mcctx.cs, builder);
     }
 
+    virtual bool skipFastPathTest(MethodCallContext &mcctx, core::ClassOrModuleRef potentialClass) const override {
+        return true;
+    }
     virtual InlinedVector<core::ClassOrModuleRef, 2> applicableClasses(const core::GlobalState &gs) const override {
         return {core::Symbols::Sorbet_Private_Static().data(gs)->lookupSingletonClass(gs)};
     };
@@ -872,6 +878,11 @@ llvm::Value *SymbolBasedIntrinsicMethod::receiverFastPathTest(MethodCallContext 
                                                               core::ClassOrModuleRef potentialClass) const {
     auto *recv = mcctx.varGetRecv();
     return Payload::typeTest(mcctx.cs, mcctx.builder, recv, core::make_type<core::ClassType>(potentialClass));
+}
+
+bool SymbolBasedIntrinsicMethod::skipFastPathTest(MethodCallContext &mcctx,
+                                                  core::ClassOrModuleRef potentialClass) const {
+    return false;
 }
 
 void SymbolBasedIntrinsicMethod::sanityCheck(const core::GlobalState &gs) const {}

--- a/test/testdata/compiler/all_arguments.llo.exp
+++ b/test/testdata/compiler/all_arguments.llo.exp
@@ -115,9 +115,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_g = private unnamed_addr constant [2 x i8] c"g\00", align 1
 @rubyIdPrecomputed_f = internal unnamed_addr global i64 0, align 8
 @str_f = private unnamed_addr constant [2 x i8] c"f\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
 @ic_take_arguments = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.2 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -398,71 +395,71 @@ define void @Init_all_arguments() local_unnamed_addr #6 {
 entry:
   %positional_table.i = alloca i64, i32 4, align 8, !dbg !29
   %keyword_table.i = alloca i64, i32 3, align 8, !dbg !29
-  %locals.i165.i = alloca i64, i32 0, align 8
+  %locals.i164.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %keywords.i = alloca i64, align 8, !dbg !31
-  %keywords5.i = alloca i64, align 8, !dbg !32
-  %keywords11.i = alloca i64, align 8, !dbg !33
-  %keywords17.i = alloca i64, align 8, !dbg !34
-  %keywords23.i = alloca i64, align 8, !dbg !35
-  %keywords29.i = alloca i64, align 8, !dbg !36
-  %keywords35.i = alloca i64, align 8, !dbg !37
-  %keywords41.i = alloca i64, i32 2, align 8, !dbg !38
-  %keywords48.i = alloca i64, i32 2, align 8, !dbg !39
-  %keywords56.i = alloca i64, i32 2, align 8, !dbg !40
-  %keywords64.i = alloca i64, i32 2, align 8, !dbg !41
-  %keywords72.i = alloca i64, i32 2, align 8, !dbg !42
-  %keywords80.i = alloca i64, i32 2, align 8, !dbg !43
-  %keywords88.i = alloca i64, i32 2, align 8, !dbg !44
-  %keywords96.i = alloca i64, i32 3, align 8, !dbg !45
-  %keywords105.i = alloca i64, i32 3, align 8, !dbg !46
-  %keywords115.i = alloca i64, i32 3, align 8, !dbg !47
-  %keywords125.i = alloca i64, i32 3, align 8, !dbg !48
-  %keywords135.i = alloca i64, i32 3, align 8, !dbg !49
-  %keywords145.i = alloca i64, i32 3, align 8, !dbg !50
-  %keywords155.i = alloca i64, i32 3, align 8, !dbg !51
+  %keywords4.i = alloca i64, align 8, !dbg !32
+  %keywords10.i = alloca i64, align 8, !dbg !33
+  %keywords16.i = alloca i64, align 8, !dbg !34
+  %keywords22.i = alloca i64, align 8, !dbg !35
+  %keywords28.i = alloca i64, align 8, !dbg !36
+  %keywords34.i = alloca i64, align 8, !dbg !37
+  %keywords40.i = alloca i64, i32 2, align 8, !dbg !38
+  %keywords47.i = alloca i64, i32 2, align 8, !dbg !39
+  %keywords55.i = alloca i64, i32 2, align 8, !dbg !40
+  %keywords63.i = alloca i64, i32 2, align 8, !dbg !41
+  %keywords71.i = alloca i64, i32 2, align 8, !dbg !42
+  %keywords79.i = alloca i64, i32 2, align 8, !dbg !43
+  %keywords87.i = alloca i64, i32 2, align 8, !dbg !44
+  %keywords95.i = alloca i64, i32 3, align 8, !dbg !45
+  %keywords104.i = alloca i64, i32 3, align 8, !dbg !46
+  %keywords114.i = alloca i64, i32 3, align 8, !dbg !47
+  %keywords124.i = alloca i64, i32 3, align 8, !dbg !48
+  %keywords134.i = alloca i64, i32 3, align 8, !dbg !49
+  %keywords144.i = alloca i64, i32 3, align 8, !dbg !50
+  %keywords154.i = alloca i64, i32 3, align 8, !dbg !51
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
-  %1 = bitcast i64* %keywords5.i to i8*
+  %1 = bitcast i64* %keywords4.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %1)
-  %2 = bitcast i64* %keywords11.i to i8*
+  %2 = bitcast i64* %keywords10.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %2)
-  %3 = bitcast i64* %keywords17.i to i8*
+  %3 = bitcast i64* %keywords16.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %3)
-  %4 = bitcast i64* %keywords23.i to i8*
+  %4 = bitcast i64* %keywords22.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %4)
-  %5 = bitcast i64* %keywords29.i to i8*
+  %5 = bitcast i64* %keywords28.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %5)
-  %6 = bitcast i64* %keywords35.i to i8*
+  %6 = bitcast i64* %keywords34.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %6)
-  %7 = bitcast i64* %keywords41.i to i8*
+  %7 = bitcast i64* %keywords40.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %7)
-  %8 = bitcast i64* %keywords48.i to i8*
+  %8 = bitcast i64* %keywords47.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %8)
-  %9 = bitcast i64* %keywords56.i to i8*
+  %9 = bitcast i64* %keywords55.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %9)
-  %10 = bitcast i64* %keywords64.i to i8*
+  %10 = bitcast i64* %keywords63.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %10)
-  %11 = bitcast i64* %keywords72.i to i8*
+  %11 = bitcast i64* %keywords71.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %11)
-  %12 = bitcast i64* %keywords80.i to i8*
+  %12 = bitcast i64* %keywords79.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %12)
-  %13 = bitcast i64* %keywords88.i to i8*
+  %13 = bitcast i64* %keywords87.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %13)
-  %14 = bitcast i64* %keywords96.i to i8*
+  %14 = bitcast i64* %keywords95.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %14)
-  %15 = bitcast i64* %keywords105.i to i8*
+  %15 = bitcast i64* %keywords104.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %15)
-  %16 = bitcast i64* %keywords115.i to i8*
+  %16 = bitcast i64* %keywords114.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %16)
-  %17 = bitcast i64* %keywords125.i to i8*
+  %17 = bitcast i64* %keywords124.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %17)
-  %18 = bitcast i64* %keywords135.i to i8*
+  %18 = bitcast i64* %keywords134.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %18)
-  %19 = bitcast i64* %keywords145.i to i8*
+  %19 = bitcast i64* %keywords144.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %19)
-  %20 = bitcast i64* %keywords155.i to i8*
+  %20 = bitcast i64* %keywords154.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %20)
   %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 noundef 14) #10
   store i64 %21, i64* @rubyIdPrecomputed_take_arguments, align 8
@@ -489,223 +486,219 @@ entry:
   store i64 %32, i64* @rubyIdPrecomputed_g, align 8
   %33 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_f, i64 0, i64 0), i64 noundef 1) #10
   store i64 %33, i64* @rubyIdPrecomputed_f, align 8
-  %34 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #10
-  store i64 %34, i64* @rubyIdPrecomputed_keep_def, align 8
-  %35 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_baz, i64 0, i64 0), i64 noundef 3) #10
-  store i64 %35, i64* @rubyIdPrecomputed_baz, align 8
-  %36 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 noundef 14) #10
+  %34 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_baz, i64 0, i64 0), i64 noundef 3) #10
+  store i64 %34, i64* @rubyIdPrecomputed_baz, align 8
+  %35 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 noundef 14) #10
+  tail call void @rb_gc_register_mark_object(i64 %35) #10
+  store i64 %35, i64* @rubyStrFrozen_take_arguments, align 8
+  %36 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([40 x i8], [40 x i8]* @"str_test/testdata/compiler/all_arguments.rb", i64 0, i64 0), i64 noundef 39) #10
   tail call void @rb_gc_register_mark_object(i64 %36) #10
-  store i64 %36, i64* @rubyStrFrozen_take_arguments, align 8
-  %37 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([40 x i8], [40 x i8]* @"str_test/testdata/compiler/all_arguments.rb", i64 0, i64 0), i64 noundef 39) #10
-  tail call void @rb_gc_register_mark_object(i64 %37) #10
-  store i64 %37, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
+  store i64 %36, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 32)
   %rubyId_take_arguments.i.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8
   %rubyStr_take_arguments.i.i = load i64, i64* @rubyStrFrozen_take_arguments, align 8
   %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
-  %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_take_arguments.i.i, i64 %rubyId_take_arguments.i.i, i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 8)
-  store %struct.rb_iseq_struct* %38, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8
+  %37 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_take_arguments.i.i, i64 %rubyId_take_arguments.i.i, i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 8)
+  store %struct.rb_iseq_struct* %37, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8
   %rubyId_inspect.i = load i64, i64* @rubyIdPrecomputed_inspect, align 8, !dbg !24
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_inspect, i64 %rubyId_inspect.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !28
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  %39 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
-  call void @rb_gc_register_mark_object(i64 %39) #10
+  %38 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
+  call void @rb_gc_register_mark_object(i64 %38) #10
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/all_arguments.rb.i164.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
-  %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %39, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i164.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i165.i, i32 noundef 0, i32 noundef 11)
-  store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !29
+  %"rubyStr_test/testdata/compiler/all_arguments.rb.i163.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
+  %39 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %38, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i163.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i164.i, i32 noundef 0, i32 noundef 11)
+  store %struct.rb_iseq_struct* %39, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_take_arguments.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !31
   %rubyId_d.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !31
-  %41 = call i64 @rb_id2sym(i64 %rubyId_d.i) #10, !dbg !31
-  store i64 %41, i64* %keywords.i, align 8, !dbg !31
+  %40 = call i64 @rb_id2sym(i64 %rubyId_d.i) #10, !dbg !31
+  store i64 %40, i64* %keywords.i, align 8, !dbg !31
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments.i, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !31
-  %rubyId_take_arguments4.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !32
-  %rubyId_d6.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !32
-  %42 = call i64 @rb_id2sym(i64 %rubyId_d6.i) #10, !dbg !32
-  store i64 %42, i64* %keywords5.i, align 8, !dbg !32
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments4.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull %keywords5.i), !dbg !32
-  %rubyId_take_arguments10.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !33
-  %rubyId_d12.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !33
-  %43 = call i64 @rb_id2sym(i64 %rubyId_d12.i) #10, !dbg !33
-  store i64 %43, i64* %keywords11.i, align 8, !dbg !33
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments10.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull %keywords11.i), !dbg !33
-  %rubyId_take_arguments16.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !34
-  %rubyId_d18.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !34
-  %44 = call i64 @rb_id2sym(i64 %rubyId_d18.i) #10, !dbg !34
-  store i64 %44, i64* %keywords17.i, align 8, !dbg !34
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments16.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull %keywords17.i), !dbg !34
-  %rubyId_take_arguments22.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !35
-  %rubyId_d24.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !35
-  %45 = call i64 @rb_id2sym(i64 %rubyId_d24.i) #10, !dbg !35
-  store i64 %45, i64* %keywords23.i, align 8, !dbg !35
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments22.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull %keywords23.i), !dbg !35
-  %rubyId_take_arguments28.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !36
-  %rubyId_d30.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !36
-  %46 = call i64 @rb_id2sym(i64 %rubyId_d30.i) #10, !dbg !36
-  store i64 %46, i64* %keywords29.i, align 8, !dbg !36
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments28.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull %keywords29.i), !dbg !36
-  %rubyId_take_arguments34.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !37
-  %rubyId_d36.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !37
-  %47 = call i64 @rb_id2sym(i64 %rubyId_d36.i) #10, !dbg !37
-  store i64 %47, i64* %keywords35.i, align 8, !dbg !37
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments34.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull %keywords35.i), !dbg !37
-  %rubyId_take_arguments40.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !38
-  %rubyId_d42.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !38
-  %48 = call i64 @rb_id2sym(i64 %rubyId_d42.i) #10, !dbg !38
-  store i64 %48, i64* %keywords41.i, align 8, !dbg !38
+  %rubyId_take_arguments3.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !32
+  %rubyId_d5.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !32
+  %41 = call i64 @rb_id2sym(i64 %rubyId_d5.i) #10, !dbg !32
+  store i64 %41, i64* %keywords4.i, align 8, !dbg !32
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments3.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull %keywords4.i), !dbg !32
+  %rubyId_take_arguments9.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !33
+  %rubyId_d11.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !33
+  %42 = call i64 @rb_id2sym(i64 %rubyId_d11.i) #10, !dbg !33
+  store i64 %42, i64* %keywords10.i, align 8, !dbg !33
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments9.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull %keywords10.i), !dbg !33
+  %rubyId_take_arguments15.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !34
+  %rubyId_d17.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !34
+  %43 = call i64 @rb_id2sym(i64 %rubyId_d17.i) #10, !dbg !34
+  store i64 %43, i64* %keywords16.i, align 8, !dbg !34
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments15.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull %keywords16.i), !dbg !34
+  %rubyId_take_arguments21.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !35
+  %rubyId_d23.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !35
+  %44 = call i64 @rb_id2sym(i64 %rubyId_d23.i) #10, !dbg !35
+  store i64 %44, i64* %keywords22.i, align 8, !dbg !35
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments21.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull %keywords22.i), !dbg !35
+  %rubyId_take_arguments27.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !36
+  %rubyId_d29.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !36
+  %45 = call i64 @rb_id2sym(i64 %rubyId_d29.i) #10, !dbg !36
+  store i64 %45, i64* %keywords28.i, align 8, !dbg !36
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments27.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull %keywords28.i), !dbg !36
+  %rubyId_take_arguments33.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !37
+  %rubyId_d35.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !37
+  %46 = call i64 @rb_id2sym(i64 %rubyId_d35.i) #10, !dbg !37
+  store i64 %46, i64* %keywords34.i, align 8, !dbg !37
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments33.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull %keywords34.i), !dbg !37
+  %rubyId_take_arguments39.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !38
+  %rubyId_d41.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !38
+  %47 = call i64 @rb_id2sym(i64 %rubyId_d41.i) #10, !dbg !38
+  store i64 %47, i64* %keywords40.i, align 8, !dbg !38
   %rubyId_e.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !38
-  %49 = call i64 @rb_id2sym(i64 %rubyId_e.i) #10, !dbg !38
-  %50 = getelementptr i64, i64* %keywords41.i, i32 1, !dbg !38
-  store i64 %49, i64* %50, align 8, !dbg !38
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments40.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull %keywords41.i), !dbg !38
-  %rubyId_take_arguments47.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !39
-  %rubyId_d49.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !39
-  %51 = call i64 @rb_id2sym(i64 %rubyId_d49.i) #10, !dbg !39
-  store i64 %51, i64* %keywords48.i, align 8, !dbg !39
-  %rubyId_e51.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !39
-  %52 = call i64 @rb_id2sym(i64 %rubyId_e51.i) #10, !dbg !39
-  %53 = getelementptr i64, i64* %keywords48.i, i32 1, !dbg !39
-  store i64 %52, i64* %53, align 8, !dbg !39
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments47.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull %keywords48.i), !dbg !39
-  %rubyId_take_arguments55.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !40
-  %rubyId_d57.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !40
-  %54 = call i64 @rb_id2sym(i64 %rubyId_d57.i) #10, !dbg !40
-  store i64 %54, i64* %keywords56.i, align 8, !dbg !40
-  %rubyId_e59.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !40
-  %55 = call i64 @rb_id2sym(i64 %rubyId_e59.i) #10, !dbg !40
-  %56 = getelementptr i64, i64* %keywords56.i, i32 1, !dbg !40
-  store i64 %55, i64* %56, align 8, !dbg !40
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments55.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull %keywords56.i), !dbg !40
-  %rubyId_take_arguments63.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !41
-  %rubyId_d65.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !41
-  %57 = call i64 @rb_id2sym(i64 %rubyId_d65.i) #10, !dbg !41
-  store i64 %57, i64* %keywords64.i, align 8, !dbg !41
-  %rubyId_e67.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !41
-  %58 = call i64 @rb_id2sym(i64 %rubyId_e67.i) #10, !dbg !41
-  %59 = getelementptr i64, i64* %keywords64.i, i32 1, !dbg !41
-  store i64 %58, i64* %59, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments63.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull %keywords64.i), !dbg !41
-  %rubyId_take_arguments71.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !42
-  %rubyId_d73.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !42
-  %60 = call i64 @rb_id2sym(i64 %rubyId_d73.i) #10, !dbg !42
-  store i64 %60, i64* %keywords72.i, align 8, !dbg !42
-  %rubyId_e75.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !42
-  %61 = call i64 @rb_id2sym(i64 %rubyId_e75.i) #10, !dbg !42
-  %62 = getelementptr i64, i64* %keywords72.i, i32 1, !dbg !42
-  store i64 %61, i64* %62, align 8, !dbg !42
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments71.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull %keywords72.i), !dbg !42
-  %rubyId_take_arguments79.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !43
-  %rubyId_d81.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !43
-  %63 = call i64 @rb_id2sym(i64 %rubyId_d81.i) #10, !dbg !43
-  store i64 %63, i64* %keywords80.i, align 8, !dbg !43
-  %rubyId_e83.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !43
-  %64 = call i64 @rb_id2sym(i64 %rubyId_e83.i) #10, !dbg !43
-  %65 = getelementptr i64, i64* %keywords80.i, i32 1, !dbg !43
-  store i64 %64, i64* %65, align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments79.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull %keywords80.i), !dbg !43
-  %rubyId_take_arguments87.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !44
-  %rubyId_d89.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !44
-  %66 = call i64 @rb_id2sym(i64 %rubyId_d89.i) #10, !dbg !44
-  store i64 %66, i64* %keywords88.i, align 8, !dbg !44
-  %rubyId_e91.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !44
-  %67 = call i64 @rb_id2sym(i64 %rubyId_e91.i) #10, !dbg !44
-  %68 = getelementptr i64, i64* %keywords88.i, i32 1, !dbg !44
-  store i64 %67, i64* %68, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments87.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull %keywords88.i), !dbg !44
-  %rubyId_take_arguments95.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !45
-  %rubyId_d97.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !45
-  %69 = call i64 @rb_id2sym(i64 %rubyId_d97.i) #10, !dbg !45
-  store i64 %69, i64* %keywords96.i, align 8, !dbg !45
-  %rubyId_e99.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !45
-  %70 = call i64 @rb_id2sym(i64 %rubyId_e99.i) #10, !dbg !45
-  %71 = getelementptr i64, i64* %keywords96.i, i32 1, !dbg !45
-  store i64 %70, i64* %71, align 8, !dbg !45
+  %48 = call i64 @rb_id2sym(i64 %rubyId_e.i) #10, !dbg !38
+  %49 = getelementptr i64, i64* %keywords40.i, i32 1, !dbg !38
+  store i64 %48, i64* %49, align 8, !dbg !38
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments39.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull %keywords40.i), !dbg !38
+  %rubyId_take_arguments46.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !39
+  %rubyId_d48.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !39
+  %50 = call i64 @rb_id2sym(i64 %rubyId_d48.i) #10, !dbg !39
+  store i64 %50, i64* %keywords47.i, align 8, !dbg !39
+  %rubyId_e50.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !39
+  %51 = call i64 @rb_id2sym(i64 %rubyId_e50.i) #10, !dbg !39
+  %52 = getelementptr i64, i64* %keywords47.i, i32 1, !dbg !39
+  store i64 %51, i64* %52, align 8, !dbg !39
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments46.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull %keywords47.i), !dbg !39
+  %rubyId_take_arguments54.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !40
+  %rubyId_d56.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !40
+  %53 = call i64 @rb_id2sym(i64 %rubyId_d56.i) #10, !dbg !40
+  store i64 %53, i64* %keywords55.i, align 8, !dbg !40
+  %rubyId_e58.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !40
+  %54 = call i64 @rb_id2sym(i64 %rubyId_e58.i) #10, !dbg !40
+  %55 = getelementptr i64, i64* %keywords55.i, i32 1, !dbg !40
+  store i64 %54, i64* %55, align 8, !dbg !40
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments54.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull %keywords55.i), !dbg !40
+  %rubyId_take_arguments62.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !41
+  %rubyId_d64.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !41
+  %56 = call i64 @rb_id2sym(i64 %rubyId_d64.i) #10, !dbg !41
+  store i64 %56, i64* %keywords63.i, align 8, !dbg !41
+  %rubyId_e66.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !41
+  %57 = call i64 @rb_id2sym(i64 %rubyId_e66.i) #10, !dbg !41
+  %58 = getelementptr i64, i64* %keywords63.i, i32 1, !dbg !41
+  store i64 %57, i64* %58, align 8, !dbg !41
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments62.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull %keywords63.i), !dbg !41
+  %rubyId_take_arguments70.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !42
+  %rubyId_d72.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !42
+  %59 = call i64 @rb_id2sym(i64 %rubyId_d72.i) #10, !dbg !42
+  store i64 %59, i64* %keywords71.i, align 8, !dbg !42
+  %rubyId_e74.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !42
+  %60 = call i64 @rb_id2sym(i64 %rubyId_e74.i) #10, !dbg !42
+  %61 = getelementptr i64, i64* %keywords71.i, i32 1, !dbg !42
+  store i64 %60, i64* %61, align 8, !dbg !42
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments70.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull %keywords71.i), !dbg !42
+  %rubyId_take_arguments78.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !43
+  %rubyId_d80.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !43
+  %62 = call i64 @rb_id2sym(i64 %rubyId_d80.i) #10, !dbg !43
+  store i64 %62, i64* %keywords79.i, align 8, !dbg !43
+  %rubyId_e82.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !43
+  %63 = call i64 @rb_id2sym(i64 %rubyId_e82.i) #10, !dbg !43
+  %64 = getelementptr i64, i64* %keywords79.i, i32 1, !dbg !43
+  store i64 %63, i64* %64, align 8, !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments78.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull %keywords79.i), !dbg !43
+  %rubyId_take_arguments86.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !44
+  %rubyId_d88.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !44
+  %65 = call i64 @rb_id2sym(i64 %rubyId_d88.i) #10, !dbg !44
+  store i64 %65, i64* %keywords87.i, align 8, !dbg !44
+  %rubyId_e90.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !44
+  %66 = call i64 @rb_id2sym(i64 %rubyId_e90.i) #10, !dbg !44
+  %67 = getelementptr i64, i64* %keywords87.i, i32 1, !dbg !44
+  store i64 %66, i64* %67, align 8, !dbg !44
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments86.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull %keywords87.i), !dbg !44
+  %rubyId_take_arguments94.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !45
+  %rubyId_d96.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !45
+  %68 = call i64 @rb_id2sym(i64 %rubyId_d96.i) #10, !dbg !45
+  store i64 %68, i64* %keywords95.i, align 8, !dbg !45
+  %rubyId_e98.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !45
+  %69 = call i64 @rb_id2sym(i64 %rubyId_e98.i) #10, !dbg !45
+  %70 = getelementptr i64, i64* %keywords95.i, i32 1, !dbg !45
+  store i64 %69, i64* %70, align 8, !dbg !45
   %rubyId_baz.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !45
-  %72 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #10, !dbg !45
-  %73 = getelementptr i64, i64* %keywords96.i, i32 2, !dbg !45
-  store i64 %72, i64* %73, align 8, !dbg !45
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments95.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull %keywords96.i), !dbg !45
-  %rubyId_take_arguments104.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !46
-  %rubyId_d106.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !46
-  %74 = call i64 @rb_id2sym(i64 %rubyId_d106.i) #10, !dbg !46
-  store i64 %74, i64* %keywords105.i, align 8, !dbg !46
-  %rubyId_e108.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !46
-  %75 = call i64 @rb_id2sym(i64 %rubyId_e108.i) #10, !dbg !46
-  %76 = getelementptr i64, i64* %keywords105.i, i32 1, !dbg !46
-  store i64 %75, i64* %76, align 8, !dbg !46
-  %rubyId_baz110.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !46
-  %77 = call i64 @rb_id2sym(i64 %rubyId_baz110.i) #10, !dbg !46
-  %78 = getelementptr i64, i64* %keywords105.i, i32 2, !dbg !46
-  store i64 %77, i64* %78, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments104.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull %keywords105.i), !dbg !46
-  %rubyId_take_arguments114.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !47
-  %rubyId_d116.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !47
-  %79 = call i64 @rb_id2sym(i64 %rubyId_d116.i) #10, !dbg !47
-  store i64 %79, i64* %keywords115.i, align 8, !dbg !47
-  %rubyId_e118.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !47
-  %80 = call i64 @rb_id2sym(i64 %rubyId_e118.i) #10, !dbg !47
-  %81 = getelementptr i64, i64* %keywords115.i, i32 1, !dbg !47
-  store i64 %80, i64* %81, align 8, !dbg !47
-  %rubyId_baz120.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !47
-  %82 = call i64 @rb_id2sym(i64 %rubyId_baz120.i) #10, !dbg !47
-  %83 = getelementptr i64, i64* %keywords115.i, i32 2, !dbg !47
-  store i64 %82, i64* %83, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments114.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull %keywords115.i), !dbg !47
-  %rubyId_take_arguments124.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !48
-  %rubyId_d126.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !48
-  %84 = call i64 @rb_id2sym(i64 %rubyId_d126.i) #10, !dbg !48
-  store i64 %84, i64* %keywords125.i, align 8, !dbg !48
-  %rubyId_e128.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !48
-  %85 = call i64 @rb_id2sym(i64 %rubyId_e128.i) #10, !dbg !48
-  %86 = getelementptr i64, i64* %keywords125.i, i32 1, !dbg !48
-  store i64 %85, i64* %86, align 8, !dbg !48
-  %rubyId_baz130.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !48
-  %87 = call i64 @rb_id2sym(i64 %rubyId_baz130.i) #10, !dbg !48
-  %88 = getelementptr i64, i64* %keywords125.i, i32 2, !dbg !48
-  store i64 %87, i64* %88, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments124.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull %keywords125.i), !dbg !48
-  %rubyId_take_arguments134.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !49
-  %rubyId_d136.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !49
-  %89 = call i64 @rb_id2sym(i64 %rubyId_d136.i) #10, !dbg !49
-  store i64 %89, i64* %keywords135.i, align 8, !dbg !49
-  %rubyId_e138.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !49
-  %90 = call i64 @rb_id2sym(i64 %rubyId_e138.i) #10, !dbg !49
-  %91 = getelementptr i64, i64* %keywords135.i, i32 1, !dbg !49
-  store i64 %90, i64* %91, align 8, !dbg !49
-  %rubyId_baz140.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !49
-  %92 = call i64 @rb_id2sym(i64 %rubyId_baz140.i) #10, !dbg !49
-  %93 = getelementptr i64, i64* %keywords135.i, i32 2, !dbg !49
-  store i64 %92, i64* %93, align 8, !dbg !49
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments134.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull %keywords135.i), !dbg !49
-  %rubyId_take_arguments144.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !50
-  %rubyId_d146.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !50
-  %94 = call i64 @rb_id2sym(i64 %rubyId_d146.i) #10, !dbg !50
-  store i64 %94, i64* %keywords145.i, align 8, !dbg !50
-  %rubyId_e148.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !50
-  %95 = call i64 @rb_id2sym(i64 %rubyId_e148.i) #10, !dbg !50
-  %96 = getelementptr i64, i64* %keywords145.i, i32 1, !dbg !50
-  store i64 %95, i64* %96, align 8, !dbg !50
-  %rubyId_baz150.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !50
-  %97 = call i64 @rb_id2sym(i64 %rubyId_baz150.i) #10, !dbg !50
-  %98 = getelementptr i64, i64* %keywords145.i, i32 2, !dbg !50
-  store i64 %97, i64* %98, align 8, !dbg !50
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments144.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull %keywords145.i), !dbg !50
-  %rubyId_take_arguments154.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !51
-  %rubyId_d156.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !51
-  %99 = call i64 @rb_id2sym(i64 %rubyId_d156.i) #10, !dbg !51
-  store i64 %99, i64* %keywords155.i, align 8, !dbg !51
-  %rubyId_e158.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !51
-  %100 = call i64 @rb_id2sym(i64 %rubyId_e158.i) #10, !dbg !51
-  %101 = getelementptr i64, i64* %keywords155.i, i32 1, !dbg !51
-  store i64 %100, i64* %101, align 8, !dbg !51
-  %rubyId_baz160.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !51
-  %102 = call i64 @rb_id2sym(i64 %rubyId_baz160.i) #10, !dbg !51
-  %103 = getelementptr i64, i64* %keywords155.i, i32 2, !dbg !51
-  store i64 %102, i64* %103, align 8, !dbg !51
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments154.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull %keywords155.i), !dbg !51
+  %71 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #10, !dbg !45
+  %72 = getelementptr i64, i64* %keywords95.i, i32 2, !dbg !45
+  store i64 %71, i64* %72, align 8, !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments94.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull %keywords95.i), !dbg !45
+  %rubyId_take_arguments103.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !46
+  %rubyId_d105.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !46
+  %73 = call i64 @rb_id2sym(i64 %rubyId_d105.i) #10, !dbg !46
+  store i64 %73, i64* %keywords104.i, align 8, !dbg !46
+  %rubyId_e107.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !46
+  %74 = call i64 @rb_id2sym(i64 %rubyId_e107.i) #10, !dbg !46
+  %75 = getelementptr i64, i64* %keywords104.i, i32 1, !dbg !46
+  store i64 %74, i64* %75, align 8, !dbg !46
+  %rubyId_baz109.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !46
+  %76 = call i64 @rb_id2sym(i64 %rubyId_baz109.i) #10, !dbg !46
+  %77 = getelementptr i64, i64* %keywords104.i, i32 2, !dbg !46
+  store i64 %76, i64* %77, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments103.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull %keywords104.i), !dbg !46
+  %rubyId_take_arguments113.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !47
+  %rubyId_d115.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !47
+  %78 = call i64 @rb_id2sym(i64 %rubyId_d115.i) #10, !dbg !47
+  store i64 %78, i64* %keywords114.i, align 8, !dbg !47
+  %rubyId_e117.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !47
+  %79 = call i64 @rb_id2sym(i64 %rubyId_e117.i) #10, !dbg !47
+  %80 = getelementptr i64, i64* %keywords114.i, i32 1, !dbg !47
+  store i64 %79, i64* %80, align 8, !dbg !47
+  %rubyId_baz119.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !47
+  %81 = call i64 @rb_id2sym(i64 %rubyId_baz119.i) #10, !dbg !47
+  %82 = getelementptr i64, i64* %keywords114.i, i32 2, !dbg !47
+  store i64 %81, i64* %82, align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments113.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull %keywords114.i), !dbg !47
+  %rubyId_take_arguments123.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !48
+  %rubyId_d125.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !48
+  %83 = call i64 @rb_id2sym(i64 %rubyId_d125.i) #10, !dbg !48
+  store i64 %83, i64* %keywords124.i, align 8, !dbg !48
+  %rubyId_e127.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !48
+  %84 = call i64 @rb_id2sym(i64 %rubyId_e127.i) #10, !dbg !48
+  %85 = getelementptr i64, i64* %keywords124.i, i32 1, !dbg !48
+  store i64 %84, i64* %85, align 8, !dbg !48
+  %rubyId_baz129.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !48
+  %86 = call i64 @rb_id2sym(i64 %rubyId_baz129.i) #10, !dbg !48
+  %87 = getelementptr i64, i64* %keywords124.i, i32 2, !dbg !48
+  store i64 %86, i64* %87, align 8, !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments123.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull %keywords124.i), !dbg !48
+  %rubyId_take_arguments133.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !49
+  %rubyId_d135.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !49
+  %88 = call i64 @rb_id2sym(i64 %rubyId_d135.i) #10, !dbg !49
+  store i64 %88, i64* %keywords134.i, align 8, !dbg !49
+  %rubyId_e137.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !49
+  %89 = call i64 @rb_id2sym(i64 %rubyId_e137.i) #10, !dbg !49
+  %90 = getelementptr i64, i64* %keywords134.i, i32 1, !dbg !49
+  store i64 %89, i64* %90, align 8, !dbg !49
+  %rubyId_baz139.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !49
+  %91 = call i64 @rb_id2sym(i64 %rubyId_baz139.i) #10, !dbg !49
+  %92 = getelementptr i64, i64* %keywords134.i, i32 2, !dbg !49
+  store i64 %91, i64* %92, align 8, !dbg !49
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments133.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull %keywords134.i), !dbg !49
+  %rubyId_take_arguments143.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !50
+  %rubyId_d145.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !50
+  %93 = call i64 @rb_id2sym(i64 %rubyId_d145.i) #10, !dbg !50
+  store i64 %93, i64* %keywords144.i, align 8, !dbg !50
+  %rubyId_e147.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !50
+  %94 = call i64 @rb_id2sym(i64 %rubyId_e147.i) #10, !dbg !50
+  %95 = getelementptr i64, i64* %keywords144.i, i32 1, !dbg !50
+  store i64 %94, i64* %95, align 8, !dbg !50
+  %rubyId_baz149.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !50
+  %96 = call i64 @rb_id2sym(i64 %rubyId_baz149.i) #10, !dbg !50
+  %97 = getelementptr i64, i64* %keywords144.i, i32 2, !dbg !50
+  store i64 %96, i64* %97, align 8, !dbg !50
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments143.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull %keywords144.i), !dbg !50
+  %rubyId_take_arguments153.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !51
+  %rubyId_d155.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !51
+  %98 = call i64 @rb_id2sym(i64 %rubyId_d155.i) #10, !dbg !51
+  store i64 %98, i64* %keywords154.i, align 8, !dbg !51
+  %rubyId_e157.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !51
+  %99 = call i64 @rb_id2sym(i64 %rubyId_e157.i) #10, !dbg !51
+  %100 = getelementptr i64, i64* %keywords154.i, i32 1, !dbg !51
+  store i64 %99, i64* %100, align 8, !dbg !51
+  %rubyId_baz159.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !51
+  %101 = call i64 @rb_id2sym(i64 %rubyId_baz159.i) #10, !dbg !51
+  %102 = getelementptr i64, i64* %keywords154.i, i32 2, !dbg !51
+  store i64 %101, i64* %102, align 8, !dbg !51
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments153.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull %keywords154.i), !dbg !51
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %2)
@@ -727,579 +720,579 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %18)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %19)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %20)
-  %104 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %105 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %104, i64 0, i32 18
-  %106 = load i64, i64* %105, align 8, !tbaa !52
-  %107 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %108 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %107, i64 0, i32 2
-  %109 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %108, align 8, !tbaa !62
-  %110 = bitcast i64* %positional_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %110)
-  %111 = bitcast i64* %keyword_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %111)
+  %103 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %104 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %103, i64 0, i32 18
+  %105 = load i64, i64* %104, align 8, !tbaa !52
+  %106 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 2
+  %108 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %107, align 8, !tbaa !62
+  %109 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %109)
+  %110 = bitcast i64* %keyword_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %110)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %112 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %112, align 8, !tbaa !65
-  %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 4
-  %114 = load i64*, i64** %113, align 8, !tbaa !67
-  %115 = load i64, i64* %114, align 8, !tbaa !6
-  %116 = and i64 %115, -33
-  store i64 %116, i64* %114, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %107, %struct.rb_control_frame_struct* %109, %struct.rb_iseq_struct* %stackFrame.i) #10
-  %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %117, align 8, !dbg !68, !tbaa !14
+  %111 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %111, align 8, !tbaa !65
+  %112 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 4
+  %113 = load i64*, i64** %112, align 8, !tbaa !67
+  %114 = load i64, i64* %113, align 8, !tbaa !6
+  %115 = and i64 %114, -33
+  store i64 %115, i64* %113, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %106, %struct.rb_control_frame_struct* %108, %struct.rb_iseq_struct* %stackFrame.i) #10
+  %116 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 0
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %116, align 8, !dbg !68, !tbaa !14
   %rubyId_take_arguments.i1 = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !29
   %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_take_arguments.i1) #10, !dbg !29
   %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !29
   %rawSym386.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #10, !dbg !29
-  %118 = load i64, i64* @rb_cObject, align 8, !dbg !29
+  %117 = load i64, i64* @rb_cObject, align 8, !dbg !29
   %stackFrame387.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8, !dbg !29
-  %119 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !29
-  %120 = bitcast i8* %119 to i16*, !dbg !29
-  %121 = load i16, i16* %120, align 8, !dbg !29
-  %122 = and i16 %121, -384, !dbg !29
-  %123 = or i16 %122, 119, !dbg !29
-  store i16 %123, i16* %120, align 8, !dbg !29
-  %124 = getelementptr inbounds i8, i8* %119, i64 8, !dbg !29
-  %125 = bitcast i8* %124 to i32*, !dbg !29
-  %126 = getelementptr inbounds i8, i8* %119, i64 12, !dbg !29
-  %127 = bitcast i8* %126 to i32*, !dbg !29
-  %128 = getelementptr inbounds i8, i8* %119, i64 16, !dbg !29
-  %129 = getelementptr inbounds i8, i8* %119, i64 20, !dbg !29
-  %130 = bitcast i8* %129 to i32*, !dbg !29
-  store i32 0, i32* %130, align 4, !dbg !29, !tbaa !69
-  %131 = getelementptr inbounds i8, i8* %119, i64 24, !dbg !29
-  %132 = bitcast i8* %131 to i32*, !dbg !29
-  store i32 0, i32* %132, align 8, !dbg !29, !tbaa !72
-  %133 = getelementptr inbounds i8, i8* %119, i64 28, !dbg !29
-  %134 = bitcast i8* %133 to i32*, !dbg !29
-  store i32 3, i32* %134, align 4, !dbg !29, !tbaa !73
-  %135 = getelementptr inbounds i8, i8* %119, i64 4, !dbg !29
-  %136 = bitcast i8* %135 to i32*, !dbg !29
-  %137 = bitcast i32* %136 to <4 x i32>*, !dbg !29
-  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %137, align 4, !dbg !29, !tbaa !74
+  %118 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !29
+  %119 = bitcast i8* %118 to i16*, !dbg !29
+  %120 = load i16, i16* %119, align 8, !dbg !29
+  %121 = and i16 %120, -384, !dbg !29
+  %122 = or i16 %121, 119, !dbg !29
+  store i16 %122, i16* %119, align 8, !dbg !29
+  %123 = getelementptr inbounds i8, i8* %118, i64 8, !dbg !29
+  %124 = bitcast i8* %123 to i32*, !dbg !29
+  %125 = getelementptr inbounds i8, i8* %118, i64 12, !dbg !29
+  %126 = bitcast i8* %125 to i32*, !dbg !29
+  %127 = getelementptr inbounds i8, i8* %118, i64 16, !dbg !29
+  %128 = getelementptr inbounds i8, i8* %118, i64 20, !dbg !29
+  %129 = bitcast i8* %128 to i32*, !dbg !29
+  store i32 0, i32* %129, align 4, !dbg !29, !tbaa !69
+  %130 = getelementptr inbounds i8, i8* %118, i64 24, !dbg !29
+  %131 = bitcast i8* %130 to i32*, !dbg !29
+  store i32 0, i32* %131, align 8, !dbg !29, !tbaa !72
+  %132 = getelementptr inbounds i8, i8* %118, i64 28, !dbg !29
+  %133 = bitcast i8* %132 to i32*, !dbg !29
+  store i32 3, i32* %133, align 4, !dbg !29, !tbaa !73
+  %134 = getelementptr inbounds i8, i8* %118, i64 4, !dbg !29
+  %135 = bitcast i8* %134 to i32*, !dbg !29
+  %136 = bitcast i32* %135 to <4 x i32>*, !dbg !29
+  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %136, align 4, !dbg !29, !tbaa !74
   %rubyId_a.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !29
   store i64 %rubyId_a.i, i64* %positional_table.i, align 8, !dbg !29
   %rubyId_b.i = load i64, i64* @rubyIdPrecomputed_b, align 8, !dbg !29
-  %138 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !29
-  store i64 %rubyId_b.i, i64* %138, align 8, !dbg !29
+  %137 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !29
+  store i64 %rubyId_b.i, i64* %137, align 8, !dbg !29
   %rubyId_c.i = load i64, i64* @rubyIdPrecomputed_c, align 8, !dbg !29
-  %139 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !29
-  store i64 %rubyId_c.i, i64* %139, align 8, !dbg !29
+  %138 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !29
+  store i64 %rubyId_c.i, i64* %138, align 8, !dbg !29
   %rubyId_g.i = load i64, i64* @rubyIdPrecomputed_g, align 8, !dbg !29
-  %140 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !29
-  store i64 %rubyId_g.i, i64* %140, align 8, !dbg !29
-  %141 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #12, !dbg !29
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %141, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %110, i64 noundef 32, i1 noundef false) #10, !dbg !29
-  %142 = getelementptr inbounds i8, i8* %119, i64 32, !dbg !29
-  %143 = bitcast i8* %142 to i8**, !dbg !29
-  store i8* %141, i8** %143, align 8, !dbg !29, !tbaa !75
+  %139 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !29
+  store i64 %rubyId_g.i, i64* %139, align 8, !dbg !29
+  %140 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #12, !dbg !29
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %140, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %109, i64 noundef 32, i1 noundef false) #10, !dbg !29
+  %141 = getelementptr inbounds i8, i8* %118, i64 32, !dbg !29
+  %142 = bitcast i8* %141 to i8**, !dbg !29
+  store i8* %140, i8** %142, align 8, !dbg !29, !tbaa !75
   %rubyId_d.i2 = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !29
   store i64 %rubyId_d.i2, i64* %keyword_table.i, align 8, !dbg !29
   %rubyId_e.i3 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !29
-  %144 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !29
-  store i64 %rubyId_e.i3, i64* %144, align 8, !dbg !29
+  %143 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !29
+  store i64 %rubyId_e.i3, i64* %143, align 8, !dbg !29
   %rubyId_f.i = load i64, i64* @rubyIdPrecomputed_f, align 8, !dbg !29
-  %145 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !29
-  store i64 %rubyId_f.i, i64* %145, align 8, !dbg !29
-  %146 = getelementptr inbounds i8, i8* %119, i64 40, !dbg !29
-  %147 = bitcast i8* %146 to i32*, !dbg !29
-  store i32 2, i32* %147, align 8, !dbg !29, !tbaa !76
-  %148 = getelementptr inbounds i8, i8* %119, i64 44, !dbg !29
-  %149 = bitcast i8* %148 to i32*, !dbg !29
-  store i32 1, i32* %149, align 4, !dbg !29, !tbaa !77
-  %150 = load i32, i32* %125, align 8, !dbg !29, !tbaa !78
-  %151 = load i32, i32* %127, align 4, !dbg !29, !tbaa !79
-  %152 = add i32 %150, 2, !dbg !29
-  %153 = add i32 %152, %151, !dbg !29
-  %154 = getelementptr inbounds i8, i8* %119, i64 48, !dbg !29
-  %155 = bitcast i8* %154 to i32*, !dbg !29
-  store i32 %153, i32* %155, align 8, !dbg !29, !tbaa !80
-  %156 = load i16, i16* %120, align 8, !dbg !29
-  %157 = and i16 %156, 32, !dbg !29
-  %158 = icmp eq i16 %157, 0, !dbg !29
-  br i1 %158, label %sorbet_setupParamKeywords.exit.i, label %159, !dbg !29
+  %144 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !29
+  store i64 %rubyId_f.i, i64* %144, align 8, !dbg !29
+  %145 = getelementptr inbounds i8, i8* %118, i64 40, !dbg !29
+  %146 = bitcast i8* %145 to i32*, !dbg !29
+  store i32 2, i32* %146, align 8, !dbg !29, !tbaa !76
+  %147 = getelementptr inbounds i8, i8* %118, i64 44, !dbg !29
+  %148 = bitcast i8* %147 to i32*, !dbg !29
+  store i32 1, i32* %148, align 4, !dbg !29, !tbaa !77
+  %149 = load i32, i32* %124, align 8, !dbg !29, !tbaa !78
+  %150 = load i32, i32* %126, align 4, !dbg !29, !tbaa !79
+  %151 = add i32 %149, 2, !dbg !29
+  %152 = add i32 %151, %150, !dbg !29
+  %153 = getelementptr inbounds i8, i8* %118, i64 48, !dbg !29
+  %154 = bitcast i8* %153 to i32*, !dbg !29
+  store i32 %152, i32* %154, align 8, !dbg !29, !tbaa !80
+  %155 = load i16, i16* %119, align 8, !dbg !29
+  %156 = and i16 %155, 32, !dbg !29
+  %157 = icmp eq i16 %156, 0, !dbg !29
+  br i1 %157, label %sorbet_setupParamKeywords.exit.i, label %158, !dbg !29
 
-159:                                              ; preds = %entry
-  %160 = add nsw i32 %153, 1, !dbg !29
-  %161 = getelementptr inbounds i8, i8* %119, i64 52, !dbg !29
-  %162 = bitcast i8* %161 to i32*, !dbg !29
-  store i32 %160, i32* %162, align 4, !dbg !29, !tbaa !81
+158:                                              ; preds = %entry
+  %159 = add nsw i32 %152, 1, !dbg !29
+  %160 = getelementptr inbounds i8, i8* %118, i64 52, !dbg !29
+  %161 = bitcast i8* %160 to i32*, !dbg !29
+  store i32 %159, i32* %161, align 4, !dbg !29, !tbaa !81
   br label %sorbet_setupParamKeywords.exit.i, !dbg !29
 
-sorbet_setupParamKeywords.exit.i:                 ; preds = %159, %entry
-  %163 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #12, !dbg !29
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %163, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %111, i64 noundef 24, i1 noundef false) #10, !dbg !29
-  %164 = getelementptr inbounds i8, i8* %119, i64 56, !dbg !29
-  %165 = bitcast i8* %164 to i8**, !dbg !29
-  store i8* %163, i8** %165, align 8, !dbg !29, !tbaa !82
-  call void @sorbet_vm_define_method(i64 %118, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#14take_arguments", i8* nonnull %119, %struct.rb_iseq_struct* %stackFrame387.i, i1 noundef zeroext false) #10, !dbg !29
-  %166 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
-  %167 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 5, !dbg !29
-  %168 = load i32, i32* %167, align 8, !dbg !29, !tbaa !83
-  %169 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 6, !dbg !29
-  %170 = load i32, i32* %169, align 4, !dbg !29, !tbaa !84
-  %171 = xor i32 %170, -1, !dbg !29
-  %172 = and i32 %171, %168, !dbg !29
-  %173 = icmp eq i32 %172, 0, !dbg !29
-  br i1 %173, label %"func_<root>.17<static-init>$152.exit", label %174, !dbg !29, !prof !20
+sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
+  %162 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #12, !dbg !29
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %162, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %110, i64 noundef 24, i1 noundef false) #10, !dbg !29
+  %163 = getelementptr inbounds i8, i8* %118, i64 56, !dbg !29
+  %164 = bitcast i8* %163 to i8**, !dbg !29
+  store i8* %162, i8** %164, align 8, !dbg !29, !tbaa !82
+  call void @sorbet_vm_define_method(i64 %117, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#14take_arguments", i8* nonnull %118, %struct.rb_iseq_struct* %stackFrame387.i, i1 noundef zeroext false) #10, !dbg !29
+  %165 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
+  %166 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %165, i64 0, i32 5, !dbg !29
+  %167 = load i32, i32* %166, align 8, !dbg !29, !tbaa !83
+  %168 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %165, i64 0, i32 6, !dbg !29
+  %169 = load i32, i32* %168, align 4, !dbg !29, !tbaa !84
+  %170 = xor i32 %169, -1, !dbg !29
+  %171 = and i32 %170, %167, !dbg !29
+  %172 = icmp eq i32 %171, 0, !dbg !29
+  br i1 %172, label %"func_<root>.17<static-init>$152.exit", label %173, !dbg !29, !prof !20
 
-174:                                              ; preds = %sorbet_setupParamKeywords.exit.i
-  %175 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 8, !dbg !29
-  %176 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %175, align 8, !dbg !29, !tbaa !85
-  %177 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %176, i32 noundef 0) #10, !dbg !29
+173:                                              ; preds = %sorbet_setupParamKeywords.exit.i
+  %174 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %165, i64 0, i32 8, !dbg !29
+  %175 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %174, align 8, !dbg !29, !tbaa !85
+  %176 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %175, i32 noundef 0) #10, !dbg !29
   br label %"func_<root>.17<static-init>$152.exit", !dbg !29
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %sorbet_setupParamKeywords.exit.i, %174
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %117, align 8, !dbg !29, !tbaa !14
-  %rubyId_d398.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !86
-  %rawSym399.i = call i64 @rb_id2sym(i64 %rubyId_d398.i) #10, !dbg !86
-  %178 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !31
-  %179 = load i64*, i64** %178, align 8, !dbg !31
-  store i64 %106, i64* %179, align 8, !dbg !31, !tbaa !6
+"func_<root>.17<static-init>$152.exit":           ; preds = %sorbet_setupParamKeywords.exit.i, %173
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %116, align 8, !dbg !29, !tbaa !14
+  %rubyId_d395.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !86
+  %rawSym396.i = call i64 @rb_id2sym(i64 %rubyId_d395.i) #10, !dbg !86
+  %177 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !31
+  %178 = load i64*, i64** %177, align 8, !dbg !31
+  store i64 %105, i64* %178, align 8, !dbg !31, !tbaa !6
+  %179 = getelementptr inbounds i64, i64* %178, i64 1, !dbg !31
   %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !31
   %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !31
   %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !31
-  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !31
-  %184 = bitcast i64* %180 to <4 x i64>*, !dbg !31
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %184, align 8, !dbg !31, !tbaa !6
-  %185 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !31
-  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !31
-  %187 = bitcast i64* %185 to <2 x i64>*, !dbg !31
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %187, align 8, !dbg !31, !tbaa !6
-  %188 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !31
-  store i64 -13, i64* %188, align 8, !dbg !31, !tbaa !6
+  %183 = bitcast i64* %179 to <4 x i64>*, !dbg !31
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %183, align 8, !dbg !31, !tbaa !6
+  %184 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !31
+  %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !31
+  %186 = bitcast i64* %184 to <2 x i64>*, !dbg !31
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %186, align 8, !dbg !31, !tbaa !6
+  %187 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !31
+  store i64 -13, i64* %187, align 8, !dbg !31, !tbaa !6
+  %188 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !31
+  store i64 -15, i64* %188, align 8, !dbg !31, !tbaa !6
   %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !31
-  store i64 -15, i64* %189, align 8, !dbg !31, !tbaa !6
-  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !31
-  store i64* %190, i64** %178, align 8, !dbg !31
+  store i64* %189, i64** %177, align 8, !dbg !31
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments, i64 0), !dbg !31
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %117, align 8, !dbg !31, !tbaa !14
-  %rubyId_d419.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !87
-  %rawSym420.i = call i64 @rb_id2sym(i64 %rubyId_d419.i) #10, !dbg !87
-  %191 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !32
-  %192 = load i64*, i64** %191, align 8, !dbg !32
-  store i64 %106, i64* %192, align 8, !dbg !32, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %116, align 8, !dbg !31, !tbaa !14
+  %rubyId_d416.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !87
+  %rawSym417.i = call i64 @rb_id2sym(i64 %rubyId_d416.i) #10, !dbg !87
+  %190 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !32
+  %191 = load i64*, i64** %190, align 8, !dbg !32
+  store i64 %105, i64* %191, align 8, !dbg !32, !tbaa !6
+  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !32
   %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !32
   %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !32
   %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !32
-  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !32
-  %197 = bitcast i64* %193 to <4 x i64>*, !dbg !32
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %197, align 8, !dbg !32, !tbaa !6
-  %198 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !32
-  %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !32
-  %200 = bitcast i64* %198 to <2 x i64>*, !dbg !32
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %200, align 8, !dbg !32, !tbaa !6
-  %201 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !32
-  store i64 -15, i64* %201, align 8, !dbg !32, !tbaa !6
-  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !32
-  store i64* %202, i64** %191, align 8, !dbg !32
+  %196 = bitcast i64* %192 to <4 x i64>*, !dbg !32
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %196, align 8, !dbg !32, !tbaa !6
+  %197 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !32
+  %198 = getelementptr inbounds i64, i64* %197, i64 1, !dbg !32
+  %199 = bitcast i64* %197 to <2 x i64>*, !dbg !32
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %199, align 8, !dbg !32, !tbaa !6
+  %200 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !32
+  store i64 -15, i64* %200, align 8, !dbg !32, !tbaa !6
+  %201 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !32
+  store i64* %201, i64** %190, align 8, !dbg !32
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !32
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %117, align 8, !dbg !32, !tbaa !14
-  %rubyId_d439.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !88
-  %rawSym440.i = call i64 @rb_id2sym(i64 %rubyId_d439.i) #10, !dbg !88
-  %203 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !33
-  %204 = load i64*, i64** %203, align 8, !dbg !33
-  store i64 %106, i64* %204, align 8, !dbg !33, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %116, align 8, !dbg !32, !tbaa !14
+  %rubyId_d436.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !88
+  %rawSym437.i = call i64 @rb_id2sym(i64 %rubyId_d436.i) #10, !dbg !88
+  %202 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !33
+  %203 = load i64*, i64** %202, align 8, !dbg !33
+  store i64 %105, i64* %203, align 8, !dbg !33, !tbaa !6
+  %204 = getelementptr inbounds i64, i64* %203, i64 1, !dbg !33
   %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !33
   %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !33
   %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !33
-  %208 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !33
-  %209 = bitcast i64* %205 to <4 x i64>*, !dbg !33
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %209, align 8, !dbg !33, !tbaa !6
-  %210 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !33
-  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !33
-  %212 = bitcast i64* %210 to <2 x i64>*, !dbg !33
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %212, align 8, !dbg !33, !tbaa !6
-  %213 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !33
-  store i64* %213, i64** %203, align 8, !dbg !33
+  %208 = bitcast i64* %204 to <4 x i64>*, !dbg !33
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %208, align 8, !dbg !33, !tbaa !6
+  %209 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !33
+  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !33
+  %211 = bitcast i64* %209 to <2 x i64>*, !dbg !33
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %211, align 8, !dbg !33, !tbaa !6
+  %212 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !33
+  store i64* %212, i64** %202, align 8, !dbg !33
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !33
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %117, align 8, !dbg !33, !tbaa !14
-  %rubyId_d457.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !89
-  %rawSym458.i = call i64 @rb_id2sym(i64 %rubyId_d457.i) #10, !dbg !89
-  %214 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !34
-  %215 = load i64*, i64** %214, align 8, !dbg !34
-  store i64 %106, i64* %215, align 8, !dbg !34, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %116, align 8, !dbg !33, !tbaa !14
+  %rubyId_d454.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !89
+  %rawSym455.i = call i64 @rb_id2sym(i64 %rubyId_d454.i) #10, !dbg !89
+  %213 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !34
+  %214 = load i64*, i64** %213, align 8, !dbg !34
+  store i64 %105, i64* %214, align 8, !dbg !34, !tbaa !6
+  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !34
   %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !34
   %217 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !34
   %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !34
-  %219 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !34
-  %220 = bitcast i64* %216 to <4 x i64>*, !dbg !34
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %220, align 8, !dbg !34, !tbaa !6
-  %221 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !34
-  store i64 -15, i64* %221, align 8, !dbg !34, !tbaa !6
-  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !34
-  store i64* %222, i64** %214, align 8, !dbg !34
+  %219 = bitcast i64* %215 to <4 x i64>*, !dbg !34
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %219, align 8, !dbg !34, !tbaa !6
+  %220 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !34
+  store i64 -15, i64* %220, align 8, !dbg !34, !tbaa !6
+  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !34
+  store i64* %221, i64** %213, align 8, !dbg !34
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !34
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %117, align 8, !dbg !34, !tbaa !14
-  %rubyId_d473.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !90
-  %rawSym474.i = call i64 @rb_id2sym(i64 %rubyId_d473.i) #10, !dbg !90
-  %223 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !35
-  %224 = load i64*, i64** %223, align 8, !dbg !35
-  store i64 %106, i64* %224, align 8, !dbg !35, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %116, align 8, !dbg !34, !tbaa !14
+  %rubyId_d470.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !90
+  %rawSym471.i = call i64 @rb_id2sym(i64 %rubyId_d470.i) #10, !dbg !90
+  %222 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !35
+  %223 = load i64*, i64** %222, align 8, !dbg !35
+  store i64 %105, i64* %223, align 8, !dbg !35, !tbaa !6
+  %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !35
   %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !35
   %226 = getelementptr inbounds i64, i64* %225, i64 1, !dbg !35
   %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !35
-  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !35
-  %229 = bitcast i64* %225 to <4 x i64>*, !dbg !35
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %229, align 8, !dbg !35, !tbaa !6
-  %230 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !35
-  store i64* %230, i64** %223, align 8, !dbg !35
+  %228 = bitcast i64* %224 to <4 x i64>*, !dbg !35
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %228, align 8, !dbg !35, !tbaa !6
+  %229 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !35
+  store i64* %229, i64** %222, align 8, !dbg !35
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !35
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %117, align 8, !dbg !35, !tbaa !14
-  %rubyId_d487.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !91
-  %rawSym488.i = call i64 @rb_id2sym(i64 %rubyId_d487.i) #10, !dbg !91
-  %231 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !36
-  %232 = load i64*, i64** %231, align 8, !dbg !36
-  store i64 %106, i64* %232, align 8, !dbg !36, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %116, align 8, !dbg !35, !tbaa !14
+  %rubyId_d484.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !91
+  %rawSym485.i = call i64 @rb_id2sym(i64 %rubyId_d484.i) #10, !dbg !91
+  %230 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !36
+  %231 = load i64*, i64** %230, align 8, !dbg !36
+  store i64 %105, i64* %231, align 8, !dbg !36, !tbaa !6
+  %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !36
   %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !36
-  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !36
-  %235 = bitcast i64* %233 to <2 x i64>*, !dbg !36
-  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %235, align 8, !dbg !36, !tbaa !6
-  %236 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !36
-  store i64 -15, i64* %236, align 8, !dbg !36, !tbaa !6
-  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !36
-  store i64* %237, i64** %231, align 8, !dbg !36
+  %234 = bitcast i64* %232 to <2 x i64>*, !dbg !36
+  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %234, align 8, !dbg !36, !tbaa !6
+  %235 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !36
+  store i64 -15, i64* %235, align 8, !dbg !36, !tbaa !6
+  %236 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !36
+  store i64* %236, i64** %230, align 8, !dbg !36
   %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !36
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %117, align 8, !dbg !36, !tbaa !14
-  %rubyId_d499.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !92
-  %rawSym500.i = call i64 @rb_id2sym(i64 %rubyId_d499.i) #10, !dbg !92
-  %238 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !37
-  %239 = load i64*, i64** %238, align 8, !dbg !37
-  store i64 %106, i64* %239, align 8, !dbg !37, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %116, align 8, !dbg !36, !tbaa !14
+  %rubyId_d496.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !92
+  %rawSym497.i = call i64 @rb_id2sym(i64 %rubyId_d496.i) #10, !dbg !92
+  %237 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !37
+  %238 = load i64*, i64** %237, align 8, !dbg !37
+  store i64 %105, i64* %238, align 8, !dbg !37, !tbaa !6
+  %239 = getelementptr inbounds i64, i64* %238, i64 1, !dbg !37
   %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !37
-  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !37
-  %242 = bitcast i64* %240 to <2 x i64>*, !dbg !37
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %242, align 8, !dbg !37, !tbaa !6
-  %243 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !37
-  store i64* %243, i64** %238, align 8, !dbg !37
+  %241 = bitcast i64* %239 to <2 x i64>*, !dbg !37
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %241, align 8, !dbg !37, !tbaa !6
+  %242 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !37
+  store i64* %242, i64** %237, align 8, !dbg !37
   %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !37
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %117, align 8, !dbg !37, !tbaa !14
-  %rubyId_d516.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !93
-  %rawSym517.i = call i64 @rb_id2sym(i64 %rubyId_d516.i) #10, !dbg !93
-  %rubyId_e519.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !94
-  %rawSym520.i = call i64 @rb_id2sym(i64 %rubyId_e519.i) #10, !dbg !94
-  %244 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !38
-  %245 = load i64*, i64** %244, align 8, !dbg !38
-  store i64 %106, i64* %245, align 8, !dbg !38, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %116, align 8, !dbg !37, !tbaa !14
+  %rubyId_d513.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !93
+  %rawSym514.i = call i64 @rb_id2sym(i64 %rubyId_d513.i) #10, !dbg !93
+  %rubyId_e516.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !94
+  %rawSym517.i = call i64 @rb_id2sym(i64 %rubyId_e516.i) #10, !dbg !94
+  %243 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !38
+  %244 = load i64*, i64** %243, align 8, !dbg !38
+  store i64 %105, i64* %244, align 8, !dbg !38, !tbaa !6
+  %245 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !38
   %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !38
   %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !38
   %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !38
-  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !38
-  %250 = bitcast i64* %246 to <4 x i64>*, !dbg !38
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %250, align 8, !dbg !38, !tbaa !6
-  %251 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !38
-  %252 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !38
-  %253 = bitcast i64* %251 to <2 x i64>*, !dbg !38
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %253, align 8, !dbg !38, !tbaa !6
-  %254 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !38
-  store i64 -13, i64* %254, align 8, !dbg !38, !tbaa !6
+  %249 = bitcast i64* %245 to <4 x i64>*, !dbg !38
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %249, align 8, !dbg !38, !tbaa !6
+  %250 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !38
+  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !38
+  %252 = bitcast i64* %250 to <2 x i64>*, !dbg !38
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %252, align 8, !dbg !38, !tbaa !6
+  %253 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !38
+  store i64 -13, i64* %253, align 8, !dbg !38, !tbaa !6
+  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !38
+  store i64 -15, i64* %254, align 8, !dbg !38, !tbaa !6
   %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !38
-  store i64 -15, i64* %255, align 8, !dbg !38, !tbaa !6
+  store i64 -17, i64* %255, align 8, !dbg !38, !tbaa !6
   %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !38
-  store i64 -17, i64* %256, align 8, !dbg !38, !tbaa !6
-  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !38
-  store i64* %257, i64** %244, align 8, !dbg !38
+  store i64* %256, i64** %243, align 8, !dbg !38
   %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !38
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %117, align 8, !dbg !38, !tbaa !14
-  %rubyId_d542.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !95
-  %rawSym543.i = call i64 @rb_id2sym(i64 %rubyId_d542.i) #10, !dbg !95
-  %rubyId_e545.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !96
-  %rawSym546.i = call i64 @rb_id2sym(i64 %rubyId_e545.i) #10, !dbg !96
-  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !39
-  %259 = load i64*, i64** %258, align 8, !dbg !39
-  store i64 %106, i64* %259, align 8, !dbg !39, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %116, align 8, !dbg !38, !tbaa !14
+  %rubyId_d539.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !95
+  %rawSym540.i = call i64 @rb_id2sym(i64 %rubyId_d539.i) #10, !dbg !95
+  %rubyId_e542.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !96
+  %rawSym543.i = call i64 @rb_id2sym(i64 %rubyId_e542.i) #10, !dbg !96
+  %257 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !39
+  %258 = load i64*, i64** %257, align 8, !dbg !39
+  store i64 %105, i64* %258, align 8, !dbg !39, !tbaa !6
+  %259 = getelementptr inbounds i64, i64* %258, i64 1, !dbg !39
   %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !39
   %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !39
   %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !39
-  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !39
-  %264 = bitcast i64* %260 to <4 x i64>*, !dbg !39
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %264, align 8, !dbg !39, !tbaa !6
-  %265 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !39
-  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !39
-  %267 = bitcast i64* %265 to <2 x i64>*, !dbg !39
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %267, align 8, !dbg !39, !tbaa !6
-  %268 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !39
-  store i64 -15, i64* %268, align 8, !dbg !39, !tbaa !6
+  %263 = bitcast i64* %259 to <4 x i64>*, !dbg !39
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %263, align 8, !dbg !39, !tbaa !6
+  %264 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !39
+  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !39
+  %266 = bitcast i64* %264 to <2 x i64>*, !dbg !39
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %266, align 8, !dbg !39, !tbaa !6
+  %267 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !39
+  store i64 -15, i64* %267, align 8, !dbg !39, !tbaa !6
+  %268 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !39
+  store i64 -17, i64* %268, align 8, !dbg !39, !tbaa !6
   %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !39
-  store i64 -17, i64* %269, align 8, !dbg !39, !tbaa !6
-  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !39
-  store i64* %270, i64** %258, align 8, !dbg !39
+  store i64* %269, i64** %257, align 8, !dbg !39
   %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !39
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %117, align 8, !dbg !39, !tbaa !14
-  %rubyId_d566.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !97
-  %rawSym567.i = call i64 @rb_id2sym(i64 %rubyId_d566.i) #10, !dbg !97
-  %rubyId_e569.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !98
-  %rawSym570.i = call i64 @rb_id2sym(i64 %rubyId_e569.i) #10, !dbg !98
-  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !40
-  %272 = load i64*, i64** %271, align 8, !dbg !40
-  store i64 %106, i64* %272, align 8, !dbg !40, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %116, align 8, !dbg !39, !tbaa !14
+  %rubyId_d563.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !97
+  %rawSym564.i = call i64 @rb_id2sym(i64 %rubyId_d563.i) #10, !dbg !97
+  %rubyId_e566.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !98
+  %rawSym567.i = call i64 @rb_id2sym(i64 %rubyId_e566.i) #10, !dbg !98
+  %270 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !40
+  %271 = load i64*, i64** %270, align 8, !dbg !40
+  store i64 %105, i64* %271, align 8, !dbg !40, !tbaa !6
+  %272 = getelementptr inbounds i64, i64* %271, i64 1, !dbg !40
   %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !40
   %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !40
   %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !40
-  %276 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !40
-  %277 = bitcast i64* %273 to <4 x i64>*, !dbg !40
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %277, align 8, !dbg !40, !tbaa !6
-  %278 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !40
-  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !40
-  %280 = bitcast i64* %278 to <2 x i64>*, !dbg !40
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %280, align 8, !dbg !40, !tbaa !6
-  %281 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !40
-  store i64 -17, i64* %281, align 8, !dbg !40, !tbaa !6
-  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !40
-  store i64* %282, i64** %271, align 8, !dbg !40
+  %276 = bitcast i64* %272 to <4 x i64>*, !dbg !40
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %276, align 8, !dbg !40, !tbaa !6
+  %277 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !40
+  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !40
+  %279 = bitcast i64* %277 to <2 x i64>*, !dbg !40
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %279, align 8, !dbg !40, !tbaa !6
+  %280 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !40
+  store i64 -17, i64* %280, align 8, !dbg !40, !tbaa !6
+  %281 = getelementptr inbounds i64, i64* %280, i64 1, !dbg !40
+  store i64* %281, i64** %270, align 8, !dbg !40
   %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !40
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %117, align 8, !dbg !40, !tbaa !14
-  %rubyId_d588.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !99
-  %rawSym589.i = call i64 @rb_id2sym(i64 %rubyId_d588.i) #10, !dbg !99
-  %rubyId_e591.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !100
-  %rawSym592.i = call i64 @rb_id2sym(i64 %rubyId_e591.i) #10, !dbg !100
-  %283 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !41
-  %284 = load i64*, i64** %283, align 8, !dbg !41
-  store i64 %106, i64* %284, align 8, !dbg !41, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %116, align 8, !dbg !40, !tbaa !14
+  %rubyId_d585.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !99
+  %rawSym586.i = call i64 @rb_id2sym(i64 %rubyId_d585.i) #10, !dbg !99
+  %rubyId_e588.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !100
+  %rawSym589.i = call i64 @rb_id2sym(i64 %rubyId_e588.i) #10, !dbg !100
+  %282 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !41
+  %283 = load i64*, i64** %282, align 8, !dbg !41
+  store i64 %105, i64* %283, align 8, !dbg !41, !tbaa !6
+  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !41
   %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !41
   %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !41
   %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !41
-  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !41
-  %289 = bitcast i64* %285 to <4 x i64>*, !dbg !41
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %289, align 8, !dbg !41, !tbaa !6
-  %290 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !41
-  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !41
-  %292 = bitcast i64* %290 to <2 x i64>*, !dbg !41
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %292, align 8, !dbg !41, !tbaa !6
-  %293 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !41
-  store i64* %293, i64** %283, align 8, !dbg !41
+  %288 = bitcast i64* %284 to <4 x i64>*, !dbg !41
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %288, align 8, !dbg !41, !tbaa !6
+  %289 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !41
+  %290 = getelementptr inbounds i64, i64* %289, i64 1, !dbg !41
+  %291 = bitcast i64* %289 to <2 x i64>*, !dbg !41
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %291, align 8, !dbg !41, !tbaa !6
+  %292 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !41
+  store i64* %292, i64** %282, align 8, !dbg !41
   %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !41
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %117, align 8, !dbg !41, !tbaa !14
-  %rubyId_d608.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !101
-  %rawSym609.i = call i64 @rb_id2sym(i64 %rubyId_d608.i) #10, !dbg !101
-  %rubyId_e611.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !102
-  %rawSym612.i = call i64 @rb_id2sym(i64 %rubyId_e611.i) #10, !dbg !102
-  %294 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !42
-  %295 = load i64*, i64** %294, align 8, !dbg !42
-  store i64 %106, i64* %295, align 8, !dbg !42, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %116, align 8, !dbg !41, !tbaa !14
+  %rubyId_d605.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !101
+  %rawSym606.i = call i64 @rb_id2sym(i64 %rubyId_d605.i) #10, !dbg !101
+  %rubyId_e608.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !102
+  %rawSym609.i = call i64 @rb_id2sym(i64 %rubyId_e608.i) #10, !dbg !102
+  %293 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !42
+  %294 = load i64*, i64** %293, align 8, !dbg !42
+  store i64 %105, i64* %294, align 8, !dbg !42, !tbaa !6
+  %295 = getelementptr inbounds i64, i64* %294, i64 1, !dbg !42
   %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !42
   %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !42
   %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !42
-  %299 = getelementptr inbounds i64, i64* %298, i64 1, !dbg !42
-  %300 = bitcast i64* %296 to <4 x i64>*, !dbg !42
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %300, align 8, !dbg !42, !tbaa !6
-  %301 = getelementptr inbounds i64, i64* %299, i64 1, !dbg !42
-  store i64 -17, i64* %301, align 8, !dbg !42, !tbaa !6
-  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !42
-  store i64* %302, i64** %294, align 8, !dbg !42
+  %299 = bitcast i64* %295 to <4 x i64>*, !dbg !42
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %299, align 8, !dbg !42, !tbaa !6
+  %300 = getelementptr inbounds i64, i64* %298, i64 1, !dbg !42
+  store i64 -17, i64* %300, align 8, !dbg !42, !tbaa !6
+  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !42
+  store i64* %301, i64** %293, align 8, !dbg !42
   %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !42
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %117, align 8, !dbg !42, !tbaa !14
-  %rubyId_d626.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !103
-  %rawSym627.i = call i64 @rb_id2sym(i64 %rubyId_d626.i) #10, !dbg !103
-  %rubyId_e629.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !104
-  %rawSym630.i = call i64 @rb_id2sym(i64 %rubyId_e629.i) #10, !dbg !104
-  %303 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !43
-  %304 = load i64*, i64** %303, align 8, !dbg !43
-  store i64 %106, i64* %304, align 8, !dbg !43, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %116, align 8, !dbg !42, !tbaa !14
+  %rubyId_d623.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !103
+  %rawSym624.i = call i64 @rb_id2sym(i64 %rubyId_d623.i) #10, !dbg !103
+  %rubyId_e626.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !104
+  %rawSym627.i = call i64 @rb_id2sym(i64 %rubyId_e626.i) #10, !dbg !104
+  %302 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !43
+  %303 = load i64*, i64** %302, align 8, !dbg !43
+  store i64 %105, i64* %303, align 8, !dbg !43, !tbaa !6
+  %304 = getelementptr inbounds i64, i64* %303, i64 1, !dbg !43
   %305 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !43
   %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !43
   %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !43
-  %308 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !43
-  %309 = bitcast i64* %305 to <4 x i64>*, !dbg !43
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %309, align 8, !dbg !43, !tbaa !6
-  %310 = getelementptr inbounds i64, i64* %308, i64 1, !dbg !43
-  store i64* %310, i64** %303, align 8, !dbg !43
+  %308 = bitcast i64* %304 to <4 x i64>*, !dbg !43
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %308, align 8, !dbg !43, !tbaa !6
+  %309 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !43
+  store i64* %309, i64** %302, align 8, !dbg !43
   %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %117, align 8, !dbg !43, !tbaa !14
-  %rubyId_d642.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !105
-  %rawSym643.i = call i64 @rb_id2sym(i64 %rubyId_d642.i) #10, !dbg !105
-  %rubyId_e645.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !106
-  %rawSym646.i = call i64 @rb_id2sym(i64 %rubyId_e645.i) #10, !dbg !106
-  %311 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !44
-  %312 = load i64*, i64** %311, align 8, !dbg !44
-  store i64 %106, i64* %312, align 8, !dbg !44, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %116, align 8, !dbg !43, !tbaa !14
+  %rubyId_d639.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !105
+  %rawSym640.i = call i64 @rb_id2sym(i64 %rubyId_d639.i) #10, !dbg !105
+  %rubyId_e642.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !106
+  %rawSym643.i = call i64 @rb_id2sym(i64 %rubyId_e642.i) #10, !dbg !106
+  %310 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !44
+  %311 = load i64*, i64** %310, align 8, !dbg !44
+  store i64 %105, i64* %311, align 8, !dbg !44, !tbaa !6
+  %312 = getelementptr inbounds i64, i64* %311, i64 1, !dbg !44
   %313 = getelementptr inbounds i64, i64* %312, i64 1, !dbg !44
-  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !44
-  %315 = bitcast i64* %313 to <2 x i64>*, !dbg !44
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %315, align 8, !dbg !44, !tbaa !6
-  %316 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !44
-  store i64 -17, i64* %316, align 8, !dbg !44, !tbaa !6
-  %317 = getelementptr inbounds i64, i64* %316, i64 1, !dbg !44
-  store i64* %317, i64** %311, align 8, !dbg !44
+  %314 = bitcast i64* %312 to <2 x i64>*, !dbg !44
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %314, align 8, !dbg !44, !tbaa !6
+  %315 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !44
+  store i64 -17, i64* %315, align 8, !dbg !44, !tbaa !6
+  %316 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !44
+  store i64* %316, i64** %310, align 8, !dbg !44
   %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !44
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %117, align 8, !dbg !44, !tbaa !14
-  %rubyId_d663.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !107
-  %rawSym664.i = call i64 @rb_id2sym(i64 %rubyId_d663.i) #10, !dbg !107
-  %rubyId_e666.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !108
-  %rawSym667.i = call i64 @rb_id2sym(i64 %rubyId_e666.i) #10, !dbg !108
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %116, align 8, !dbg !44, !tbaa !14
+  %rubyId_d660.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !107
+  %rawSym661.i = call i64 @rb_id2sym(i64 %rubyId_d660.i) #10, !dbg !107
+  %rubyId_e663.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !108
+  %rawSym664.i = call i64 @rb_id2sym(i64 %rubyId_e663.i) #10, !dbg !108
   %rubyId_baz.i4 = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !109
-  %rawSym669.i = call i64 @rb_id2sym(i64 %rubyId_baz.i4) #10, !dbg !109
-  %318 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !45
-  %319 = load i64*, i64** %318, align 8, !dbg !45
-  store i64 %106, i64* %319, align 8, !dbg !45, !tbaa !6
+  %rawSym666.i = call i64 @rb_id2sym(i64 %rubyId_baz.i4) #10, !dbg !109
+  %317 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !45
+  %318 = load i64*, i64** %317, align 8, !dbg !45
+  store i64 %105, i64* %318, align 8, !dbg !45, !tbaa !6
+  %319 = getelementptr inbounds i64, i64* %318, i64 1, !dbg !45
   %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !45
   %321 = getelementptr inbounds i64, i64* %320, i64 1, !dbg !45
   %322 = getelementptr inbounds i64, i64* %321, i64 1, !dbg !45
-  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !45
-  %324 = bitcast i64* %320 to <4 x i64>*, !dbg !45
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %324, align 8, !dbg !45, !tbaa !6
-  %325 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !45
-  %326 = getelementptr inbounds i64, i64* %325, i64 1, !dbg !45
-  %327 = bitcast i64* %325 to <2 x i64>*, !dbg !45
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %327, align 8, !dbg !45, !tbaa !6
-  %328 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !45
-  store i64 -13, i64* %328, align 8, !dbg !45, !tbaa !6
+  %323 = bitcast i64* %319 to <4 x i64>*, !dbg !45
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %323, align 8, !dbg !45, !tbaa !6
+  %324 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !45
+  %325 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !45
+  %326 = bitcast i64* %324 to <2 x i64>*, !dbg !45
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %326, align 8, !dbg !45, !tbaa !6
+  %327 = getelementptr inbounds i64, i64* %325, i64 1, !dbg !45
+  store i64 -13, i64* %327, align 8, !dbg !45, !tbaa !6
+  %328 = getelementptr inbounds i64, i64* %327, i64 1, !dbg !45
+  store i64 -15, i64* %328, align 8, !dbg !45, !tbaa !6
   %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !45
-  store i64 -15, i64* %329, align 8, !dbg !45, !tbaa !6
+  store i64 -17, i64* %329, align 8, !dbg !45, !tbaa !6
   %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !45
-  store i64 -17, i64* %330, align 8, !dbg !45, !tbaa !6
+  store i64 -19, i64* %330, align 8, !dbg !45, !tbaa !6
   %331 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !45
-  store i64 -19, i64* %331, align 8, !dbg !45, !tbaa !6
-  %332 = getelementptr inbounds i64, i64* %331, i64 1, !dbg !45
-  store i64* %332, i64** %318, align 8, !dbg !45
+  store i64* %331, i64** %317, align 8, !dbg !45
   %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !45
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %117, align 8, !dbg !45, !tbaa !14
-  %rubyId_d692.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !110
-  %rawSym693.i = call i64 @rb_id2sym(i64 %rubyId_d692.i) #10, !dbg !110
-  %rubyId_e695.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !111
-  %rawSym696.i = call i64 @rb_id2sym(i64 %rubyId_e695.i) #10, !dbg !111
-  %rubyId_baz698.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !112
-  %rawSym699.i = call i64 @rb_id2sym(i64 %rubyId_baz698.i) #10, !dbg !112
-  %333 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !46
-  %334 = load i64*, i64** %333, align 8, !dbg !46
-  store i64 %106, i64* %334, align 8, !dbg !46, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %116, align 8, !dbg !45, !tbaa !14
+  %rubyId_d689.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !110
+  %rawSym690.i = call i64 @rb_id2sym(i64 %rubyId_d689.i) #10, !dbg !110
+  %rubyId_e692.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !111
+  %rawSym693.i = call i64 @rb_id2sym(i64 %rubyId_e692.i) #10, !dbg !111
+  %rubyId_baz695.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !112
+  %rawSym696.i = call i64 @rb_id2sym(i64 %rubyId_baz695.i) #10, !dbg !112
+  %332 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !46
+  %333 = load i64*, i64** %332, align 8, !dbg !46
+  store i64 %105, i64* %333, align 8, !dbg !46, !tbaa !6
+  %334 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !46
   %335 = getelementptr inbounds i64, i64* %334, i64 1, !dbg !46
   %336 = getelementptr inbounds i64, i64* %335, i64 1, !dbg !46
   %337 = getelementptr inbounds i64, i64* %336, i64 1, !dbg !46
-  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !46
-  %339 = bitcast i64* %335 to <4 x i64>*, !dbg !46
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %339, align 8, !dbg !46, !tbaa !6
-  %340 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !46
-  %341 = getelementptr inbounds i64, i64* %340, i64 1, !dbg !46
-  %342 = bitcast i64* %340 to <2 x i64>*, !dbg !46
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %342, align 8, !dbg !46, !tbaa !6
-  %343 = getelementptr inbounds i64, i64* %341, i64 1, !dbg !46
-  store i64 -15, i64* %343, align 8, !dbg !46, !tbaa !6
+  %338 = bitcast i64* %334 to <4 x i64>*, !dbg !46
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %338, align 8, !dbg !46, !tbaa !6
+  %339 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !46
+  %340 = getelementptr inbounds i64, i64* %339, i64 1, !dbg !46
+  %341 = bitcast i64* %339 to <2 x i64>*, !dbg !46
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %341, align 8, !dbg !46, !tbaa !6
+  %342 = getelementptr inbounds i64, i64* %340, i64 1, !dbg !46
+  store i64 -15, i64* %342, align 8, !dbg !46, !tbaa !6
+  %343 = getelementptr inbounds i64, i64* %342, i64 1, !dbg !46
+  store i64 -17, i64* %343, align 8, !dbg !46, !tbaa !6
   %344 = getelementptr inbounds i64, i64* %343, i64 1, !dbg !46
-  store i64 -17, i64* %344, align 8, !dbg !46, !tbaa !6
+  store i64 -19, i64* %344, align 8, !dbg !46, !tbaa !6
   %345 = getelementptr inbounds i64, i64* %344, i64 1, !dbg !46
-  store i64 -19, i64* %345, align 8, !dbg !46, !tbaa !6
-  %346 = getelementptr inbounds i64, i64* %345, i64 1, !dbg !46
-  store i64* %346, i64** %333, align 8, !dbg !46
+  store i64* %345, i64** %332, align 8, !dbg !46
   %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !46
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %117, align 8, !dbg !46, !tbaa !14
-  %rubyId_d720.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !113
-  %rawSym721.i = call i64 @rb_id2sym(i64 %rubyId_d720.i) #10, !dbg !113
-  %rubyId_e723.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !114
-  %rawSym724.i = call i64 @rb_id2sym(i64 %rubyId_e723.i) #10, !dbg !114
-  %rubyId_baz726.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !115
-  %rawSym727.i = call i64 @rb_id2sym(i64 %rubyId_baz726.i) #10, !dbg !115
-  %347 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !47
-  %348 = load i64*, i64** %347, align 8, !dbg !47
-  store i64 %106, i64* %348, align 8, !dbg !47, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %116, align 8, !dbg !46, !tbaa !14
+  %rubyId_d717.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !113
+  %rawSym718.i = call i64 @rb_id2sym(i64 %rubyId_d717.i) #10, !dbg !113
+  %rubyId_e720.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !114
+  %rawSym721.i = call i64 @rb_id2sym(i64 %rubyId_e720.i) #10, !dbg !114
+  %rubyId_baz723.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !115
+  %rawSym724.i = call i64 @rb_id2sym(i64 %rubyId_baz723.i) #10, !dbg !115
+  %346 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !47
+  %347 = load i64*, i64** %346, align 8, !dbg !47
+  store i64 %105, i64* %347, align 8, !dbg !47, !tbaa !6
+  %348 = getelementptr inbounds i64, i64* %347, i64 1, !dbg !47
   %349 = getelementptr inbounds i64, i64* %348, i64 1, !dbg !47
   %350 = getelementptr inbounds i64, i64* %349, i64 1, !dbg !47
   %351 = getelementptr inbounds i64, i64* %350, i64 1, !dbg !47
-  %352 = getelementptr inbounds i64, i64* %351, i64 1, !dbg !47
-  %353 = bitcast i64* %349 to <4 x i64>*, !dbg !47
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %353, align 8, !dbg !47, !tbaa !6
-  %354 = getelementptr inbounds i64, i64* %352, i64 1, !dbg !47
-  %355 = getelementptr inbounds i64, i64* %354, i64 1, !dbg !47
-  %356 = bitcast i64* %354 to <2 x i64>*, !dbg !47
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %356, align 8, !dbg !47, !tbaa !6
-  %357 = getelementptr inbounds i64, i64* %355, i64 1, !dbg !47
-  store i64 -17, i64* %357, align 8, !dbg !47, !tbaa !6
+  %352 = bitcast i64* %348 to <4 x i64>*, !dbg !47
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %352, align 8, !dbg !47, !tbaa !6
+  %353 = getelementptr inbounds i64, i64* %351, i64 1, !dbg !47
+  %354 = getelementptr inbounds i64, i64* %353, i64 1, !dbg !47
+  %355 = bitcast i64* %353 to <2 x i64>*, !dbg !47
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %355, align 8, !dbg !47, !tbaa !6
+  %356 = getelementptr inbounds i64, i64* %354, i64 1, !dbg !47
+  store i64 -17, i64* %356, align 8, !dbg !47, !tbaa !6
+  %357 = getelementptr inbounds i64, i64* %356, i64 1, !dbg !47
+  store i64 -19, i64* %357, align 8, !dbg !47, !tbaa !6
   %358 = getelementptr inbounds i64, i64* %357, i64 1, !dbg !47
-  store i64 -19, i64* %358, align 8, !dbg !47, !tbaa !6
-  %359 = getelementptr inbounds i64, i64* %358, i64 1, !dbg !47
-  store i64* %359, i64** %347, align 8, !dbg !47
+  store i64* %358, i64** %346, align 8, !dbg !47
   %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !47
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %117, align 8, !dbg !47, !tbaa !14
-  %rubyId_d746.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !116
-  %rawSym747.i = call i64 @rb_id2sym(i64 %rubyId_d746.i) #10, !dbg !116
-  %rubyId_e749.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !117
-  %rawSym750.i = call i64 @rb_id2sym(i64 %rubyId_e749.i) #10, !dbg !117
-  %rubyId_baz752.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !118
-  %rawSym753.i = call i64 @rb_id2sym(i64 %rubyId_baz752.i) #10, !dbg !118
-  %360 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !48
-  %361 = load i64*, i64** %360, align 8, !dbg !48
-  store i64 %106, i64* %361, align 8, !dbg !48, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %116, align 8, !dbg !47, !tbaa !14
+  %rubyId_d743.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !116
+  %rawSym744.i = call i64 @rb_id2sym(i64 %rubyId_d743.i) #10, !dbg !116
+  %rubyId_e746.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !117
+  %rawSym747.i = call i64 @rb_id2sym(i64 %rubyId_e746.i) #10, !dbg !117
+  %rubyId_baz749.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !118
+  %rawSym750.i = call i64 @rb_id2sym(i64 %rubyId_baz749.i) #10, !dbg !118
+  %359 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !48
+  %360 = load i64*, i64** %359, align 8, !dbg !48
+  store i64 %105, i64* %360, align 8, !dbg !48, !tbaa !6
+  %361 = getelementptr inbounds i64, i64* %360, i64 1, !dbg !48
   %362 = getelementptr inbounds i64, i64* %361, i64 1, !dbg !48
   %363 = getelementptr inbounds i64, i64* %362, i64 1, !dbg !48
   %364 = getelementptr inbounds i64, i64* %363, i64 1, !dbg !48
-  %365 = getelementptr inbounds i64, i64* %364, i64 1, !dbg !48
-  %366 = bitcast i64* %362 to <4 x i64>*, !dbg !48
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %366, align 8, !dbg !48, !tbaa !6
-  %367 = getelementptr inbounds i64, i64* %365, i64 1, !dbg !48
-  %368 = getelementptr inbounds i64, i64* %367, i64 1, !dbg !48
-  %369 = bitcast i64* %367 to <2 x i64>*, !dbg !48
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %369, align 8, !dbg !48, !tbaa !6
-  %370 = getelementptr inbounds i64, i64* %368, i64 1, !dbg !48
-  store i64 -19, i64* %370, align 8, !dbg !48, !tbaa !6
-  %371 = getelementptr inbounds i64, i64* %370, i64 1, !dbg !48
-  store i64* %371, i64** %360, align 8, !dbg !48
+  %365 = bitcast i64* %361 to <4 x i64>*, !dbg !48
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %365, align 8, !dbg !48, !tbaa !6
+  %366 = getelementptr inbounds i64, i64* %364, i64 1, !dbg !48
+  %367 = getelementptr inbounds i64, i64* %366, i64 1, !dbg !48
+  %368 = bitcast i64* %366 to <2 x i64>*, !dbg !48
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %368, align 8, !dbg !48, !tbaa !6
+  %369 = getelementptr inbounds i64, i64* %367, i64 1, !dbg !48
+  store i64 -19, i64* %369, align 8, !dbg !48, !tbaa !6
+  %370 = getelementptr inbounds i64, i64* %369, i64 1, !dbg !48
+  store i64* %370, i64** %359, align 8, !dbg !48
   %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !48
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %117, align 8, !dbg !48, !tbaa !14
-  %rubyId_d770.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !119
-  %rawSym771.i = call i64 @rb_id2sym(i64 %rubyId_d770.i) #10, !dbg !119
-  %rubyId_e773.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !120
-  %rawSym774.i = call i64 @rb_id2sym(i64 %rubyId_e773.i) #10, !dbg !120
-  %rubyId_baz776.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !121
-  %rawSym777.i = call i64 @rb_id2sym(i64 %rubyId_baz776.i) #10, !dbg !121
-  %372 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !49
-  %373 = load i64*, i64** %372, align 8, !dbg !49
-  store i64 %106, i64* %373, align 8, !dbg !49, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %116, align 8, !dbg !48, !tbaa !14
+  %rubyId_d767.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !119
+  %rawSym768.i = call i64 @rb_id2sym(i64 %rubyId_d767.i) #10, !dbg !119
+  %rubyId_e770.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !120
+  %rawSym771.i = call i64 @rb_id2sym(i64 %rubyId_e770.i) #10, !dbg !120
+  %rubyId_baz773.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !121
+  %rawSym774.i = call i64 @rb_id2sym(i64 %rubyId_baz773.i) #10, !dbg !121
+  %371 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !49
+  %372 = load i64*, i64** %371, align 8, !dbg !49
+  store i64 %105, i64* %372, align 8, !dbg !49, !tbaa !6
+  %373 = getelementptr inbounds i64, i64* %372, i64 1, !dbg !49
   %374 = getelementptr inbounds i64, i64* %373, i64 1, !dbg !49
   %375 = getelementptr inbounds i64, i64* %374, i64 1, !dbg !49
   %376 = getelementptr inbounds i64, i64* %375, i64 1, !dbg !49
-  %377 = getelementptr inbounds i64, i64* %376, i64 1, !dbg !49
-  %378 = bitcast i64* %374 to <4 x i64>*, !dbg !49
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %378, align 8, !dbg !49, !tbaa !6
-  %379 = getelementptr inbounds i64, i64* %377, i64 1, !dbg !49
-  %380 = getelementptr inbounds i64, i64* %379, i64 1, !dbg !49
-  %381 = bitcast i64* %379 to <2 x i64>*, !dbg !49
-  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %381, align 8, !dbg !49, !tbaa !6
-  %382 = getelementptr inbounds i64, i64* %380, i64 1, !dbg !49
-  store i64* %382, i64** %372, align 8, !dbg !49
+  %377 = bitcast i64* %373 to <4 x i64>*, !dbg !49
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %377, align 8, !dbg !49, !tbaa !6
+  %378 = getelementptr inbounds i64, i64* %376, i64 1, !dbg !49
+  %379 = getelementptr inbounds i64, i64* %378, i64 1, !dbg !49
+  %380 = bitcast i64* %378 to <2 x i64>*, !dbg !49
+  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %380, align 8, !dbg !49, !tbaa !6
+  %381 = getelementptr inbounds i64, i64* %379, i64 1, !dbg !49
+  store i64* %381, i64** %371, align 8, !dbg !49
   %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !49
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %117, align 8, !dbg !49, !tbaa !14
-  %rubyId_d792.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !122
-  %rawSym793.i = call i64 @rb_id2sym(i64 %rubyId_d792.i) #10, !dbg !122
-  %rubyId_e795.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !123
-  %rawSym796.i = call i64 @rb_id2sym(i64 %rubyId_e795.i) #10, !dbg !123
-  %rubyId_baz798.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !124
-  %rawSym799.i = call i64 @rb_id2sym(i64 %rubyId_baz798.i) #10, !dbg !124
-  %383 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !50
-  %384 = load i64*, i64** %383, align 8, !dbg !50
-  store i64 %106, i64* %384, align 8, !dbg !50, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %116, align 8, !dbg !49, !tbaa !14
+  %rubyId_d789.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !122
+  %rawSym790.i = call i64 @rb_id2sym(i64 %rubyId_d789.i) #10, !dbg !122
+  %rubyId_e792.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !123
+  %rawSym793.i = call i64 @rb_id2sym(i64 %rubyId_e792.i) #10, !dbg !123
+  %rubyId_baz795.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !124
+  %rawSym796.i = call i64 @rb_id2sym(i64 %rubyId_baz795.i) #10, !dbg !124
+  %382 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !50
+  %383 = load i64*, i64** %382, align 8, !dbg !50
+  store i64 %105, i64* %383, align 8, !dbg !50, !tbaa !6
+  %384 = getelementptr inbounds i64, i64* %383, i64 1, !dbg !50
   %385 = getelementptr inbounds i64, i64* %384, i64 1, !dbg !50
   %386 = getelementptr inbounds i64, i64* %385, i64 1, !dbg !50
   %387 = getelementptr inbounds i64, i64* %386, i64 1, !dbg !50
-  %388 = getelementptr inbounds i64, i64* %387, i64 1, !dbg !50
-  %389 = bitcast i64* %385 to <4 x i64>*, !dbg !50
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %389, align 8, !dbg !50, !tbaa !6
-  %390 = getelementptr inbounds i64, i64* %388, i64 1, !dbg !50
-  store i64 -19, i64* %390, align 8, !dbg !50, !tbaa !6
-  %391 = getelementptr inbounds i64, i64* %390, i64 1, !dbg !50
-  store i64* %391, i64** %383, align 8, !dbg !50
+  %388 = bitcast i64* %384 to <4 x i64>*, !dbg !50
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %388, align 8, !dbg !50, !tbaa !6
+  %389 = getelementptr inbounds i64, i64* %387, i64 1, !dbg !50
+  store i64 -19, i64* %389, align 8, !dbg !50, !tbaa !6
+  %390 = getelementptr inbounds i64, i64* %389, i64 1, !dbg !50
+  store i64* %390, i64** %382, align 8, !dbg !50
   %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !50
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %117, align 8, !dbg !50, !tbaa !14
-  %rubyId_d812.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !125
-  %rawSym813.i = call i64 @rb_id2sym(i64 %rubyId_d812.i) #10, !dbg !125
-  %rubyId_e815.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !126
-  %rawSym816.i = call i64 @rb_id2sym(i64 %rubyId_e815.i) #10, !dbg !126
-  %rubyId_baz818.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !127
-  %rawSym819.i = call i64 @rb_id2sym(i64 %rubyId_baz818.i) #10, !dbg !127
-  %392 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !51
-  %393 = load i64*, i64** %392, align 8, !dbg !51
-  store i64 %106, i64* %393, align 8, !dbg !51, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %116, align 8, !dbg !50, !tbaa !14
+  %rubyId_d809.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !125
+  %rawSym810.i = call i64 @rb_id2sym(i64 %rubyId_d809.i) #10, !dbg !125
+  %rubyId_e812.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !126
+  %rawSym813.i = call i64 @rb_id2sym(i64 %rubyId_e812.i) #10, !dbg !126
+  %rubyId_baz815.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !127
+  %rawSym816.i = call i64 @rb_id2sym(i64 %rubyId_baz815.i) #10, !dbg !127
+  %391 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !51
+  %392 = load i64*, i64** %391, align 8, !dbg !51
+  store i64 %105, i64* %392, align 8, !dbg !51, !tbaa !6
+  %393 = getelementptr inbounds i64, i64* %392, i64 1, !dbg !51
   %394 = getelementptr inbounds i64, i64* %393, i64 1, !dbg !51
   %395 = getelementptr inbounds i64, i64* %394, i64 1, !dbg !51
   %396 = getelementptr inbounds i64, i64* %395, i64 1, !dbg !51
-  %397 = getelementptr inbounds i64, i64* %396, i64 1, !dbg !51
-  %398 = bitcast i64* %394 to <4 x i64>*, !dbg !51
-  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %398, align 8, !dbg !51, !tbaa !6
-  %399 = getelementptr inbounds i64, i64* %397, i64 1, !dbg !51
-  store i64* %399, i64** %392, align 8, !dbg !51
+  %397 = bitcast i64* %393 to <4 x i64>*, !dbg !51
+  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %397, align 8, !dbg !51, !tbaa !6
+  %398 = getelementptr inbounds i64, i64* %396, i64 1, !dbg !51
+  store i64* %398, i64** %391, align 8, !dbg !51
   %send44 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !51
-  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %110)
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %111)
+  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %109)
+  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %110)
   ret void
 }
 

--- a/test/testdata/compiler/block_no_args_captures_constant.llo.exp
+++ b/test/testdata/compiler/block_no_args_captures_constant.llo.exp
@@ -108,9 +108,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_hi = private unnamed_addr constant [3 x i8] c"hi\00", align 1
 @rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
@@ -335,7 +332,7 @@ functionEntryInitializers:
 ; Function Attrs: sspreq
 define void @Init_block_no_args_captures_constant() local_unnamed_addr #6 {
 entry:
-  %locals.i8.i = alloca i64, i32 0, align 8
+  %locals.i7.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #12
@@ -349,102 +346,98 @@ entry:
   store i64 %4, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #12
   store i64 %5, i64* @rubyIdPrecomputed_normal, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #12
-  store i64 %6, i64* @rubyIdPrecomputed_keep_def, align 8
-  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #12
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #12
+  tail call void @rb_gc_register_mark_object(i64 %6) #12
+  store i64 %6, i64* @rubyStrFrozen_foo, align 8
+  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([58 x i8], [58 x i8]* @"str_test/testdata/compiler/block_no_args_captures_constant.rb", i64 0, i64 0), i64 noundef 57) #12
   tail call void @rb_gc_register_mark_object(i64 %7) #12
-  store i64 %7, i64* @rubyStrFrozen_foo, align 8
-  %8 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([58 x i8], [58 x i8]* @"str_test/testdata/compiler/block_no_args_captures_constant.rb", i64 0, i64 0), i64 noundef 57) #12
-  tail call void @rb_gc_register_mark_object(i64 %8) #12
-  store i64 %8, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
+  store i64 %7, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
   %rubyStr_foo.i.i = load i64, i64* @rubyStrFrozen_foo, align 8
   %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
-  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
-  %10 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_block in foo", i64 0, i64 0), i64 noundef 12) #12
-  call void @rb_gc_register_mark_object(i64 %10) #12
+  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
+  %9 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_block in foo", i64 0, i64 0), i64 noundef 12) #12
+  call void @rb_gc_register_mark_object(i64 %9) #12
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
   %"rubyId_block in foo.i.i" = load i64, i64* @"rubyIdPrecomputed_block in foo", align 8
-  %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
-  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %10, i64 %"rubyId_block in foo.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo$block_1", align 8
+  %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i5.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
+  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %"rubyId_block in foo.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo$block_1", align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !52
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !52
-  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
-  call void @rb_gc_register_mark_object(i64 %12) #12
+  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
+  call void @rb_gc_register_mark_object(i64 %11) #12
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i7.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %12, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i7.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #12
-  call void @rb_gc_register_mark_object(i64 %14) #12
-  store i64 %14, i64* @rubyStrFrozen_hi, align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !53
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !53
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !55
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !55
-  %15 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %16 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %15, i64 0, i32 18
-  %17 = load i64, i64* %16, align 8, !tbaa !56
-  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 2
-  %20 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %19, align 8, !tbaa !24
+  %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i7.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #12
+  call void @rb_gc_register_mark_object(i64 %13) #12
+  store i64 %13, i64* @rubyStrFrozen_hi, align 8
+  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !53
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !53
+  %14 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %15 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %14, i64 0, i32 18
+  %16 = load i64, i64* %15, align 8, !tbaa !55
+  %17 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %17, i64 0, i32 2
+  %19 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %18, align 8, !tbaa !24
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %21, align 8, !tbaa !38
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 4
-  %23 = load i64*, i64** %22, align 8, !tbaa !40
-  %24 = load i64, i64* %23, align 8, !tbaa !6
-  %25 = and i64 %24, -33
-  store i64 %25, i64* %23, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %18, %struct.rb_control_frame_struct* %20, %struct.rb_iseq_struct* %stackFrame.i) #12
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %26, align 8, !dbg !64, !tbaa !14
-  %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !65
-  %27 = load i64, i64* @rb_cObject, align 8, !dbg !65
-  %28 = call i64 @sorbet_setConstant(i64 %27, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 noundef 1, i64 %rubyStr_hi.i) #12, !dbg !65
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %26, align 8, !dbg !65, !tbaa !14
-  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !53
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #12, !dbg !53
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !53
-  %rawSym12.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #12, !dbg !53
-  %stackFrame13.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !53
-  %29 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !53
-  %30 = bitcast i8* %29 to i16*, !dbg !53
-  %31 = load i16, i16* %30, align 8, !dbg !53
-  %32 = and i16 %31, -384, !dbg !53
-  store i16 %32, i16* %30, align 8, !dbg !53
-  %33 = getelementptr inbounds i8, i8* %29, i64 4, !dbg !53
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %33, i8 0, i64 28, i1 false) #12, !dbg !53
-  call void @sorbet_vm_define_method(i64 %27, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#3foo", i8* nonnull %29, %struct.rb_iseq_struct* %stackFrame13.i, i1 noundef zeroext false) #12, !dbg !53
-  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !53, !tbaa !14
-  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 5, !dbg !53
-  %36 = load i32, i32* %35, align 8, !dbg !53, !tbaa !47
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 6, !dbg !53
-  %38 = load i32, i32* %37, align 4, !dbg !53, !tbaa !48
-  %39 = xor i32 %38, -1, !dbg !53
-  %40 = and i32 %39, %36, !dbg !53
-  %41 = icmp eq i32 %40, 0, !dbg !53
-  br i1 %41, label %"func_<root>.17<static-init>$152.exit", label %42, !dbg !53, !prof !49
+  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %19, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %20, align 8, !tbaa !38
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %19, i64 0, i32 4
+  %22 = load i64*, i64** %21, align 8, !tbaa !40
+  %23 = load i64, i64* %22, align 8, !tbaa !6
+  %24 = and i64 %23, -33
+  store i64 %24, i64* %22, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %17, %struct.rb_control_frame_struct* %19, %struct.rb_iseq_struct* %stackFrame.i) #12
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %19, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %25, align 8, !dbg !63, !tbaa !14
+  %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !64
+  %26 = load i64, i64* @rb_cObject, align 8, !dbg !64
+  %27 = call i64 @sorbet_setConstant(i64 %26, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 noundef 1, i64 %rubyStr_hi.i) #12, !dbg !64
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %25, align 8, !dbg !64, !tbaa !14
+  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !65
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #12, !dbg !65
+  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !65
+  %rawSym12.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #12, !dbg !65
+  %stackFrame13.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !65
+  %28 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !65
+  %29 = bitcast i8* %28 to i16*, !dbg !65
+  %30 = load i16, i16* %29, align 8, !dbg !65
+  %31 = and i16 %30, -384, !dbg !65
+  store i16 %31, i16* %29, align 8, !dbg !65
+  %32 = getelementptr inbounds i8, i8* %28, i64 4, !dbg !65
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %32, i8 0, i64 28, i1 false) #12, !dbg !65
+  call void @sorbet_vm_define_method(i64 %26, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#3foo", i8* nonnull %28, %struct.rb_iseq_struct* %stackFrame13.i, i1 noundef zeroext false) #12, !dbg !65
+  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !14
+  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 5, !dbg !65
+  %35 = load i32, i32* %34, align 8, !dbg !65, !tbaa !47
+  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 6, !dbg !65
+  %37 = load i32, i32* %36, align 4, !dbg !65, !tbaa !48
+  %38 = xor i32 %37, -1, !dbg !65
+  %39 = and i32 %38, %35, !dbg !65
+  %40 = icmp eq i32 %39, 0, !dbg !65
+  br i1 %40, label %"func_<root>.17<static-init>$152.exit", label %41, !dbg !65, !prof !49
 
-42:                                               ; preds = %entry
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 8, !dbg !53
-  %44 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %43, align 8, !dbg !53, !tbaa !50
-  %45 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %44, i32 noundef 0) #12, !dbg !53
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !53
+41:                                               ; preds = %entry
+  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 8, !dbg !65
+  %43 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %42, align 8, !dbg !65, !tbaa !50
+  %44 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %43, i32 noundef 0) #12, !dbg !65
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !65
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %entry, %42
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %26, align 8, !dbg !53, !tbaa !14
-  %46 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 1, !dbg !55
-  %47 = load i64*, i64** %46, align 8, !dbg !55
-  store i64 %17, i64* %47, align 8, !dbg !55, !tbaa !6
-  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !55
-  store i64* %48, i64** %46, align 8, !dbg !55
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !55
+"func_<root>.17<static-init>$152.exit":           ; preds = %entry, %41
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %25, align 8, !dbg !65, !tbaa !14
+  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %19, i64 0, i32 1, !dbg !53
+  %46 = load i64*, i64** %45, align 8, !dbg !53
+  store i64 %16, i64* %46, align 8, !dbg !53, !tbaa !6
+  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !53
+  store i64* %47, i64** %45, align 8, !dbg !53
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !53
   ret void
 }
 
@@ -537,16 +530,16 @@ attributes #13 = { nounwind allocsize(0,1) }
 !50 = !{!25, !15, i64 56}
 !51 = !DILocation(line: 7, column: 3, scope: !42)
 !52 = !DILocation(line: 8, column: 5, scope: !42)
-!53 = !DILocation(line: 5, column: 1, scope: !54)
+!53 = !DILocation(line: 12, column: 1, scope: !54)
 !54 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!55 = !DILocation(line: 12, column: 1, scope: !54)
-!56 = !{!57, !7, i64 400}
-!57 = !{!"rb_vm_struct", !7, i64 0, !58, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !21, i64 216, !8, i64 224, !59, i64 264, !59, i64 280, !59, i64 296, !59, i64 312, !7, i64 328, !26, i64 336, !26, i64 340, !26, i64 344, !26, i64 344, !26, i64 344, !26, i64 344, !26, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !61, i64 472, !62, i64 992, !15, i64 1016, !15, i64 1024, !26, i64 1032, !26, i64 1036, !59, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !26, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !26, i64 1192, !63, i64 1200, !8, i64 1232}
-!58 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !59, i64 48, !15, i64 64, !26, i64 72, !8, i64 80, !8, i64 128, !26, i64 176, !26, i64 180}
-!59 = !{!"list_head", !60, i64 0}
-!60 = !{!"list_node", !15, i64 0, !15, i64 8}
-!61 = !{!"", !8, i64 0}
-!62 = !{!"rb_hook_list_struct", !15, i64 0, !26, i64 8, !26, i64 12, !26, i64 16}
-!63 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!64 = !DILocation(line: 0, scope: !54)
-!65 = !DILocation(line: 4, column: 5, scope: !54)
+!55 = !{!56, !7, i64 400}
+!56 = !{!"rb_vm_struct", !7, i64 0, !57, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !21, i64 216, !8, i64 224, !58, i64 264, !58, i64 280, !58, i64 296, !58, i64 312, !7, i64 328, !26, i64 336, !26, i64 340, !26, i64 344, !26, i64 344, !26, i64 344, !26, i64 344, !26, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !60, i64 472, !61, i64 992, !15, i64 1016, !15, i64 1024, !26, i64 1032, !26, i64 1036, !58, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !26, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !26, i64 1192, !62, i64 1200, !8, i64 1232}
+!57 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !58, i64 48, !15, i64 64, !26, i64 72, !8, i64 80, !8, i64 128, !26, i64 176, !26, i64 180}
+!58 = !{!"list_head", !59, i64 0}
+!59 = !{!"list_node", !15, i64 0, !15, i64 8}
+!60 = !{!"", !8, i64 0}
+!61 = !{!"rb_hook_list_struct", !15, i64 0, !26, i64 8, !26, i64 12, !26, i64 16}
+!62 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!63 = !DILocation(line: 0, scope: !54)
+!64 = !DILocation(line: 4, column: 5, scope: !54)
+!65 = !DILocation(line: 5, column: 1, scope: !54)

--- a/test/testdata/compiler/block_type_checking.llo.exp
+++ b/test/testdata/compiler/block_type_checking.llo.exp
@@ -141,9 +141,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
 @rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
 @guard_epoch_Foo = linkonce local_unnamed_addr global i64 0
@@ -281,116 +278,116 @@ fastSymCallIntrinsic_ResolvedSig_sig:
   %14 = xor i32 %13, -1, !dbg !28
   %15 = and i32 %14, %11, !dbg !28
   %16 = icmp eq i32 %15, 0, !dbg !28
-  br i1 %16, label %fastSymCallIntrinsic_Static_keep_def, label %17, !dbg !28, !prof !31
+  br i1 %16, label %afterSend, label %65, !dbg !28, !prof !31
 
-17:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig
-  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !28
-  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !28, !tbaa !32
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !28
-  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !28
+afterSend:                                        ; preds = %65, %fastSymCallIntrinsic_ResolvedSig_sig
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !28, !tbaa !15
+  %17 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !32
+  %18 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !32, !tbaa !33
+  %needTakeSlowPath = icmp ne i64 %17, %18, !dbg !32
+  br i1 %needTakeSlowPath, label %19, label %20, !dbg !32, !prof !35
 
-afterSend45:                                      ; preds = %65, %35
+19:                                               ; preds = %afterSend
+  tail call void @"const_recompute_T::Sig"(), !dbg !32
+  br label %20, !dbg !32
+
+20:                                               ; preds = %afterSend, %19
+  %21 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !32
+  %22 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !32
+  %23 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !32, !tbaa !33
+  %guardUpdated = icmp eq i64 %22, %23, !dbg !32
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !32
+  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !32
+  %25 = load i64*, i64** %24, align 8, !dbg !32
+  store i64 %selfRaw, i64* %25, align 8, !dbg !32, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !32
+  store i64 %21, i64* %26, align 8, !dbg !32, !tbaa !6
+  %27 = getelementptr inbounds i64, i64* %26, i64 1, !dbg !32
+  store i64* %27, i64** %24, align 8, !dbg !32
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !32
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !32, !tbaa !15
+  %rubyId_bar40 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !36
+  %rawSym41 = tail call i64 @rb_id2sym(i64 %rubyId_bar40), !dbg !36
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !36
+  %rawSym42 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !36
+  %28 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !36
+  %29 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !36, !tbaa !33
+  %needTakeSlowPath2 = icmp ne i64 %28, %29, !dbg !36
+  br i1 %needTakeSlowPath2, label %30, label %31, !dbg !36, !prof !35
+
+30:                                               ; preds = %20
+  tail call void @const_recompute_Foo(), !dbg !36
+  br label %31, !dbg !36
+
+31:                                               ; preds = %20, %30
+  %32 = load i64, i64* @guarded_const_Foo, align 8, !dbg !36
+  %33 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !36
+  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !36, !tbaa !33
+  %guardUpdated3 = icmp eq i64 %33, %34, !dbg !36
+  tail call void @llvm.assume(i1 %guardUpdated3), !dbg !36
+  %stackFrame46 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8, !dbg !36
+  %35 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !36
+  %36 = bitcast i8* %35 to i16*, !dbg !36
+  %37 = load i16, i16* %36, align 8, !dbg !36
+  %38 = and i16 %37, -384, !dbg !36
+  %39 = or i16 %38, 65, !dbg !36
+  store i16 %39, i16* %36, align 8, !dbg !36
+  %40 = getelementptr inbounds i8, i8* %35, i64 8, !dbg !36
+  %41 = bitcast i8* %40 to i32*, !dbg !36
+  store i32 1, i32* %41, align 8, !dbg !36, !tbaa !37
+  %42 = getelementptr inbounds i8, i8* %35, i64 12, !dbg !36
+  %43 = bitcast i8* %42 to i32*, !dbg !36
+  %44 = getelementptr inbounds i8, i8* %35, i64 28, !dbg !36
+  %45 = bitcast i8* %44 to i32*, !dbg !36
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %42, i8 0, i64 16, i1 false), !dbg !36
+  store i32 1, i32* %45, align 4, !dbg !36, !tbaa !40
+  %46 = getelementptr inbounds i8, i8* %35, i64 4, !dbg !36
+  %47 = bitcast i8* %46 to i32*, !dbg !36
+  store i32 2, i32* %47, align 4, !dbg !36, !tbaa !41
+  %positional_table = alloca i64, i32 2, align 8, !dbg !36
+  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !36
+  store i64 %rubyId_x, i64* %positional_table, align 8, !dbg !36
+  %rubyId_blk = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !36
+  %48 = getelementptr i64, i64* %positional_table, i32 1, !dbg !36
+  store i64 %rubyId_blk, i64* %48, align 8, !dbg !36
+  %49 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !36
+  %50 = bitcast i64* %positional_table to i8*, !dbg !36
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %49, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %50, i64 noundef 16, i1 noundef false) #16, !dbg !36
+  %51 = getelementptr inbounds i8, i8* %35, i64 32, !dbg !36
+  %52 = bitcast i8* %51 to i8**, !dbg !36
+  store i8* %49, i8** %52, align 8, !dbg !36, !tbaa !42
+  tail call void @sorbet_vm_define_method(i64 %32, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Foo#3bar", i8* nonnull %35, %struct.rb_iseq_struct* %stackFrame46, i1 noundef zeroext false) #16, !dbg !36
+  %53 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !36, !tbaa !15
+  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 5, !dbg !36
+  %55 = load i32, i32* %54, align 8, !dbg !36, !tbaa !29
+  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 6, !dbg !36
+  %57 = load i32, i32* %56, align 4, !dbg !36, !tbaa !30
+  %58 = xor i32 %57, -1, !dbg !36
+  %59 = and i32 %58, %55, !dbg !36
+  %60 = icmp eq i32 %59, 0, !dbg !36
+  br i1 %60, label %rb_vm_check_ints.exit1, label %61, !dbg !36, !prof !31
+
+61:                                               ; preds = %31
+  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 8, !dbg !36
+  %63 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %62, align 8, !dbg !36, !tbaa !43
+  %64 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %63, i32 noundef 0) #16, !dbg !36
+  br label %rb_vm_check_ints.exit1, !dbg !36
+
+rb_vm_check_ints.exit1:                           ; preds = %31, %61
   ret void
 
-fastSymCallIntrinsic_Static_keep_def:             ; preds = %fastSymCallIntrinsic_ResolvedSig_sig, %17
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !28, !tbaa !15
-  %21 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !33
-  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !34
-  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !33
-  br i1 %needTakeSlowPath, label %23, label %24, !dbg !33, !prof !36
-
-23:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
-  tail call void @"const_recompute_T::Sig"(), !dbg !33
-  br label %24, !dbg !33
-
-24:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def, %23
-  %25 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !33
-  %26 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !33
-  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !34
-  %guardUpdated = icmp eq i64 %26, %27, !dbg !33
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !33
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !33
-  %29 = load i64*, i64** %28, align 8, !dbg !33
-  store i64 %selfRaw, i64* %29, align 8, !dbg !33, !tbaa !6
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !33
-  store i64 %25, i64* %30, align 8, !dbg !33, !tbaa !6
-  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !33
-  store i64* %31, i64** %28, align 8, !dbg !33
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !33
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !33, !tbaa !15
-  %rubyId_bar40 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !37
-  %rawSym41 = tail call i64 @rb_id2sym(i64 %rubyId_bar40), !dbg !37
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !37
-  %rawSym42 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !37
-  %32 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !37
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !37, !tbaa !34
-  %needTakeSlowPath2 = icmp ne i64 %32, %33, !dbg !37
-  br i1 %needTakeSlowPath2, label %34, label %35, !dbg !37, !prof !36
-
-34:                                               ; preds = %24
-  tail call void @const_recompute_Foo(), !dbg !37
-  br label %35, !dbg !37
-
-35:                                               ; preds = %24, %34
-  %36 = load i64, i64* @guarded_const_Foo, align 8, !dbg !37
-  %37 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !37
-  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !37, !tbaa !34
-  %guardUpdated3 = icmp eq i64 %37, %38, !dbg !37
-  tail call void @llvm.assume(i1 %guardUpdated3), !dbg !37
-  %stackFrame46 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8, !dbg !37
-  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !37
-  %40 = bitcast i8* %39 to i16*, !dbg !37
-  %41 = load i16, i16* %40, align 8, !dbg !37
-  %42 = and i16 %41, -384, !dbg !37
-  %43 = or i16 %42, 65, !dbg !37
-  store i16 %43, i16* %40, align 8, !dbg !37
-  %44 = getelementptr inbounds i8, i8* %39, i64 8, !dbg !37
-  %45 = bitcast i8* %44 to i32*, !dbg !37
-  store i32 1, i32* %45, align 8, !dbg !37, !tbaa !38
-  %46 = getelementptr inbounds i8, i8* %39, i64 12, !dbg !37
-  %47 = bitcast i8* %46 to i32*, !dbg !37
-  %48 = getelementptr inbounds i8, i8* %39, i64 28, !dbg !37
-  %49 = bitcast i8* %48 to i32*, !dbg !37
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 16, i1 false), !dbg !37
-  store i32 1, i32* %49, align 4, !dbg !37, !tbaa !41
-  %50 = getelementptr inbounds i8, i8* %39, i64 4, !dbg !37
-  %51 = bitcast i8* %50 to i32*, !dbg !37
-  store i32 2, i32* %51, align 4, !dbg !37, !tbaa !42
-  %positional_table = alloca i64, i32 2, align 8, !dbg !37
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !37
-  store i64 %rubyId_x, i64* %positional_table, align 8, !dbg !37
-  %rubyId_blk = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !37
-  %52 = getelementptr i64, i64* %positional_table, i32 1, !dbg !37
-  store i64 %rubyId_blk, i64* %52, align 8, !dbg !37
-  %53 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !37
-  %54 = bitcast i64* %positional_table to i8*, !dbg !37
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %53, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %54, i64 noundef 16, i1 noundef false) #16, !dbg !37
-  %55 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !37
-  %56 = bitcast i8* %55 to i8**, !dbg !37
-  store i8* %53, i8** %56, align 8, !dbg !37, !tbaa !43
-  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Foo#3bar", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame46, i1 noundef zeroext false) #16, !dbg !37
-  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !15
-  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 5, !dbg !37
-  %59 = load i32, i32* %58, align 8, !dbg !37, !tbaa !29
-  %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 6, !dbg !37
-  %61 = load i32, i32* %60, align 4, !dbg !37, !tbaa !30
-  %62 = xor i32 %61, -1, !dbg !37
-  %63 = and i32 %62, %59, !dbg !37
-  %64 = icmp eq i32 %63, 0, !dbg !37
-  br i1 %64, label %afterSend45, label %65, !dbg !37, !prof !31
-
-65:                                               ; preds = %35
-  %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 8, !dbg !37
-  %67 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %66, align 8, !dbg !37, !tbaa !32
-  %68 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %67, i32 noundef 0) #16, !dbg !37
-  br label %afterSend45, !dbg !37
+65:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig
+  %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !28
+  %67 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %66, align 8, !dbg !28, !tbaa !43
+  %68 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %67, i32 noundef 0) #16, !dbg !28
+  br label %afterSend, !dbg !28
 }
 
 ; Function Attrs: sspreq
 define void @Init_block_type_checking() local_unnamed_addr #9 {
 entry:
-  %locals.i19.i = alloca i64, i32 0, align 8
-  %locals.i17.i = alloca i64, i32 0, align 8
+  %locals.i18.i = alloca i64, i32 0, align 8
+  %locals.i16.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %keywords.i = alloca i64, i32 2, align 8, !dbg !44
   %realpath = tail call i64 @sorbet_readRealpath()
@@ -427,52 +424,50 @@ entry:
   store i64 %15, i64* @rubyIdPrecomputed_extend, align 8
   %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
   store i64 %16, i64* @rubyIdPrecomputed_normal, align 8
-  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #16
-  store i64 %17, i64* @rubyIdPrecomputed_keep_def, align 8
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  tail call void @rb_gc_register_mark_object(i64 %17) #16
+  store i64 %17, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([46 x i8], [46 x i8]* @"str_test/testdata/compiler/block_type_checking.rb", i64 0, i64 0), i64 noundef 45) #16
   tail call void @rb_gc_register_mark_object(i64 %18) #16
-  store i64 %18, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([46 x i8], [46 x i8]* @"str_test/testdata/compiler/block_type_checking.rb", i64 0, i64 0), i64 noundef 45) #16
-  tail call void @rb_gc_register_mark_object(i64 %19) #16
-  store i64 %19, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
+  store i64 %18, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 19)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #16
-  call void @rb_gc_register_mark_object(i64 %21) #16
+  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #16
+  call void @rb_gc_register_mark_object(i64 %20) #16
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %22 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %22, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8
+  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
+  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !46
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !46
   %rubyId_bar.i = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !46
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
   %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !47
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
-  %23 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #16
-  call void @rb_gc_register_mark_object(i64 %23) #16
+  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #16
+  call void @rb_gc_register_mark_object(i64 %22) #16
   %rubyId_bar.i.i = load i64, i64* @rubyIdPrecomputed_bar, align 8
-  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %23, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8
-  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Foo>", i64 0, i64 0), i64 noundef 11) #16
-  call void @rb_gc_register_mark_object(i64 %25) #16
+  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
+  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8
+  %24 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Foo>", i64 0, i64 0), i64 noundef 11) #16
+  call void @rb_gc_register_mark_object(i64 %24) #16
   %"rubyId_<class:Foo>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:Foo>", align 8
-  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %25, i64 %"rubyId_<class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
-  %27 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @"str_block in <class:Foo>", i64 0, i64 0), i64 noundef 20) #16
-  call void @rb_gc_register_mark_object(i64 %27) #16
-  %stackFrame.i20.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
+  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
+  %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %24, i64 %"rubyId_<class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
+  %26 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @"str_block in <class:Foo>", i64 0, i64 0), i64 noundef 20) #16
+  call void @rb_gc_register_mark_object(i64 %26) #16
+  %stackFrame.i19.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
   %"rubyId_block in <class:Foo>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:Foo>", align 8
-  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i21.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %27, i64 %"rubyId_block in <class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i20.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>$block_1", align 8
+  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
+  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %26, i64 %"rubyId_block in <class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i19.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>$block_1", align 8
   %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !28
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !28
   %rubyId_proc.i = load i64, i64* @rubyIdPrecomputed_proc, align 8, !dbg !48
@@ -481,94 +476,92 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !44
   %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !44
-  %29 = call i64 @rb_id2sym(i64 %rubyId_x.i) #16, !dbg !44
-  store i64 %29, i64* %keywords.i, align 8, !dbg !44
+  %28 = call i64 @rb_id2sym(i64 %rubyId_x.i) #16, !dbg !44
+  store i64 %28, i64* %keywords.i, align 8, !dbg !44
   %rubyId_blk.i = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !44
-  %30 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #16, !dbg !44
-  %31 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !44
-  store i64 %30, i64* %31, align 8, !dbg !44
+  %29 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #16, !dbg !44
+  %30 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !44
+  store i64 %29, i64* %30, align 8, !dbg !44
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords.i), !dbg !44
   %rubyId_returns10.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !44
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.1, i64 %rubyId_returns10.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !44
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !33
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !33
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !37
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !37
+  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !32
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !32
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %0)
-  %32 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
-  %33 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %32, i64 0, i32 18
-  %34 = load i64, i64* %33, align 8, !tbaa !49
-  %35 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %35, i64 0, i32 2
-  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %36, align 8, !tbaa !17
+  %31 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %32 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %31, i64 0, i32 18
+  %33 = load i64, i64* %32, align 8, !tbaa !49
+  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
+  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !17
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %38, align 8, !tbaa !21
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 4
-  %40 = load i64*, i64** %39, align 8, !tbaa !23
-  %41 = load i64, i64* %40, align 8, !tbaa !6
-  %42 = and i64 %41, -33
-  store i64 %42, i64* %40, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %35, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i) #16
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %43, align 8, !dbg !57, !tbaa !15
-  %44 = load i64, i64* @rb_cObject, align 8, !dbg !58
-  %45 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 %44) #16, !dbg !58
-  %46 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %45) #16, !dbg !58
-  call fastcc void @"func_Foo.13<static-init>L62"(i64 %45, %struct.rb_control_frame_struct* %46) #16, !dbg !58
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !21
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
+  %39 = load i64*, i64** %38, align 8, !tbaa !23
+  %40 = load i64, i64* %39, align 8, !tbaa !6
+  %41 = and i64 %40, -33
+  store i64 %41, i64* %39, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i) #16
+  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 0
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %42, align 8, !dbg !57, !tbaa !15
+  %43 = load i64, i64* @rb_cObject, align 8, !dbg !58
+  %44 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 %43) #16, !dbg !58
+  %45 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %44) #16, !dbg !58
+  call fastcc void @"func_Foo.13<static-init>L62"(i64 %44, %struct.rb_control_frame_struct* %45) #16, !dbg !58
   call void @sorbet_popFrame() #16, !dbg !58
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %43, align 8, !dbg !58, !tbaa !15
-  %47 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !46
-  %48 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !34
-  %needTakeSlowPath = icmp ne i64 %47, %48, !dbg !46
-  br i1 %needTakeSlowPath, label %49, label %50, !dbg !46, !prof !36
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %42, align 8, !dbg !58, !tbaa !15
+  %46 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !46
+  %47 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !33
+  %needTakeSlowPath = icmp ne i64 %46, %47, !dbg !46
+  br i1 %needTakeSlowPath, label %48, label %49, !dbg !46, !prof !35
 
-49:                                               ; preds = %entry
+48:                                               ; preds = %entry
   call void @const_recompute_Foo(), !dbg !46
-  br label %50, !dbg !46
+  br label %49, !dbg !46
 
-50:                                               ; preds = %entry, %49
-  %51 = load i64, i64* @guarded_const_Foo, align 8, !dbg !46
-  %52 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !46
-  %53 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !34
-  %guardUpdated = icmp eq i64 %52, %53, !dbg !46
+49:                                               ; preds = %entry, %48
+  %50 = load i64, i64* @guarded_const_Foo, align 8, !dbg !46
+  %51 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !46
+  %52 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !33
+  %guardUpdated = icmp eq i64 %51, %52, !dbg !46
   call void @llvm.assume(i1 %guardUpdated), !dbg !46
-  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !46
-  %55 = load i64*, i64** %54, align 8, !dbg !46
-  store i64 %51, i64* %55, align 8, !dbg !46, !tbaa !6
-  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !46
-  store i64* %56, i64** %54, align 8, !dbg !46
+  %53 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !46
+  %54 = load i64*, i64** %53, align 8, !dbg !46
+  store i64 %50, i64* %54, align 8, !dbg !46, !tbaa !6
+  %55 = getelementptr inbounds i64, i64* %54, i64 1, !dbg !46
+  store i64* %55, i64** %53, align 8, !dbg !46
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !46
-  %57 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !46
-  %58 = load i64*, i64** %57, align 8, !dbg !46
-  store i64 %send, i64* %58, align 8, !dbg !46, !tbaa !6
+  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !46
+  %57 = load i64*, i64** %56, align 8, !dbg !46
+  store i64 %send, i64* %57, align 8, !dbg !46, !tbaa !6
+  %58 = getelementptr inbounds i64, i64* %57, i64 1, !dbg !46
+  store i64 11, i64* %58, align 8, !dbg !46, !tbaa !6
   %59 = getelementptr inbounds i64, i64* %58, i64 1, !dbg !46
-  store i64 11, i64* %59, align 8, !dbg !46, !tbaa !6
-  %60 = getelementptr inbounds i64, i64* %59, i64 1, !dbg !46
-  store i64* %60, i64** %57, align 8, !dbg !46
-  %61 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !15
-  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 2, !dbg !46
-  %63 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %62, align 8, !dbg !46, !tbaa !17
-  %64 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.17<static-init>$152$block_1", i8* null, i32 noundef 0, i32 noundef -1) #16, !dbg !46
-  %65 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %63, i64 0, i32 3, !dbg !46
-  %66 = bitcast i64* %65 to %struct.rb_captured_block*, !dbg !46
-  %67 = getelementptr inbounds i64, i64* %65, i64 2, !dbg !46
-  %68 = bitcast i64* %67 to %struct.vm_ifunc**, !dbg !46
-  store %struct.vm_ifunc* %64, %struct.vm_ifunc** %68, align 8, !dbg !46, !tbaa !59
-  %69 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 17, !dbg !46
-  store i64 0, i64* %69, align 8, !dbg !46, !tbaa !60
+  store i64* %59, i64** %56, align 8, !dbg !46
+  %60 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !15
+  %61 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %60, i64 0, i32 2, !dbg !46
+  %62 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %61, align 8, !dbg !46, !tbaa !17
+  %63 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.17<static-init>$152$block_1", i8* null, i32 noundef 0, i32 noundef -1) #16, !dbg !46
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %62, i64 0, i32 3, !dbg !46
+  %65 = bitcast i64* %64 to %struct.rb_captured_block*, !dbg !46
+  %66 = getelementptr inbounds i64, i64* %64, i64 2, !dbg !46
+  %67 = bitcast i64* %66 to %struct.vm_ifunc**, !dbg !46
+  store %struct.vm_ifunc* %63, %struct.vm_ifunc** %67, align 8, !dbg !46, !tbaa !59
+  %68 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %60, i64 0, i32 17, !dbg !46
+  store i64 0, i64* %68, align 8, !dbg !46, !tbaa !60
   call void @llvm.experimental.noalias.scope.decl(metadata !61) #16, !dbg !46
-  %70 = ptrtoint %struct.rb_captured_block* %66 to i64, !dbg !46
-  %71 = or i64 %70, 3, !dbg !46
-  %72 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %71) #16, !dbg !46
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %43, align 8, !dbg !46, !tbaa !15
-  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !47
-  %74 = load i64*, i64** %73, align 8, !dbg !47
-  store i64 %34, i64* %74, align 8, !dbg !47, !tbaa !6
+  %69 = ptrtoint %struct.rb_captured_block* %65 to i64, !dbg !46
+  %70 = or i64 %69, 3, !dbg !46
+  %71 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %70) #16, !dbg !46
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %42, align 8, !dbg !46, !tbaa !15
+  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !47
+  %73 = load i64*, i64** %72, align 8, !dbg !47
+  store i64 %33, i64* %73, align 8, !dbg !47, !tbaa !6
+  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !47
+  store i64 %71, i64* %74, align 8, !dbg !47, !tbaa !6
   %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !47
-  store i64 %72, i64* %75, align 8, !dbg !47, !tbaa !6
-  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !47
-  store i64* %76, i64** %73, align 8, !dbg !47
+  store i64* %75, i64** %72, align 8, !dbg !47
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !47
   ret void
 }
@@ -670,7 +663,7 @@ sorbet_rb_int_plus.exit:                          ; preds = %29, %24, %33
 
 44:                                               ; preds = %sorbet_rb_int_plus.exit
   %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 8, !dbg !77
-  %46 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %45, align 8, !dbg !77, !tbaa !32
+  %46 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %45, align 8, !dbg !77, !tbaa !43
   %47 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %46, i32 noundef 0) #16, !dbg !77
   br label %rb_vm_check_ints.exit, !dbg !77
 
@@ -730,9 +723,9 @@ functionEntryInitializers:
   %rubyId_blk = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !80
   %rawSym19 = tail call i64 @rb_id2sym(i64 %rubyId_blk), !dbg !80
   %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !48
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !34
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !33
   %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !48
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !48, !prof !36
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !48, !prof !35
 
 13:                                               ; preds = %functionEntryInitializers
   tail call void @const_recompute_T(), !dbg !48
@@ -741,7 +734,7 @@ functionEntryInitializers:
 14:                                               ; preds = %functionEntryInitializers, %13
   %15 = load i64, i64* @guarded_const_T, align 8, !dbg !48
   %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !48
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !34
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !33
   %guardUpdated = icmp eq i64 %16, %17, !dbg !48
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !48
   %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !48
@@ -820,7 +813,7 @@ declare void @llvm.assume(i1 noundef) #14
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !33
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
@@ -829,7 +822,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #10 {
 define linkonce void @const_recompute_Foo() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 3)
   store i64 %1, i64* @guarded_const_Foo, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !33
   store i64 %2, i64* @guard_epoch_Foo, align 8
   ret void
 }
@@ -838,7 +831,7 @@ define linkonce void @const_recompute_Foo() local_unnamed_addr #10 {
 define linkonce void @const_recompute_T() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_T, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_T, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !33
   store i64 %2, i64* @guard_epoch_T, align 8
   ret void
 }
@@ -900,25 +893,25 @@ attributes #20 = { nounwind willreturn }
 !29 = !{!18, !19, i64 40}
 !30 = !{!18, !19, i64 44}
 !31 = !{!"branch_weights", i32 2000, i32 1}
-!32 = !{!18, !16, i64 56}
-!33 = !DILocation(line: 6, column: 3, scope: !26)
-!34 = !{!35, !35, i64 0}
-!35 = !{!"long long", !8, i64 0}
-!36 = !{!"branch_weights", i32 1, i32 10000}
-!37 = !DILocation(line: 9, column: 3, scope: !26)
-!38 = !{!39, !19, i64 8}
-!39 = !{!"rb_sorbet_param_struct", !40, i64 0, !19, i64 4, !19, i64 8, !19, i64 12, !19, i64 16, !19, i64 20, !19, i64 24, !19, i64 28, !16, i64 32, !19, i64 40, !19, i64 44, !19, i64 48, !19, i64 52, !16, i64 56}
-!40 = !{!"", !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 1, !19, i64 1}
-!41 = !{!39, !19, i64 28}
-!42 = !{!39, !19, i64 4}
-!43 = !{!39, !16, i64 32}
+!32 = !DILocation(line: 6, column: 3, scope: !26)
+!33 = !{!34, !34, i64 0}
+!34 = !{!"long long", !8, i64 0}
+!35 = !{!"branch_weights", i32 1, i32 10000}
+!36 = !DILocation(line: 9, column: 3, scope: !26)
+!37 = !{!38, !19, i64 8}
+!38 = !{!"rb_sorbet_param_struct", !39, i64 0, !19, i64 4, !19, i64 8, !19, i64 12, !19, i64 16, !19, i64 20, !19, i64 24, !19, i64 28, !16, i64 32, !19, i64 40, !19, i64 44, !19, i64 48, !19, i64 52, !16, i64 56}
+!39 = !{!"", !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 1, !19, i64 1}
+!40 = !{!38, !19, i64 28}
+!41 = !{!38, !19, i64 4}
+!42 = !{!38, !16, i64 32}
+!43 = !{!18, !16, i64 56}
 !44 = !DILocation(line: 8, column: 8, scope: !45)
 !45 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.13<static-init>L62$block_1", scope: !26, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !46 = !DILocation(line: 15, column: 10, scope: !11)
 !47 = !DILocation(line: 18, column: 1, scope: !11)
 !48 = !DILocation(line: 8, column: 32, scope: !45)
 !49 = !{!50, !7, i64 400}
-!50 = !{!"rb_vm_struct", !7, i64 0, !51, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !35, i64 216, !8, i64 224, !52, i64 264, !52, i64 280, !52, i64 296, !52, i64 312, !7, i64 328, !19, i64 336, !19, i64 340, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !54, i64 472, !55, i64 992, !16, i64 1016, !16, i64 1024, !19, i64 1032, !19, i64 1036, !52, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !19, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !19, i64 1192, !56, i64 1200, !8, i64 1232}
+!50 = !{!"rb_vm_struct", !7, i64 0, !51, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !34, i64 216, !8, i64 224, !52, i64 264, !52, i64 280, !52, i64 296, !52, i64 312, !7, i64 328, !19, i64 336, !19, i64 340, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !54, i64 472, !55, i64 992, !16, i64 1016, !16, i64 1024, !19, i64 1032, !19, i64 1036, !52, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !19, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !19, i64 1192, !56, i64 1200, !8, i64 1232}
 !51 = !{!"rb_global_vm_lock_struct", !16, i64 0, !8, i64 8, !52, i64 48, !16, i64 64, !19, i64 72, !8, i64 80, !8, i64 128, !19, i64 176, !19, i64 180}
 !52 = !{!"list_head", !53, i64 0}
 !53 = !{!"list_node", !16, i64 0, !16, i64 8}

--- a/test/testdata/compiler/casts.llo.exp
+++ b/test/testdata/compiler/casts.llo.exp
@@ -115,26 +115,19 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_arg = internal unnamed_addr global i64 0, align 8
 @str_arg = private unnamed_addr constant [4 x i8] c"arg\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
-@ic_keep_def.1 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_keep_def.2 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_keep_def.3 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_keep_def.4 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_fooInt = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @ic_fooAny1 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_fooAny2 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_puts.6 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_puts.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_fooAll = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_puts.7 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @"str_<build-array>" = private unnamed_addr constant [14 x i8] c"<build-array>\00", align 1
 @ic_fooArray = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_puts.8 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
 @rb_mKernel = external local_unnamed_addr constant i64
 @rb_cObject = external local_unnamed_addr constant i64
 
@@ -496,7 +489,7 @@ codeRepl:                                         ; preds = %fillRequiredArgs, %
 
 ; Function Attrs: nounwind sspreq uwtable
 define internal fastcc void @"func_<root>.17<static-init>$152"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !49 {
-fastSymCallIntrinsic_Static_keep_def:
+functionEntryInitializers:
   %callArgs = alloca [4 x i64], align 8
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
@@ -551,21 +544,21 @@ fastSymCallIntrinsic_Static_keep_def:
   %30 = xor i32 %29, -1, !dbg !55
   %31 = and i32 %30, %27, !dbg !55
   %32 = icmp eq i32 %31, 0, !dbg !55
-  br i1 %32, label %fastSymCallIntrinsic_Static_keep_def87, label %33, !dbg !55, !prof !20
+  br i1 %32, label %rb_vm_check_ints.exit4, label %33, !dbg !55, !prof !20
 
-33:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
+33:                                               ; preds = %functionEntryInitializers
   %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 8, !dbg !55
   %35 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %34, align 8, !dbg !55, !tbaa !44
   %36 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %35, i32 noundef 0) #17, !dbg !55
-  br label %fastSymCallIntrinsic_Static_keep_def87, !dbg !55
+  br label %rb_vm_check_ints.exit4, !dbg !55
 
-fastSymCallIntrinsic_Static_keep_def87:           ; preds = %fastSymCallIntrinsic_Static_keep_def, %33
+rb_vm_check_ints.exit4:                           ; preds = %functionEntryInitializers, %33
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !55, !tbaa !14
   %rubyId_fooAny1 = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8, !dbg !61
-  %rawSym79 = tail call i64 @rb_id2sym(i64 %rubyId_fooAny1), !dbg !61
-  %rubyId_normal80 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !61
-  %rawSym81 = tail call i64 @rb_id2sym(i64 %rubyId_normal80), !dbg !61
-  %stackFrame88 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8, !dbg !61
+  %rawSym76 = tail call i64 @rb_id2sym(i64 %rubyId_fooAny1), !dbg !61
+  %rubyId_normal77 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !61
+  %rawSym78 = tail call i64 @rb_id2sym(i64 %rubyId_normal77), !dbg !61
+  %stackFrame83 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8, !dbg !61
   %37 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !61
   %38 = bitcast i8* %37 to i16*, !dbg !61
   %39 = load i16, i16* %38, align 8, !dbg !61
@@ -581,16 +574,16 @@ fastSymCallIntrinsic_Static_keep_def87:           ; preds = %fastSymCallIntrinsi
   %47 = bitcast i8* %46 to i32*, !dbg !61
   tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %44, i8 0, i64 20, i1 false), !dbg !61
   store i32 1, i32* %47, align 4, !dbg !61, !tbaa !59
-  %positional_table90 = alloca i64, align 8, !dbg !61
-  %rubyId_arg91 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !61
-  store i64 %rubyId_arg91, i64* %positional_table90, align 8, !dbg !61
+  %positional_table85 = alloca i64, align 8, !dbg !61
+  %rubyId_arg86 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !61
+  store i64 %rubyId_arg86, i64* %positional_table85, align 8, !dbg !61
   %48 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !61
-  %49 = bitcast i64* %positional_table90 to i8*, !dbg !61
+  %49 = bitcast i64* %positional_table85 to i8*, !dbg !61
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %48, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %49, i64 noundef 8, i1 noundef false) #17, !dbg !61
   %50 = getelementptr inbounds i8, i8* %37, i64 32, !dbg !61
   %51 = bitcast i8* %50 to i8**, !dbg !61
   store i8* %48, i8** %51, align 8, !dbg !61, !tbaa !60
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#7fooAny1", i8* nonnull %37, %struct.rb_iseq_struct* %stackFrame88, i1 noundef zeroext false) #17, !dbg !61
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#7fooAny1", i8* nonnull %37, %struct.rb_iseq_struct* %stackFrame83, i1 noundef zeroext false) #17, !dbg !61
   %52 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !61, !tbaa !14
   %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 5, !dbg !61
   %54 = load i32, i32* %53, align 8, !dbg !61, !tbaa !39
@@ -599,21 +592,21 @@ fastSymCallIntrinsic_Static_keep_def87:           ; preds = %fastSymCallIntrinsi
   %57 = xor i32 %56, -1, !dbg !61
   %58 = and i32 %57, %54, !dbg !61
   %59 = icmp eq i32 %58, 0, !dbg !61
-  br i1 %59, label %fastSymCallIntrinsic_Static_keep_def104, label %60, !dbg !61, !prof !20
+  br i1 %59, label %rb_vm_check_ints.exit3, label %60, !dbg !61, !prof !20
 
-60:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def87
+60:                                               ; preds = %rb_vm_check_ints.exit4
   %61 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 8, !dbg !61
   %62 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %61, align 8, !dbg !61, !tbaa !44
   %63 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %62, i32 noundef 0) #17, !dbg !61
-  br label %fastSymCallIntrinsic_Static_keep_def104, !dbg !61
+  br label %rb_vm_check_ints.exit3, !dbg !61
 
-fastSymCallIntrinsic_Static_keep_def104:          ; preds = %fastSymCallIntrinsic_Static_keep_def87, %60
+rb_vm_check_ints.exit3:                           ; preds = %rb_vm_check_ints.exit4, %60
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !61, !tbaa !14
   %rubyId_fooAny2 = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8, !dbg !62
-  %rawSym96 = tail call i64 @rb_id2sym(i64 %rubyId_fooAny2), !dbg !62
-  %rubyId_normal97 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !62
-  %rawSym98 = tail call i64 @rb_id2sym(i64 %rubyId_normal97), !dbg !62
-  %stackFrame105 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8, !dbg !62
+  %rawSym88 = tail call i64 @rb_id2sym(i64 %rubyId_fooAny2), !dbg !62
+  %rubyId_normal89 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !62
+  %rawSym90 = tail call i64 @rb_id2sym(i64 %rubyId_normal89), !dbg !62
+  %stackFrame95 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8, !dbg !62
   %64 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !62
   %65 = bitcast i8* %64 to i16*, !dbg !62
   %66 = load i16, i16* %65, align 8, !dbg !62
@@ -629,16 +622,16 @@ fastSymCallIntrinsic_Static_keep_def104:          ; preds = %fastSymCallIntrinsi
   %74 = bitcast i8* %73 to i32*, !dbg !62
   tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %71, i8 0, i64 20, i1 false), !dbg !62
   store i32 1, i32* %74, align 4, !dbg !62, !tbaa !59
-  %positional_table107 = alloca i64, align 8, !dbg !62
-  %rubyId_arg108 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !62
-  store i64 %rubyId_arg108, i64* %positional_table107, align 8, !dbg !62
+  %positional_table97 = alloca i64, align 8, !dbg !62
+  %rubyId_arg98 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !62
+  store i64 %rubyId_arg98, i64* %positional_table97, align 8, !dbg !62
   %75 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !62
-  %76 = bitcast i64* %positional_table107 to i8*, !dbg !62
+  %76 = bitcast i64* %positional_table97 to i8*, !dbg !62
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %75, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %76, i64 noundef 8, i1 noundef false) #17, !dbg !62
   %77 = getelementptr inbounds i8, i8* %64, i64 32, !dbg !62
   %78 = bitcast i8* %77 to i8**, !dbg !62
   store i8* %75, i8** %78, align 8, !dbg !62, !tbaa !60
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#7fooAny2", i8* nonnull %64, %struct.rb_iseq_struct* %stackFrame105, i1 noundef zeroext false) #17, !dbg !62
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#7fooAny2", i8* nonnull %64, %struct.rb_iseq_struct* %stackFrame95, i1 noundef zeroext false) #17, !dbg !62
   %79 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !62, !tbaa !14
   %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 5, !dbg !62
   %81 = load i32, i32* %80, align 8, !dbg !62, !tbaa !39
@@ -647,21 +640,21 @@ fastSymCallIntrinsic_Static_keep_def104:          ; preds = %fastSymCallIntrinsi
   %84 = xor i32 %83, -1, !dbg !62
   %85 = and i32 %84, %81, !dbg !62
   %86 = icmp eq i32 %85, 0, !dbg !62
-  br i1 %86, label %fastSymCallIntrinsic_Static_keep_def121, label %87, !dbg !62, !prof !20
+  br i1 %86, label %rb_vm_check_ints.exit2, label %87, !dbg !62, !prof !20
 
-87:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def104
+87:                                               ; preds = %rb_vm_check_ints.exit3
   %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 8, !dbg !62
   %89 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %88, align 8, !dbg !62, !tbaa !44
   %90 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %89, i32 noundef 0) #17, !dbg !62
-  br label %fastSymCallIntrinsic_Static_keep_def121, !dbg !62
+  br label %rb_vm_check_ints.exit2, !dbg !62
 
-fastSymCallIntrinsic_Static_keep_def121:          ; preds = %fastSymCallIntrinsic_Static_keep_def104, %87
+rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.exit3, %87
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %8, align 8, !dbg !62, !tbaa !14
   %rubyId_fooInt = load i64, i64* @rubyIdPrecomputed_fooInt, align 8, !dbg !63
-  %rawSym113 = tail call i64 @rb_id2sym(i64 %rubyId_fooInt), !dbg !63
-  %rubyId_normal114 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !63
-  %rawSym115 = tail call i64 @rb_id2sym(i64 %rubyId_normal114), !dbg !63
-  %stackFrame122 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8, !dbg !63
+  %rawSym100 = tail call i64 @rb_id2sym(i64 %rubyId_fooInt), !dbg !63
+  %rubyId_normal101 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !63
+  %rawSym102 = tail call i64 @rb_id2sym(i64 %rubyId_normal101), !dbg !63
+  %stackFrame107 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8, !dbg !63
   %91 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !63
   %92 = bitcast i8* %91 to i16*, !dbg !63
   %93 = load i16, i16* %92, align 8, !dbg !63
@@ -677,16 +670,16 @@ fastSymCallIntrinsic_Static_keep_def121:          ; preds = %fastSymCallIntrinsi
   %101 = bitcast i8* %100 to i32*, !dbg !63
   tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %98, i8 0, i64 20, i1 false), !dbg !63
   store i32 1, i32* %101, align 4, !dbg !63, !tbaa !59
-  %positional_table124 = alloca i64, align 8, !dbg !63
-  %rubyId_arg125 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !63
-  store i64 %rubyId_arg125, i64* %positional_table124, align 8, !dbg !63
+  %positional_table109 = alloca i64, align 8, !dbg !63
+  %rubyId_arg110 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !63
+  store i64 %rubyId_arg110, i64* %positional_table109, align 8, !dbg !63
   %102 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !63
-  %103 = bitcast i64* %positional_table124 to i8*, !dbg !63
+  %103 = bitcast i64* %positional_table109 to i8*, !dbg !63
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %102, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %103, i64 noundef 8, i1 noundef false) #17, !dbg !63
   %104 = getelementptr inbounds i8, i8* %91, i64 32, !dbg !63
   %105 = bitcast i8* %104 to i8**, !dbg !63
   store i8* %102, i8** %105, align 8, !dbg !63, !tbaa !60
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#6fooInt", i8* nonnull %91, %struct.rb_iseq_struct* %stackFrame122, i1 noundef zeroext false) #17, !dbg !63
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#6fooInt", i8* nonnull %91, %struct.rb_iseq_struct* %stackFrame107, i1 noundef zeroext false) #17, !dbg !63
   %106 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !63, !tbaa !14
   %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 5, !dbg !63
   %108 = load i32, i32* %107, align 8, !dbg !63, !tbaa !39
@@ -695,164 +688,164 @@ fastSymCallIntrinsic_Static_keep_def121:          ; preds = %fastSymCallIntrinsi
   %111 = xor i32 %110, -1, !dbg !63
   %112 = and i32 %111, %108, !dbg !63
   %113 = icmp eq i32 %112, 0, !dbg !63
-  br i1 %113, label %fastSymCallIntrinsic_Static_keep_def138, label %114, !dbg !63, !prof !20
+  br i1 %113, label %rb_vm_check_ints.exit1, label %114, !dbg !63, !prof !20
 
-114:                                              ; preds = %fastSymCallIntrinsic_Static_keep_def121
+114:                                              ; preds = %rb_vm_check_ints.exit2
   %115 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 8, !dbg !63
   %116 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %115, align 8, !dbg !63, !tbaa !44
   %117 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %116, i32 noundef 0) #17, !dbg !63
-  br label %fastSymCallIntrinsic_Static_keep_def138, !dbg !63
+  br label %rb_vm_check_ints.exit1, !dbg !63
 
-afterSend135:                                     ; preds = %183, %fastSymCallIntrinsic_Static_keep_def138
+rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.exit2, %114
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %8, align 8, !dbg !63, !tbaa !14
+  %rubyId_fooArray = load i64, i64* @rubyIdPrecomputed_fooArray, align 8, !dbg !64
+  %rawSym112 = tail call i64 @rb_id2sym(i64 %rubyId_fooArray), !dbg !64
+  %rubyId_normal113 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !64
+  %rawSym114 = tail call i64 @rb_id2sym(i64 %rubyId_normal113), !dbg !64
+  %stackFrame119 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8, !dbg !64
+  %118 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !64
+  %119 = bitcast i8* %118 to i16*, !dbg !64
+  %120 = load i16, i16* %119, align 8, !dbg !64
+  %121 = and i16 %120, -384, !dbg !64
+  %122 = or i16 %121, 1, !dbg !64
+  store i16 %122, i16* %119, align 8, !dbg !64
+  %123 = getelementptr inbounds i8, i8* %118, i64 8, !dbg !64
+  %124 = bitcast i8* %123 to i32*, !dbg !64
+  store i32 1, i32* %124, align 8, !dbg !64, !tbaa !56
+  %125 = getelementptr inbounds i8, i8* %118, i64 12, !dbg !64
+  %126 = bitcast i8* %125 to i32*, !dbg !64
+  %127 = getelementptr inbounds i8, i8* %118, i64 4, !dbg !64
+  %128 = bitcast i8* %127 to i32*, !dbg !64
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %125, i8 0, i64 20, i1 false), !dbg !64
+  store i32 1, i32* %128, align 4, !dbg !64, !tbaa !59
+  %positional_table121 = alloca i64, align 8, !dbg !64
+  %rubyId_arg122 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !64
+  store i64 %rubyId_arg122, i64* %positional_table121, align 8, !dbg !64
+  %129 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !64
+  %130 = bitcast i64* %positional_table121 to i8*, !dbg !64
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %129, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %130, i64 noundef 8, i1 noundef false) #17, !dbg !64
+  %131 = getelementptr inbounds i8, i8* %118, i64 32, !dbg !64
+  %132 = bitcast i8* %131 to i8**, !dbg !64
+  store i8* %129, i8** %132, align 8, !dbg !64, !tbaa !60
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#8fooArray", i8* nonnull %118, %struct.rb_iseq_struct* %stackFrame119, i1 noundef zeroext false) #17, !dbg !64
+  %133 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !64, !tbaa !14
+  %134 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 5, !dbg !64
+  %135 = load i32, i32* %134, align 8, !dbg !64, !tbaa !39
+  %136 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 6, !dbg !64
+  %137 = load i32, i32* %136, align 4, !dbg !64, !tbaa !43
+  %138 = xor i32 %137, -1, !dbg !64
+  %139 = and i32 %138, %135, !dbg !64
+  %140 = icmp eq i32 %139, 0, !dbg !64
+  br i1 %140, label %rb_vm_check_ints.exit, label %141, !dbg !64, !prof !20
+
+141:                                              ; preds = %rb_vm_check_ints.exit1
+  %142 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 8, !dbg !64
+  %143 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %142, align 8, !dbg !64, !tbaa !44
+  %144 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %143, i32 noundef 0) #17, !dbg !64
+  br label %rb_vm_check_ints.exit, !dbg !64
+
+rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.exit1, %141
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %8, align 8, !dbg !64, !tbaa !14
-  %118 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !65
-  %119 = load i64*, i64** %118, align 8, !dbg !65
-  store i64 %selfRaw, i64* %119, align 8, !dbg !65, !tbaa !6
-  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !65
-  store i64 5, i64* %120, align 8, !dbg !65, !tbaa !6
-  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !65
-  store i64* %121, i64** %118, align 8, !dbg !65
+  %145 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !65
+  %146 = load i64*, i64** %145, align 8, !dbg !65
+  store i64 %selfRaw, i64* %146, align 8, !dbg !65, !tbaa !6
+  %147 = getelementptr inbounds i64, i64* %146, i64 1, !dbg !65
+  store i64 5, i64* %147, align 8, !dbg !65, !tbaa !6
+  %148 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !65
+  store i64* %148, i64** %145, align 8, !dbg !65
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooInt, i64 0), !dbg !65
-  %122 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !66
-  %123 = load i64*, i64** %122, align 8, !dbg !66
-  store i64 %selfRaw, i64* %123, align 8, !dbg !66, !tbaa !6
-  %124 = getelementptr inbounds i64, i64* %123, i64 1, !dbg !66
-  store i64 %send, i64* %124, align 8, !dbg !66, !tbaa !6
-  %125 = getelementptr inbounds i64, i64* %124, i64 1, !dbg !66
-  store i64* %125, i64** %122, align 8, !dbg !66
+  %149 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !66
+  %150 = load i64*, i64** %149, align 8, !dbg !66
+  store i64 %selfRaw, i64* %150, align 8, !dbg !66, !tbaa !6
+  %151 = getelementptr inbounds i64, i64* %150, i64 1, !dbg !66
+  store i64 %send, i64* %151, align 8, !dbg !66, !tbaa !6
+  %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !66
+  store i64* %152, i64** %149, align 8, !dbg !66
   %send6 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !66
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %8, align 8, !dbg !66, !tbaa !14
-  %126 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !67
-  %127 = load i64*, i64** %126, align 8, !dbg !67
-  store i64 %selfRaw, i64* %127, align 8, !dbg !67, !tbaa !6
-  %128 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !67
-  store i64 5, i64* %128, align 8, !dbg !67, !tbaa !6
-  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !67
-  store i64* %129, i64** %126, align 8, !dbg !67
+  %153 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !67
+  %154 = load i64*, i64** %153, align 8, !dbg !67
+  store i64 %selfRaw, i64* %154, align 8, !dbg !67, !tbaa !6
+  %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !67
+  store i64 5, i64* %155, align 8, !dbg !67, !tbaa !6
+  %156 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !67
+  store i64* %156, i64** %153, align 8, !dbg !67
   %send8 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny1, i64 0), !dbg !67
-  %130 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !68
-  %131 = load i64*, i64** %130, align 8, !dbg !68
-  store i64 %selfRaw, i64* %131, align 8, !dbg !68, !tbaa !6
-  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !68
-  store i64 %send8, i64* %132, align 8, !dbg !68, !tbaa !6
-  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !68
-  store i64* %133, i64** %130, align 8, !dbg !68
-  %send10 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !68
+  %157 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !68
+  %158 = load i64*, i64** %157, align 8, !dbg !68
+  store i64 %selfRaw, i64* %158, align 8, !dbg !68, !tbaa !6
+  %159 = getelementptr inbounds i64, i64* %158, i64 1, !dbg !68
+  store i64 %send8, i64* %159, align 8, !dbg !68, !tbaa !6
+  %160 = getelementptr inbounds i64, i64* %159, i64 1, !dbg !68
+  store i64* %160, i64** %157, align 8, !dbg !68
+  %send10 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !68
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %8, align 8, !dbg !68, !tbaa !14
-  %134 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !69
-  %135 = load i64*, i64** %134, align 8, !dbg !69
-  store i64 %selfRaw, i64* %135, align 8, !dbg !69, !tbaa !6
-  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !69
-  store i64 5, i64* %136, align 8, !dbg !69, !tbaa !6
-  %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !69
-  store i64* %137, i64** %134, align 8, !dbg !69
+  %161 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !69
+  %162 = load i64*, i64** %161, align 8, !dbg !69
+  store i64 %selfRaw, i64* %162, align 8, !dbg !69, !tbaa !6
+  %163 = getelementptr inbounds i64, i64* %162, i64 1, !dbg !69
+  store i64 5, i64* %163, align 8, !dbg !69, !tbaa !6
+  %164 = getelementptr inbounds i64, i64* %163, i64 1, !dbg !69
+  store i64* %164, i64** %161, align 8, !dbg !69
   %send12 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny2, i64 0), !dbg !69
-  %138 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !70
-  %139 = load i64*, i64** %138, align 8, !dbg !70
-  store i64 %selfRaw, i64* %139, align 8, !dbg !70, !tbaa !6
-  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !70
-  store i64 %send12, i64* %140, align 8, !dbg !70, !tbaa !6
-  %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !70
-  store i64* %141, i64** %138, align 8, !dbg !70
-  %send14 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !70
+  %165 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !70
+  %166 = load i64*, i64** %165, align 8, !dbg !70
+  store i64 %selfRaw, i64* %166, align 8, !dbg !70, !tbaa !6
+  %167 = getelementptr inbounds i64, i64* %166, i64 1, !dbg !70
+  store i64 %send12, i64* %167, align 8, !dbg !70, !tbaa !6
+  %168 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !70
+  store i64* %168, i64** %165, align 8, !dbg !70
+  %send14 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !70
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %8, align 8, !dbg !70, !tbaa !14
-  %142 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !71
-  %143 = load i64*, i64** %142, align 8, !dbg !71
-  store i64 %selfRaw, i64* %143, align 8, !dbg !71, !tbaa !6
-  %144 = getelementptr inbounds i64, i64* %143, i64 1, !dbg !71
-  store i64 5, i64* %144, align 8, !dbg !71, !tbaa !6
-  %145 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !71
-  store i64* %145, i64** %142, align 8, !dbg !71
+  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !71
+  %170 = load i64*, i64** %169, align 8, !dbg !71
+  store i64 %selfRaw, i64* %170, align 8, !dbg !71, !tbaa !6
+  %171 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !71
+  store i64 5, i64* %171, align 8, !dbg !71, !tbaa !6
+  %172 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !71
+  store i64* %172, i64** %169, align 8, !dbg !71
   %send16 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAll, i64 0), !dbg !71
-  %146 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !72
-  %147 = load i64*, i64** %146, align 8, !dbg !72
-  store i64 %selfRaw, i64* %147, align 8, !dbg !72, !tbaa !6
-  %148 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !72
-  store i64 %send16, i64* %148, align 8, !dbg !72, !tbaa !6
-  %149 = getelementptr inbounds i64, i64* %148, i64 1, !dbg !72
-  store i64* %149, i64** %146, align 8, !dbg !72
-  %send18 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.7, i64 0), !dbg !72
+  %173 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !72
+  %174 = load i64*, i64** %173, align 8, !dbg !72
+  store i64 %selfRaw, i64* %174, align 8, !dbg !72, !tbaa !6
+  %175 = getelementptr inbounds i64, i64* %174, i64 1, !dbg !72
+  store i64 %send16, i64* %175, align 8, !dbg !72, !tbaa !6
+  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !72
+  store i64* %176, i64** %173, align 8, !dbg !72
+  %send18 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !72
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %8, align 8, !dbg !72, !tbaa !14
   %callArgs0Addr = getelementptr [4 x i64], [4 x i64]* %callArgs, i32 0, i64 0, !dbg !73
   store i64 5, i64* %callArgs0Addr, align 8, !dbg !73
-  %150 = getelementptr [4 x i64], [4 x i64]* %callArgs, i64 0, i64 0, !dbg !73
+  %177 = getelementptr [4 x i64], [4 x i64]* %callArgs, i64 0, i64 0, !dbg !73
   tail call void @llvm.experimental.noalias.scope.decl(metadata !74), !dbg !73
-  %151 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %150) #17, !dbg !73
-  %152 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !77
-  %153 = load i64*, i64** %152, align 8, !dbg !77
-  store i64 %selfRaw, i64* %153, align 8, !dbg !77, !tbaa !6
-  %154 = getelementptr inbounds i64, i64* %153, i64 1, !dbg !77
-  store i64 %151, i64* %154, align 8, !dbg !77, !tbaa !6
-  %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !77
-  store i64* %155, i64** %152, align 8, !dbg !77
+  %178 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %177) #17, !dbg !73
+  %179 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !77
+  %180 = load i64*, i64** %179, align 8, !dbg !77
+  store i64 %selfRaw, i64* %180, align 8, !dbg !77, !tbaa !6
+  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !77
+  store i64 %178, i64* %181, align 8, !dbg !77, !tbaa !6
+  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !77
+  store i64* %182, i64** %179, align 8, !dbg !77
   %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooArray, i64 0), !dbg !77
-  %156 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !78
-  %157 = load i64*, i64** %156, align 8, !dbg !78
-  store i64 %selfRaw, i64* %157, align 8, !dbg !78, !tbaa !6
-  %158 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !78
-  store i64 %send20, i64* %158, align 8, !dbg !78, !tbaa !6
-  %159 = getelementptr inbounds i64, i64* %158, i64 1, !dbg !78
-  store i64* %159, i64** %156, align 8, !dbg !78
-  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.8, i64 0), !dbg !78
+  %183 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !78
+  %184 = load i64*, i64** %183, align 8, !dbg !78
+  store i64 %selfRaw, i64* %184, align 8, !dbg !78, !tbaa !6
+  %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !78
+  store i64 %send20, i64* %185, align 8, !dbg !78, !tbaa !6
+  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !78
+  store i64* %186, i64** %183, align 8, !dbg !78
+  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !78
   ret void
-
-fastSymCallIntrinsic_Static_keep_def138:          ; preds = %fastSymCallIntrinsic_Static_keep_def121, %114
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %8, align 8, !dbg !63, !tbaa !14
-  %rubyId_fooArray = load i64, i64* @rubyIdPrecomputed_fooArray, align 8, !dbg !64
-  %rawSym130 = tail call i64 @rb_id2sym(i64 %rubyId_fooArray), !dbg !64
-  %rubyId_normal131 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !64
-  %rawSym132 = tail call i64 @rb_id2sym(i64 %rubyId_normal131), !dbg !64
-  %stackFrame139 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8, !dbg !64
-  %160 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !64
-  %161 = bitcast i8* %160 to i16*, !dbg !64
-  %162 = load i16, i16* %161, align 8, !dbg !64
-  %163 = and i16 %162, -384, !dbg !64
-  %164 = or i16 %163, 1, !dbg !64
-  store i16 %164, i16* %161, align 8, !dbg !64
-  %165 = getelementptr inbounds i8, i8* %160, i64 8, !dbg !64
-  %166 = bitcast i8* %165 to i32*, !dbg !64
-  store i32 1, i32* %166, align 8, !dbg !64, !tbaa !56
-  %167 = getelementptr inbounds i8, i8* %160, i64 12, !dbg !64
-  %168 = bitcast i8* %167 to i32*, !dbg !64
-  %169 = getelementptr inbounds i8, i8* %160, i64 4, !dbg !64
-  %170 = bitcast i8* %169 to i32*, !dbg !64
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %167, i8 0, i64 20, i1 false), !dbg !64
-  store i32 1, i32* %170, align 4, !dbg !64, !tbaa !59
-  %positional_table141 = alloca i64, align 8, !dbg !64
-  %rubyId_arg142 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !64
-  store i64 %rubyId_arg142, i64* %positional_table141, align 8, !dbg !64
-  %171 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !64
-  %172 = bitcast i64* %positional_table141 to i8*, !dbg !64
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %171, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %172, i64 noundef 8, i1 noundef false) #17, !dbg !64
-  %173 = getelementptr inbounds i8, i8* %160, i64 32, !dbg !64
-  %174 = bitcast i8* %173 to i8**, !dbg !64
-  store i8* %171, i8** %174, align 8, !dbg !64, !tbaa !60
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#8fooArray", i8* nonnull %160, %struct.rb_iseq_struct* %stackFrame139, i1 noundef zeroext false) #17, !dbg !64
-  %175 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !64, !tbaa !14
-  %176 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 5, !dbg !64
-  %177 = load i32, i32* %176, align 8, !dbg !64, !tbaa !39
-  %178 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 6, !dbg !64
-  %179 = load i32, i32* %178, align 4, !dbg !64, !tbaa !43
-  %180 = xor i32 %179, -1, !dbg !64
-  %181 = and i32 %180, %177, !dbg !64
-  %182 = icmp eq i32 %181, 0, !dbg !64
-  br i1 %182, label %afterSend135, label %183, !dbg !64, !prof !20
-
-183:                                              ; preds = %fastSymCallIntrinsic_Static_keep_def138
-  %184 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 8, !dbg !64
-  %185 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %184, align 8, !dbg !64, !tbaa !44
-  %186 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %185, i32 noundef 0) #17, !dbg !64
-  br label %afterSend135, !dbg !64
 }
 
 ; Function Attrs: ssp
 define void @Init_casts() local_unnamed_addr #9 {
 entry:
-  %locals.i42.i = alloca i64, i32 0, align 8
-  %locals.i40.i = alloca i64, i32 0, align 8
-  %locals.i38.i = alloca i64, i32 0, align 8
-  %locals.i36.i = alloca i64, i32 0, align 8
-  %locals.i34.i = alloca i64, i32 0, align 8
+  %locals.i33.i = alloca i64, i32 0, align 8
+  %locals.i31.i = alloca i64, i32 0, align 8
+  %locals.i29.i = alloca i64, i32 0, align 8
+  %locals.i27.i = alloca i64, i32 0, align 8
+  %locals.i25.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 noundef 6) #17
@@ -872,90 +865,78 @@ entry:
   store i64 %7, i64* @rubyIdPrecomputed_normal, align 8
   %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_arg, i64 0, i64 0), i64 noundef 3) #17
   store i64 %8, i64* @rubyIdPrecomputed_arg, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #17
-  store i64 %9, i64* @rubyIdPrecomputed_keep_def, align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #17
-  store i64 %10, i64* @rubyIdPrecomputed_puts, align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #17
-  %12 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 noundef 6) #17
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #17
+  store i64 %9, i64* @rubyIdPrecomputed_puts, align 8
+  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #17
+  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 noundef 6) #17
+  tail call void @rb_gc_register_mark_object(i64 %11) #17
+  store i64 %11, i64* @rubyStrFrozen_fooAll, align 8
+  %12 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([32 x i8], [32 x i8]* @"str_test/testdata/compiler/casts.rb", i64 0, i64 0), i64 noundef 31) #17
   tail call void @rb_gc_register_mark_object(i64 %12) #17
-  store i64 %12, i64* @rubyStrFrozen_fooAll, align 8
-  %13 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([32 x i8], [32 x i8]* @"str_test/testdata/compiler/casts.rb", i64 0, i64 0), i64 noundef 31) #17
-  tail call void @rb_gc_register_mark_object(i64 %13) #17
-  store i64 %13, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
+  store i64 %12, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 30)
   %rubyId_fooAll.i.i = load i64, i64* @rubyIdPrecomputed_fooAll, align 8
   %rubyStr_fooAll.i.i = load i64, i64* @rubyStrFrozen_fooAll, align 8
   %"rubyStr_test/testdata/compiler/casts.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_fooAll.i.i, i64 %rubyId_fooAll.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8
-  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 noundef 7) #17
-  call void @rb_gc_register_mark_object(i64 %15) #17
+  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_fooAll.i.i, i64 %rubyId_fooAll.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8
+  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 noundef 7) #17
+  call void @rb_gc_register_mark_object(i64 %14) #17
   %rubyId_fooAny1.i.i = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8
-  %"rubyStr_test/testdata/compiler/casts.rb.i33.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %rubyId_fooAny1.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i33.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i34.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8
-  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 noundef 7) #17
-  call void @rb_gc_register_mark_object(i64 %17) #17
+  %"rubyStr_test/testdata/compiler/casts.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
+  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_fooAny1.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8
+  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 noundef 7) #17
+  call void @rb_gc_register_mark_object(i64 %16) #17
   %rubyId_fooAny2.i.i = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8
-  %"rubyStr_test/testdata/compiler/casts.rb.i35.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %rubyId_fooAny2.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i35.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i36.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 noundef 6) #17
-  call void @rb_gc_register_mark_object(i64 %19) #17
+  %"rubyStr_test/testdata/compiler/casts.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
+  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %rubyId_fooAny2.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i27.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8
+  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 noundef 6) #17
+  call void @rb_gc_register_mark_object(i64 %18) #17
   %rubyId_fooInt.i.i = load i64, i64* @rubyIdPrecomputed_fooInt, align 8
-  %"rubyStr_test/testdata/compiler/casts.rb.i37.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %rubyId_fooInt.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i37.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 17, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i38.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8
-  %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 noundef 8) #17
-  call void @rb_gc_register_mark_object(i64 %21) #17
+  %"rubyStr_test/testdata/compiler/casts.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
+  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %rubyId_fooInt.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 17, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i29.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8
+  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 noundef 8) #17
+  call void @rb_gc_register_mark_object(i64 %20) #17
   %rubyId_fooArray.i.i = load i64, i64* @rubyIdPrecomputed_fooArray, align 8
-  %"rubyStr_test/testdata/compiler/casts.rb.i39.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %22 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %rubyId_fooArray.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i39.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 21, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i40.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %22, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8
-  %23 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
-  call void @rb_gc_register_mark_object(i64 %23) #17
+  %"rubyStr_test/testdata/compiler/casts.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
+  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %rubyId_fooArray.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 21, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8
+  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
+  call void @rb_gc_register_mark_object(i64 %22) #17
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/casts.rb.i41.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %23, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/casts.rb.i41.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i42.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !55
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !55
-  %rubyId_keep_def2.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !61
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.1, i64 %rubyId_keep_def2.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !61
-  %rubyId_keep_def4.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !62
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.2, i64 %rubyId_keep_def4.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !62
-  %rubyId_keep_def6.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !63
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.3, i64 %rubyId_keep_def6.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !63
-  %rubyId_keep_def8.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !64
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def8.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !64
+  %"rubyStr_test/testdata/compiler/casts.rb.i32.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
+  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/casts.rb.i32.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i33.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_fooInt.i = load i64, i64* @rubyIdPrecomputed_fooInt, align 8, !dbg !65
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooInt, i64 %rubyId_fooInt.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !65
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !66
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !66
   %rubyId_fooAny1.i = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8, !dbg !67
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny1, i64 %rubyId_fooAny1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !67
-  %rubyId_puts15.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !68
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts15.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !68
+  %rubyId_puts6.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !68
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts6.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !68
   %rubyId_fooAny2.i = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8, !dbg !69
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny2, i64 %rubyId_fooAny2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !69
-  %rubyId_puts20.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !70
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts20.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !70
+  %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !70
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !70
   %rubyId_fooAll.i = load i64, i64* @rubyIdPrecomputed_fooAll, align 8, !dbg !71
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAll, i64 %rubyId_fooAll.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !71
-  %rubyId_puts25.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !72
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts25.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !72
+  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !72
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !72
   %rubyId_fooArray.i = load i64, i64* @rubyIdPrecomputed_fooArray, align 8, !dbg !77
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooArray, i64 %rubyId_fooArray.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !77
-  %rubyId_puts30.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !78
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.8, i64 %rubyId_puts30.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !78
-  %25 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %26 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %25, i64 0, i32 18
-  %27 = load i64, i64* %26, align 8, !tbaa !79
-  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 2
-  %30 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %29, align 8, !tbaa !50
-  call fastcc void @"func_<root>.17<static-init>$152"(i64 %27, %struct.rb_control_frame_struct* %30) #17
+  %rubyId_puts21.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !78
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts21.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !78
+  %24 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %25 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %24, i64 0, i32 18
+  %26 = load i64, i64* %25, align 8, !tbaa !79
+  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2
+  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !tbaa !50
+  call fastcc void @"func_<root>.17<static-init>$152"(i64 %26, %struct.rb_control_frame_struct* %29) #17
   ret void
 }
 

--- a/test/testdata/compiler/classfields.llo.exp
+++ b/test/testdata/compiler/classfields.llo.exp
@@ -118,13 +118,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
 @str_a = private unnamed_addr constant [2 x i8] c"a\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
-@ic_keep_def.4 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_keep_self_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_self_def = internal unnamed_addr global i64 0, align 8
-@str_keep_self_def = private unnamed_addr constant [14 x i8] c"keep_self_def\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_B = linkonce local_unnamed_addr global i64 0
 @guarded_const_B = linkonce local_unnamed_addr global i64 0
@@ -198,10 +191,10 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
 define void @Init_classfields() local_unnamed_addr #5 {
 entry:
   %positional_table.i.i = alloca i64, align 8, !dbg !10
-  %locals.i24.i = alloca i64, i32 0, align 8
-  %locals.i22.i = alloca i64, i32 0, align 8
+  %locals.i20.i = alloca i64, i32 0, align 8
   %locals.i18.i = alloca i64, i32 0, align 8
-  %locals.i16.i = alloca i64, i32 0, align 8
+  %locals.i14.i = alloca i64, i32 0, align 8
+  %locals.i12.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
@@ -222,22 +215,18 @@ entry:
   store i64 %7, i64* @rubyIdPrecomputed_normal, align 8
   %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #11
   store i64 %8, i64* @rubyIdPrecomputed_a, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #11
-  store i64 %9, i64* @rubyIdPrecomputed_keep_def, align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @str_keep_self_def, i64 0, i64 0), i64 noundef 13) #11
-  store i64 %10, i64* @rubyIdPrecomputed_keep_self_def, align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %11) #11
-  store i64 %11, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %12 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_test/testdata/compiler/classfields.rb", i64 0, i64 0), i64 noundef 37) #11
-  tail call void @rb_gc_register_mark_object(i64 %12) #11
-  store i64 %12, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
+  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %9) #11
+  store i64 %9, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_test/testdata/compiler/classfields.rb", i64 0, i64 0), i64 noundef 37) #11
+  tail call void @rb_gc_register_mark_object(i64 %10) #11
+  store i64 %10, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 29)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/classfields.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !17
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
   %rubyId_write.i = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !17
@@ -252,353 +241,347 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.2, i64 %rubyId_read6.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
   %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %14) #11
+  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %12) #11
   %rubyId_write.i.i = load i64, i64* @rubyIdPrecomputed_write, align 8
-  %"rubyStr_test/testdata/compiler/classfields.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_write.i.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#5write", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %16) #11
-  store i64 %16, i64* @rubyStrFrozen_read, align 8
+  %"rubyStr_test/testdata/compiler/classfields.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
+  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %12, i64 %rubyId_write.i.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#5write", align 8
+  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %14) #11
+  store i64 %14, i64* @rubyStrFrozen_read, align 8
   %rubyId_read.i.i = load i64, i64* @rubyIdPrecomputed_read, align 8
+  %"rubyStr_test/testdata/compiler/classfields.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
+  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_read.i.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 16, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i14.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8
+  %rubyId_read.i15.i = load i64, i64* @rubyIdPrecomputed_read, align 8
+  %rubyStr_read.i16.i = load i64, i64* @rubyStrFrozen_read, align 8
   %"rubyStr_test/testdata/compiler/classfields.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %rubyId_read.i.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 16, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8
-  %rubyId_read.i19.i = load i64, i64* @rubyIdPrecomputed_read, align 8
-  %rubyStr_read.i20.i = load i64, i64* @rubyStrFrozen_read, align 8
-  %"rubyStr_test/testdata/compiler/classfields.rb.i21.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_read.i20.i, i64 %rubyId_read.i19.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 19, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i22.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:B>", i64 0, i64 0), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %19) #11
+  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_read.i16.i, i64 %rubyId_read.i15.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 19, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8
+  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:B>", i64 0, i64 0), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %17) #11
   %"rubyId_<class:B>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:B>", align 8
-  %"rubyStr_test/testdata/compiler/classfields.rb.i23.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %"rubyId_<class:B>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i23.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i24.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.13<static-init>", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !22
-  %rubyId_keep_def12.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def12.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !23
-  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
-  %21 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !25
-  %22 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %21, i64 0, i32 18
-  %23 = load i64, i64* %22, align 8, !tbaa !27
-  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !25
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2
-  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !tbaa !37
+  %"rubyStr_test/testdata/compiler/classfields.rb.i19.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
+  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %"rubyId_<class:B>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i19.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i20.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.13<static-init>", align 8
+  %19 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !22
+  %20 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %19, i64 0, i32 18
+  %21 = load i64, i64* %20, align 8, !tbaa !24
+  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
+  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
+  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !34
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %27, align 8, !tbaa !40
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4
-  %29 = load i64*, i64** %28, align 8, !tbaa !42
-  %30 = load i64, i64* %29, align 8, !tbaa !6
-  %31 = and i64 %30, -33
-  store i64 %31, i64* %29, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %24, %struct.rb_control_frame_struct* %26, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %32, align 8, !dbg !43, !tbaa !25
-  %33 = load i64, i64* @rb_cObject, align 8, !dbg !44
-  %34 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_B, i64 0, i64 0), i64 %33) #11, !dbg !44
-  %35 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %34) #11, !dbg !44
-  %36 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %36) #11
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !37
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
+  %27 = load i64*, i64** %26, align 8, !tbaa !39
+  %28 = load i64, i64* %27, align 8, !tbaa !6
+  %29 = and i64 %28, -33
+  store i64 %29, i64* %27, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !40, !tbaa !22
+  %31 = load i64, i64* @rb_cObject, align 8, !dbg !41
+  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_B, i64 0, i64 0), i64 %31) #11, !dbg !41
+  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #11, !dbg !41
+  %34 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %34) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.13<static-init>", align 8
-  %37 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !25
-  %38 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %37, i64 0, i32 2
-  %39 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %38, align 8, !tbaa !37
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %40, align 8, !tbaa !40
-  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 4
-  %42 = load i64*, i64** %41, align 8, !tbaa !42
-  %43 = load i64, i64* %42, align 8, !tbaa !6
-  %44 = and i64 %43, -33
-  store i64 %44, i64* %42, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %37, %struct.rb_control_frame_struct* %39, %struct.rb_iseq_struct* %stackFrame.i.i) #11
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %45, align 8, !dbg !45, !tbaa !25
+  %35 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
+  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %35, i64 0, i32 2
+  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %36, align 8, !tbaa !34
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %38, align 8, !tbaa !37
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 4
+  %40 = load i64*, i64** %39, align 8, !tbaa !39
+  %41 = load i64, i64* %40, align 8, !tbaa !6
+  %42 = and i64 %41, -33
+  store i64 %42, i64* %40, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %35, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %43, align 8, !dbg !42, !tbaa !22
   %rubyId_write.i.i1 = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !10
   %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_write.i.i1) #11, !dbg !10
   %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !10
   %rawSym25.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !10
-  %46 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
-  %47 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !46
-  %needTakeSlowPath = icmp ne i64 %46, %47, !dbg !10
-  br i1 %needTakeSlowPath, label %48, label %49, !dbg !10, !prof !47
+  %44 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
+  %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !43
+  %needTakeSlowPath = icmp ne i64 %44, %45, !dbg !10
+  br i1 %needTakeSlowPath, label %46, label %47, !dbg !10, !prof !44
 
-48:                                               ; preds = %entry
+46:                                               ; preds = %entry
   call void @const_recompute_B(), !dbg !10
-  br label %49, !dbg !10
+  br label %47, !dbg !10
 
-49:                                               ; preds = %entry, %48
-  %50 = load i64, i64* @guarded_const_B, align 8, !dbg !10
-  %51 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
-  %52 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !46
-  %guardUpdated = icmp eq i64 %51, %52, !dbg !10
+47:                                               ; preds = %entry, %46
+  %48 = load i64, i64* @guarded_const_B, align 8, !dbg !10
+  %49 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
+  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !43
+  %guardUpdated = icmp eq i64 %49, %50, !dbg !10
   call void @llvm.assume(i1 %guardUpdated), !dbg !10
   %stackFrame26.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#5write", align 8, !dbg !10
-  %53 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
-  %54 = bitcast i8* %53 to i16*, !dbg !10
-  %55 = load i16, i16* %54, align 8, !dbg !10
-  %56 = and i16 %55, -384, !dbg !10
-  %57 = or i16 %56, 1, !dbg !10
-  store i16 %57, i16* %54, align 8, !dbg !10
-  %58 = getelementptr inbounds i8, i8* %53, i64 8, !dbg !10
-  %59 = bitcast i8* %58 to i32*, !dbg !10
-  store i32 1, i32* %59, align 8, !dbg !10, !tbaa !48
-  %60 = getelementptr inbounds i8, i8* %53, i64 12, !dbg !10
-  %61 = getelementptr inbounds i8, i8* %53, i64 4, !dbg !10
-  %62 = bitcast i8* %61 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %60, i8 0, i64 20, i1 false) #11, !dbg !10
-  store i32 1, i32* %62, align 4, !dbg !10, !tbaa !51
+  %51 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %52 = bitcast i8* %51 to i16*, !dbg !10
+  %53 = load i16, i16* %52, align 8, !dbg !10
+  %54 = and i16 %53, -384, !dbg !10
+  %55 = or i16 %54, 1, !dbg !10
+  store i16 %55, i16* %52, align 8, !dbg !10
+  %56 = getelementptr inbounds i8, i8* %51, i64 8, !dbg !10
+  %57 = bitcast i8* %56 to i32*, !dbg !10
+  store i32 1, i32* %57, align 8, !dbg !10, !tbaa !45
+  %58 = getelementptr inbounds i8, i8* %51, i64 12, !dbg !10
+  %59 = getelementptr inbounds i8, i8* %51, i64 4, !dbg !10
+  %60 = bitcast i8* %59 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %58, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %60, align 4, !dbg !10, !tbaa !48
   %rubyId_a.i.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !10
   store i64 %rubyId_a.i.i, i64* %positional_table.i.i, align 8, !dbg !10
-  %63 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %63, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %36, i64 noundef 8, i1 noundef false) #11, !dbg !10
-  %64 = getelementptr inbounds i8, i8* %53, i64 32, !dbg !10
-  %65 = bitcast i8* %64 to i8**, !dbg !10
-  store i8* %63, i8** %65, align 8, !dbg !10, !tbaa !52
-  call void @sorbet_vm_define_method(i64 %50, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_B#5write", i8* nonnull %53, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext false) #11, !dbg !10
-  %66 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !25
-  %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 5, !dbg !10
-  %68 = load i32, i32* %67, align 8, !dbg !10, !tbaa !53
-  %69 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 6, !dbg !10
-  %70 = load i32, i32* %69, align 4, !dbg !10, !tbaa !54
-  %71 = xor i32 %70, -1, !dbg !10
-  %72 = and i32 %71, %68, !dbg !10
-  %73 = icmp eq i32 %72, 0, !dbg !10
-  br i1 %73, label %fastSymCallIntrinsic_Static_keep_def39.i.i, label %74, !dbg !10, !prof !55
+  %61 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %61, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %34, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %62 = getelementptr inbounds i8, i8* %51, i64 32, !dbg !10
+  %63 = bitcast i8* %62 to i8**, !dbg !10
+  store i8* %61, i8** %63, align 8, !dbg !10, !tbaa !49
+  call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_B#5write", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext false) #11, !dbg !10
+  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !22
+  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 5, !dbg !10
+  %66 = load i32, i32* %65, align 8, !dbg !10, !tbaa !50
+  %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 6, !dbg !10
+  %68 = load i32, i32* %67, align 4, !dbg !10, !tbaa !51
+  %69 = xor i32 %68, -1, !dbg !10
+  %70 = and i32 %69, %66, !dbg !10
+  %71 = icmp eq i32 %70, 0, !dbg !10
+  br i1 %71, label %rb_vm_check_ints.exit2.i.i, label %72, !dbg !10, !prof !52
 
-74:                                               ; preds = %49
-  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 8, !dbg !10
-  %76 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %75, align 8, !dbg !10, !tbaa !56
-  %77 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %76, i32 noundef 0) #11, !dbg !10
-  br label %fastSymCallIntrinsic_Static_keep_def39.i.i, !dbg !10
+72:                                               ; preds = %47
+  %73 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 8, !dbg !10
+  %74 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %73, align 8, !dbg !10, !tbaa !53
+  %75 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %74, i32 noundef 0) #11, !dbg !10
+  br label %rb_vm_check_ints.exit2.i.i, !dbg !10
 
-fastSymCallIntrinsic_Static_keep_def39.i.i:       ; preds = %74, %49
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %45, align 8, !dbg !10, !tbaa !25
-  %rubyId_read.i.i2 = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !57
-  %rawSym31.i.i = call i64 @rb_id2sym(i64 %rubyId_read.i.i2) #11, !dbg !57
-  %rubyId_normal32.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !57
-  %rawSym33.i.i = call i64 @rb_id2sym(i64 %rubyId_normal32.i.i) #11, !dbg !57
-  %stackFrame40.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8, !dbg !57
-  %78 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !57
-  %79 = bitcast i8* %78 to i16*, !dbg !57
-  %80 = load i16, i16* %79, align 8, !dbg !57
-  %81 = and i16 %80, -384, !dbg !57
-  store i16 %81, i16* %79, align 8, !dbg !57
-  %82 = getelementptr inbounds i8, i8* %78, i64 4, !dbg !57
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %82, i8 0, i64 28, i1 false) #11, !dbg !57
-  call void @sorbet_vm_define_method(i64 %50, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_B#4read", i8* nonnull %78, %struct.rb_iseq_struct* %stackFrame40.i.i, i1 noundef zeroext false) #11, !dbg !57
-  %83 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !57, !tbaa !25
-  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 5, !dbg !57
-  %85 = load i32, i32* %84, align 8, !dbg !57, !tbaa !53
-  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 6, !dbg !57
-  %87 = load i32, i32* %86, align 4, !dbg !57, !tbaa !54
-  %88 = xor i32 %87, -1, !dbg !57
-  %89 = and i32 %88, %85, !dbg !57
-  %90 = icmp eq i32 %89, 0, !dbg !57
-  br i1 %90, label %fastSymCallIntrinsic_Static_keep_self_def.i.i, label %91, !dbg !57, !prof !55
+rb_vm_check_ints.exit2.i.i:                       ; preds = %72, %47
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %43, align 8, !dbg !10, !tbaa !22
+  %rubyId_read.i.i2 = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !54
+  %rawSym28.i.i = call i64 @rb_id2sym(i64 %rubyId_read.i.i2) #11, !dbg !54
+  %rubyId_normal29.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !54
+  %rawSym30.i.i = call i64 @rb_id2sym(i64 %rubyId_normal29.i.i) #11, !dbg !54
+  %stackFrame35.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8, !dbg !54
+  %76 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !54
+  %77 = bitcast i8* %76 to i16*, !dbg !54
+  %78 = load i16, i16* %77, align 8, !dbg !54
+  %79 = and i16 %78, -384, !dbg !54
+  store i16 %79, i16* %77, align 8, !dbg !54
+  %80 = getelementptr inbounds i8, i8* %76, i64 4, !dbg !54
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %80, i8 0, i64 28, i1 false) #11, !dbg !54
+  call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_B#4read", i8* nonnull %76, %struct.rb_iseq_struct* %stackFrame35.i.i, i1 noundef zeroext false) #11, !dbg !54
+  %81 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !54, !tbaa !22
+  %82 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 5, !dbg !54
+  %83 = load i32, i32* %82, align 8, !dbg !54, !tbaa !50
+  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 6, !dbg !54
+  %85 = load i32, i32* %84, align 4, !dbg !54, !tbaa !51
+  %86 = xor i32 %85, -1, !dbg !54
+  %87 = and i32 %86, %83, !dbg !54
+  %88 = icmp eq i32 %87, 0, !dbg !54
+  br i1 %88, label %rb_vm_check_ints.exit1.i.i, label %89, !dbg !54, !prof !52
 
-91:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def39.i.i
-  %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 8, !dbg !57
-  %93 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %92, align 8, !dbg !57, !tbaa !56
-  %94 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %93, i32 noundef 0) #11, !dbg !57
-  br label %fastSymCallIntrinsic_Static_keep_self_def.i.i, !dbg !57
+89:                                               ; preds = %rb_vm_check_ints.exit2.i.i
+  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 8, !dbg !54
+  %91 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %90, align 8, !dbg !54, !tbaa !53
+  %92 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %91, i32 noundef 0) #11, !dbg !54
+  br label %rb_vm_check_ints.exit1.i.i, !dbg !54
 
-fastSymCallIntrinsic_Static_keep_self_def.i.i:    ; preds = %91, %fastSymCallIntrinsic_Static_keep_def39.i.i
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %45, align 8, !dbg !57, !tbaa !25
-  %rubyId_read46.i.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !58
-  %rawSym47.i.i = call i64 @rb_id2sym(i64 %rubyId_read46.i.i) #11, !dbg !58
-  %rubyId_normal48.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !58
-  %rawSym49.i.i = call i64 @rb_id2sym(i64 %rubyId_normal48.i.i) #11, !dbg !58
-  %stackFrame53.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8, !dbg !58
-  %95 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !58
-  %96 = bitcast i8* %95 to i16*, !dbg !58
-  %97 = load i16, i16* %96, align 8, !dbg !58
-  %98 = and i16 %97, -384, !dbg !58
-  store i16 %98, i16* %96, align 8, !dbg !58
-  %99 = getelementptr inbounds i8, i8* %95, i64 4, !dbg !58
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %99, i8 0, i64 28, i1 false) #11, !dbg !58
-  call void @sorbet_vm_define_method(i64 %50, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_B.4read, i8* nonnull %95, %struct.rb_iseq_struct* %stackFrame53.i.i, i1 noundef zeroext true) #11, !dbg !58
-  %100 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !58, !tbaa !25
-  %101 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %100, i64 0, i32 5, !dbg !58
-  %102 = load i32, i32* %101, align 8, !dbg !58, !tbaa !53
-  %103 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %100, i64 0, i32 6, !dbg !58
-  %104 = load i32, i32* %103, align 4, !dbg !58, !tbaa !54
-  %105 = xor i32 %104, -1, !dbg !58
-  %106 = and i32 %105, %102, !dbg !58
-  %107 = icmp eq i32 %106, 0, !dbg !58
-  br i1 %107, label %"func_<root>.17<static-init>$152.exit", label %108, !dbg !58, !prof !55
+rb_vm_check_ints.exit1.i.i:                       ; preds = %89, %rb_vm_check_ints.exit2.i.i
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %43, align 8, !dbg !54, !tbaa !22
+  %rubyId_read38.i.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !55
+  %rawSym39.i.i = call i64 @rb_id2sym(i64 %rubyId_read38.i.i) #11, !dbg !55
+  %rubyId_normal40.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !55
+  %rawSym41.i.i = call i64 @rb_id2sym(i64 %rubyId_normal40.i.i) #11, !dbg !55
+  %stackFrame45.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8, !dbg !55
+  %93 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !55
+  %94 = bitcast i8* %93 to i16*, !dbg !55
+  %95 = load i16, i16* %94, align 8, !dbg !55
+  %96 = and i16 %95, -384, !dbg !55
+  store i16 %96, i16* %94, align 8, !dbg !55
+  %97 = getelementptr inbounds i8, i8* %93, i64 4, !dbg !55
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %97, i8 0, i64 28, i1 false) #11, !dbg !55
+  call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_B.4read, i8* nonnull %93, %struct.rb_iseq_struct* %stackFrame45.i.i, i1 noundef zeroext true) #11, !dbg !55
+  %98 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !55, !tbaa !22
+  %99 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 5, !dbg !55
+  %100 = load i32, i32* %99, align 8, !dbg !55, !tbaa !50
+  %101 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 6, !dbg !55
+  %102 = load i32, i32* %101, align 4, !dbg !55, !tbaa !51
+  %103 = xor i32 %102, -1, !dbg !55
+  %104 = and i32 %103, %100, !dbg !55
+  %105 = icmp eq i32 %104, 0, !dbg !55
+  br i1 %105, label %"func_<root>.17<static-init>$152.exit", label %106, !dbg !55, !prof !52
 
-108:                                              ; preds = %fastSymCallIntrinsic_Static_keep_self_def.i.i
-  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %100, i64 0, i32 8, !dbg !58
-  %110 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %109, align 8, !dbg !58, !tbaa !56
-  %111 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %110, i32 noundef 0) #11, !dbg !58
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !58
+106:                                              ; preds = %rb_vm_check_ints.exit1.i.i
+  %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 8, !dbg !55
+  %108 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %107, align 8, !dbg !55, !tbaa !53
+  %109 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %108, i32 noundef 0) #11, !dbg !55
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !55
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %fastSymCallIntrinsic_Static_keep_self_def.i.i, %108
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %36) #11
-  call void @sorbet_popFrame() #11, !dbg !44
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %32, align 8, !dbg !44, !tbaa !25
-  %112 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !17
-  %113 = load i64*, i64** %112, align 8, !dbg !17
-  store i64 %50, i64* %113, align 8, !dbg !17, !tbaa !6
-  %114 = getelementptr inbounds i64, i64* %113, i64 1, !dbg !17
-  store i64* %114, i64** %112, align 8, !dbg !17
+"func_<root>.17<static-init>$152.exit":           ; preds = %rb_vm_check_ints.exit1.i.i, %106
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %34) #11
+  call void @sorbet_popFrame() #11, !dbg !41
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %30, align 8, !dbg !41, !tbaa !22
+  %110 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !17
+  %111 = load i64*, i64** %110, align 8, !dbg !17
+  store i64 %48, i64* %111, align 8, !dbg !17, !tbaa !6
+  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !17
+  store i64* %112, i64** %110, align 8, !dbg !17
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !17
-  %115 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !17
-  %116 = load i64*, i64** %115, align 8, !dbg !17
-  store i64 %send, i64* %116, align 8, !dbg !17, !tbaa !6
-  %117 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !17
-  store i64 3, i64* %117, align 8, !dbg !17, !tbaa !6
-  %118 = getelementptr inbounds i64, i64* %117, i64 1, !dbg !17
-  store i64* %118, i64** %115, align 8, !dbg !17
+  %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !17
+  %114 = load i64*, i64** %113, align 8, !dbg !17
+  store i64 %send, i64* %114, align 8, !dbg !17, !tbaa !6
+  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !17
+  store i64 3, i64* %115, align 8, !dbg !17, !tbaa !6
+  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !17
+  store i64* %116, i64** %113, align 8, !dbg !17
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %32, align 8, !dbg !17, !tbaa !25
-  %119 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !18
-  %120 = load i64*, i64** %119, align 8, !dbg !18
-  store i64 %50, i64* %120, align 8, !dbg !18, !tbaa !6
-  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !18
-  store i64* %121, i64** %119, align 8, !dbg !18
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %30, align 8, !dbg !17, !tbaa !22
+  %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !18
+  %118 = load i64*, i64** %117, align 8, !dbg !18
+  store i64 %48, i64* %118, align 8, !dbg !18, !tbaa !6
+  %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !18
+  store i64* %119, i64** %117, align 8, !dbg !18
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
-  %122 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !19
-  %123 = load i64*, i64** %122, align 8, !dbg !19
-  store i64 %23, i64* %123, align 8, !dbg !19, !tbaa !6
-  %124 = getelementptr inbounds i64, i64* %123, i64 1, !dbg !19
-  store i64 %send6, i64* %124, align 8, !dbg !19, !tbaa !6
-  %125 = getelementptr inbounds i64, i64* %124, i64 1, !dbg !19
-  store i64* %125, i64** %122, align 8, !dbg !19
+  %120 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !19
+  %121 = load i64*, i64** %120, align 8, !dbg !19
+  store i64 %21, i64* %121, align 8, !dbg !19, !tbaa !6
+  %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !19
+  store i64 %send6, i64* %122, align 8, !dbg !19, !tbaa !6
+  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !19
+  store i64* %123, i64** %120, align 8, !dbg !19
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %32, align 8, !dbg !19, !tbaa !25
-  %126 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !20
-  %127 = load i64*, i64** %126, align 8, !dbg !20
-  store i64 %50, i64* %127, align 8, !dbg !20, !tbaa !6
-  %128 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !20
-  store i64* %128, i64** %126, align 8, !dbg !20
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %30, align 8, !dbg !19, !tbaa !22
+  %124 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !20
+  %125 = load i64*, i64** %124, align 8, !dbg !20
+  store i64 %48, i64* %125, align 8, !dbg !20, !tbaa !6
+  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !20
+  store i64* %126, i64** %124, align 8, !dbg !20
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new.1, i64 0), !dbg !20
-  %129 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !20
-  %130 = load i64*, i64** %129, align 8, !dbg !20
-  store i64 %send10, i64* %130, align 8, !dbg !20, !tbaa !6
-  %131 = getelementptr inbounds i64, i64* %130, i64 1, !dbg !20
-  store i64* %131, i64** %129, align 8, !dbg !20
+  %127 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !20
+  %128 = load i64*, i64** %127, align 8, !dbg !20
+  store i64 %send10, i64* %128, align 8, !dbg !20, !tbaa !6
+  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !20
+  store i64* %129, i64** %127, align 8, !dbg !20
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.2, i64 0), !dbg !20
-  %132 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !21
-  %133 = load i64*, i64** %132, align 8, !dbg !21
-  store i64 %23, i64* %133, align 8, !dbg !21, !tbaa !6
-  %134 = getelementptr inbounds i64, i64* %133, i64 1, !dbg !21
-  store i64 %send12, i64* %134, align 8, !dbg !21, !tbaa !6
-  %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !21
-  store i64* %135, i64** %132, align 8, !dbg !21
+  %130 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !21
+  %131 = load i64*, i64** %130, align 8, !dbg !21
+  store i64 %21, i64* %131, align 8, !dbg !21, !tbaa !6
+  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !21
+  store i64 %send12, i64* %132, align 8, !dbg !21, !tbaa !6
+  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !21
+  store i64* %133, i64** %130, align 8, !dbg !21
   %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !21
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_B#5write"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !59 {
+define i64 @"func_B#5write"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !56 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !25
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !60
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !60
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !60
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !60, !prof !61
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !22
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !57
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !57
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !57
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !57, !prof !58
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !60
-  unreachable, !dbg !60
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !57
+  unreachable, !dbg !57
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !60
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !62, !tbaa !25
-  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !63
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !63, !tbaa !46
-  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !63
-  br i1 %needTakeSlowPath, label %3, label %4, !dbg !63, !prof !47
+  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !57
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !59, !tbaa !22
+  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !60
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !60, !tbaa !43
+  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !60
+  br i1 %needTakeSlowPath, label %3, label %4, !dbg !60, !prof !44
 
 3:                                                ; preds = %fillRequiredArgs
-  tail call void @const_recompute_B(), !dbg !63
-  br label %4, !dbg !63
+  tail call void @const_recompute_B(), !dbg !60
+  br label %4, !dbg !60
 
 4:                                                ; preds = %fillRequiredArgs, %3
-  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !63
-  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !63
-  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !63, !tbaa !46
-  %guardUpdated = icmp eq i64 %6, %7, !dbg !63
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !63
-  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !63
-  tail call void @rb_cvar_set(i64 %5, i64 %"rubyId_@@f", i64 %rawArg_a) #11, !dbg !63
-  %"rubyId_@@f7" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !64
-  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f7") #11, !dbg !64
+  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !60
+  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !60
+  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !60, !tbaa !43
+  %guardUpdated = icmp eq i64 %6, %7, !dbg !60
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !60
+  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !60
+  tail call void @rb_cvar_set(i64 %5, i64 %"rubyId_@@f", i64 %rawArg_a) #11, !dbg !60
+  %"rubyId_@@f7" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !61
+  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f7") #11, !dbg !61
   ret i64 %8
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_B#4read"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !65 {
+define i64 @"func_B#4read"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !62 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !tbaa !25
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !66
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !66, !prof !67
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !tbaa !22
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !63
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !63, !prof !64
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !66
-  unreachable, !dbg !66
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !63
+  unreachable, !dbg !63
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !68, !tbaa !25
-  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !69
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !69, !tbaa !46
-  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !69
-  br i1 %needTakeSlowPath, label %3, label %4, !dbg !69, !prof !47
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !65, !tbaa !22
+  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !66
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !66, !tbaa !43
+  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !66
+  br i1 %needTakeSlowPath, label %3, label %4, !dbg !66, !prof !44
 
 3:                                                ; preds = %fillRequiredArgs
-  tail call void @const_recompute_B(), !dbg !69
-  br label %4, !dbg !69
+  tail call void @const_recompute_B(), !dbg !66
+  br label %4, !dbg !66
 
 4:                                                ; preds = %fillRequiredArgs, %3
-  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !69
-  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !69
-  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !69, !tbaa !46
-  %guardUpdated = icmp eq i64 %6, %7, !dbg !69
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !69
-  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !69
-  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !69
+  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !66
+  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !66
+  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !66, !tbaa !43
+  %guardUpdated = icmp eq i64 %6, %7, !dbg !66
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !66
+  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !66
+  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !66
   ret i64 %8
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @func_B.4read(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !70 {
+define i64 @func_B.4read(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !67 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %0, align 8, !tbaa !25
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !71
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !71, !prof !67
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %0, align 8, !tbaa !22
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !68
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !68, !prof !64
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !71
-  unreachable, !dbg !71
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !68
+  unreachable, !dbg !68
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %0, align 8, !dbg !72, !tbaa !25
-  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !73
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !73, !tbaa !46
-  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !73
-  br i1 %needTakeSlowPath, label %3, label %4, !dbg !73, !prof !47
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %0, align 8, !dbg !69, !tbaa !22
+  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !70
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !70, !tbaa !43
+  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !70
+  br i1 %needTakeSlowPath, label %3, label %4, !dbg !70, !prof !44
 
 3:                                                ; preds = %fillRequiredArgs
-  tail call void @const_recompute_B(), !dbg !73
-  br label %4, !dbg !73
+  tail call void @const_recompute_B(), !dbg !70
+  br label %4, !dbg !70
 
 4:                                                ; preds = %fillRequiredArgs, %3
-  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !73
-  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !73
-  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !73, !tbaa !46
-  %guardUpdated = icmp eq i64 %6, %7, !dbg !73
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !73
-  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !73
-  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !73
+  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !70
+  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !70
+  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !70, !tbaa !43
+  %guardUpdated = icmp eq i64 %6, %7, !dbg !70
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !70
+  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !70
+  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !70
   ret i64 %8
 }
 
@@ -618,7 +601,7 @@ declare void @llvm.assume(i1 noundef) #8
 define linkonce void @const_recompute_B() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_B, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_B, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !46
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !43
   store i64 %2, i64* @guard_epoch_B, align 8
   ret void
 }
@@ -663,55 +646,52 @@ attributes #13 = { noreturn }
 !19 = !DILocation(line: 27, column: 1, scope: !16)
 !20 = !DILocation(line: 28, column: 6, scope: !16)
 !21 = !DILocation(line: 28, column: 1, scope: !16)
-!22 = !DILocation(line: 7, column: 3, scope: !11)
-!23 = !DILocation(line: 16, column: 3, scope: !11)
-!24 = !DILocation(line: 19, column: 3, scope: !11)
-!25 = !{!26, !26, i64 0}
-!26 = !{!"any pointer", !8, i64 0}
-!27 = !{!28, !7, i64 400}
-!28 = !{!"rb_vm_struct", !7, i64 0, !29, i64 8, !26, i64 192, !26, i64 200, !26, i64 208, !33, i64 216, !8, i64 224, !30, i64 264, !30, i64 280, !30, i64 296, !30, i64 312, !7, i64 328, !32, i64 336, !32, i64 340, !32, i64 344, !32, i64 344, !32, i64 344, !32, i64 344, !32, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !26, i64 456, !26, i64 464, !34, i64 472, !35, i64 992, !26, i64 1016, !26, i64 1024, !32, i64 1032, !32, i64 1036, !30, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !32, i64 1136, !26, i64 1144, !26, i64 1152, !26, i64 1160, !26, i64 1168, !26, i64 1176, !26, i64 1184, !32, i64 1192, !36, i64 1200, !8, i64 1232}
-!29 = !{!"rb_global_vm_lock_struct", !26, i64 0, !8, i64 8, !30, i64 48, !26, i64 64, !32, i64 72, !8, i64 80, !8, i64 128, !32, i64 176, !32, i64 180}
-!30 = !{!"list_head", !31, i64 0}
-!31 = !{!"list_node", !26, i64 0, !26, i64 8}
-!32 = !{!"int", !8, i64 0}
-!33 = !{!"long long", !8, i64 0}
-!34 = !{!"", !8, i64 0}
-!35 = !{!"rb_hook_list_struct", !26, i64 0, !32, i64 8, !32, i64 12, !32, i64 16}
-!36 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!37 = !{!38, !26, i64 16}
-!38 = !{!"rb_execution_context_struct", !26, i64 0, !7, i64 8, !26, i64 16, !26, i64 24, !26, i64 32, !32, i64 40, !32, i64 44, !26, i64 48, !26, i64 56, !26, i64 64, !7, i64 72, !7, i64 80, !26, i64 88, !7, i64 96, !26, i64 104, !26, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !39, i64 152}
-!39 = !{!"", !26, i64 0, !26, i64 8, !7, i64 16, !8, i64 24}
-!40 = !{!41, !26, i64 16}
-!41 = !{!"rb_control_frame_struct", !26, i64 0, !26, i64 8, !26, i64 16, !7, i64 24, !26, i64 32, !26, i64 40, !26, i64 48}
-!42 = !{!41, !26, i64 32}
-!43 = !DILocation(line: 0, scope: !16)
-!44 = !DILocation(line: 5, column: 1, scope: !16)
-!45 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
-!46 = !{!33, !33, i64 0}
-!47 = !{!"branch_weights", i32 1, i32 10000}
-!48 = !{!49, !32, i64 8}
-!49 = !{!"rb_sorbet_param_struct", !50, i64 0, !32, i64 4, !32, i64 8, !32, i64 12, !32, i64 16, !32, i64 20, !32, i64 24, !32, i64 28, !26, i64 32, !32, i64 40, !32, i64 44, !32, i64 48, !32, i64 52, !26, i64 56}
-!50 = !{!"", !32, i64 0, !32, i64 0, !32, i64 0, !32, i64 0, !32, i64 0, !32, i64 0, !32, i64 0, !32, i64 0, !32, i64 1, !32, i64 1}
-!51 = !{!49, !32, i64 4}
-!52 = !{!49, !26, i64 32}
-!53 = !{!38, !32, i64 40}
-!54 = !{!38, !32, i64 44}
-!55 = !{!"branch_weights", i32 2000, i32 1}
-!56 = !{!38, !26, i64 56}
-!57 = !DILocation(line: 16, column: 3, scope: !11, inlinedAt: !15)
-!58 = !DILocation(line: 19, column: 3, scope: !11, inlinedAt: !15)
-!59 = distinct !DISubprogram(name: "B#write", linkageName: "func_B#5write", scope: null, file: !4, line: 7, type: !12, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!60 = !DILocation(line: 7, column: 3, scope: !59)
-!61 = !{!"branch_weights", i32 4001, i32 4000000}
-!62 = !DILocation(line: 7, column: 13, scope: !59)
-!63 = !DILocation(line: 8, column: 11, scope: !59)
-!64 = !DILocation(line: 8, column: 5, scope: !59)
-!65 = distinct !DISubprogram(name: "B#read", linkageName: "func_B#4read", scope: null, file: !4, line: 16, type: !12, scopeLine: 16, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!66 = !DILocation(line: 16, column: 3, scope: !65)
-!67 = !{!"branch_weights", i32 1, i32 2000}
-!68 = !DILocation(line: 0, scope: !65)
-!69 = !DILocation(line: 17, column: 5, scope: !65)
-!70 = distinct !DISubprogram(name: "B.read", linkageName: "func_B.4read", scope: null, file: !4, line: 19, type: !12, scopeLine: 19, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!71 = !DILocation(line: 19, column: 3, scope: !70)
-!72 = !DILocation(line: 0, scope: !70)
-!73 = !DILocation(line: 20, column: 5, scope: !70)
+!22 = !{!23, !23, i64 0}
+!23 = !{!"any pointer", !8, i64 0}
+!24 = !{!25, !7, i64 400}
+!25 = !{!"rb_vm_struct", !7, i64 0, !26, i64 8, !23, i64 192, !23, i64 200, !23, i64 208, !30, i64 216, !8, i64 224, !27, i64 264, !27, i64 280, !27, i64 296, !27, i64 312, !7, i64 328, !29, i64 336, !29, i64 340, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !23, i64 456, !23, i64 464, !31, i64 472, !32, i64 992, !23, i64 1016, !23, i64 1024, !29, i64 1032, !29, i64 1036, !27, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !29, i64 1136, !23, i64 1144, !23, i64 1152, !23, i64 1160, !23, i64 1168, !23, i64 1176, !23, i64 1184, !29, i64 1192, !33, i64 1200, !8, i64 1232}
+!26 = !{!"rb_global_vm_lock_struct", !23, i64 0, !8, i64 8, !27, i64 48, !23, i64 64, !29, i64 72, !8, i64 80, !8, i64 128, !29, i64 176, !29, i64 180}
+!27 = !{!"list_head", !28, i64 0}
+!28 = !{!"list_node", !23, i64 0, !23, i64 8}
+!29 = !{!"int", !8, i64 0}
+!30 = !{!"long long", !8, i64 0}
+!31 = !{!"", !8, i64 0}
+!32 = !{!"rb_hook_list_struct", !23, i64 0, !29, i64 8, !29, i64 12, !29, i64 16}
+!33 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!34 = !{!35, !23, i64 16}
+!35 = !{!"rb_execution_context_struct", !23, i64 0, !7, i64 8, !23, i64 16, !23, i64 24, !23, i64 32, !29, i64 40, !29, i64 44, !23, i64 48, !23, i64 56, !23, i64 64, !7, i64 72, !7, i64 80, !23, i64 88, !7, i64 96, !23, i64 104, !23, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !36, i64 152}
+!36 = !{!"", !23, i64 0, !23, i64 8, !7, i64 16, !8, i64 24}
+!37 = !{!38, !23, i64 16}
+!38 = !{!"rb_control_frame_struct", !23, i64 0, !23, i64 8, !23, i64 16, !7, i64 24, !23, i64 32, !23, i64 40, !23, i64 48}
+!39 = !{!38, !23, i64 32}
+!40 = !DILocation(line: 0, scope: !16)
+!41 = !DILocation(line: 5, column: 1, scope: !16)
+!42 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
+!43 = !{!30, !30, i64 0}
+!44 = !{!"branch_weights", i32 1, i32 10000}
+!45 = !{!46, !29, i64 8}
+!46 = !{!"rb_sorbet_param_struct", !47, i64 0, !29, i64 4, !29, i64 8, !29, i64 12, !29, i64 16, !29, i64 20, !29, i64 24, !29, i64 28, !23, i64 32, !29, i64 40, !29, i64 44, !29, i64 48, !29, i64 52, !23, i64 56}
+!47 = !{!"", !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 1, !29, i64 1}
+!48 = !{!46, !29, i64 4}
+!49 = !{!46, !23, i64 32}
+!50 = !{!35, !29, i64 40}
+!51 = !{!35, !29, i64 44}
+!52 = !{!"branch_weights", i32 2000, i32 1}
+!53 = !{!35, !23, i64 56}
+!54 = !DILocation(line: 16, column: 3, scope: !11, inlinedAt: !15)
+!55 = !DILocation(line: 19, column: 3, scope: !11, inlinedAt: !15)
+!56 = distinct !DISubprogram(name: "B#write", linkageName: "func_B#5write", scope: null, file: !4, line: 7, type: !12, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!57 = !DILocation(line: 7, column: 3, scope: !56)
+!58 = !{!"branch_weights", i32 4001, i32 4000000}
+!59 = !DILocation(line: 7, column: 13, scope: !56)
+!60 = !DILocation(line: 8, column: 11, scope: !56)
+!61 = !DILocation(line: 8, column: 5, scope: !56)
+!62 = distinct !DISubprogram(name: "B#read", linkageName: "func_B#4read", scope: null, file: !4, line: 16, type: !12, scopeLine: 16, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!63 = !DILocation(line: 16, column: 3, scope: !62)
+!64 = !{!"branch_weights", i32 1, i32 2000}
+!65 = !DILocation(line: 0, scope: !62)
+!66 = !DILocation(line: 17, column: 5, scope: !62)
+!67 = distinct !DISubprogram(name: "B.read", linkageName: "func_B.4read", scope: null, file: !4, line: 19, type: !12, scopeLine: 19, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!68 = !DILocation(line: 19, column: 3, scope: !67)
+!69 = !DILocation(line: 0, scope: !67)
+!70 = !DILocation(line: 20, column: 5, scope: !67)

--- a/test/testdata/compiler/constant_cache.llo.exp
+++ b/test/testdata/compiler/constant_cache.llo.exp
@@ -101,9 +101,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_A.13<static-init>" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
@@ -237,8 +234,8 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
 ; Function Attrs: sspreq
 define void @Init_constant_cache() local_unnamed_addr #5 {
 entry:
-  %locals.i16.i = alloca i64, i32 0, align 8
-  %locals.i14.i = alloca i64, i32 0, align 8
+  %locals.i15.i = alloca i64, i32 0, align 8
+  %locals.i13.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
@@ -249,22 +246,20 @@ entry:
   store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
   store i64 %3, i64* @rubyIdPrecomputed_normal, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #11
-  store i64 %4, i64* @rubyIdPrecomputed_keep_def, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
-  store i64 %5, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  store i64 %4, i64* @"rubyIdPrecomputed_<class:A>", align 8
+  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
+  tail call void @rb_gc_register_mark_object(i64 %5) #11
+  store i64 %5, i64* @rubyStrFrozen_foo, align 8
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([41 x i8], [41 x i8]* @"str_test/testdata/compiler/constant_cache.rb", i64 0, i64 0), i64 noundef 40) #11
   tail call void @rb_gc_register_mark_object(i64 %6) #11
-  store i64 %6, i64* @rubyStrFrozen_foo, align 8
-  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([41 x i8], [41 x i8]* @"str_test/testdata/compiler/constant_cache.rb", i64 0, i64 0), i64 noundef 40) #11
-  tail call void @rb_gc_register_mark_object(i64 %7) #11
-  store i64 %7, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
+  store i64 %6, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
   %rubyStr_foo.i.i = load i64, i64* @rubyStrFrozen_foo, align 8
   %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
-  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
+  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   %rubyId_puts1.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
@@ -273,95 +268,93 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts4.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
   %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
-  %9 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
-  call void @rb_gc_register_mark_object(i64 %9) #11
+  %8 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  call void @rb_gc_register_mark_object(i64 %8) #11
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/constant_cache.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
-  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i14.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !26
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !26
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !28
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !28
-  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %11) #11
+  %"rubyStr_test/testdata/compiler/constant_cache.rb.i12.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
+  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %8, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i12.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i13.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !26
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
+  %10 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %10) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %"rubyStr_test/testdata/compiler/constant_cache.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %13 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %14 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %13, i64 0, i32 18
-  %15 = load i64, i64* %14, align 8, !tbaa !29
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2
-  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !38
+  %"rubyStr_test/testdata/compiler/constant_cache.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
+  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %10, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %12 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %13 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %12, i64 0, i32 18
+  %14 = load i64, i64* %13, align 8, !tbaa !28
+  %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 2
+  %17 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %16, align 8, !tbaa !37
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %19, align 8, !tbaa !41
-  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 4
-  %21 = load i64*, i64** %20, align 8, !tbaa !43
-  %22 = load i64, i64* %21, align 8, !tbaa !6
-  %23 = and i64 %22, -33
-  store i64 %23, i64* %21, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %16, %struct.rb_control_frame_struct* %18, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %24, align 8, !dbg !44, !tbaa !14
-  %25 = load i64, i64* @rb_cObject, align 8, !dbg !45
-  %26 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %25) #11, !dbg !45
-  %27 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %26) #11, !dbg !45
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %18, align 8, !tbaa !40
+  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 4
+  %20 = load i64*, i64** %19, align 8, !tbaa !42
+  %21 = load i64, i64* %20, align 8, !tbaa !6
+  %22 = and i64 %21, -33
+  store i64 %22, i64* %20, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %15, %struct.rb_control_frame_struct* %17, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %23, align 8, !dbg !43, !tbaa !14
+  %24 = load i64, i64* @rb_cObject, align 8, !dbg !44
+  %25 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %24) #11, !dbg !44
+  %26 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %25) #11, !dbg !44
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 2
-  %30 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %29, align 8, !tbaa !38
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %31, align 8, !tbaa !41
-  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 4
-  %33 = load i64*, i64** %32, align 8, !tbaa !43
-  %34 = load i64, i64* %33, align 8, !tbaa !6
-  %35 = and i64 %34, -33
-  store i64 %35, i64* %33, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %28, %struct.rb_control_frame_struct* %30, %struct.rb_iseq_struct* %stackFrame.i.i) #11
-  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %36, align 8, !dbg !46, !tbaa !14
-  call void @sorbet_popFrame() #11, !dbg !45
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %24, align 8, !dbg !45, !tbaa !14
-  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !26
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #11, !dbg !26
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !26
-  %rawSym18.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #11, !dbg !26
-  %stackFrame22.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !26
-  %37 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !26
-  %38 = bitcast i8* %37 to i16*, !dbg !26
-  %39 = load i16, i16* %38, align 8, !dbg !26
-  %40 = and i16 %39, -384, !dbg !26
-  store i16 %40, i16* %38, align 8, !dbg !26
-  %41 = getelementptr inbounds i8, i8* %37, i64 4, !dbg !26
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %41, i8 0, i64 28, i1 false) #11, !dbg !26
-  call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#3foo", i8* nonnull %37, %struct.rb_iseq_struct* %stackFrame22.i, i1 noundef zeroext false) #11, !dbg !26
-  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !14
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 5, !dbg !26
-  %44 = load i32, i32* %43, align 8, !dbg !26, !tbaa !49
-  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 6, !dbg !26
-  %46 = load i32, i32* %45, align 4, !dbg !26, !tbaa !50
-  %47 = xor i32 %46, -1, !dbg !26
-  %48 = and i32 %47, %44, !dbg !26
-  %49 = icmp eq i32 %48, 0, !dbg !26
-  br i1 %49, label %"func_<root>.17<static-init>$152.exit", label %50, !dbg !26, !prof !51
+  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2
+  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !tbaa !37
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %30, align 8, !tbaa !40
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4
+  %32 = load i64*, i64** %31, align 8, !tbaa !42
+  %33 = load i64, i64* %32, align 8, !tbaa !6
+  %34 = and i64 %33, -33
+  store i64 %34, i64* %32, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %27, %struct.rb_control_frame_struct* %29, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %35, align 8, !dbg !45, !tbaa !14
+  call void @sorbet_popFrame() #11, !dbg !44
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %23, align 8, !dbg !44, !tbaa !14
+  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !48
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #11, !dbg !48
+  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !48
+  %rawSym18.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #11, !dbg !48
+  %stackFrame22.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !48
+  %36 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !48
+  %37 = bitcast i8* %36 to i16*, !dbg !48
+  %38 = load i16, i16* %37, align 8, !dbg !48
+  %39 = and i16 %38, -384, !dbg !48
+  store i16 %39, i16* %37, align 8, !dbg !48
+  %40 = getelementptr inbounds i8, i8* %36, i64 4, !dbg !48
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %40, i8 0, i64 28, i1 false) #11, !dbg !48
+  call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#3foo", i8* nonnull %36, %struct.rb_iseq_struct* %stackFrame22.i, i1 noundef zeroext false) #11, !dbg !48
+  %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !48, !tbaa !14
+  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 5, !dbg !48
+  %43 = load i32, i32* %42, align 8, !dbg !48, !tbaa !49
+  %44 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 6, !dbg !48
+  %45 = load i32, i32* %44, align 4, !dbg !48, !tbaa !50
+  %46 = xor i32 %45, -1, !dbg !48
+  %47 = and i32 %46, %43, !dbg !48
+  %48 = icmp eq i32 %47, 0, !dbg !48
+  br i1 %48, label %"func_<root>.17<static-init>$152.exit", label %49, !dbg !48, !prof !51
 
-50:                                               ; preds = %entry
-  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 8, !dbg !26
-  %52 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %51, align 8, !dbg !26, !tbaa !52
-  %53 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %52, i32 noundef 0) #11, !dbg !26
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !26
+49:                                               ; preds = %entry
+  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 8, !dbg !48
+  %51 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %50, align 8, !dbg !48, !tbaa !52
+  %52 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %51, i32 noundef 0) #11, !dbg !48
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !48
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %entry, %50
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %24, align 8, !dbg !26, !tbaa !14
-  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !28
-  %55 = load i64*, i64** %54, align 8, !dbg !28
-  store i64 %15, i64* %55, align 8, !dbg !28, !tbaa !6
-  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !28
-  store i64* %56, i64** %54, align 8, !dbg !28
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !28
+"func_<root>.17<static-init>$152.exit":           ; preds = %entry, %49
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %23, align 8, !dbg !48, !tbaa !14
+  %53 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !26
+  %54 = load i64*, i64** %53, align 8, !dbg !26
+  store i64 %14, i64* %54, align 8, !dbg !26, !tbaa !6
+  %55 = getelementptr inbounds i64, i64* %54, i64 1, !dbg !26
+  store i64* %55, i64** %53, align 8, !dbg !26
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !26
   ret void
 }
 
@@ -423,30 +416,30 @@ attributes #12 = { nounwind allocsize(0,1) }
 !23 = !DILocation(line: 7, column: 3, scope: !10)
 !24 = !DILocation(line: 8, column: 3, scope: !10)
 !25 = !DILocation(line: 9, column: 3, scope: !10)
-!26 = !DILocation(line: 5, column: 1, scope: !27)
+!26 = !DILocation(line: 12, column: 1, scope: !27)
 !27 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!28 = !DILocation(line: 12, column: 1, scope: !27)
-!29 = !{!30, !7, i64 400}
-!30 = !{!"rb_vm_struct", !7, i64 0, !31, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !21, i64 216, !8, i64 224, !32, i64 264, !32, i64 280, !32, i64 296, !32, i64 312, !7, i64 328, !34, i64 336, !34, i64 340, !34, i64 344, !34, i64 344, !34, i64 344, !34, i64 344, !34, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !35, i64 472, !36, i64 992, !15, i64 1016, !15, i64 1024, !34, i64 1032, !34, i64 1036, !32, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !34, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !34, i64 1192, !37, i64 1200, !8, i64 1232}
-!31 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !32, i64 48, !15, i64 64, !34, i64 72, !8, i64 80, !8, i64 128, !34, i64 176, !34, i64 180}
-!32 = !{!"list_head", !33, i64 0}
-!33 = !{!"list_node", !15, i64 0, !15, i64 8}
-!34 = !{!"int", !8, i64 0}
-!35 = !{!"", !8, i64 0}
-!36 = !{!"rb_hook_list_struct", !15, i64 0, !34, i64 8, !34, i64 12, !34, i64 16}
-!37 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!38 = !{!39, !15, i64 16}
-!39 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !34, i64 40, !34, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !40, i64 152}
-!40 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
-!41 = !{!42, !15, i64 16}
-!42 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
-!43 = !{!42, !15, i64 32}
-!44 = !DILocation(line: 0, scope: !27)
-!45 = !DILocation(line: 4, column: 1, scope: !27)
-!46 = !DILocation(line: 0, scope: !47, inlinedAt: !48)
-!47 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.13<static-init>L61", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!48 = distinct !DILocation(line: 4, column: 1, scope: !27)
-!49 = !{!39, !34, i64 40}
-!50 = !{!39, !34, i64 44}
+!28 = !{!29, !7, i64 400}
+!29 = !{!"rb_vm_struct", !7, i64 0, !30, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !21, i64 216, !8, i64 224, !31, i64 264, !31, i64 280, !31, i64 296, !31, i64 312, !7, i64 328, !33, i64 336, !33, i64 340, !33, i64 344, !33, i64 344, !33, i64 344, !33, i64 344, !33, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !34, i64 472, !35, i64 992, !15, i64 1016, !15, i64 1024, !33, i64 1032, !33, i64 1036, !31, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !33, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !33, i64 1192, !36, i64 1200, !8, i64 1232}
+!30 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !31, i64 48, !15, i64 64, !33, i64 72, !8, i64 80, !8, i64 128, !33, i64 176, !33, i64 180}
+!31 = !{!"list_head", !32, i64 0}
+!32 = !{!"list_node", !15, i64 0, !15, i64 8}
+!33 = !{!"int", !8, i64 0}
+!34 = !{!"", !8, i64 0}
+!35 = !{!"rb_hook_list_struct", !15, i64 0, !33, i64 8, !33, i64 12, !33, i64 16}
+!36 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!37 = !{!38, !15, i64 16}
+!38 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !33, i64 40, !33, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !39, i64 152}
+!39 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!40 = !{!41, !15, i64 16}
+!41 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!42 = !{!41, !15, i64 32}
+!43 = !DILocation(line: 0, scope: !27)
+!44 = !DILocation(line: 4, column: 1, scope: !27)
+!45 = !DILocation(line: 0, scope: !46, inlinedAt: !47)
+!46 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.13<static-init>L61", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!47 = distinct !DILocation(line: 4, column: 1, scope: !27)
+!48 = !DILocation(line: 5, column: 1, scope: !27)
+!49 = !{!38, !33, i64 40}
+!50 = !{!38, !33, i64 44}
 !51 = !{!"branch_weights", i32 2000, i32 1}
-!52 = !{!39, !15, i64 56}
+!52 = !{!38, !15, i64 56}

--- a/test/testdata/compiler/custom_plus.llo.exp
+++ b/test/testdata/compiler/custom_plus.llo.exp
@@ -114,9 +114,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
 @str_a = private unnamed_addr constant [2 x i8] c"a\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
 @ic_delegate = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_A#1+" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A.13<static-init>" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
@@ -124,7 +121,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"str_<class:A>" = private unnamed_addr constant [10 x i8] c"<class:A>\00", align 1
 @rubyIdPrecomputed_b = internal unnamed_addr global i64 0, align 8
 @str_b = private unnamed_addr constant [2 x i8] c"b\00", align 1
-@ic_keep_def.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
@@ -329,90 +325,90 @@ functionEntryInitializers:
   %47 = xor i32 %46, -1, !dbg !22
   %48 = and i32 %47, %44, !dbg !22
   %49 = icmp eq i32 %48, 0, !dbg !22
-  br i1 %49, label %fastSymCallIntrinsic_Static_keep_def, label %50, !dbg !22, !prof !45
+  br i1 %49, label %"func_A.13<static-init>L79.exit", label %50, !dbg !22, !prof !45
 
 50:                                               ; preds = %25
   %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 8, !dbg !22
   %52 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %51, align 8, !dbg !22, !tbaa !46
   %53 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %52, i32 noundef 0) #11, !dbg !22
-  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !22
+  br label %"func_A.13<static-init>L79.exit", !dbg !22
 
-afterSend27:                                      ; preds = %84, %fastSymCallIntrinsic_Static_keep_def
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %8, align 8, !dbg !47, !tbaa !14
-  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !48
-  %55 = load i64*, i64** %54, align 8, !dbg !48
-  store i64 %selfRaw, i64* %55, align 8, !dbg !48, !tbaa !6
-  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !48
-  store i64 %send2, i64* %56, align 8, !dbg !48, !tbaa !6
-  %57 = getelementptr inbounds i64, i64* %56, i64 1, !dbg !48
-  store i64* %57, i64** %54, align 8, !dbg !48
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_delegate, i64 0), !dbg !48
-  ret void
-
-fastSymCallIntrinsic_Static_keep_def:             ; preds = %50, %25
+"func_A.13<static-init>L79.exit":                 ; preds = %25, %50
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %12)
   tail call void @sorbet_popFrame() #11, !dbg !33
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !33, !tbaa !14
-  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !49
-  %59 = load i64*, i64** %58, align 8, !dbg !49
-  store i64 %26, i64* %59, align 8, !dbg !49, !tbaa !6
-  %60 = getelementptr inbounds i64, i64* %59, i64 1, !dbg !49
-  store i64* %60, i64** %58, align 8, !dbg !49
-  %send2 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !49
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !49, !tbaa !14
-  %rubyId_delegate = load i64, i64* @rubyIdPrecomputed_delegate, align 8, !dbg !47
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_delegate), !dbg !47
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !47
-  %rawSym24 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !47
-  %stackFrame28 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8delegate", align 8, !dbg !47
-  %61 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !47
-  %62 = bitcast i8* %61 to i16*, !dbg !47
-  %63 = load i16, i16* %62, align 8, !dbg !47
-  %64 = and i16 %63, -384, !dbg !47
-  %65 = or i16 %64, 1, !dbg !47
-  store i16 %65, i16* %62, align 8, !dbg !47
-  %66 = getelementptr inbounds i8, i8* %61, i64 8, !dbg !47
-  %67 = bitcast i8* %66 to i32*, !dbg !47
-  store i32 1, i32* %67, align 8, !dbg !47, !tbaa !38
-  %68 = getelementptr inbounds i8, i8* %61, i64 12, !dbg !47
-  %69 = bitcast i8* %68 to i32*, !dbg !47
-  %70 = getelementptr inbounds i8, i8* %61, i64 4, !dbg !47
-  %71 = bitcast i8* %70 to i32*, !dbg !47
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %68, i8 0, i64 20, i1 false), !dbg !47
-  store i32 1, i32* %71, align 4, !dbg !47, !tbaa !41
-  %positional_table = alloca i64, align 8, !dbg !47
-  %rubyId_a = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !47
-  store i64 %rubyId_a, i64* %positional_table, align 8, !dbg !47
-  %72 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !47
-  %73 = bitcast i64* %positional_table to i8*, !dbg !47
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %72, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %73, i64 noundef 8, i1 noundef false) #11, !dbg !47
-  %74 = getelementptr inbounds i8, i8* %61, i64 32, !dbg !47
-  %75 = bitcast i8* %74 to i8**, !dbg !47
-  store i8* %72, i8** %75, align 8, !dbg !47, !tbaa !42
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_delegate, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#8delegate", i8* nonnull %61, %struct.rb_iseq_struct* %stackFrame28, i1 noundef zeroext false) #11, !dbg !47
-  %76 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !14
-  %77 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 5, !dbg !47
-  %78 = load i32, i32* %77, align 8, !dbg !47, !tbaa !43
-  %79 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 6, !dbg !47
-  %80 = load i32, i32* %79, align 4, !dbg !47, !tbaa !44
-  %81 = xor i32 %80, -1, !dbg !47
-  %82 = and i32 %81, %78, !dbg !47
-  %83 = icmp eq i32 %82, 0, !dbg !47
-  br i1 %83, label %afterSend27, label %84, !dbg !47, !prof !45
+  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !47
+  %55 = load i64*, i64** %54, align 8, !dbg !47
+  store i64 %26, i64* %55, align 8, !dbg !47, !tbaa !6
+  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !47
+  store i64* %56, i64** %54, align 8, !dbg !47
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !47
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !47, !tbaa !14
+  %rubyId_delegate = load i64, i64* @rubyIdPrecomputed_delegate, align 8, !dbg !48
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_delegate), !dbg !48
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !48
+  %rawSym24 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !48
+  %stackFrame28 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8delegate", align 8, !dbg !48
+  %57 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !48
+  %58 = bitcast i8* %57 to i16*, !dbg !48
+  %59 = load i16, i16* %58, align 8, !dbg !48
+  %60 = and i16 %59, -384, !dbg !48
+  %61 = or i16 %60, 1, !dbg !48
+  store i16 %61, i16* %58, align 8, !dbg !48
+  %62 = getelementptr inbounds i8, i8* %57, i64 8, !dbg !48
+  %63 = bitcast i8* %62 to i32*, !dbg !48
+  store i32 1, i32* %63, align 8, !dbg !48, !tbaa !38
+  %64 = getelementptr inbounds i8, i8* %57, i64 12, !dbg !48
+  %65 = bitcast i8* %64 to i32*, !dbg !48
+  %66 = getelementptr inbounds i8, i8* %57, i64 4, !dbg !48
+  %67 = bitcast i8* %66 to i32*, !dbg !48
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %64, i8 0, i64 20, i1 false), !dbg !48
+  store i32 1, i32* %67, align 4, !dbg !48, !tbaa !41
+  %positional_table = alloca i64, align 8, !dbg !48
+  %rubyId_a = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !48
+  store i64 %rubyId_a, i64* %positional_table, align 8, !dbg !48
+  %68 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !48
+  %69 = bitcast i64* %positional_table to i8*, !dbg !48
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %68, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %69, i64 noundef 8, i1 noundef false) #11, !dbg !48
+  %70 = getelementptr inbounds i8, i8* %57, i64 32, !dbg !48
+  %71 = bitcast i8* %70 to i8**, !dbg !48
+  store i8* %68, i8** %71, align 8, !dbg !48, !tbaa !42
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_delegate, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#8delegate", i8* nonnull %57, %struct.rb_iseq_struct* %stackFrame28, i1 noundef zeroext false) #11, !dbg !48
+  %72 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !48, !tbaa !14
+  %73 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 5, !dbg !48
+  %74 = load i32, i32* %73, align 8, !dbg !48, !tbaa !43
+  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 6, !dbg !48
+  %76 = load i32, i32* %75, align 4, !dbg !48, !tbaa !44
+  %77 = xor i32 %76, -1, !dbg !48
+  %78 = and i32 %77, %74, !dbg !48
+  %79 = icmp eq i32 %78, 0, !dbg !48
+  br i1 %79, label %rb_vm_check_ints.exit, label %80, !dbg !48, !prof !45
 
-84:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
-  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 8, !dbg !47
-  %86 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %85, align 8, !dbg !47, !tbaa !46
-  %87 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %86, i32 noundef 0) #11, !dbg !47
-  br label %afterSend27, !dbg !47
+80:                                               ; preds = %"func_A.13<static-init>L79.exit"
+  %81 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 8, !dbg !48
+  %82 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %81, align 8, !dbg !48, !tbaa !46
+  %83 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %82, i32 noundef 0) #11, !dbg !48
+  br label %rb_vm_check_ints.exit, !dbg !48
+
+rb_vm_check_ints.exit:                            ; preds = %"func_A.13<static-init>L79.exit", %80
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %8, align 8, !dbg !48, !tbaa !14
+  %84 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !49
+  %85 = load i64*, i64** %84, align 8, !dbg !49
+  store i64 %selfRaw, i64* %85, align 8, !dbg !49, !tbaa !6
+  %86 = getelementptr inbounds i64, i64* %85, i64 1, !dbg !49
+  store i64 %send, i64* %86, align 8, !dbg !49, !tbaa !6
+  %87 = getelementptr inbounds i64, i64* %86, i64 1, !dbg !49
+  store i64* %87, i64** %84, align 8, !dbg !49
+  %send2 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_delegate, i64 0), !dbg !49
+  ret void
 }
 
 ; Function Attrs: ssp
 define void @Init_custom_plus() local_unnamed_addr #6 {
 entry:
-  %locals.i17.i = alloca i64, i32 0, align 8
-  %locals.i15.i = alloca i64, i32 0, align 8
-  %locals.i13.i = alloca i64, i32 0, align 8
+  %locals.i14.i = alloca i64, i32 0, align 8
+  %locals.i12.i = alloca i64, i32 0, align 8
+  %locals.i10.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_delegate, i64 0, i64 0), i64 noundef 8) #11
@@ -431,90 +427,84 @@ entry:
   store i64 %6, i64* @rubyIdPrecomputed_normal, align 8
   %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #11
   store i64 %7, i64* @rubyIdPrecomputed_a, align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #11
-  store i64 %8, i64* @rubyIdPrecomputed_keep_def, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
-  store i64 %9, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_b, i64 0, i64 0), i64 noundef 1) #11
-  store i64 %10, i64* @rubyIdPrecomputed_b, align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_delegate, i64 0, i64 0), i64 noundef 8) #11
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  store i64 %8, i64* @"rubyIdPrecomputed_<class:A>", align 8
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_b, i64 0, i64 0), i64 noundef 1) #11
+  store i64 %9, i64* @rubyIdPrecomputed_b, align 8
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_delegate, i64 0, i64 0), i64 noundef 8) #11
+  tail call void @rb_gc_register_mark_object(i64 %10) #11
+  store i64 %10, i64* @rubyStrFrozen_delegate, align 8
+  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_test/testdata/compiler/custom_plus.rb", i64 0, i64 0), i64 noundef 37) #11
   tail call void @rb_gc_register_mark_object(i64 %11) #11
-  store i64 %11, i64* @rubyStrFrozen_delegate, align 8
-  %12 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_test/testdata/compiler/custom_plus.rb", i64 0, i64 0), i64 noundef 37) #11
-  tail call void @rb_gc_register_mark_object(i64 %12) #11
-  store i64 %12, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
+  store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 23)
   %rubyId_delegate.i.i = load i64, i64* @rubyIdPrecomputed_delegate, align 8
   %rubyStr_delegate.i.i = load i64, i64* @rubyStrFrozen_delegate, align 8
   %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_delegate.i.i, i64 %rubyId_delegate.i.i, i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8delegate", align 8
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_delegate.i.i, i64 %rubyId_delegate.i.i, i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8delegate", align 8
   %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   %"rubyId_==.i" = load i64, i64* @"rubyIdPrecomputed_==", align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_==", i64 %"rubyId_==.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_ok, i64 0, i64 0), i64 noundef 2) #11
-  call void @rb_gc_register_mark_object(i64 %14) #11
-  store i64 %14, i64* @rubyStrFrozen_ok, align 8
+  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_ok, i64 0, i64 0), i64 noundef 2) #11
+  call void @rb_gc_register_mark_object(i64 %13) #11
+  store i64 %13, i64* @rubyStrFrozen_ok, align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !50
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
-  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_fail, i64 0, i64 0), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %15) #11
-  store i64 %15, i64* @rubyStrFrozen_fail, align 8
+  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_fail, i64 0, i64 0), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %14) #11
+  store i64 %14, i64* @rubyStrFrozen_fail, align 8
   %rubyId_puts3.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !51
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts3.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !51
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
-  call void @rb_gc_register_mark_object(i64 %16) #11
+  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  call void @rb_gc_register_mark_object(i64 %15) #11
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/custom_plus.rb.i12.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i12.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i13.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !49
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !49
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !47
-  %rubyId_delegate.i = load i64, i64* @rubyIdPrecomputed_delegate, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_delegate, i64 %rubyId_delegate.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #11
-  call void @rb_gc_register_mark_object(i64 %18) #11
+  %"rubyStr_test/testdata/compiler/custom_plus.rb.i9.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
+  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i9.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i10.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !47
+  %rubyId_delegate.i = load i64, i64* @rubyIdPrecomputed_delegate, align 8, !dbg !49
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_delegate, i64 %rubyId_delegate.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
+  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #11
+  call void @rb_gc_register_mark_object(i64 %17) #11
   %"rubyId_+.i.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8
-  %"rubyStr_test/testdata/compiler/custom_plus.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %"rubyId_+.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#1+", align 8
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %20) #11
+  %"rubyStr_test/testdata/compiler/custom_plus.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
+  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %"rubyId_+.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#1+", align 8
+  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %19) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %"rubyStr_test/testdata/compiler/custom_plus.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %rubyId_keep_def10.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !52
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.2, i64 %rubyId_keep_def10.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !52
-  %22 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %23 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %22, i64 0, i32 18
-  %24 = load i64, i64* %23, align 8, !tbaa !53
-  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 2
-  %27 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !25
-  call fastcc void @"func_<root>.17<static-init>$152"(i64 %24, %struct.rb_control_frame_struct* %27) #11
+  %"rubyStr_test/testdata/compiler/custom_plus.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
+  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i14.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %21 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %22 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %21, i64 0, i32 18
+  %23 = load i64, i64* %22, align 8, !tbaa !52
+  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2
+  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !tbaa !25
+  call fastcc void @"func_<root>.17<static-init>$152"(i64 %23, %struct.rb_control_frame_struct* %26) #11
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_A#1+"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 returned %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #5 !dbg !61 {
+define i64 @"func_A#1+"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 returned %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #5 !dbg !60 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !14
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !62
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !62
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !62
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !62, !prof !17
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !61
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !61
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !61
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !61, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #10, !dbg !62
-  unreachable, !dbg !62
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #10, !dbg !61
+  unreachable, !dbg !61
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !63, !tbaa !14
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !62, !tbaa !14
   ret i64 %selfRaw
 }
 
@@ -603,20 +593,19 @@ attributes #12 = { nounwind allocsize(0,1) }
 !44 = !{!26, !27, i64 44}
 !45 = !{!"branch_weights", i32 2000, i32 1}
 !46 = !{!26, !15, i64 56}
-!47 = !DILocation(line: 14, column: 1, scope: !21)
-!48 = !DILocation(line: 22, column: 1, scope: !21)
-!49 = !DILocation(line: 12, column: 5, scope: !21)
+!47 = !DILocation(line: 12, column: 5, scope: !21)
+!48 = !DILocation(line: 14, column: 1, scope: !21)
+!49 = !DILocation(line: 22, column: 1, scope: !21)
 !50 = !DILocation(line: 16, column: 5, scope: !10)
 !51 = !DILocation(line: 18, column: 5, scope: !10)
-!52 = !DILocation(line: 7, column: 3, scope: !23)
-!53 = !{!54, !7, i64 400}
-!54 = !{!"rb_vm_struct", !7, i64 0, !55, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !36, i64 216, !8, i64 224, !56, i64 264, !56, i64 280, !56, i64 296, !56, i64 312, !7, i64 328, !27, i64 336, !27, i64 340, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !58, i64 472, !59, i64 992, !15, i64 1016, !15, i64 1024, !27, i64 1032, !27, i64 1036, !56, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !27, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !27, i64 1192, !60, i64 1200, !8, i64 1232}
-!55 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !56, i64 48, !15, i64 64, !27, i64 72, !8, i64 80, !8, i64 128, !27, i64 176, !27, i64 180}
-!56 = !{!"list_head", !57, i64 0}
-!57 = !{!"list_node", !15, i64 0, !15, i64 8}
-!58 = !{!"", !8, i64 0}
-!59 = !{!"rb_hook_list_struct", !15, i64 0, !27, i64 8, !27, i64 12, !27, i64 16}
-!60 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!61 = distinct !DISubprogram(name: "A#+", linkageName: "func_A#1+", scope: null, file: !4, line: 7, type: !11, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!62 = !DILocation(line: 7, column: 3, scope: !61)
-!63 = !DILocation(line: 0, scope: !61)
+!52 = !{!53, !7, i64 400}
+!53 = !{!"rb_vm_struct", !7, i64 0, !54, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !36, i64 216, !8, i64 224, !55, i64 264, !55, i64 280, !55, i64 296, !55, i64 312, !7, i64 328, !27, i64 336, !27, i64 340, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !57, i64 472, !58, i64 992, !15, i64 1016, !15, i64 1024, !27, i64 1032, !27, i64 1036, !55, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !27, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !27, i64 1192, !59, i64 1200, !8, i64 1232}
+!54 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !55, i64 48, !15, i64 64, !27, i64 72, !8, i64 80, !8, i64 128, !27, i64 176, !27, i64 180}
+!55 = !{!"list_head", !56, i64 0}
+!56 = !{!"list_node", !15, i64 0, !15, i64 8}
+!57 = !{!"", !8, i64 0}
+!58 = !{!"rb_hook_list_struct", !15, i64 0, !27, i64 8, !27, i64 12, !27, i64 16}
+!59 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!60 = distinct !DISubprogram(name: "A#+", linkageName: "func_A#1+", scope: null, file: !4, line: 7, type: !11, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!61 = !DILocation(line: 7, column: 3, scope: !60)
+!62 = !DILocation(line: 0, scope: !60)

--- a/test/testdata/compiler/direct_call.llo.exp
+++ b/test/testdata/compiler/direct_call.llo.exp
@@ -97,10 +97,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
-@ic_keep_def.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_bar = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
@@ -197,8 +193,8 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
 ; Function Attrs: sspreq
 define void @Init_direct_call() local_unnamed_addr #5 {
 entry:
-  %locals.i11.i = alloca i64, i32 0, align 8
-  %locals.i9.i = alloca i64, i32 0, align 8
+  %locals.i8.i = alloca i64, i32 0, align 8
+  %locals.i6.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #9
@@ -209,138 +205,132 @@ entry:
   store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #9
   store i64 %3, i64* @rubyIdPrecomputed_normal, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #9
-  store i64 %4, i64* @rubyIdPrecomputed_keep_def, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #9
-  store i64 %5, i64* @rubyIdPrecomputed_puts, align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #9
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #9
+  store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
+  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #9
+  tail call void @rb_gc_register_mark_object(i64 %5) #9
+  store i64 %5, i64* @rubyStrFrozen_foo, align 8
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_test/testdata/compiler/direct_call.rb", i64 0, i64 0), i64 noundef 37) #9
   tail call void @rb_gc_register_mark_object(i64 %6) #9
-  store i64 %6, i64* @rubyStrFrozen_foo, align 8
-  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_test/testdata/compiler/direct_call.rb", i64 0, i64 0), i64 noundef 37) #9
-  tail call void @rb_gc_register_mark_object(i64 %7) #9
-  store i64 %7, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
+  store i64 %6, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
   %rubyStr_foo.i.i = load i64, i64* @rubyStrFrozen_foo, align 8
   %"rubyStr_test/testdata/compiler/direct_call.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
-  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
-  %9 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #9
-  call void @rb_gc_register_mark_object(i64 %9) #9
+  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
+  %8 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #9
+  call void @rb_gc_register_mark_object(i64 %8) #9
   %rubyId_bar.i.i = load i64, i64* @rubyIdPrecomputed_bar, align 8
-  %"rubyStr_test/testdata/compiler/direct_call.rb.i8.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
-  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i8.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i9.i, i32 noundef 0, i32 noundef 1)
-  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8
+  %"rubyStr_test/testdata/compiler/direct_call.rb.i5.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
+  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %8, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i6.i, i32 noundef 0, i32 noundef 1)
+  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8
   %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !22
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
-  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #9
-  call void @rb_gc_register_mark_object(i64 %11) #9
+  %10 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #9
+  call void @rb_gc_register_mark_object(i64 %10) #9
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/direct_call.rb.i10.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i10.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i11.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !23
-  %rubyId_keep_def2.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !25
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.1, i64 %rubyId_keep_def2.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !25
-  %rubyId_bar.i = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !26
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !27
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !27
-  %13 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %14 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %13, i64 0, i32 18
-  %15 = load i64, i64* %14, align 8, !tbaa !28
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2
-  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !38
+  %"rubyStr_test/testdata/compiler/direct_call.rb.i7.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
+  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %10, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i7.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %rubyId_bar.i = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !23
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !23
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
+  %12 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %13 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %12, i64 0, i32 18
+  %14 = load i64, i64* %13, align 8, !tbaa !26
+  %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 2
+  %17 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %16, align 8, !tbaa !36
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %19, align 8, !tbaa !41
-  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 4
-  %21 = load i64*, i64** %20, align 8, !tbaa !43
-  %22 = load i64, i64* %21, align 8, !tbaa !6
-  %23 = and i64 %22, -33
-  store i64 %23, i64* %21, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %16, %struct.rb_control_frame_struct* %18, %struct.rb_iseq_struct* %stackFrame.i) #9
-  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %24, align 8, !dbg !44, !tbaa !14
-  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !23
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #9, !dbg !23
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !23
-  %rawSym21.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #9, !dbg !23
-  %25 = load i64, i64* @rb_cObject, align 8, !dbg !23
-  %stackFrame22.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !23
-  %26 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !23
-  %27 = bitcast i8* %26 to i16*, !dbg !23
-  %28 = load i16, i16* %27, align 8, !dbg !23
-  %29 = and i16 %28, -384, !dbg !23
-  store i16 %29, i16* %27, align 8, !dbg !23
-  %30 = getelementptr inbounds i8, i8* %26, i64 4, !dbg !23
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %30, i8 0, i64 28, i1 false) #9, !dbg !23
-  call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#3foo", i8* nonnull %26, %struct.rb_iseq_struct* %stackFrame22.i, i1 noundef zeroext false) #9, !dbg !23
-  %31 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !14
-  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 5, !dbg !23
-  %33 = load i32, i32* %32, align 8, !dbg !23, !tbaa !45
-  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 6, !dbg !23
-  %35 = load i32, i32* %34, align 4, !dbg !23, !tbaa !46
-  %36 = xor i32 %35, -1, !dbg !23
-  %37 = and i32 %36, %33, !dbg !23
-  %38 = icmp eq i32 %37, 0, !dbg !23
-  br i1 %38, label %fastSymCallIntrinsic_Static_keep_def35.i, label %39, !dbg !23, !prof !47
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %18, align 8, !tbaa !39
+  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 4
+  %20 = load i64*, i64** %19, align 8, !tbaa !41
+  %21 = load i64, i64* %20, align 8, !tbaa !6
+  %22 = and i64 %21, -33
+  store i64 %22, i64* %20, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %15, %struct.rb_control_frame_struct* %17, %struct.rb_iseq_struct* %stackFrame.i) #9
+  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %23, align 8, !dbg !42, !tbaa !14
+  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !43
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #9, !dbg !43
+  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !43
+  %rawSym21.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #9, !dbg !43
+  %24 = load i64, i64* @rb_cObject, align 8, !dbg !43
+  %stackFrame22.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !43
+  %25 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !43
+  %26 = bitcast i8* %25 to i16*, !dbg !43
+  %27 = load i16, i16* %26, align 8, !dbg !43
+  %28 = and i16 %27, -384, !dbg !43
+  store i16 %28, i16* %26, align 8, !dbg !43
+  %29 = getelementptr inbounds i8, i8* %25, i64 4, !dbg !43
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %29, i8 0, i64 28, i1 false) #9, !dbg !43
+  call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#3foo", i8* nonnull %25, %struct.rb_iseq_struct* %stackFrame22.i, i1 noundef zeroext false) #9, !dbg !43
+  %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !43, !tbaa !14
+  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 5, !dbg !43
+  %32 = load i32, i32* %31, align 8, !dbg !43, !tbaa !44
+  %33 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 6, !dbg !43
+  %34 = load i32, i32* %33, align 4, !dbg !43, !tbaa !45
+  %35 = xor i32 %34, -1, !dbg !43
+  %36 = and i32 %35, %32, !dbg !43
+  %37 = icmp eq i32 %36, 0, !dbg !43
+  br i1 %37, label %rb_vm_check_ints.exit1.i, label %38, !dbg !43, !prof !46
 
-39:                                               ; preds = %entry
-  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 8, !dbg !23
-  %41 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %40, align 8, !dbg !23, !tbaa !48
-  %42 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %41, i32 noundef 0) #9, !dbg !23
-  br label %fastSymCallIntrinsic_Static_keep_def35.i, !dbg !23
+38:                                               ; preds = %entry
+  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 8, !dbg !43
+  %40 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %39, align 8, !dbg !43, !tbaa !47
+  %41 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %40, i32 noundef 0) #9, !dbg !43
+  br label %rb_vm_check_ints.exit1.i, !dbg !43
 
-fastSymCallIntrinsic_Static_keep_def35.i:         ; preds = %39, %entry
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %24, align 8, !dbg !23, !tbaa !14
-  %rubyId_bar.i2 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !25
-  %rawSym27.i = call i64 @rb_id2sym(i64 %rubyId_bar.i2) #9, !dbg !25
-  %rubyId_normal28.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !25
-  %rawSym29.i = call i64 @rb_id2sym(i64 %rubyId_normal28.i) #9, !dbg !25
-  %stackFrame36.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8, !dbg !25
-  %43 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !25
-  %44 = bitcast i8* %43 to i16*, !dbg !25
-  %45 = load i16, i16* %44, align 8, !dbg !25
-  %46 = and i16 %45, -384, !dbg !25
-  store i16 %46, i16* %44, align 8, !dbg !25
-  %47 = getelementptr inbounds i8, i8* %43, i64 4, !dbg !25
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %47, i8 0, i64 28, i1 false) #9, !dbg !25
-  call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#3bar", i8* nonnull %43, %struct.rb_iseq_struct* %stackFrame36.i, i1 noundef zeroext false) #9, !dbg !25
-  %48 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !25, !tbaa !14
-  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 5, !dbg !25
-  %50 = load i32, i32* %49, align 8, !dbg !25, !tbaa !45
-  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 6, !dbg !25
-  %52 = load i32, i32* %51, align 4, !dbg !25, !tbaa !46
-  %53 = xor i32 %52, -1, !dbg !25
-  %54 = and i32 %53, %50, !dbg !25
-  %55 = icmp eq i32 %54, 0, !dbg !25
-  br i1 %55, label %"func_<root>.17<static-init>$152.exit", label %56, !dbg !25, !prof !47
+rb_vm_check_ints.exit1.i:                         ; preds = %38, %entry
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %23, align 8, !dbg !43, !tbaa !14
+  %rubyId_bar.i2 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !48
+  %rawSym24.i = call i64 @rb_id2sym(i64 %rubyId_bar.i2) #9, !dbg !48
+  %rubyId_normal25.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !48
+  %rawSym26.i = call i64 @rb_id2sym(i64 %rubyId_normal25.i) #9, !dbg !48
+  %stackFrame31.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8, !dbg !48
+  %42 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !48
+  %43 = bitcast i8* %42 to i16*, !dbg !48
+  %44 = load i16, i16* %43, align 8, !dbg !48
+  %45 = and i16 %44, -384, !dbg !48
+  store i16 %45, i16* %43, align 8, !dbg !48
+  %46 = getelementptr inbounds i8, i8* %42, i64 4, !dbg !48
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 28, i1 false) #9, !dbg !48
+  call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#3bar", i8* nonnull %42, %struct.rb_iseq_struct* %stackFrame31.i, i1 noundef zeroext false) #9, !dbg !48
+  %47 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !48, !tbaa !14
+  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 5, !dbg !48
+  %49 = load i32, i32* %48, align 8, !dbg !48, !tbaa !44
+  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 6, !dbg !48
+  %51 = load i32, i32* %50, align 4, !dbg !48, !tbaa !45
+  %52 = xor i32 %51, -1, !dbg !48
+  %53 = and i32 %52, %49, !dbg !48
+  %54 = icmp eq i32 %53, 0, !dbg !48
+  br i1 %54, label %"func_<root>.17<static-init>$152.exit", label %55, !dbg !48, !prof !46
 
-56:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def35.i
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 8, !dbg !25
-  %58 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %57, align 8, !dbg !25, !tbaa !48
-  %59 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %58, i32 noundef 0) #9, !dbg !25
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !25
+55:                                               ; preds = %rb_vm_check_ints.exit1.i
+  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 8, !dbg !48
+  %57 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %56, align 8, !dbg !48, !tbaa !47
+  %58 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %57, i32 noundef 0) #9, !dbg !48
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !48
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %fastSymCallIntrinsic_Static_keep_def35.i, %56
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %24, align 8, !dbg !25, !tbaa !14
-  %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !26
-  %61 = load i64*, i64** %60, align 8, !dbg !26
-  store i64 %15, i64* %61, align 8, !dbg !26, !tbaa !6
-  %62 = getelementptr inbounds i64, i64* %61, i64 1, !dbg !26
-  store i64* %62, i64** %60, align 8, !dbg !26
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 0), !dbg !26
-  %63 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !27
-  %64 = load i64*, i64** %63, align 8, !dbg !27
-  store i64 %15, i64* %64, align 8, !dbg !27, !tbaa !6
-  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !27
-  store i64 %send, i64* %65, align 8, !dbg !27, !tbaa !6
-  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !27
-  store i64* %66, i64** %63, align 8, !dbg !27
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !27
+"func_<root>.17<static-init>$152.exit":           ; preds = %rb_vm_check_ints.exit1.i, %55
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %23, align 8, !dbg !48, !tbaa !14
+  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !23
+  %60 = load i64*, i64** %59, align 8, !dbg !23
+  store i64 %14, i64* %60, align 8, !dbg !23, !tbaa !6
+  %61 = getelementptr inbounds i64, i64* %60, i64 1, !dbg !23
+  store i64* %61, i64** %59, align 8, !dbg !23
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 0), !dbg !23
+  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !25
+  %63 = load i64*, i64** %62, align 8, !dbg !25
+  store i64 %14, i64* %63, align 8, !dbg !25, !tbaa !6
+  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !25
+  store i64 %send, i64* %64, align 8, !dbg !25, !tbaa !6
+  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !25
+  store i64* %65, i64** %62, align 8, !dbg !25
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !25
   ret void
 }
 
@@ -385,29 +375,29 @@ attributes #10 = { nounwind allocsize(0,1) }
 !20 = !DILocation(line: 8, column: 1, scope: !19)
 !21 = !DILocation(line: 0, scope: !19)
 !22 = !DILocation(line: 9, column: 3, scope: !19)
-!23 = !DILocation(line: 4, column: 1, scope: !24)
+!23 = !DILocation(line: 12, column: 6, scope: !24)
 !24 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!25 = !DILocation(line: 8, column: 1, scope: !24)
-!26 = !DILocation(line: 12, column: 6, scope: !24)
-!27 = !DILocation(line: 12, column: 1, scope: !24)
-!28 = !{!29, !7, i64 400}
-!29 = !{!"rb_vm_struct", !7, i64 0, !30, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !34, i64 216, !8, i64 224, !31, i64 264, !31, i64 280, !31, i64 296, !31, i64 312, !7, i64 328, !33, i64 336, !33, i64 340, !33, i64 344, !33, i64 344, !33, i64 344, !33, i64 344, !33, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !35, i64 472, !36, i64 992, !15, i64 1016, !15, i64 1024, !33, i64 1032, !33, i64 1036, !31, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !33, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !33, i64 1192, !37, i64 1200, !8, i64 1232}
-!30 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !31, i64 48, !15, i64 64, !33, i64 72, !8, i64 80, !8, i64 128, !33, i64 176, !33, i64 180}
-!31 = !{!"list_head", !32, i64 0}
-!32 = !{!"list_node", !15, i64 0, !15, i64 8}
-!33 = !{!"int", !8, i64 0}
-!34 = !{!"long long", !8, i64 0}
-!35 = !{!"", !8, i64 0}
-!36 = !{!"rb_hook_list_struct", !15, i64 0, !33, i64 8, !33, i64 12, !33, i64 16}
-!37 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!38 = !{!39, !15, i64 16}
-!39 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !33, i64 40, !33, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !40, i64 152}
-!40 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
-!41 = !{!42, !15, i64 16}
-!42 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
-!43 = !{!42, !15, i64 32}
-!44 = !DILocation(line: 0, scope: !24)
-!45 = !{!39, !33, i64 40}
-!46 = !{!39, !33, i64 44}
-!47 = !{!"branch_weights", i32 2000, i32 1}
-!48 = !{!39, !15, i64 56}
+!25 = !DILocation(line: 12, column: 1, scope: !24)
+!26 = !{!27, !7, i64 400}
+!27 = !{!"rb_vm_struct", !7, i64 0, !28, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !32, i64 216, !8, i64 224, !29, i64 264, !29, i64 280, !29, i64 296, !29, i64 312, !7, i64 328, !31, i64 336, !31, i64 340, !31, i64 344, !31, i64 344, !31, i64 344, !31, i64 344, !31, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !33, i64 472, !34, i64 992, !15, i64 1016, !15, i64 1024, !31, i64 1032, !31, i64 1036, !29, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !31, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !31, i64 1192, !35, i64 1200, !8, i64 1232}
+!28 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !29, i64 48, !15, i64 64, !31, i64 72, !8, i64 80, !8, i64 128, !31, i64 176, !31, i64 180}
+!29 = !{!"list_head", !30, i64 0}
+!30 = !{!"list_node", !15, i64 0, !15, i64 8}
+!31 = !{!"int", !8, i64 0}
+!32 = !{!"long long", !8, i64 0}
+!33 = !{!"", !8, i64 0}
+!34 = !{!"rb_hook_list_struct", !15, i64 0, !31, i64 8, !31, i64 12, !31, i64 16}
+!35 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!36 = !{!37, !15, i64 16}
+!37 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !31, i64 40, !31, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !38, i64 152}
+!38 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!39 = !{!40, !15, i64 16}
+!40 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!41 = !{!40, !15, i64 32}
+!42 = !DILocation(line: 0, scope: !24)
+!43 = !DILocation(line: 4, column: 1, scope: !24)
+!44 = !{!37, !31, i64 40}
+!45 = !{!37, !31, i64 44}
+!46 = !{!"branch_weights", i32 2000, i32 1}
+!47 = !{!37, !15, i64 56}
+!48 = !DILocation(line: 8, column: 1, scope: !24)

--- a/test/testdata/compiler/exceptions/basic.llo.exp
+++ b/test/testdata/compiler/exceptions/basic.llo.exp
@@ -145,9 +145,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"str_<class:A>" = private unnamed_addr constant [10 x i8] c"<class:A>\00", align 1
 @rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@ic_keep_self_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_self_def = internal unnamed_addr global i64 0, align 8
-@str_keep_self_def = private unnamed_addr constant [14 x i8] c"keep_self_def\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
@@ -224,8 +221,8 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
 define void @Init_basic() local_unnamed_addr #5 {
 entry:
   %positional_table.i.i = alloca i64, align 8, !dbg !10
-  %locals.i32.i = alloca i64, i32 0, align 8
-  %locals.i27.i = alloca i64, i32 5, align 8
+  %locals.i31.i = alloca i64, i32 0, align 8
+  %locals.i26.i = alloca i64, i32 5, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
@@ -256,241 +253,237 @@ entry:
   store i64 %12, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
   store i64 %13, i64* @rubyIdPrecomputed_normal, align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @str_keep_self_def, i64 0, i64 0), i64 noundef 13) #11
-  store i64 %14, i64* @rubyIdPrecomputed_keep_self_def, align 8
-  %15 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %14 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %14) #11
+  store i64 %14, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %15 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/exceptions/basic.rb", i64 0, i64 0), i64 noundef 42) #11
   tail call void @rb_gc_register_mark_object(i64 %15) #11
-  store i64 %15, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %16 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/exceptions/basic.rb", i64 0, i64 0), i64 noundef 42) #11
-  tail call void @rb_gc_register_mark_object(i64 %16) #11
-  store i64 %16, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
+  store i64 %15, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_=== no-raise ===", i64 0, i64 0), i64 noundef 16) #11
-  call void @rb_gc_register_mark_object(i64 %18) #11
-  store i64 %18, i64* @"rubyStrFrozen_=== no-raise ===", align 8
+  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_=== no-raise ===", i64 0, i64 0), i64 noundef 16) #11
+  call void @rb_gc_register_mark_object(i64 %17) #11
+  store i64 %17, i64* @"rubyStrFrozen_=== no-raise ===", align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
   %rubyId_test.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !18
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_=== raise ===", i64 0, i64 0), i64 noundef 13) #11
-  call void @rb_gc_register_mark_object(i64 %19) #11
-  store i64 %19, i64* @"rubyStrFrozen_=== raise ===", align 8
+  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_=== raise ===", i64 0, i64 0), i64 noundef 13) #11
+  call void @rb_gc_register_mark_object(i64 %18) #11
+  store i64 %18, i64* @"rubyStrFrozen_=== raise ===", align 8
   %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   %rubyId_test5.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !20
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test.2, i64 %rubyId_test5.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %20) #11
-  %21 = bitcast i64* %locals.i27.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %21)
+  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %19) #11
+  %20 = bitcast i64* %locals.i26.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %20)
   %rubyId_test.i.i = load i64, i64* @rubyIdPrecomputed_test, align 8
-  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
+  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i25.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
   %"rubyId_<exceptionValue>.i.i" = load i64, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
-  store i64 %"rubyId_<exceptionValue>.i.i", i64* %locals.i27.i, align 8
+  store i64 %"rubyId_<exceptionValue>.i.i", i64* %locals.i26.i, align 8
   %rubyId_x.i.i = load i64, i64* @rubyIdPrecomputed_x, align 8
-  %22 = getelementptr i64, i64* %locals.i27.i, i32 1
-  store i64 %rubyId_x.i.i, i64* %22, align 8
+  %21 = getelementptr i64, i64* %locals.i26.i, i32 1
+  store i64 %rubyId_x.i.i, i64* %21, align 8
   %"rubyId_<returnMethodTemp>.i.i" = load i64, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %23 = getelementptr i64, i64* %locals.i27.i, i32 2
-  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %23, align 8
+  %22 = getelementptr i64, i64* %locals.i26.i, i32 2
+  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %22, align 8
   %"rubyId_<magic>.i.i" = load i64, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %24 = getelementptr i64, i64* %locals.i27.i, i32 3
-  store i64 %"rubyId_<magic>.i.i", i64* %24, align 8
+  %23 = getelementptr i64, i64* %locals.i26.i, i32 3
+  store i64 %"rubyId_<magic>.i.i", i64* %23, align 8
   %"rubyId_<gotoDeadTemp>.i.i" = load i64, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %25 = getelementptr i64, i64* %locals.i27.i, i32 4
-  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %25, align 8
-  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i27.i, i32 noundef 5, i32 noundef 2)
-  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
-  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %21)
-  %27 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_rescue in test", i64 0, i64 0), i64 noundef 14) #11
-  call void @rb_gc_register_mark_object(i64 %27) #11
+  %24 = getelementptr i64, i64* %locals.i26.i, i32 4
+  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %24, align 8
+  %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i25.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i26.i, i32 noundef 5, i32 noundef 2)
+  store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %20)
+  %26 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_rescue in test", i64 0, i64 0), i64 noundef 14) #11
+  call void @rb_gc_register_mark_object(i64 %26) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
   %"rubyId_rescue in test.i.i" = load i64, i64* @"rubyIdPrecomputed_rescue in test", align 8
-  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %27, i64 %"rubyId_rescue in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_2", align 8
-  %29 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_ensure in test", i64 0, i64 0), i64 noundef 14) #11
-  call void @rb_gc_register_mark_object(i64 %29) #11
-  %stackFrame.i29.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
+  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i27.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
+  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %26, i64 %"rubyId_rescue in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i27.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_2", align 8
+  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_ensure in test", i64 0, i64 0), i64 noundef 14) #11
+  call void @rb_gc_register_mark_object(i64 %28) #11
+  %stackFrame.i28.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
   %"rubyId_ensure in test.i.i" = load i64, i64* @"rubyIdPrecomputed_ensure in test", align 8
-  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %29, i64 %"rubyId_ensure in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i29.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_3", align 8
-  %31 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #11
-  store i64 %31, i64* @"<retry-singleton>", align 8
-  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_begin, i64 0, i64 0), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %32) #11
-  store i64 %32, i64* @rubyStrFrozen_begin, align 8
+  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i29.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
+  %29 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %28, i64 %"rubyId_ensure in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i29.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i28.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %29, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_3", align 8
+  %30 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #11
+  store i64 %30, i64* @"<retry-singleton>", align 8
+  %31 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_begin, i64 0, i64 0), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %31) #11
+  store i64 %31, i64* @rubyStrFrozen_begin, align 8
   %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
   %rubyId_puts10.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts10.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %33 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
-  call void @rb_gc_register_mark_object(i64 %33) #11
-  store i64 %33, i64* @rubyStrFrozen_foo, align 8
+  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
+  call void @rb_gc_register_mark_object(i64 %32) #11
+  store i64 %32, i64* @rubyStrFrozen_foo, align 8
   %rubyId_raise.i = load i64, i64* @rubyIdPrecomputed_raise, align 8, !dbg !25
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_raise, i64 %rubyId_raise.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
   %"rubyId_is_a?.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !26
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
   %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !28
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  %34 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_else, i64 0, i64 0), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %34) #11
-  store i64 %34, i64* @rubyStrFrozen_else, align 8
+  %33 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_else, i64 0, i64 0), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %33) #11
+  store i64 %33, i64* @rubyStrFrozen_else, align 8
   %rubyId_puts19.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !29
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts19.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
-  %35 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_ensure, i64 0, i64 0), i64 noundef 6) #11
-  call void @rb_gc_register_mark_object(i64 %35) #11
-  store i64 %35, i64* @rubyStrFrozen_ensure, align 8
+  %34 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_ensure, i64 0, i64 0), i64 noundef 6) #11
+  call void @rb_gc_register_mark_object(i64 %34) #11
+  store i64 %34, i64* @rubyStrFrozen_ensure, align 8
   %rubyId_puts22.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !31
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts22.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !31
-  %36 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %36) #11
+  %35 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %35) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i31.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %37 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %36, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i32.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %37, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !33
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !33
-  %38 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !34
-  %39 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %38, i64 0, i32 18
-  %40 = load i64, i64* %39, align 8, !tbaa !36
-  %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
-  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 2
-  %43 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %42, align 8, !tbaa !46
+  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
+  %36 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %35, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %36, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %37 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !33
+  %38 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %37, i64 0, i32 18
+  %39 = load i64, i64* %38, align 8, !tbaa !35
+  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
+  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 2
+  %42 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %41, align 8, !tbaa !45
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %44, align 8, !tbaa !49
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 4
-  %46 = load i64*, i64** %45, align 8, !tbaa !51
-  %47 = load i64, i64* %46, align 8, !tbaa !6
-  %48 = and i64 %47, -33
-  store i64 %48, i64* %46, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %41, %struct.rb_control_frame_struct* %43, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %49, align 8, !dbg !52, !tbaa !34
-  %50 = load i64, i64* @rb_cObject, align 8, !dbg !53
-  %51 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %50) #11, !dbg !53
-  %52 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %51) #11, !dbg !53
-  %53 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %53) #11
+  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %43, align 8, !tbaa !48
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 4
+  %45 = load i64*, i64** %44, align 8, !tbaa !50
+  %46 = load i64, i64* %45, align 8, !tbaa !6
+  %47 = and i64 %46, -33
+  store i64 %47, i64* %45, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %40, %struct.rb_control_frame_struct* %42, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %48, align 8, !dbg !51, !tbaa !33
+  %49 = load i64, i64* @rb_cObject, align 8, !dbg !52
+  %50 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %49) #11, !dbg !52
+  %51 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %50) #11, !dbg !52
+  %52 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %52) #11
   %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
-  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 2
-  %56 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %55, align 8, !tbaa !46
-  %57 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %57, align 8, !tbaa !49
-  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 4
-  %59 = load i64*, i64** %58, align 8, !tbaa !51
-  %60 = load i64, i64* %59, align 8, !tbaa !6
-  %61 = and i64 %60, -33
-  store i64 %61, i64* %59, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %54, %struct.rb_control_frame_struct* %56, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
-  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %52, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %62, align 8, !dbg !54, !tbaa !34
+  %53 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
+  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 2
+  %55 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %54, align 8, !tbaa !45
+  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %55, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %56, align 8, !tbaa !48
+  %57 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %55, i64 0, i32 4
+  %58 = load i64*, i64** %57, align 8, !tbaa !50
+  %59 = load i64, i64* %58, align 8, !tbaa !6
+  %60 = and i64 %59, -33
+  store i64 %60, i64* %58, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %53, %struct.rb_control_frame_struct* %55, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
+  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %61, align 8, !dbg !53, !tbaa !33
   %rubyId_test.i.i2 = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !10
   %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_test.i.i2) #11, !dbg !10
   %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !10
   %rawSym7.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !10
-  %63 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %64 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !55
-  %needTakeSlowPath = icmp ne i64 %63, %64, !dbg !10
-  br i1 %needTakeSlowPath, label %65, label %66, !dbg !10, !prof !56
+  %62 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !54
+  %needTakeSlowPath = icmp ne i64 %62, %63, !dbg !10
+  br i1 %needTakeSlowPath, label %64, label %65, !dbg !10, !prof !55
 
-65:                                               ; preds = %entry
+64:                                               ; preds = %entry
   call void @const_recompute_A(), !dbg !10
-  br label %66, !dbg !10
+  br label %65, !dbg !10
 
-66:                                               ; preds = %entry, %65
-  %67 = load i64, i64* @guarded_const_A, align 8, !dbg !10
-  %68 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %69 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !55
-  %guardUpdated = icmp eq i64 %68, %69, !dbg !10
+65:                                               ; preds = %entry, %64
+  %66 = load i64, i64* @guarded_const_A, align 8, !dbg !10
+  %67 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %68 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !54
+  %guardUpdated = icmp eq i64 %67, %68, !dbg !10
   call void @llvm.assume(i1 %guardUpdated), !dbg !10
   %stackFrame8.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8, !dbg !10
-  %70 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
-  %71 = bitcast i8* %70 to i16*, !dbg !10
-  %72 = load i16, i16* %71, align 8, !dbg !10
-  %73 = and i16 %72, -384, !dbg !10
-  %74 = or i16 %73, 1, !dbg !10
-  store i16 %74, i16* %71, align 8, !dbg !10
-  %75 = getelementptr inbounds i8, i8* %70, i64 8, !dbg !10
-  %76 = bitcast i8* %75 to i32*, !dbg !10
-  store i32 1, i32* %76, align 8, !dbg !10, !tbaa !57
-  %77 = getelementptr inbounds i8, i8* %70, i64 12, !dbg !10
-  %78 = getelementptr inbounds i8, i8* %70, i64 4, !dbg !10
-  %79 = bitcast i8* %78 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %77, i8 0, i64 20, i1 false) #11, !dbg !10
-  store i32 1, i32* %79, align 4, !dbg !10, !tbaa !60
+  %69 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %70 = bitcast i8* %69 to i16*, !dbg !10
+  %71 = load i16, i16* %70, align 8, !dbg !10
+  %72 = and i16 %71, -384, !dbg !10
+  %73 = or i16 %72, 1, !dbg !10
+  store i16 %73, i16* %70, align 8, !dbg !10
+  %74 = getelementptr inbounds i8, i8* %69, i64 8, !dbg !10
+  %75 = bitcast i8* %74 to i32*, !dbg !10
+  store i32 1, i32* %75, align 8, !dbg !10, !tbaa !56
+  %76 = getelementptr inbounds i8, i8* %69, i64 12, !dbg !10
+  %77 = getelementptr inbounds i8, i8* %69, i64 4, !dbg !10
+  %78 = bitcast i8* %77 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %78, align 4, !dbg !10, !tbaa !59
   %rubyId_x.i.i3 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !10
   store i64 %rubyId_x.i.i3, i64* %positional_table.i.i, align 8, !dbg !10
-  %80 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %80, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %53, i64 noundef 8, i1 noundef false) #11, !dbg !10
-  %81 = getelementptr inbounds i8, i8* %70, i64 32, !dbg !10
-  %82 = bitcast i8* %81 to i8**, !dbg !10
-  store i8* %80, i8** %82, align 8, !dbg !10, !tbaa !61
-  call void @sorbet_vm_define_method(i64 %67, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_A.4test, i8* nonnull %70, %struct.rb_iseq_struct* %stackFrame8.i.i, i1 noundef zeroext true) #11, !dbg !10
-  %83 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !34
-  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 5, !dbg !10
-  %85 = load i32, i32* %84, align 8, !dbg !10, !tbaa !62
-  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 6, !dbg !10
-  %87 = load i32, i32* %86, align 4, !dbg !10, !tbaa !63
-  %88 = xor i32 %87, -1, !dbg !10
-  %89 = and i32 %88, %85, !dbg !10
-  %90 = icmp eq i32 %89, 0, !dbg !10
-  br i1 %90, label %"func_<root>.17<static-init>$152.exit", label %91, !dbg !10, !prof !64
+  %79 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %79, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %52, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %80 = getelementptr inbounds i8, i8* %69, i64 32, !dbg !10
+  %81 = bitcast i8* %80 to i8**, !dbg !10
+  store i8* %79, i8** %81, align 8, !dbg !10, !tbaa !60
+  call void @sorbet_vm_define_method(i64 %66, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_A.4test, i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame8.i.i, i1 noundef zeroext true) #11, !dbg !10
+  %82 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !33
+  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 5, !dbg !10
+  %84 = load i32, i32* %83, align 8, !dbg !10, !tbaa !61
+  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 6, !dbg !10
+  %86 = load i32, i32* %85, align 4, !dbg !10, !tbaa !62
+  %87 = xor i32 %86, -1, !dbg !10
+  %88 = and i32 %87, %84, !dbg !10
+  %89 = icmp eq i32 %88, 0, !dbg !10
+  br i1 %89, label %"func_<root>.17<static-init>$152.exit", label %90, !dbg !10, !prof !63
 
-91:                                               ; preds = %66
-  %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 8, !dbg !10
-  %93 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %92, align 8, !dbg !10, !tbaa !65
-  %94 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %93, i32 noundef 0) #11, !dbg !10
+90:                                               ; preds = %65
+  %91 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 8, !dbg !10
+  %92 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %91, align 8, !dbg !10, !tbaa !64
+  %93 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %92, i32 noundef 0) #11, !dbg !10
   br label %"func_<root>.17<static-init>$152.exit", !dbg !10
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %66, %91
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %53) #11
-  call void @sorbet_popFrame() #11, !dbg !53
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %49, align 8, !dbg !53, !tbaa !34
-  %"rubyStr_=== no-raise ===.i" = load i64, i64* @"rubyStrFrozen_=== no-raise ===", align 8, !dbg !66
-  %95 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !17
-  %96 = load i64*, i64** %95, align 8, !dbg !17
-  store i64 %40, i64* %96, align 8, !dbg !17, !tbaa !6
+"func_<root>.17<static-init>$152.exit":           ; preds = %65, %90
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %52) #11
+  call void @sorbet_popFrame() #11, !dbg !52
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %48, align 8, !dbg !52, !tbaa !33
+  %"rubyStr_=== no-raise ===.i" = load i64, i64* @"rubyStrFrozen_=== no-raise ===", align 8, !dbg !65
+  %94 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !17
+  %95 = load i64*, i64** %94, align 8, !dbg !17
+  store i64 %39, i64* %95, align 8, !dbg !17, !tbaa !6
+  %96 = getelementptr inbounds i64, i64* %95, i64 1, !dbg !17
+  store i64 %"rubyStr_=== no-raise ===.i", i64* %96, align 8, !dbg !17, !tbaa !6
   %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !17
-  store i64 %"rubyStr_=== no-raise ===.i", i64* %97, align 8, !dbg !17, !tbaa !6
-  %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !17
-  store i64* %98, i64** %95, align 8, !dbg !17
+  store i64* %97, i64** %94, align 8, !dbg !17
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %49, align 8, !dbg !17, !tbaa !34
-  %99 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !18
-  %100 = load i64*, i64** %99, align 8, !dbg !18
-  store i64 %67, i64* %100, align 8, !dbg !18, !tbaa !6
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %48, align 8, !dbg !17, !tbaa !33
+  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !18
+  %99 = load i64*, i64** %98, align 8, !dbg !18
+  store i64 %66, i64* %99, align 8, !dbg !18, !tbaa !6
+  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !18
+  store i64 0, i64* %100, align 8, !dbg !18, !tbaa !6
   %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !18
-  store i64 0, i64* %101, align 8, !dbg !18, !tbaa !6
-  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !18
-  store i64* %102, i64** %99, align 8, !dbg !18
+  store i64* %101, i64** %98, align 8, !dbg !18
   %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !18
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %49, align 8, !dbg !18, !tbaa !34
-  %"rubyStr_=== raise ===.i" = load i64, i64* @"rubyStrFrozen_=== raise ===", align 8, !dbg !67
-  %103 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !19
-  %104 = load i64*, i64** %103, align 8, !dbg !19
-  store i64 %40, i64* %104, align 8, !dbg !19, !tbaa !6
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %48, align 8, !dbg !18, !tbaa !33
+  %"rubyStr_=== raise ===.i" = load i64, i64* @"rubyStrFrozen_=== raise ===", align 8, !dbg !66
+  %102 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !19
+  %103 = load i64*, i64** %102, align 8, !dbg !19
+  store i64 %39, i64* %103, align 8, !dbg !19, !tbaa !6
+  %104 = getelementptr inbounds i64, i64* %103, i64 1, !dbg !19
+  store i64 %"rubyStr_=== raise ===.i", i64* %104, align 8, !dbg !19, !tbaa !6
   %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !19
-  store i64 %"rubyStr_=== raise ===.i", i64* %105, align 8, !dbg !19, !tbaa !6
-  %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !19
-  store i64* %106, i64** %103, align 8, !dbg !19
+  store i64* %105, i64** %102, align 8, !dbg !19
   %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %49, align 8, !dbg !19, !tbaa !34
-  %107 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !20
-  %108 = load i64*, i64** %107, align 8, !dbg !20
-  store i64 %67, i64* %108, align 8, !dbg !20, !tbaa !6
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %48, align 8, !dbg !19, !tbaa !33
+  %106 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !20
+  %107 = load i64*, i64** %106, align 8, !dbg !20
+  store i64 %66, i64* %107, align 8, !dbg !20, !tbaa !6
+  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !20
+  store i64 20, i64* %108, align 8, !dbg !20, !tbaa !6
   %109 = getelementptr inbounds i64, i64* %108, i64 1, !dbg !20
-  store i64 20, i64* %109, align 8, !dbg !20, !tbaa !6
-  %110 = getelementptr inbounds i64, i64* %109, i64 1, !dbg !20
-  store i64* %110, i64** %107, align 8, !dbg !20
+  store i64* %109, i64** %106, align 8, !dbg !20
   %send9 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test.2, i64 0), !dbg !20
   ret void
 }
@@ -499,64 +492,64 @@ entry:
 define i64 @func_A.4test(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #6 !dbg !23 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !34
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !68
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !68
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !68
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !68, !prof !69
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !33
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !67
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !67
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !67
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !67, !prof !68
 
 postProcess:                                      ; preds = %sorbet_writeLocal.exit, %exception-continue
-  %"<returnValue>.sroa.0.0" = phi i64 [ %13, %exception-continue ], [ %10, %sorbet_writeLocal.exit ], !dbg !70
+  %"<returnValue>.sroa.0.0" = phi i64 [ %13, %exception-continue ], [ %10, %sorbet_writeLocal.exit ], !dbg !69
   ret i64 %"<returnValue>.sroa.0.0"
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !68
-  unreachable, !dbg !68
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !67
+  unreachable, !dbg !67
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !68
-  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !68
-  %2 = load i64*, i64** %1, align 8, !dbg !68, !tbaa !51
-  %3 = load i64, i64* %2, align 8, !dbg !68, !tbaa !6
-  %4 = and i64 %3, 8, !dbg !68
-  %5 = icmp eq i64 %4, 0, !dbg !68
-  br i1 %5, label %6, label %8, !dbg !68, !prof !64
+  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !67
+  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !67
+  %2 = load i64*, i64** %1, align 8, !dbg !67, !tbaa !50
+  %3 = load i64, i64* %2, align 8, !dbg !67, !tbaa !6
+  %4 = and i64 %3, 8, !dbg !67
+  %5 = icmp eq i64 %4, 0, !dbg !67
+  br i1 %5, label %6, label %8, !dbg !67, !prof !63
 
 6:                                                ; preds = %fillRequiredArgs
-  %7 = getelementptr inbounds i64, i64* %2, i64 -4, !dbg !68
-  store i64 %rawArg_x, i64* %7, align 8, !dbg !68, !tbaa !6
-  br label %sorbet_writeLocal.exit, !dbg !68
+  %7 = getelementptr inbounds i64, i64* %2, i64 -4, !dbg !67
+  store i64 %rawArg_x, i64* %7, align 8, !dbg !67, !tbaa !6
+  br label %sorbet_writeLocal.exit, !dbg !67
 
 8:                                                ; preds = %fillRequiredArgs
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %2, i32 noundef -4, i64 %rawArg_x) #11, !dbg !68
-  br label %sorbet_writeLocal.exit, !dbg !68
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %2, i32 noundef -4, i64 %rawArg_x) #11, !dbg !67
+  br label %sorbet_writeLocal.exit, !dbg !67
 
 sorbet_writeLocal.exit:                           ; preds = %6, %8
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !70, !tbaa !34
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !71, !tbaa !34
-  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !71
-  %10 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %9, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_1", i64** nonnull %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !71
-  %ensureReturnValue = icmp ne i64 %10, 52, !dbg !71
-  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !71
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !69, !tbaa !33
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !70, !tbaa !33
+  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !70
+  %10 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %9, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_1", i64** nonnull %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !70
+  %ensureReturnValue = icmp ne i64 %10, 52, !dbg !70
+  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !70
 
 exception-continue:                               ; preds = %sorbet_writeLocal.exit
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %0, align 8, !tbaa !34
-  %11 = load i64*, i64** %1, align 8, !dbg !72, !tbaa !51
-  %12 = getelementptr inbounds i64, i64* %11, i64 -5, !dbg !72
-  %13 = load i64, i64* %12, align 8, !dbg !72, !tbaa !6
-  br label %postProcess, !dbg !72
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %0, align 8, !tbaa !33
+  %11 = load i64*, i64** %1, align 8, !dbg !71, !tbaa !50
+  %12 = getelementptr inbounds i64, i64* %11, i64 -5, !dbg !71
+  %13 = load i64, i64* %12, align 8, !dbg !71, !tbaa !6
+  br label %postProcess, !dbg !71
 }
 
 ; Function Attrs: ssp
 define internal noundef i64 @"func_A.4test$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* %cfp) #7 !dbg !22 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !46
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !45
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !73
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !34
-  %rubyStr_begin = load i64, i64* @rubyStrFrozen_begin, align 8, !dbg !74
+  %4 = load i64, i64* %3, align 8, !tbaa !72
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !33
+  %rubyStr_begin = load i64, i64* @rubyStrFrozen_begin, align 8, !dbg !73
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !21
   %6 = load i64*, i64** %5, align 8, !dbg !21
   store i64 %4, i64* %6, align 8, !dbg !21, !tbaa !6
@@ -566,7 +559,7 @@ functionEntryInitializers:
   store i64* %8, i64** %5, align 8, !dbg !21
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !21
   %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !21
-  %10 = load i64*, i64** %9, align 8, !dbg !21, !tbaa !51
+  %10 = load i64*, i64** %9, align 8, !dbg !21, !tbaa !50
   %11 = getelementptr inbounds i64, i64* %10, i64 -4, !dbg !21
   %12 = load i64, i64* %11, align 8, !dbg !21, !tbaa !6
   %13 = and i64 %12, -9, !dbg !21
@@ -574,8 +567,8 @@ functionEntryInitializers:
   br i1 %14, label %BB5, label %BB7, !dbg !21
 
 BB5:                                              ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %pc, align 8, !tbaa !34
-  %15 = load i64*, i64** %9, align 8, !dbg !24, !tbaa !51
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %pc, align 8, !tbaa !33
+  %15 = load i64*, i64** %9, align 8, !dbg !24, !tbaa !50
   %16 = getelementptr inbounds i64, i64* %15, i64 -4, !dbg !24
   %17 = load i64, i64* %16, align 8, !dbg !24, !tbaa !6
   %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !24
@@ -586,8 +579,8 @@ BB5:                                              ; preds = %functionEntryInitia
   %21 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !24
   store i64* %21, i64** %18, align 8, !dbg !24
   %send25 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !24
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %pc, align 8, !dbg !24, !tbaa !34
-  %rubyStr_foo = load i64, i64* @rubyStrFrozen_foo, align 8, !dbg !75
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %pc, align 8, !dbg !24, !tbaa !33
+  %rubyStr_foo = load i64, i64* @rubyStrFrozen_foo, align 8, !dbg !74
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !25
   %23 = load i64*, i64** %22, align 8, !dbg !25
   store i64 %4, i64* %23, align 8, !dbg !25, !tbaa !6
@@ -596,11 +589,11 @@ BB5:                                              ; preds = %functionEntryInitia
   %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !25
   store i64* %25, i64** %22, align 8, !dbg !25
   %send27 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_raise, i64 0), !dbg !25
-  %26 = load i64*, i64** %9, align 8, !dbg !25, !tbaa !51
+  %26 = load i64*, i64** %9, align 8, !dbg !25, !tbaa !50
   %27 = load i64, i64* %26, align 8, !dbg !25, !tbaa !6
   %28 = and i64 %27, 8, !dbg !25
   %29 = icmp eq i64 %28, 0, !dbg !25
-  br i1 %29, label %30, label %32, !dbg !25, !prof !64
+  br i1 %29, label %30, label %32, !dbg !25, !prof !63
 
 30:                                               ; preds = %BB5
   %31 = getelementptr inbounds i64, i64* %26, i64 -5, !dbg !25
@@ -612,28 +605,28 @@ BB5:                                              ; preds = %functionEntryInitia
   br label %BB7, !dbg !25
 
 BB7:                                              ; preds = %32, %30, %functionEntryInitializers
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !34
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !33
   ret i64 52
 }
 
 ; Function Attrs: ssp
 define internal noundef i64 @"func_A.4test$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #7 !dbg !27 {
 vm_get_ep.exit34:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !46
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !45
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !73
+  %4 = load i64, i64* %3, align 8, !tbaa !72
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_2", align 8
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #11
-  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
+  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
   %6 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %5, i64 0, i32 2
-  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !46
+  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !45
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !tbaa !34
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !34
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !tbaa !33
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !33
   %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !26
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !26, !tbaa !46
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !26, !tbaa !45
   %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !26
   %13 = load i64*, i64** %12, align 8, !dbg !26
   %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !26
@@ -660,34 +653,34 @@ blockExit:                                        ; preds = %78, %76, %63, %61
   ret i64 52
 
 vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
-  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !76, !tbaa !34
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2, !dbg !76
-  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !dbg !76, !tbaa !46
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4, !dbg !76
-  %31 = load i64*, i64** %30, align 8, !dbg !76
-  %32 = getelementptr inbounds i64, i64* %31, i64 -1, !dbg !76
-  %33 = load i64, i64* %32, align 8, !dbg !76, !tbaa !6
-  %34 = and i64 %33, -4, !dbg !76
-  %35 = inttoptr i64 %34 to i64*, !dbg !76
-  %36 = load i64, i64* %35, align 8, !dbg !76, !tbaa !6
-  %37 = and i64 %36, 8, !dbg !76
-  %38 = icmp eq i64 %37, 0, !dbg !76
-  br i1 %38, label %39, label %41, !dbg !76, !prof !64
+  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !75, !tbaa !33
+  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2, !dbg !75
+  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !dbg !75, !tbaa !45
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4, !dbg !75
+  %31 = load i64*, i64** %30, align 8, !dbg !75
+  %32 = getelementptr inbounds i64, i64* %31, i64 -1, !dbg !75
+  %33 = load i64, i64* %32, align 8, !dbg !75, !tbaa !6
+  %34 = and i64 %33, -4, !dbg !75
+  %35 = inttoptr i64 %34 to i64*, !dbg !75
+  %36 = load i64, i64* %35, align 8, !dbg !75, !tbaa !6
+  %37 = and i64 %36, 8, !dbg !75
+  %38 = icmp eq i64 %37, 0, !dbg !75
+  br i1 %38, label %39, label %41, !dbg !75, !prof !63
 
 39:                                               ; preds = %vm_get_ep.exit32
-  %40 = getelementptr inbounds i64, i64* %35, i64 -3, !dbg !76
-  store i64 8, i64* %40, align 8, !dbg !76, !tbaa !6
-  br label %vm_get_ep.exit30, !dbg !76
+  %40 = getelementptr inbounds i64, i64* %35, i64 -3, !dbg !75
+  store i64 8, i64* %40, align 8, !dbg !75, !tbaa !6
+  br label %vm_get_ep.exit30, !dbg !75
 
 41:                                               ; preds = %vm_get_ep.exit32
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %35, i32 noundef -3, i64 noundef 8) #11, !dbg !76
-  br label %vm_get_ep.exit30, !dbg !76
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %35, i32 noundef -3, i64 noundef 8) #11, !dbg !75
+  br label %vm_get_ep.exit30, !dbg !75
 
 vm_get_ep.exit30:                                 ; preds = %39, %41
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !77, !tbaa !34
-  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !34
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !76, !tbaa !33
+  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !33
   %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !28
-  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !28, !tbaa !46
+  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !28, !tbaa !45
   %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !28
   %46 = load i64*, i64** %45, align 8, !dbg !28
   store i64 %4, i64* %46, align 8, !dbg !28, !tbaa !6
@@ -696,9 +689,9 @@ vm_get_ep.exit30:                                 ; preds = %39, %41
   %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !28
   store i64* %48, i64** %45, align 8, !dbg !28
   %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !28
-  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !34
+  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !33
   %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 2, !dbg !28
-  %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !28, !tbaa !46
+  %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !28, !tbaa !45
   %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 4, !dbg !28
   %53 = load i64*, i64** %52, align 8, !dbg !28
   %54 = getelementptr inbounds i64, i64* %53, i64 -1, !dbg !28
@@ -708,7 +701,7 @@ vm_get_ep.exit30:                                 ; preds = %39, %41
   %58 = load i64, i64* %57, align 8, !dbg !28, !tbaa !6
   %59 = and i64 %58, 8, !dbg !28
   %60 = icmp eq i64 %59, 0, !dbg !28
-  br i1 %60, label %61, label %63, !dbg !28, !prof !64
+  br i1 %60, label %61, label %63, !dbg !28, !prof !63
 
 61:                                               ; preds = %vm_get_ep.exit30
   %62 = getelementptr inbounds i64, i64* %57, i64 -5, !dbg !28
@@ -720,50 +713,50 @@ vm_get_ep.exit30:                                 ; preds = %39, %41
   br label %blockExit, !dbg !28
 
 vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !tbaa !34
-  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !34
-  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2, !dbg !78
-  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !dbg !78, !tbaa !46
-  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %66, i64 0, i32 4, !dbg !78
-  %68 = load i64*, i64** %67, align 8, !dbg !78
-  %69 = getelementptr inbounds i64, i64* %68, i64 -1, !dbg !78
-  %70 = load i64, i64* %69, align 8, !dbg !78, !tbaa !6
-  %71 = and i64 %70, -4, !dbg !78
-  %72 = inttoptr i64 %71 to i64*, !dbg !78
-  %73 = load i64, i64* %72, align 8, !dbg !78, !tbaa !6
-  %74 = and i64 %73, 8, !dbg !78
-  %75 = icmp eq i64 %74, 0, !dbg !78
-  br i1 %75, label %76, label %78, !dbg !78, !prof !64
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !tbaa !33
+  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !77, !tbaa !33
+  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2, !dbg !77
+  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !dbg !77, !tbaa !45
+  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %66, i64 0, i32 4, !dbg !77
+  %68 = load i64*, i64** %67, align 8, !dbg !77
+  %69 = getelementptr inbounds i64, i64* %68, i64 -1, !dbg !77
+  %70 = load i64, i64* %69, align 8, !dbg !77, !tbaa !6
+  %71 = and i64 %70, -4, !dbg !77
+  %72 = inttoptr i64 %71 to i64*, !dbg !77
+  %73 = load i64, i64* %72, align 8, !dbg !77, !tbaa !6
+  %74 = and i64 %73, 8, !dbg !77
+  %75 = icmp eq i64 %74, 0, !dbg !77
+  br i1 %75, label %76, label %78, !dbg !77, !prof !63
 
 76:                                               ; preds = %vm_get_ep.exit
-  %77 = getelementptr inbounds i64, i64* %72, i64 -7, !dbg !78
-  store i64 20, i64* %77, align 8, !dbg !78, !tbaa !6
-  br label %blockExit, !dbg !78
+  %77 = getelementptr inbounds i64, i64* %72, i64 -7, !dbg !77
+  store i64 20, i64* %77, align 8, !dbg !77, !tbaa !6
+  br label %blockExit, !dbg !77
 
 78:                                               ; preds = %vm_get_ep.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %72, i32 noundef -7, i64 noundef 20) #11, !dbg !78
-  br label %blockExit, !dbg !78
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %72, i32 noundef -7, i64 noundef 20) #11, !dbg !77
+  br label %blockExit, !dbg !77
 }
 
 ; Function Attrs: ssp
 define internal noundef i64 @"func_A.4test$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #7 !dbg !32 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !46
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !45
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !73
+  %4 = load i64, i64* %3, align 8, !tbaa !72
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_3", align 8
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #11
-  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
+  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
   %6 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %5, i64 0, i32 2
-  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !46
+  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !45
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !tbaa !34
-  %rubyStr_ensure = load i64, i64* @rubyStrFrozen_ensure, align 8, !dbg !79
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !31, !tbaa !34
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !tbaa !33
+  %rubyStr_ensure = load i64, i64* @rubyStrFrozen_ensure, align 8, !dbg !78
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !31, !tbaa !33
   %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !31
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !31, !tbaa !46
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !31, !tbaa !45
   %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !31
   %13 = load i64*, i64** %12, align 8, !dbg !31
   store i64 %4, i64* %13, align 8, !dbg !31, !tbaa !6
@@ -779,13 +772,13 @@ functionEntryInitializers:
 ; Function Attrs: ssp
 define internal noundef i64 @"func_A.4test$block_4"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* %cfp) #7 !dbg !30 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !34
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !46
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !45
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !73
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !tbaa !34
-  %rubyStr_else = load i64, i64* @rubyStrFrozen_else, align 8, !dbg !80
+  %4 = load i64, i64* %3, align 8, !tbaa !72
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !tbaa !33
+  %rubyStr_else = load i64, i64* @rubyStrFrozen_else, align 8, !dbg !79
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !29
   %6 = load i64*, i64** %5, align 8, !dbg !29
   store i64 %4, i64* %6, align 8, !dbg !29, !tbaa !6
@@ -795,11 +788,11 @@ functionEntryInitializers:
   store i64* %8, i64** %5, align 8, !dbg !29
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !29
   %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !29
-  %10 = load i64*, i64** %9, align 8, !dbg !29, !tbaa !51
+  %10 = load i64*, i64** %9, align 8, !dbg !29, !tbaa !50
   %11 = load i64, i64* %10, align 8, !dbg !29, !tbaa !6
   %12 = and i64 %11, 8, !dbg !29
   %13 = icmp eq i64 %12, 0, !dbg !29
-  br i1 %13, label %14, label %16, !dbg !29, !prof !64
+  br i1 %13, label %14, label %16, !dbg !29, !prof !63
 
 14:                                               ; preds = %functionEntryInitializers
   %15 = getelementptr inbounds i64, i64* %10, i64 -5, !dbg !29
@@ -830,7 +823,7 @@ declare void @llvm.assume(i1 noundef) #9
 define linkonce void @const_recompute_A() local_unnamed_addr #7 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !55
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !54
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -886,51 +879,50 @@ attributes #13 = { noreturn }
 !30 = distinct !DISubprogram(name: "A.test", linkageName: "func_A.4test$block_4", scope: !23, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !31 = !DILocation(line: 18, column: 7, scope: !32)
 !32 = distinct !DISubprogram(name: "A.test", linkageName: "func_A.4test$block_3", scope: !23, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!33 = !DILocation(line: 6, column: 3, scope: !11)
-!34 = !{!35, !35, i64 0}
-!35 = !{!"any pointer", !8, i64 0}
-!36 = !{!37, !7, i64 400}
-!37 = !{!"rb_vm_struct", !7, i64 0, !38, i64 8, !35, i64 192, !35, i64 200, !35, i64 208, !42, i64 216, !8, i64 224, !39, i64 264, !39, i64 280, !39, i64 296, !39, i64 312, !7, i64 328, !41, i64 336, !41, i64 340, !41, i64 344, !41, i64 344, !41, i64 344, !41, i64 344, !41, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !35, i64 456, !35, i64 464, !43, i64 472, !44, i64 992, !35, i64 1016, !35, i64 1024, !41, i64 1032, !41, i64 1036, !39, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !41, i64 1136, !35, i64 1144, !35, i64 1152, !35, i64 1160, !35, i64 1168, !35, i64 1176, !35, i64 1184, !41, i64 1192, !45, i64 1200, !8, i64 1232}
-!38 = !{!"rb_global_vm_lock_struct", !35, i64 0, !8, i64 8, !39, i64 48, !35, i64 64, !41, i64 72, !8, i64 80, !8, i64 128, !41, i64 176, !41, i64 180}
-!39 = !{!"list_head", !40, i64 0}
-!40 = !{!"list_node", !35, i64 0, !35, i64 8}
-!41 = !{!"int", !8, i64 0}
-!42 = !{!"long long", !8, i64 0}
-!43 = !{!"", !8, i64 0}
-!44 = !{!"rb_hook_list_struct", !35, i64 0, !41, i64 8, !41, i64 12, !41, i64 16}
-!45 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!46 = !{!47, !35, i64 16}
-!47 = !{!"rb_execution_context_struct", !35, i64 0, !7, i64 8, !35, i64 16, !35, i64 24, !35, i64 32, !41, i64 40, !41, i64 44, !35, i64 48, !35, i64 56, !35, i64 64, !7, i64 72, !7, i64 80, !35, i64 88, !7, i64 96, !35, i64 104, !35, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !48, i64 152}
-!48 = !{!"", !35, i64 0, !35, i64 8, !7, i64 16, !8, i64 24}
-!49 = !{!50, !35, i64 16}
-!50 = !{!"rb_control_frame_struct", !35, i64 0, !35, i64 8, !35, i64 16, !7, i64 24, !35, i64 32, !35, i64 40, !35, i64 48}
-!51 = !{!50, !35, i64 32}
-!52 = !DILocation(line: 0, scope: !16)
-!53 = !DILocation(line: 5, column: 1, scope: !16)
-!54 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
-!55 = !{!42, !42, i64 0}
-!56 = !{!"branch_weights", i32 1, i32 10000}
-!57 = !{!58, !41, i64 8}
-!58 = !{!"rb_sorbet_param_struct", !59, i64 0, !41, i64 4, !41, i64 8, !41, i64 12, !41, i64 16, !41, i64 20, !41, i64 24, !41, i64 28, !35, i64 32, !41, i64 40, !41, i64 44, !41, i64 48, !41, i64 52, !35, i64 56}
-!59 = !{!"", !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 1, !41, i64 1}
-!60 = !{!58, !41, i64 4}
-!61 = !{!58, !35, i64 32}
-!62 = !{!47, !41, i64 40}
-!63 = !{!47, !41, i64 44}
-!64 = !{!"branch_weights", i32 2000, i32 1}
-!65 = !{!47, !35, i64 56}
-!66 = !DILocation(line: 23, column: 6, scope: !16)
-!67 = !DILocation(line: 26, column: 6, scope: !16)
-!68 = !DILocation(line: 6, column: 3, scope: !23)
-!69 = !{!"branch_weights", i32 4001, i32 4000000}
-!70 = !DILocation(line: 0, scope: !23)
-!71 = !DILocation(line: 8, column: 7, scope: !23)
-!72 = !DILocation(line: 20, column: 3, scope: !23)
-!73 = !{!50, !7, i64 24}
-!74 = !DILocation(line: 8, column: 12, scope: !22)
-!75 = !DILocation(line: 11, column: 15, scope: !22)
-!76 = !DILocation(line: 0, scope: !27)
-!77 = !DILocation(line: 13, column: 5, scope: !27)
-!78 = !DILocation(line: 8, column: 7, scope: !27)
-!79 = !DILocation(line: 18, column: 12, scope: !32)
-!80 = !DILocation(line: 16, column: 12, scope: !30)
+!33 = !{!34, !34, i64 0}
+!34 = !{!"any pointer", !8, i64 0}
+!35 = !{!36, !7, i64 400}
+!36 = !{!"rb_vm_struct", !7, i64 0, !37, i64 8, !34, i64 192, !34, i64 200, !34, i64 208, !41, i64 216, !8, i64 224, !38, i64 264, !38, i64 280, !38, i64 296, !38, i64 312, !7, i64 328, !40, i64 336, !40, i64 340, !40, i64 344, !40, i64 344, !40, i64 344, !40, i64 344, !40, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !34, i64 456, !34, i64 464, !42, i64 472, !43, i64 992, !34, i64 1016, !34, i64 1024, !40, i64 1032, !40, i64 1036, !38, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !40, i64 1136, !34, i64 1144, !34, i64 1152, !34, i64 1160, !34, i64 1168, !34, i64 1176, !34, i64 1184, !40, i64 1192, !44, i64 1200, !8, i64 1232}
+!37 = !{!"rb_global_vm_lock_struct", !34, i64 0, !8, i64 8, !38, i64 48, !34, i64 64, !40, i64 72, !8, i64 80, !8, i64 128, !40, i64 176, !40, i64 180}
+!38 = !{!"list_head", !39, i64 0}
+!39 = !{!"list_node", !34, i64 0, !34, i64 8}
+!40 = !{!"int", !8, i64 0}
+!41 = !{!"long long", !8, i64 0}
+!42 = !{!"", !8, i64 0}
+!43 = !{!"rb_hook_list_struct", !34, i64 0, !40, i64 8, !40, i64 12, !40, i64 16}
+!44 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!45 = !{!46, !34, i64 16}
+!46 = !{!"rb_execution_context_struct", !34, i64 0, !7, i64 8, !34, i64 16, !34, i64 24, !34, i64 32, !40, i64 40, !40, i64 44, !34, i64 48, !34, i64 56, !34, i64 64, !7, i64 72, !7, i64 80, !34, i64 88, !7, i64 96, !34, i64 104, !34, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !47, i64 152}
+!47 = !{!"", !34, i64 0, !34, i64 8, !7, i64 16, !8, i64 24}
+!48 = !{!49, !34, i64 16}
+!49 = !{!"rb_control_frame_struct", !34, i64 0, !34, i64 8, !34, i64 16, !7, i64 24, !34, i64 32, !34, i64 40, !34, i64 48}
+!50 = !{!49, !34, i64 32}
+!51 = !DILocation(line: 0, scope: !16)
+!52 = !DILocation(line: 5, column: 1, scope: !16)
+!53 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
+!54 = !{!41, !41, i64 0}
+!55 = !{!"branch_weights", i32 1, i32 10000}
+!56 = !{!57, !40, i64 8}
+!57 = !{!"rb_sorbet_param_struct", !58, i64 0, !40, i64 4, !40, i64 8, !40, i64 12, !40, i64 16, !40, i64 20, !40, i64 24, !40, i64 28, !34, i64 32, !40, i64 40, !40, i64 44, !40, i64 48, !40, i64 52, !34, i64 56}
+!58 = !{!"", !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 1, !40, i64 1}
+!59 = !{!57, !40, i64 4}
+!60 = !{!57, !34, i64 32}
+!61 = !{!46, !40, i64 40}
+!62 = !{!46, !40, i64 44}
+!63 = !{!"branch_weights", i32 2000, i32 1}
+!64 = !{!46, !34, i64 56}
+!65 = !DILocation(line: 23, column: 6, scope: !16)
+!66 = !DILocation(line: 26, column: 6, scope: !16)
+!67 = !DILocation(line: 6, column: 3, scope: !23)
+!68 = !{!"branch_weights", i32 4001, i32 4000000}
+!69 = !DILocation(line: 0, scope: !23)
+!70 = !DILocation(line: 8, column: 7, scope: !23)
+!71 = !DILocation(line: 20, column: 3, scope: !23)
+!72 = !{!49, !7, i64 24}
+!73 = !DILocation(line: 8, column: 12, scope: !22)
+!74 = !DILocation(line: 11, column: 15, scope: !22)
+!75 = !DILocation(line: 0, scope: !27)
+!76 = !DILocation(line: 13, column: 5, scope: !27)
+!77 = !DILocation(line: 8, column: 7, scope: !27)
+!78 = !DILocation(line: 18, column: 12, scope: !32)
+!79 = !DILocation(line: 16, column: 12, scope: !30)

--- a/test/testdata/compiler/float-intrinsics.llo.exp
+++ b/test/testdata/compiler/float-intrinsics.llo.exp
@@ -157,70 +157,64 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
 @rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
-@ic_keep_def.15 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_keep_def.16 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_keep_def.17 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_plus = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_p = internal unnamed_addr global i64 0, align 8
 @str_p = private unnamed_addr constant [2 x i8] c"p\00", align 1
 @ic_minus = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.18 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.15 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lt = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.19 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lt.20 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.21 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.16 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lt.17 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.18 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lte = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.22 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lte.23 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.24 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lte.25 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.26 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_plus.27 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.28 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.19 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lte.20 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.21 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lte.22 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.23 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_plus.24 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.25 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_8.9 = internal unnamed_addr global i64 0, align 8
 @str_8.9 = private unnamed_addr constant [4 x i8] c"8.9\00", align 1
 @ic_Rational = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_Rational = internal unnamed_addr global i64 0, align 8
 @str_Rational = private unnamed_addr constant [9 x i8] c"Rational\00", align 1
-@ic_plus.29 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.30 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_plus.26 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.27 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_5 = internal unnamed_addr global i64 0, align 8
 @str_5 = private unnamed_addr constant [2 x i8] c"5\00", align 1
 @ic_Complex = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_Complex = internal unnamed_addr global i64 0, align 8
 @str_Complex = private unnamed_addr constant [8 x i8] c"Complex\00", align 1
-@ic_plus.31 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.32 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_minus.33 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.34 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_plus.28 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.29 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_minus.30 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.31 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_15.4 = internal unnamed_addr global i64 0, align 8
 @str_15.4 = private unnamed_addr constant [5 x i8] c"15.4\00", align 1
-@ic_Rational.35 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_minus.36 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.37 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_Rational.32 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_minus.33 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.34 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_18 = internal unnamed_addr global i64 0, align 8
 @str_18 = private unnamed_addr constant [3 x i8] c"18\00", align 1
-@ic_Complex.38 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_minus.39 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.40 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lt.41 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.42 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_Complex.35 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_minus.36 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.37 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lt.38 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.39 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_25.4 = internal unnamed_addr global i64 0, align 8
 @str_25.4 = private unnamed_addr constant [5 x i8] c"25.4\00", align 1
-@ic_Rational.43 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lt.44 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.45 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lte.46 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.47 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_Rational.40 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lt.41 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.42 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lte.43 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.44 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_5.923 = internal unnamed_addr global i64 0, align 8
 @str_5.923 = private unnamed_addr constant [6 x i8] c"5.923\00", align 1
-@ic_Rational.48 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lte.49 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.50 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_Rational.45 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lte.46 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.47 = internal global %struct.FunctionInlineCache zeroinitializer
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
@@ -664,640 +658,640 @@ fastSymCallIntrinsic_ResolvedSig_sig286:          ; preds = %fastSymCallIntrinsi
   %44 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %43, i32 noundef 0) #15, !dbg !65
   br label %fastSymCallIntrinsic_ResolvedSig_sig305, !dbg !65
 
-fastSymCallIntrinsic_ResolvedSig_sig305:          ; preds = %fastSymCallIntrinsic_ResolvedSig_sig286, %41
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %8, align 8, !dbg !65, !tbaa !14
-  %rubyId_lte = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !66
-  %rawSym299 = tail call i64 @rb_id2sym(i64 %rubyId_lte), !dbg !66
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym299, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_4"), !dbg !66
-  %45 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !14
-  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 5, !dbg !66
-  %47 = load i32, i32* %46, align 8, !dbg !66, !tbaa !27
-  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 6, !dbg !66
-  %49 = load i32, i32* %48, align 4, !dbg !66, !tbaa !31
-  %50 = xor i32 %49, -1, !dbg !66
-  %51 = and i32 %50, %47, !dbg !66
-  %52 = icmp eq i32 %51, 0, !dbg !66
-  br i1 %52, label %fastSymCallIntrinsic_Static_keep_def, label %53, !dbg !66, !prof !21
-
-53:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig305
-  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 8, !dbg !66
-  %55 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %54, align 8, !dbg !66, !tbaa !32
-  %56 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %55, i32 noundef 0) #15, !dbg !66
-  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !66
-
-fastSymCallIntrinsic_Static_keep_def:             ; preds = %fastSymCallIntrinsic_ResolvedSig_sig305, %53
+afterSend302:                                     ; preds = %368, %fastSymCallIntrinsic_ResolvedSig_sig305
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !66, !tbaa !14
-  %57 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !67
-  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !68
-  %needTakeSlowPath = icmp ne i64 %57, %58, !dbg !67
-  br i1 %needTakeSlowPath, label %59, label %60, !dbg !67, !prof !70
+  %45 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !67
+  %46 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !68
+  %needTakeSlowPath = icmp ne i64 %45, %46, !dbg !67
+  br i1 %needTakeSlowPath, label %47, label %48, !dbg !67, !prof !70
 
-59:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
+47:                                               ; preds = %afterSend302
   tail call void @"const_recompute_T::Sig"(), !dbg !67
-  br label %60, !dbg !67
+  br label %48, !dbg !67
 
-60:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def, %59
-  %61 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !67
-  %62 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !67
-  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !68
-  %guardUpdated = icmp eq i64 %62, %63, !dbg !67
+48:                                               ; preds = %afterSend302, %47
+  %49 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !67
+  %50 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !67
+  %51 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !68
+  %guardUpdated = icmp eq i64 %50, %51, !dbg !67
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !67
-  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !67
-  %65 = load i64*, i64** %64, align 8, !dbg !67
-  store i64 %selfRaw, i64* %65, align 8, !dbg !67, !tbaa !6
-  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !67
-  store i64 %61, i64* %66, align 8, !dbg !67, !tbaa !6
-  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !67
-  store i64* %67, i64** %64, align 8, !dbg !67
+  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !67
+  %53 = load i64*, i64** %52, align 8, !dbg !67
+  store i64 %selfRaw, i64* %53, align 8, !dbg !67, !tbaa !6
+  %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !67
+  store i64 %49, i64* %54, align 8, !dbg !67, !tbaa !6
+  %55 = getelementptr inbounds i64, i64* %54, i64 1, !dbg !67
+  store i64* %55, i64** %52, align 8, !dbg !67
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !67
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !67, !tbaa !14
   %rubyId_plus321 = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !71
   %rawSym322 = tail call i64 @rb_id2sym(i64 %rubyId_plus321), !dbg !71
   %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !71
   %rawSym323 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !71
-  %68 = load i64, i64* @rb_cObject, align 8, !dbg !71
+  %56 = load i64, i64* @rb_cObject, align 8, !dbg !71
   %stackFrame327 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8, !dbg !71
-  %69 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !71
-  %70 = bitcast i8* %69 to i16*, !dbg !71
-  %71 = load i16, i16* %70, align 8, !dbg !71
-  %72 = and i16 %71, -384, !dbg !71
-  %73 = or i16 %72, 1, !dbg !71
-  store i16 %73, i16* %70, align 8, !dbg !71
-  %74 = getelementptr inbounds i8, i8* %69, i64 8, !dbg !71
-  %75 = bitcast i8* %74 to i32*, !dbg !71
-  store i32 2, i32* %75, align 8, !dbg !71, !tbaa !72
-  %76 = getelementptr inbounds i8, i8* %69, i64 12, !dbg !71
-  %77 = bitcast i8* %76 to i32*, !dbg !71
-  %78 = getelementptr inbounds i8, i8* %69, i64 4, !dbg !71
-  %79 = bitcast i8* %78 to i32*, !dbg !71
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 20, i1 false), !dbg !71
-  store i32 2, i32* %79, align 4, !dbg !71, !tbaa !75
+  %57 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !71
+  %58 = bitcast i8* %57 to i16*, !dbg !71
+  %59 = load i16, i16* %58, align 8, !dbg !71
+  %60 = and i16 %59, -384, !dbg !71
+  %61 = or i16 %60, 1, !dbg !71
+  store i16 %61, i16* %58, align 8, !dbg !71
+  %62 = getelementptr inbounds i8, i8* %57, i64 8, !dbg !71
+  %63 = bitcast i8* %62 to i32*, !dbg !71
+  store i32 2, i32* %63, align 8, !dbg !71, !tbaa !72
+  %64 = getelementptr inbounds i8, i8* %57, i64 12, !dbg !71
+  %65 = bitcast i8* %64 to i32*, !dbg !71
+  %66 = getelementptr inbounds i8, i8* %57, i64 4, !dbg !71
+  %67 = bitcast i8* %66 to i32*, !dbg !71
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %64, i8 0, i64 20, i1 false), !dbg !71
+  store i32 2, i32* %67, align 4, !dbg !71, !tbaa !75
   %positional_table = alloca i64, i32 2, align 8, !dbg !71
   %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !71
   store i64 %rubyId_x, i64* %positional_table, align 8, !dbg !71
   %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !71
-  %80 = getelementptr i64, i64* %positional_table, i32 1, !dbg !71
-  store i64 %rubyId_y, i64* %80, align 8, !dbg !71
-  %81 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !71
-  %82 = bitcast i64* %positional_table to i8*, !dbg !71
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %81, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %82, i64 noundef 16, i1 noundef false) #15, !dbg !71
-  %83 = getelementptr inbounds i8, i8* %69, i64 32, !dbg !71
-  %84 = bitcast i8* %83 to i8**, !dbg !71
-  store i8* %81, i8** %84, align 8, !dbg !71, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#4plus", i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame327, i1 noundef zeroext false) #15, !dbg !71
-  %85 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !71, !tbaa !14
-  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 5, !dbg !71
-  %87 = load i32, i32* %86, align 8, !dbg !71, !tbaa !27
-  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 6, !dbg !71
-  %89 = load i32, i32* %88, align 4, !dbg !71, !tbaa !31
-  %90 = xor i32 %89, -1, !dbg !71
-  %91 = and i32 %90, %87, !dbg !71
-  %92 = icmp eq i32 %91, 0, !dbg !71
-  br i1 %92, label %fastSymCallIntrinsic_Static_keep_def341, label %93, !dbg !71, !prof !21
+  %68 = getelementptr i64, i64* %positional_table, i32 1, !dbg !71
+  store i64 %rubyId_y, i64* %68, align 8, !dbg !71
+  %69 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !71
+  %70 = bitcast i64* %positional_table to i8*, !dbg !71
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %69, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %70, i64 noundef 16, i1 noundef false) #15, !dbg !71
+  %71 = getelementptr inbounds i8, i8* %57, i64 32, !dbg !71
+  %72 = bitcast i8* %71 to i8**, !dbg !71
+  store i8* %69, i8** %72, align 8, !dbg !71, !tbaa !76
+  tail call void @sorbet_vm_define_method(i64 %56, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#4plus", i8* nonnull %57, %struct.rb_iseq_struct* %stackFrame327, i1 noundef zeroext false) #15, !dbg !71
+  %73 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !71, !tbaa !14
+  %74 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %73, i64 0, i32 5, !dbg !71
+  %75 = load i32, i32* %74, align 8, !dbg !71, !tbaa !27
+  %76 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %73, i64 0, i32 6, !dbg !71
+  %77 = load i32, i32* %76, align 4, !dbg !71, !tbaa !31
+  %78 = xor i32 %77, -1, !dbg !71
+  %79 = and i32 %78, %75, !dbg !71
+  %80 = icmp eq i32 %79, 0, !dbg !71
+  br i1 %80, label %rb_vm_check_ints.exit5, label %81, !dbg !71, !prof !21
 
-93:                                               ; preds = %60
-  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 8, !dbg !71
-  %95 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %94, align 8, !dbg !71, !tbaa !32
-  %96 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %95, i32 noundef 0) #15, !dbg !71
-  br label %fastSymCallIntrinsic_Static_keep_def341, !dbg !71
+81:                                               ; preds = %48
+  %82 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %73, i64 0, i32 8, !dbg !71
+  %83 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %82, align 8, !dbg !71, !tbaa !32
+  %84 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %83, i32 noundef 0) #15, !dbg !71
+  br label %rb_vm_check_ints.exit5, !dbg !71
 
-fastSymCallIntrinsic_Static_keep_def341:          ; preds = %60, %93
+rb_vm_check_ints.exit5:                           ; preds = %48, %81
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !71, !tbaa !14
-  %rubyId_minus332 = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !77
-  %rawSym333 = tail call i64 @rb_id2sym(i64 %rubyId_minus332), !dbg !77
-  %rubyId_normal334 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !77
-  %rawSym335 = tail call i64 @rb_id2sym(i64 %rubyId_normal334), !dbg !77
-  %stackFrame342 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8, !dbg !77
-  %97 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !77
-  %98 = bitcast i8* %97 to i16*, !dbg !77
-  %99 = load i16, i16* %98, align 8, !dbg !77
-  %100 = and i16 %99, -384, !dbg !77
-  %101 = or i16 %100, 1, !dbg !77
-  store i16 %101, i16* %98, align 8, !dbg !77
-  %102 = getelementptr inbounds i8, i8* %97, i64 8, !dbg !77
-  %103 = bitcast i8* %102 to i32*, !dbg !77
-  store i32 2, i32* %103, align 8, !dbg !77, !tbaa !72
-  %104 = getelementptr inbounds i8, i8* %97, i64 12, !dbg !77
-  %105 = bitcast i8* %104 to i32*, !dbg !77
-  %106 = getelementptr inbounds i8, i8* %97, i64 4, !dbg !77
-  %107 = bitcast i8* %106 to i32*, !dbg !77
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %104, i8 0, i64 20, i1 false), !dbg !77
-  store i32 2, i32* %107, align 4, !dbg !77, !tbaa !75
-  %positional_table344 = alloca i64, i32 2, align 8, !dbg !77
-  %rubyId_x345 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !77
-  store i64 %rubyId_x345, i64* %positional_table344, align 8, !dbg !77
-  %rubyId_y346 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !77
-  %108 = getelementptr i64, i64* %positional_table344, i32 1, !dbg !77
-  store i64 %rubyId_y346, i64* %108, align 8, !dbg !77
-  %109 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !77
-  %110 = bitcast i64* %positional_table344 to i8*, !dbg !77
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %109, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %110, i64 noundef 16, i1 noundef false) #15, !dbg !77
-  %111 = getelementptr inbounds i8, i8* %97, i64 32, !dbg !77
-  %112 = bitcast i8* %111 to i8**, !dbg !77
-  store i8* %109, i8** %112, align 8, !dbg !77, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#5minus", i8* nonnull %97, %struct.rb_iseq_struct* %stackFrame342, i1 noundef zeroext false) #15, !dbg !77
-  %113 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !77, !tbaa !14
-  %114 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 5, !dbg !77
-  %115 = load i32, i32* %114, align 8, !dbg !77, !tbaa !27
-  %116 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 6, !dbg !77
-  %117 = load i32, i32* %116, align 4, !dbg !77, !tbaa !31
-  %118 = xor i32 %117, -1, !dbg !77
-  %119 = and i32 %118, %115, !dbg !77
-  %120 = icmp eq i32 %119, 0, !dbg !77
-  br i1 %120, label %fastSymCallIntrinsic_Static_keep_def360, label %121, !dbg !77, !prof !21
+  %rubyId_minus329 = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !77
+  %rawSym330 = tail call i64 @rb_id2sym(i64 %rubyId_minus329), !dbg !77
+  %rubyId_normal331 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !77
+  %rawSym332 = tail call i64 @rb_id2sym(i64 %rubyId_normal331), !dbg !77
+  %stackFrame337 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8, !dbg !77
+  %85 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !77
+  %86 = bitcast i8* %85 to i16*, !dbg !77
+  %87 = load i16, i16* %86, align 8, !dbg !77
+  %88 = and i16 %87, -384, !dbg !77
+  %89 = or i16 %88, 1, !dbg !77
+  store i16 %89, i16* %86, align 8, !dbg !77
+  %90 = getelementptr inbounds i8, i8* %85, i64 8, !dbg !77
+  %91 = bitcast i8* %90 to i32*, !dbg !77
+  store i32 2, i32* %91, align 8, !dbg !77, !tbaa !72
+  %92 = getelementptr inbounds i8, i8* %85, i64 12, !dbg !77
+  %93 = bitcast i8* %92 to i32*, !dbg !77
+  %94 = getelementptr inbounds i8, i8* %85, i64 4, !dbg !77
+  %95 = bitcast i8* %94 to i32*, !dbg !77
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %92, i8 0, i64 20, i1 false), !dbg !77
+  store i32 2, i32* %95, align 4, !dbg !77, !tbaa !75
+  %positional_table339 = alloca i64, i32 2, align 8, !dbg !77
+  %rubyId_x340 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !77
+  store i64 %rubyId_x340, i64* %positional_table339, align 8, !dbg !77
+  %rubyId_y341 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !77
+  %96 = getelementptr i64, i64* %positional_table339, i32 1, !dbg !77
+  store i64 %rubyId_y341, i64* %96, align 8, !dbg !77
+  %97 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !77
+  %98 = bitcast i64* %positional_table339 to i8*, !dbg !77
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %97, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %98, i64 noundef 16, i1 noundef false) #15, !dbg !77
+  %99 = getelementptr inbounds i8, i8* %85, i64 32, !dbg !77
+  %100 = bitcast i8* %99 to i8**, !dbg !77
+  store i8* %97, i8** %100, align 8, !dbg !77, !tbaa !76
+  tail call void @sorbet_vm_define_method(i64 %56, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#5minus", i8* nonnull %85, %struct.rb_iseq_struct* %stackFrame337, i1 noundef zeroext false) #15, !dbg !77
+  %101 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !77, !tbaa !14
+  %102 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 5, !dbg !77
+  %103 = load i32, i32* %102, align 8, !dbg !77, !tbaa !27
+  %104 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 6, !dbg !77
+  %105 = load i32, i32* %104, align 4, !dbg !77, !tbaa !31
+  %106 = xor i32 %105, -1, !dbg !77
+  %107 = and i32 %106, %103, !dbg !77
+  %108 = icmp eq i32 %107, 0, !dbg !77
+  br i1 %108, label %rb_vm_check_ints.exit3, label %109, !dbg !77, !prof !21
 
-121:                                              ; preds = %fastSymCallIntrinsic_Static_keep_def341
-  %122 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 8, !dbg !77
-  %123 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %122, align 8, !dbg !77, !tbaa !32
-  %124 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %123, i32 noundef 0) #15, !dbg !77
-  br label %fastSymCallIntrinsic_Static_keep_def360, !dbg !77
+109:                                              ; preds = %rb_vm_check_ints.exit5
+  %110 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 8, !dbg !77
+  %111 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %110, align 8, !dbg !77, !tbaa !32
+  %112 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %111, i32 noundef 0) #15, !dbg !77
+  br label %rb_vm_check_ints.exit3, !dbg !77
 
-fastSymCallIntrinsic_Static_keep_def360:          ; preds = %fastSymCallIntrinsic_Static_keep_def341, %121
+rb_vm_check_ints.exit3:                           ; preds = %rb_vm_check_ints.exit5, %109
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !dbg !77, !tbaa !14
-  %rubyId_lt351 = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !78
-  %rawSym352 = tail call i64 @rb_id2sym(i64 %rubyId_lt351), !dbg !78
-  %rubyId_normal353 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !78
-  %rawSym354 = tail call i64 @rb_id2sym(i64 %rubyId_normal353), !dbg !78
-  %stackFrame361 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8, !dbg !78
-  %125 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !78
-  %126 = bitcast i8* %125 to i16*, !dbg !78
-  %127 = load i16, i16* %126, align 8, !dbg !78
-  %128 = and i16 %127, -384, !dbg !78
-  %129 = or i16 %128, 1, !dbg !78
-  store i16 %129, i16* %126, align 8, !dbg !78
-  %130 = getelementptr inbounds i8, i8* %125, i64 8, !dbg !78
-  %131 = bitcast i8* %130 to i32*, !dbg !78
-  store i32 2, i32* %131, align 8, !dbg !78, !tbaa !72
-  %132 = getelementptr inbounds i8, i8* %125, i64 12, !dbg !78
-  %133 = bitcast i8* %132 to i32*, !dbg !78
-  %134 = getelementptr inbounds i8, i8* %125, i64 4, !dbg !78
-  %135 = bitcast i8* %134 to i32*, !dbg !78
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %132, i8 0, i64 20, i1 false), !dbg !78
-  store i32 2, i32* %135, align 4, !dbg !78, !tbaa !75
-  %positional_table363 = alloca i64, i32 2, align 8, !dbg !78
-  %rubyId_x364 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !78
-  store i64 %rubyId_x364, i64* %positional_table363, align 8, !dbg !78
-  %rubyId_y365 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !78
-  %136 = getelementptr i64, i64* %positional_table363, i32 1, !dbg !78
-  store i64 %rubyId_y365, i64* %136, align 8, !dbg !78
-  %137 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !78
-  %138 = bitcast i64* %positional_table363 to i8*, !dbg !78
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %137, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %138, i64 noundef 16, i1 noundef false) #15, !dbg !78
-  %139 = getelementptr inbounds i8, i8* %125, i64 32, !dbg !78
-  %140 = bitcast i8* %139 to i8**, !dbg !78
-  store i8* %137, i8** %140, align 8, !dbg !78, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#2lt", i8* nonnull %125, %struct.rb_iseq_struct* %stackFrame361, i1 noundef zeroext false) #15, !dbg !78
-  %141 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !14
-  %142 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 5, !dbg !78
-  %143 = load i32, i32* %142, align 8, !dbg !78, !tbaa !27
-  %144 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 6, !dbg !78
-  %145 = load i32, i32* %144, align 4, !dbg !78, !tbaa !31
-  %146 = xor i32 %145, -1, !dbg !78
-  %147 = and i32 %146, %143, !dbg !78
-  %148 = icmp eq i32 %147, 0, !dbg !78
-  br i1 %148, label %fastSymCallIntrinsic_Static_keep_def379, label %149, !dbg !78, !prof !21
+  %rubyId_lt343 = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !78
+  %rawSym344 = tail call i64 @rb_id2sym(i64 %rubyId_lt343), !dbg !78
+  %rubyId_normal345 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !78
+  %rawSym346 = tail call i64 @rb_id2sym(i64 %rubyId_normal345), !dbg !78
+  %stackFrame351 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8, !dbg !78
+  %113 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !78
+  %114 = bitcast i8* %113 to i16*, !dbg !78
+  %115 = load i16, i16* %114, align 8, !dbg !78
+  %116 = and i16 %115, -384, !dbg !78
+  %117 = or i16 %116, 1, !dbg !78
+  store i16 %117, i16* %114, align 8, !dbg !78
+  %118 = getelementptr inbounds i8, i8* %113, i64 8, !dbg !78
+  %119 = bitcast i8* %118 to i32*, !dbg !78
+  store i32 2, i32* %119, align 8, !dbg !78, !tbaa !72
+  %120 = getelementptr inbounds i8, i8* %113, i64 12, !dbg !78
+  %121 = bitcast i8* %120 to i32*, !dbg !78
+  %122 = getelementptr inbounds i8, i8* %113, i64 4, !dbg !78
+  %123 = bitcast i8* %122 to i32*, !dbg !78
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %120, i8 0, i64 20, i1 false), !dbg !78
+  store i32 2, i32* %123, align 4, !dbg !78, !tbaa !75
+  %positional_table353 = alloca i64, i32 2, align 8, !dbg !78
+  %rubyId_x354 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !78
+  store i64 %rubyId_x354, i64* %positional_table353, align 8, !dbg !78
+  %rubyId_y355 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !78
+  %124 = getelementptr i64, i64* %positional_table353, i32 1, !dbg !78
+  store i64 %rubyId_y355, i64* %124, align 8, !dbg !78
+  %125 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !78
+  %126 = bitcast i64* %positional_table353 to i8*, !dbg !78
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %125, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %126, i64 noundef 16, i1 noundef false) #15, !dbg !78
+  %127 = getelementptr inbounds i8, i8* %113, i64 32, !dbg !78
+  %128 = bitcast i8* %127 to i8**, !dbg !78
+  store i8* %125, i8** %128, align 8, !dbg !78, !tbaa !76
+  tail call void @sorbet_vm_define_method(i64 %56, i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#2lt", i8* nonnull %113, %struct.rb_iseq_struct* %stackFrame351, i1 noundef zeroext false) #15, !dbg !78
+  %129 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !14
+  %130 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %129, i64 0, i32 5, !dbg !78
+  %131 = load i32, i32* %130, align 8, !dbg !78, !tbaa !27
+  %132 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %129, i64 0, i32 6, !dbg !78
+  %133 = load i32, i32* %132, align 4, !dbg !78, !tbaa !31
+  %134 = xor i32 %133, -1, !dbg !78
+  %135 = and i32 %134, %131, !dbg !78
+  %136 = icmp eq i32 %135, 0, !dbg !78
+  br i1 %136, label %rb_vm_check_ints.exit2, label %137, !dbg !78, !prof !21
 
-149:                                              ; preds = %fastSymCallIntrinsic_Static_keep_def360
-  %150 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 8, !dbg !78
-  %151 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %150, align 8, !dbg !78, !tbaa !32
-  %152 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %151, i32 noundef 0) #15, !dbg !78
-  br label %fastSymCallIntrinsic_Static_keep_def379, !dbg !78
+137:                                              ; preds = %rb_vm_check_ints.exit3
+  %138 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %129, i64 0, i32 8, !dbg !78
+  %139 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %138, align 8, !dbg !78, !tbaa !32
+  %140 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %139, i32 noundef 0) #15, !dbg !78
+  br label %rb_vm_check_ints.exit2, !dbg !78
 
-afterSend376:                                     ; preds = %368, %fastSymCallIntrinsic_Static_keep_def379
+rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.exit3, %137
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %8, align 8, !dbg !78, !tbaa !14
+  %rubyId_lte357 = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !79
+  %rawSym358 = tail call i64 @rb_id2sym(i64 %rubyId_lte357), !dbg !79
+  %rubyId_normal359 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !79
+  %rawSym360 = tail call i64 @rb_id2sym(i64 %rubyId_normal359), !dbg !79
+  %stackFrame365 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8, !dbg !79
+  %141 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !79
+  %142 = bitcast i8* %141 to i16*, !dbg !79
+  %143 = load i16, i16* %142, align 8, !dbg !79
+  %144 = and i16 %143, -384, !dbg !79
+  %145 = or i16 %144, 1, !dbg !79
+  store i16 %145, i16* %142, align 8, !dbg !79
+  %146 = getelementptr inbounds i8, i8* %141, i64 8, !dbg !79
+  %147 = bitcast i8* %146 to i32*, !dbg !79
+  store i32 2, i32* %147, align 8, !dbg !79, !tbaa !72
+  %148 = getelementptr inbounds i8, i8* %141, i64 12, !dbg !79
+  %149 = bitcast i8* %148 to i32*, !dbg !79
+  %150 = getelementptr inbounds i8, i8* %141, i64 4, !dbg !79
+  %151 = bitcast i8* %150 to i32*, !dbg !79
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %148, i8 0, i64 20, i1 false), !dbg !79
+  store i32 2, i32* %151, align 4, !dbg !79, !tbaa !75
+  %positional_table367 = alloca i64, i32 2, align 8, !dbg !79
+  %rubyId_x368 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !79
+  store i64 %rubyId_x368, i64* %positional_table367, align 8, !dbg !79
+  %rubyId_y369 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !79
+  %152 = getelementptr i64, i64* %positional_table367, i32 1, !dbg !79
+  store i64 %rubyId_y369, i64* %152, align 8, !dbg !79
+  %153 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !79
+  %154 = bitcast i64* %positional_table367 to i8*, !dbg !79
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %153, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %154, i64 noundef 16, i1 noundef false) #15, !dbg !79
+  %155 = getelementptr inbounds i8, i8* %141, i64 32, !dbg !79
+  %156 = bitcast i8* %155 to i8**, !dbg !79
+  store i8* %153, i8** %156, align 8, !dbg !79, !tbaa !76
+  tail call void @sorbet_vm_define_method(i64 %56, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#3lte", i8* nonnull %141, %struct.rb_iseq_struct* %stackFrame365, i1 noundef zeroext false) #15, !dbg !79
+  %157 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !79, !tbaa !14
+  %158 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %157, i64 0, i32 5, !dbg !79
+  %159 = load i32, i32* %158, align 8, !dbg !79, !tbaa !27
+  %160 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %157, i64 0, i32 6, !dbg !79
+  %161 = load i32, i32* %160, align 4, !dbg !79, !tbaa !31
+  %162 = xor i32 %161, -1, !dbg !79
+  %163 = and i32 %162, %159, !dbg !79
+  %164 = icmp eq i32 %163, 0, !dbg !79
+  br i1 %164, label %rb_vm_check_ints.exit1, label %165, !dbg !79, !prof !21
+
+165:                                              ; preds = %rb_vm_check_ints.exit2
+  %166 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %157, i64 0, i32 8, !dbg !79
+  %167 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %166, align 8, !dbg !79, !tbaa !32
+  %168 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %167, i32 noundef 0) #15, !dbg !79
+  br label %rb_vm_check_ints.exit1, !dbg !79
+
+rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.exit2, %165
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %8, align 8, !dbg !79, !tbaa !14
-  %153 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !80
-  %154 = load i64*, i64** %153, align 8, !dbg !80
-  store i64 %selfRaw, i64* %154, align 8, !dbg !80, !tbaa !6
-  %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !80
-  %156 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !80
-  %157 = bitcast i64* %155 to <2 x i64>*, !dbg !80
-  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %157, align 8, !dbg !80, !tbaa !6
-  %158 = getelementptr inbounds i64, i64* %156, i64 1, !dbg !80
-  store i64* %158, i64** %153, align 8, !dbg !80
+  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !80
+  %170 = load i64*, i64** %169, align 8, !dbg !80
+  store i64 %selfRaw, i64* %170, align 8, !dbg !80, !tbaa !6
+  %171 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !80
+  %172 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !80
+  %173 = bitcast i64* %171 to <2 x i64>*, !dbg !80
+  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %173, align 8, !dbg !80, !tbaa !6
+  %174 = getelementptr inbounds i64, i64* %172, i64 1, !dbg !80
+  store i64* %174, i64** %169, align 8, !dbg !80
   %send9 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus, i64 0), !dbg !80
-  %159 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !81
-  %160 = load i64*, i64** %159, align 8, !dbg !81
-  store i64 %selfRaw, i64* %160, align 8, !dbg !81, !tbaa !6
-  %161 = getelementptr inbounds i64, i64* %160, i64 1, !dbg !81
-  store i64 %send9, i64* %161, align 8, !dbg !81, !tbaa !6
-  %162 = getelementptr inbounds i64, i64* %161, i64 1, !dbg !81
-  store i64* %162, i64** %159, align 8, !dbg !81
+  %175 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !81
+  %176 = load i64*, i64** %175, align 8, !dbg !81
+  store i64 %selfRaw, i64* %176, align 8, !dbg !81, !tbaa !6
+  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !81
+  store i64 %send9, i64* %177, align 8, !dbg !81, !tbaa !6
+  %178 = getelementptr inbounds i64, i64* %177, i64 1, !dbg !81
+  store i64* %178, i64** %175, align 8, !dbg !81
   %send11 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !81
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %8, align 8, !dbg !81, !tbaa !14
-  %163 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !82
-  %164 = load i64*, i64** %163, align 8, !dbg !82
-  store i64 %selfRaw, i64* %164, align 8, !dbg !82, !tbaa !6
-  %165 = getelementptr inbounds i64, i64* %164, i64 1, !dbg !82
-  %166 = getelementptr inbounds i64, i64* %165, i64 1, !dbg !82
-  %167 = bitcast i64* %165 to <2 x i64>*, !dbg !82
-  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %167, align 8, !dbg !82, !tbaa !6
-  %168 = getelementptr inbounds i64, i64* %166, i64 1, !dbg !82
-  store i64* %168, i64** %163, align 8, !dbg !82
+  %179 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !82
+  %180 = load i64*, i64** %179, align 8, !dbg !82
+  store i64 %selfRaw, i64* %180, align 8, !dbg !82, !tbaa !6
+  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !82
+  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !82
+  %183 = bitcast i64* %181 to <2 x i64>*, !dbg !82
+  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %183, align 8, !dbg !82, !tbaa !6
+  %184 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !82
+  store i64* %184, i64** %179, align 8, !dbg !82
   %send13 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus, i64 0), !dbg !82
-  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !83
-  %170 = load i64*, i64** %169, align 8, !dbg !83
-  store i64 %selfRaw, i64* %170, align 8, !dbg !83, !tbaa !6
-  %171 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !83
-  store i64 %send13, i64* %171, align 8, !dbg !83, !tbaa !6
-  %172 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !83
-  store i64* %172, i64** %169, align 8, !dbg !83
-  %send15 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.18, i64 0), !dbg !83
+  %185 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !83
+  %186 = load i64*, i64** %185, align 8, !dbg !83
+  store i64 %selfRaw, i64* %186, align 8, !dbg !83, !tbaa !6
+  %187 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !83
+  store i64 %send13, i64* %187, align 8, !dbg !83, !tbaa !6
+  %188 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !83
+  store i64* %188, i64** %185, align 8, !dbg !83
+  %send15 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.15, i64 0), !dbg !83
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %8, align 8, !dbg !83, !tbaa !14
-  %173 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !84
-  %174 = load i64*, i64** %173, align 8, !dbg !84
-  store i64 %selfRaw, i64* %174, align 8, !dbg !84, !tbaa !6
-  %175 = getelementptr inbounds i64, i64* %174, i64 1, !dbg !84
-  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !84
-  %177 = bitcast i64* %175 to <2 x i64>*, !dbg !84
-  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %177, align 8, !dbg !84, !tbaa !6
-  %178 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !84
-  store i64* %178, i64** %173, align 8, !dbg !84
+  %189 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !84
+  %190 = load i64*, i64** %189, align 8, !dbg !84
+  store i64 %selfRaw, i64* %190, align 8, !dbg !84, !tbaa !6
+  %191 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !84
+  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !84
+  %193 = bitcast i64* %191 to <2 x i64>*, !dbg !84
+  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %193, align 8, !dbg !84, !tbaa !6
+  %194 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !84
+  store i64* %194, i64** %189, align 8, !dbg !84
   %send17 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt, i64 0), !dbg !84
-  %179 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !85
-  %180 = load i64*, i64** %179, align 8, !dbg !85
-  store i64 %selfRaw, i64* %180, align 8, !dbg !85, !tbaa !6
-  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !85
-  store i64 %send17, i64* %181, align 8, !dbg !85, !tbaa !6
-  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !85
-  store i64* %182, i64** %179, align 8, !dbg !85
-  %send19 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.19, i64 0), !dbg !85
+  %195 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !85
+  %196 = load i64*, i64** %195, align 8, !dbg !85
+  store i64 %selfRaw, i64* %196, align 8, !dbg !85, !tbaa !6
+  %197 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !85
+  store i64 %send17, i64* %197, align 8, !dbg !85, !tbaa !6
+  %198 = getelementptr inbounds i64, i64* %197, i64 1, !dbg !85
+  store i64* %198, i64** %195, align 8, !dbg !85
+  %send19 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.16, i64 0), !dbg !85
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %8, align 8, !dbg !85, !tbaa !14
-  %183 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !86
-  %184 = load i64*, i64** %183, align 8, !dbg !86
-  store i64 %selfRaw, i64* %184, align 8, !dbg !86, !tbaa !6
-  %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !86
-  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !86
-  %187 = bitcast i64* %185 to <2 x i64>*, !dbg !86
-  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %187, align 8, !dbg !86, !tbaa !6
-  %188 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !86
-  store i64* %188, i64** %183, align 8, !dbg !86
-  %send21 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.20, i64 0), !dbg !86
-  %189 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !87
-  %190 = load i64*, i64** %189, align 8, !dbg !87
-  store i64 %selfRaw, i64* %190, align 8, !dbg !87, !tbaa !6
-  %191 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !87
-  store i64 %send21, i64* %191, align 8, !dbg !87, !tbaa !6
-  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !87
-  store i64* %192, i64** %189, align 8, !dbg !87
-  %send23 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.21, i64 0), !dbg !87
+  %199 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !86
+  %200 = load i64*, i64** %199, align 8, !dbg !86
+  store i64 %selfRaw, i64* %200, align 8, !dbg !86, !tbaa !6
+  %201 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !86
+  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !86
+  %203 = bitcast i64* %201 to <2 x i64>*, !dbg !86
+  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %203, align 8, !dbg !86, !tbaa !6
+  %204 = getelementptr inbounds i64, i64* %202, i64 1, !dbg !86
+  store i64* %204, i64** %199, align 8, !dbg !86
+  %send21 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.17, i64 0), !dbg !86
+  %205 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !87
+  %206 = load i64*, i64** %205, align 8, !dbg !87
+  store i64 %selfRaw, i64* %206, align 8, !dbg !87, !tbaa !6
+  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !87
+  store i64 %send21, i64* %207, align 8, !dbg !87, !tbaa !6
+  %208 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !87
+  store i64* %208, i64** %205, align 8, !dbg !87
+  %send23 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.18, i64 0), !dbg !87
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 31), i64** %8, align 8, !dbg !87, !tbaa !14
-  %193 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !88
-  %194 = load i64*, i64** %193, align 8, !dbg !88
-  store i64 %selfRaw, i64* %194, align 8, !dbg !88, !tbaa !6
-  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !88
-  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !88
-  %197 = bitcast i64* %195 to <2 x i64>*, !dbg !88
-  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %197, align 8, !dbg !88, !tbaa !6
-  %198 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !88
-  store i64* %198, i64** %193, align 8, !dbg !88
+  %209 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !88
+  %210 = load i64*, i64** %209, align 8, !dbg !88
+  store i64 %selfRaw, i64* %210, align 8, !dbg !88, !tbaa !6
+  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !88
+  %212 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !88
+  %213 = bitcast i64* %211 to <2 x i64>*, !dbg !88
+  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %213, align 8, !dbg !88, !tbaa !6
+  %214 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !88
+  store i64* %214, i64** %209, align 8, !dbg !88
   %send25 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte, i64 0), !dbg !88
-  %199 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !89
-  %200 = load i64*, i64** %199, align 8, !dbg !89
-  store i64 %selfRaw, i64* %200, align 8, !dbg !89, !tbaa !6
-  %201 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !89
-  store i64 %send25, i64* %201, align 8, !dbg !89, !tbaa !6
-  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !89
-  store i64* %202, i64** %199, align 8, !dbg !89
-  %send27 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.22, i64 0), !dbg !89
+  %215 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !89
+  %216 = load i64*, i64** %215, align 8, !dbg !89
+  store i64 %selfRaw, i64* %216, align 8, !dbg !89, !tbaa !6
+  %217 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !89
+  store i64 %send25, i64* %217, align 8, !dbg !89, !tbaa !6
+  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !89
+  store i64* %218, i64** %215, align 8, !dbg !89
+  %send27 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.19, i64 0), !dbg !89
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 32), i64** %8, align 8, !dbg !89, !tbaa !14
-  %203 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !90
-  %204 = load i64*, i64** %203, align 8, !dbg !90
-  store i64 %selfRaw, i64* %204, align 8, !dbg !90, !tbaa !6
-  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !90
-  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !90
-  %207 = bitcast i64* %205 to <2 x i64>*, !dbg !90
-  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %207, align 8, !dbg !90, !tbaa !6
-  %208 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !90
-  store i64* %208, i64** %203, align 8, !dbg !90
-  %send29 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.23, i64 0), !dbg !90
-  %209 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !91
-  %210 = load i64*, i64** %209, align 8, !dbg !91
-  store i64 %selfRaw, i64* %210, align 8, !dbg !91, !tbaa !6
-  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !91
-  store i64 %send29, i64* %211, align 8, !dbg !91, !tbaa !6
-  %212 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !91
-  store i64* %212, i64** %209, align 8, !dbg !91
-  %send31 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.24, i64 0), !dbg !91
+  %219 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !90
+  %220 = load i64*, i64** %219, align 8, !dbg !90
+  store i64 %selfRaw, i64* %220, align 8, !dbg !90, !tbaa !6
+  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !90
+  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !90
+  %223 = bitcast i64* %221 to <2 x i64>*, !dbg !90
+  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %223, align 8, !dbg !90, !tbaa !6
+  %224 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !90
+  store i64* %224, i64** %219, align 8, !dbg !90
+  %send29 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.20, i64 0), !dbg !90
+  %225 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !91
+  %226 = load i64*, i64** %225, align 8, !dbg !91
+  store i64 %selfRaw, i64* %226, align 8, !dbg !91, !tbaa !6
+  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !91
+  store i64 %send29, i64* %227, align 8, !dbg !91, !tbaa !6
+  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !91
+  store i64* %228, i64** %225, align 8, !dbg !91
+  %send31 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.21, i64 0), !dbg !91
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 33), i64** %8, align 8, !dbg !91, !tbaa !14
-  %213 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !92
-  %214 = load i64*, i64** %213, align 8, !dbg !92
-  store i64 %selfRaw, i64* %214, align 8, !dbg !92, !tbaa !6
-  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !92
-  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !92
-  %217 = bitcast i64* %215 to <2 x i64>*, !dbg !92
-  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %217, align 8, !dbg !92, !tbaa !6
-  %218 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !92
-  store i64* %218, i64** %213, align 8, !dbg !92
-  %send33 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.25, i64 0), !dbg !92
-  %219 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !93
-  %220 = load i64*, i64** %219, align 8, !dbg !93
-  store i64 %selfRaw, i64* %220, align 8, !dbg !93, !tbaa !6
-  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !93
-  store i64 %send33, i64* %221, align 8, !dbg !93, !tbaa !6
-  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !93
-  store i64* %222, i64** %219, align 8, !dbg !93
-  %send35 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.26, i64 0), !dbg !93
+  %229 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !92
+  %230 = load i64*, i64** %229, align 8, !dbg !92
+  store i64 %selfRaw, i64* %230, align 8, !dbg !92, !tbaa !6
+  %231 = getelementptr inbounds i64, i64* %230, i64 1, !dbg !92
+  %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !92
+  %233 = bitcast i64* %231 to <2 x i64>*, !dbg !92
+  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %233, align 8, !dbg !92, !tbaa !6
+  %234 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !92
+  store i64* %234, i64** %229, align 8, !dbg !92
+  %send33 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.22, i64 0), !dbg !92
+  %235 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !93
+  %236 = load i64*, i64** %235, align 8, !dbg !93
+  store i64 %selfRaw, i64* %236, align 8, !dbg !93, !tbaa !6
+  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !93
+  store i64 %send33, i64* %237, align 8, !dbg !93, !tbaa !6
+  %238 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !93
+  store i64* %238, i64** %235, align 8, !dbg !93
+  %send35 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.23, i64 0), !dbg !93
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 36), i64** %8, align 8, !dbg !93, !tbaa !14
-  %223 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !94
-  %224 = load i64*, i64** %223, align 8, !dbg !94
-  store i64 %selfRaw, i64* %224, align 8, !dbg !94, !tbaa !6
-  %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !94
-  %226 = getelementptr inbounds i64, i64* %225, i64 1, !dbg !94
-  %227 = bitcast i64* %225 to <2 x i64>*, !dbg !94
-  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %227, align 8, !dbg !94, !tbaa !6
-  %228 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !94
-  store i64* %228, i64** %223, align 8, !dbg !94
-  %send37 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.27, i64 0), !dbg !94
-  %229 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !95
-  %230 = load i64*, i64** %229, align 8, !dbg !95
-  store i64 %selfRaw, i64* %230, align 8, !dbg !95, !tbaa !6
-  %231 = getelementptr inbounds i64, i64* %230, i64 1, !dbg !95
-  store i64 %send37, i64* %231, align 8, !dbg !95, !tbaa !6
-  %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !95
-  store i64* %232, i64** %229, align 8, !dbg !95
-  %send39 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.28, i64 0), !dbg !95
+  %239 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !94
+  %240 = load i64*, i64** %239, align 8, !dbg !94
+  store i64 %selfRaw, i64* %240, align 8, !dbg !94, !tbaa !6
+  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !94
+  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !94
+  %243 = bitcast i64* %241 to <2 x i64>*, !dbg !94
+  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %243, align 8, !dbg !94, !tbaa !6
+  %244 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !94
+  store i64* %244, i64** %239, align 8, !dbg !94
+  %send37 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.24, i64 0), !dbg !94
+  %245 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !95
+  %246 = load i64*, i64** %245, align 8, !dbg !95
+  store i64 %selfRaw, i64* %246, align 8, !dbg !95, !tbaa !6
+  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !95
+  store i64 %send37, i64* %247, align 8, !dbg !95, !tbaa !6
+  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !95
+  store i64* %248, i64** %245, align 8, !dbg !95
+  %send39 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.25, i64 0), !dbg !95
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 37), i64** %8, align 8, !dbg !95, !tbaa !14
   %rubyStr_8.9 = load i64, i64* @rubyStrFrozen_8.9, align 8, !dbg !96
-  %233 = load i64, i64* @rb_mKernel, align 8, !dbg !96
-  %234 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !96
-  %235 = load i64*, i64** %234, align 8, !dbg !96
-  store i64 %233, i64* %235, align 8, !dbg !96, !tbaa !6
-  %236 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !96
-  store i64 %rubyStr_8.9, i64* %236, align 8, !dbg !96, !tbaa !6
-  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !96
-  store i64* %237, i64** %234, align 8, !dbg !96
+  %249 = load i64, i64* @rb_mKernel, align 8, !dbg !96
+  %250 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !96
+  %251 = load i64*, i64** %250, align 8, !dbg !96
+  store i64 %249, i64* %251, align 8, !dbg !96, !tbaa !6
+  %252 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !96
+  store i64 %rubyStr_8.9, i64* %252, align 8, !dbg !96, !tbaa !6
+  %253 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !96
+  store i64* %253, i64** %250, align 8, !dbg !96
   %send41 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational, i64 0), !dbg !96
-  %238 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !97
-  %239 = load i64*, i64** %238, align 8, !dbg !97
-  store i64 %selfRaw, i64* %239, align 8, !dbg !97, !tbaa !6
-  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !97
-  store i64 36028797018963970, i64* %240, align 8, !dbg !97, !tbaa !6
-  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !97
-  store i64 %send41, i64* %241, align 8, !dbg !97, !tbaa !6
-  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !97
-  store i64* %242, i64** %238, align 8, !dbg !97
-  %send43 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.29, i64 0), !dbg !97
-  %243 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !98
-  %244 = load i64*, i64** %243, align 8, !dbg !98
-  store i64 %selfRaw, i64* %244, align 8, !dbg !98, !tbaa !6
-  %245 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !98
-  store i64 %send43, i64* %245, align 8, !dbg !98, !tbaa !6
-  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !98
-  store i64* %246, i64** %243, align 8, !dbg !98
-  %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.30, i64 0), !dbg !98
+  %254 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !97
+  %255 = load i64*, i64** %254, align 8, !dbg !97
+  store i64 %selfRaw, i64* %255, align 8, !dbg !97, !tbaa !6
+  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !97
+  store i64 36028797018963970, i64* %256, align 8, !dbg !97, !tbaa !6
+  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !97
+  store i64 %send41, i64* %257, align 8, !dbg !97, !tbaa !6
+  %258 = getelementptr inbounds i64, i64* %257, i64 1, !dbg !97
+  store i64* %258, i64** %254, align 8, !dbg !97
+  %send43 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.26, i64 0), !dbg !97
+  %259 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !98
+  %260 = load i64*, i64** %259, align 8, !dbg !98
+  store i64 %selfRaw, i64* %260, align 8, !dbg !98, !tbaa !6
+  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !98
+  store i64 %send43, i64* %261, align 8, !dbg !98, !tbaa !6
+  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !98
+  store i64* %262, i64** %259, align 8, !dbg !98
+  %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.27, i64 0), !dbg !98
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 38), i64** %8, align 8, !dbg !98, !tbaa !14
   %rubyStr_5 = load i64, i64* @rubyStrFrozen_5, align 8, !dbg !99
-  %247 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !99
-  %248 = load i64*, i64** %247, align 8, !dbg !99
-  store i64 %233, i64* %248, align 8, !dbg !99, !tbaa !6
-  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !99
-  store i64 1, i64* %249, align 8, !dbg !99, !tbaa !6
-  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !99
-  store i64 %rubyStr_5, i64* %250, align 8, !dbg !99, !tbaa !6
-  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !99
-  store i64* %251, i64** %247, align 8, !dbg !99
+  %263 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !99
+  %264 = load i64*, i64** %263, align 8, !dbg !99
+  store i64 %249, i64* %264, align 8, !dbg !99, !tbaa !6
+  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !99
+  store i64 1, i64* %265, align 8, !dbg !99, !tbaa !6
+  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !99
+  store i64 %rubyStr_5, i64* %266, align 8, !dbg !99, !tbaa !6
+  %267 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !99
+  store i64* %267, i64** %263, align 8, !dbg !99
   %send47 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex, i64 0), !dbg !99
-  %252 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !100
-  %253 = load i64*, i64** %252, align 8, !dbg !100
-  store i64 %selfRaw, i64* %253, align 8, !dbg !100, !tbaa !6
-  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !100
-  store i64 36028797018963970, i64* %254, align 8, !dbg !100, !tbaa !6
-  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !100
-  store i64 %send47, i64* %255, align 8, !dbg !100, !tbaa !6
-  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !100
-  store i64* %256, i64** %252, align 8, !dbg !100
-  %send49 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.31, i64 0), !dbg !100
-  %257 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !101
-  %258 = load i64*, i64** %257, align 8, !dbg !101
-  store i64 %selfRaw, i64* %258, align 8, !dbg !101, !tbaa !6
-  %259 = getelementptr inbounds i64, i64* %258, i64 1, !dbg !101
-  store i64 %send49, i64* %259, align 8, !dbg !101, !tbaa !6
-  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !101
-  store i64* %260, i64** %257, align 8, !dbg !101
-  %send51 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.32, i64 0), !dbg !101
+  %268 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !100
+  %269 = load i64*, i64** %268, align 8, !dbg !100
+  store i64 %selfRaw, i64* %269, align 8, !dbg !100, !tbaa !6
+  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !100
+  store i64 36028797018963970, i64* %270, align 8, !dbg !100, !tbaa !6
+  %271 = getelementptr inbounds i64, i64* %270, i64 1, !dbg !100
+  store i64 %send47, i64* %271, align 8, !dbg !100, !tbaa !6
+  %272 = getelementptr inbounds i64, i64* %271, i64 1, !dbg !100
+  store i64* %272, i64** %268, align 8, !dbg !100
+  %send49 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.28, i64 0), !dbg !100
+  %273 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !101
+  %274 = load i64*, i64** %273, align 8, !dbg !101
+  store i64 %selfRaw, i64* %274, align 8, !dbg !101, !tbaa !6
+  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !101
+  store i64 %send49, i64* %275, align 8, !dbg !101, !tbaa !6
+  %276 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !101
+  store i64* %276, i64** %273, align 8, !dbg !101
+  %send51 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.29, i64 0), !dbg !101
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 40), i64** %8, align 8, !dbg !101, !tbaa !14
-  %261 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !102
-  %262 = load i64*, i64** %261, align 8, !dbg !102
-  store i64 %selfRaw, i64* %262, align 8, !dbg !102, !tbaa !6
-  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !102
-  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !102
-  %265 = bitcast i64* %263 to <2 x i64>*, !dbg !102
-  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %265, align 8, !dbg !102, !tbaa !6
-  %266 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !102
-  store i64* %266, i64** %261, align 8, !dbg !102
-  %send53 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.33, i64 0), !dbg !102
-  %267 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !103
-  %268 = load i64*, i64** %267, align 8, !dbg !103
-  store i64 %selfRaw, i64* %268, align 8, !dbg !103, !tbaa !6
-  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !103
-  store i64 %send53, i64* %269, align 8, !dbg !103, !tbaa !6
-  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !103
-  store i64* %270, i64** %267, align 8, !dbg !103
-  %send55 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.34, i64 0), !dbg !103
+  %277 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !102
+  %278 = load i64*, i64** %277, align 8, !dbg !102
+  store i64 %selfRaw, i64* %278, align 8, !dbg !102, !tbaa !6
+  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !102
+  %280 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !102
+  %281 = bitcast i64* %279 to <2 x i64>*, !dbg !102
+  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %281, align 8, !dbg !102, !tbaa !6
+  %282 = getelementptr inbounds i64, i64* %280, i64 1, !dbg !102
+  store i64* %282, i64** %277, align 8, !dbg !102
+  %send53 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.30, i64 0), !dbg !102
+  %283 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !103
+  %284 = load i64*, i64** %283, align 8, !dbg !103
+  store i64 %selfRaw, i64* %284, align 8, !dbg !103, !tbaa !6
+  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !103
+  store i64 %send53, i64* %285, align 8, !dbg !103, !tbaa !6
+  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !103
+  store i64* %286, i64** %283, align 8, !dbg !103
+  %send55 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.31, i64 0), !dbg !103
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 41), i64** %8, align 8, !dbg !103, !tbaa !14
   %rubyStr_15.4 = load i64, i64* @rubyStrFrozen_15.4, align 8, !dbg !104
-  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !104
-  %272 = load i64*, i64** %271, align 8, !dbg !104
-  store i64 %233, i64* %272, align 8, !dbg !104, !tbaa !6
-  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !104
-  store i64 %rubyStr_15.4, i64* %273, align 8, !dbg !104, !tbaa !6
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !104
-  store i64* %274, i64** %271, align 8, !dbg !104
-  %send57 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.35, i64 0), !dbg !104
-  %275 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !105
-  %276 = load i64*, i64** %275, align 8, !dbg !105
-  store i64 %selfRaw, i64* %276, align 8, !dbg !105, !tbaa !6
-  %277 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !105
-  store i64 199622053483197234, i64* %277, align 8, !dbg !105, !tbaa !6
-  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !105
-  store i64 %send57, i64* %278, align 8, !dbg !105, !tbaa !6
-  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !105
-  store i64* %279, i64** %275, align 8, !dbg !105
-  %send59 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.36, i64 0), !dbg !105
-  %280 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !106
-  %281 = load i64*, i64** %280, align 8, !dbg !106
-  store i64 %selfRaw, i64* %281, align 8, !dbg !106, !tbaa !6
-  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !106
-  store i64 %send59, i64* %282, align 8, !dbg !106, !tbaa !6
-  %283 = getelementptr inbounds i64, i64* %282, i64 1, !dbg !106
-  store i64* %283, i64** %280, align 8, !dbg !106
-  %send61 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.37, i64 0), !dbg !106
+  %287 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !104
+  %288 = load i64*, i64** %287, align 8, !dbg !104
+  store i64 %249, i64* %288, align 8, !dbg !104, !tbaa !6
+  %289 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !104
+  store i64 %rubyStr_15.4, i64* %289, align 8, !dbg !104, !tbaa !6
+  %290 = getelementptr inbounds i64, i64* %289, i64 1, !dbg !104
+  store i64* %290, i64** %287, align 8, !dbg !104
+  %send57 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.32, i64 0), !dbg !104
+  %291 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !105
+  %292 = load i64*, i64** %291, align 8, !dbg !105
+  store i64 %selfRaw, i64* %292, align 8, !dbg !105, !tbaa !6
+  %293 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !105
+  store i64 199622053483197234, i64* %293, align 8, !dbg !105, !tbaa !6
+  %294 = getelementptr inbounds i64, i64* %293, i64 1, !dbg !105
+  store i64 %send57, i64* %294, align 8, !dbg !105, !tbaa !6
+  %295 = getelementptr inbounds i64, i64* %294, i64 1, !dbg !105
+  store i64* %295, i64** %291, align 8, !dbg !105
+  %send59 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.33, i64 0), !dbg !105
+  %296 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !106
+  %297 = load i64*, i64** %296, align 8, !dbg !106
+  store i64 %selfRaw, i64* %297, align 8, !dbg !106, !tbaa !6
+  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !106
+  store i64 %send59, i64* %298, align 8, !dbg !106, !tbaa !6
+  %299 = getelementptr inbounds i64, i64* %298, i64 1, !dbg !106
+  store i64* %299, i64** %296, align 8, !dbg !106
+  %send61 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.34, i64 0), !dbg !106
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 42), i64** %8, align 8, !dbg !106, !tbaa !14
   %rubyStr_18 = load i64, i64* @rubyStrFrozen_18, align 8, !dbg !107
-  %284 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !107
-  %285 = load i64*, i64** %284, align 8, !dbg !107
-  store i64 %233, i64* %285, align 8, !dbg !107, !tbaa !6
-  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !107
-  store i64 1, i64* %286, align 8, !dbg !107, !tbaa !6
-  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !107
-  store i64 %rubyStr_18, i64* %287, align 8, !dbg !107, !tbaa !6
-  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !107
-  store i64* %288, i64** %284, align 8, !dbg !107
-  %send63 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex.38, i64 0), !dbg !107
-  %289 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !108
-  %290 = load i64*, i64** %289, align 8, !dbg !108
-  store i64 %selfRaw, i64* %290, align 8, !dbg !108, !tbaa !6
-  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !108
-  store i64 199565758487855106, i64* %291, align 8, !dbg !108, !tbaa !6
-  %292 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !108
-  store i64 %send63, i64* %292, align 8, !dbg !108, !tbaa !6
-  %293 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !108
-  store i64* %293, i64** %289, align 8, !dbg !108
-  %send65 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.39, i64 0), !dbg !108
-  %294 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !109
-  %295 = load i64*, i64** %294, align 8, !dbg !109
-  store i64 %selfRaw, i64* %295, align 8, !dbg !109, !tbaa !6
-  %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !109
-  store i64 %send65, i64* %296, align 8, !dbg !109, !tbaa !6
-  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !109
-  store i64* %297, i64** %294, align 8, !dbg !109
-  %send67 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.40, i64 0), !dbg !109
+  %300 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !107
+  %301 = load i64*, i64** %300, align 8, !dbg !107
+  store i64 %249, i64* %301, align 8, !dbg !107, !tbaa !6
+  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !107
+  store i64 1, i64* %302, align 8, !dbg !107, !tbaa !6
+  %303 = getelementptr inbounds i64, i64* %302, i64 1, !dbg !107
+  store i64 %rubyStr_18, i64* %303, align 8, !dbg !107, !tbaa !6
+  %304 = getelementptr inbounds i64, i64* %303, i64 1, !dbg !107
+  store i64* %304, i64** %300, align 8, !dbg !107
+  %send63 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex.35, i64 0), !dbg !107
+  %305 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !108
+  %306 = load i64*, i64** %305, align 8, !dbg !108
+  store i64 %selfRaw, i64* %306, align 8, !dbg !108, !tbaa !6
+  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !108
+  store i64 199565758487855106, i64* %307, align 8, !dbg !108, !tbaa !6
+  %308 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !108
+  store i64 %send63, i64* %308, align 8, !dbg !108, !tbaa !6
+  %309 = getelementptr inbounds i64, i64* %308, i64 1, !dbg !108
+  store i64* %309, i64** %305, align 8, !dbg !108
+  %send65 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.36, i64 0), !dbg !108
+  %310 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !109
+  %311 = load i64*, i64** %310, align 8, !dbg !109
+  store i64 %selfRaw, i64* %311, align 8, !dbg !109, !tbaa !6
+  %312 = getelementptr inbounds i64, i64* %311, i64 1, !dbg !109
+  store i64 %send65, i64* %312, align 8, !dbg !109, !tbaa !6
+  %313 = getelementptr inbounds i64, i64* %312, i64 1, !dbg !109
+  store i64* %313, i64** %310, align 8, !dbg !109
+  %send67 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.37, i64 0), !dbg !109
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 44), i64** %8, align 8, !dbg !109, !tbaa !14
-  %298 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !110
-  %299 = load i64*, i64** %298, align 8, !dbg !110
-  store i64 %selfRaw, i64* %299, align 8, !dbg !110, !tbaa !6
-  %300 = getelementptr inbounds i64, i64* %299, i64 1, !dbg !110
-  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !110
-  %302 = bitcast i64* %300 to <2 x i64>*, !dbg !110
-  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %302, align 8, !dbg !110, !tbaa !6
-  %303 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !110
-  store i64* %303, i64** %298, align 8, !dbg !110
-  %send69 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.41, i64 0), !dbg !110
-  %304 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !111
-  %305 = load i64*, i64** %304, align 8, !dbg !111
-  store i64 %selfRaw, i64* %305, align 8, !dbg !111, !tbaa !6
-  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !111
-  store i64 %send69, i64* %306, align 8, !dbg !111, !tbaa !6
-  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !111
-  store i64* %307, i64** %304, align 8, !dbg !111
-  %send71 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.42, i64 0), !dbg !111
+  %314 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !110
+  %315 = load i64*, i64** %314, align 8, !dbg !110
+  store i64 %selfRaw, i64* %315, align 8, !dbg !110, !tbaa !6
+  %316 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !110
+  %317 = getelementptr inbounds i64, i64* %316, i64 1, !dbg !110
+  %318 = bitcast i64* %316 to <2 x i64>*, !dbg !110
+  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %318, align 8, !dbg !110, !tbaa !6
+  %319 = getelementptr inbounds i64, i64* %317, i64 1, !dbg !110
+  store i64* %319, i64** %314, align 8, !dbg !110
+  %send69 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.38, i64 0), !dbg !110
+  %320 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !111
+  %321 = load i64*, i64** %320, align 8, !dbg !111
+  store i64 %selfRaw, i64* %321, align 8, !dbg !111, !tbaa !6
+  %322 = getelementptr inbounds i64, i64* %321, i64 1, !dbg !111
+  store i64 %send69, i64* %322, align 8, !dbg !111, !tbaa !6
+  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !111
+  store i64* %323, i64** %320, align 8, !dbg !111
+  %send71 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.39, i64 0), !dbg !111
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 45), i64** %8, align 8, !dbg !111, !tbaa !14
   %rubyStr_25.4 = load i64, i64* @rubyStrFrozen_25.4, align 8, !dbg !112
-  %308 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !112
-  %309 = load i64*, i64** %308, align 8, !dbg !112
-  store i64 %233, i64* %309, align 8, !dbg !112, !tbaa !6
-  %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !112
-  store i64 %rubyStr_25.4, i64* %310, align 8, !dbg !112, !tbaa !6
-  %311 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !112
-  store i64* %311, i64** %308, align 8, !dbg !112
-  %send73 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.43, i64 0), !dbg !112
-  %312 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !113
-  %313 = load i64*, i64** %312, align 8, !dbg !113
-  store i64 %selfRaw, i64* %313, align 8, !dbg !113, !tbaa !6
-  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !113
-  store i64 113040350646999450, i64* %314, align 8, !dbg !113, !tbaa !6
-  %315 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !113
-  store i64 %send73, i64* %315, align 8, !dbg !113, !tbaa !6
-  %316 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !113
-  store i64* %316, i64** %312, align 8, !dbg !113
-  %send75 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.44, i64 0), !dbg !113
-  %317 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !114
-  %318 = load i64*, i64** %317, align 8, !dbg !114
-  store i64 %selfRaw, i64* %318, align 8, !dbg !114, !tbaa !6
-  %319 = getelementptr inbounds i64, i64* %318, i64 1, !dbg !114
-  store i64 %send75, i64* %319, align 8, !dbg !114, !tbaa !6
-  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !114
-  store i64* %320, i64** %317, align 8, !dbg !114
-  %send77 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.45, i64 0), !dbg !114
+  %324 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !112
+  %325 = load i64*, i64** %324, align 8, !dbg !112
+  store i64 %249, i64* %325, align 8, !dbg !112, !tbaa !6
+  %326 = getelementptr inbounds i64, i64* %325, i64 1, !dbg !112
+  store i64 %rubyStr_25.4, i64* %326, align 8, !dbg !112, !tbaa !6
+  %327 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !112
+  store i64* %327, i64** %324, align 8, !dbg !112
+  %send73 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.40, i64 0), !dbg !112
+  %328 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !113
+  %329 = load i64*, i64** %328, align 8, !dbg !113
+  store i64 %selfRaw, i64* %329, align 8, !dbg !113, !tbaa !6
+  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !113
+  store i64 113040350646999450, i64* %330, align 8, !dbg !113, !tbaa !6
+  %331 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !113
+  store i64 %send73, i64* %331, align 8, !dbg !113, !tbaa !6
+  %332 = getelementptr inbounds i64, i64* %331, i64 1, !dbg !113
+  store i64* %332, i64** %328, align 8, !dbg !113
+  %send75 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.41, i64 0), !dbg !113
+  %333 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !114
+  %334 = load i64*, i64** %333, align 8, !dbg !114
+  store i64 %selfRaw, i64* %334, align 8, !dbg !114, !tbaa !6
+  %335 = getelementptr inbounds i64, i64* %334, i64 1, !dbg !114
+  store i64 %send75, i64* %335, align 8, !dbg !114, !tbaa !6
+  %336 = getelementptr inbounds i64, i64* %335, i64 1, !dbg !114
+  store i64* %336, i64** %333, align 8, !dbg !114
+  %send77 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.42, i64 0), !dbg !114
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 47), i64** %8, align 8, !dbg !114, !tbaa !14
-  %321 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !115
-  %322 = load i64*, i64** %321, align 8, !dbg !115
-  store i64 %selfRaw, i64* %322, align 8, !dbg !115, !tbaa !6
-  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !115
-  %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !115
-  %325 = bitcast i64* %323 to <2 x i64>*, !dbg !115
-  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %325, align 8, !dbg !115, !tbaa !6
-  %326 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !115
-  store i64* %326, i64** %321, align 8, !dbg !115
-  %send79 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.46, i64 0), !dbg !115
-  %327 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !116
-  %328 = load i64*, i64** %327, align 8, !dbg !116
-  store i64 %selfRaw, i64* %328, align 8, !dbg !116, !tbaa !6
-  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !116
-  store i64 %send79, i64* %329, align 8, !dbg !116, !tbaa !6
-  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !116
-  store i64* %330, i64** %327, align 8, !dbg !116
-  %send81 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.47, i64 0), !dbg !116
+  %337 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !115
+  %338 = load i64*, i64** %337, align 8, !dbg !115
+  store i64 %selfRaw, i64* %338, align 8, !dbg !115, !tbaa !6
+  %339 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !115
+  %340 = getelementptr inbounds i64, i64* %339, i64 1, !dbg !115
+  %341 = bitcast i64* %339 to <2 x i64>*, !dbg !115
+  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %341, align 8, !dbg !115, !tbaa !6
+  %342 = getelementptr inbounds i64, i64* %340, i64 1, !dbg !115
+  store i64* %342, i64** %337, align 8, !dbg !115
+  %send79 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.43, i64 0), !dbg !115
+  %343 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !116
+  %344 = load i64*, i64** %343, align 8, !dbg !116
+  store i64 %selfRaw, i64* %344, align 8, !dbg !116, !tbaa !6
+  %345 = getelementptr inbounds i64, i64* %344, i64 1, !dbg !116
+  store i64 %send79, i64* %345, align 8, !dbg !116, !tbaa !6
+  %346 = getelementptr inbounds i64, i64* %345, i64 1, !dbg !116
+  store i64* %346, i64** %343, align 8, !dbg !116
+  %send81 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.44, i64 0), !dbg !116
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 48), i64** %8, align 8, !dbg !116, !tbaa !14
   %rubyStr_5.923 = load i64, i64* @rubyStrFrozen_5.923, align 8, !dbg !117
-  %331 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !117
-  %332 = load i64*, i64** %331, align 8, !dbg !117
-  store i64 %233, i64* %332, align 8, !dbg !117, !tbaa !6
-  %333 = getelementptr inbounds i64, i64* %332, i64 1, !dbg !117
-  store i64 %rubyStr_5.923, i64* %333, align 8, !dbg !117, !tbaa !6
-  %334 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !117
-  store i64* %334, i64** %331, align 8, !dbg !117
-  %send83 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.48, i64 0), !dbg !117
-  %335 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !118
-  %336 = load i64*, i64** %335, align 8, !dbg !118
-  store i64 %selfRaw, i64* %336, align 8, !dbg !118, !tbaa !6
-  %337 = getelementptr inbounds i64, i64* %336, i64 1, !dbg !118
-  store i64 113040350646999450, i64* %337, align 8, !dbg !118, !tbaa !6
-  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !118
-  store i64 %send83, i64* %338, align 8, !dbg !118, !tbaa !6
-  %339 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !118
-  store i64* %339, i64** %335, align 8, !dbg !118
-  %send85 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.49, i64 0), !dbg !118
-  %340 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !119
-  %341 = load i64*, i64** %340, align 8, !dbg !119
-  store i64 %selfRaw, i64* %341, align 8, !dbg !119, !tbaa !6
-  %342 = getelementptr inbounds i64, i64* %341, i64 1, !dbg !119
-  store i64 %send85, i64* %342, align 8, !dbg !119, !tbaa !6
-  %343 = getelementptr inbounds i64, i64* %342, i64 1, !dbg !119
-  store i64* %343, i64** %340, align 8, !dbg !119
-  %send87 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.50, i64 0), !dbg !119
+  %347 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !117
+  %348 = load i64*, i64** %347, align 8, !dbg !117
+  store i64 %249, i64* %348, align 8, !dbg !117, !tbaa !6
+  %349 = getelementptr inbounds i64, i64* %348, i64 1, !dbg !117
+  store i64 %rubyStr_5.923, i64* %349, align 8, !dbg !117, !tbaa !6
+  %350 = getelementptr inbounds i64, i64* %349, i64 1, !dbg !117
+  store i64* %350, i64** %347, align 8, !dbg !117
+  %send83 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.45, i64 0), !dbg !117
+  %351 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !118
+  %352 = load i64*, i64** %351, align 8, !dbg !118
+  store i64 %selfRaw, i64* %352, align 8, !dbg !118, !tbaa !6
+  %353 = getelementptr inbounds i64, i64* %352, i64 1, !dbg !118
+  store i64 113040350646999450, i64* %353, align 8, !dbg !118, !tbaa !6
+  %354 = getelementptr inbounds i64, i64* %353, i64 1, !dbg !118
+  store i64 %send83, i64* %354, align 8, !dbg !118, !tbaa !6
+  %355 = getelementptr inbounds i64, i64* %354, i64 1, !dbg !118
+  store i64* %355, i64** %351, align 8, !dbg !118
+  %send85 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.46, i64 0), !dbg !118
+  %356 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !119
+  %357 = load i64*, i64** %356, align 8, !dbg !119
+  store i64 %selfRaw, i64* %357, align 8, !dbg !119, !tbaa !6
+  %358 = getelementptr inbounds i64, i64* %357, i64 1, !dbg !119
+  store i64 %send85, i64* %358, align 8, !dbg !119, !tbaa !6
+  %359 = getelementptr inbounds i64, i64* %358, i64 1, !dbg !119
+  store i64* %359, i64** %356, align 8, !dbg !119
+  %send87 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.47, i64 0), !dbg !119
   ret void
 
-fastSymCallIntrinsic_Static_keep_def379:          ; preds = %fastSymCallIntrinsic_Static_keep_def360, %149
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %8, align 8, !dbg !78, !tbaa !14
-  %rubyId_lte370 = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !79
-  %rawSym371 = tail call i64 @rb_id2sym(i64 %rubyId_lte370), !dbg !79
-  %rubyId_normal372 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !79
-  %rawSym373 = tail call i64 @rb_id2sym(i64 %rubyId_normal372), !dbg !79
-  %stackFrame380 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8, !dbg !79
-  %344 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !79
-  %345 = bitcast i8* %344 to i16*, !dbg !79
-  %346 = load i16, i16* %345, align 8, !dbg !79
-  %347 = and i16 %346, -384, !dbg !79
-  %348 = or i16 %347, 1, !dbg !79
-  store i16 %348, i16* %345, align 8, !dbg !79
-  %349 = getelementptr inbounds i8, i8* %344, i64 8, !dbg !79
-  %350 = bitcast i8* %349 to i32*, !dbg !79
-  store i32 2, i32* %350, align 8, !dbg !79, !tbaa !72
-  %351 = getelementptr inbounds i8, i8* %344, i64 12, !dbg !79
-  %352 = bitcast i8* %351 to i32*, !dbg !79
-  %353 = getelementptr inbounds i8, i8* %344, i64 4, !dbg !79
-  %354 = bitcast i8* %353 to i32*, !dbg !79
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %351, i8 0, i64 20, i1 false), !dbg !79
-  store i32 2, i32* %354, align 4, !dbg !79, !tbaa !75
-  %positional_table382 = alloca i64, i32 2, align 8, !dbg !79
-  %rubyId_x383 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !79
-  store i64 %rubyId_x383, i64* %positional_table382, align 8, !dbg !79
-  %rubyId_y384 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !79
-  %355 = getelementptr i64, i64* %positional_table382, i32 1, !dbg !79
-  store i64 %rubyId_y384, i64* %355, align 8, !dbg !79
-  %356 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !79
-  %357 = bitcast i64* %positional_table382 to i8*, !dbg !79
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %356, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %357, i64 noundef 16, i1 noundef false) #15, !dbg !79
-  %358 = getelementptr inbounds i8, i8* %344, i64 32, !dbg !79
-  %359 = bitcast i8* %358 to i8**, !dbg !79
-  store i8* %356, i8** %359, align 8, !dbg !79, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#3lte", i8* nonnull %344, %struct.rb_iseq_struct* %stackFrame380, i1 noundef zeroext false) #15, !dbg !79
-  %360 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !79, !tbaa !14
-  %361 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 5, !dbg !79
-  %362 = load i32, i32* %361, align 8, !dbg !79, !tbaa !27
-  %363 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 6, !dbg !79
-  %364 = load i32, i32* %363, align 4, !dbg !79, !tbaa !31
-  %365 = xor i32 %364, -1, !dbg !79
-  %366 = and i32 %365, %362, !dbg !79
-  %367 = icmp eq i32 %366, 0, !dbg !79
-  br i1 %367, label %afterSend376, label %368, !dbg !79, !prof !21
+fastSymCallIntrinsic_ResolvedSig_sig305:          ; preds = %fastSymCallIntrinsic_ResolvedSig_sig286, %41
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %8, align 8, !dbg !65, !tbaa !14
+  %rubyId_lte = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !66
+  %rawSym299 = tail call i64 @rb_id2sym(i64 %rubyId_lte), !dbg !66
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym299, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_4"), !dbg !66
+  %360 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !14
+  %361 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 5, !dbg !66
+  %362 = load i32, i32* %361, align 8, !dbg !66, !tbaa !27
+  %363 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 6, !dbg !66
+  %364 = load i32, i32* %363, align 4, !dbg !66, !tbaa !31
+  %365 = xor i32 %364, -1, !dbg !66
+  %366 = and i32 %365, %362, !dbg !66
+  %367 = icmp eq i32 %366, 0, !dbg !66
+  br i1 %367, label %afterSend302, label %368, !dbg !66, !prof !21
 
-368:                                              ; preds = %fastSymCallIntrinsic_Static_keep_def379
-  %369 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 8, !dbg !79
-  %370 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %369, align 8, !dbg !79, !tbaa !32
-  %371 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %370, i32 noundef 0) #15, !dbg !79
-  br label %afterSend376, !dbg !79
+368:                                              ; preds = %fastSymCallIntrinsic_ResolvedSig_sig305
+  %369 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 8, !dbg !66
+  %370 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %369, align 8, !dbg !66, !tbaa !32
+  %371 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %370, i32 noundef 0) #15, !dbg !66
+  br label %afterSend302, !dbg !66
 }
 
 ; Function Attrs: ssp
@@ -1605,10 +1599,10 @@ functionEntryInitializers:
 ; Function Attrs: ssp
 define void @Init_float-intrinsics() local_unnamed_addr #7 {
 entry:
-  %locals.i181.i = alloca i64, align 8
-  %locals.i179.i = alloca i64, i32 0, align 8
-  %locals.i177.i = alloca i64, i32 0, align 8
-  %locals.i175.i = alloca i64, i32 0, align 8
+  %locals.i174.i = alloca i64, align 8
+  %locals.i172.i = alloca i64, i32 0, align 8
+  %locals.i170.i = alloca i64, i32 0, align 8
+  %locals.i168.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %keywords.i = alloca i64, i32 2, align 8, !dbg !125
   %keywords17.i = alloca i64, i32 2, align 8, !dbg !132
@@ -1658,95 +1652,93 @@ entry:
   store i64 %21, i64* @rubyIdPrecomputed_extend, align 8
   %22 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
   store i64 %22, i64* @rubyIdPrecomputed_normal, align 8
-  %23 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #15
-  store i64 %23, i64* @rubyIdPrecomputed_keep_def, align 8
-  %24 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #15
-  store i64 %24, i64* @rubyIdPrecomputed_p, align 8
-  %25 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_Rational, i64 0, i64 0), i64 noundef 8) #15
-  store i64 %25, i64* @rubyIdPrecomputed_Rational, align 8
-  %26 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Complex, i64 0, i64 0), i64 noundef 7) #15
-  store i64 %26, i64* @rubyIdPrecomputed_Complex, align 8
-  %27 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #15
+  %23 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #15
+  store i64 %23, i64* @rubyIdPrecomputed_p, align 8
+  %24 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_Rational, i64 0, i64 0), i64 noundef 8) #15
+  store i64 %24, i64* @rubyIdPrecomputed_Rational, align 8
+  %25 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Complex, i64 0, i64 0), i64 noundef 7) #15
+  store i64 %25, i64* @rubyIdPrecomputed_Complex, align 8
+  %26 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #15
+  tail call void @rb_gc_register_mark_object(i64 %26) #15
+  store i64 %26, i64* @rubyStrFrozen_plus, align 8
+  %27 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/float-intrinsics.rb", i64 0, i64 0), i64 noundef 42) #15
   tail call void @rb_gc_register_mark_object(i64 %27) #15
-  store i64 %27, i64* @rubyStrFrozen_plus, align 8
-  %28 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/float-intrinsics.rb", i64 0, i64 0), i64 noundef 42) #15
-  tail call void @rb_gc_register_mark_object(i64 %28) #15
-  store i64 %28, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  store i64 %27, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 49)
   %rubyId_plus.i.i = load i64, i64* @rubyIdPrecomputed_plus, align 8
   %rubyStr_plus.i.i = load i64, i64* @rubyStrFrozen_plus, align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %29 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_plus.i.i, i64 %rubyId_plus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %29, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8
-  %30 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #15
-  call void @rb_gc_register_mark_object(i64 %30) #15
+  %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_plus.i.i, i64 %rubyId_plus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8
+  %29 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #15
+  call void @rb_gc_register_mark_object(i64 %29) #15
   %rubyId_minus.i.i = load i64, i64* @rubyIdPrecomputed_minus, align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i174.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %31 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %30, i64 %rubyId_minus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i174.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i175.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %31, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i167.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %29, i64 %rubyId_minus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i167.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i168.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8
   %rubyId_-.i = load i64, i64* @rubyIdPrecomputed_-, align 8, !dbg !37
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_-, i64 %rubyId_-.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !37
-  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #15
-  call void @rb_gc_register_mark_object(i64 %32) #15
+  %31 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #15
+  call void @rb_gc_register_mark_object(i64 %31) #15
   %rubyId_lt.i.i = load i64, i64* @rubyIdPrecomputed_lt, align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i176.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %33 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %32, i64 %rubyId_lt.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i176.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 18, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i177.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %33, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8
-  %34 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #15
-  call void @rb_gc_register_mark_object(i64 %34) #15
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i169.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %32 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %31, i64 %rubyId_lt.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i169.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 18, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i170.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %32, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8
+  %33 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #15
+  call void @rb_gc_register_mark_object(i64 %33) #15
   %rubyId_lte.i.i = load i64, i64* @rubyIdPrecomputed_lte, align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i178.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %35 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %34, i64 %rubyId_lte.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i178.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 23, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i179.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %35, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8
-  %36 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
-  call void @rb_gc_register_mark_object(i64 %36) #15
-  %37 = bitcast i64* %locals.i181.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %37)
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i171.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %34 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %33, i64 %rubyId_lte.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i171.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 23, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i172.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %34, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8
+  %35 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  call void @rb_gc_register_mark_object(i64 %35) #15
+  %36 = bitcast i64* %locals.i174.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %36)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i180.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i173.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %"rubyId_<block-call>.i.i" = load i64, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  store i64 %"rubyId_<block-call>.i.i", i64* %locals.i181.i, align 8
-  %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %36, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i180.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i181.i, i32 noundef 1, i32 noundef 4)
-  store %struct.rb_iseq_struct* %38, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %37)
-  %39 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #15
-  call void @rb_gc_register_mark_object(i64 %39) #15
-  store i64 %39, i64* @"rubyStrFrozen_block in <top (required)>", align 8
+  store i64 %"rubyId_<block-call>.i.i", i64* %locals.i174.i, align 8
+  %37 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %35, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i173.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i174.i, i32 noundef 1, i32 noundef 4)
+  store %struct.rb_iseq_struct* %37, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %36)
+  %38 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #15
+  call void @rb_gc_register_mark_object(i64 %38) #15
+  store i64 %38, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i182.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %39, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i182.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8
-  %stackFrame.i183.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %"rubyId_block in <top (required)>.i184.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %"rubyStr_block in <top (required)>.i185.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i186.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %41 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i185.i", i64 %"rubyId_block in <top (required)>.i184.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i186.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i183.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %41, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_2", align 8
-  %stackFrame.i187.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %"rubyId_block in <top (required)>.i188.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %"rubyStr_block in <top (required)>.i189.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i190.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %42 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i189.i", i64 %"rubyId_block in <top (required)>.i188.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i190.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i187.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %42, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_3", align 8
-  %stackFrame.i191.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %"rubyId_block in <top (required)>.i192.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %"rubyStr_block in <top (required)>.i193.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i194.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %43 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i193.i", i64 %"rubyId_block in <top (required)>.i192.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i194.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i191.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %43, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_4", align 8
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i175.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %39 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %38, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i175.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %39, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8
+  %stackFrame.i176.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %"rubyId_block in <top (required)>.i177.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
+  %"rubyStr_block in <top (required)>.i178.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i179.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i178.i", i64 %"rubyId_block in <top (required)>.i177.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i179.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i176.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_2", align 8
+  %stackFrame.i180.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %"rubyId_block in <top (required)>.i181.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
+  %"rubyStr_block in <top (required)>.i182.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i183.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %41 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i182.i", i64 %"rubyId_block in <top (required)>.i181.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i183.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i180.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %41, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_3", align 8
+  %stackFrame.i184.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %"rubyId_block in <top (required)>.i185.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
+  %"rubyStr_block in <top (required)>.i186.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i187.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %42 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i186.i", i64 %"rubyId_block in <top (required)>.i185.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i187.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i184.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %42, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_4", align 8
   %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !63
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !63
   %rubyId_untyped.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !124
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !124
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !125
   %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !125
-  %44 = call i64 @rb_id2sym(i64 %rubyId_x.i) #15, !dbg !125
-  store i64 %44, i64* %keywords.i, align 8, !dbg !125
+  %43 = call i64 @rb_id2sym(i64 %rubyId_x.i) #15, !dbg !125
+  store i64 %43, i64* %keywords.i, align 8, !dbg !125
   %rubyId_y.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !125
-  %45 = call i64 @rb_id2sym(i64 %rubyId_y.i) #15, !dbg !125
-  %46 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !125
-  store i64 %45, i64* %46, align 8, !dbg !125
+  %44 = call i64 @rb_id2sym(i64 %rubyId_y.i) #15, !dbg !125
+  %45 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !125
+  store i64 %44, i64* %45, align 8, !dbg !125
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords.i), !dbg !125
   %rubyId_untyped8.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !126
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped8.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !126
@@ -1758,12 +1750,12 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.3, i64 %rubyId_untyped14.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !131
   %rubyId_params16.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !132
   %rubyId_x18.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !132
-  %47 = call i64 @rb_id2sym(i64 %rubyId_x18.i) #15, !dbg !132
-  store i64 %47, i64* %keywords17.i, align 8, !dbg !132
+  %46 = call i64 @rb_id2sym(i64 %rubyId_x18.i) #15, !dbg !132
+  store i64 %46, i64* %keywords17.i, align 8, !dbg !132
   %rubyId_y20.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !132
-  %48 = call i64 @rb_id2sym(i64 %rubyId_y20.i) #15, !dbg !132
-  %49 = getelementptr i64, i64* %keywords17.i, i32 1, !dbg !132
-  store i64 %48, i64* %49, align 8, !dbg !132
+  %47 = call i64 @rb_id2sym(i64 %rubyId_y20.i) #15, !dbg !132
+  %48 = getelementptr i64, i64* %keywords17.i, i32 1, !dbg !132
+  store i64 %47, i64* %48, align 8, !dbg !132
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.4, i64 %rubyId_params16.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords17.i), !dbg !132
   %rubyId_untyped24.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !133
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.5, i64 %rubyId_untyped24.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !133
@@ -1775,12 +1767,12 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.8, i64 %rubyId_untyped31.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !138
   %rubyId_params33.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !139
   %rubyId_x35.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !139
-  %50 = call i64 @rb_id2sym(i64 %rubyId_x35.i) #15, !dbg !139
-  store i64 %50, i64* %keywords34.i, align 8, !dbg !139
+  %49 = call i64 @rb_id2sym(i64 %rubyId_x35.i) #15, !dbg !139
+  store i64 %49, i64* %keywords34.i, align 8, !dbg !139
   %rubyId_y37.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !139
-  %51 = call i64 @rb_id2sym(i64 %rubyId_y37.i) #15, !dbg !139
-  %52 = getelementptr i64, i64* %keywords34.i, i32 1, !dbg !139
-  store i64 %51, i64* %52, align 8, !dbg !139
+  %50 = call i64 @rb_id2sym(i64 %rubyId_y37.i) #15, !dbg !139
+  %51 = getelementptr i64, i64* %keywords34.i, i32 1, !dbg !139
+  store i64 %50, i64* %51, align 8, !dbg !139
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.9, i64 %rubyId_params33.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords34.i), !dbg !139
   %rubyId_returns41.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !139
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.10, i64 %rubyId_returns41.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !139
@@ -1790,134 +1782,126 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.12, i64 %rubyId_untyped46.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !144
   %rubyId_params48.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !145
   %rubyId_x50.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !145
-  %53 = call i64 @rb_id2sym(i64 %rubyId_x50.i) #15, !dbg !145
-  store i64 %53, i64* %keywords49.i, align 8, !dbg !145
+  %52 = call i64 @rb_id2sym(i64 %rubyId_x50.i) #15, !dbg !145
+  store i64 %52, i64* %keywords49.i, align 8, !dbg !145
   %rubyId_y52.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !145
-  %54 = call i64 @rb_id2sym(i64 %rubyId_y52.i) #15, !dbg !145
-  %55 = getelementptr i64, i64* %keywords49.i, i32 1, !dbg !145
-  store i64 %54, i64* %55, align 8, !dbg !145
+  %53 = call i64 @rb_id2sym(i64 %rubyId_y52.i) #15, !dbg !145
+  %54 = getelementptr i64, i64* %keywords49.i, i32 1, !dbg !145
+  store i64 %53, i64* %54, align 8, !dbg !145
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.13, i64 %rubyId_params48.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords49.i), !dbg !145
   %rubyId_returns56.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !145
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.14, i64 %rubyId_returns56.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !145
   %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !67
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !67
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !71
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !71
-  %rubyId_keep_def61.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !77
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.15, i64 %rubyId_keep_def61.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !77
-  %rubyId_keep_def63.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !78
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.16, i64 %rubyId_keep_def63.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !78
-  %rubyId_keep_def65.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !79
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.17, i64 %rubyId_keep_def65.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !79
   %rubyId_plus.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !80
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus, i64 %rubyId_plus.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !80
   %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !81
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !81
   %rubyId_minus.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !82
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus, i64 %rubyId_minus.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !82
-  %rubyId_p73.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !83
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.18, i64 %rubyId_p73.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !83
+  %rubyId_p66.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !83
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.15, i64 %rubyId_p66.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !83
   %rubyId_lt.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !84
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt, i64 %rubyId_lt.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !84
-  %rubyId_p78.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !85
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.19, i64 %rubyId_p78.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !85
-  %rubyId_lt81.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !86
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.20, i64 %rubyId_lt81.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !86
-  %rubyId_p84.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !87
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.21, i64 %rubyId_p84.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !87
+  %rubyId_p71.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !85
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.16, i64 %rubyId_p71.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !85
+  %rubyId_lt74.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !86
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.17, i64 %rubyId_lt74.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !86
+  %rubyId_p77.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !87
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.18, i64 %rubyId_p77.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !87
   %rubyId_lte.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !88
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte, i64 %rubyId_lte.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !88
-  %rubyId_p89.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !89
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.22, i64 %rubyId_p89.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !89
-  %rubyId_lte92.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !90
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.23, i64 %rubyId_lte92.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !90
-  %rubyId_p95.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !91
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.24, i64 %rubyId_p95.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !91
-  %rubyId_lte98.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !92
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.25, i64 %rubyId_lte98.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !92
-  %rubyId_p101.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !93
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.26, i64 %rubyId_p101.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !93
-  %rubyId_plus104.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !94
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.27, i64 %rubyId_plus104.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !94
-  %rubyId_p107.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !95
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.28, i64 %rubyId_p107.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !95
-  %56 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_8.9, i64 0, i64 0), i64 noundef 3) #15
-  call void @rb_gc_register_mark_object(i64 %56) #15
-  store i64 %56, i64* @rubyStrFrozen_8.9, align 8
+  %rubyId_p82.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !89
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.19, i64 %rubyId_p82.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !89
+  %rubyId_lte85.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !90
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.20, i64 %rubyId_lte85.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !90
+  %rubyId_p88.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !91
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.21, i64 %rubyId_p88.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !91
+  %rubyId_lte91.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !92
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.22, i64 %rubyId_lte91.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !92
+  %rubyId_p94.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !93
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.23, i64 %rubyId_p94.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !93
+  %rubyId_plus97.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !94
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.24, i64 %rubyId_plus97.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !94
+  %rubyId_p100.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !95
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.25, i64 %rubyId_p100.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !95
+  %55 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_8.9, i64 0, i64 0), i64 noundef 3) #15
+  call void @rb_gc_register_mark_object(i64 %55) #15
+  store i64 %55, i64* @rubyStrFrozen_8.9, align 8
   %rubyId_Rational.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !96
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !96
-  %rubyId_plus111.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !97
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.29, i64 %rubyId_plus111.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !97
-  %rubyId_p114.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !98
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.30, i64 %rubyId_p114.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !98
-  %57 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_5, i64 0, i64 0), i64 noundef 1) #15
-  call void @rb_gc_register_mark_object(i64 %57) #15
-  store i64 %57, i64* @rubyStrFrozen_5, align 8
+  %rubyId_plus104.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !97
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.26, i64 %rubyId_plus104.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !97
+  %rubyId_p107.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !98
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.27, i64 %rubyId_p107.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !98
+  %56 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_5, i64 0, i64 0), i64 noundef 1) #15
+  call void @rb_gc_register_mark_object(i64 %56) #15
+  store i64 %56, i64* @rubyStrFrozen_5, align 8
   %rubyId_Complex.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !99
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex, i64 %rubyId_Complex.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !99
-  %rubyId_plus118.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !100
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.31, i64 %rubyId_plus118.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !100
-  %rubyId_p121.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !101
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.32, i64 %rubyId_p121.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !101
-  %rubyId_minus124.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !102
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.33, i64 %rubyId_minus124.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !102
-  %rubyId_p127.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !103
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.34, i64 %rubyId_p127.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !103
-  %58 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_15.4, i64 0, i64 0), i64 noundef 4) #15
+  %rubyId_plus111.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !100
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.28, i64 %rubyId_plus111.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !100
+  %rubyId_p114.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !101
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.29, i64 %rubyId_p114.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !101
+  %rubyId_minus117.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !102
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.30, i64 %rubyId_minus117.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !102
+  %rubyId_p120.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !103
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.31, i64 %rubyId_p120.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !103
+  %57 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_15.4, i64 0, i64 0), i64 noundef 4) #15
+  call void @rb_gc_register_mark_object(i64 %57) #15
+  store i64 %57, i64* @rubyStrFrozen_15.4, align 8
+  %rubyId_Rational123.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !104
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.32, i64 %rubyId_Rational123.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
+  %rubyId_minus125.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !105
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.33, i64 %rubyId_minus125.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !105
+  %rubyId_p128.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !106
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.34, i64 %rubyId_p128.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !106
+  %58 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_18, i64 0, i64 0), i64 noundef 2) #15
   call void @rb_gc_register_mark_object(i64 %58) #15
-  store i64 %58, i64* @rubyStrFrozen_15.4, align 8
-  %rubyId_Rational130.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !104
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.35, i64 %rubyId_Rational130.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
-  %rubyId_minus132.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !105
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.36, i64 %rubyId_minus132.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !105
-  %rubyId_p135.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !106
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.37, i64 %rubyId_p135.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !106
-  %59 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_18, i64 0, i64 0), i64 noundef 2) #15
+  store i64 %58, i64* @rubyStrFrozen_18, align 8
+  %rubyId_Complex131.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !107
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.35, i64 %rubyId_Complex131.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !107
+  %rubyId_minus133.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !108
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.36, i64 %rubyId_minus133.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !108
+  %rubyId_p136.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !109
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.37, i64 %rubyId_p136.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !109
+  %rubyId_lt139.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !110
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.38, i64 %rubyId_lt139.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !110
+  %rubyId_p142.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !111
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.39, i64 %rubyId_p142.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !111
+  %59 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_25.4, i64 0, i64 0), i64 noundef 4) #15
   call void @rb_gc_register_mark_object(i64 %59) #15
-  store i64 %59, i64* @rubyStrFrozen_18, align 8
-  %rubyId_Complex138.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !107
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.38, i64 %rubyId_Complex138.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !107
-  %rubyId_minus140.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !108
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.39, i64 %rubyId_minus140.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !108
-  %rubyId_p143.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !109
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.40, i64 %rubyId_p143.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !109
-  %rubyId_lt146.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !110
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.41, i64 %rubyId_lt146.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !110
-  %rubyId_p149.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !111
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.42, i64 %rubyId_p149.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !111
-  %60 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_25.4, i64 0, i64 0), i64 noundef 4) #15
+  store i64 %59, i64* @rubyStrFrozen_25.4, align 8
+  %rubyId_Rational145.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !112
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.40, i64 %rubyId_Rational145.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
+  %rubyId_lt147.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !113
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.41, i64 %rubyId_lt147.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !113
+  %rubyId_p150.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !114
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.42, i64 %rubyId_p150.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !114
+  %rubyId_lte153.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !115
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.43, i64 %rubyId_lte153.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !115
+  %rubyId_p156.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !116
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.44, i64 %rubyId_p156.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !116
+  %60 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_5.923, i64 0, i64 0), i64 noundef 5) #15
   call void @rb_gc_register_mark_object(i64 %60) #15
-  store i64 %60, i64* @rubyStrFrozen_25.4, align 8
-  %rubyId_Rational152.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !112
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.43, i64 %rubyId_Rational152.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
-  %rubyId_lt154.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !113
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.44, i64 %rubyId_lt154.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !113
-  %rubyId_p157.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !114
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.45, i64 %rubyId_p157.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !114
-  %rubyId_lte160.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !115
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.46, i64 %rubyId_lte160.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !115
-  %rubyId_p163.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !116
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.47, i64 %rubyId_p163.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !116
-  %61 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_5.923, i64 0, i64 0), i64 noundef 5) #15
-  call void @rb_gc_register_mark_object(i64 %61) #15
-  store i64 %61, i64* @rubyStrFrozen_5.923, align 8
-  %rubyId_Rational166.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !117
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.48, i64 %rubyId_Rational166.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !117
-  %rubyId_lte168.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !118
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.49, i64 %rubyId_lte168.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !118
-  %rubyId_p171.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !119
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.50, i64 %rubyId_p171.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !119
+  store i64 %60, i64* @rubyStrFrozen_5.923, align 8
+  %rubyId_Rational159.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !117
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.45, i64 %rubyId_Rational159.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !117
+  %rubyId_lte161.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !118
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.46, i64 %rubyId_lte161.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !118
+  %rubyId_p164.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !119
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.47, i64 %rubyId_p164.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !119
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %3)
-  %62 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %63 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %62, i64 0, i32 18
-  %64 = load i64, i64* %63, align 8, !tbaa !147
-  %65 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %65, i64 0, i32 2
-  %67 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %66, align 8, !tbaa !58
-  call fastcc void @"func_<root>.17<static-init>$152"(i64 %64, %struct.rb_control_frame_struct* %67) #15
+  %61 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %62 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %61, i64 0, i32 18
+  %63 = load i64, i64* %62, align 8, !tbaa !147
+  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2
+  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !tbaa !58
+  call fastcc void @"func_<root>.17<static-init>$152"(i64 %63, %struct.rb_control_frame_struct* %66) #15
   ret void
 }
 

--- a/test/testdata/compiler/globalfields.llo.exp
+++ b/test/testdata/compiler/globalfields.llo.exp
@@ -121,10 +121,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_v = internal unnamed_addr global i64 0, align 8
 @str_v = private unnamed_addr constant [2 x i8] c"v\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
-@ic_keep_def.4 = internal global %struct.FunctionInlineCache zeroinitializer
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
@@ -202,9 +198,9 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
 define void @Init_globalfields() local_unnamed_addr #5 {
 entry:
   %positional_table.i.i = alloca i64, align 8, !dbg !10
-  %locals.i20.i = alloca i64, i32 0, align 8
-  %locals.i18.i = alloca i64, i32 0, align 8
-  %locals.i16.i = alloca i64, i32 0, align 8
+  %locals.i17.i = alloca i64, i32 0, align 8
+  %locals.i15.i = alloca i64, i32 0, align 8
+  %locals.i13.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
@@ -225,29 +221,27 @@ entry:
   store i64 %7, i64* @rubyIdPrecomputed_normal, align 8
   %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_v, i64 0, i64 0), i64 noundef 1) #11
   store i64 %8, i64* @rubyIdPrecomputed_v, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #11
-  store i64 %9, i64* @rubyIdPrecomputed_keep_def, align 8
-  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %9) #11
+  store i64 %9, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/globalfields.rb", i64 0, i64 0), i64 noundef 38) #11
   tail call void @rb_gc_register_mark_object(i64 %10) #11
-  store i64 %10, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/globalfields.rb", i64 0, i64 0), i64 noundef 38) #11
-  tail call void @rb_gc_register_mark_object(i64 %11) #11
-  store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
+  store i64 %10, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 20)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/globalfields.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !17
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
   %rubyId_read.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !18
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !18
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_value, i64 0, i64 0), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %13) #11
-  store i64 %13, i64* @rubyStrFrozen_value, align 8
+  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_value, i64 0, i64 0), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %12) #11
+  store i64 %12, i64* @rubyStrFrozen_value, align 8
   %rubyId_write.i = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !20
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_write, i64 %rubyId_write.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
   %rubyId_read4.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !21
@@ -256,263 +250,259 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts6.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
   %rubyId_puts9.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts9.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %14) #11
+  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %13) #11
   %rubyId_write.i.i = load i64, i64* @rubyIdPrecomputed_write, align 8
-  %"rubyStr_test/testdata/compiler/globalfields.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_write.i.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#5write", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %16) #11
+  %"rubyStr_test/testdata/compiler/globalfields.rb.i12.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
+  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %rubyId_write.i.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i12.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i13.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#5write", align 8
+  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %15) #11
   %rubyId_read.i.i = load i64, i64* @rubyIdPrecomputed_read, align 8
-  %"rubyStr_test/testdata/compiler/globalfields.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %rubyId_read.i.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %18) #11
+  %"rubyStr_test/testdata/compiler/globalfields.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
+  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %rubyId_read.i.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8
+  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %17) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %"rubyStr_test/testdata/compiler/globalfields.rb.i19.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i19.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i20.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
-  %rubyId_keep_def13.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !25
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def13.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !25
-  %20 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !26
-  %21 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %20, i64 0, i32 18
-  %22 = load i64, i64* %21, align 8, !tbaa !28
-  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !26
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
-  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !38
+  %"rubyStr_test/testdata/compiler/globalfields.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
+  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %19 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !24
+  %20 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %19, i64 0, i32 18
+  %21 = load i64, i64* %20, align 8, !tbaa !26
+  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
+  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !36
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %26, align 8, !tbaa !41
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
-  %28 = load i64*, i64** %27, align 8, !tbaa !43
-  %29 = load i64, i64* %28, align 8, !tbaa !6
-  %30 = and i64 %29, -33
-  store i64 %30, i64* %28, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %23, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %31, align 8, !dbg !44, !tbaa !26
-  %32 = load i64, i64* @rb_cObject, align 8, !dbg !45
-  %33 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %32) #11, !dbg !45
-  %34 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %33) #11, !dbg !45
-  %35 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35) #11
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !39
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
+  %27 = load i64*, i64** %26, align 8, !tbaa !41
+  %28 = load i64, i64* %27, align 8, !tbaa !6
+  %29 = and i64 %28, -33
+  store i64 %29, i64* %27, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !42, !tbaa !24
+  %31 = load i64, i64* @rb_cObject, align 8, !dbg !43
+  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %31) #11, !dbg !43
+  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #11, !dbg !43
+  %34 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %34) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !26
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2
-  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !tbaa !38
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %39, align 8, !tbaa !41
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 4
-  %41 = load i64*, i64** %40, align 8, !tbaa !43
-  %42 = load i64, i64* %41, align 8, !tbaa !6
-  %43 = and i64 %42, -33
-  store i64 %43, i64* %41, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %36, %struct.rb_control_frame_struct* %38, %struct.rb_iseq_struct* %stackFrame.i.i) #11
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %44, align 8, !dbg !46, !tbaa !26
+  %35 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %35, i64 0, i32 2
+  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %36, align 8, !tbaa !36
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %38, align 8, !tbaa !39
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 4
+  %40 = load i64*, i64** %39, align 8, !tbaa !41
+  %41 = load i64, i64* %40, align 8, !tbaa !6
+  %42 = and i64 %41, -33
+  store i64 %42, i64* %40, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %35, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %43, align 8, !dbg !44, !tbaa !24
   %rubyId_write.i.i1 = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !10
   %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_write.i.i1) #11, !dbg !10
   %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !10
   %rawSym17.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !10
-  %45 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %46 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !47
-  %needTakeSlowPath = icmp ne i64 %45, %46, !dbg !10
-  br i1 %needTakeSlowPath, label %47, label %48, !dbg !10, !prof !48
+  %44 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !45
+  %needTakeSlowPath = icmp ne i64 %44, %45, !dbg !10
+  br i1 %needTakeSlowPath, label %46, label %47, !dbg !10, !prof !46
 
-47:                                               ; preds = %entry
+46:                                               ; preds = %entry
   call void @const_recompute_A(), !dbg !10
-  br label %48, !dbg !10
+  br label %47, !dbg !10
 
-48:                                               ; preds = %entry, %47
-  %49 = load i64, i64* @guarded_const_A, align 8, !dbg !10
-  %50 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %51 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !47
-  %guardUpdated = icmp eq i64 %50, %51, !dbg !10
+47:                                               ; preds = %entry, %46
+  %48 = load i64, i64* @guarded_const_A, align 8, !dbg !10
+  %49 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !45
+  %guardUpdated = icmp eq i64 %49, %50, !dbg !10
   call void @llvm.assume(i1 %guardUpdated), !dbg !10
   %stackFrame18.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#5write", align 8, !dbg !10
-  %52 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
-  %53 = bitcast i8* %52 to i16*, !dbg !10
-  %54 = load i16, i16* %53, align 8, !dbg !10
-  %55 = and i16 %54, -384, !dbg !10
-  %56 = or i16 %55, 1, !dbg !10
-  store i16 %56, i16* %53, align 8, !dbg !10
-  %57 = getelementptr inbounds i8, i8* %52, i64 8, !dbg !10
-  %58 = bitcast i8* %57 to i32*, !dbg !10
-  store i32 1, i32* %58, align 8, !dbg !10, !tbaa !49
-  %59 = getelementptr inbounds i8, i8* %52, i64 12, !dbg !10
-  %60 = getelementptr inbounds i8, i8* %52, i64 4, !dbg !10
-  %61 = bitcast i8* %60 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %59, i8 0, i64 20, i1 false) #11, !dbg !10
-  store i32 1, i32* %61, align 4, !dbg !10, !tbaa !52
+  %51 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %52 = bitcast i8* %51 to i16*, !dbg !10
+  %53 = load i16, i16* %52, align 8, !dbg !10
+  %54 = and i16 %53, -384, !dbg !10
+  %55 = or i16 %54, 1, !dbg !10
+  store i16 %55, i16* %52, align 8, !dbg !10
+  %56 = getelementptr inbounds i8, i8* %51, i64 8, !dbg !10
+  %57 = bitcast i8* %56 to i32*, !dbg !10
+  store i32 1, i32* %57, align 8, !dbg !10, !tbaa !47
+  %58 = getelementptr inbounds i8, i8* %51, i64 12, !dbg !10
+  %59 = getelementptr inbounds i8, i8* %51, i64 4, !dbg !10
+  %60 = bitcast i8* %59 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %58, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %60, align 4, !dbg !10, !tbaa !50
   %rubyId_v.i.i = load i64, i64* @rubyIdPrecomputed_v, align 8, !dbg !10
   store i64 %rubyId_v.i.i, i64* %positional_table.i.i, align 8, !dbg !10
-  %62 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %35, i64 noundef 8, i1 noundef false) #11, !dbg !10
-  %63 = getelementptr inbounds i8, i8* %52, i64 32, !dbg !10
-  %64 = bitcast i8* %63 to i8**, !dbg !10
-  store i8* %62, i8** %64, align 8, !dbg !10, !tbaa !53
-  call void @sorbet_vm_define_method(i64 %49, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#5write", i8* nonnull %52, %struct.rb_iseq_struct* %stackFrame18.i.i, i1 noundef zeroext false) #11, !dbg !10
-  %65 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !26
-  %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %65, i64 0, i32 5, !dbg !10
-  %67 = load i32, i32* %66, align 8, !dbg !10, !tbaa !54
-  %68 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %65, i64 0, i32 6, !dbg !10
-  %69 = load i32, i32* %68, align 4, !dbg !10, !tbaa !55
-  %70 = xor i32 %69, -1, !dbg !10
-  %71 = and i32 %70, %67, !dbg !10
-  %72 = icmp eq i32 %71, 0, !dbg !10
-  br i1 %72, label %fastSymCallIntrinsic_Static_keep_def31.i.i, label %73, !dbg !10, !prof !56
+  %61 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %61, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %34, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %62 = getelementptr inbounds i8, i8* %51, i64 32, !dbg !10
+  %63 = bitcast i8* %62 to i8**, !dbg !10
+  store i8* %61, i8** %63, align 8, !dbg !10, !tbaa !51
+  call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#5write", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame18.i.i, i1 noundef zeroext false) #11, !dbg !10
+  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !24
+  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 5, !dbg !10
+  %66 = load i32, i32* %65, align 8, !dbg !10, !tbaa !52
+  %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 6, !dbg !10
+  %68 = load i32, i32* %67, align 4, !dbg !10, !tbaa !53
+  %69 = xor i32 %68, -1, !dbg !10
+  %70 = and i32 %69, %66, !dbg !10
+  %71 = icmp eq i32 %70, 0, !dbg !10
+  br i1 %71, label %rb_vm_check_ints.exit1.i.i, label %72, !dbg !10, !prof !54
 
-73:                                               ; preds = %48
-  %74 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %65, i64 0, i32 8, !dbg !10
-  %75 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %74, align 8, !dbg !10, !tbaa !57
-  %76 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %75, i32 noundef 0) #11, !dbg !10
-  br label %fastSymCallIntrinsic_Static_keep_def31.i.i, !dbg !10
+72:                                               ; preds = %47
+  %73 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 8, !dbg !10
+  %74 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %73, align 8, !dbg !10, !tbaa !55
+  %75 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %74, i32 noundef 0) #11, !dbg !10
+  br label %rb_vm_check_ints.exit1.i.i, !dbg !10
 
-fastSymCallIntrinsic_Static_keep_def31.i.i:       ; preds = %73, %48
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %44, align 8, !dbg !10, !tbaa !26
-  %rubyId_read.i.i2 = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !58
-  %rawSym23.i.i = call i64 @rb_id2sym(i64 %rubyId_read.i.i2) #11, !dbg !58
-  %rubyId_normal24.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !58
-  %rawSym25.i.i = call i64 @rb_id2sym(i64 %rubyId_normal24.i.i) #11, !dbg !58
-  %stackFrame32.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8, !dbg !58
-  %77 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !58
-  %78 = bitcast i8* %77 to i16*, !dbg !58
-  %79 = load i16, i16* %78, align 8, !dbg !58
-  %80 = and i16 %79, -384, !dbg !58
-  store i16 %80, i16* %78, align 8, !dbg !58
-  %81 = getelementptr inbounds i8, i8* %77, i64 4, !dbg !58
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %81, i8 0, i64 28, i1 false) #11, !dbg !58
-  call void @sorbet_vm_define_method(i64 %49, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#4read", i8* nonnull %77, %struct.rb_iseq_struct* %stackFrame32.i.i, i1 noundef zeroext false) #11, !dbg !58
-  %82 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !58, !tbaa !26
-  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 5, !dbg !58
-  %84 = load i32, i32* %83, align 8, !dbg !58, !tbaa !54
-  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 6, !dbg !58
-  %86 = load i32, i32* %85, align 4, !dbg !58, !tbaa !55
-  %87 = xor i32 %86, -1, !dbg !58
-  %88 = and i32 %87, %84, !dbg !58
-  %89 = icmp eq i32 %88, 0, !dbg !58
-  br i1 %89, label %"func_<root>.17<static-init>$152.exit", label %90, !dbg !58, !prof !56
+rb_vm_check_ints.exit1.i.i:                       ; preds = %72, %47
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %43, align 8, !dbg !10, !tbaa !24
+  %rubyId_read.i.i2 = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !56
+  %rawSym20.i.i = call i64 @rb_id2sym(i64 %rubyId_read.i.i2) #11, !dbg !56
+  %rubyId_normal21.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !56
+  %rawSym22.i.i = call i64 @rb_id2sym(i64 %rubyId_normal21.i.i) #11, !dbg !56
+  %stackFrame27.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8, !dbg !56
+  %76 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !56
+  %77 = bitcast i8* %76 to i16*, !dbg !56
+  %78 = load i16, i16* %77, align 8, !dbg !56
+  %79 = and i16 %78, -384, !dbg !56
+  store i16 %79, i16* %77, align 8, !dbg !56
+  %80 = getelementptr inbounds i8, i8* %76, i64 4, !dbg !56
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %80, i8 0, i64 28, i1 false) #11, !dbg !56
+  call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#4read", i8* nonnull %76, %struct.rb_iseq_struct* %stackFrame27.i.i, i1 noundef zeroext false) #11, !dbg !56
+  %81 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !56, !tbaa !24
+  %82 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 5, !dbg !56
+  %83 = load i32, i32* %82, align 8, !dbg !56, !tbaa !52
+  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 6, !dbg !56
+  %85 = load i32, i32* %84, align 4, !dbg !56, !tbaa !53
+  %86 = xor i32 %85, -1, !dbg !56
+  %87 = and i32 %86, %83, !dbg !56
+  %88 = icmp eq i32 %87, 0, !dbg !56
+  br i1 %88, label %"func_<root>.17<static-init>$152.exit", label %89, !dbg !56, !prof !54
 
-90:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def31.i.i
-  %91 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 8, !dbg !58
-  %92 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %91, align 8, !dbg !58, !tbaa !57
-  %93 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %92, i32 noundef 0) #11, !dbg !58
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !58
+89:                                               ; preds = %rb_vm_check_ints.exit1.i.i
+  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %81, i64 0, i32 8, !dbg !56
+  %91 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %90, align 8, !dbg !56, !tbaa !55
+  %92 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %91, i32 noundef 0) #11, !dbg !56
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !56
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %fastSymCallIntrinsic_Static_keep_def31.i.i, %90
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35) #11
-  call void @sorbet_popFrame() #11, !dbg !45
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %31, align 8, !dbg !45, !tbaa !26
-  %94 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !17
-  %95 = load i64*, i64** %94, align 8, !dbg !17
-  store i64 %49, i64* %95, align 8, !dbg !17, !tbaa !6
-  %96 = getelementptr inbounds i64, i64* %95, i64 1, !dbg !17
-  store i64* %96, i64** %94, align 8, !dbg !17
+"func_<root>.17<static-init>$152.exit":           ; preds = %rb_vm_check_ints.exit1.i.i, %89
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %34) #11
+  call void @sorbet_popFrame() #11, !dbg !43
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %30, align 8, !dbg !43, !tbaa !24
+  %93 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !17
+  %94 = load i64*, i64** %93, align 8, !dbg !17
+  store i64 %48, i64* %94, align 8, !dbg !17, !tbaa !6
+  %95 = getelementptr inbounds i64, i64* %94, i64 1, !dbg !17
+  store i64* %95, i64** %93, align 8, !dbg !17
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %31, align 8, !dbg !17, !tbaa !26
-  %97 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !18
-  %98 = load i64*, i64** %97, align 8, !dbg !18
-  store i64 %send, i64* %98, align 8, !dbg !18, !tbaa !6
-  %99 = getelementptr inbounds i64, i64* %98, i64 1, !dbg !18
-  store i64* %99, i64** %97, align 8, !dbg !18
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %30, align 8, !dbg !17, !tbaa !24
+  %96 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !18
+  %97 = load i64*, i64** %96, align 8, !dbg !18
+  store i64 %send, i64* %97, align 8, !dbg !18, !tbaa !6
+  %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !18
+  store i64* %98, i64** %96, align 8, !dbg !18
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
-  %100 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !19
-  %101 = load i64*, i64** %100, align 8, !dbg !19
-  store i64 %22, i64* %101, align 8, !dbg !19, !tbaa !6
+  %99 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !19
+  %100 = load i64*, i64** %99, align 8, !dbg !19
+  store i64 %21, i64* %100, align 8, !dbg !19, !tbaa !6
+  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !19
+  store i64 %send4, i64* %101, align 8, !dbg !19, !tbaa !6
   %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !19
-  store i64 %send4, i64* %102, align 8, !dbg !19, !tbaa !6
-  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !19
-  store i64* %103, i64** %100, align 8, !dbg !19
+  store i64* %102, i64** %99, align 8, !dbg !19
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %31, align 8, !dbg !19, !tbaa !26
-  %rubyStr_value.i = load i64, i64* @rubyStrFrozen_value, align 8, !dbg !59
-  %104 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !20
-  %105 = load i64*, i64** %104, align 8, !dbg !20
-  store i64 %send, i64* %105, align 8, !dbg !20, !tbaa !6
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %30, align 8, !dbg !19, !tbaa !24
+  %rubyStr_value.i = load i64, i64* @rubyStrFrozen_value, align 8, !dbg !57
+  %103 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !20
+  %104 = load i64*, i64** %103, align 8, !dbg !20
+  store i64 %send, i64* %104, align 8, !dbg !20, !tbaa !6
+  %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !20
+  store i64 %rubyStr_value.i, i64* %105, align 8, !dbg !20, !tbaa !6
   %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !20
-  store i64 %rubyStr_value.i, i64* %106, align 8, !dbg !20, !tbaa !6
-  %107 = getelementptr inbounds i64, i64* %106, i64 1, !dbg !20
-  store i64* %107, i64** %104, align 8, !dbg !20
+  store i64* %106, i64** %103, align 8, !dbg !20
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !20
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %31, align 8, !dbg !20, !tbaa !26
-  %108 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !21
-  %109 = load i64*, i64** %108, align 8, !dbg !21
-  store i64 %send, i64* %109, align 8, !dbg !21, !tbaa !6
-  %110 = getelementptr inbounds i64, i64* %109, i64 1, !dbg !21
-  store i64* %110, i64** %108, align 8, !dbg !21
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %30, align 8, !dbg !20, !tbaa !24
+  %107 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !21
+  %108 = load i64*, i64** %107, align 8, !dbg !21
+  store i64 %send, i64* %108, align 8, !dbg !21, !tbaa !6
+  %109 = getelementptr inbounds i64, i64* %108, i64 1, !dbg !21
+  store i64* %109, i64** %107, align 8, !dbg !21
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.1, i64 0), !dbg !21
-  %111 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !22
-  %112 = load i64*, i64** %111, align 8, !dbg !22
-  store i64 %22, i64* %112, align 8, !dbg !22, !tbaa !6
+  %110 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !22
+  %111 = load i64*, i64** %110, align 8, !dbg !22
+  store i64 %21, i64* %111, align 8, !dbg !22, !tbaa !6
+  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !22
+  store i64 %send10, i64* %112, align 8, !dbg !22, !tbaa !6
   %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !22
-  store i64 %send10, i64* %113, align 8, !dbg !22, !tbaa !6
-  %114 = getelementptr inbounds i64, i64* %113, i64 1, !dbg !22
-  store i64* %114, i64** %111, align 8, !dbg !22
+  store i64* %113, i64** %110, align 8, !dbg !22
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !22
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %31, align 8, !dbg !22, !tbaa !26
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %30, align 8, !dbg !22, !tbaa !24
   %"rubyId_$f.i" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !23
-  %115 = call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f.i") #11, !dbg !23
-  %116 = call i64 @rb_gvar_get(%struct.rb_global_entry* %115) #11, !dbg !23
-  %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !23
-  %118 = load i64*, i64** %117, align 8, !dbg !23
-  store i64 %22, i64* %118, align 8, !dbg !23, !tbaa !6
+  %114 = call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f.i") #11, !dbg !23
+  %115 = call i64 @rb_gvar_get(%struct.rb_global_entry* %114) #11, !dbg !23
+  %116 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !23
+  %117 = load i64*, i64** %116, align 8, !dbg !23
+  store i64 %21, i64* %117, align 8, !dbg !23, !tbaa !6
+  %118 = getelementptr inbounds i64, i64* %117, i64 1, !dbg !23
+  store i64 %115, i64* %118, align 8, !dbg !23, !tbaa !6
   %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !23
-  store i64 %116, i64* %119, align 8, !dbg !23, !tbaa !6
-  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !23
-  store i64* %120, i64** %117, align 8, !dbg !23
+  store i64* %119, i64** %116, align 8, !dbg !23
   %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !23
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %31, align 8, !dbg !23, !tbaa !26
-  %121 = call i64 @sorbet_setConstant(i64 %32, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_F, i64 0, i64 0), i64 noundef 1, i64 noundef 3) #11, !dbg !60
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %30, align 8, !dbg !23, !tbaa !24
+  %120 = call i64 @sorbet_setConstant(i64 %31, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_F, i64 0, i64 0), i64 noundef 1, i64 noundef 3) #11, !dbg !58
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_A#5write"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !61 {
+define i64 @"func_A#5write"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !59 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !26
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !62
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !62
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !62
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !62, !prof !63
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !24
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !60
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !60
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !60
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !60, !prof !61
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !62
-  unreachable, !dbg !62
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !60
+  unreachable, !dbg !60
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_v = load i64, i64* %argArray, align 8, !dbg !62
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !64, !tbaa !26
-  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !65
-  %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !65
-  %2 = tail call i64 @rb_gvar_set(%struct.rb_global_entry* %1, i64 %rawArg_v) #11, !dbg !65
-  %"rubyId_$f7" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !66
-  %3 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f7") #11, !dbg !66
-  %4 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %3) #11, !dbg !66
+  %rawArg_v = load i64, i64* %argArray, align 8, !dbg !60
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !62, !tbaa !24
+  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !63
+  %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !63
+  %2 = tail call i64 @rb_gvar_set(%struct.rb_global_entry* %1, i64 %rawArg_v) #11, !dbg !63
+  %"rubyId_$f7" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !64
+  %3 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f7") #11, !dbg !64
+  %4 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %3) #11, !dbg !64
   ret i64 %4
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_A#4read"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !67 {
+define i64 @"func_A#4read"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #6 !dbg !65 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !tbaa !26
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !68
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !68, !prof !69
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !tbaa !24
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !66
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !66, !prof !67
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !68
-  unreachable, !dbg !68
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !66
+  unreachable, !dbg !66
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !70, !tbaa !26
-  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !71
-  %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !71
-  %2 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %1) #11, !dbg !71
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !68, !tbaa !24
+  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !69
+  %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !69
+  %2 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %1) #11, !dbg !69
   ret i64 %2
 }
 
@@ -532,7 +522,7 @@ declare void @llvm.assume(i1 noundef) #8
 define linkonce void @const_recompute_A() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !47
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !45
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -579,51 +569,49 @@ attributes #13 = { noreturn }
 !21 = !DILocation(line: 17, column: 6, scope: !16)
 !22 = !DILocation(line: 17, column: 1, scope: !16)
 !23 = !DILocation(line: 18, column: 1, scope: !16)
-!24 = !DILocation(line: 6, column: 3, scope: !11)
-!25 = !DILocation(line: 9, column: 3, scope: !11)
-!26 = !{!27, !27, i64 0}
-!27 = !{!"any pointer", !8, i64 0}
-!28 = !{!29, !7, i64 400}
-!29 = !{!"rb_vm_struct", !7, i64 0, !30, i64 8, !27, i64 192, !27, i64 200, !27, i64 208, !34, i64 216, !8, i64 224, !31, i64 264, !31, i64 280, !31, i64 296, !31, i64 312, !7, i64 328, !33, i64 336, !33, i64 340, !33, i64 344, !33, i64 344, !33, i64 344, !33, i64 344, !33, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !27, i64 456, !27, i64 464, !35, i64 472, !36, i64 992, !27, i64 1016, !27, i64 1024, !33, i64 1032, !33, i64 1036, !31, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !33, i64 1136, !27, i64 1144, !27, i64 1152, !27, i64 1160, !27, i64 1168, !27, i64 1176, !27, i64 1184, !33, i64 1192, !37, i64 1200, !8, i64 1232}
-!30 = !{!"rb_global_vm_lock_struct", !27, i64 0, !8, i64 8, !31, i64 48, !27, i64 64, !33, i64 72, !8, i64 80, !8, i64 128, !33, i64 176, !33, i64 180}
-!31 = !{!"list_head", !32, i64 0}
-!32 = !{!"list_node", !27, i64 0, !27, i64 8}
-!33 = !{!"int", !8, i64 0}
-!34 = !{!"long long", !8, i64 0}
-!35 = !{!"", !8, i64 0}
-!36 = !{!"rb_hook_list_struct", !27, i64 0, !33, i64 8, !33, i64 12, !33, i64 16}
-!37 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!38 = !{!39, !27, i64 16}
-!39 = !{!"rb_execution_context_struct", !27, i64 0, !7, i64 8, !27, i64 16, !27, i64 24, !27, i64 32, !33, i64 40, !33, i64 44, !27, i64 48, !27, i64 56, !27, i64 64, !7, i64 72, !7, i64 80, !27, i64 88, !7, i64 96, !27, i64 104, !27, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !40, i64 152}
-!40 = !{!"", !27, i64 0, !27, i64 8, !7, i64 16, !8, i64 24}
-!41 = !{!42, !27, i64 16}
-!42 = !{!"rb_control_frame_struct", !27, i64 0, !27, i64 8, !27, i64 16, !7, i64 24, !27, i64 32, !27, i64 40, !27, i64 48}
-!43 = !{!42, !27, i64 32}
-!44 = !DILocation(line: 0, scope: !16)
-!45 = !DILocation(line: 5, column: 1, scope: !16)
-!46 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
-!47 = !{!34, !34, i64 0}
-!48 = !{!"branch_weights", i32 1, i32 10000}
-!49 = !{!50, !33, i64 8}
-!50 = !{!"rb_sorbet_param_struct", !51, i64 0, !33, i64 4, !33, i64 8, !33, i64 12, !33, i64 16, !33, i64 20, !33, i64 24, !33, i64 28, !27, i64 32, !33, i64 40, !33, i64 44, !33, i64 48, !33, i64 52, !27, i64 56}
-!51 = !{!"", !33, i64 0, !33, i64 0, !33, i64 0, !33, i64 0, !33, i64 0, !33, i64 0, !33, i64 0, !33, i64 0, !33, i64 1, !33, i64 1}
-!52 = !{!50, !33, i64 4}
-!53 = !{!50, !27, i64 32}
-!54 = !{!39, !33, i64 40}
-!55 = !{!39, !33, i64 44}
-!56 = !{!"branch_weights", i32 2000, i32 1}
-!57 = !{!39, !27, i64 56}
-!58 = !DILocation(line: 9, column: 3, scope: !11, inlinedAt: !15)
-!59 = !DILocation(line: 16, column: 9, scope: !16)
-!60 = !DILocation(line: 19, column: 5, scope: !16)
-!61 = distinct !DISubprogram(name: "A#write", linkageName: "func_A#5write", scope: null, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!62 = !DILocation(line: 6, column: 3, scope: !61)
-!63 = !{!"branch_weights", i32 4001, i32 4000000}
-!64 = !DILocation(line: 6, column: 13, scope: !61)
-!65 = !DILocation(line: 7, column: 10, scope: !61)
-!66 = !DILocation(line: 7, column: 5, scope: !61)
-!67 = distinct !DISubprogram(name: "A#read", linkageName: "func_A#4read", scope: null, file: !4, line: 9, type: !12, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!68 = !DILocation(line: 9, column: 3, scope: !67)
-!69 = !{!"branch_weights", i32 1, i32 2000}
-!70 = !DILocation(line: 0, scope: !67)
-!71 = !DILocation(line: 10, column: 5, scope: !67)
+!24 = !{!25, !25, i64 0}
+!25 = !{!"any pointer", !8, i64 0}
+!26 = !{!27, !7, i64 400}
+!27 = !{!"rb_vm_struct", !7, i64 0, !28, i64 8, !25, i64 192, !25, i64 200, !25, i64 208, !32, i64 216, !8, i64 224, !29, i64 264, !29, i64 280, !29, i64 296, !29, i64 312, !7, i64 328, !31, i64 336, !31, i64 340, !31, i64 344, !31, i64 344, !31, i64 344, !31, i64 344, !31, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !25, i64 456, !25, i64 464, !33, i64 472, !34, i64 992, !25, i64 1016, !25, i64 1024, !31, i64 1032, !31, i64 1036, !29, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !31, i64 1136, !25, i64 1144, !25, i64 1152, !25, i64 1160, !25, i64 1168, !25, i64 1176, !25, i64 1184, !31, i64 1192, !35, i64 1200, !8, i64 1232}
+!28 = !{!"rb_global_vm_lock_struct", !25, i64 0, !8, i64 8, !29, i64 48, !25, i64 64, !31, i64 72, !8, i64 80, !8, i64 128, !31, i64 176, !31, i64 180}
+!29 = !{!"list_head", !30, i64 0}
+!30 = !{!"list_node", !25, i64 0, !25, i64 8}
+!31 = !{!"int", !8, i64 0}
+!32 = !{!"long long", !8, i64 0}
+!33 = !{!"", !8, i64 0}
+!34 = !{!"rb_hook_list_struct", !25, i64 0, !31, i64 8, !31, i64 12, !31, i64 16}
+!35 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!36 = !{!37, !25, i64 16}
+!37 = !{!"rb_execution_context_struct", !25, i64 0, !7, i64 8, !25, i64 16, !25, i64 24, !25, i64 32, !31, i64 40, !31, i64 44, !25, i64 48, !25, i64 56, !25, i64 64, !7, i64 72, !7, i64 80, !25, i64 88, !7, i64 96, !25, i64 104, !25, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !38, i64 152}
+!38 = !{!"", !25, i64 0, !25, i64 8, !7, i64 16, !8, i64 24}
+!39 = !{!40, !25, i64 16}
+!40 = !{!"rb_control_frame_struct", !25, i64 0, !25, i64 8, !25, i64 16, !7, i64 24, !25, i64 32, !25, i64 40, !25, i64 48}
+!41 = !{!40, !25, i64 32}
+!42 = !DILocation(line: 0, scope: !16)
+!43 = !DILocation(line: 5, column: 1, scope: !16)
+!44 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
+!45 = !{!32, !32, i64 0}
+!46 = !{!"branch_weights", i32 1, i32 10000}
+!47 = !{!48, !31, i64 8}
+!48 = !{!"rb_sorbet_param_struct", !49, i64 0, !31, i64 4, !31, i64 8, !31, i64 12, !31, i64 16, !31, i64 20, !31, i64 24, !31, i64 28, !25, i64 32, !31, i64 40, !31, i64 44, !31, i64 48, !31, i64 52, !25, i64 56}
+!49 = !{!"", !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 1, !31, i64 1}
+!50 = !{!48, !31, i64 4}
+!51 = !{!48, !25, i64 32}
+!52 = !{!37, !31, i64 40}
+!53 = !{!37, !31, i64 44}
+!54 = !{!"branch_weights", i32 2000, i32 1}
+!55 = !{!37, !25, i64 56}
+!56 = !DILocation(line: 9, column: 3, scope: !11, inlinedAt: !15)
+!57 = !DILocation(line: 16, column: 9, scope: !16)
+!58 = !DILocation(line: 19, column: 5, scope: !16)
+!59 = distinct !DISubprogram(name: "A#write", linkageName: "func_A#5write", scope: null, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!60 = !DILocation(line: 6, column: 3, scope: !59)
+!61 = !{!"branch_weights", i32 4001, i32 4000000}
+!62 = !DILocation(line: 6, column: 13, scope: !59)
+!63 = !DILocation(line: 7, column: 10, scope: !59)
+!64 = !DILocation(line: 7, column: 5, scope: !59)
+!65 = distinct !DISubprogram(name: "A#read", linkageName: "func_A#4read", scope: null, file: !4, line: 9, type: !12, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!66 = !DILocation(line: 9, column: 3, scope: !65)
+!67 = !{!"branch_weights", i32 1, i32 2000}
+!68 = !DILocation(line: 0, scope: !65)
+!69 = !DILocation(line: 10, column: 5, scope: !65)

--- a/test/testdata/compiler/intrinsics/bang.llo.exp
+++ b/test/testdata/compiler/intrinsics/bang.llo.exp
@@ -107,9 +107,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"str_<class:Bad>" = private unnamed_addr constant [12 x i8] c"<class:Bad>\00", align 1
 @rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
 @stackFramePrecomputed_func_Main.4test = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.2 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -124,9 +121,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_Main.13<static-init>" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<module:Main>" = internal unnamed_addr global i64 0, align 8
 @"str_<module:Main>" = private unnamed_addr constant [14 x i8] c"<module:Main>\00", align 1
-@ic_keep_self_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_self_def = internal unnamed_addr global i64 0, align 8
-@str_keep_self_def = private unnamed_addr constant [14 x i8] c"keep_self_def\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_Bad = linkonce local_unnamed_addr global i64 0
 @guarded_const_Bad = linkonce local_unnamed_addr global i64 0
@@ -195,10 +189,10 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
 ; Function Attrs: sspreq
 define void @Init_bang() local_unnamed_addr #4 {
 entry:
-  %locals.i27.i = alloca i64, i32 0, align 8
   %locals.i25.i = alloca i64, i32 0, align 8
   %locals.i23.i = alloca i64, i32 0, align 8
   %locals.i21.i = alloca i64, i32 0, align 8
+  %locals.i19.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
@@ -213,222 +207,214 @@ entry:
   store i64 %4, i64* @"rubyIdPrecomputed_<class:Bad>", align 8
   %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
   store i64 %5, i64* @rubyIdPrecomputed_normal, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #11
-  store i64 %6, i64* @rubyIdPrecomputed_keep_def, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
-  store i64 %7, i64* @rubyIdPrecomputed_new, align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #11
-  store i64 %8, i64* @"rubyIdPrecomputed_<module:Main>", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @str_keep_self_def, i64 0, i64 0), i64 noundef 13) #11
-  store i64 %9, i64* @rubyIdPrecomputed_keep_self_def, align 8
-  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %10) #11
-  store i64 %10, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @"str_test/testdata/compiler/intrinsics/bang.rb", i64 0, i64 0), i64 noundef 41) #11
-  tail call void @rb_gc_register_mark_object(i64 %11) #11
-  store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
+  store i64 %6, i64* @rubyIdPrecomputed_new, align 8
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #11
+  store i64 %7, i64* @"rubyIdPrecomputed_<module:Main>", align 8
+  %8 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %8) #11
+  store i64 %8, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @"str_test/testdata/compiler/intrinsics/bang.rb", i64 0, i64 0), i64 noundef 41) #11
+  tail call void @rb_gc_register_mark_object(i64 %9) #11
+  store i64 %9, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 23)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_test.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !10
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
-  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #11
-  call void @rb_gc_register_mark_object(i64 %13) #11
+  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #11
+  call void @rb_gc_register_mark_object(i64 %11) #11
   %"rubyId_!.i.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %"rubyId_!.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i21.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8
-  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @"str_bad bang overload", i64 0, i64 0), i64 noundef 17) #11
-  call void @rb_gc_register_mark_object(i64 %15) #11
-  store i64 %15, i64* @"rubyStrFrozen_bad bang overload", align 8
+  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_!.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8
+  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @"str_bad bang overload", i64 0, i64 0), i64 noundef 17) #11
+  call void @rb_gc_register_mark_object(i64 %13) #11
+  store i64 %13, i64* @"rubyStrFrozen_bad bang overload", align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Bad>", i64 0, i64 0), i64 noundef 11) #11
-  call void @rb_gc_register_mark_object(i64 %16) #11
+  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Bad>", i64 0, i64 0), i64 noundef 11) #11
+  call void @rb_gc_register_mark_object(i64 %14) #11
   %"rubyId_<class:Bad>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:Bad>", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %"rubyId_<class:Bad>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !17
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %18) #11
+  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
+  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %"rubyId_<class:Bad>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i21.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
+  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %16) #11
   %rubyId_test.i.i = load i64, i64* @rubyIdPrecomputed_test, align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8
-  %rubyId_puts3.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts3.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %rubyId_puts6.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts6.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  %rubyId_puts9.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts9.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_hello, i64 0, i64 0), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %20) #11
-  store i64 %20, i64* @rubyStrFrozen_hello, align 8
-  %rubyId_puts12.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts12.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
-  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
-  %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #11
-  call void @rb_gc_register_mark_object(i64 %21) #11
+  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
+  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8
+  %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
+  %rubyId_puts5.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts5.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !20
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
+  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_hello, i64 0, i64 0), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %18) #11
+  store i64 %18, i64* @rubyStrFrozen_hello, align 8
+  %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !22
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
+  %rubyId_puts15.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts15.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
+  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #11
+  call void @rb_gc_register_mark_object(i64 %19) #11
   %"rubyId_<module:Main>.i.i" = load i64, i64* @"rubyIdPrecomputed_<module:Main>", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %22 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %"rubyId_<module:Main>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 12, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i27.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %22, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
-  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !26
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !26
-  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !28
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
-  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !30
+  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
+  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %"rubyId_<module:Main>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 12, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
+  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 2
+  %23 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %22, align 8, !tbaa !26
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %26, align 8, !tbaa !34
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
-  %28 = load i64*, i64** %27, align 8, !tbaa !36
-  %29 = load i64, i64* %28, align 8, !tbaa !6
-  %30 = and i64 %29, -33
-  store i64 %30, i64* %28, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %23, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %31, align 8, !dbg !37, !tbaa !28
-  %32 = load i64, i64* @rb_cObject, align 8, !dbg !38
-  %33 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 %32) #11, !dbg !38
-  %34 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %33) #11, !dbg !38
+  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %24, align 8, !tbaa !30
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 4
+  %26 = load i64*, i64** %25, align 8, !tbaa !32
+  %27 = load i64, i64* %26, align 8, !tbaa !6
+  %28 = and i64 %27, -33
+  store i64 %28, i64* %26, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %21, %struct.rb_control_frame_struct* %23, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %29, align 8, !dbg !33, !tbaa !24
+  %30 = load i64, i64* @rb_cObject, align 8, !dbg !34
+  %31 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 %30) #11, !dbg !34
+  %32 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %31) #11, !dbg !34
   %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
-  %35 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !28
-  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %35, i64 0, i32 2
-  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %36, align 8, !tbaa !30
-  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %38, align 8, !tbaa !34
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 4
-  %40 = load i64*, i64** %39, align 8, !tbaa !36
-  %41 = load i64, i64* %40, align 8, !tbaa !6
-  %42 = and i64 %41, -33
-  store i64 %42, i64* %40, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %35, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i1.i) #11
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %43, align 8, !dbg !39, !tbaa !28
-  %"rubyId_!.i.i1" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !41
-  %rawSym.i2.i = call i64 @rb_id2sym(i64 %"rubyId_!.i.i1") #11, !dbg !41
-  %rubyId_normal.i3.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !41
-  %rawSym7.i4.i = call i64 @rb_id2sym(i64 %rubyId_normal.i3.i) #11, !dbg !41
-  %44 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !41
-  %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !42
-  %needTakeSlowPath = icmp ne i64 %44, %45, !dbg !41
-  br i1 %needTakeSlowPath, label %46, label %47, !dbg !41, !prof !44
+  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 2
+  %35 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %34, align 8, !tbaa !26
+  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %36, align 8, !tbaa !30
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 4
+  %38 = load i64*, i64** %37, align 8, !tbaa !32
+  %39 = load i64, i64* %38, align 8, !tbaa !6
+  %40 = and i64 %39, -33
+  store i64 %40, i64* %38, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %33, %struct.rb_control_frame_struct* %35, %struct.rb_iseq_struct* %stackFrame.i1.i) #11
+  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %41, align 8, !dbg !35, !tbaa !24
+  %"rubyId_!.i.i1" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !38
+  %rawSym.i2.i = call i64 @rb_id2sym(i64 %"rubyId_!.i.i1") #11, !dbg !38
+  %rubyId_normal.i3.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !38
+  %rawSym7.i4.i = call i64 @rb_id2sym(i64 %rubyId_normal.i3.i) #11, !dbg !38
+  %42 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !38
+  %43 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !39
+  %needTakeSlowPath = icmp ne i64 %42, %43, !dbg !38
+  br i1 %needTakeSlowPath, label %44, label %45, !dbg !38, !prof !41
 
-46:                                               ; preds = %entry
-  call void @const_recompute_Bad(), !dbg !41
-  br label %47, !dbg !41
+44:                                               ; preds = %entry
+  call void @const_recompute_Bad(), !dbg !38
+  br label %45, !dbg !38
 
-47:                                               ; preds = %entry, %46
-  %48 = load i64, i64* @guarded_const_Bad, align 8, !dbg !41
-  %49 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !41
-  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !42
-  %guardUpdated = icmp eq i64 %49, %50, !dbg !41
-  call void @llvm.assume(i1 %guardUpdated), !dbg !41
-  %stackFrame8.i5.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8, !dbg !41
-  %51 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !41
-  %52 = bitcast i8* %51 to i16*, !dbg !41
-  %53 = load i16, i16* %52, align 8, !dbg !41
-  %54 = and i16 %53, -384, !dbg !41
-  store i16 %54, i16* %52, align 8, !dbg !41
-  %55 = getelementptr inbounds i8, i8* %51, i64 4, !dbg !41
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %55, i8 0, i64 28, i1 false) #11, !dbg !41
-  call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Bad#1!", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame8.i5.i, i1 noundef zeroext false) #11, !dbg !41
-  %56 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !41, !tbaa !28
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 5, !dbg !41
-  %58 = load i32, i32* %57, align 8, !dbg !41, !tbaa !45
-  %59 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 6, !dbg !41
-  %60 = load i32, i32* %59, align 4, !dbg !41, !tbaa !46
-  %61 = xor i32 %60, -1, !dbg !41
-  %62 = and i32 %61, %58, !dbg !41
-  %63 = icmp eq i32 %62, 0, !dbg !41
-  br i1 %63, label %"func_Bad.13<static-init>L62.exit.i", label %64, !dbg !41, !prof !47
+45:                                               ; preds = %entry, %44
+  %46 = load i64, i64* @guarded_const_Bad, align 8, !dbg !38
+  %47 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !38
+  %48 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !39
+  %guardUpdated = icmp eq i64 %47, %48, !dbg !38
+  call void @llvm.assume(i1 %guardUpdated), !dbg !38
+  %stackFrame8.i5.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8, !dbg !38
+  %49 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !38
+  %50 = bitcast i8* %49 to i16*, !dbg !38
+  %51 = load i16, i16* %50, align 8, !dbg !38
+  %52 = and i16 %51, -384, !dbg !38
+  store i16 %52, i16* %50, align 8, !dbg !38
+  %53 = getelementptr inbounds i8, i8* %49, i64 4, !dbg !38
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %53, i8 0, i64 28, i1 false) #11, !dbg !38
+  call void @sorbet_vm_define_method(i64 %46, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Bad#1!", i8* nonnull %49, %struct.rb_iseq_struct* %stackFrame8.i5.i, i1 noundef zeroext false) #11, !dbg !38
+  %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !38, !tbaa !24
+  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 5, !dbg !38
+  %56 = load i32, i32* %55, align 8, !dbg !38, !tbaa !42
+  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 6, !dbg !38
+  %58 = load i32, i32* %57, align 4, !dbg !38, !tbaa !43
+  %59 = xor i32 %58, -1, !dbg !38
+  %60 = and i32 %59, %56, !dbg !38
+  %61 = icmp eq i32 %60, 0, !dbg !38
+  br i1 %61, label %"func_Bad.13<static-init>L62.exit.i", label %62, !dbg !38, !prof !44
 
-64:                                               ; preds = %47
-  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 8, !dbg !41
-  %66 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %65, align 8, !dbg !41, !tbaa !48
-  %67 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %66, i32 noundef 0) #11, !dbg !41
-  br label %"func_Bad.13<static-init>L62.exit.i", !dbg !41
+62:                                               ; preds = %45
+  %63 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 8, !dbg !38
+  %64 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %63, align 8, !dbg !38, !tbaa !45
+  %65 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %64, i32 noundef 0) #11, !dbg !38
+  br label %"func_Bad.13<static-init>L62.exit.i", !dbg !38
 
-"func_Bad.13<static-init>L62.exit.i":             ; preds = %64, %47
-  call void @sorbet_popFrame() #11, !dbg !38
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %31, align 8, !dbg !38, !tbaa !28
-  %68 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0)) #11, !dbg !49
-  %69 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %68) #11, !dbg !49
+"func_Bad.13<static-init>L62.exit.i":             ; preds = %62, %45
+  call void @sorbet_popFrame() #11, !dbg !34
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %29, align 8, !dbg !34, !tbaa !24
+  %66 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0)) #11, !dbg !46
+  %67 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %66) #11, !dbg !46
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
-  %70 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !28
-  %71 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %70, i64 0, i32 2
-  %72 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %71, align 8, !tbaa !30
-  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %72, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %73, align 8, !tbaa !34
-  %74 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %72, i64 0, i32 4
-  %75 = load i64*, i64** %74, align 8, !tbaa !36
-  %76 = load i64, i64* %75, align 8, !tbaa !6
-  %77 = and i64 %76, -33
-  store i64 %77, i64* %75, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %70, %struct.rb_control_frame_struct* %72, %struct.rb_iseq_struct* %stackFrame.i.i) #11
-  %78 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %69, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %78, align 8, !dbg !50, !tbaa !28
-  %rubyId_test.i.i2 = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !52
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_test.i.i2) #11, !dbg !52
-  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !52
-  %rawSym7.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !52
-  %79 = load i64, i64* @guard_epoch_Main, align 8, !dbg !52
-  %80 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !42
-  %needTakeSlowPath3 = icmp ne i64 %79, %80, !dbg !52
-  br i1 %needTakeSlowPath3, label %81, label %82, !dbg !52, !prof !44
+  %68 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %69 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %68, i64 0, i32 2
+  %70 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %69, align 8, !tbaa !26
+  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %70, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %71, align 8, !tbaa !30
+  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %70, i64 0, i32 4
+  %73 = load i64*, i64** %72, align 8, !tbaa !32
+  %74 = load i64, i64* %73, align 8, !tbaa !6
+  %75 = and i64 %74, -33
+  store i64 %75, i64* %73, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %68, %struct.rb_control_frame_struct* %70, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %76 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %67, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %76, align 8, !dbg !47, !tbaa !24
+  %rubyId_test.i.i2 = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !50
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_test.i.i2) #11, !dbg !50
+  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !50
+  %rawSym7.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !50
+  %77 = load i64, i64* @guard_epoch_Main, align 8, !dbg !50
+  %78 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !39
+  %needTakeSlowPath3 = icmp ne i64 %77, %78, !dbg !50
+  br i1 %needTakeSlowPath3, label %79, label %80, !dbg !50, !prof !41
 
-81:                                               ; preds = %"func_Bad.13<static-init>L62.exit.i"
-  call void @const_recompute_Main(), !dbg !52
-  br label %82, !dbg !52
+79:                                               ; preds = %"func_Bad.13<static-init>L62.exit.i"
+  call void @const_recompute_Main(), !dbg !50
+  br label %80, !dbg !50
 
-82:                                               ; preds = %"func_Bad.13<static-init>L62.exit.i", %81
-  %83 = load i64, i64* @guarded_const_Main, align 8, !dbg !52
-  %84 = load i64, i64* @guard_epoch_Main, align 8, !dbg !52
-  %85 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !42
-  %guardUpdated4 = icmp eq i64 %84, %85, !dbg !52
-  call void @llvm.assume(i1 %guardUpdated4), !dbg !52
-  %stackFrame8.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8, !dbg !52
-  %86 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !52
-  %87 = bitcast i8* %86 to i16*, !dbg !52
-  %88 = load i16, i16* %87, align 8, !dbg !52
-  %89 = and i16 %88, -384, !dbg !52
-  store i16 %89, i16* %87, align 8, !dbg !52
-  %90 = getelementptr inbounds i8, i8* %86, i64 4, !dbg !52
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %90, i8 0, i64 28, i1 false) #11, !dbg !52
-  call void @sorbet_vm_define_method(i64 %83, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_Main.4test, i8* nonnull %86, %struct.rb_iseq_struct* %stackFrame8.i.i, i1 noundef zeroext true) #11, !dbg !52
-  %91 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !28
-  %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %91, i64 0, i32 5, !dbg !52
-  %93 = load i32, i32* %92, align 8, !dbg !52, !tbaa !45
-  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %91, i64 0, i32 6, !dbg !52
-  %95 = load i32, i32* %94, align 4, !dbg !52, !tbaa !46
-  %96 = xor i32 %95, -1, !dbg !52
-  %97 = and i32 %96, %93, !dbg !52
-  %98 = icmp eq i32 %97, 0, !dbg !52
-  br i1 %98, label %"func_<root>.17<static-init>$152.exit", label %99, !dbg !52, !prof !47
+80:                                               ; preds = %"func_Bad.13<static-init>L62.exit.i", %79
+  %81 = load i64, i64* @guarded_const_Main, align 8, !dbg !50
+  %82 = load i64, i64* @guard_epoch_Main, align 8, !dbg !50
+  %83 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !39
+  %guardUpdated4 = icmp eq i64 %82, %83, !dbg !50
+  call void @llvm.assume(i1 %guardUpdated4), !dbg !50
+  %stackFrame8.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8, !dbg !50
+  %84 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !50
+  %85 = bitcast i8* %84 to i16*, !dbg !50
+  %86 = load i16, i16* %85, align 8, !dbg !50
+  %87 = and i16 %86, -384, !dbg !50
+  store i16 %87, i16* %85, align 8, !dbg !50
+  %88 = getelementptr inbounds i8, i8* %84, i64 4, !dbg !50
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %88, i8 0, i64 28, i1 false) #11, !dbg !50
+  call void @sorbet_vm_define_method(i64 %81, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_Main.4test, i8* nonnull %84, %struct.rb_iseq_struct* %stackFrame8.i.i, i1 noundef zeroext true) #11, !dbg !50
+  %89 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !50, !tbaa !24
+  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %89, i64 0, i32 5, !dbg !50
+  %91 = load i32, i32* %90, align 8, !dbg !50, !tbaa !42
+  %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %89, i64 0, i32 6, !dbg !50
+  %93 = load i32, i32* %92, align 4, !dbg !50, !tbaa !43
+  %94 = xor i32 %93, -1, !dbg !50
+  %95 = and i32 %94, %91, !dbg !50
+  %96 = icmp eq i32 %95, 0, !dbg !50
+  br i1 %96, label %"func_<root>.17<static-init>$152.exit", label %97, !dbg !50, !prof !44
 
-99:                                               ; preds = %82
-  %100 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %91, i64 0, i32 8, !dbg !52
-  %101 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %100, align 8, !dbg !52, !tbaa !48
-  %102 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %101, i32 noundef 0) #11, !dbg !52
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !52
+97:                                               ; preds = %80
+  %98 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %89, i64 0, i32 8, !dbg !50
+  %99 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %98, align 8, !dbg !50, !tbaa !45
+  %100 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %99, i32 noundef 0) #11, !dbg !50
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !50
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %82, %99
-  call void @sorbet_popFrame() #11, !dbg !49
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %31, align 8, !dbg !49, !tbaa !28
-  %103 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !10
-  %104 = load i64*, i64** %103, align 8, !dbg !10
-  store i64 %83, i64* %104, align 8, !dbg !10, !tbaa !6
-  %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !10
-  store i64* %105, i64** %103, align 8, !dbg !10
+"func_<root>.17<static-init>$152.exit":           ; preds = %80, %97
+  call void @sorbet_popFrame() #11, !dbg !46
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %29, align 8, !dbg !46, !tbaa !24
+  %101 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !10
+  %102 = load i64*, i64** %101, align 8, !dbg !10
+  store i64 %81, i64* %102, align 8, !dbg !10, !tbaa !6
+  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !10
+  store i64* %103, i64** %101, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !10
   ret void
 }
@@ -437,17 +423,17 @@ entry:
 define noundef i64 @"func_Bad#1!"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !16 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !28
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !53
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !53, !prof !54
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !24
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !51
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !51, !prof !52
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !53
-  unreachable, !dbg !53
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !51
+  unreachable, !dbg !51
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !55, !tbaa !28
-  %"rubyStr_bad bang overload" = load i64, i64* @"rubyStrFrozen_bad bang overload", align 8, !dbg !56
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !53, !tbaa !24
+  %"rubyStr_bad bang overload" = load i64, i64* @"rubyStrFrozen_bad bang overload", align 8, !dbg !54
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !15
   %2 = load i64*, i64** %1, align 8, !dbg !15
   store i64 %selfRaw, i64* %2, align 8, !dbg !15, !tbaa !6
@@ -456,125 +442,125 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
   %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !15
   store i64* %4, i64** %1, align 8, !dbg !15
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !15, !tbaa !28
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !15, !tbaa !24
   ret i64 20
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @func_Main.4test(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !20 {
+define i64 @func_Main.4test(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp) #5 !dbg !18 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !28
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !57
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !57, !prof !54
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !24
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !55
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !55, !prof !52
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !57
-  unreachable, !dbg !57
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !55
+  unreachable, !dbg !55
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !58, !tbaa !28
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !59), !dbg !62
-  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !19
-  %2 = load i64*, i64** %1, align 8, !dbg !19
-  store i64 %selfRaw, i64* %2, align 8, !dbg !19, !tbaa !6
-  %3 = getelementptr inbounds i64, i64* %2, i64 1, !dbg !19
-  store i64 0, i64* %3, align 8, !dbg !19, !tbaa !6
-  %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !19
-  store i64* %4, i64** %1, align 8, !dbg !19
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %0, align 8, !dbg !19, !tbaa !28
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !63), !dbg !66
-  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !21
-  %6 = load i64*, i64** %5, align 8, !dbg !21
-  store i64 %selfRaw, i64* %6, align 8, !dbg !21, !tbaa !6
-  %7 = getelementptr inbounds i64, i64* %6, i64 1, !dbg !21
-  store i64 20, i64* %7, align 8, !dbg !21, !tbaa !6
-  %8 = getelementptr inbounds i64, i64* %7, i64 1, !dbg !21
-  store i64* %8, i64** %5, align 8, !dbg !21
-  %send109 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !21
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !dbg !21, !tbaa !28
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !67), !dbg !70
-  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !22
-  %10 = load i64*, i64** %9, align 8, !dbg !22
-  store i64 %selfRaw, i64* %10, align 8, !dbg !22, !tbaa !6
-  %11 = getelementptr inbounds i64, i64* %10, i64 1, !dbg !22
-  store i64 20, i64* %11, align 8, !dbg !22, !tbaa !6
-  %12 = getelementptr inbounds i64, i64* %11, i64 1, !dbg !22
-  store i64* %12, i64** %9, align 8, !dbg !22
-  %send111 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !22
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !22, !tbaa !28
-  %rubyStr_hello = load i64, i64* @rubyStrFrozen_hello, align 8, !dbg !71
-  %"rubyId_!69" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !72
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !73), !dbg !72
-  %13 = and i64 %rubyStr_hello, -9, !dbg !72
-  %14 = icmp eq i64 %13, 0, !dbg !72
-  br i1 %14, label %sorbet_bang.exit105, label %15, !dbg !72
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !56, !tbaa !24
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !57), !dbg !60
+  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !17
+  %2 = load i64*, i64** %1, align 8, !dbg !17
+  store i64 %selfRaw, i64* %2, align 8, !dbg !17, !tbaa !6
+  %3 = getelementptr inbounds i64, i64* %2, i64 1, !dbg !17
+  store i64 0, i64* %3, align 8, !dbg !17, !tbaa !6
+  %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !17
+  store i64* %4, i64** %1, align 8, !dbg !17
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !17
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %0, align 8, !dbg !17, !tbaa !24
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !61), !dbg !64
+  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !19
+  %6 = load i64*, i64** %5, align 8, !dbg !19
+  store i64 %selfRaw, i64* %6, align 8, !dbg !19, !tbaa !6
+  %7 = getelementptr inbounds i64, i64* %6, i64 1, !dbg !19
+  store i64 20, i64* %7, align 8, !dbg !19, !tbaa !6
+  %8 = getelementptr inbounds i64, i64* %7, i64 1, !dbg !19
+  store i64* %8, i64** %5, align 8, !dbg !19
+  %send109 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !dbg !19, !tbaa !24
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !65), !dbg !68
+  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !20
+  %10 = load i64*, i64** %9, align 8, !dbg !20
+  store i64 %selfRaw, i64* %10, align 8, !dbg !20, !tbaa !6
+  %11 = getelementptr inbounds i64, i64* %10, i64 1, !dbg !20
+  store i64 20, i64* %11, align 8, !dbg !20, !tbaa !6
+  %12 = getelementptr inbounds i64, i64* %11, i64 1, !dbg !20
+  store i64* %12, i64** %9, align 8, !dbg !20
+  %send111 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !20
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !20, !tbaa !24
+  %rubyStr_hello = load i64, i64* @rubyStrFrozen_hello, align 8, !dbg !69
+  %"rubyId_!69" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !70
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !71), !dbg !70
+  %13 = and i64 %rubyStr_hello, -9, !dbg !70
+  %14 = icmp eq i64 %13, 0, !dbg !70
+  br i1 %14, label %sorbet_bang.exit105, label %15, !dbg !70
 
 15:                                               ; preds = %fillRequiredArgs
-  %16 = icmp eq i64 %rubyStr_hello, 20, !dbg !72
-  br i1 %16, label %sorbet_bang.exit105, label %17, !dbg !72
+  %16 = icmp eq i64 %rubyStr_hello, 20, !dbg !70
+  br i1 %16, label %sorbet_bang.exit105, label %17, !dbg !70
 
 17:                                               ; preds = %15
-  %18 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %rubyStr_hello, i64 %"rubyId_!69", i32 noundef 0, i64* noundef null) #11, !dbg !72
-  br label %sorbet_bang.exit105, !dbg !72
+  %18 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %rubyStr_hello, i64 %"rubyId_!69", i32 noundef 0, i64* noundef null) #11, !dbg !70
+  br label %sorbet_bang.exit105, !dbg !70
 
 sorbet_bang.exit105:                              ; preds = %fillRequiredArgs, %15, %17
-  %19 = phi i64 [ %18, %17 ], [ 0, %15 ], [ 20, %fillRequiredArgs ], !dbg !72
-  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !23
-  %21 = load i64*, i64** %20, align 8, !dbg !23
-  store i64 %selfRaw, i64* %21, align 8, !dbg !23, !tbaa !6
-  %22 = getelementptr inbounds i64, i64* %21, i64 1, !dbg !23
-  store i64 %19, i64* %22, align 8, !dbg !23, !tbaa !6
-  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !23
-  store i64* %23, i64** %20, align 8, !dbg !23
-  %send113 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !23
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %0, align 8, !dbg !23, !tbaa !28
-  %24 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !24
-  %25 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !42
-  %needTakeSlowPath = icmp ne i64 %24, %25, !dbg !24
-  br i1 %needTakeSlowPath, label %26, label %27, !dbg !24, !prof !44
+  %19 = phi i64 [ %18, %17 ], [ 0, %15 ], [ 20, %fillRequiredArgs ], !dbg !70
+  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !21
+  %21 = load i64*, i64** %20, align 8, !dbg !21
+  store i64 %selfRaw, i64* %21, align 8, !dbg !21, !tbaa !6
+  %22 = getelementptr inbounds i64, i64* %21, i64 1, !dbg !21
+  store i64 %19, i64* %22, align 8, !dbg !21, !tbaa !6
+  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !21
+  store i64* %23, i64** %20, align 8, !dbg !21
+  %send113 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !21
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %0, align 8, !dbg !21, !tbaa !24
+  %24 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !22
+  %25 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !39
+  %needTakeSlowPath = icmp ne i64 %24, %25, !dbg !22
+  br i1 %needTakeSlowPath, label %26, label %27, !dbg !22, !prof !41
 
 26:                                               ; preds = %sorbet_bang.exit105
-  tail call void @const_recompute_Bad(), !dbg !24
-  br label %27, !dbg !24
+  tail call void @const_recompute_Bad(), !dbg !22
+  br label %27, !dbg !22
 
 27:                                               ; preds = %sorbet_bang.exit105, %26
-  %28 = load i64, i64* @guarded_const_Bad, align 8, !dbg !24
-  %29 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !24
-  %30 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !42
-  %guardUpdated = icmp eq i64 %29, %30, !dbg !24
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !24
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !24
-  %32 = load i64*, i64** %31, align 8, !dbg !24
-  store i64 %28, i64* %32, align 8, !dbg !24, !tbaa !6
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !24
-  store i64* %33, i64** %31, align 8, !dbg !24
-  %send115 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !24
-  %"rubyId_!85" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !76
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !77), !dbg !76
-  %34 = and i64 %send115, -9, !dbg !76
-  %35 = icmp eq i64 %34, 0, !dbg !76
-  br i1 %35, label %sorbet_bang.exit, label %36, !dbg !76
+  %28 = load i64, i64* @guarded_const_Bad, align 8, !dbg !22
+  %29 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !22
+  %30 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !39
+  %guardUpdated = icmp eq i64 %29, %30, !dbg !22
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !22
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !22
+  %32 = load i64*, i64** %31, align 8, !dbg !22
+  store i64 %28, i64* %32, align 8, !dbg !22, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !22
+  store i64* %33, i64** %31, align 8, !dbg !22
+  %send115 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !22
+  %"rubyId_!85" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !74
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !75), !dbg !74
+  %34 = and i64 %send115, -9, !dbg !74
+  %35 = icmp eq i64 %34, 0, !dbg !74
+  br i1 %35, label %sorbet_bang.exit, label %36, !dbg !74
 
 36:                                               ; preds = %27
-  %37 = icmp eq i64 %send115, 20, !dbg !76
-  br i1 %37, label %sorbet_bang.exit, label %38, !dbg !76
+  %37 = icmp eq i64 %send115, 20, !dbg !74
+  br i1 %37, label %sorbet_bang.exit, label %38, !dbg !74
 
 38:                                               ; preds = %36
-  %39 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %send115, i64 %"rubyId_!85", i32 noundef 0, i64* noundef null) #11, !dbg !76
-  br label %sorbet_bang.exit, !dbg !76
+  %39 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %send115, i64 %"rubyId_!85", i32 noundef 0, i64* noundef null) #11, !dbg !74
+  br label %sorbet_bang.exit, !dbg !74
 
 sorbet_bang.exit:                                 ; preds = %27, %36, %38
-  %40 = phi i64 [ %39, %38 ], [ 0, %36 ], [ 20, %27 ], !dbg !76
-  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !25
-  %42 = load i64*, i64** %41, align 8, !dbg !25
-  store i64 %selfRaw, i64* %42, align 8, !dbg !25, !tbaa !6
-  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !25
-  store i64 %40, i64* %43, align 8, !dbg !25, !tbaa !6
-  %44 = getelementptr inbounds i64, i64* %43, i64 1, !dbg !25
-  store i64* %44, i64** %41, align 8, !dbg !25
-  %send117 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !25
+  %40 = phi i64 [ %39, %38 ], [ 0, %36 ], [ 20, %27 ], !dbg !74
+  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !23
+  %42 = load i64*, i64** %41, align 8, !dbg !23
+  store i64 %selfRaw, i64* %42, align 8, !dbg !23, !tbaa !6
+  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !23
+  store i64 %40, i64* %43, align 8, !dbg !23, !tbaa !6
+  %44 = getelementptr inbounds i64, i64* %43, i64 1, !dbg !23
+  store i64* %44, i64** %41, align 8, !dbg !23
+  %send117 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !23
   ret i64 %send117
 }
 
@@ -591,7 +577,7 @@ declare void @llvm.assume(i1 noundef) #8
 define linkonce void @const_recompute_Bad() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 3)
   store i64 %1, i64* @guarded_const_Bad, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !42
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !39
   store i64 %2, i64* @guard_epoch_Bad, align 8
   ret void
 }
@@ -600,7 +586,7 @@ define linkonce void @const_recompute_Bad() local_unnamed_addr #9 {
 define linkonce void @const_recompute_Main() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0), i64 4)
   store i64 %1, i64* @guarded_const_Main, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !42
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !39
   store i64 %2, i64* @guard_epoch_Main, align 8
   ret void
 }
@@ -640,66 +626,64 @@ attributes #13 = { noreturn }
 !14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
 !15 = !DILocation(line: 7, column: 5, scope: !16)
 !16 = distinct !DISubprogram(name: "Bad#!", linkageName: "func_Bad#1!", scope: null, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!17 = !DILocation(line: 6, column: 3, scope: !18)
-!18 = distinct !DISubprogram(name: "Bad.<static-init>", linkageName: "func_Bad.13<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!19 = !DILocation(line: 14, column: 5, scope: !20)
-!20 = distinct !DISubprogram(name: "Main.test", linkageName: "func_Main.4test", scope: null, file: !4, line: 13, type: !12, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!21 = !DILocation(line: 15, column: 5, scope: !20)
-!22 = !DILocation(line: 16, column: 5, scope: !20)
-!23 = !DILocation(line: 17, column: 5, scope: !20)
-!24 = !DILocation(line: 18, column: 11, scope: !20)
-!25 = !DILocation(line: 18, column: 5, scope: !20)
-!26 = !DILocation(line: 13, column: 3, scope: !27)
-!27 = distinct !DISubprogram(name: "Main.<static-init>", linkageName: "func_Main.13<static-init>L129", scope: null, file: !4, line: 12, type: !12, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!28 = !{!29, !29, i64 0}
-!29 = !{!"any pointer", !8, i64 0}
-!30 = !{!31, !29, i64 16}
-!31 = !{!"rb_execution_context_struct", !29, i64 0, !7, i64 8, !29, i64 16, !29, i64 24, !29, i64 32, !32, i64 40, !32, i64 44, !29, i64 48, !29, i64 56, !29, i64 64, !7, i64 72, !7, i64 80, !29, i64 88, !7, i64 96, !29, i64 104, !29, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !33, i64 152}
-!32 = !{!"int", !8, i64 0}
-!33 = !{!"", !29, i64 0, !29, i64 8, !7, i64 16, !8, i64 24}
-!34 = !{!35, !29, i64 16}
-!35 = !{!"rb_control_frame_struct", !29, i64 0, !29, i64 8, !29, i64 16, !7, i64 24, !29, i64 32, !29, i64 40, !29, i64 48}
-!36 = !{!35, !29, i64 32}
-!37 = !DILocation(line: 0, scope: !11)
-!38 = !DILocation(line: 5, column: 1, scope: !11)
-!39 = !DILocation(line: 0, scope: !18, inlinedAt: !40)
-!40 = distinct !DILocation(line: 5, column: 1, scope: !11)
-!41 = !DILocation(line: 6, column: 3, scope: !18, inlinedAt: !40)
-!42 = !{!43, !43, i64 0}
-!43 = !{!"long long", !8, i64 0}
-!44 = !{!"branch_weights", i32 1, i32 10000}
-!45 = !{!31, !32, i64 40}
-!46 = !{!31, !32, i64 44}
-!47 = !{!"branch_weights", i32 2000, i32 1}
-!48 = !{!31, !29, i64 56}
-!49 = !DILocation(line: 12, column: 1, scope: !11)
-!50 = !DILocation(line: 0, scope: !27, inlinedAt: !51)
-!51 = distinct !DILocation(line: 12, column: 1, scope: !11)
-!52 = !DILocation(line: 13, column: 3, scope: !27, inlinedAt: !51)
-!53 = !DILocation(line: 6, column: 3, scope: !16)
-!54 = !{!"branch_weights", i32 1, i32 2000}
-!55 = !DILocation(line: 0, scope: !16)
-!56 = !DILocation(line: 7, column: 10, scope: !16)
-!57 = !DILocation(line: 13, column: 3, scope: !20)
-!58 = !DILocation(line: 0, scope: !20)
-!59 = !{!60}
-!60 = distinct !{!60, !61, !"sorbet_bang: argument 0"}
-!61 = distinct !{!61, !"sorbet_bang"}
-!62 = !DILocation(line: 14, column: 10, scope: !20)
-!63 = !{!64}
-!64 = distinct !{!64, !65, !"sorbet_bang: argument 0"}
-!65 = distinct !{!65, !"sorbet_bang"}
-!66 = !DILocation(line: 15, column: 10, scope: !20)
-!67 = !{!68}
-!68 = distinct !{!68, !69, !"sorbet_bang: argument 0"}
-!69 = distinct !{!69, !"sorbet_bang"}
-!70 = !DILocation(line: 16, column: 10, scope: !20)
-!71 = !DILocation(line: 17, column: 11, scope: !20)
-!72 = !DILocation(line: 17, column: 10, scope: !20)
-!73 = !{!74}
-!74 = distinct !{!74, !75, !"sorbet_bang: argument 0"}
-!75 = distinct !{!75, !"sorbet_bang"}
-!76 = !DILocation(line: 18, column: 10, scope: !20)
-!77 = !{!78}
-!78 = distinct !{!78, !79, !"sorbet_bang: argument 0"}
-!79 = distinct !{!79, !"sorbet_bang"}
+!17 = !DILocation(line: 14, column: 5, scope: !18)
+!18 = distinct !DISubprogram(name: "Main.test", linkageName: "func_Main.4test", scope: null, file: !4, line: 13, type: !12, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!19 = !DILocation(line: 15, column: 5, scope: !18)
+!20 = !DILocation(line: 16, column: 5, scope: !18)
+!21 = !DILocation(line: 17, column: 5, scope: !18)
+!22 = !DILocation(line: 18, column: 11, scope: !18)
+!23 = !DILocation(line: 18, column: 5, scope: !18)
+!24 = !{!25, !25, i64 0}
+!25 = !{!"any pointer", !8, i64 0}
+!26 = !{!27, !25, i64 16}
+!27 = !{!"rb_execution_context_struct", !25, i64 0, !7, i64 8, !25, i64 16, !25, i64 24, !25, i64 32, !28, i64 40, !28, i64 44, !25, i64 48, !25, i64 56, !25, i64 64, !7, i64 72, !7, i64 80, !25, i64 88, !7, i64 96, !25, i64 104, !25, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !29, i64 152}
+!28 = !{!"int", !8, i64 0}
+!29 = !{!"", !25, i64 0, !25, i64 8, !7, i64 16, !8, i64 24}
+!30 = !{!31, !25, i64 16}
+!31 = !{!"rb_control_frame_struct", !25, i64 0, !25, i64 8, !25, i64 16, !7, i64 24, !25, i64 32, !25, i64 40, !25, i64 48}
+!32 = !{!31, !25, i64 32}
+!33 = !DILocation(line: 0, scope: !11)
+!34 = !DILocation(line: 5, column: 1, scope: !11)
+!35 = !DILocation(line: 0, scope: !36, inlinedAt: !37)
+!36 = distinct !DISubprogram(name: "Bad.<static-init>", linkageName: "func_Bad.13<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!37 = distinct !DILocation(line: 5, column: 1, scope: !11)
+!38 = !DILocation(line: 6, column: 3, scope: !36, inlinedAt: !37)
+!39 = !{!40, !40, i64 0}
+!40 = !{!"long long", !8, i64 0}
+!41 = !{!"branch_weights", i32 1, i32 10000}
+!42 = !{!27, !28, i64 40}
+!43 = !{!27, !28, i64 44}
+!44 = !{!"branch_weights", i32 2000, i32 1}
+!45 = !{!27, !25, i64 56}
+!46 = !DILocation(line: 12, column: 1, scope: !11)
+!47 = !DILocation(line: 0, scope: !48, inlinedAt: !49)
+!48 = distinct !DISubprogram(name: "Main.<static-init>", linkageName: "func_Main.13<static-init>L129", scope: null, file: !4, line: 12, type: !12, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!49 = distinct !DILocation(line: 12, column: 1, scope: !11)
+!50 = !DILocation(line: 13, column: 3, scope: !48, inlinedAt: !49)
+!51 = !DILocation(line: 6, column: 3, scope: !16)
+!52 = !{!"branch_weights", i32 1, i32 2000}
+!53 = !DILocation(line: 0, scope: !16)
+!54 = !DILocation(line: 7, column: 10, scope: !16)
+!55 = !DILocation(line: 13, column: 3, scope: !18)
+!56 = !DILocation(line: 0, scope: !18)
+!57 = !{!58}
+!58 = distinct !{!58, !59, !"sorbet_bang: argument 0"}
+!59 = distinct !{!59, !"sorbet_bang"}
+!60 = !DILocation(line: 14, column: 10, scope: !18)
+!61 = !{!62}
+!62 = distinct !{!62, !63, !"sorbet_bang: argument 0"}
+!63 = distinct !{!63, !"sorbet_bang"}
+!64 = !DILocation(line: 15, column: 10, scope: !18)
+!65 = !{!66}
+!66 = distinct !{!66, !67, !"sorbet_bang: argument 0"}
+!67 = distinct !{!67, !"sorbet_bang"}
+!68 = !DILocation(line: 16, column: 10, scope: !18)
+!69 = !DILocation(line: 17, column: 11, scope: !18)
+!70 = !DILocation(line: 17, column: 10, scope: !18)
+!71 = !{!72}
+!72 = distinct !{!72, !73, !"sorbet_bang: argument 0"}
+!73 = distinct !{!73, !"sorbet_bang"}
+!74 = !DILocation(line: 18, column: 10, scope: !18)
+!75 = !{!76}
+!76 = distinct !{!76, !77, !"sorbet_bang: argument 0"}
+!77 = distinct !{!77, !"sorbet_bang"}

--- a/test/testdata/compiler/intrinsics/t_must.llo.exp
+++ b/test/testdata/compiler/intrinsics/t_must.llo.exp
@@ -147,10 +147,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"str_<module:Test>" = private unnamed_addr constant [14 x i8] c"<module:Test>\00", align 1
 @rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@ic_keep_self_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_self_def = internal unnamed_addr global i64 0, align 8
-@str_keep_self_def = private unnamed_addr constant [14 x i8] c"keep_self_def\00", align 1
-@ic_keep_self_def.7 = internal global %struct.FunctionInlineCache zeroinitializer
 @guard_epoch_Test = linkonce local_unnamed_addr global i64 0
 @guarded_const_Test = linkonce local_unnamed_addr global i64 0
 @rb_eStandardError = external local_unnamed_addr constant i64
@@ -225,8 +221,8 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_Test.13<static-init>L62"(%struct.rb_control_frame_struct* %cfp) unnamed_addr #5 !dbg !10 {
-fastSymCallIntrinsic_Static_keep_self_def:
+define internal fastcc void @"func_Test.13<static-init>L62"(%struct.rb_control_frame_struct* nocapture writeonly %cfp) unnamed_addr #5 !dbg !10 {
+functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -250,11 +246,11 @@ fastSymCallIntrinsic_Static_keep_self_def:
   %needTakeSlowPath = icmp ne i64 %9, %10, !dbg !24
   br i1 %needTakeSlowPath, label %11, label %12, !dbg !24, !prof !27
 
-11:                                               ; preds = %fastSymCallIntrinsic_Static_keep_self_def
+11:                                               ; preds = %functionEntryInitializers
   tail call void @const_recompute_Test(), !dbg !24
   br label %12, !dbg !24
 
-12:                                               ; preds = %fastSymCallIntrinsic_Static_keep_self_def, %11
+12:                                               ; preds = %functionEntryInitializers, %11
   %13 = load i64, i64* @guarded_const_Test, align 8, !dbg !24
   %14 = load i64, i64* @guard_epoch_Test, align 8, !dbg !24
   %15 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !25
@@ -278,24 +274,21 @@ fastSymCallIntrinsic_Static_keep_self_def:
   %27 = xor i32 %26, -1, !dbg !24
   %28 = and i32 %27, %24, !dbg !24
   %29 = icmp eq i32 %28, 0, !dbg !24
-  br i1 %29, label %fastSymCallIntrinsic_Static_keep_self_def31, label %30, !dbg !24, !prof !30
+  br i1 %29, label %rb_vm_check_ints.exit1, label %30, !dbg !24, !prof !30
 
 30:                                               ; preds = %12
   %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 8, !dbg !24
   %32 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %31, align 8, !dbg !24, !tbaa !31
   %33 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %32, i32 noundef 0) #14, !dbg !24
-  br label %fastSymCallIntrinsic_Static_keep_self_def31, !dbg !24
+  br label %rb_vm_check_ints.exit1, !dbg !24
 
-afterSend28:                                      ; preds = %57, %fastSymCallIntrinsic_Static_keep_self_def31
-  ret void
-
-fastSymCallIntrinsic_Static_keep_self_def31:      ; preds = %12, %30
+rb_vm_check_ints.exit1:                           ; preds = %12, %30
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !24, !tbaa !14
   %rubyId_test_nilable_arg = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !32
-  %rawSym23 = tail call i64 @rb_id2sym(i64 %rubyId_test_nilable_arg), !dbg !32
-  %rubyId_normal24 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !32
-  %rawSym25 = tail call i64 @rb_id2sym(i64 %rubyId_normal24), !dbg !32
-  %stackFrame32 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8, !dbg !32
+  %rawSym20 = tail call i64 @rb_id2sym(i64 %rubyId_test_nilable_arg), !dbg !32
+  %rubyId_normal21 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !32
+  %rawSym22 = tail call i64 @rb_id2sym(i64 %rubyId_normal21), !dbg !32
+  %stackFrame27 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8, !dbg !32
   %34 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !32
   %35 = bitcast i8* %34 to i16*, !dbg !32
   %36 = load i16, i16* %35, align 8, !dbg !32
@@ -320,7 +313,7 @@ fastSymCallIntrinsic_Static_keep_self_def31:      ; preds = %12, %30
   %47 = getelementptr inbounds i8, i8* %34, i64 32, !dbg !32
   %48 = bitcast i8* %47 to i8**, !dbg !32
   store i8* %45, i8** %48, align 8, !dbg !32, !tbaa !37
-  tail call void @sorbet_vm_define_method(i64 %13, i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_Test.16test_nilable_arg, i8* nonnull %34, %struct.rb_iseq_struct* %stackFrame32, i1 noundef zeroext true) #14, !dbg !32
+  tail call void @sorbet_vm_define_method(i64 %13, i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_Test.16test_nilable_arg, i8* nonnull %34, %struct.rb_iseq_struct* %stackFrame27, i1 noundef zeroext true) #14, !dbg !32
   %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !32, !tbaa !14
   %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 5, !dbg !32
   %51 = load i32, i32* %50, align 8, !dbg !32, !tbaa !28
@@ -329,21 +322,24 @@ fastSymCallIntrinsic_Static_keep_self_def31:      ; preds = %12, %30
   %54 = xor i32 %53, -1, !dbg !32
   %55 = and i32 %54, %51, !dbg !32
   %56 = icmp eq i32 %55, 0, !dbg !32
-  br i1 %56, label %afterSend28, label %57, !dbg !32, !prof !30
+  br i1 %56, label %rb_vm_check_ints.exit, label %57, !dbg !32, !prof !30
 
-57:                                               ; preds = %fastSymCallIntrinsic_Static_keep_self_def31
+57:                                               ; preds = %rb_vm_check_ints.exit1
   %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 8, !dbg !32
   %59 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %58, align 8, !dbg !32, !tbaa !31
   %60 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %59, i32 noundef 0) #14, !dbg !32
-  br label %afterSend28, !dbg !32
+  br label %rb_vm_check_ints.exit, !dbg !32
+
+rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.exit1, %57
+  ret void
 }
 
 ; Function Attrs: sspreq
 define void @Init_t_must() local_unnamed_addr #6 {
 entry:
-  %locals.i38.i = alloca i64, i32 0, align 8
-  %locals.i28.i = alloca i64, i32 5, align 8
-  %locals.i23.i = alloca i64, i32 4, align 8
+  %locals.i35.i = alloca i64, i32 0, align 8
+  %locals.i25.i = alloca i64, i32 5, align 8
+  %locals.i20.i = alloca i64, i32 4, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #14
@@ -382,20 +378,18 @@ entry:
   store i64 %16, i64* @"rubyIdPrecomputed_<module:Test>", align 8
   %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #14
   store i64 %17, i64* @rubyIdPrecomputed_normal, align 8
-  %18 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @str_keep_self_def, i64 0, i64 0), i64 noundef 13) #14
-  store i64 %18, i64* @rubyIdPrecomputed_keep_self_def, align 8
-  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #14
+  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #14
+  tail call void @rb_gc_register_mark_object(i64 %18) #14
+  store i64 %18, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([44 x i8], [44 x i8]* @"str_test/testdata/compiler/intrinsics/t_must.rb", i64 0, i64 0), i64 noundef 43) #14
   tail call void @rb_gc_register_mark_object(i64 %19) #14
-  store i64 %19, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %20 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([44 x i8], [44 x i8]* @"str_test/testdata/compiler/intrinsics/t_must.rb", i64 0, i64 0), i64 noundef 43) #14
-  tail call void @rb_gc_register_mark_object(i64 %20) #14
-  store i64 %20, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  store i64 %19, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_test_known_nil.i = load i64, i64* @rubyIdPrecomputed_test_known_nil, align 8, !dbg !38
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_known_nil, i64 %rubyId_test_known_nil.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !38
   %rubyId_test_nilable_arg.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !40
@@ -404,172 +398,168 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.1, i64 %rubyId_test_nilable_arg2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !41
   %rubyId_test_nilable_arg4.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !42
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.2, i64 %rubyId_test_nilable_arg4.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !42
-  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_test_known_nil, i64 0, i64 0), i64 noundef 14) #14
-  call void @rb_gc_register_mark_object(i64 %22) #14
-  %23 = bitcast i64* %locals.i23.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %23)
+  %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_test_known_nil, i64 0, i64 0), i64 noundef 14) #14
+  call void @rb_gc_register_mark_object(i64 %21) #14
+  %22 = bitcast i64* %locals.i20.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %22)
   %rubyId_test_known_nil.i.i = load i64, i64* @rubyIdPrecomputed_test_known_nil, align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i19.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
   %"rubyId_<exceptionValue>.i.i" = load i64, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
-  store i64 %"rubyId_<exceptionValue>.i.i", i64* %locals.i23.i, align 8
+  store i64 %"rubyId_<exceptionValue>.i.i", i64* %locals.i20.i, align 8
   %"rubyId_<magic>.i.i" = load i64, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %24 = getelementptr i64, i64* %locals.i23.i, i32 1
-  store i64 %"rubyId_<magic>.i.i", i64* %24, align 8
+  %23 = getelementptr i64, i64* %locals.i20.i, i32 1
+  store i64 %"rubyId_<magic>.i.i", i64* %23, align 8
   %"rubyId_<returnMethodTemp>.i.i" = load i64, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %25 = getelementptr i64, i64* %locals.i23.i, i32 2
-  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %25, align 8
+  %24 = getelementptr i64, i64* %locals.i20.i, i32 2
+  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %24, align 8
   %"rubyId_<gotoDeadTemp>.i.i" = load i64, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %26 = getelementptr i64, i64* %locals.i23.i, i32 3
-  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %26, align 8
-  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %rubyId_test_known_nil.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i23.i, i32 noundef 4, i32 noundef 2)
-  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
-  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %23)
-  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @"str_rescue in test_known_nil", i64 0, i64 0), i64 noundef 24) #14
-  call void @rb_gc_register_mark_object(i64 %28) #14
+  %25 = getelementptr i64, i64* %locals.i20.i, i32 3
+  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %25, align 8
+  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %rubyId_test_known_nil.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i19.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i20.i, i32 noundef 4, i32 noundef 2)
+  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
+  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %22)
+  %27 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @"str_rescue in test_known_nil", i64 0, i64 0), i64 noundef 24) #14
+  call void @rb_gc_register_mark_object(i64 %27) #14
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
   %"rubyId_rescue in test_known_nil.i.i" = load i64, i64* @"rubyIdPrecomputed_rescue in test_known_nil", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %29 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %28, i64 %"rubyId_rescue in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %29, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_2", align 8
-  %30 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @"str_ensure in test_known_nil", i64 0, i64 0), i64 noundef 24) #14
-  call void @rb_gc_register_mark_object(i64 %30) #14
-  %stackFrame.i25.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i21.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %27, i64 %"rubyId_rescue in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_2", align 8
+  %29 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @"str_ensure in test_known_nil", i64 0, i64 0), i64 noundef 24) #14
+  call void @rb_gc_register_mark_object(i64 %29) #14
+  %stackFrame.i22.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
   %"rubyId_ensure in test_known_nil.i.i" = load i64, i64* @"rubyIdPrecomputed_ensure in test_known_nil", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %31 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %30, i64 %"rubyId_ensure in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i25.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %31, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_3", align 8
-  %32 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #14
-  store i64 %32, i64* @"<retry-singleton>", align 8
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i23.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %29, i64 %"rubyId_ensure in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i23.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i22.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_3", align 8
+  %31 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #14
+  store i64 %31, i64* @"<retry-singleton>", align 8
   %rubyId_must.i = load i64, i64* @rubyIdPrecomputed_must, align 8, !dbg !43
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_must, i64 %rubyId_must.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !43
   %"rubyId_is_a?.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !46
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !48
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
-  %33 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 noundef 16) #14
-  call void @rb_gc_register_mark_object(i64 %33) #14
-  %34 = bitcast i64* %locals.i28.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %34)
+  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 noundef 16) #14
+  call void @rb_gc_register_mark_object(i64 %32) #14
+  %33 = bitcast i64* %locals.i25.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %33)
   %rubyId_test_nilable_arg.i.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i27.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %"rubyId_<exceptionValue>.i29.i" = load i64, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
-  store i64 %"rubyId_<exceptionValue>.i29.i", i64* %locals.i28.i, align 8
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %"rubyId_<exceptionValue>.i26.i" = load i64, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
+  store i64 %"rubyId_<exceptionValue>.i26.i", i64* %locals.i25.i, align 8
   %rubyId_arg.i.i = load i64, i64* @rubyIdPrecomputed_arg, align 8
-  %35 = getelementptr i64, i64* %locals.i28.i, i32 1
-  store i64 %rubyId_arg.i.i, i64* %35, align 8
-  %"rubyId_<magic>.i30.i" = load i64, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %36 = getelementptr i64, i64* %locals.i28.i, i32 2
-  store i64 %"rubyId_<magic>.i30.i", i64* %36, align 8
-  %"rubyId_<returnMethodTemp>.i31.i" = load i64, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %37 = getelementptr i64, i64* %locals.i28.i, i32 3
-  store i64 %"rubyId_<returnMethodTemp>.i31.i", i64* %37, align 8
-  %"rubyId_<gotoDeadTemp>.i32.i" = load i64, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %38 = getelementptr i64, i64* %locals.i28.i, i32 4
-  store i64 %"rubyId_<gotoDeadTemp>.i32.i", i64* %38, align 8
-  %39 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %33, i64 %rubyId_test_nilable_arg.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i27.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i28.i, i32 noundef 5, i32 noundef 3)
-  store %struct.rb_iseq_struct* %39, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
-  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %34)
-  %40 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([27 x i8], [27 x i8]* @"str_rescue in test_nilable_arg", i64 0, i64 0), i64 noundef 26) #14
-  call void @rb_gc_register_mark_object(i64 %40) #14
-  %stackFrame.i33.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
+  %34 = getelementptr i64, i64* %locals.i25.i, i32 1
+  store i64 %rubyId_arg.i.i, i64* %34, align 8
+  %"rubyId_<magic>.i27.i" = load i64, i64* @"rubyIdPrecomputed_<magic>", align 8
+  %35 = getelementptr i64, i64* %locals.i25.i, i32 2
+  store i64 %"rubyId_<magic>.i27.i", i64* %35, align 8
+  %"rubyId_<returnMethodTemp>.i28.i" = load i64, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
+  %36 = getelementptr i64, i64* %locals.i25.i, i32 3
+  store i64 %"rubyId_<returnMethodTemp>.i28.i", i64* %36, align 8
+  %"rubyId_<gotoDeadTemp>.i29.i" = load i64, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
+  %37 = getelementptr i64, i64* %locals.i25.i, i32 4
+  store i64 %"rubyId_<gotoDeadTemp>.i29.i", i64* %37, align 8
+  %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %32, i64 %rubyId_test_nilable_arg.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i25.i, i32 noundef 5, i32 noundef 3)
+  store %struct.rb_iseq_struct* %38, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %33)
+  %39 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([27 x i8], [27 x i8]* @"str_rescue in test_nilable_arg", i64 0, i64 0), i64 noundef 26) #14
+  call void @rb_gc_register_mark_object(i64 %39) #14
+  %stackFrame.i30.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
   %"rubyId_rescue in test_nilable_arg.i.i" = load i64, i64* @"rubyIdPrecomputed_rescue in test_nilable_arg", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i34.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %41 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %40, i64 %"rubyId_rescue in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i34.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i33.i, i32 noundef 4, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %41, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_2", align 8
-  %42 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([27 x i8], [27 x i8]* @"str_ensure in test_nilable_arg", i64 0, i64 0), i64 noundef 26) #14
-  call void @rb_gc_register_mark_object(i64 %42) #14
-  %stackFrame.i35.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %39, i64 %"rubyId_rescue in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i30.i, i32 noundef 4, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_2", align 8
+  %41 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([27 x i8], [27 x i8]* @"str_ensure in test_nilable_arg", i64 0, i64 0), i64 noundef 26) #14
+  call void @rb_gc_register_mark_object(i64 %41) #14
+  %stackFrame.i32.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
   %"rubyId_ensure in test_nilable_arg.i.i" = load i64, i64* @"rubyIdPrecomputed_ensure in test_nilable_arg", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i36.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %43 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %42, i64 %"rubyId_ensure in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i36.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i35.i, i32 noundef 5, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %43, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3", align 8
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i33.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %42 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %41, i64 %"rubyId_ensure in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i33.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i32.i, i32 noundef 5, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %42, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3", align 8
   %rubyId_must9.i = load i64, i64* @rubyIdPrecomputed_must, align 8, !dbg !49
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_must.3, i64 %rubyId_must9.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
-  %44 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_ wasn't nil", i64 0, i64 0), i64 noundef 11) #14
-  call void @rb_gc_register_mark_object(i64 %44) #14
-  store i64 %44, i64* @"rubyStrFrozen_ wasn't nil", align 8
+  %43 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_ wasn't nil", i64 0, i64 0), i64 noundef 11) #14
+  call void @rb_gc_register_mark_object(i64 %43) #14
+  store i64 %43, i64* @"rubyStrFrozen_ wasn't nil", align 8
   %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !52
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !52
   %"rubyId_is_a?14.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !53
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?.5", i64 %"rubyId_is_a?14.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !53
   %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !55
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !55
-  %45 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Test>", i64 0, i64 0), i64 noundef 13) #14
-  call void @rb_gc_register_mark_object(i64 %45) #14
+  %44 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Test>", i64 0, i64 0), i64 noundef 13) #14
+  call void @rb_gc_register_mark_object(i64 %44) #14
   %"rubyId_<module:Test>.i.i" = load i64, i64* @"rubyIdPrecomputed_<module:Test>", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i37.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %46 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %45, i64 %"rubyId_<module:Test>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i37.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i38.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %46, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
-  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
-  %rubyId_keep_self_def20.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !32
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def.7, i64 %rubyId_keep_self_def20.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !32
-  %47 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 2
-  %49 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %48, align 8, !tbaa !16
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i34.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %45 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %44, i64 %"rubyId_<module:Test>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i34.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i35.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %45, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
+  %46 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2
+  %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !tbaa !16
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %50, align 8, !tbaa !20
-  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 4
-  %52 = load i64*, i64** %51, align 8, !tbaa !22
-  %53 = load i64, i64* %52, align 8, !tbaa !6
-  %54 = and i64 %53, -33
-  store i64 %54, i64* %52, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %47, %struct.rb_control_frame_struct* %49, %struct.rb_iseq_struct* %stackFrame.i) #14
-  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %55, align 8, !dbg !56, !tbaa !14
-  %56 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Test, i64 0, i64 0)) #14, !dbg !57
-  %57 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %56) #14, !dbg !57
-  call fastcc void @"func_Test.13<static-init>L62"(%struct.rb_control_frame_struct* %57) #14, !dbg !57
+  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %49, align 8, !tbaa !20
+  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 4
+  %51 = load i64*, i64** %50, align 8, !tbaa !22
+  %52 = load i64, i64* %51, align 8, !tbaa !6
+  %53 = and i64 %52, -33
+  store i64 %53, i64* %51, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %46, %struct.rb_control_frame_struct* %48, %struct.rb_iseq_struct* %stackFrame.i) #14
+  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %54, align 8, !dbg !56, !tbaa !14
+  %55 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Test, i64 0, i64 0)) #14, !dbg !57
+  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #14, !dbg !57
+  call fastcc void @"func_Test.13<static-init>L62"(%struct.rb_control_frame_struct* nocapture writeonly %56) #14, !dbg !57
   call void @sorbet_popFrame() #14, !dbg !57
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %55, align 8, !dbg !57, !tbaa !14
-  %58 = load i64, i64* @guard_epoch_Test, align 8, !dbg !38
-  %59 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !25
-  %needTakeSlowPath = icmp ne i64 %58, %59, !dbg !38
-  br i1 %needTakeSlowPath, label %60, label %61, !dbg !38, !prof !27
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %54, align 8, !dbg !57, !tbaa !14
+  %57 = load i64, i64* @guard_epoch_Test, align 8, !dbg !38
+  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !25
+  %needTakeSlowPath = icmp ne i64 %57, %58, !dbg !38
+  br i1 %needTakeSlowPath, label %59, label %60, !dbg !38, !prof !27
 
-60:                                               ; preds = %entry
+59:                                               ; preds = %entry
   call void @const_recompute_Test(), !dbg !38
-  br label %61, !dbg !38
+  br label %60, !dbg !38
 
-61:                                               ; preds = %entry, %60
-  %62 = load i64, i64* @guarded_const_Test, align 8, !dbg !38
-  %63 = load i64, i64* @guard_epoch_Test, align 8, !dbg !38
-  %64 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !25
-  %guardUpdated = icmp eq i64 %63, %64, !dbg !38
+60:                                               ; preds = %entry, %59
+  %61 = load i64, i64* @guarded_const_Test, align 8, !dbg !38
+  %62 = load i64, i64* @guard_epoch_Test, align 8, !dbg !38
+  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !25
+  %guardUpdated = icmp eq i64 %62, %63, !dbg !38
   call void @llvm.assume(i1 %guardUpdated), !dbg !38
-  %65 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 1, !dbg !38
-  %66 = load i64*, i64** %65, align 8, !dbg !38
-  store i64 %62, i64* %66, align 8, !dbg !38, !tbaa !6
-  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !38
-  store i64* %67, i64** %65, align 8, !dbg !38
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !38
+  %65 = load i64*, i64** %64, align 8, !dbg !38
+  store i64 %61, i64* %65, align 8, !dbg !38, !tbaa !6
+  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !38
+  store i64* %66, i64** %64, align 8, !dbg !38
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_known_nil, i64 0), !dbg !38
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %55, align 8, !dbg !38, !tbaa !14
-  %68 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 1, !dbg !40
-  %69 = load i64*, i64** %68, align 8, !dbg !40
-  store i64 %62, i64* %69, align 8, !dbg !40, !tbaa !6
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %54, align 8, !dbg !38, !tbaa !14
+  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !40
+  %68 = load i64*, i64** %67, align 8, !dbg !40
+  store i64 %61, i64* %68, align 8, !dbg !40, !tbaa !6
+  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !40
+  store i64 21, i64* %69, align 8, !dbg !40, !tbaa !6
   %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !40
-  store i64 21, i64* %70, align 8, !dbg !40, !tbaa !6
-  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !40
-  store i64* %71, i64** %68, align 8, !dbg !40
+  store i64* %70, i64** %67, align 8, !dbg !40
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg, i64 0), !dbg !40
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %55, align 8, !dbg !40, !tbaa !14
-  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 1, !dbg !41
-  %73 = load i64*, i64** %72, align 8, !dbg !41
-  store i64 %62, i64* %73, align 8, !dbg !41, !tbaa !6
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %54, align 8, !dbg !40, !tbaa !14
+  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !41
+  %72 = load i64*, i64** %71, align 8, !dbg !41
+  store i64 %61, i64* %72, align 8, !dbg !41, !tbaa !6
+  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !41
+  store i64 0, i64* %73, align 8, !dbg !41, !tbaa !6
   %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !41
-  store i64 0, i64* %74, align 8, !dbg !41, !tbaa !6
-  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !41
-  store i64* %75, i64** %72, align 8, !dbg !41
+  store i64* %74, i64** %71, align 8, !dbg !41
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.1, i64 0), !dbg !41
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %55, align 8, !dbg !41, !tbaa !14
-  %76 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 1, !dbg !42
-  %77 = load i64*, i64** %76, align 8, !dbg !42
-  store i64 %62, i64* %77, align 8, !dbg !42, !tbaa !6
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %54, align 8, !dbg !41, !tbaa !14
+  %75 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !42
+  %76 = load i64*, i64** %75, align 8, !dbg !42
+  store i64 %61, i64* %76, align 8, !dbg !42, !tbaa !6
+  %77 = getelementptr inbounds i64, i64* %76, i64 1, !dbg !42
+  store i64 8, i64* %77, align 8, !dbg !42, !tbaa !6
   %78 = getelementptr inbounds i64, i64* %77, i64 1, !dbg !42
-  store i64 8, i64* %78, align 8, !dbg !42, !tbaa !6
-  %79 = getelementptr inbounds i64, i64* %78, i64 1, !dbg !42
-  store i64* %79, i64** %76, align 8, !dbg !42
+  store i64* %78, i64** %75, align 8, !dbg !42
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.2, i64 0), !dbg !42
   ret void
 }

--- a/test/testdata/compiler/repeated_casts.llo.exp
+++ b/test/testdata/compiler/repeated_casts.llo.exp
@@ -2,12 +2,6 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
-%struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
-%struct.list_node = type { %struct.list_node*, %struct.list_node* }
 %struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
 %struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
@@ -32,6 +26,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
 %union.anon.10 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
+%struct.rb_calling_info = type { i64, i64, i32, i32 }
 %union.anon.12 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
 %struct.anon.13 = type { i64, i64, i64, i64* }
@@ -39,43 +34,47 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.anon.15 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
+%struct.rb_fiber_struct = type opaque
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%struct.list_node = type { %struct.list_node*, %struct.list_node* }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
+%union.pthread_cond_t = type { %struct.anon.2 }
+%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
+%struct.anon.3 = type { [65 x i64] }
+%struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
+%struct.rb_event_hook_struct = type opaque
+%struct.rb_postponed_job_struct = type opaque
+%struct.list_head = type { %struct.list_node }
+%struct.rb_objspace = type opaque
+%struct.rb_at_exit_list = type { void (%struct.rb_vm_struct*)*, %struct.rb_at_exit_list* }
+%struct.rb_builtin_function = type opaque
+%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
+%union.anon.6 = type { %union.pthread_cond_t }
+%union.pthread_mutex_t = type { %struct.__pthread_mutex_s }
+%struct.__pthread_mutex_s = type { i32, i32, i32, i32, i32, i16, i16, %struct.__pthread_internal_list }
+%struct.__pthread_internal_list = type { %struct.__pthread_internal_list*, %struct.__pthread_internal_list* }
+%struct.rb_unblock_callback = type { void (i8*)*, i8* }
+%struct.rb_mutex_struct = type opaque
+%struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
+%union.anon.7 = type { %struct.anon.8 }
+%struct.anon.8 = type { i64, i64, i32 }
+%struct.st_table = type { i8, i8, i8, i32, %struct.st_hash_type*, i64, i64*, i64, i64, %struct.st_table_entry* }
+%struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
+%struct.st_table_entry = type opaque
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
 %struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
-%struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
-%struct.rb_unblock_callback = type { void (i8*)*, i8* }
-%struct.rb_mutex_struct = type opaque
-%struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
-%struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
-%struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
-%struct.rb_event_hook_struct = type opaque
-%struct.rb_postponed_job_struct = type opaque
-%struct.list_head = type { %struct.list_node }
-%union.pthread_mutex_t = type { %struct.__pthread_mutex_s }
-%struct.__pthread_mutex_s = type { i32, i32, i32, i32, i32, i16, i16, %struct.__pthread_internal_list }
-%struct.__pthread_internal_list = type { %struct.__pthread_internal_list*, %struct.__pthread_internal_list* }
-%struct.rb_objspace = type opaque
-%struct.rb_at_exit_list = type { void (%struct.rb_vm_struct*)*, %struct.rb_at_exit_list* }
-%struct.st_table = type { i8, i8, i8, i32, %struct.st_hash_type*, i64, i64*, i64, i64, %struct.st_table_entry* }
-%struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
-%struct.st_table_entry = type opaque
-%struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
@@ -102,14 +101,10 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
 @str_a = private unnamed_addr constant [2 x i8] c"a\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
 @"stackFramePrecomputed_func_A#3foo" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A.13<static-init>" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
 @"str_<class:A>" = private unnamed_addr constant [10 x i8] c"<class:A>\00", align 1
-@ic_keep_def.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
@@ -239,7 +234,7 @@ codeRepl:                                         ; preds = %4
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_<root>.17<static-init>$152"(%struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !25 {
+define internal fastcc void @"func_<root>.17<static-init>$152"(%struct.rb_control_frame_struct* nocapture writeonly %cfp) unnamed_addr #7 !dbg !25 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
@@ -308,18 +303,15 @@ functionEntryInitializers:
   %38 = xor i32 %37, -1, !dbg !38
   %39 = and i32 %38, %35, !dbg !38
   %40 = icmp eq i32 %39, 0, !dbg !38
-  br i1 %40, label %fastSymCallIntrinsic_Static_keep_def, label %41, !dbg !38, !prof !23
+  br i1 %40, label %"func_A.13<static-init>L61.exit", label %41, !dbg !38, !prof !23
 
 41:                                               ; preds = %24
   %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 8, !dbg !38
   %43 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %42, align 8, !dbg !38, !tbaa !41
   %44 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %43, i32 noundef 0) #15, !dbg !38
-  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !38
+  br label %"func_A.13<static-init>L61.exit", !dbg !38
 
-afterSend19:                                      ; preds = %68, %fastSymCallIntrinsic_Static_keep_def
-  ret void
-
-fastSymCallIntrinsic_Static_keep_def:             ; preds = %41, %24
+"func_A.13<static-init>L61.exit":                 ; preds = %24, %41
   tail call void @sorbet_popFrame() #15, !dbg !34
   store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !34, !tbaa !14
   %rubyId_doubleCast = load i64, i64* @rubyIdPrecomputed_doubleCast, align 8, !dbg !42
@@ -360,21 +352,24 @@ fastSymCallIntrinsic_Static_keep_def:             ; preds = %41, %24
   %65 = xor i32 %64, -1, !dbg !42
   %66 = and i32 %65, %62, !dbg !42
   %67 = icmp eq i32 %66, 0, !dbg !42
-  br i1 %67, label %afterSend19, label %68, !dbg !42, !prof !23
+  br i1 %67, label %rb_vm_check_ints.exit, label %68, !dbg !42, !prof !23
 
-68:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
+68:                                               ; preds = %"func_A.13<static-init>L61.exit"
   %69 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %60, i64 0, i32 8, !dbg !42
   %70 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %69, align 8, !dbg !42, !tbaa !41
   %71 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %70, i32 noundef 0) #15, !dbg !42
-  br label %afterSend19, !dbg !42
+  br label %rb_vm_check_ints.exit, !dbg !42
+
+rb_vm_check_ints.exit:                            ; preds = %"func_A.13<static-init>L61.exit", %68
+  ret void
 }
 
 ; Function Attrs: ssp
 define void @Init_repeated_casts() local_unnamed_addr #8 {
 entry:
-  %locals.i11.i = alloca i64, i32 0, align 8
-  %locals.i9.i = alloca i64, i32 0, align 8
-  %locals.i7.i = alloca i64, i32 0, align 8
+  %locals.i8.i = alloca i64, i32 0, align 8
+  %locals.i6.i = alloca i64, i32 0, align 8
+  %locals.i4.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 noundef 10) #15
@@ -387,71 +382,63 @@ entry:
   store i64 %3, i64* @rubyIdPrecomputed_normal, align 8
   %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #15
   store i64 %4, i64* @rubyIdPrecomputed_a, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #15
-  store i64 %5, i64* @rubyIdPrecomputed_keep_def, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #15
-  store i64 %6, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 noundef 10) #15
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #15
+  store i64 %5, i64* @"rubyIdPrecomputed_<class:A>", align 8
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 noundef 10) #15
+  tail call void @rb_gc_register_mark_object(i64 %6) #15
+  store i64 %6, i64* @rubyStrFrozen_doubleCast, align 8
+  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([41 x i8], [41 x i8]* @"str_test/testdata/compiler/repeated_casts.rb", i64 0, i64 0), i64 noundef 40) #15
   tail call void @rb_gc_register_mark_object(i64 %7) #15
-  store i64 %7, i64* @rubyStrFrozen_doubleCast, align 8
-  %8 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([41 x i8], [41 x i8]* @"str_test/testdata/compiler/repeated_casts.rb", i64 0, i64 0), i64 noundef 40) #15
-  tail call void @rb_gc_register_mark_object(i64 %8) #15
-  store i64 %8, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
+  store i64 %7, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 12)
   %rubyId_doubleCast.i.i = load i64, i64* @rubyIdPrecomputed_doubleCast, align 8
   %rubyStr_doubleCast.i.i = load i64, i64* @rubyStrFrozen_doubleCast, align 8
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
-  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_doubleCast.i.i, i64 %rubyId_doubleCast.i.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 1)
-  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#10doubleCast", align 8
+  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_doubleCast.i.i, i64 %rubyId_doubleCast.i.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 1)
+  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#10doubleCast", align 8
   %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !19
   %rubyId_foo1.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !24
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo1.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
-  %10 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
-  call void @rb_gc_register_mark_object(i64 %10) #15
+  %9 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  call void @rb_gc_register_mark_object(i64 %9) #15
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/repeated_casts.rb.i6.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
-  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %10, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i6.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i7.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !42
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !42
-  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #15
-  call void @rb_gc_register_mark_object(i64 %12) #15
+  %"rubyStr_test/testdata/compiler/repeated_casts.rb.i3.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
+  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i3.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i4.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #15
+  call void @rb_gc_register_mark_object(i64 %11) #15
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
-  %"rubyStr_test/testdata/compiler/repeated_casts.rb.i8.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %12, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i8.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i9.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #15
-  call void @rb_gc_register_mark_object(i64 %14) #15
+  %"rubyStr_test/testdata/compiler/repeated_casts.rb.i5.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i6.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
+  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #15
+  call void @rb_gc_register_mark_object(i64 %13) #15
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %"rubyStr_test/testdata/compiler/repeated_casts.rb.i10.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
-  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i10.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i11.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %rubyId_keep_def4.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.2, i64 %rubyId_keep_def4.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !48
-  %16 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %17 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %16, i64 0, i32 18
-  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 2
-  %20 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %19, align 8, !tbaa !26
-  call fastcc void @"func_<root>.17<static-init>$152"(%struct.rb_control_frame_struct* %20) #15
+  %"rubyStr_test/testdata/compiler/repeated_casts.rb.i7.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
+  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i7.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 2
+  %17 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %16, align 8, !tbaa !26
+  call fastcc void @"func_<root>.17<static-init>$152"(%struct.rb_control_frame_struct* nocapture writeonly %17) #15
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define noundef i64 @"func_A#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #7 !dbg !49 {
+define noundef i64 @"func_A#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #7 !dbg !48 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !tbaa !14
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !50
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !50, !prof !51
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !49
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !49, !prof !50
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !50
-  unreachable, !dbg !50
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !49
+  unreachable, !dbg !49
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !52, !tbaa !14
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !51, !tbaa !14
   ret i64 8
 }
 
@@ -459,10 +446,10 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #9
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#10doubleCast.cold.1"(i64 %rawArg_a) unnamed_addr #10 !dbg !53 {
+define internal fastcc void @"func_Object#10doubleCast.cold.1"(i64 %rawArg_a) unnamed_addr #10 !dbg !52 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_a, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0)) #13, !dbg !55
-  unreachable, !dbg !55
+  tail call void @sorbet_cast_failure(i64 %rawArg_a, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0)) #13, !dbg !54
+  unreachable, !dbg !54
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
@@ -546,11 +533,10 @@ attributes #16 = { nounwind allocsize(0,1) }
 !45 = !{!"", !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 1, !28, i64 1}
 !46 = !{!44, !28, i64 4}
 !47 = !{!44, !15, i64 32}
-!48 = !DILocation(line: 5, column: 3, scope: !36)
-!49 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#3foo", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!50 = !DILocation(line: 5, column: 3, scope: !49)
-!51 = !{!"branch_weights", i32 1, i32 2000}
-!52 = !DILocation(line: 0, scope: !49)
-!53 = distinct !DISubprogram(name: "func_Object#10doubleCast.cold.1", linkageName: "func_Object#10doubleCast.cold.1", scope: null, file: !4, type: !54, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!54 = !DISubroutineType(types: !5)
-!55 = !DILocation(line: 9, column: 3, scope: !53)
+!48 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#3foo", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!49 = !DILocation(line: 5, column: 3, scope: !48)
+!50 = !{!"branch_weights", i32 1, i32 2000}
+!51 = !DILocation(line: 0, scope: !48)
+!52 = distinct !DISubprogram(name: "func_Object#10doubleCast.cold.1", linkageName: "func_Object#10doubleCast.cold.1", scope: null, file: !4, type: !53, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!53 = !DISubroutineType(types: !5)
+!54 = !DILocation(line: 9, column: 3, scope: !52)

--- a/test/testdata/compiler/sig_rewriter.llo.exp
+++ b/test/testdata/compiler/sig_rewriter.llo.exp
@@ -118,9 +118,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
 @rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
@@ -188,8 +185,8 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
 ; Function Attrs: sspreq
 define void @Init_sig_rewriter() local_unnamed_addr #4 {
 entry:
-  %locals.i13.i = alloca i64, i32 0, align 8
-  %locals.i11.i = alloca i64, i32 0, align 8
+  %locals.i12.i = alloca i64, i32 0, align 8
+  %locals.i10.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
@@ -212,237 +209,233 @@ entry:
   store i64 %8, i64* @rubyIdPrecomputed_extend, align 8
   %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #10
   store i64 %9, i64* @rubyIdPrecomputed_normal, align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #10
-  store i64 %10, i64* @rubyIdPrecomputed_keep_def, align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
+  tail call void @rb_gc_register_mark_object(i64 %10) #10
+  store i64 %10, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/sig_rewriter.rb", i64 0, i64 0), i64 noundef 38) #10
   tail call void @rb_gc_register_mark_object(i64 %11) #10
-  store i64 %11, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %12 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/sig_rewriter.rb", i64 0, i64 0), i64 noundef 38) #10
-  tail call void @rb_gc_register_mark_object(i64 %12) #10
-  store i64 %12, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
+  store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 14)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !10
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !10
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #10
-  call void @rb_gc_register_mark_object(i64 %14) #10
+  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #10
+  call void @rb_gc_register_mark_object(i64 %13) #10
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
-  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i10.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i10.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i11.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #10
-  call void @rb_gc_register_mark_object(i64 %16) #10
+  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
+  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i10.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
+  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #10
+  call void @rb_gc_register_mark_object(i64 %15) #10
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i12.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i12.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i13.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #10
-  call void @rb_gc_register_mark_object(i64 %18) #10
+  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
+  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #10
+  call void @rb_gc_register_mark_object(i64 %17) #10
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
   %"rubyId_block in <class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:A>", align 8
-  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %"rubyId_block in <class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>$block_1", align 8
+  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
+  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %"rubyId_block in <class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>$block_1", align 8
   %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !16
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !16
   %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !18
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
   %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !20
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !21
-  %20 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !22
-  %21 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %20, i64 0, i32 18
-  %22 = load i64, i64* %21, align 8, !tbaa !24
-  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
-  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !34
+  %19 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !21
+  %20 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %19, i64 0, i32 18
+  %21 = load i64, i64* %20, align 8, !tbaa !23
+  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !21
+  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
+  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !33
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %26, align 8, !tbaa !37
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
-  %28 = load i64*, i64** %27, align 8, !tbaa !39
-  %29 = load i64, i64* %28, align 8, !tbaa !6
-  %30 = and i64 %29, -33
-  store i64 %30, i64* %28, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %23, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #10
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %31, align 8, !dbg !40, !tbaa !22
-  %32 = load i64, i64* @rb_cObject, align 8, !dbg !41
-  %33 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %32) #10, !dbg !41
-  %34 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %33) #10, !dbg !41
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !36
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
+  %27 = load i64*, i64** %26, align 8, !tbaa !38
+  %28 = load i64, i64* %27, align 8, !tbaa !6
+  %29 = and i64 %28, -33
+  store i64 %29, i64* %27, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i) #10
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !39, !tbaa !21
+  %31 = load i64, i64* @rb_cObject, align 8, !dbg !40
+  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %31) #10, !dbg !40
+  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #10, !dbg !40
   %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %35 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
-  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %35, i64 0, i32 2
-  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %36, align 8, !tbaa !34
-  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %38, align 8, !tbaa !37
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 4
-  %40 = load i64*, i64** %39, align 8, !tbaa !39
-  %41 = load i64, i64* %40, align 8, !tbaa !6
-  %42 = and i64 %41, -33
-  store i64 %42, i64* %40, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %35, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i.i1) #10
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %43, align 8, !dbg !42, !tbaa !22
-  %rubyId_foo.i.i2 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !44
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_foo.i.i2) #10, !dbg !44
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %33, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.13<static-init>L62$block_1") #10, !dbg !44
-  %44 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !44, !tbaa !22
-  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %44, i64 0, i32 5, !dbg !44
-  %46 = load i32, i32* %45, align 8, !dbg !44, !tbaa !45
-  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %44, i64 0, i32 6, !dbg !44
-  %48 = load i32, i32* %47, align 4, !dbg !44, !tbaa !46
-  %49 = xor i32 %48, -1, !dbg !44
-  %50 = and i32 %49, %46, !dbg !44
-  %51 = icmp eq i32 %50, 0, !dbg !44
-  br i1 %51, label %fastSymCallIntrinsic_Static_keep_def.i.i, label %52, !dbg !44, !prof !47
+  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !21
+  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
+  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !33
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %37, align 8, !tbaa !36
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
+  %39 = load i64*, i64** %38, align 8, !tbaa !38
+  %40 = load i64, i64* %39, align 8, !tbaa !6
+  %41 = and i64 %40, -33
+  store i64 %41, i64* %39, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i.i1) #10
+  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %42, align 8, !dbg !41, !tbaa !21
+  %rubyId_foo.i.i2 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !43
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_foo.i.i2) #10, !dbg !43
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %32, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.13<static-init>L62$block_1") #10, !dbg !43
+  %43 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !43, !tbaa !21
+  %44 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 5, !dbg !43
+  %45 = load i32, i32* %44, align 8, !dbg !43, !tbaa !44
+  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 6, !dbg !43
+  %47 = load i32, i32* %46, align 4, !dbg !43, !tbaa !45
+  %48 = xor i32 %47, -1, !dbg !43
+  %49 = and i32 %48, %45, !dbg !43
+  %50 = icmp eq i32 %49, 0, !dbg !43
+  br i1 %50, label %afterSend.i.i, label %86, !dbg !43, !prof !46
 
-52:                                               ; preds = %entry
-  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %44, i64 0, i32 8, !dbg !44
-  %54 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %53, align 8, !dbg !44, !tbaa !48
-  %55 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %54, i32 noundef 0) #10, !dbg !44
-  br label %fastSymCallIntrinsic_Static_keep_def.i.i, !dbg !44
+afterSend.i.i:                                    ; preds = %86, %entry
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !43, !tbaa !21
+  %51 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !47
+  %52 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !47, !tbaa !48
+  %needTakeSlowPath = icmp ne i64 %51, %52, !dbg !47
+  br i1 %needTakeSlowPath, label %53, label %54, !dbg !47, !prof !49
 
-fastSymCallIntrinsic_Static_keep_def.i.i:         ; preds = %52, %entry
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %43, align 8, !dbg !44, !tbaa !22
-  %56 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !49
-  %57 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !49, !tbaa !50
-  %needTakeSlowPath = icmp ne i64 %56, %57, !dbg !49
-  br i1 %needTakeSlowPath, label %58, label %59, !dbg !49, !prof !51
+53:                                               ; preds = %afterSend.i.i
+  call void @"const_recompute_T::Sig"(), !dbg !47
+  br label %54, !dbg !47
 
-58:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def.i.i
-  call void @"const_recompute_T::Sig"(), !dbg !49
-  br label %59, !dbg !49
+54:                                               ; preds = %afterSend.i.i, %53
+  %55 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !47
+  %56 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !47
+  %57 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !47, !tbaa !48
+  %guardUpdated = icmp eq i64 %56, %57, !dbg !47
+  call void @llvm.assume(i1 %guardUpdated), !dbg !47
+  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !47
+  %59 = load i64*, i64** %58, align 8, !dbg !47
+  store i64 %32, i64* %59, align 8, !dbg !47, !tbaa !6
+  %60 = getelementptr inbounds i64, i64* %59, i64 1, !dbg !47
+  store i64 %55, i64* %60, align 8, !dbg !47, !tbaa !6
+  %61 = getelementptr inbounds i64, i64* %60, i64 1, !dbg !47
+  store i64* %61, i64** %58, align 8, !dbg !47
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !47
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %42, align 8, !dbg !47, !tbaa !21
+  %rubyId_foo40.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !50
+  %rawSym41.i.i = call i64 @rb_id2sym(i64 %rubyId_foo40.i.i) #10, !dbg !50
+  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !50
+  %rawSym42.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #10, !dbg !50
+  %62 = load i64, i64* @guard_epoch_A, align 8, !dbg !50
+  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !48
+  %needTakeSlowPath3 = icmp ne i64 %62, %63, !dbg !50
+  br i1 %needTakeSlowPath3, label %64, label %65, !dbg !50, !prof !49
 
-59:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def.i.i, %58
-  %60 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !49
-  %61 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !49
-  %62 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !49, !tbaa !50
-  %guardUpdated = icmp eq i64 %61, %62, !dbg !49
-  call void @llvm.assume(i1 %guardUpdated), !dbg !49
-  %63 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 1, !dbg !49
-  %64 = load i64*, i64** %63, align 8, !dbg !49
-  store i64 %33, i64* %64, align 8, !dbg !49, !tbaa !6
-  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !49
-  store i64 %60, i64* %65, align 8, !dbg !49, !tbaa !6
-  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !49
-  store i64* %66, i64** %63, align 8, !dbg !49
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !49
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %43, align 8, !dbg !49, !tbaa !22
-  %rubyId_foo40.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !52
-  %rawSym41.i.i = call i64 @rb_id2sym(i64 %rubyId_foo40.i.i) #10, !dbg !52
-  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !52
-  %rawSym42.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #10, !dbg !52
-  %67 = load i64, i64* @guard_epoch_A, align 8, !dbg !52
-  %68 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !50
-  %needTakeSlowPath3 = icmp ne i64 %67, %68, !dbg !52
-  br i1 %needTakeSlowPath3, label %69, label %70, !dbg !52, !prof !51
+64:                                               ; preds = %54
+  call void @const_recompute_A(), !dbg !50
+  br label %65, !dbg !50
 
-69:                                               ; preds = %59
-  call void @const_recompute_A(), !dbg !52
-  br label %70, !dbg !52
+65:                                               ; preds = %54, %64
+  %66 = load i64, i64* @guarded_const_A, align 8, !dbg !50
+  %67 = load i64, i64* @guard_epoch_A, align 8, !dbg !50
+  %68 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !48
+  %guardUpdated4 = icmp eq i64 %67, %68, !dbg !50
+  call void @llvm.assume(i1 %guardUpdated4), !dbg !50
+  %stackFrame46.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8, !dbg !50
+  %69 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !50
+  %70 = bitcast i8* %69 to i16*, !dbg !50
+  %71 = load i16, i16* %70, align 8, !dbg !50
+  %72 = and i16 %71, -384, !dbg !50
+  store i16 %72, i16* %70, align 8, !dbg !50
+  %73 = getelementptr inbounds i8, i8* %69, i64 4, !dbg !50
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %73, i8 0, i64 28, i1 false) #10, !dbg !50
+  call void @sorbet_vm_define_method(i64 %66, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#3foo", i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame46.i.i, i1 noundef zeroext false) #10, !dbg !50
+  %74 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !50, !tbaa !21
+  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 5, !dbg !50
+  %76 = load i32, i32* %75, align 8, !dbg !50, !tbaa !44
+  %77 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 6, !dbg !50
+  %78 = load i32, i32* %77, align 4, !dbg !50, !tbaa !45
+  %79 = xor i32 %78, -1, !dbg !50
+  %80 = and i32 %79, %76, !dbg !50
+  %81 = icmp eq i32 %80, 0, !dbg !50
+  br i1 %81, label %"func_<root>.17<static-init>$152.exit", label %82, !dbg !50, !prof !46
 
-70:                                               ; preds = %59, %69
-  %71 = load i64, i64* @guarded_const_A, align 8, !dbg !52
-  %72 = load i64, i64* @guard_epoch_A, align 8, !dbg !52
-  %73 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !50
-  %guardUpdated4 = icmp eq i64 %72, %73, !dbg !52
-  call void @llvm.assume(i1 %guardUpdated4), !dbg !52
-  %stackFrame46.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8, !dbg !52
-  %74 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !52
-  %75 = bitcast i8* %74 to i16*, !dbg !52
-  %76 = load i16, i16* %75, align 8, !dbg !52
-  %77 = and i16 %76, -384, !dbg !52
-  store i16 %77, i16* %75, align 8, !dbg !52
-  %78 = getelementptr inbounds i8, i8* %74, i64 4, !dbg !52
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %78, i8 0, i64 28, i1 false) #10, !dbg !52
-  call void @sorbet_vm_define_method(i64 %71, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#3foo", i8* nonnull %74, %struct.rb_iseq_struct* %stackFrame46.i.i, i1 noundef zeroext false) #10, !dbg !52
-  %79 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !22
-  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 5, !dbg !52
-  %81 = load i32, i32* %80, align 8, !dbg !52, !tbaa !45
-  %82 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 6, !dbg !52
-  %83 = load i32, i32* %82, align 4, !dbg !52, !tbaa !46
-  %84 = xor i32 %83, -1, !dbg !52
-  %85 = and i32 %84, %81, !dbg !52
-  %86 = icmp eq i32 %85, 0, !dbg !52
-  br i1 %86, label %"func_<root>.17<static-init>$152.exit", label %87, !dbg !52, !prof !47
+82:                                               ; preds = %65
+  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 8, !dbg !50
+  %84 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %83, align 8, !dbg !50, !tbaa !51
+  %85 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %84, i32 noundef 0) #10, !dbg !50
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !50
 
-87:                                               ; preds = %70
-  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 8, !dbg !52
-  %89 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %88, align 8, !dbg !52, !tbaa !48
-  %90 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %89, i32 noundef 0) #10, !dbg !52
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !52
+86:                                               ; preds = %entry
+  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 8, !dbg !43
+  %88 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %87, align 8, !dbg !43, !tbaa !51
+  %89 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %88, i32 noundef 0) #10, !dbg !43
+  br label %afterSend.i.i, !dbg !43
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %70, %87
-  call void @sorbet_popFrame() #10, !dbg !41
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %31, align 8, !dbg !41, !tbaa !22
-  %91 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !10
-  %92 = load i64*, i64** %91, align 8, !dbg !10
-  store i64 %71, i64* %92, align 8, !dbg !10, !tbaa !6
-  %93 = getelementptr inbounds i64, i64* %92, i64 1, !dbg !10
-  store i64* %93, i64** %91, align 8, !dbg !10
+"func_<root>.17<static-init>$152.exit":           ; preds = %65, %82
+  call void @sorbet_popFrame() #10, !dbg !40
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %30, align 8, !dbg !40, !tbaa !21
+  %90 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
+  %91 = load i64*, i64** %90, align 8, !dbg !10
+  store i64 %66, i64* %91, align 8, !dbg !10, !tbaa !6
+  %92 = getelementptr inbounds i64, i64* %91, i64 1, !dbg !10
+  store i64* %92, i64** %90, align 8, !dbg !10
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !10
-  %94 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !10
-  %95 = load i64*, i64** %94, align 8, !dbg !10
-  store i64 %send6, i64* %95, align 8, !dbg !10, !tbaa !6
-  %96 = getelementptr inbounds i64, i64* %95, i64 1, !dbg !10
-  store i64* %96, i64** %94, align 8, !dbg !10
+  %93 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
+  %94 = load i64*, i64** %93, align 8, !dbg !10
+  store i64 %send6, i64* %94, align 8, !dbg !10, !tbaa !6
+  %95 = getelementptr inbounds i64, i64* %94, i64 1, !dbg !10
+  store i64* %95, i64** %93, align 8, !dbg !10
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !10
-  %97 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !15
-  %98 = load i64*, i64** %97, align 8, !dbg !15
-  store i64 %22, i64* %98, align 8, !dbg !15, !tbaa !6
+  %96 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !15
+  %97 = load i64*, i64** %96, align 8, !dbg !15
+  store i64 %21, i64* %97, align 8, !dbg !15, !tbaa !6
+  %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !15
+  store i64 %send8, i64* %98, align 8, !dbg !15, !tbaa !6
   %99 = getelementptr inbounds i64, i64* %98, i64 1, !dbg !15
-  store i64 %send8, i64* %99, align 8, !dbg !15, !tbaa !6
-  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !15
-  store i64* %100, i64** %97, align 8, !dbg !15
+  store i64* %99, i64** %96, align 8, !dbg !15
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define noundef i64 @"func_A#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #5 !dbg !53 {
+define noundef i64 @"func_A#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #5 !dbg !52 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !22
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !54
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !54, !prof !55
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !21
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !53
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !53, !prof !54
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #12, !dbg !54
-  unreachable, !dbg !54
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #12, !dbg !53
+  unreachable, !dbg !53
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !56, !tbaa !22
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !55, !tbaa !21
   ret i64 183
 }
 
 ; Function Attrs: ssp
 define internal i64 @"func_A.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #6 !dbg !19 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !21
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !34
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !33
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !57
+  %4 = load i64, i64* %3, align 8, !tbaa !56
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>$block_1", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !37
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !36
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !39
+  %7 = load i64*, i64** %6, align 8, !tbaa !38
   %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !22
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !21
   %11 = load i64, i64* @rb_cInteger, align 8, !dbg !18
   %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !18
   %13 = load i64*, i64** %12, align 8, !dbg !18
@@ -452,7 +445,7 @@ functionEntryInitializers:
   %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !18
   store i64* %15, i64** %12, align 8, !dbg !18
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !18
-  ret i64 %send, !dbg !58
+  ret i64 %send, !dbg !57
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
@@ -465,7 +458,7 @@ declare void @llvm.assume(i1 noundef) #8
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #6 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !50
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !48
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
@@ -474,7 +467,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #6 {
 define linkonce void @const_recompute_A() local_unnamed_addr #6 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !50
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !48
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -517,41 +510,40 @@ attributes #12 = { noreturn }
 !18 = !DILocation(line: 7, column: 8, scope: !19)
 !19 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.13<static-init>L62$block_1", scope: !17, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !20 = !DILocation(line: 6, column: 3, scope: !17)
-!21 = !DILocation(line: 8, column: 3, scope: !17)
-!22 = !{!23, !23, i64 0}
-!23 = !{!"any pointer", !8, i64 0}
-!24 = !{!25, !7, i64 400}
-!25 = !{!"rb_vm_struct", !7, i64 0, !26, i64 8, !23, i64 192, !23, i64 200, !23, i64 208, !30, i64 216, !8, i64 224, !27, i64 264, !27, i64 280, !27, i64 296, !27, i64 312, !7, i64 328, !29, i64 336, !29, i64 340, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !23, i64 456, !23, i64 464, !31, i64 472, !32, i64 992, !23, i64 1016, !23, i64 1024, !29, i64 1032, !29, i64 1036, !27, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !29, i64 1136, !23, i64 1144, !23, i64 1152, !23, i64 1160, !23, i64 1168, !23, i64 1176, !23, i64 1184, !29, i64 1192, !33, i64 1200, !8, i64 1232}
-!26 = !{!"rb_global_vm_lock_struct", !23, i64 0, !8, i64 8, !27, i64 48, !23, i64 64, !29, i64 72, !8, i64 80, !8, i64 128, !29, i64 176, !29, i64 180}
-!27 = !{!"list_head", !28, i64 0}
-!28 = !{!"list_node", !23, i64 0, !23, i64 8}
-!29 = !{!"int", !8, i64 0}
-!30 = !{!"long long", !8, i64 0}
-!31 = !{!"", !8, i64 0}
-!32 = !{!"rb_hook_list_struct", !23, i64 0, !29, i64 8, !29, i64 12, !29, i64 16}
-!33 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!34 = !{!35, !23, i64 16}
-!35 = !{!"rb_execution_context_struct", !23, i64 0, !7, i64 8, !23, i64 16, !23, i64 24, !23, i64 32, !29, i64 40, !29, i64 44, !23, i64 48, !23, i64 56, !23, i64 64, !7, i64 72, !7, i64 80, !23, i64 88, !7, i64 96, !23, i64 104, !23, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !36, i64 152}
-!36 = !{!"", !23, i64 0, !23, i64 8, !7, i64 16, !8, i64 24}
-!37 = !{!38, !23, i64 16}
-!38 = !{!"rb_control_frame_struct", !23, i64 0, !23, i64 8, !23, i64 16, !7, i64 24, !23, i64 32, !23, i64 40, !23, i64 48}
-!39 = !{!38, !23, i64 32}
-!40 = !DILocation(line: 0, scope: !11)
-!41 = !DILocation(line: 5, column: 1, scope: !11)
-!42 = !DILocation(line: 0, scope: !17, inlinedAt: !43)
-!43 = distinct !DILocation(line: 5, column: 1, scope: !11)
-!44 = !DILocation(line: 7, column: 3, scope: !17, inlinedAt: !43)
-!45 = !{!35, !29, i64 40}
-!46 = !{!35, !29, i64 44}
-!47 = !{!"branch_weights", i32 2000, i32 1}
-!48 = !{!35, !23, i64 56}
-!49 = !DILocation(line: 6, column: 3, scope: !17, inlinedAt: !43)
-!50 = !{!30, !30, i64 0}
-!51 = !{!"branch_weights", i32 1, i32 10000}
-!52 = !DILocation(line: 8, column: 3, scope: !17, inlinedAt: !43)
-!53 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#3foo", scope: null, file: !4, line: 8, type: !12, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!54 = !DILocation(line: 8, column: 3, scope: !53)
-!55 = !{!"branch_weights", i32 1, i32 2000}
-!56 = !DILocation(line: 0, scope: !53)
-!57 = !{!38, !7, i64 24}
-!58 = !DILocation(line: 7, column: 3, scope: !19)
+!21 = !{!22, !22, i64 0}
+!22 = !{!"any pointer", !8, i64 0}
+!23 = !{!24, !7, i64 400}
+!24 = !{!"rb_vm_struct", !7, i64 0, !25, i64 8, !22, i64 192, !22, i64 200, !22, i64 208, !29, i64 216, !8, i64 224, !26, i64 264, !26, i64 280, !26, i64 296, !26, i64 312, !7, i64 328, !28, i64 336, !28, i64 340, !28, i64 344, !28, i64 344, !28, i64 344, !28, i64 344, !28, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !22, i64 456, !22, i64 464, !30, i64 472, !31, i64 992, !22, i64 1016, !22, i64 1024, !28, i64 1032, !28, i64 1036, !26, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !28, i64 1136, !22, i64 1144, !22, i64 1152, !22, i64 1160, !22, i64 1168, !22, i64 1176, !22, i64 1184, !28, i64 1192, !32, i64 1200, !8, i64 1232}
+!25 = !{!"rb_global_vm_lock_struct", !22, i64 0, !8, i64 8, !26, i64 48, !22, i64 64, !28, i64 72, !8, i64 80, !8, i64 128, !28, i64 176, !28, i64 180}
+!26 = !{!"list_head", !27, i64 0}
+!27 = !{!"list_node", !22, i64 0, !22, i64 8}
+!28 = !{!"int", !8, i64 0}
+!29 = !{!"long long", !8, i64 0}
+!30 = !{!"", !8, i64 0}
+!31 = !{!"rb_hook_list_struct", !22, i64 0, !28, i64 8, !28, i64 12, !28, i64 16}
+!32 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!33 = !{!34, !22, i64 16}
+!34 = !{!"rb_execution_context_struct", !22, i64 0, !7, i64 8, !22, i64 16, !22, i64 24, !22, i64 32, !28, i64 40, !28, i64 44, !22, i64 48, !22, i64 56, !22, i64 64, !7, i64 72, !7, i64 80, !22, i64 88, !7, i64 96, !22, i64 104, !22, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !35, i64 152}
+!35 = !{!"", !22, i64 0, !22, i64 8, !7, i64 16, !8, i64 24}
+!36 = !{!37, !22, i64 16}
+!37 = !{!"rb_control_frame_struct", !22, i64 0, !22, i64 8, !22, i64 16, !7, i64 24, !22, i64 32, !22, i64 40, !22, i64 48}
+!38 = !{!37, !22, i64 32}
+!39 = !DILocation(line: 0, scope: !11)
+!40 = !DILocation(line: 5, column: 1, scope: !11)
+!41 = !DILocation(line: 0, scope: !17, inlinedAt: !42)
+!42 = distinct !DILocation(line: 5, column: 1, scope: !11)
+!43 = !DILocation(line: 7, column: 3, scope: !17, inlinedAt: !42)
+!44 = !{!34, !28, i64 40}
+!45 = !{!34, !28, i64 44}
+!46 = !{!"branch_weights", i32 2000, i32 1}
+!47 = !DILocation(line: 6, column: 3, scope: !17, inlinedAt: !42)
+!48 = !{!29, !29, i64 0}
+!49 = !{!"branch_weights", i32 1, i32 10000}
+!50 = !DILocation(line: 8, column: 3, scope: !17, inlinedAt: !42)
+!51 = !{!34, !22, i64 56}
+!52 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#3foo", scope: null, file: !4, line: 8, type: !12, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!53 = !DILocation(line: 8, column: 3, scope: !52)
+!54 = !{!"branch_weights", i32 1, i32 2000}
+!55 = !DILocation(line: 0, scope: !52)
+!56 = !{!37, !7, i64 24}
+!57 = !DILocation(line: 7, column: 3, scope: !19)

--- a/test/testdata/ruby_benchmark/app_fib.llo.exp
+++ b/test/testdata/ruby_benchmark/app_fib.llo.exp
@@ -116,8 +116,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"str_block in <class:HasFib>" = private unnamed_addr constant [24 x i8] c"block in <class:HasFib>\00", align 1
 @rubyIdPrecomputed_final = internal unnamed_addr global i64 0, align 8
 @str_final = private unnamed_addr constant [6 x i8] c"final\00", align 1
-@ic_sig = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_sig = internal unnamed_addr global i64 0, align 8
 @rubyIdPrecomputed_n = internal unnamed_addr global i64 0, align 8
 @str_n = private unnamed_addr constant [2 x i8] c"n\00", align 1
 @ic_params = internal global %struct.FunctionInlineCache zeroinitializer
@@ -128,9 +126,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_returns = private unnamed_addr constant [8 x i8] c"returns\00", align 1
 @rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@ic_keep_self_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_self_def = internal unnamed_addr global i64 0, align 8
-@str_keep_self_def = private unnamed_addr constant [14 x i8] c"keep_self_def\00", align 1
 @guard_epoch_HasFib = linkonce local_unnamed_addr global i64 0
 @guarded_const_HasFib = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
@@ -224,8 +219,8 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #7 {
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_HasFib.13<static-init>L64"(%struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !10 {
-fastSymCallIntrinsic_Static_sig:
+define internal fastcc void @"func_HasFib.13<static-init>L64"(%struct.rb_control_frame_struct* nocapture writeonly %cfp) unnamed_addr #8 !dbg !10 {
+functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_HasFib.13<static-init>", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -250,39 +245,36 @@ fastSymCallIntrinsic_Static_sig:
   %14 = xor i32 %13, -1, !dbg !25
   %15 = and i32 %14, %11, !dbg !25
   %16 = icmp eq i32 %15, 0, !dbg !25
-  br i1 %16, label %fastSymCallIntrinsic_Static_keep_self_def, label %17, !dbg !25, !prof !28
+  br i1 %16, label %rb_vm_check_ints.exit1, label %17, !dbg !25, !prof !28
 
-17:                                               ; preds = %fastSymCallIntrinsic_Static_sig
+17:                                               ; preds = %functionEntryInitializers
   %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !25
   %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !25, !tbaa !29
   %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !25
-  br label %fastSymCallIntrinsic_Static_keep_self_def, !dbg !25
+  br label %rb_vm_check_ints.exit1, !dbg !25
 
-afterSend32:                                      ; preds = %51, %24
-  ret void
-
-fastSymCallIntrinsic_Static_keep_self_def:        ; preds = %fastSymCallIntrinsic_Static_sig, %17
+rb_vm_check_ints.exit1:                           ; preds = %functionEntryInitializers, %17
   store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !25, !tbaa !14
   %rubyId_fib = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !30
-  %rawSym28 = tail call i64 @rb_id2sym(i64 %rubyId_fib), !dbg !30
+  %rawSym27 = tail call i64 @rb_id2sym(i64 %rubyId_fib), !dbg !30
   %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !30
-  %rawSym29 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !30
+  %rawSym28 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !30
   %21 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !30
   %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
   %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !30
   br i1 %needTakeSlowPath, label %23, label %24, !dbg !30, !prof !33
 
-23:                                               ; preds = %fastSymCallIntrinsic_Static_keep_self_def
+23:                                               ; preds = %rb_vm_check_ints.exit1
   tail call void @const_recompute_HasFib(), !dbg !30
   br label %24, !dbg !30
 
-24:                                               ; preds = %fastSymCallIntrinsic_Static_keep_self_def, %23
+24:                                               ; preds = %rb_vm_check_ints.exit1, %23
   %25 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !30
   %26 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !30
   %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
   %guardUpdated = icmp eq i64 %26, %27, !dbg !30
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !30
-  %stackFrame33 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8, !dbg !30
+  %stackFrame32 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8, !dbg !30
   %28 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !30
   %29 = bitcast i8* %28 to i16*, !dbg !30
   %30 = load i16, i16* %29, align 8, !dbg !30
@@ -307,7 +299,7 @@ fastSymCallIntrinsic_Static_keep_self_def:        ; preds = %fastSymCallIntrinsi
   %41 = getelementptr inbounds i8, i8* %28, i64 32, !dbg !30
   %42 = bitcast i8* %41 to i8**, !dbg !30
   store i8* %39, i8** %42, align 8, !dbg !30, !tbaa !38
-  tail call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_fib, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_HasFib.3fib, i8* nonnull %28, %struct.rb_iseq_struct* %stackFrame33, i1 noundef zeroext true) #16, !dbg !30
+  tail call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_fib, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @func_HasFib.3fib, i8* nonnull %28, %struct.rb_iseq_struct* %stackFrame32, i1 noundef zeroext true) #16, !dbg !30
   %43 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !14
   %44 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 5, !dbg !30
   %45 = load i32, i32* %44, align 8, !dbg !30, !tbaa !26
@@ -316,13 +308,16 @@ fastSymCallIntrinsic_Static_keep_self_def:        ; preds = %fastSymCallIntrinsi
   %48 = xor i32 %47, -1, !dbg !30
   %49 = and i32 %48, %45, !dbg !30
   %50 = icmp eq i32 %49, 0, !dbg !30
-  br i1 %50, label %afterSend32, label %51, !dbg !30, !prof !28
+  br i1 %50, label %rb_vm_check_ints.exit, label %51, !dbg !30, !prof !28
 
 51:                                               ; preds = %24
   %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 8, !dbg !30
   %53 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %52, align 8, !dbg !30, !tbaa !29
   %54 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %53, i32 noundef 0) #16, !dbg !30
-  br label %afterSend32, !dbg !30
+  br label %rb_vm_check_ints.exit, !dbg !30
+
+rb_vm_check_ints.exit:                            ; preds = %24, %51
+  ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
@@ -708,8 +703,8 @@ codeRepl:                                         ; preds = %44, %sorbet_isa_Int
 define void @Init_app_fib() local_unnamed_addr #9 {
 entry:
   %callArgs.i = alloca [2 x i64], align 8
-  %locals.i25.i = alloca i64, i32 0, align 8
   %locals.i23.i = alloca i64, i32 0, align 8
+  %locals.i21.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %keywords.i = alloca i64, align 8, !dbg !71
   %realpath = tail call i64 @sorbet_readRealpath()
@@ -729,40 +724,36 @@ entry:
   store i64 %7, i64* @"rubyIdPrecomputed_block in <class:HasFib>", align 8
   %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_final, i64 0, i64 0), i64 noundef 5) #16
   store i64 %8, i64* @rubyIdPrecomputed_final, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i64 noundef 3) #16
-  store i64 %9, i64* @rubyIdPrecomputed_sig, align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_n, i64 0, i64 0), i64 noundef 1) #16
-  store i64 %10, i64* @rubyIdPrecomputed_n, align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #16
-  store i64 %11, i64* @rubyIdPrecomputed_params, align 8
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #16
-  store i64 %12, i64* @rubyIdPrecomputed_returns, align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
-  store i64 %13, i64* @rubyIdPrecomputed_normal, align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @str_keep_self_def, i64 0, i64 0), i64 noundef 13) #16
-  store i64 %14, i64* @rubyIdPrecomputed_keep_self_def, align 8
-  %15 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
-  tail call void @rb_gc_register_mark_object(i64 %15) #16
-  store i64 %15, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %16 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([40 x i8], [40 x i8]* @"str_test/testdata/ruby_benchmark/app_fib.rb", i64 0, i64 0), i64 noundef 39) #16
-  tail call void @rb_gc_register_mark_object(i64 %16) #16
-  store i64 %16, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_n, i64 0, i64 0), i64 noundef 1) #16
+  store i64 %9, i64* @rubyIdPrecomputed_n, align 8
+  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #16
+  store i64 %10, i64* @rubyIdPrecomputed_params, align 8
+  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #16
+  store i64 %11, i64* @rubyIdPrecomputed_returns, align 8
+  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
+  store i64 %12, i64* @rubyIdPrecomputed_normal, align 8
+  %13 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  tail call void @rb_gc_register_mark_object(i64 %13) #16
+  store i64 %13, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %14 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([40 x i8], [40 x i8]* @"str_test/testdata/ruby_benchmark/app_fib.rb", i64 0, i64 0), i64 noundef 39) #16
+  tail call void @rb_gc_register_mark_object(i64 %14) #16
+  store i64 %14, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 18)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_fib1.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !73
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %rubyId_fib1.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !73
   %rubyId_fib2.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !73
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.2, i64 %rubyId_fib2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !73
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_fib, i64 0, i64 0), i64 noundef 3) #16
-  call void @rb_gc_register_mark_object(i64 %18) #16
+  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_fib, i64 0, i64 0), i64 noundef 3) #16
+  call void @rb_gc_register_mark_object(i64 %16) #16
   %rubyId_fib.i.i = load i64, i64* @rubyIdPrecomputed_fib, align 8
-  %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %rubyId_fib.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8
+  %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
+  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %rubyId_fib.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i21.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8
   %rubyId_fib6.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !46
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.3, i64 %rubyId_fib6.i, i32 noundef 4, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !46
   %rubyId_fib7.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !46
@@ -773,85 +764,81 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.7, i64 %rubyId_fib14.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !67
   %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !46
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_<class:HasFib>", i64 0, i64 0), i64 noundef 14) #16
-  call void @rb_gc_register_mark_object(i64 %20) #16
+  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_<class:HasFib>", i64 0, i64 0), i64 noundef 14) #16
+  call void @rb_gc_register_mark_object(i64 %18) #16
   %"rubyId_<class:HasFib>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:HasFib>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_<class:HasFib>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_HasFib.13<static-init>", align 8
-  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_block in <class:HasFib>", i64 0, i64 0), i64 noundef 23) #16
-  call void @rb_gc_register_mark_object(i64 %22) #16
+  %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
+  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %"rubyId_<class:HasFib>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_HasFib.13<static-init>", align 8
+  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_block in <class:HasFib>", i64 0, i64 0), i64 noundef 23) #16
+  call void @rb_gc_register_mark_object(i64 %20) #16
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_HasFib.13<static-init>", align 8
   %"rubyId_block in <class:HasFib>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:HasFib>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
-  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %"rubyId_block in <class:HasFib>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_HasFib.13<static-init>$block_1", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !25
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !25
+  %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
+  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_block in <class:HasFib>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_HasFib.13<static-init>$block_1", align 8
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !71
   %rubyId_n.i = load i64, i64* @rubyIdPrecomputed_n, align 8, !dbg !71
-  %24 = call i64 @rb_id2sym(i64 %rubyId_n.i) #16, !dbg !71
-  store i64 %24, i64* %keywords.i, align 8, !dbg !71
+  %22 = call i64 @rb_id2sym(i64 %rubyId_n.i) #16, !dbg !71
+  store i64 %22, i64* %keywords.i, align 8, !dbg !71
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !71
   %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !71
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !71
-  %rubyId_keep_self_def.i = load i64, i64* @rubyIdPrecomputed_keep_self_def, align 8, !dbg !30
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_self_def, i64 %rubyId_keep_self_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !30
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
-  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 2
-  %27 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !16
-  %28 = bitcast [2 x i64]* %callArgs.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %28)
+  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
+  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !16
+  %26 = bitcast [2 x i64]* %callArgs.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %26)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %29, align 8, !tbaa !20
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 4
-  %31 = load i64*, i64** %30, align 8, !tbaa !22
-  %32 = load i64, i64* %31, align 8, !tbaa !6
-  %33 = and i64 %32, -33
-  store i64 %33, i64* %31, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %25, %struct.rb_control_frame_struct* %27, %struct.rb_iseq_struct* %stackFrame.i) #16
-  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 0
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %34, align 8, !dbg !75, !tbaa !14
-  %35 = load i64, i64* @rb_cObject, align 8, !dbg !76
-  %36 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_HasFib, i64 0, i64 0), i64 %35) #16, !dbg !76
-  %37 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %36) #16, !dbg !76
-  call fastcc void @"func_HasFib.13<static-init>L64"(%struct.rb_control_frame_struct* %37) #16, !dbg !76
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %27, align 8, !tbaa !20
+  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
+  %29 = load i64*, i64** %28, align 8, !tbaa !22
+  %30 = load i64, i64* %29, align 8, !tbaa !6
+  %31 = and i64 %30, -33
+  store i64 %31, i64* %29, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %23, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #16
+  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %32, align 8, !dbg !75, !tbaa !14
+  %33 = load i64, i64* @rb_cObject, align 8, !dbg !76
+  %34 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_HasFib, i64 0, i64 0), i64 %33) #16, !dbg !76
+  %35 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %34) #16, !dbg !76
+  call fastcc void @"func_HasFib.13<static-init>L64"(%struct.rb_control_frame_struct* nocapture writeonly %35) #16, !dbg !76
   call void @sorbet_popFrame() #16, !dbg !76
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %34, align 8, !dbg !76, !tbaa !14
-  %38 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !73
-  %39 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !73, !tbaa !31
-  %needTakeSlowPath = icmp ne i64 %38, %39, !dbg !73
-  br i1 %needTakeSlowPath, label %40, label %41, !dbg !73, !prof !33
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %32, align 8, !dbg !76, !tbaa !14
+  %36 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !73
+  %37 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !73, !tbaa !31
+  %needTakeSlowPath = icmp ne i64 %36, %37, !dbg !73
+  br i1 %needTakeSlowPath, label %38, label %39, !dbg !73, !prof !33
 
-40:                                               ; preds = %entry
+38:                                               ; preds = %entry
   call void @const_recompute_HasFib(), !dbg !73
-  br label %41, !dbg !73
+  br label %39, !dbg !73
 
-41:                                               ; preds = %entry, %40
-  %42 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !73
-  %43 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !73
-  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !73, !tbaa !31
-  %guardUpdated = icmp eq i64 %43, %44, !dbg !73
+39:                                               ; preds = %entry, %38
+  %40 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !73
+  %41 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !73
+  %42 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !73, !tbaa !31
+  %guardUpdated = icmp eq i64 %41, %42, !dbg !73
   call void @llvm.assume(i1 %guardUpdated), !dbg !73
   %callArgs0Addr.i = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i32 0, i64 0, !dbg !73
   store i64 69, i64* %callArgs0Addr.i, align 8, !dbg !73
-  %45 = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i64 0, i64 0, !dbg !73
-  %46 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8, !dbg !73
-  %47 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.1, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !73, !tbaa !57
-  %48 = icmp eq %struct.rb_callable_method_entry_struct* %47, null, !dbg !73
-  br i1 %48, label %49, label %"func_<root>.17<static-init>$152.exit", !dbg !73, !prof !49
+  %43 = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i64 0, i64 0, !dbg !73
+  %44 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8, !dbg !73
+  %45 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.1, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !73, !tbaa !57
+  %46 = icmp eq %struct.rb_callable_method_entry_struct* %45, null, !dbg !73
+  br i1 %46, label %47, label %"func_<root>.17<static-init>$152.exit", !dbg !73, !prof !49
 
-49:                                               ; preds = %41
-  call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %42) #16, !dbg !73
+47:                                               ; preds = %39
+  call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %40) #16, !dbg !73
   br label %"func_<root>.17<static-init>$152.exit", !dbg !73
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %41, %49
-  %50 = call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %42, %struct.rb_iseq_struct* %46) #16, !dbg !73
-  %51 = call i64 @func_HasFib.3fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %45, i64 %42, %struct.rb_control_frame_struct* align 8 %50) #16, !dbg !73
+"func_<root>.17<static-init>$152.exit":           ; preds = %39, %47
+  %48 = call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %40, %struct.rb_iseq_struct* %44) #16, !dbg !73
+  %49 = call i64 @func_HasFib.3fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %43, i64 %40, %struct.rb_control_frame_struct* align 8 %48) #16, !dbg !73
   call void @sorbet_popFrame() #16, !dbg !73
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %28)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %26)
   ret void
 }
 

--- a/test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.llo.exp
@@ -140,12 +140,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
 @rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
 @rubyIdPrecomputed_attr_reader = internal unnamed_addr global i64 0, align 8
 @str_attr_reader = private unnamed_addr constant [12 x i8] c"attr_reader\00", align 1
-@ic_keep_def.4 = internal global %struct.FunctionInlineCache zeroinitializer
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
 @guard_epoch_AttrReaderNoSig = linkonce local_unnamed_addr global i64 0
@@ -270,138 +266,138 @@ fastSymCallIntrinsic_ResolvedSig_sig:
   %14 = xor i32 %13, -1, !dbg !24
   %15 = and i32 %14, %11, !dbg !24
   %16 = icmp eq i32 %15, 0, !dbg !24
-  br i1 %16, label %fastSymCallIntrinsic_Static_keep_def, label %17, !dbg !24, !prof !27
+  br i1 %16, label %afterSend, label %79, !dbg !24, !prof !27
 
-17:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig
-  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
-  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !24, !tbaa !28
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !24
-  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !24
-
-fastSymCallIntrinsic_Static_keep_def:             ; preds = %fastSymCallIntrinsic_ResolvedSig_sig, %17
+afterSend:                                        ; preds = %79, %fastSymCallIntrinsic_ResolvedSig_sig
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !24, !tbaa !14
-  %21 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !29
-  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !29, !tbaa !30
-  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !29
-  br i1 %needTakeSlowPath, label %23, label %24, !dbg !29, !prof !32
+  %17 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !28
+  %18 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !28, !tbaa !29
+  %needTakeSlowPath = icmp ne i64 %17, %18, !dbg !28
+  br i1 %needTakeSlowPath, label %19, label %20, !dbg !28, !prof !31
 
-23:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
-  tail call void @"const_recompute_T::Sig"(), !dbg !29
-  br label %24, !dbg !29
+19:                                               ; preds = %afterSend
+  tail call void @"const_recompute_T::Sig"(), !dbg !28
+  br label %20, !dbg !28
 
-24:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def, %23
-  %25 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !29
-  %26 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !29
-  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !29, !tbaa !30
-  %guardUpdated = icmp eq i64 %26, %27, !dbg !29
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !29
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !29
-  %29 = load i64*, i64** %28, align 8, !dbg !29
-  store i64 %selfRaw, i64* %29, align 8, !dbg !29, !tbaa !6
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !29
-  store i64 %25, i64* %30, align 8, !dbg !29, !tbaa !6
-  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !29
-  store i64* %31, i64** %28, align 8, !dbg !29
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !29
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !29, !tbaa !14
-  %rubyId_initialize48 = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !33
-  %rawSym49 = tail call i64 @rb_id2sym(i64 %rubyId_initialize48), !dbg !33
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !33
-  %rawSym50 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !33
-  %32 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !33
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !30
-  %needTakeSlowPath3 = icmp ne i64 %32, %33, !dbg !33
-  br i1 %needTakeSlowPath3, label %34, label %35, !dbg !33, !prof !32
+20:                                               ; preds = %afterSend, %19
+  %21 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !28
+  %22 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !28
+  %23 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !28, !tbaa !29
+  %guardUpdated = icmp eq i64 %22, %23, !dbg !28
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !28
+  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !28
+  %25 = load i64*, i64** %24, align 8, !dbg !28
+  store i64 %selfRaw, i64* %25, align 8, !dbg !28, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !28
+  store i64 %21, i64* %26, align 8, !dbg !28, !tbaa !6
+  %27 = getelementptr inbounds i64, i64* %26, i64 1, !dbg !28
+  store i64* %27, i64** %24, align 8, !dbg !28
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !28
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !28, !tbaa !14
+  %rubyId_initialize48 = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !32
+  %rawSym49 = tail call i64 @rb_id2sym(i64 %rubyId_initialize48), !dbg !32
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !32
+  %rawSym50 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !32
+  %28 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !32
+  %29 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !32, !tbaa !29
+  %needTakeSlowPath3 = icmp ne i64 %28, %29, !dbg !32
+  br i1 %needTakeSlowPath3, label %30, label %31, !dbg !32, !prof !31
 
-34:                                               ; preds = %24
-  tail call void @const_recompute_AttrReaderNoSig(), !dbg !33
-  br label %35, !dbg !33
+30:                                               ; preds = %20
+  tail call void @const_recompute_AttrReaderNoSig(), !dbg !32
+  br label %31, !dbg !32
 
-35:                                               ; preds = %24, %34
-  %36 = load i64, i64* @guarded_const_AttrReaderNoSig, align 8, !dbg !33
-  %37 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !33
-  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !30
-  %guardUpdated4 = icmp eq i64 %37, %38, !dbg !33
-  tail call void @llvm.assume(i1 %guardUpdated4), !dbg !33
-  %stackFrame54 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig#10initialize", align 8, !dbg !33
-  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !33
-  %40 = bitcast i8* %39 to i16*, !dbg !33
-  %41 = load i16, i16* %40, align 8, !dbg !33
-  %42 = and i16 %41, -384, !dbg !33
-  %43 = or i16 %42, 1, !dbg !33
-  store i16 %43, i16* %40, align 8, !dbg !33
-  %44 = getelementptr inbounds i8, i8* %39, i64 8, !dbg !33
-  %45 = bitcast i8* %44 to i32*, !dbg !33
-  store i32 1, i32* %45, align 8, !dbg !33, !tbaa !34
-  %46 = getelementptr inbounds i8, i8* %39, i64 12, !dbg !33
-  %47 = bitcast i8* %46 to i32*, !dbg !33
-  %48 = getelementptr inbounds i8, i8* %39, i64 4, !dbg !33
-  %49 = bitcast i8* %48 to i32*, !dbg !33
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 20, i1 false), !dbg !33
-  store i32 1, i32* %49, align 4, !dbg !33, !tbaa !37
-  %positional_table = alloca i64, align 8, !dbg !33
-  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !33
-  store i64 %rubyId_foo, i64* %positional_table, align 8, !dbg !33
-  %50 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !33
-  %51 = bitcast i64* %positional_table to i8*, !dbg !33
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %50, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %51, i64 noundef 8, i1 noundef false) #15, !dbg !33
-  %52 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !33
-  %53 = bitcast i8* %52 to i8**, !dbg !33
-  store i8* %50, i8** %53, align 8, !dbg !33, !tbaa !38
-  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderNoSig#10initialize", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame54, i1 noundef zeroext false) #15, !dbg !33
-  %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !33, !tbaa !14
-  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 5, !dbg !33
-  %56 = load i32, i32* %55, align 8, !dbg !33, !tbaa !25
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 6, !dbg !33
-  %58 = load i32, i32* %57, align 4, !dbg !33, !tbaa !26
-  %59 = xor i32 %58, -1, !dbg !33
-  %60 = and i32 %59, %56, !dbg !33
-  %61 = icmp eq i32 %60, 0, !dbg !33
-  br i1 %61, label %fastSymCallIntrinsic_Static_keep_def67, label %62, !dbg !33, !prof !27
+31:                                               ; preds = %20, %30
+  %32 = load i64, i64* @guarded_const_AttrReaderNoSig, align 8, !dbg !32
+  %33 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !32
+  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !32, !tbaa !29
+  %guardUpdated4 = icmp eq i64 %33, %34, !dbg !32
+  tail call void @llvm.assume(i1 %guardUpdated4), !dbg !32
+  %stackFrame54 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig#10initialize", align 8, !dbg !32
+  %35 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !32
+  %36 = bitcast i8* %35 to i16*, !dbg !32
+  %37 = load i16, i16* %36, align 8, !dbg !32
+  %38 = and i16 %37, -384, !dbg !32
+  %39 = or i16 %38, 1, !dbg !32
+  store i16 %39, i16* %36, align 8, !dbg !32
+  %40 = getelementptr inbounds i8, i8* %35, i64 8, !dbg !32
+  %41 = bitcast i8* %40 to i32*, !dbg !32
+  store i32 1, i32* %41, align 8, !dbg !32, !tbaa !33
+  %42 = getelementptr inbounds i8, i8* %35, i64 12, !dbg !32
+  %43 = bitcast i8* %42 to i32*, !dbg !32
+  %44 = getelementptr inbounds i8, i8* %35, i64 4, !dbg !32
+  %45 = bitcast i8* %44 to i32*, !dbg !32
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %42, i8 0, i64 20, i1 false), !dbg !32
+  store i32 1, i32* %45, align 4, !dbg !32, !tbaa !36
+  %positional_table = alloca i64, align 8, !dbg !32
+  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !32
+  store i64 %rubyId_foo, i64* %positional_table, align 8, !dbg !32
+  %46 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !32
+  %47 = bitcast i64* %positional_table to i8*, !dbg !32
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %46, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %47, i64 noundef 8, i1 noundef false) #15, !dbg !32
+  %48 = getelementptr inbounds i8, i8* %35, i64 32, !dbg !32
+  %49 = bitcast i8* %48 to i8**, !dbg !32
+  store i8* %46, i8** %49, align 8, !dbg !32, !tbaa !37
+  tail call void @sorbet_vm_define_method(i64 %32, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderNoSig#10initialize", i8* nonnull %35, %struct.rb_iseq_struct* %stackFrame54, i1 noundef zeroext false) #15, !dbg !32
+  %50 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !32, !tbaa !14
+  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %50, i64 0, i32 5, !dbg !32
+  %52 = load i32, i32* %51, align 8, !dbg !32, !tbaa !25
+  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %50, i64 0, i32 6, !dbg !32
+  %54 = load i32, i32* %53, align 4, !dbg !32, !tbaa !26
+  %55 = xor i32 %54, -1, !dbg !32
+  %56 = and i32 %55, %52, !dbg !32
+  %57 = icmp eq i32 %56, 0, !dbg !32
+  br i1 %57, label %rb_vm_check_ints.exit2, label %58, !dbg !32, !prof !27
 
-62:                                               ; preds = %35
-  %63 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 8, !dbg !33
-  %64 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %63, align 8, !dbg !33, !tbaa !28
-  %65 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %64, i32 noundef 0) #15, !dbg !33
-  br label %fastSymCallIntrinsic_Static_keep_def67, !dbg !33
+58:                                               ; preds = %31
+  %59 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %50, i64 0, i32 8, !dbg !32
+  %60 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %59, align 8, !dbg !32, !tbaa !38
+  %61 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %60, i32 noundef 0) #15, !dbg !32
+  br label %rb_vm_check_ints.exit2, !dbg !32
 
-afterSend64:                                      ; preds = %79, %fastSymCallIntrinsic_Static_keep_def67
+rb_vm_check_ints.exit2:                           ; preds = %31, %58
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !32, !tbaa !14
+  %rubyId_foo56 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !39
+  %rawSym57 = tail call i64 @rb_id2sym(i64 %rubyId_foo56), !dbg !39
+  %rubyId_attr_reader = load i64, i64* @rubyIdPrecomputed_attr_reader, align 8, !dbg !39
+  %rawSym58 = tail call i64 @rb_id2sym(i64 %rubyId_attr_reader), !dbg !39
+  %62 = tail call i64 @rb_intern(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0)) #15, !dbg !39
+  %63 = tail call i64 @rb_id2str(i64 %62) #15, !dbg !39
+  %64 = tail call i64 (i8*, ...) @rb_sprintf(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i64 %63) #15, !dbg !39
+  %65 = tail call i64 @rb_intern_str(i64 %64) #15, !dbg !39
+  %66 = inttoptr i64 %65 to i8*, !dbg !39
+  tail call void @rb_add_method(i64 %32, i64 %62, i32 noundef 4, i8* %66, i32 noundef 1) #15, !dbg !39
+  %67 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !39, !tbaa !14
+  %68 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %67, i64 0, i32 5, !dbg !39
+  %69 = load i32, i32* %68, align 8, !dbg !39, !tbaa !25
+  %70 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %67, i64 0, i32 6, !dbg !39
+  %71 = load i32, i32* %70, align 4, !dbg !39, !tbaa !26
+  %72 = xor i32 %71, -1, !dbg !39
+  %73 = and i32 %72, %69, !dbg !39
+  %74 = icmp eq i32 %73, 0, !dbg !39
+  br i1 %74, label %rb_vm_check_ints.exit1, label %75, !dbg !39, !prof !27
+
+75:                                               ; preds = %rb_vm_check_ints.exit2
+  %76 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %67, i64 0, i32 8, !dbg !39
+  %77 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %76, align 8, !dbg !39, !tbaa !38
+  %78 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %77, i32 noundef 0) #15, !dbg !39
+  br label %rb_vm_check_ints.exit1, !dbg !39
+
+rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.exit2, %75
   ret void
 
-fastSymCallIntrinsic_Static_keep_def67:           ; preds = %35, %62
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !33, !tbaa !14
-  %rubyId_foo59 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !39
-  %rawSym60 = tail call i64 @rb_id2sym(i64 %rubyId_foo59), !dbg !39
-  %rubyId_attr_reader = load i64, i64* @rubyIdPrecomputed_attr_reader, align 8, !dbg !39
-  %rawSym61 = tail call i64 @rb_id2sym(i64 %rubyId_attr_reader), !dbg !39
-  %66 = tail call i64 @rb_intern(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0)) #15, !dbg !39
-  %67 = tail call i64 @rb_id2str(i64 %66) #15, !dbg !39
-  %68 = tail call i64 (i8*, ...) @rb_sprintf(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i64 %67) #15, !dbg !39
-  %69 = tail call i64 @rb_intern_str(i64 %68) #15, !dbg !39
-  %70 = inttoptr i64 %69 to i8*, !dbg !39
-  tail call void @rb_add_method(i64 %36, i64 %66, i32 noundef 4, i8* %70, i32 noundef 1) #15, !dbg !39
-  %71 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !39, !tbaa !14
-  %72 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 5, !dbg !39
-  %73 = load i32, i32* %72, align 8, !dbg !39, !tbaa !25
-  %74 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 6, !dbg !39
-  %75 = load i32, i32* %74, align 4, !dbg !39, !tbaa !26
-  %76 = xor i32 %75, -1, !dbg !39
-  %77 = and i32 %76, %73, !dbg !39
-  %78 = icmp eq i32 %77, 0, !dbg !39
-  br i1 %78, label %afterSend64, label %79, !dbg !39, !prof !27
-
-79:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def67
-  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 8, !dbg !39
-  %81 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %80, align 8, !dbg !39, !tbaa !28
-  %82 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %81, i32 noundef 0) #15, !dbg !39
-  br label %afterSend64, !dbg !39
+79:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig
+  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
+  %81 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %80, align 8, !dbg !24, !tbaa !38
+  %82 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %81, i32 noundef 0) #15, !dbg !24
+  br label %afterSend, !dbg !24
 }
 
 ; Function Attrs: sspreq
 define void @Init_no_sig() local_unnamed_addr #8 {
 entry:
-  %locals.i23.i = alloca i64, i32 0, align 8
-  %locals.i21.i = alloca i64, i32 0, align 8
+  %locals.i20.i = alloca i64, i32 0, align 8
+  %locals.i18.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %keywords.i = alloca i64, align 8, !dbg !40
   %realpath = tail call i64 @sorbet_readRealpath()
@@ -437,22 +433,20 @@ entry:
   store i64 %14, i64* @rubyIdPrecomputed_extend, align 8
   %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
   store i64 %15, i64* @rubyIdPrecomputed_normal, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #15
-  store i64 %16, i64* @rubyIdPrecomputed_keep_def, align 8
-  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @str_attr_reader, i64 0, i64 0), i64 noundef 11) #15
-  store i64 %17, i64* @rubyIdPrecomputed_attr_reader, align 8
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @str_attr_reader, i64 0, i64 0), i64 noundef 11) #15
+  store i64 %16, i64* @rubyIdPrecomputed_attr_reader, align 8
+  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  tail call void @rb_gc_register_mark_object(i64 %17) #15
+  store i64 %17, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([58 x i8], [58 x i8]* @"str_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", i64 0, i64 0), i64 noundef 57) #15
   tail call void @rb_gc_register_mark_object(i64 %18) #15
-  store i64 %18, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([58 x i8], [58 x i8]* @"str_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", i64 0, i64 0), i64 noundef 57) #15
-  tail call void @rb_gc_register_mark_object(i64 %19) #15
-  store i64 %19, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
+  store i64 %18, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
-  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !42
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !42
   %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !44
@@ -467,259 +461,255 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !48
   %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !49
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
-  %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
-  call void @rb_gc_register_mark_object(i64 %21) #15
+  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
+  call void @rb_gc_register_mark_object(i64 %20) #15
   %rubyId_initialize.i.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
-  %22 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %rubyId_initialize.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i21.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %22, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig#10initialize", align 8
-  %23 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #15
-  store i64 %23, i64* @"<void-singleton>", align 8
-  %24 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_<class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 23) #15
-  call void @rb_gc_register_mark_object(i64 %24) #15
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
+  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %rubyId_initialize.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig#10initialize", align 8
+  %22 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #15
+  store i64 %22, i64* @"<void-singleton>", align 8
+  %23 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_<class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 23) #15
+  call void @rb_gc_register_mark_object(i64 %23) #15
   %"rubyId_<class:AttrReaderNoSig>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:AttrReaderNoSig>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
-  %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %24, i64 %"rubyId_<class:AttrReaderNoSig>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>", align 8
-  %26 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([33 x i8], [33 x i8]* @"str_block in <class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 32) #15
-  call void @rb_gc_register_mark_object(i64 %26) #15
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i19.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
+  %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %23, i64 %"rubyId_<class:AttrReaderNoSig>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i19.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i20.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>", align 8
+  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([33 x i8], [33 x i8]* @"str_block in <class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 32) #15
+  call void @rb_gc_register_mark_object(i64 %25) #15
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>", align 8
   %"rubyId_block in <class:AttrReaderNoSig>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:AttrReaderNoSig>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
-  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %26, i64 %"rubyId_block in <class:AttrReaderNoSig>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>$block_1", align 8
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i21.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
+  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %25, i64 %"rubyId_block in <class:AttrReaderNoSig>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>$block_1", align 8
   %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !24
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !40
   %rubyId_foo12.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
-  %28 = call i64 @rb_id2sym(i64 %rubyId_foo12.i) #15, !dbg !40
-  store i64 %28, i64* %keywords.i, align 8, !dbg !40
+  %27 = call i64 @rb_id2sym(i64 %rubyId_foo12.i) #15, !dbg !40
+  store i64 %27, i64* %keywords.i, align 8, !dbg !40
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !40
   %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !40
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !40
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !33
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !33
-  %rubyId_keep_def18.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !39
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def18.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !39
+  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !28
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
-  %29 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %30 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %29, i64 0, i32 18
-  %31 = load i64, i64* %30, align 8, !tbaa !50
-  %32 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %33 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %32, i64 0, i32 2
-  %34 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %33, align 8, !tbaa !16
+  %28 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %29 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %28, i64 0, i32 18
+  %30 = load i64, i64* %29, align 8, !tbaa !50
+  %31 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 2
+  %33 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %32, align 8, !tbaa !16
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %35, align 8, !tbaa !20
-  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 4
-  %37 = load i64*, i64** %36, align 8, !tbaa !22
-  %38 = load i64, i64* %37, align 8, !tbaa !6
-  %39 = and i64 %38, -33
-  store i64 %39, i64* %37, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %32, %struct.rb_control_frame_struct* %34, %struct.rb_iseq_struct* %stackFrame.i) #15
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %40, align 8, !dbg !58, !tbaa !14
-  %41 = load i64, i64* @rb_cObject, align 8, !dbg !59
-  %42 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([16 x i8], [16 x i8]* @str_AttrReaderNoSig, i64 0, i64 0), i64 %41) #15, !dbg !59
-  %43 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %42) #15, !dbg !59
-  call fastcc void @"func_AttrReaderNoSig.13<static-init>L62"(i64 %42, %struct.rb_control_frame_struct* %43) #15, !dbg !59
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %34, align 8, !tbaa !20
+  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 4
+  %36 = load i64*, i64** %35, align 8, !tbaa !22
+  %37 = load i64, i64* %36, align 8, !tbaa !6
+  %38 = and i64 %37, -33
+  store i64 %38, i64* %36, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %31, %struct.rb_control_frame_struct* %33, %struct.rb_iseq_struct* %stackFrame.i) #15
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %39, align 8, !dbg !58, !tbaa !14
+  %40 = load i64, i64* @rb_cObject, align 8, !dbg !59
+  %41 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([16 x i8], [16 x i8]* @str_AttrReaderNoSig, i64 0, i64 0), i64 %40) #15, !dbg !59
+  %42 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %41) #15, !dbg !59
+  call fastcc void @"func_AttrReaderNoSig.13<static-init>L62"(i64 %41, %struct.rb_control_frame_struct* %42) #15, !dbg !59
   call void @sorbet_popFrame() #15, !dbg !59
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %40, align 8, !dbg !59, !tbaa !14
-  %44 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !42
-  %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !42, !tbaa !30
-  %needTakeSlowPath = icmp ne i64 %44, %45, !dbg !42
-  br i1 %needTakeSlowPath, label %46, label %47, !dbg !42, !prof !32
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %39, align 8, !dbg !59, !tbaa !14
+  %43 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !42
+  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !42, !tbaa !29
+  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !42
+  br i1 %needTakeSlowPath, label %45, label %46, !dbg !42, !prof !31
 
-46:                                               ; preds = %entry
+45:                                               ; preds = %entry
   call void @const_recompute_AttrReaderNoSig(), !dbg !42
-  br label %47, !dbg !42
+  br label %46, !dbg !42
 
-47:                                               ; preds = %entry, %46
-  %48 = load i64, i64* @guarded_const_AttrReaderNoSig, align 8, !dbg !42
-  %49 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !42
-  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !42, !tbaa !30
-  %guardUpdated = icmp eq i64 %49, %50, !dbg !42
+46:                                               ; preds = %entry, %45
+  %47 = load i64, i64* @guarded_const_AttrReaderNoSig, align 8, !dbg !42
+  %48 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !42
+  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !42, !tbaa !29
+  %guardUpdated = icmp eq i64 %48, %49, !dbg !42
   call void @llvm.assume(i1 %guardUpdated), !dbg !42
-  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 1, !dbg !42
-  %52 = load i64*, i64** %51, align 8, !dbg !42
-  store i64 %48, i64* %52, align 8, !dbg !42, !tbaa !6
+  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !42
+  %51 = load i64*, i64** %50, align 8, !dbg !42
+  store i64 %47, i64* %51, align 8, !dbg !42, !tbaa !6
+  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !42
+  store i64 2497, i64* %52, align 8, !dbg !42, !tbaa !6
   %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !42
-  store i64 2497, i64* %53, align 8, !dbg !42, !tbaa !6
-  %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !42
-  store i64* %54, i64** %51, align 8, !dbg !42
+  store i64* %53, i64** %50, align 8, !dbg !42
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !42
   br label %BB2.i, !dbg !60
 
-BB2.i:                                            ; preds = %BB2.i.backedge, %47
-  %i.sroa.0.0.i = phi i64 [ 1, %47 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !58
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %40, align 8, !tbaa !14
-  %55 = and i64 %i.sroa.0.0.i, 1, !dbg !44
-  %56 = icmp eq i64 %55, 0, !dbg !44
-  br i1 %56, label %57, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !44, !prof !61
+BB2.i:                                            ; preds = %BB2.i.backedge, %46
+  %i.sroa.0.0.i = phi i64 [ 1, %46 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !58
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %39, align 8, !tbaa !14
+  %54 = and i64 %i.sroa.0.0.i, 1, !dbg !44
+  %55 = icmp eq i64 %54, 0, !dbg !44
+  br i1 %55, label %56, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !44, !prof !61
 
-57:                                               ; preds = %BB2.i
-  %58 = and i64 %i.sroa.0.0.i, 7, !dbg !44
-  %59 = icmp ne i64 %58, 0, !dbg !44
-  %60 = and i64 %i.sroa.0.0.i, -9, !dbg !44
-  %61 = icmp eq i64 %60, 0, !dbg !44
-  %62 = or i1 %59, %61, !dbg !44
-  br i1 %62, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !44, !prof !62
+56:                                               ; preds = %BB2.i
+  %57 = and i64 %i.sroa.0.0.i, 7, !dbg !44
+  %58 = icmp ne i64 %57, 0, !dbg !44
+  %59 = and i64 %i.sroa.0.0.i, -9, !dbg !44
+  %60 = icmp eq i64 %59, 0, !dbg !44
+  %61 = or i1 %58, %60, !dbg !44
+  br i1 %61, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !44, !prof !62
 
-sorbet_isa_Integer.exit:                          ; preds = %57
-  %63 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !44
-  %64 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %63, i64 0, i32 0, !dbg !44
-  %65 = load i64, i64* %64, align 8, !dbg !44, !tbaa !63
-  %66 = and i64 %65, 31, !dbg !44
-  %67 = icmp eq i64 %66, 10, !dbg !44
-  br i1 %67, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !44, !prof !27
+sorbet_isa_Integer.exit:                          ; preds = %56
+  %62 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !44
+  %63 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %62, i64 0, i32 0, !dbg !44
+  %64 = load i64, i64* %63, align 8, !dbg !44, !tbaa !63
+  %65 = and i64 %64, 31, !dbg !44
+  %66 = icmp eq i64 %65, 10, !dbg !44
+  br i1 %66, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !44, !prof !27
 
 BB5.i:                                            ; preds = %afterSend37.i
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %40, align 8, !tbaa !14
-  %68 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 1, !dbg !45
-  %69 = load i64*, i64** %68, align 8, !dbg !45
-  store i64 %send, i64* %69, align 8, !dbg !45, !tbaa !6
-  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !45
-  store i64* %70, i64** %68, align 8, !dbg !45
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %39, align 8, !tbaa !14
+  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !45
+  %68 = load i64*, i64** %67, align 8, !dbg !45
+  store i64 %send, i64* %68, align 8, !dbg !45, !tbaa !6
+  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !45
+  store i64* %69, i64** %67, align 8, !dbg !45
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !45
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %40, align 8, !dbg !45, !tbaa !14
-  br i1 %71, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !46
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %39, align 8, !dbg !45, !tbaa !14
+  br i1 %70, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !46
 
-afterSend37.i:                                    ; preds = %96, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
-  %71 = phi i1 [ %74, %"alternativeCallIntrinsic_Integer_<.i" ], [ %79, %sorbet_rb_int_lt.exit.i ], [ %79, %96 ]
-  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send4, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult89.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult89.i, %96 ], !dbg !44
-  %72 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !44
-  %73 = icmp ne i64 %72, 0, !dbg !44
-  br i1 %73, label %BB5.i, label %"func_<root>.17<static-init>$152.exit", !dbg !44
+afterSend37.i:                                    ; preds = %95, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
+  %70 = phi i1 [ %73, %"alternativeCallIntrinsic_Integer_<.i" ], [ %78, %sorbet_rb_int_lt.exit.i ], [ %78, %95 ]
+  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send4, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult89.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult89.i, %95 ], !dbg !44
+  %71 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !44
+  %72 = icmp ne i64 %71, 0, !dbg !44
+  br i1 %72, label %BB5.i, label %"func_<root>.17<static-init>$152.exit", !dbg !44
 
-"alternativeCallIntrinsic_Integer_<.i":           ; preds = %57, %sorbet_isa_Integer.exit
-  %74 = phi i1 [ %67, %sorbet_isa_Integer.exit ], [ false, %57 ]
-  %75 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 1, !dbg !44
-  %76 = load i64*, i64** %75, align 8, !dbg !44
-  store i64 %i.sroa.0.0.i, i64* %76, align 8, !dbg !44, !tbaa !6
+"alternativeCallIntrinsic_Integer_<.i":           ; preds = %56, %sorbet_isa_Integer.exit
+  %73 = phi i1 [ %66, %sorbet_isa_Integer.exit ], [ false, %56 ]
+  %74 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !44
+  %75 = load i64*, i64** %74, align 8, !dbg !44
+  store i64 %i.sroa.0.0.i, i64* %75, align 8, !dbg !44, !tbaa !6
+  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !44
+  store i64 20000001, i64* %76, align 8, !dbg !44, !tbaa !6
   %77 = getelementptr inbounds i64, i64* %76, i64 1, !dbg !44
-  store i64 20000001, i64* %77, align 8, !dbg !44, !tbaa !6
-  %78 = getelementptr inbounds i64, i64* %77, i64 1, !dbg !44
-  store i64* %78, i64** %75, align 8, !dbg !44
+  store i64* %77, i64** %74, align 8, !dbg !44
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !44
   br label %afterSend37.i, !dbg !44
 
 "fastSymCallIntrinsic_Integer_<.i":               ; preds = %BB2.i, %sorbet_isa_Integer.exit
-  %79 = phi i1 [ %67, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
+  %78 = phi i1 [ %66, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
   call void @llvm.experimental.noalias.scope.decl(metadata !65) #15, !dbg !44
-  %80 = and i64 %i.sroa.0.0.i, 1, !dbg !44
-  %81 = icmp eq i64 %80, 0, !dbg !44
-  br i1 %81, label %86, label %82, !dbg !44, !prof !68
+  %79 = and i64 %i.sroa.0.0.i, 1, !dbg !44
+  %80 = icmp eq i64 %79, 0, !dbg !44
+  br i1 %80, label %85, label %81, !dbg !44, !prof !68
 
-82:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %83 = ashr i64 %i.sroa.0.0.i, 1, !dbg !44
-  %84 = icmp slt i64 %83, 10000000, !dbg !44
-  %85 = select i1 %84, i64 20, i64 0, !dbg !44
+81:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
+  %82 = ashr i64 %i.sroa.0.0.i, 1, !dbg !44
+  %83 = icmp slt i64 %82, 10000000, !dbg !44
+  %84 = select i1 %83, i64 20, i64 0, !dbg !44
   br label %sorbet_rb_int_lt.exit.i, !dbg !44
 
-86:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %87 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !44, !noalias !65
+85:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
+  %86 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !44, !noalias !65
   br label %sorbet_rb_int_lt.exit.i, !dbg !44
 
-sorbet_rb_int_lt.exit.i:                          ; preds = %86, %82
-  %rawSendResult89.i = phi i64 [ %85, %82 ], [ %87, %86 ]
-  %88 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !44, !tbaa !14
-  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %88, i64 0, i32 5, !dbg !44
-  %90 = load i32, i32* %89, align 8, !dbg !44, !tbaa !25
-  %91 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %88, i64 0, i32 6, !dbg !44
-  %92 = load i32, i32* %91, align 4, !dbg !44, !tbaa !26
-  %93 = xor i32 %92, -1, !dbg !44
-  %94 = and i32 %93, %90, !dbg !44
-  %95 = icmp eq i32 %94, 0, !dbg !44
-  br i1 %95, label %afterSend37.i, label %96, !dbg !44, !prof !27
+sorbet_rb_int_lt.exit.i:                          ; preds = %85, %81
+  %rawSendResult89.i = phi i64 [ %84, %81 ], [ %86, %85 ]
+  %87 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !44, !tbaa !14
+  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 5, !dbg !44
+  %89 = load i32, i32* %88, align 8, !dbg !44, !tbaa !25
+  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 6, !dbg !44
+  %91 = load i32, i32* %90, align 4, !dbg !44, !tbaa !26
+  %92 = xor i32 %91, -1, !dbg !44
+  %93 = and i32 %92, %89, !dbg !44
+  %94 = icmp eq i32 %93, 0, !dbg !44
+  br i1 %94, label %afterSend37.i, label %95, !dbg !44, !prof !27
 
-96:                                               ; preds = %sorbet_rb_int_lt.exit.i
-  %97 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %88, i64 0, i32 8, !dbg !44
-  %98 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %97, align 8, !dbg !44, !tbaa !28
-  %99 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %98, i32 noundef 0) #15, !dbg !44
+95:                                               ; preds = %sorbet_rb_int_lt.exit.i
+  %96 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 8, !dbg !44
+  %97 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %96, align 8, !dbg !44, !tbaa !38
+  %98 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %97, i32 noundef 0) #15, !dbg !44
   br label %afterSend37.i, !dbg !44
 
 "alternativeCallIntrinsic_Integer_+.i":           ; preds = %BB5.i
-  %100 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 1, !dbg !46
-  %101 = load i64*, i64** %100, align 8, !dbg !46
-  store i64 %i.sroa.0.0.i, i64* %101, align 8, !dbg !46, !tbaa !6
+  %99 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !46
+  %100 = load i64*, i64** %99, align 8, !dbg !46
+  store i64 %i.sroa.0.0.i, i64* %100, align 8, !dbg !46, !tbaa !6
+  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !46
+  store i64 3, i64* %101, align 8, !dbg !46, !tbaa !6
   %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !46
-  store i64 3, i64* %102, align 8, !dbg !46, !tbaa !6
-  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !46
-  store i64* %103, i64** %100, align 8, !dbg !46
+  store i64* %102, i64** %99, align 8, !dbg !46
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !46
   br label %BB2.i.backedge, !dbg !46
 
 "fastSymCallIntrinsic_Integer_+.i":               ; preds = %BB5.i
   call void @llvm.experimental.noalias.scope.decl(metadata !69) #15, !dbg !46
-  %104 = and i64 %i.sroa.0.0.i, 1, !dbg !46
-  %105 = icmp eq i64 %104, 0, !dbg !46
-  br i1 %105, label %114, label %106, !dbg !46, !prof !68
+  %103 = and i64 %i.sroa.0.0.i, 1, !dbg !46
+  %104 = icmp eq i64 %103, 0, !dbg !46
+  br i1 %104, label %113, label %105, !dbg !46, !prof !68
 
-106:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %107 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !46
-  %108 = extractvalue { i64, i1 } %107, 1, !dbg !46
-  %109 = extractvalue { i64, i1 } %107, 0, !dbg !46
-  br i1 %108, label %110, label %sorbet_rb_int_plus.exit.i, !dbg !46
+105:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
+  %106 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !46
+  %107 = extractvalue { i64, i1 } %106, 1, !dbg !46
+  %108 = extractvalue { i64, i1 } %106, 0, !dbg !46
+  br i1 %107, label %109, label %sorbet_rb_int_plus.exit.i, !dbg !46
 
-110:                                              ; preds = %106
-  %111 = ashr i64 %109, 1, !dbg !46
-  %112 = xor i64 %111, -9223372036854775808, !dbg !46
-  %113 = call i64 @rb_int2big(i64 %112) #15, !dbg !46
+109:                                              ; preds = %105
+  %110 = ashr i64 %108, 1, !dbg !46
+  %111 = xor i64 %110, -9223372036854775808, !dbg !46
+  %112 = call i64 @rb_int2big(i64 %111) #15, !dbg !46
   br label %sorbet_rb_int_plus.exit.i, !dbg !46
 
-114:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %115 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !46, !noalias !69
+113:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
+  %114 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !46, !noalias !69
   br label %sorbet_rb_int_plus.exit.i, !dbg !46
 
-sorbet_rb_int_plus.exit.i:                        ; preds = %114, %110, %106
-  %116 = phi i64 [ %115, %114 ], [ %113, %110 ], [ %109, %106 ], !dbg !46
-  %117 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !14
-  %118 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %117, i64 0, i32 5, !dbg !46
-  %119 = load i32, i32* %118, align 8, !dbg !46, !tbaa !25
-  %120 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %117, i64 0, i32 6, !dbg !46
-  %121 = load i32, i32* %120, align 4, !dbg !46, !tbaa !26
-  %122 = xor i32 %121, -1, !dbg !46
-  %123 = and i32 %122, %119, !dbg !46
-  %124 = icmp eq i32 %123, 0, !dbg !46
-  br i1 %124, label %BB2.i.backedge, label %125, !dbg !46, !prof !27
+sorbet_rb_int_plus.exit.i:                        ; preds = %113, %109, %105
+  %115 = phi i64 [ %114, %113 ], [ %112, %109 ], [ %108, %105 ], !dbg !46
+  %116 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !14
+  %117 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %116, i64 0, i32 5, !dbg !46
+  %118 = load i32, i32* %117, align 8, !dbg !46, !tbaa !25
+  %119 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %116, i64 0, i32 6, !dbg !46
+  %120 = load i32, i32* %119, align 4, !dbg !46, !tbaa !26
+  %121 = xor i32 %120, -1, !dbg !46
+  %122 = and i32 %121, %118, !dbg !46
+  %123 = icmp eq i32 %122, 0, !dbg !46
+  br i1 %123, label %BB2.i.backedge, label %124, !dbg !46, !prof !27
 
-125:                                              ; preds = %sorbet_rb_int_plus.exit.i
-  %126 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %117, i64 0, i32 8, !dbg !46
-  %127 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %126, align 8, !dbg !46, !tbaa !28
-  %128 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %127, i32 noundef 0) #15, !dbg !46
+124:                                              ; preds = %sorbet_rb_int_plus.exit.i
+  %125 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %116, i64 0, i32 8, !dbg !46
+  %126 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %125, align 8, !dbg !46, !tbaa !38
+  %127 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %126, i32 noundef 0) #15, !dbg !46
   br label %BB2.i.backedge, !dbg !46
 
-BB2.i.backedge:                                   ; preds = %125, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
-  %i.sroa.0.0.i.be = phi i64 [ %send6, %"alternativeCallIntrinsic_Integer_+.i" ], [ %116, %sorbet_rb_int_plus.exit.i ], [ %116, %125 ]
+BB2.i.backedge:                                   ; preds = %124, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
+  %i.sroa.0.0.i.be = phi i64 [ %send6, %"alternativeCallIntrinsic_Integer_+.i" ], [ %115, %sorbet_rb_int_plus.exit.i ], [ %115, %124 ]
   br label %BB2.i
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %afterSend37.i
   %i.sroa.0.0.i.lcssa = phi i64 [ %i.sroa.0.0.i, %afterSend37.i ], !dbg !58
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %40, align 8, !tbaa !14
-  %129 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 1, !dbg !47
-  %130 = load i64*, i64** %129, align 8, !dbg !47
-  store i64 %31, i64* %130, align 8, !dbg !47, !tbaa !6
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %39, align 8, !tbaa !14
+  %128 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !47
+  %129 = load i64*, i64** %128, align 8, !dbg !47
+  store i64 %30, i64* %129, align 8, !dbg !47, !tbaa !6
+  %130 = getelementptr inbounds i64, i64* %129, i64 1, !dbg !47
+  store i64 %i.sroa.0.0.i.lcssa, i64* %130, align 8, !dbg !47, !tbaa !6
   %131 = getelementptr inbounds i64, i64* %130, i64 1, !dbg !47
-  store i64 %i.sroa.0.0.i.lcssa, i64* %131, align 8, !dbg !47, !tbaa !6
-  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !47
-  store i64* %132, i64** %129, align 8, !dbg !47
+  store i64* %131, i64** %128, align 8, !dbg !47
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !47
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %40, align 8, !dbg !47, !tbaa !14
-  %133 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 1, !dbg !48
-  %134 = load i64*, i64** %133, align 8, !dbg !48
-  store i64 %send, i64* %134, align 8, !dbg !48, !tbaa !6
-  %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !48
-  store i64* %135, i64** %133, align 8, !dbg !48
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %39, align 8, !dbg !47, !tbaa !14
+  %132 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !48
+  %133 = load i64*, i64** %132, align 8, !dbg !48
+  store i64 %send, i64* %133, align 8, !dbg !48, !tbaa !6
+  %134 = getelementptr inbounds i64, i64* %133, i64 1, !dbg !48
+  store i64* %134, i64** %132, align 8, !dbg !48
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !48
-  %136 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 1, !dbg !49
-  %137 = load i64*, i64** %136, align 8, !dbg !49
-  store i64 %31, i64* %137, align 8, !dbg !49, !tbaa !6
+  %135 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !49
+  %136 = load i64*, i64** %135, align 8, !dbg !49
+  store i64 %30, i64* %136, align 8, !dbg !49, !tbaa !6
+  %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !49
+  store i64 %send10, i64* %137, align 8, !dbg !49, !tbaa !6
   %138 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !49
-  store i64 %send10, i64* %138, align 8, !dbg !49, !tbaa !6
-  %139 = getelementptr inbounds i64, i64* %138, i64 1, !dbg !49
-  store i64* %139, i64** %136, align 8, !dbg !49
+  store i64* %138, i64** %135, align 8, !dbg !49
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !49
   ret void
 }
@@ -838,7 +828,7 @@ declare void @llvm.assume(i1 noundef) #13
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !30
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !29
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
@@ -847,7 +837,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #9 {
 define linkonce void @const_recompute_AttrReaderNoSig() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @str_AttrReaderNoSig, i64 0, i64 0), i64 15)
   store i64 %1, i64* @guarded_const_AttrReaderNoSig, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !30
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !29
   store i64 %2, i64* @guard_epoch_AttrReaderNoSig, align 8
   ret void
 }
@@ -904,17 +894,17 @@ attributes #19 = { noinline }
 !25 = !{!17, !18, i64 40}
 !26 = !{!17, !18, i64 44}
 !27 = !{!"branch_weights", i32 2000, i32 1}
-!28 = !{!17, !15, i64 56}
-!29 = !DILocation(line: 6, column: 3, scope: !10)
-!30 = !{!31, !31, i64 0}
-!31 = !{!"long long", !8, i64 0}
-!32 = !{!"branch_weights", i32 1, i32 10000}
-!33 = !DILocation(line: 8, column: 3, scope: !10)
-!34 = !{!35, !18, i64 8}
-!35 = !{!"rb_sorbet_param_struct", !36, i64 0, !18, i64 4, !18, i64 8, !18, i64 12, !18, i64 16, !18, i64 20, !18, i64 24, !18, i64 28, !15, i64 32, !18, i64 40, !18, i64 44, !18, i64 48, !18, i64 52, !15, i64 56}
-!36 = !{!"", !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 1, !18, i64 1}
-!37 = !{!35, !18, i64 4}
-!38 = !{!35, !15, i64 32}
+!28 = !DILocation(line: 6, column: 3, scope: !10)
+!29 = !{!30, !30, i64 0}
+!30 = !{!"long long", !8, i64 0}
+!31 = !{!"branch_weights", i32 1, i32 10000}
+!32 = !DILocation(line: 8, column: 3, scope: !10)
+!33 = !{!34, !18, i64 8}
+!34 = !{!"rb_sorbet_param_struct", !35, i64 0, !18, i64 4, !18, i64 8, !18, i64 12, !18, i64 16, !18, i64 20, !18, i64 24, !18, i64 28, !15, i64 32, !18, i64 40, !18, i64 44, !18, i64 48, !18, i64 52, !15, i64 56}
+!35 = !{!"", !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 1, !18, i64 1}
+!36 = !{!34, !18, i64 4}
+!37 = !{!34, !15, i64 32}
+!38 = !{!17, !15, i64 56}
 !39 = !DILocation(line: 13, column: 3, scope: !10)
 !40 = !DILocation(line: 7, column: 8, scope: !41)
 !41 = distinct !DISubprogram(name: "AttrReaderNoSig.<static-init>", linkageName: "func_AttrReaderNoSig.13<static-init>L62$block_1", scope: !10, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
@@ -927,7 +917,7 @@ attributes #19 = { noinline }
 !48 = !DILocation(line: 27, column: 6, scope: !43)
 !49 = !DILocation(line: 27, column: 1, scope: !43)
 !50 = !{!51, !7, i64 400}
-!51 = !{!"rb_vm_struct", !7, i64 0, !52, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !31, i64 216, !8, i64 224, !53, i64 264, !53, i64 280, !53, i64 296, !53, i64 312, !7, i64 328, !18, i64 336, !18, i64 340, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !55, i64 472, !56, i64 992, !15, i64 1016, !15, i64 1024, !18, i64 1032, !18, i64 1036, !53, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !18, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !18, i64 1192, !57, i64 1200, !8, i64 1232}
+!51 = !{!"rb_vm_struct", !7, i64 0, !52, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !30, i64 216, !8, i64 224, !53, i64 264, !53, i64 280, !53, i64 296, !53, i64 312, !7, i64 328, !18, i64 336, !18, i64 340, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !55, i64 472, !56, i64 992, !15, i64 1016, !15, i64 1024, !18, i64 1032, !18, i64 1036, !53, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !18, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !18, i64 1192, !57, i64 1200, !8, i64 1232}
 !52 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !53, i64 48, !15, i64 64, !18, i64 72, !8, i64 80, !8, i64 128, !18, i64 176, !18, i64 180}
 !53 = !{!"list_head", !54, i64 0}
 !54 = !{!"list_node", !15, i64 0, !15, i64 8}

--- a/test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.llo.exp
@@ -150,10 +150,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
 @rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
-@ic_keep_def.6 = internal global %struct.FunctionInlineCache zeroinitializer
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
 @guard_epoch_AttrReaderSigChecked = linkonce local_unnamed_addr global i64 0
@@ -276,156 +272,156 @@ fastSymCallIntrinsic_ResolvedSig_sig:
   %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !24
   br label %fastSymCallIntrinsic_ResolvedSig_sig63, !dbg !24
 
-fastSymCallIntrinsic_ResolvedSig_sig63:           ; preds = %fastSymCallIntrinsic_ResolvedSig_sig, %17
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !24, !tbaa !14
-  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !29
-  %rawSym57 = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !29
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym57, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_AttrReaderSigChecked.13<static-init>L62$block_2"), !dbg !29
-  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
-  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !29
-  %23 = load i32, i32* %22, align 8, !dbg !29, !tbaa !25
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 6, !dbg !29
-  %25 = load i32, i32* %24, align 4, !dbg !29, !tbaa !26
-  %26 = xor i32 %25, -1, !dbg !29
-  %27 = and i32 %26, %23, !dbg !29
-  %28 = icmp eq i32 %27, 0, !dbg !29
-  br i1 %28, label %fastSymCallIntrinsic_Static_keep_def, label %29, !dbg !29, !prof !27
-
-29:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig63
-  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !29
-  %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !29, !tbaa !28
-  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #15, !dbg !29
-  br label %fastSymCallIntrinsic_Static_keep_def, !dbg !29
-
-fastSymCallIntrinsic_Static_keep_def:             ; preds = %fastSymCallIntrinsic_ResolvedSig_sig63, %29
+afterSend60:                                      ; preds = %92, %fastSymCallIntrinsic_ResolvedSig_sig63
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !29, !tbaa !14
-  %33 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !30
-  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
-  %needTakeSlowPath = icmp ne i64 %33, %34, !dbg !30
-  br i1 %needTakeSlowPath, label %35, label %36, !dbg !30, !prof !33
+  %21 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !30
+  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
+  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !30
+  br i1 %needTakeSlowPath, label %23, label %24, !dbg !30, !prof !33
 
-35:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def
+23:                                               ; preds = %afterSend60
   tail call void @"const_recompute_T::Sig"(), !dbg !30
-  br label %36, !dbg !30
+  br label %24, !dbg !30
 
-36:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def, %35
-  %37 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !30
-  %38 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !30
-  %39 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
-  %guardUpdated = icmp eq i64 %38, %39, !dbg !30
+24:                                               ; preds = %afterSend60, %23
+  %25 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !30
+  %26 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !30
+  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
+  %guardUpdated = icmp eq i64 %26, %27, !dbg !30
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !30
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !30
-  %41 = load i64*, i64** %40, align 8, !dbg !30
-  store i64 %selfRaw, i64* %41, align 8, !dbg !30, !tbaa !6
-  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !30
-  store i64 %37, i64* %42, align 8, !dbg !30, !tbaa !6
-  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !30
-  store i64* %43, i64** %40, align 8, !dbg !30
+  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !30
+  %29 = load i64*, i64** %28, align 8, !dbg !30
+  store i64 %selfRaw, i64* %29, align 8, !dbg !30, !tbaa !6
+  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !30
+  store i64 %25, i64* %30, align 8, !dbg !30, !tbaa !6
+  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !30
+  store i64* %31, i64** %28, align 8, !dbg !30
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !30
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !30, !tbaa !14
   %rubyId_initialize79 = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !34
   %rawSym80 = tail call i64 @rb_id2sym(i64 %rubyId_initialize79), !dbg !34
   %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !34
   %rawSym81 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !34
-  %44 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !34
-  %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !34, !tbaa !31
-  %needTakeSlowPath4 = icmp ne i64 %44, %45, !dbg !34
-  br i1 %needTakeSlowPath4, label %46, label %47, !dbg !34, !prof !33
+  %32 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !34
+  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !34, !tbaa !31
+  %needTakeSlowPath4 = icmp ne i64 %32, %33, !dbg !34
+  br i1 %needTakeSlowPath4, label %34, label %35, !dbg !34, !prof !33
 
-46:                                               ; preds = %36
+34:                                               ; preds = %24
   tail call void @const_recompute_AttrReaderSigChecked(), !dbg !34
-  br label %47, !dbg !34
+  br label %35, !dbg !34
 
-47:                                               ; preds = %36, %46
-  %48 = load i64, i64* @guarded_const_AttrReaderSigChecked, align 8, !dbg !34
-  %49 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !34
-  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !34, !tbaa !31
-  %guardUpdated5 = icmp eq i64 %49, %50, !dbg !34
+35:                                               ; preds = %24, %34
+  %36 = load i64, i64* @guarded_const_AttrReaderSigChecked, align 8, !dbg !34
+  %37 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !34
+  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !34, !tbaa !31
+  %guardUpdated5 = icmp eq i64 %37, %38, !dbg !34
   tail call void @llvm.assume(i1 %guardUpdated5), !dbg !34
   %stackFrame85 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#10initialize", align 8, !dbg !34
-  %51 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !34
-  %52 = bitcast i8* %51 to i16*, !dbg !34
-  %53 = load i16, i16* %52, align 8, !dbg !34
-  %54 = and i16 %53, -384, !dbg !34
-  %55 = or i16 %54, 1, !dbg !34
-  store i16 %55, i16* %52, align 8, !dbg !34
-  %56 = getelementptr inbounds i8, i8* %51, i64 8, !dbg !34
-  %57 = bitcast i8* %56 to i32*, !dbg !34
-  store i32 1, i32* %57, align 8, !dbg !34, !tbaa !35
-  %58 = getelementptr inbounds i8, i8* %51, i64 12, !dbg !34
-  %59 = bitcast i8* %58 to i32*, !dbg !34
-  %60 = getelementptr inbounds i8, i8* %51, i64 4, !dbg !34
-  %61 = bitcast i8* %60 to i32*, !dbg !34
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %58, i8 0, i64 20, i1 false), !dbg !34
-  store i32 1, i32* %61, align 4, !dbg !34, !tbaa !38
+  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !34
+  %40 = bitcast i8* %39 to i16*, !dbg !34
+  %41 = load i16, i16* %40, align 8, !dbg !34
+  %42 = and i16 %41, -384, !dbg !34
+  %43 = or i16 %42, 1, !dbg !34
+  store i16 %43, i16* %40, align 8, !dbg !34
+  %44 = getelementptr inbounds i8, i8* %39, i64 8, !dbg !34
+  %45 = bitcast i8* %44 to i32*, !dbg !34
+  store i32 1, i32* %45, align 8, !dbg !34, !tbaa !35
+  %46 = getelementptr inbounds i8, i8* %39, i64 12, !dbg !34
+  %47 = bitcast i8* %46 to i32*, !dbg !34
+  %48 = getelementptr inbounds i8, i8* %39, i64 4, !dbg !34
+  %49 = bitcast i8* %48 to i32*, !dbg !34
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 20, i1 false), !dbg !34
+  store i32 1, i32* %49, align 4, !dbg !34, !tbaa !38
   %positional_table = alloca i64, align 8, !dbg !34
   %rubyId_foo86 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !34
   store i64 %rubyId_foo86, i64* %positional_table, align 8, !dbg !34
-  %62 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !34
-  %63 = bitcast i64* %positional_table to i8*, !dbg !34
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %63, i64 noundef 8, i1 noundef false) #15, !dbg !34
-  %64 = getelementptr inbounds i8, i8* %51, i64 32, !dbg !34
-  %65 = bitcast i8* %64 to i8**, !dbg !34
-  store i8* %62, i8** %65, align 8, !dbg !34, !tbaa !39
-  tail call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderSigChecked#10initialize", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame85, i1 noundef zeroext false) #15, !dbg !34
-  %66 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !34, !tbaa !14
-  %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 5, !dbg !34
-  %68 = load i32, i32* %67, align 8, !dbg !34, !tbaa !25
-  %69 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 6, !dbg !34
-  %70 = load i32, i32* %69, align 4, !dbg !34, !tbaa !26
-  %71 = xor i32 %70, -1, !dbg !34
-  %72 = and i32 %71, %68, !dbg !34
-  %73 = icmp eq i32 %72, 0, !dbg !34
-  br i1 %73, label %fastSymCallIntrinsic_Static_keep_def100, label %74, !dbg !34, !prof !27
+  %50 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !34
+  %51 = bitcast i64* %positional_table to i8*, !dbg !34
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %50, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %51, i64 noundef 8, i1 noundef false) #15, !dbg !34
+  %52 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !34
+  %53 = bitcast i8* %52 to i8**, !dbg !34
+  store i8* %50, i8** %53, align 8, !dbg !34, !tbaa !39
+  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderSigChecked#10initialize", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame85, i1 noundef zeroext false) #15, !dbg !34
+  %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !34, !tbaa !14
+  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 5, !dbg !34
+  %56 = load i32, i32* %55, align 8, !dbg !34, !tbaa !25
+  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 6, !dbg !34
+  %58 = load i32, i32* %57, align 4, !dbg !34, !tbaa !26
+  %59 = xor i32 %58, -1, !dbg !34
+  %60 = and i32 %59, %56, !dbg !34
+  %61 = icmp eq i32 %60, 0, !dbg !34
+  br i1 %61, label %rb_vm_check_ints.exit2, label %62, !dbg !34, !prof !27
 
-74:                                               ; preds = %47
-  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 8, !dbg !34
-  %76 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %75, align 8, !dbg !34, !tbaa !28
-  %77 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %76, i32 noundef 0) #15, !dbg !34
-  br label %fastSymCallIntrinsic_Static_keep_def100, !dbg !34
+62:                                               ; preds = %35
+  %63 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 8, !dbg !34
+  %64 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %63, align 8, !dbg !34, !tbaa !28
+  %65 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %64, i32 noundef 0) #15, !dbg !34
+  br label %rb_vm_check_ints.exit2, !dbg !34
 
-afterSend97:                                      ; preds = %92, %fastSymCallIntrinsic_Static_keep_def100
+rb_vm_check_ints.exit2:                           ; preds = %35, %62
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !34, !tbaa !14
+  %rubyId_foo88 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
+  %rawSym89 = tail call i64 @rb_id2sym(i64 %rubyId_foo88), !dbg !40
+  %rubyId_normal90 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !40
+  %rawSym91 = tail call i64 @rb_id2sym(i64 %rubyId_normal90), !dbg !40
+  %stackFrame96 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#3foo", align 8, !dbg !40
+  %66 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !40
+  %67 = bitcast i8* %66 to i16*, !dbg !40
+  %68 = load i16, i16* %67, align 8, !dbg !40
+  %69 = and i16 %68, -384, !dbg !40
+  store i16 %69, i16* %67, align 8, !dbg !40
+  %70 = getelementptr inbounds i8, i8* %66, i64 4, !dbg !40
+  %71 = bitcast i8* %70 to i32*, !dbg !40
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %70, i8 0, i64 28, i1 false), !dbg !40
+  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderSigChecked#3foo", i8* nonnull %66, %struct.rb_iseq_struct* %stackFrame96, i1 noundef zeroext false) #15, !dbg !40
+  %72 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !14
+  %73 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 5, !dbg !40
+  %74 = load i32, i32* %73, align 8, !dbg !40, !tbaa !25
+  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 6, !dbg !40
+  %76 = load i32, i32* %75, align 4, !dbg !40, !tbaa !26
+  %77 = xor i32 %76, -1, !dbg !40
+  %78 = and i32 %77, %74, !dbg !40
+  %79 = icmp eq i32 %78, 0, !dbg !40
+  br i1 %79, label %rb_vm_check_ints.exit1, label %80, !dbg !40, !prof !27
+
+80:                                               ; preds = %rb_vm_check_ints.exit2
+  %81 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 8, !dbg !40
+  %82 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %81, align 8, !dbg !40, !tbaa !28
+  %83 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %82, i32 noundef 0) #15, !dbg !40
+  br label %rb_vm_check_ints.exit1, !dbg !40
+
+rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.exit2, %80
   ret void
 
-fastSymCallIntrinsic_Static_keep_def100:          ; preds = %47, %74
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !34, !tbaa !14
-  %rubyId_foo91 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
-  %rawSym92 = tail call i64 @rb_id2sym(i64 %rubyId_foo91), !dbg !40
-  %rubyId_normal93 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !40
-  %rawSym94 = tail call i64 @rb_id2sym(i64 %rubyId_normal93), !dbg !40
-  %stackFrame101 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#3foo", align 8, !dbg !40
-  %78 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !40
-  %79 = bitcast i8* %78 to i16*, !dbg !40
-  %80 = load i16, i16* %79, align 8, !dbg !40
-  %81 = and i16 %80, -384, !dbg !40
-  store i16 %81, i16* %79, align 8, !dbg !40
-  %82 = getelementptr inbounds i8, i8* %78, i64 4, !dbg !40
-  %83 = bitcast i8* %82 to i32*, !dbg !40
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %82, i8 0, i64 28, i1 false), !dbg !40
-  tail call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderSigChecked#3foo", i8* nonnull %78, %struct.rb_iseq_struct* %stackFrame101, i1 noundef zeroext false) #15, !dbg !40
-  %84 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !14
-  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 5, !dbg !40
-  %86 = load i32, i32* %85, align 8, !dbg !40, !tbaa !25
-  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 6, !dbg !40
-  %88 = load i32, i32* %87, align 4, !dbg !40, !tbaa !26
-  %89 = xor i32 %88, -1, !dbg !40
-  %90 = and i32 %89, %86, !dbg !40
-  %91 = icmp eq i32 %90, 0, !dbg !40
-  br i1 %91, label %afterSend97, label %92, !dbg !40, !prof !27
+fastSymCallIntrinsic_ResolvedSig_sig63:           ; preds = %fastSymCallIntrinsic_ResolvedSig_sig, %17
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !24, !tbaa !14
+  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !29
+  %rawSym57 = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !29
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym57, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_AttrReaderSigChecked.13<static-init>L62$block_2"), !dbg !29
+  %84 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
+  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 5, !dbg !29
+  %86 = load i32, i32* %85, align 8, !dbg !29, !tbaa !25
+  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 6, !dbg !29
+  %88 = load i32, i32* %87, align 4, !dbg !29, !tbaa !26
+  %89 = xor i32 %88, -1, !dbg !29
+  %90 = and i32 %89, %86, !dbg !29
+  %91 = icmp eq i32 %90, 0, !dbg !29
+  br i1 %91, label %afterSend60, label %92, !dbg !29, !prof !27
 
-92:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def100
-  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 8, !dbg !40
-  %94 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %93, align 8, !dbg !40, !tbaa !28
-  %95 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #15, !dbg !40
-  br label %afterSend97, !dbg !40
+92:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig63
+  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 8, !dbg !29
+  %94 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %93, align 8, !dbg !29, !tbaa !28
+  %95 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #15, !dbg !29
+  br label %afterSend60, !dbg !29
 }
 
 ; Function Attrs: sspreq
 define void @Init_sig_checked() local_unnamed_addr #8 {
 entry:
-  %locals.i30.i = alloca i64, align 8
-  %locals.i28.i = alloca i64, i32 0, align 8
-  %locals.i26.i = alloca i64, i32 0, align 8
+  %locals.i27.i = alloca i64, align 8
+  %locals.i25.i = alloca i64, i32 0, align 8
+  %locals.i23.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %keywords.i = alloca i64, align 8, !dbg !41
   %realpath = tail call i64 @sorbet_readRealpath()
@@ -465,20 +461,18 @@ entry:
   store i64 %16, i64* @rubyIdPrecomputed_extend, align 8
   %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
   store i64 %17, i64* @rubyIdPrecomputed_normal, align 8
-  %18 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #15
-  store i64 %18, i64* @rubyIdPrecomputed_keep_def, align 8
-  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  tail call void @rb_gc_register_mark_object(i64 %18) #15
+  store i64 %18, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([63 x i8], [63 x i8]* @"str_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", i64 0, i64 0), i64 noundef 62) #15
   tail call void @rb_gc_register_mark_object(i64 %19) #15
-  store i64 %19, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %20 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([63 x i8], [63 x i8]* @"str_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", i64 0, i64 0), i64 noundef 62) #15
-  tail call void @rb_gc_register_mark_object(i64 %20) #15
-  store i64 %20, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
+  store i64 %19, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !43
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !43
   %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !45
@@ -493,51 +487,51 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !49
   %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !50
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
-  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
-  call void @rb_gc_register_mark_object(i64 %22) #15
+  %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
+  call void @rb_gc_register_mark_object(i64 %21) #15
   %rubyId_initialize.i.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i25.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
-  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %rubyId_initialize.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i25.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i26.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#10initialize", align 8
-  %24 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #15
-  store i64 %24, i64* @"<void-singleton>", align 8
-  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #15
-  call void @rb_gc_register_mark_object(i64 %25) #15
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
+  %22 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %rubyId_initialize.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %22, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#10initialize", align 8
+  %23 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #15
+  store i64 %23, i64* @"<void-singleton>", align 8
+  %24 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #15
+  call void @rb_gc_register_mark_object(i64 %24) #15
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i27.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
-  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %25, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i27.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i28.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#3foo", align 8
-  %27 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([29 x i8], [29 x i8]* @"str_<class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 28) #15
-  call void @rb_gc_register_mark_object(i64 %27) #15
-  %28 = bitcast i64* %locals.i30.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %28)
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
+  %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %24, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#3foo", align 8
+  %26 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([29 x i8], [29 x i8]* @"str_<class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 28) #15
+  call void @rb_gc_register_mark_object(i64 %26) #15
+  %27 = bitcast i64* %locals.i27.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %27)
   %"rubyId_<class:AttrReaderSigChecked>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:AttrReaderSigChecked>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i29.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
   %"rubyId_<block-call>.i.i" = load i64, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  store i64 %"rubyId_<block-call>.i.i", i64* %locals.i30.i, align 8
-  %29 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %27, i64 %"rubyId_<class:AttrReaderSigChecked>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i29.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i30.i, i32 noundef 1, i32 noundef 4)
-  store %struct.rb_iseq_struct* %29, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %28)
-  %30 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_block in <class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 37) #15
-  call void @rb_gc_register_mark_object(i64 %30) #15
-  store i64 %30, i64* @"rubyStrFrozen_block in <class:AttrReaderSigChecked>", align 8
+  store i64 %"rubyId_<block-call>.i.i", i64* %locals.i27.i, align 8
+  %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %26, i64 %"rubyId_<class:AttrReaderSigChecked>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i27.i, i32 noundef 1, i32 noundef 4)
+  store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %27)
+  %29 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_block in <class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 37) #15
+  call void @rb_gc_register_mark_object(i64 %29) #15
+  store i64 %29, i64* @"rubyStrFrozen_block in <class:AttrReaderSigChecked>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
   %"rubyId_block in <class:AttrReaderSigChecked>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:AttrReaderSigChecked>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i31.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
-  %31 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %30, i64 %"rubyId_block in <class:AttrReaderSigChecked>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %31, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>$block_1", align 8
-  %stackFrame.i32.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
-  %"rubyId_block in <class:AttrReaderSigChecked>.i33.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:AttrReaderSigChecked>", align 8
-  %"rubyStr_block in <class:AttrReaderSigChecked>.i34.i" = load i64, i64* @"rubyStrFrozen_block in <class:AttrReaderSigChecked>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i35.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
-  %32 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <class:AttrReaderSigChecked>.i34.i", i64 %"rubyId_block in <class:AttrReaderSigChecked>.i33.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i35.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i32.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %32, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>$block_2", align 8
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
+  %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %29, i64 %"rubyId_block in <class:AttrReaderSigChecked>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>$block_1", align 8
+  %stackFrame.i29.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
+  %"rubyId_block in <class:AttrReaderSigChecked>.i30.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:AttrReaderSigChecked>", align 8
+  %"rubyStr_block in <class:AttrReaderSigChecked>.i31.i" = load i64, i64* @"rubyStrFrozen_block in <class:AttrReaderSigChecked>", align 8
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i32.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
+  %31 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <class:AttrReaderSigChecked>.i31.i", i64 %"rubyId_block in <class:AttrReaderSigChecked>.i30.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i32.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i29.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %31, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>$block_2", align 8
   %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !24
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !41
   %rubyId_foo12.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !41
-  %33 = call i64 @rb_id2sym(i64 %rubyId_foo12.i) #15, !dbg !41
-  store i64 %33, i64* %keywords.i, align 8, !dbg !41
+  %32 = call i64 @rb_id2sym(i64 %rubyId_foo12.i) #15, !dbg !41
+  store i64 %32, i64* %keywords.i, align 8, !dbg !41
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !41
   %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !41
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !41
@@ -547,227 +541,223 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !51
   %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !30
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !34
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !34
-  %rubyId_keep_def23.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !40
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.6, i64 %rubyId_keep_def23.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !40
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
-  %34 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %35 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %34, i64 0, i32 18
-  %36 = load i64, i64* %35, align 8, !tbaa !53
-  %37 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %38 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %37, i64 0, i32 2
-  %39 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %38, align 8, !tbaa !16
+  %33 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %34 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %33, i64 0, i32 18
+  %35 = load i64, i64* %34, align 8, !tbaa !53
+  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2
+  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !tbaa !16
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %40, align 8, !tbaa !20
-  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 4
-  %42 = load i64*, i64** %41, align 8, !tbaa !22
-  %43 = load i64, i64* %42, align 8, !tbaa !6
-  %44 = and i64 %43, -33
-  store i64 %44, i64* %42, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %37, %struct.rb_control_frame_struct* %39, %struct.rb_iseq_struct* %stackFrame.i) #15
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %45, align 8, !dbg !61, !tbaa !14
-  %46 = load i64, i64* @rb_cObject, align 8, !dbg !62
-  %47 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @str_AttrReaderSigChecked, i64 0, i64 0), i64 %46) #15, !dbg !62
-  %48 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %47) #15, !dbg !62
-  call fastcc void @"func_AttrReaderSigChecked.13<static-init>L62"(i64 %47, %struct.rb_control_frame_struct* %48) #15, !dbg !62
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %39, align 8, !tbaa !20
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 4
+  %41 = load i64*, i64** %40, align 8, !tbaa !22
+  %42 = load i64, i64* %41, align 8, !tbaa !6
+  %43 = and i64 %42, -33
+  store i64 %43, i64* %41, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %36, %struct.rb_control_frame_struct* %38, %struct.rb_iseq_struct* %stackFrame.i) #15
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %44, align 8, !dbg !61, !tbaa !14
+  %45 = load i64, i64* @rb_cObject, align 8, !dbg !62
+  %46 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @str_AttrReaderSigChecked, i64 0, i64 0), i64 %45) #15, !dbg !62
+  %47 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %46) #15, !dbg !62
+  call fastcc void @"func_AttrReaderSigChecked.13<static-init>L62"(i64 %46, %struct.rb_control_frame_struct* %47) #15, !dbg !62
   call void @sorbet_popFrame() #15, !dbg !62
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %45, align 8, !dbg !62, !tbaa !14
-  %49 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !43
-  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !31
-  %needTakeSlowPath = icmp ne i64 %49, %50, !dbg !43
-  br i1 %needTakeSlowPath, label %51, label %52, !dbg !43, !prof !33
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %44, align 8, !dbg !62, !tbaa !14
+  %48 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !43
+  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !31
+  %needTakeSlowPath = icmp ne i64 %48, %49, !dbg !43
+  br i1 %needTakeSlowPath, label %50, label %51, !dbg !43, !prof !33
 
-51:                                               ; preds = %entry
+50:                                               ; preds = %entry
   call void @const_recompute_AttrReaderSigChecked(), !dbg !43
-  br label %52, !dbg !43
+  br label %51, !dbg !43
 
-52:                                               ; preds = %entry, %51
-  %53 = load i64, i64* @guarded_const_AttrReaderSigChecked, align 8, !dbg !43
-  %54 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !43
-  %55 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !31
-  %guardUpdated = icmp eq i64 %54, %55, !dbg !43
+51:                                               ; preds = %entry, %50
+  %52 = load i64, i64* @guarded_const_AttrReaderSigChecked, align 8, !dbg !43
+  %53 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !43
+  %54 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !31
+  %guardUpdated = icmp eq i64 %53, %54, !dbg !43
   call void @llvm.assume(i1 %guardUpdated), !dbg !43
-  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 1, !dbg !43
-  %57 = load i64*, i64** %56, align 8, !dbg !43
-  store i64 %53, i64* %57, align 8, !dbg !43, !tbaa !6
+  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !43
+  %56 = load i64*, i64** %55, align 8, !dbg !43
+  store i64 %52, i64* %56, align 8, !dbg !43, !tbaa !6
+  %57 = getelementptr inbounds i64, i64* %56, i64 1, !dbg !43
+  store i64 2497, i64* %57, align 8, !dbg !43, !tbaa !6
   %58 = getelementptr inbounds i64, i64* %57, i64 1, !dbg !43
-  store i64 2497, i64* %58, align 8, !dbg !43, !tbaa !6
-  %59 = getelementptr inbounds i64, i64* %58, i64 1, !dbg !43
-  store i64* %59, i64** %56, align 8, !dbg !43
+  store i64* %58, i64** %55, align 8, !dbg !43
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !43
   br label %BB2.i, !dbg !63
 
-BB2.i:                                            ; preds = %BB2.i.backedge, %52
-  %i.sroa.0.0.i = phi i64 [ 1, %52 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !61
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %45, align 8, !tbaa !14
-  %60 = and i64 %i.sroa.0.0.i, 1, !dbg !45
-  %61 = icmp eq i64 %60, 0, !dbg !45
-  br i1 %61, label %62, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !45, !prof !64
+BB2.i:                                            ; preds = %BB2.i.backedge, %51
+  %i.sroa.0.0.i = phi i64 [ 1, %51 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !61
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %44, align 8, !tbaa !14
+  %59 = and i64 %i.sroa.0.0.i, 1, !dbg !45
+  %60 = icmp eq i64 %59, 0, !dbg !45
+  br i1 %60, label %61, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !45, !prof !64
 
-62:                                               ; preds = %BB2.i
-  %63 = and i64 %i.sroa.0.0.i, 7, !dbg !45
-  %64 = icmp ne i64 %63, 0, !dbg !45
-  %65 = and i64 %i.sroa.0.0.i, -9, !dbg !45
-  %66 = icmp eq i64 %65, 0, !dbg !45
-  %67 = or i1 %64, %66, !dbg !45
-  br i1 %67, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !45, !prof !65
+61:                                               ; preds = %BB2.i
+  %62 = and i64 %i.sroa.0.0.i, 7, !dbg !45
+  %63 = icmp ne i64 %62, 0, !dbg !45
+  %64 = and i64 %i.sroa.0.0.i, -9, !dbg !45
+  %65 = icmp eq i64 %64, 0, !dbg !45
+  %66 = or i1 %63, %65, !dbg !45
+  br i1 %66, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !45, !prof !65
 
-sorbet_isa_Integer.exit:                          ; preds = %62
-  %68 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !45
-  %69 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %68, i64 0, i32 0, !dbg !45
-  %70 = load i64, i64* %69, align 8, !dbg !45, !tbaa !66
-  %71 = and i64 %70, 31, !dbg !45
-  %72 = icmp eq i64 %71, 10, !dbg !45
-  br i1 %72, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !45, !prof !27
+sorbet_isa_Integer.exit:                          ; preds = %61
+  %67 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !45
+  %68 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %67, i64 0, i32 0, !dbg !45
+  %69 = load i64, i64* %68, align 8, !dbg !45, !tbaa !66
+  %70 = and i64 %69, 31, !dbg !45
+  %71 = icmp eq i64 %70, 10, !dbg !45
+  br i1 %71, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !45, !prof !27
 
 BB5.i:                                            ; preds = %afterSend37.i
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %45, align 8, !tbaa !14
-  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 1, !dbg !46
-  %74 = load i64*, i64** %73, align 8, !dbg !46
-  store i64 %send, i64* %74, align 8, !dbg !46, !tbaa !6
-  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !46
-  store i64* %75, i64** %73, align 8, !dbg !46
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %44, align 8, !tbaa !14
+  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !46
+  %73 = load i64*, i64** %72, align 8, !dbg !46
+  store i64 %send, i64* %73, align 8, !dbg !46, !tbaa !6
+  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !46
+  store i64* %74, i64** %72, align 8, !dbg !46
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !46
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %45, align 8, !dbg !46, !tbaa !14
-  br i1 %76, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !47
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %44, align 8, !dbg !46, !tbaa !14
+  br i1 %75, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !47
 
-afterSend37.i:                                    ; preds = %101, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
-  %76 = phi i1 [ %79, %"alternativeCallIntrinsic_Integer_<.i" ], [ %84, %sorbet_rb_int_lt.exit.i ], [ %84, %101 ]
-  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send4, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult89.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult89.i, %101 ], !dbg !45
-  %77 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !45
-  %78 = icmp ne i64 %77, 0, !dbg !45
-  br i1 %78, label %BB5.i, label %"func_<root>.17<static-init>$152.exit", !dbg !45
+afterSend37.i:                                    ; preds = %100, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
+  %75 = phi i1 [ %78, %"alternativeCallIntrinsic_Integer_<.i" ], [ %83, %sorbet_rb_int_lt.exit.i ], [ %83, %100 ]
+  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send4, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult89.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult89.i, %100 ], !dbg !45
+  %76 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !45
+  %77 = icmp ne i64 %76, 0, !dbg !45
+  br i1 %77, label %BB5.i, label %"func_<root>.17<static-init>$152.exit", !dbg !45
 
-"alternativeCallIntrinsic_Integer_<.i":           ; preds = %62, %sorbet_isa_Integer.exit
-  %79 = phi i1 [ %72, %sorbet_isa_Integer.exit ], [ false, %62 ]
-  %80 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 1, !dbg !45
-  %81 = load i64*, i64** %80, align 8, !dbg !45
-  store i64 %i.sroa.0.0.i, i64* %81, align 8, !dbg !45, !tbaa !6
+"alternativeCallIntrinsic_Integer_<.i":           ; preds = %61, %sorbet_isa_Integer.exit
+  %78 = phi i1 [ %71, %sorbet_isa_Integer.exit ], [ false, %61 ]
+  %79 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !45
+  %80 = load i64*, i64** %79, align 8, !dbg !45
+  store i64 %i.sroa.0.0.i, i64* %80, align 8, !dbg !45, !tbaa !6
+  %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !45
+  store i64 20000001, i64* %81, align 8, !dbg !45, !tbaa !6
   %82 = getelementptr inbounds i64, i64* %81, i64 1, !dbg !45
-  store i64 20000001, i64* %82, align 8, !dbg !45, !tbaa !6
-  %83 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !45
-  store i64* %83, i64** %80, align 8, !dbg !45
+  store i64* %82, i64** %79, align 8, !dbg !45
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !45
   br label %afterSend37.i, !dbg !45
 
 "fastSymCallIntrinsic_Integer_<.i":               ; preds = %BB2.i, %sorbet_isa_Integer.exit
-  %84 = phi i1 [ %72, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
+  %83 = phi i1 [ %71, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
   call void @llvm.experimental.noalias.scope.decl(metadata !68) #15, !dbg !45
-  %85 = and i64 %i.sroa.0.0.i, 1, !dbg !45
-  %86 = icmp eq i64 %85, 0, !dbg !45
-  br i1 %86, label %91, label %87, !dbg !45, !prof !71
+  %84 = and i64 %i.sroa.0.0.i, 1, !dbg !45
+  %85 = icmp eq i64 %84, 0, !dbg !45
+  br i1 %85, label %90, label %86, !dbg !45, !prof !71
 
-87:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %88 = ashr i64 %i.sroa.0.0.i, 1, !dbg !45
-  %89 = icmp slt i64 %88, 10000000, !dbg !45
-  %90 = select i1 %89, i64 20, i64 0, !dbg !45
+86:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
+  %87 = ashr i64 %i.sroa.0.0.i, 1, !dbg !45
+  %88 = icmp slt i64 %87, 10000000, !dbg !45
+  %89 = select i1 %88, i64 20, i64 0, !dbg !45
   br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
-91:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %92 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !45, !noalias !68
+90:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
+  %91 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !45, !noalias !68
   br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
-sorbet_rb_int_lt.exit.i:                          ; preds = %91, %87
-  %rawSendResult89.i = phi i64 [ %90, %87 ], [ %92, %91 ]
-  %93 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !14
-  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %93, i64 0, i32 5, !dbg !45
-  %95 = load i32, i32* %94, align 8, !dbg !45, !tbaa !25
-  %96 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %93, i64 0, i32 6, !dbg !45
-  %97 = load i32, i32* %96, align 4, !dbg !45, !tbaa !26
-  %98 = xor i32 %97, -1, !dbg !45
-  %99 = and i32 %98, %95, !dbg !45
-  %100 = icmp eq i32 %99, 0, !dbg !45
-  br i1 %100, label %afterSend37.i, label %101, !dbg !45, !prof !27
+sorbet_rb_int_lt.exit.i:                          ; preds = %90, %86
+  %rawSendResult89.i = phi i64 [ %89, %86 ], [ %91, %90 ]
+  %92 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !14
+  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %92, i64 0, i32 5, !dbg !45
+  %94 = load i32, i32* %93, align 8, !dbg !45, !tbaa !25
+  %95 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %92, i64 0, i32 6, !dbg !45
+  %96 = load i32, i32* %95, align 4, !dbg !45, !tbaa !26
+  %97 = xor i32 %96, -1, !dbg !45
+  %98 = and i32 %97, %94, !dbg !45
+  %99 = icmp eq i32 %98, 0, !dbg !45
+  br i1 %99, label %afterSend37.i, label %100, !dbg !45, !prof !27
 
-101:                                              ; preds = %sorbet_rb_int_lt.exit.i
-  %102 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %93, i64 0, i32 8, !dbg !45
-  %103 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %102, align 8, !dbg !45, !tbaa !28
-  %104 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %103, i32 noundef 0) #15, !dbg !45
+100:                                              ; preds = %sorbet_rb_int_lt.exit.i
+  %101 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %92, i64 0, i32 8, !dbg !45
+  %102 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %101, align 8, !dbg !45, !tbaa !28
+  %103 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %102, i32 noundef 0) #15, !dbg !45
   br label %afterSend37.i, !dbg !45
 
 "alternativeCallIntrinsic_Integer_+.i":           ; preds = %BB5.i
-  %105 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 1, !dbg !47
-  %106 = load i64*, i64** %105, align 8, !dbg !47
-  store i64 %i.sroa.0.0.i, i64* %106, align 8, !dbg !47, !tbaa !6
+  %104 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !47
+  %105 = load i64*, i64** %104, align 8, !dbg !47
+  store i64 %i.sroa.0.0.i, i64* %105, align 8, !dbg !47, !tbaa !6
+  %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !47
+  store i64 3, i64* %106, align 8, !dbg !47, !tbaa !6
   %107 = getelementptr inbounds i64, i64* %106, i64 1, !dbg !47
-  store i64 3, i64* %107, align 8, !dbg !47, !tbaa !6
-  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !47
-  store i64* %108, i64** %105, align 8, !dbg !47
+  store i64* %107, i64** %104, align 8, !dbg !47
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !47
   br label %BB2.i.backedge, !dbg !47
 
 "fastSymCallIntrinsic_Integer_+.i":               ; preds = %BB5.i
   call void @llvm.experimental.noalias.scope.decl(metadata !72) #15, !dbg !47
-  %109 = and i64 %i.sroa.0.0.i, 1, !dbg !47
-  %110 = icmp eq i64 %109, 0, !dbg !47
-  br i1 %110, label %119, label %111, !dbg !47, !prof !71
+  %108 = and i64 %i.sroa.0.0.i, 1, !dbg !47
+  %109 = icmp eq i64 %108, 0, !dbg !47
+  br i1 %109, label %118, label %110, !dbg !47, !prof !71
 
-111:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %112 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !47
-  %113 = extractvalue { i64, i1 } %112, 1, !dbg !47
-  %114 = extractvalue { i64, i1 } %112, 0, !dbg !47
-  br i1 %113, label %115, label %sorbet_rb_int_plus.exit.i, !dbg !47
+110:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
+  %111 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !47
+  %112 = extractvalue { i64, i1 } %111, 1, !dbg !47
+  %113 = extractvalue { i64, i1 } %111, 0, !dbg !47
+  br i1 %112, label %114, label %sorbet_rb_int_plus.exit.i, !dbg !47
 
-115:                                              ; preds = %111
-  %116 = ashr i64 %114, 1, !dbg !47
-  %117 = xor i64 %116, -9223372036854775808, !dbg !47
-  %118 = call i64 @rb_int2big(i64 %117) #15, !dbg !47
+114:                                              ; preds = %110
+  %115 = ashr i64 %113, 1, !dbg !47
+  %116 = xor i64 %115, -9223372036854775808, !dbg !47
+  %117 = call i64 @rb_int2big(i64 %116) #15, !dbg !47
   br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
-119:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %120 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !47, !noalias !72
+118:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
+  %119 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !47, !noalias !72
   br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
-sorbet_rb_int_plus.exit.i:                        ; preds = %119, %115, %111
-  %121 = phi i64 [ %120, %119 ], [ %118, %115 ], [ %114, %111 ], !dbg !47
-  %122 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !14
-  %123 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %122, i64 0, i32 5, !dbg !47
-  %124 = load i32, i32* %123, align 8, !dbg !47, !tbaa !25
-  %125 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %122, i64 0, i32 6, !dbg !47
-  %126 = load i32, i32* %125, align 4, !dbg !47, !tbaa !26
-  %127 = xor i32 %126, -1, !dbg !47
-  %128 = and i32 %127, %124, !dbg !47
-  %129 = icmp eq i32 %128, 0, !dbg !47
-  br i1 %129, label %BB2.i.backedge, label %130, !dbg !47, !prof !27
+sorbet_rb_int_plus.exit.i:                        ; preds = %118, %114, %110
+  %120 = phi i64 [ %119, %118 ], [ %117, %114 ], [ %113, %110 ], !dbg !47
+  %121 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !14
+  %122 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %121, i64 0, i32 5, !dbg !47
+  %123 = load i32, i32* %122, align 8, !dbg !47, !tbaa !25
+  %124 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %121, i64 0, i32 6, !dbg !47
+  %125 = load i32, i32* %124, align 4, !dbg !47, !tbaa !26
+  %126 = xor i32 %125, -1, !dbg !47
+  %127 = and i32 %126, %123, !dbg !47
+  %128 = icmp eq i32 %127, 0, !dbg !47
+  br i1 %128, label %BB2.i.backedge, label %129, !dbg !47, !prof !27
 
-130:                                              ; preds = %sorbet_rb_int_plus.exit.i
-  %131 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %122, i64 0, i32 8, !dbg !47
-  %132 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %131, align 8, !dbg !47, !tbaa !28
-  %133 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %132, i32 noundef 0) #15, !dbg !47
+129:                                              ; preds = %sorbet_rb_int_plus.exit.i
+  %130 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %121, i64 0, i32 8, !dbg !47
+  %131 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %130, align 8, !dbg !47, !tbaa !28
+  %132 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %131, i32 noundef 0) #15, !dbg !47
   br label %BB2.i.backedge, !dbg !47
 
-BB2.i.backedge:                                   ; preds = %130, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
-  %i.sroa.0.0.i.be = phi i64 [ %send6, %"alternativeCallIntrinsic_Integer_+.i" ], [ %121, %sorbet_rb_int_plus.exit.i ], [ %121, %130 ]
+BB2.i.backedge:                                   ; preds = %129, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
+  %i.sroa.0.0.i.be = phi i64 [ %send6, %"alternativeCallIntrinsic_Integer_+.i" ], [ %120, %sorbet_rb_int_plus.exit.i ], [ %120, %129 ]
   br label %BB2.i
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %afterSend37.i
   %i.sroa.0.0.i.lcssa = phi i64 [ %i.sroa.0.0.i, %afterSend37.i ], !dbg !61
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %45, align 8, !tbaa !14
-  %134 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 1, !dbg !48
-  %135 = load i64*, i64** %134, align 8, !dbg !48
-  store i64 %36, i64* %135, align 8, !dbg !48, !tbaa !6
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %44, align 8, !tbaa !14
+  %133 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !48
+  %134 = load i64*, i64** %133, align 8, !dbg !48
+  store i64 %35, i64* %134, align 8, !dbg !48, !tbaa !6
+  %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !48
+  store i64 %i.sroa.0.0.i.lcssa, i64* %135, align 8, !dbg !48, !tbaa !6
   %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !48
-  store i64 %i.sroa.0.0.i.lcssa, i64* %136, align 8, !dbg !48, !tbaa !6
-  %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !48
-  store i64* %137, i64** %134, align 8, !dbg !48
+  store i64* %136, i64** %133, align 8, !dbg !48
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !48
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %45, align 8, !dbg !48, !tbaa !14
-  %138 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 1, !dbg !49
-  %139 = load i64*, i64** %138, align 8, !dbg !49
-  store i64 %send, i64* %139, align 8, !dbg !49, !tbaa !6
-  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !49
-  store i64* %140, i64** %138, align 8, !dbg !49
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %44, align 8, !dbg !48, !tbaa !14
+  %137 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !49
+  %138 = load i64*, i64** %137, align 8, !dbg !49
+  store i64 %send, i64* %138, align 8, !dbg !49, !tbaa !6
+  %139 = getelementptr inbounds i64, i64* %138, i64 1, !dbg !49
+  store i64* %139, i64** %137, align 8, !dbg !49
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !49
-  %141 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 1, !dbg !50
-  %142 = load i64*, i64** %141, align 8, !dbg !50
-  store i64 %36, i64* %142, align 8, !dbg !50, !tbaa !6
+  %140 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !50
+  %141 = load i64*, i64** %140, align 8, !dbg !50
+  store i64 %35, i64* %141, align 8, !dbg !50, !tbaa !6
+  %142 = getelementptr inbounds i64, i64* %141, i64 1, !dbg !50
+  store i64 %send10, i64* %142, align 8, !dbg !50, !tbaa !6
   %143 = getelementptr inbounds i64, i64* %142, i64 1, !dbg !50
-  store i64 %send10, i64* %143, align 8, !dbg !50, !tbaa !6
-  %144 = getelementptr inbounds i64, i64* %143, i64 1, !dbg !50
-  store i64* %144, i64** %141, align 8, !dbg !50
+  store i64* %143, i64** %140, align 8, !dbg !50
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !50
   ret void
 }

--- a/test/testdata/ruby_benchmark/stripe/prop_const_getter.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/prop_const_getter.llo.exp
@@ -135,23 +135,17 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"str_block in <class:MyStruct>" = private unnamed_addr constant [26 x i8] c"block in <class:MyStruct>\00", align 1
 @"rubyStrFrozen_block in <class:MyStruct>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_MyStruct.13<static-init>$block_2" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@ic_sig = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_sig = internal unnamed_addr global i64 0, align 8
 @ic_params = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_params = internal unnamed_addr global i64 0, align 8
 @str_params = private unnamed_addr constant [7 x i8] c"params\00", align 1
 @ic_void = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_void = internal unnamed_addr global i64 0, align 8
 @str_void = private unnamed_addr constant [5 x i8] c"void\00", align 1
-@ic_sig.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_returns = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_returns = internal unnamed_addr global i64 0, align 8
 @str_returns = private unnamed_addr constant [8 x i8] c"returns\00", align 1
 @rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@ic_keep_def = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_keep_def = internal unnamed_addr global i64 0, align 8
-@str_keep_def = private unnamed_addr constant [9 x i8] c"keep_def\00", align 1
 @rubyIdPrecomputed_without_accessors = internal unnamed_addr global i64 0, align 8
 @str_without_accessors = private unnamed_addr constant [18 x i8] c"without_accessors\00", align 1
 @ic_const = internal global %struct.FunctionInlineCache zeroinitializer
@@ -159,7 +153,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_const = private unnamed_addr constant [6 x i8] c"const\00", align 1
 @rubyIdPrecomputed_attr_reader = internal unnamed_addr global i64 0, align 8
 @str_attr_reader = private unnamed_addr constant [12 x i8] c"attr_reader\00", align 1
-@ic_keep_def.4 = internal global %struct.FunctionInlineCache zeroinitializer
 @guard_epoch_MyStruct = linkonce local_unnamed_addr global i64 0
 @guarded_const_MyStruct = linkonce local_unnamed_addr global i64 0
 @rb_cInteger = external local_unnamed_addr constant i64
@@ -275,7 +268,7 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
 
 ; Function Attrs: nounwind sspreq uwtable
 define internal fastcc void @"func_MyStruct.13<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !10 {
-fastSymCallIntrinsic_Static_sig:
+functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -298,15 +291,15 @@ fastSymCallIntrinsic_Static_sig:
   %14 = xor i32 %13, -1, !dbg !24
   %15 = and i32 %14, %11, !dbg !24
   %16 = icmp eq i32 %15, 0, !dbg !24
-  br i1 %16, label %fastSymCallIntrinsic_Static_sig53, label %17, !dbg !24, !prof !27
+  br i1 %16, label %rb_vm_check_ints.exit3, label %17, !dbg !24, !prof !27
 
-17:                                               ; preds = %fastSymCallIntrinsic_Static_sig
+17:                                               ; preds = %functionEntryInitializers
   %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
   %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !24, !tbaa !28
   %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !24
-  br label %fastSymCallIntrinsic_Static_sig53, !dbg !24
+  br label %rb_vm_check_ints.exit3, !dbg !24
 
-fastSymCallIntrinsic_Static_sig53:                ; preds = %fastSymCallIntrinsic_Static_sig, %17
+rb_vm_check_ints.exit3:                           ; preds = %functionEntryInitializers, %17
   store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !24, !tbaa !14
   %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
   %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !29
@@ -318,18 +311,18 @@ fastSymCallIntrinsic_Static_sig53:                ; preds = %fastSymCallIntrinsi
   %28 = icmp eq i32 %27, 0, !dbg !29
   br i1 %28, label %sorbet_setupParamKeywords.exit, label %29, !dbg !29, !prof !27
 
-29:                                               ; preds = %fastSymCallIntrinsic_Static_sig53
+29:                                               ; preds = %rb_vm_check_ints.exit3
   %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !29
   %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !29, !tbaa !28
   %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #15, !dbg !29
   br label %sorbet_setupParamKeywords.exit, !dbg !29
 
-sorbet_setupParamKeywords.exit:                   ; preds = %29, %fastSymCallIntrinsic_Static_sig53
+sorbet_setupParamKeywords.exit:                   ; preds = %29, %rb_vm_check_ints.exit3
   store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !29, !tbaa !14
   %rubyId_initialize = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !24
   %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_initialize), !dbg !24
   %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !24
-  %rawSym58 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !24
+  %rawSym56 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !24
   %33 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !24
   %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !30
   %needTakeSlowPath = icmp ne i64 %33, %34, !dbg !24
@@ -345,7 +338,7 @@ sorbet_setupParamKeywords.exit:                   ; preds = %29, %fastSymCallInt
   %39 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !30
   %guardUpdated = icmp eq i64 %38, %39, !dbg !24
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !24
-  %stackFrame62 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct#10initialize", align 8, !dbg !24
+  %stackFrame60 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct#10initialize", align 8, !dbg !24
   %40 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !24
   %41 = bitcast i8* %40 to i16*, !dbg !24
   %42 = load i16, i16* %41, align 8, !dbg !24
@@ -376,7 +369,7 @@ sorbet_setupParamKeywords.exit:                   ; preds = %29, %fastSymCallInt
   %57 = getelementptr inbounds i8, i8* %40, i64 56, !dbg !24
   %58 = bitcast i8* %57 to i8**, !dbg !24
   store i8* %55, i8** %58, align 8, !dbg !24, !tbaa !39
-  tail call void @sorbet_vm_define_method(i64 %37, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_MyStruct#10initialize", i8* nonnull %40, %struct.rb_iseq_struct* %stackFrame62, i1 noundef zeroext false) #15, !dbg !24
+  tail call void @sorbet_vm_define_method(i64 %37, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_MyStruct#10initialize", i8* nonnull %40, %struct.rb_iseq_struct* %stackFrame60, i1 noundef zeroext false) #15, !dbg !24
   %59 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !14
   %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 5, !dbg !24
   %61 = load i32, i32* %60, align 8, !dbg !24, !tbaa !25
@@ -385,29 +378,26 @@ sorbet_setupParamKeywords.exit:                   ; preds = %29, %fastSymCallInt
   %64 = xor i32 %63, -1, !dbg !24
   %65 = and i32 %64, %61, !dbg !24
   %66 = icmp eq i32 %65, 0, !dbg !24
-  br i1 %66, label %fastSymCallIntrinsic_Static_keep_def84, label %67, !dbg !24, !prof !27
+  br i1 %66, label %rb_vm_check_ints.exit1, label %67, !dbg !24, !prof !27
 
 67:                                               ; preds = %36
   %68 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 8, !dbg !24
   %69 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %68, align 8, !dbg !24, !tbaa !28
   %70 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %69, i32 noundef 0) #15, !dbg !24
-  br label %fastSymCallIntrinsic_Static_keep_def84, !dbg !24
+  br label %rb_vm_check_ints.exit1, !dbg !24
 
-afterSend81:                                      ; preds = %91, %fastSymCallIntrinsic_Static_keep_def84
-  ret void
-
-fastSymCallIntrinsic_Static_keep_def84:           ; preds = %36, %67
+rb_vm_check_ints.exit1:                           ; preds = %36, %67
   store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !24, !tbaa !14
-  %rubyId_foo67 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
-  %rawSym68 = tail call i64 @rb_id2sym(i64 %rubyId_foo67), !dbg !40
+  %rubyId_foo62 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
+  %rawSym63 = tail call i64 @rb_id2sym(i64 %rubyId_foo62), !dbg !40
   %rubyId_without_accessors = load i64, i64* @rubyIdPrecomputed_without_accessors, align 8, !dbg !29
-  %rawSym69 = tail call i64 @rb_id2sym(i64 %rubyId_without_accessors), !dbg !29
+  %rawSym64 = tail call i64 @rb_id2sym(i64 %rubyId_without_accessors), !dbg !29
   %71 = load i64, i64* @rb_cInteger, align 8, !dbg !29
   %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !29
   %73 = load i64*, i64** %72, align 8, !dbg !29
   store i64 %selfRaw, i64* %73, align 8, !dbg !29, !tbaa !6
   %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !29
-  store i64 %rawSym68, i64* %74, align 8, !dbg !29, !tbaa !6
+  store i64 %rawSym63, i64* %74, align 8, !dbg !29, !tbaa !6
   %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !29
   store i64 %71, i64* %75, align 8, !dbg !29, !tbaa !6
   %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !29
@@ -415,10 +405,10 @@ fastSymCallIntrinsic_Static_keep_def84:           ; preds = %36, %67
   %77 = getelementptr inbounds i64, i64* %76, i64 1, !dbg !29
   store i64* %77, i64** %72, align 8, !dbg !29
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_const, i64 0), !dbg !29
-  %rubyId_foo76 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !29
-  %rawSym77 = tail call i64 @rb_id2sym(i64 %rubyId_foo76), !dbg !29
+  %rubyId_foo71 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !29
+  %rawSym72 = tail call i64 @rb_id2sym(i64 %rubyId_foo71), !dbg !29
   %rubyId_attr_reader = load i64, i64* @rubyIdPrecomputed_attr_reader, align 8, !dbg !29
-  %rawSym78 = tail call i64 @rb_id2sym(i64 %rubyId_attr_reader), !dbg !29
+  %rawSym73 = tail call i64 @rb_id2sym(i64 %rubyId_attr_reader), !dbg !29
   %78 = tail call i64 @rb_intern(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0)) #15, !dbg !29
   %79 = tail call i64 @rb_id2str(i64 %78) #15, !dbg !29
   %80 = tail call i64 (i8*, ...) @rb_sprintf(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i64 %79) #15, !dbg !29
@@ -433,30 +423,33 @@ fastSymCallIntrinsic_Static_keep_def84:           ; preds = %36, %67
   %88 = xor i32 %87, -1, !dbg !29
   %89 = and i32 %88, %85, !dbg !29
   %90 = icmp eq i32 %89, 0, !dbg !29
-  br i1 %90, label %afterSend81, label %91, !dbg !29, !prof !27
+  br i1 %90, label %rb_vm_check_ints.exit, label %91, !dbg !29, !prof !27
 
-91:                                               ; preds = %fastSymCallIntrinsic_Static_keep_def84
+91:                                               ; preds = %rb_vm_check_ints.exit1
   %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 8, !dbg !29
   %93 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %92, align 8, !dbg !29, !tbaa !28
   %94 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %93, i32 noundef 0) #15, !dbg !29
-  br label %afterSend81, !dbg !29
+  br label %rb_vm_check_ints.exit, !dbg !29
+
+rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.exit1, %91
+  ret void
 }
 
 ; Function Attrs: sspreq
 define void @Init_prop_const_getter() local_unnamed_addr #8 {
 entry:
-  %locals.i29.i = alloca i64, align 8
-  %locals.i27.i = alloca i64, i32 0, align 8
+  %locals.i23.i = alloca i64, align 8
+  %locals.i21.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %keywords.i = alloca i64, align 8, !dbg !41
-  %keywords11.i = alloca i64, align 8, !dbg !43
-  %keywords20.i = alloca i64, align 8, !dbg !29
+  %keywords10.i = alloca i64, align 8, !dbg !43
+  %keywords16.i = alloca i64, align 8, !dbg !29
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
-  %1 = bitcast i64* %keywords11.i to i8*
+  %1 = bitcast i64* %keywords10.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %1)
-  %2 = bitcast i64* %keywords20.i to i8*
+  %2 = bitcast i64* %keywords16.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %2)
   %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
   store i64 %3, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -480,40 +473,36 @@ entry:
   store i64 %12, i64* @"rubyIdPrecomputed_<block-call>", align 8
   %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <class:MyStruct>", i64 0, i64 0), i64 noundef 25) #15
   store i64 %13, i64* @"rubyIdPrecomputed_block in <class:MyStruct>", align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i64 noundef 3) #15
-  store i64 %14, i64* @rubyIdPrecomputed_sig, align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %15, i64* @rubyIdPrecomputed_params, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_void, i64 0, i64 0), i64 noundef 4) #15
-  store i64 %16, i64* @rubyIdPrecomputed_void, align 8
-  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #15
-  store i64 %17, i64* @rubyIdPrecomputed_returns, align 8
-  %18 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %18, i64* @rubyIdPrecomputed_normal, align 8
-  %19 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_keep_def, i64 0, i64 0), i64 noundef 8) #15
-  store i64 %19, i64* @rubyIdPrecomputed_keep_def, align 8
-  %20 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @str_without_accessors, i64 0, i64 0), i64 noundef 17) #15
-  store i64 %20, i64* @rubyIdPrecomputed_without_accessors, align 8
-  %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_const, i64 0, i64 0), i64 noundef 5) #15
-  store i64 %21, i64* @rubyIdPrecomputed_const, align 8
-  %22 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @str_attr_reader, i64 0, i64 0), i64 noundef 11) #15
-  store i64 %22, i64* @rubyIdPrecomputed_attr_reader, align 8
-  %23 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
-  tail call void @rb_gc_register_mark_object(i64 %23) #15
-  store i64 %23, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %24 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([57 x i8], [57 x i8]* @"str_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", i64 0, i64 0), i64 noundef 56) #15
-  tail call void @rb_gc_register_mark_object(i64 %24) #15
-  store i64 %24, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
+  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #15
+  store i64 %14, i64* @rubyIdPrecomputed_params, align 8
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_void, i64 0, i64 0), i64 noundef 4) #15
+  store i64 %15, i64* @rubyIdPrecomputed_void, align 8
+  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #15
+  store i64 %16, i64* @rubyIdPrecomputed_returns, align 8
+  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
+  store i64 %17, i64* @rubyIdPrecomputed_normal, align 8
+  %18 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @str_without_accessors, i64 0, i64 0), i64 noundef 17) #15
+  store i64 %18, i64* @rubyIdPrecomputed_without_accessors, align 8
+  %19 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_const, i64 0, i64 0), i64 noundef 5) #15
+  store i64 %19, i64* @rubyIdPrecomputed_const, align 8
+  %20 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @str_attr_reader, i64 0, i64 0), i64 noundef 11) #15
+  store i64 %20, i64* @rubyIdPrecomputed_attr_reader, align 8
+  %21 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  tail call void @rb_gc_register_mark_object(i64 %21) #15
+  store i64 %21, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %22 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([57 x i8], [57 x i8]* @"str_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", i64 0, i64 0), i64 noundef 56) #15
+  tail call void @rb_gc_register_mark_object(i64 %22) #15
+  store i64 %22, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 21)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
-  %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !41
   %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !41
-  %26 = call i64 @rb_id2sym(i64 %rubyId_foo.i) #15, !dbg !41
-  store i64 %26, i64* %keywords.i, align 8, !dbg !41
+  %24 = call i64 @rb_id2sym(i64 %rubyId_foo.i) #15, !dbg !41
+  store i64 %24, i64* %keywords.i, align 8, !dbg !41
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 64, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !41
   %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !45
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_<", i64 %"rubyId_<.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
@@ -527,296 +516,288 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !49
   %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !50
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
-  %27 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
-  call void @rb_gc_register_mark_object(i64 %27) #15
+  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
+  call void @rb_gc_register_mark_object(i64 %25) #15
   %rubyId_initialize.i.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
-  %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %27, i64 %rubyId_initialize.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i27.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct#10initialize", align 8
-  %29 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #15
-  store i64 %29, i64* @"<void-singleton>", align 8
-  %30 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<class:MyStruct>", i64 0, i64 0), i64 noundef 16) #15
-  call void @rb_gc_register_mark_object(i64 %30) #15
-  %31 = bitcast i64* %locals.i29.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %31)
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
+  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %25, i64 %rubyId_initialize.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i21.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct#10initialize", align 8
+  %27 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #15
+  store i64 %27, i64* @"<void-singleton>", align 8
+  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<class:MyStruct>", i64 0, i64 0), i64 noundef 16) #15
+  call void @rb_gc_register_mark_object(i64 %28) #15
+  %29 = bitcast i64* %locals.i23.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %29)
   %"rubyId_<class:MyStruct>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:MyStruct>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
   %"rubyId_<block-call>.i.i" = load i64, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  store i64 %"rubyId_<block-call>.i.i", i64* %locals.i29.i, align 8
-  %32 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %30, i64 %"rubyId_<class:MyStruct>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i29.i, i32 noundef 1, i32 noundef 4)
-  store %struct.rb_iseq_struct* %32, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %31)
-  %33 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <class:MyStruct>", i64 0, i64 0), i64 noundef 25) #15
-  call void @rb_gc_register_mark_object(i64 %33) #15
-  store i64 %33, i64* @"rubyStrFrozen_block in <class:MyStruct>", align 8
+  store i64 %"rubyId_<block-call>.i.i", i64* %locals.i23.i, align 8
+  %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %28, i64 %"rubyId_<class:MyStruct>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i23.i, i32 noundef 1, i32 noundef 4)
+  store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %29)
+  %31 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <class:MyStruct>", i64 0, i64 0), i64 noundef 25) #15
+  call void @rb_gc_register_mark_object(i64 %31) #15
+  store i64 %31, i64* @"rubyStrFrozen_block in <class:MyStruct>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>", align 8
   %"rubyId_block in <class:MyStruct>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:MyStruct>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
-  %34 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %33, i64 %"rubyId_block in <class:MyStruct>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %34, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>$block_1", align 8
-  %stackFrame.i31.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>", align 8
-  %"rubyId_block in <class:MyStruct>.i32.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:MyStruct>", align 8
-  %"rubyStr_block in <class:MyStruct>.i33.i" = load i64, i64* @"rubyStrFrozen_block in <class:MyStruct>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i34.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
-  %35 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <class:MyStruct>.i33.i", i64 %"rubyId_block in <class:MyStruct>.i32.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i34.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i31.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %35, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>$block_2", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
+  %32 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %31, i64 %"rubyId_block in <class:MyStruct>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %32, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>$block_1", align 8
+  %stackFrame.i25.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>", align 8
+  %"rubyId_block in <class:MyStruct>.i26.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:MyStruct>", align 8
+  %"rubyStr_block in <class:MyStruct>.i27.i" = load i64, i64* @"rubyStrFrozen_block in <class:MyStruct>", align 8
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
+  %33 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <class:MyStruct>.i27.i", i64 %"rubyId_block in <class:MyStruct>.i26.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i25.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %33, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>$block_2", align 8
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !43
-  %rubyId_foo12.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !43
-  %36 = call i64 @rb_id2sym(i64 %rubyId_foo12.i) #15, !dbg !43
-  store i64 %36, i64* %keywords11.i, align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 64, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords11.i), !dbg !43
+  %rubyId_foo11.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !43
+  %34 = call i64 @rb_id2sym(i64 %rubyId_foo11.i) #15, !dbg !43
+  store i64 %34, i64* %keywords10.i, align 8, !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 64, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords10.i), !dbg !43
   %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !43
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !43
-  %rubyId_sig16.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.3, i64 %rubyId_sig16.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
   %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !51
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !51
-  %rubyId_keep_def.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def, i64 %rubyId_keep_def.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
   %rubyId_const.i = load i64, i64* @rubyIdPrecomputed_const, align 8, !dbg !29
   %rubyId_without_accessors.i = load i64, i64* @rubyIdPrecomputed_without_accessors, align 8, !dbg !29
-  %37 = call i64 @rb_id2sym(i64 %rubyId_without_accessors.i) #15, !dbg !29
-  store i64 %37, i64* %keywords20.i, align 8, !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_const, i64 %rubyId_const.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull %keywords20.i), !dbg !29
-  %rubyId_keep_def24.i = load i64, i64* @rubyIdPrecomputed_keep_def, align 8, !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_keep_def.4, i64 %rubyId_keep_def24.i, i32 noundef 16, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !29
+  %35 = call i64 @rb_id2sym(i64 %rubyId_without_accessors.i) #15, !dbg !29
+  store i64 %35, i64* %keywords16.i, align 8, !dbg !29
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_const, i64 %rubyId_const.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull %keywords16.i), !dbg !29
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %2)
-  %38 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %39 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %38, i64 0, i32 18
-  %40 = load i64, i64* %39, align 8, !tbaa !53
-  %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 2
-  %43 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %42, align 8, !tbaa !16
+  %36 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %37 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %36, i64 0, i32 18
+  %38 = load i64, i64* %37, align 8, !tbaa !53
+  %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %39, i64 0, i32 2
+  %41 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %40, align 8, !tbaa !16
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %44, align 8, !tbaa !20
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 4
-  %46 = load i64*, i64** %45, align 8, !tbaa !22
-  %47 = load i64, i64* %46, align 8, !tbaa !6
-  %48 = and i64 %47, -33
-  store i64 %48, i64* %46, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %41, %struct.rb_control_frame_struct* %43, %struct.rb_iseq_struct* %stackFrame.i) #15
-  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 0
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %49, align 8, !dbg !61, !tbaa !14
-  %50 = load i64, i64* @"guard_epoch_T::Struct", align 8, !dbg !62
-  %51 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !62, !tbaa !30
-  %needTakeSlowPath = icmp ne i64 %50, %51, !dbg !62
-  br i1 %needTakeSlowPath, label %52, label %53, !dbg !62, !prof !32
+  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %42, align 8, !tbaa !20
+  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 4
+  %44 = load i64*, i64** %43, align 8, !tbaa !22
+  %45 = load i64, i64* %44, align 8, !tbaa !6
+  %46 = and i64 %45, -33
+  store i64 %46, i64* %44, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %39, %struct.rb_control_frame_struct* %41, %struct.rb_iseq_struct* %stackFrame.i) #15
+  %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 0
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %47, align 8, !dbg !61, !tbaa !14
+  %48 = load i64, i64* @"guard_epoch_T::Struct", align 8, !dbg !62
+  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !62, !tbaa !30
+  %needTakeSlowPath = icmp ne i64 %48, %49, !dbg !62
+  br i1 %needTakeSlowPath, label %50, label %51, !dbg !62, !prof !32
 
-52:                                               ; preds = %entry
+50:                                               ; preds = %entry
   call void @"const_recompute_T::Struct"(), !dbg !62
-  br label %53, !dbg !62
+  br label %51, !dbg !62
 
-53:                                               ; preds = %entry, %52
-  %54 = load i64, i64* @"guarded_const_T::Struct", align 8, !dbg !62
-  %55 = load i64, i64* @"guard_epoch_T::Struct", align 8, !dbg !62
-  %56 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !62, !tbaa !30
-  %guardUpdated = icmp eq i64 %55, %56, !dbg !62
+51:                                               ; preds = %entry, %50
+  %52 = load i64, i64* @"guarded_const_T::Struct", align 8, !dbg !62
+  %53 = load i64, i64* @"guard_epoch_T::Struct", align 8, !dbg !62
+  %54 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !62, !tbaa !30
+  %guardUpdated = icmp eq i64 %53, %54, !dbg !62
   call void @llvm.assume(i1 %guardUpdated), !dbg !62
-  %57 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_MyStruct, i64 0, i64 0), i64 %54) #15, !dbg !62
-  %58 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %57) #15, !dbg !62
-  call fastcc void @"func_MyStruct.13<static-init>L62"(i64 %57, %struct.rb_control_frame_struct* %58) #15, !dbg !62
+  %55 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_MyStruct, i64 0, i64 0), i64 %52) #15, !dbg !62
+  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #15, !dbg !62
+  call fastcc void @"func_MyStruct.13<static-init>L62"(i64 %55, %struct.rb_control_frame_struct* %56) #15, !dbg !62
   call void @sorbet_popFrame() #15, !dbg !62
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %49, align 8, !dbg !63, !tbaa !14
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %47, align 8, !dbg !63, !tbaa !14
   %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !64
   %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #15, !dbg !64
-  %59 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !41
-  %60 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !30
-  %needTakeSlowPath2 = icmp ne i64 %59, %60, !dbg !41
-  br i1 %needTakeSlowPath2, label %61, label %62, !dbg !41, !prof !32
+  %57 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !41
+  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !30
+  %needTakeSlowPath2 = icmp ne i64 %57, %58, !dbg !41
+  br i1 %needTakeSlowPath2, label %59, label %60, !dbg !41, !prof !32
 
-61:                                               ; preds = %53
+59:                                               ; preds = %51
   call void @const_recompute_MyStruct(), !dbg !41
-  br label %62, !dbg !41
+  br label %60, !dbg !41
 
-62:                                               ; preds = %53, %61
-  %63 = load i64, i64* @guarded_const_MyStruct, align 8, !dbg !41
-  %64 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !41
-  %65 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !30
-  %guardUpdated3 = icmp eq i64 %64, %65, !dbg !41
+60:                                               ; preds = %51, %59
+  %61 = load i64, i64* @guarded_const_MyStruct, align 8, !dbg !41
+  %62 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !41
+  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !30
+  %guardUpdated3 = icmp eq i64 %62, %63, !dbg !41
   call void @llvm.assume(i1 %guardUpdated3), !dbg !41
-  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !41
-  %67 = load i64*, i64** %66, align 8, !dbg !41
-  store i64 %63, i64* %67, align 8, !dbg !41, !tbaa !6
-  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !41
-  store i64 861, i64* %68, align 8, !dbg !41, !tbaa !6
-  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !41
-  store i64* %69, i64** %66, align 8, !dbg !41
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !41
+  %65 = load i64*, i64** %64, align 8, !dbg !41
+  store i64 %61, i64* %65, align 8, !dbg !41, !tbaa !6
+  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !41
+  store i64 861, i64* %66, align 8, !dbg !41, !tbaa !6
+  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !41
+  store i64* %67, i64** %64, align 8, !dbg !41
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !41
   br label %BB2.i, !dbg !65
 
-BB2.i:                                            ; preds = %BB2.i.backedge, %62
-  %i.sroa.0.0.i = phi i64 [ 1, %62 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !61
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %49, align 8, !tbaa !14
-  %70 = and i64 %i.sroa.0.0.i, 1, !dbg !45
-  %71 = icmp eq i64 %70, 0, !dbg !45
-  br i1 %71, label %72, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !45, !prof !66
+BB2.i:                                            ; preds = %BB2.i.backedge, %60
+  %i.sroa.0.0.i = phi i64 [ 1, %60 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !61
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %47, align 8, !tbaa !14
+  %68 = and i64 %i.sroa.0.0.i, 1, !dbg !45
+  %69 = icmp eq i64 %68, 0, !dbg !45
+  br i1 %69, label %70, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !45, !prof !66
 
-72:                                               ; preds = %BB2.i
-  %73 = and i64 %i.sroa.0.0.i, 7, !dbg !45
-  %74 = icmp ne i64 %73, 0, !dbg !45
-  %75 = and i64 %i.sroa.0.0.i, -9, !dbg !45
-  %76 = icmp eq i64 %75, 0, !dbg !45
-  %77 = or i1 %74, %76, !dbg !45
-  br i1 %77, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !45, !prof !67
+70:                                               ; preds = %BB2.i
+  %71 = and i64 %i.sroa.0.0.i, 7, !dbg !45
+  %72 = icmp ne i64 %71, 0, !dbg !45
+  %73 = and i64 %i.sroa.0.0.i, -9, !dbg !45
+  %74 = icmp eq i64 %73, 0, !dbg !45
+  %75 = or i1 %72, %74, !dbg !45
+  br i1 %75, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !45, !prof !67
 
-sorbet_isa_Integer.exit:                          ; preds = %72
-  %78 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !45
-  %79 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %78, i64 0, i32 0, !dbg !45
-  %80 = load i64, i64* %79, align 8, !dbg !45, !tbaa !68
-  %81 = and i64 %80, 31, !dbg !45
-  %82 = icmp eq i64 %81, 10, !dbg !45
-  br i1 %82, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !45, !prof !27
+sorbet_isa_Integer.exit:                          ; preds = %70
+  %76 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !45
+  %77 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %76, i64 0, i32 0, !dbg !45
+  %78 = load i64, i64* %77, align 8, !dbg !45, !tbaa !68
+  %79 = and i64 %78, 31, !dbg !45
+  %80 = icmp eq i64 %79, 10, !dbg !45
+  br i1 %80, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !45, !prof !27
 
 BB5.i:                                            ; preds = %afterSend40.i
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %49, align 8, !tbaa !14
-  %83 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !46
-  %84 = load i64*, i64** %83, align 8, !dbg !46
-  store i64 %send, i64* %84, align 8, !dbg !46, !tbaa !6
-  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !46
-  store i64* %85, i64** %83, align 8, !dbg !46
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %47, align 8, !tbaa !14
+  %81 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !46
+  %82 = load i64*, i64** %81, align 8, !dbg !46
+  store i64 %send, i64* %82, align 8, !dbg !46, !tbaa !6
+  %83 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !46
+  store i64* %83, i64** %81, align 8, !dbg !46
   %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !46
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %49, align 8, !dbg !46, !tbaa !14
-  br i1 %86, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !47
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %47, align 8, !dbg !46, !tbaa !14
+  br i1 %84, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !47
 
-afterSend40.i:                                    ; preds = %111, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
-  %86 = phi i1 [ %89, %"alternativeCallIntrinsic_Integer_<.i" ], [ %94, %sorbet_rb_int_lt.exit.i ], [ %94, %111 ]
-  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send7, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult92.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult92.i, %111 ], !dbg !45
-  %87 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !45
-  %88 = icmp ne i64 %87, 0, !dbg !45
-  br i1 %88, label %BB5.i, label %"func_<root>.17<static-init>$152.exit", !dbg !45
+afterSend40.i:                                    ; preds = %109, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
+  %84 = phi i1 [ %87, %"alternativeCallIntrinsic_Integer_<.i" ], [ %92, %sorbet_rb_int_lt.exit.i ], [ %92, %109 ]
+  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send7, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult92.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult92.i, %109 ], !dbg !45
+  %85 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !45
+  %86 = icmp ne i64 %85, 0, !dbg !45
+  br i1 %86, label %BB5.i, label %"func_<root>.17<static-init>$152.exit", !dbg !45
 
-"alternativeCallIntrinsic_Integer_<.i":           ; preds = %72, %sorbet_isa_Integer.exit
-  %89 = phi i1 [ %82, %sorbet_isa_Integer.exit ], [ false, %72 ]
-  %90 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !45
-  %91 = load i64*, i64** %90, align 8, !dbg !45
-  store i64 %i.sroa.0.0.i, i64* %91, align 8, !dbg !45, !tbaa !6
-  %92 = getelementptr inbounds i64, i64* %91, i64 1, !dbg !45
-  store i64 20000001, i64* %92, align 8, !dbg !45, !tbaa !6
-  %93 = getelementptr inbounds i64, i64* %92, i64 1, !dbg !45
-  store i64* %93, i64** %90, align 8, !dbg !45
+"alternativeCallIntrinsic_Integer_<.i":           ; preds = %70, %sorbet_isa_Integer.exit
+  %87 = phi i1 [ %80, %sorbet_isa_Integer.exit ], [ false, %70 ]
+  %88 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !45
+  %89 = load i64*, i64** %88, align 8, !dbg !45
+  store i64 %i.sroa.0.0.i, i64* %89, align 8, !dbg !45, !tbaa !6
+  %90 = getelementptr inbounds i64, i64* %89, i64 1, !dbg !45
+  store i64 20000001, i64* %90, align 8, !dbg !45, !tbaa !6
+  %91 = getelementptr inbounds i64, i64* %90, i64 1, !dbg !45
+  store i64* %91, i64** %88, align 8, !dbg !45
   %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !45
   br label %afterSend40.i, !dbg !45
 
 "fastSymCallIntrinsic_Integer_<.i":               ; preds = %BB2.i, %sorbet_isa_Integer.exit
-  %94 = phi i1 [ %82, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
+  %92 = phi i1 [ %80, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
   call void @llvm.experimental.noalias.scope.decl(metadata !70) #15, !dbg !45
-  %95 = and i64 %i.sroa.0.0.i, 1, !dbg !45
-  %96 = icmp eq i64 %95, 0, !dbg !45
-  br i1 %96, label %101, label %97, !dbg !45, !prof !73
+  %93 = and i64 %i.sroa.0.0.i, 1, !dbg !45
+  %94 = icmp eq i64 %93, 0, !dbg !45
+  br i1 %94, label %99, label %95, !dbg !45, !prof !73
 
-97:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %98 = ashr i64 %i.sroa.0.0.i, 1, !dbg !45
-  %99 = icmp slt i64 %98, 10000000, !dbg !45
-  %100 = select i1 %99, i64 20, i64 0, !dbg !45
+95:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
+  %96 = ashr i64 %i.sroa.0.0.i, 1, !dbg !45
+  %97 = icmp slt i64 %96, 10000000, !dbg !45
+  %98 = select i1 %97, i64 20, i64 0, !dbg !45
   br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
-101:                                              ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %102 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !45, !noalias !70
+99:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
+  %100 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !45, !noalias !70
   br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
-sorbet_rb_int_lt.exit.i:                          ; preds = %101, %97
-  %rawSendResult92.i = phi i64 [ %100, %97 ], [ %102, %101 ]
-  %103 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !14
-  %104 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 5, !dbg !45
-  %105 = load i32, i32* %104, align 8, !dbg !45, !tbaa !25
-  %106 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 6, !dbg !45
-  %107 = load i32, i32* %106, align 4, !dbg !45, !tbaa !26
-  %108 = xor i32 %107, -1, !dbg !45
-  %109 = and i32 %108, %105, !dbg !45
-  %110 = icmp eq i32 %109, 0, !dbg !45
-  br i1 %110, label %afterSend40.i, label %111, !dbg !45, !prof !27
+sorbet_rb_int_lt.exit.i:                          ; preds = %99, %95
+  %rawSendResult92.i = phi i64 [ %98, %95 ], [ %100, %99 ]
+  %101 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !14
+  %102 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 5, !dbg !45
+  %103 = load i32, i32* %102, align 8, !dbg !45, !tbaa !25
+  %104 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 6, !dbg !45
+  %105 = load i32, i32* %104, align 4, !dbg !45, !tbaa !26
+  %106 = xor i32 %105, -1, !dbg !45
+  %107 = and i32 %106, %103, !dbg !45
+  %108 = icmp eq i32 %107, 0, !dbg !45
+  br i1 %108, label %afterSend40.i, label %109, !dbg !45, !prof !27
 
-111:                                              ; preds = %sorbet_rb_int_lt.exit.i
-  %112 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 8, !dbg !45
-  %113 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %112, align 8, !dbg !45, !tbaa !28
-  %114 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %113, i32 noundef 0) #15, !dbg !45
+109:                                              ; preds = %sorbet_rb_int_lt.exit.i
+  %110 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 8, !dbg !45
+  %111 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %110, align 8, !dbg !45, !tbaa !28
+  %112 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %111, i32 noundef 0) #15, !dbg !45
   br label %afterSend40.i, !dbg !45
 
 "alternativeCallIntrinsic_Integer_+.i":           ; preds = %BB5.i
-  %115 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !47
-  %116 = load i64*, i64** %115, align 8, !dbg !47
-  store i64 %i.sroa.0.0.i, i64* %116, align 8, !dbg !47, !tbaa !6
-  %117 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !47
-  store i64 3, i64* %117, align 8, !dbg !47, !tbaa !6
-  %118 = getelementptr inbounds i64, i64* %117, i64 1, !dbg !47
-  store i64* %118, i64** %115, align 8, !dbg !47
+  %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !47
+  %114 = load i64*, i64** %113, align 8, !dbg !47
+  store i64 %i.sroa.0.0.i, i64* %114, align 8, !dbg !47, !tbaa !6
+  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !47
+  store i64 3, i64* %115, align 8, !dbg !47, !tbaa !6
+  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !47
+  store i64* %116, i64** %113, align 8, !dbg !47
   %send9 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !47
   br label %BB2.i.backedge, !dbg !47
 
 "fastSymCallIntrinsic_Integer_+.i":               ; preds = %BB5.i
   call void @llvm.experimental.noalias.scope.decl(metadata !74) #15, !dbg !47
-  %119 = and i64 %i.sroa.0.0.i, 1, !dbg !47
-  %120 = icmp eq i64 %119, 0, !dbg !47
-  br i1 %120, label %129, label %121, !dbg !47, !prof !73
+  %117 = and i64 %i.sroa.0.0.i, 1, !dbg !47
+  %118 = icmp eq i64 %117, 0, !dbg !47
+  br i1 %118, label %127, label %119, !dbg !47, !prof !73
 
-121:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %122 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !47
-  %123 = extractvalue { i64, i1 } %122, 1, !dbg !47
-  %124 = extractvalue { i64, i1 } %122, 0, !dbg !47
-  br i1 %123, label %125, label %sorbet_rb_int_plus.exit.i, !dbg !47
+119:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
+  %120 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !47
+  %121 = extractvalue { i64, i1 } %120, 1, !dbg !47
+  %122 = extractvalue { i64, i1 } %120, 0, !dbg !47
+  br i1 %121, label %123, label %sorbet_rb_int_plus.exit.i, !dbg !47
 
-125:                                              ; preds = %121
-  %126 = ashr i64 %124, 1, !dbg !47
-  %127 = xor i64 %126, -9223372036854775808, !dbg !47
-  %128 = call i64 @rb_int2big(i64 %127) #15, !dbg !47
+123:                                              ; preds = %119
+  %124 = ashr i64 %122, 1, !dbg !47
+  %125 = xor i64 %124, -9223372036854775808, !dbg !47
+  %126 = call i64 @rb_int2big(i64 %125) #15, !dbg !47
   br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
-129:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %130 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !47, !noalias !74
+127:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
+  %128 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !47, !noalias !74
   br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
-sorbet_rb_int_plus.exit.i:                        ; preds = %129, %125, %121
-  %131 = phi i64 [ %130, %129 ], [ %128, %125 ], [ %124, %121 ], !dbg !47
-  %132 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !14
-  %133 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %132, i64 0, i32 5, !dbg !47
-  %134 = load i32, i32* %133, align 8, !dbg !47, !tbaa !25
-  %135 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %132, i64 0, i32 6, !dbg !47
-  %136 = load i32, i32* %135, align 4, !dbg !47, !tbaa !26
-  %137 = xor i32 %136, -1, !dbg !47
-  %138 = and i32 %137, %134, !dbg !47
-  %139 = icmp eq i32 %138, 0, !dbg !47
-  br i1 %139, label %BB2.i.backedge, label %140, !dbg !47, !prof !27
+sorbet_rb_int_plus.exit.i:                        ; preds = %127, %123, %119
+  %129 = phi i64 [ %128, %127 ], [ %126, %123 ], [ %122, %119 ], !dbg !47
+  %130 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !14
+  %131 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %130, i64 0, i32 5, !dbg !47
+  %132 = load i32, i32* %131, align 8, !dbg !47, !tbaa !25
+  %133 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %130, i64 0, i32 6, !dbg !47
+  %134 = load i32, i32* %133, align 4, !dbg !47, !tbaa !26
+  %135 = xor i32 %134, -1, !dbg !47
+  %136 = and i32 %135, %132, !dbg !47
+  %137 = icmp eq i32 %136, 0, !dbg !47
+  br i1 %137, label %BB2.i.backedge, label %138, !dbg !47, !prof !27
 
-140:                                              ; preds = %sorbet_rb_int_plus.exit.i
-  %141 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %132, i64 0, i32 8, !dbg !47
-  %142 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %141, align 8, !dbg !47, !tbaa !28
-  %143 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %142, i32 noundef 0) #15, !dbg !47
+138:                                              ; preds = %sorbet_rb_int_plus.exit.i
+  %139 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %130, i64 0, i32 8, !dbg !47
+  %140 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %139, align 8, !dbg !47, !tbaa !28
+  %141 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %140, i32 noundef 0) #15, !dbg !47
   br label %BB2.i.backedge, !dbg !47
 
-BB2.i.backedge:                                   ; preds = %140, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
-  %i.sroa.0.0.i.be = phi i64 [ %send9, %"alternativeCallIntrinsic_Integer_+.i" ], [ %131, %sorbet_rb_int_plus.exit.i ], [ %131, %140 ]
+BB2.i.backedge:                                   ; preds = %138, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
+  %i.sroa.0.0.i.be = phi i64 [ %send9, %"alternativeCallIntrinsic_Integer_+.i" ], [ %129, %sorbet_rb_int_plus.exit.i ], [ %129, %138 ]
   br label %BB2.i
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %afterSend40.i
   %i.sroa.0.0.i.lcssa = phi i64 [ %i.sroa.0.0.i, %afterSend40.i ], !dbg !61
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %49, align 8, !tbaa !14
-  %144 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !48
-  %145 = load i64*, i64** %144, align 8, !dbg !48
-  store i64 %40, i64* %145, align 8, !dbg !48, !tbaa !6
-  %146 = getelementptr inbounds i64, i64* %145, i64 1, !dbg !48
-  store i64 %i.sroa.0.0.i.lcssa, i64* %146, align 8, !dbg !48, !tbaa !6
-  %147 = getelementptr inbounds i64, i64* %146, i64 1, !dbg !48
-  store i64* %147, i64** %144, align 8, !dbg !48
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %47, align 8, !tbaa !14
+  %142 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !48
+  %143 = load i64*, i64** %142, align 8, !dbg !48
+  store i64 %38, i64* %143, align 8, !dbg !48, !tbaa !6
+  %144 = getelementptr inbounds i64, i64* %143, i64 1, !dbg !48
+  store i64 %i.sroa.0.0.i.lcssa, i64* %144, align 8, !dbg !48, !tbaa !6
+  %145 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !48
+  store i64* %145, i64** %142, align 8, !dbg !48
   %send11 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !48
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %49, align 8, !dbg !48, !tbaa !14
-  %148 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !49
-  %149 = load i64*, i64** %148, align 8, !dbg !49
-  store i64 %send, i64* %149, align 8, !dbg !49, !tbaa !6
-  %150 = getelementptr inbounds i64, i64* %149, i64 1, !dbg !49
-  store i64* %150, i64** %148, align 8, !dbg !49
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %47, align 8, !dbg !48, !tbaa !14
+  %146 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !49
+  %147 = load i64*, i64** %146, align 8, !dbg !49
+  store i64 %send, i64* %147, align 8, !dbg !49, !tbaa !6
+  %148 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !49
+  store i64* %148, i64** %146, align 8, !dbg !49
   %send13 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !49
-  %151 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !50
-  %152 = load i64*, i64** %151, align 8, !dbg !50
-  store i64 %40, i64* %152, align 8, !dbg !50, !tbaa !6
-  %153 = getelementptr inbounds i64, i64* %152, i64 1, !dbg !50
-  store i64 %send13, i64* %153, align 8, !dbg !50, !tbaa !6
-  %154 = getelementptr inbounds i64, i64* %153, i64 1, !dbg !50
-  store i64* %154, i64** %151, align 8, !dbg !50
+  %149 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !50
+  %150 = load i64*, i64** %149, align 8, !dbg !50
+  store i64 %38, i64* %150, align 8, !dbg !50, !tbaa !6
+  %151 = getelementptr inbounds i64, i64* %150, i64 1, !dbg !50
+  store i64 %send13, i64* %151, align 8, !dbg !50, !tbaa !6
+  %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !50
+  store i64* %152, i64** %149, align 8, !dbg !50
   %send15 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !50
   ret void
 }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a followon PR to #4591, where we rejected VM calls to `<Magic>` methods.  We wanted to do the same for calls on `Sorbet::Private::Static`, but we couldn't, because our current compilation strategy turns a call like:

```ruby
  Sorbet::Private::Static.keep_def(self, :foo, :normal)
```

into (pseudocode)

```
c = get_constant("Sorbet::Private::Static")
recv = get_constant("Sorbet::Private::Static")
if is_class_of(recv, c)
  ...do the fast thing...
else
  ...do a call into the Ruby VM...
end
```

The slow path gets optimized out by a combination of LLVM and clever declarations on things in the codegen payload.  But this strategy is not great for ensuring that we never make calls into the VM for `Sorbet::Private::Static` methods.  It also generates a bunch of LLVM IR that is just dead code, creating more work for the optimizers, etc.

This PR provides a separate function on `SymbolBasedIntrinsicMethod` for making *compile-time* decisions about whether we need a fast path test, and modifies our symbol-based intrinsic implementation strategy to use it.  As the comments note, this function should not normally be overridden, but there are several cases where it comes in very handy, like this PR.  (I have a WIP patch to provide type assumptions for the result of `Thread.current`, which makes the generated code for `Thread.current[:foo]` much nicer.)

Once we have such a function, the only things to do are return `true` from it where appropriate and to modify `sends.cc` to take advantage of the function.  I looked at integrating the logic for the single-intrinsic, skippable fast path with the current logic and decided it was too gnarly, so we have a little bit of duplication.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
