### PR TITLE
skip type tests for Sorbet::Private::Static::ResolvedSig

### DIFF
--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -536,6 +536,9 @@ public:
         return Payload::rubyNil(mcctx.cs, builder);
     }
 
+    virtual bool skipFastPathTest(MethodCallContext &mcctx, core::ClassOrModuleRef potentialClass) const override {
+        return true;
+    }
     virtual InlinedVector<core::ClassOrModuleRef, 2> applicableClasses(const core::GlobalState &gs) const override {
         return {core::Symbols::Sorbet_Private_Static_ResolvedSig().data(gs)->lookupSingletonClass(gs)};
     };

--- a/test/testdata/compiler/block_type_checking.llo.exp
+++ b/test/testdata/compiler/block_type_checking.llo.exp
@@ -118,8 +118,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_Foo.13<static-init>$block_1" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_block in <class:Foo>" = internal unnamed_addr global i64 0, align 8
 @"str_block in <class:Foo>" = private unnamed_addr constant [21 x i8] c"block in <class:Foo>\00", align 1
-@ic_sig = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_sig = internal unnamed_addr global i64 0, align 8
 @rubyIdPrecomputed_x = internal unnamed_addr global i64 0, align 8
 @str_x = private unnamed_addr constant [2 x i8] c"x\00", align 1
 @rubyIdPrecomputed_blk = internal unnamed_addr global i64 0, align 8
@@ -252,7 +250,7 @@ functionEntryInitializers:
 
 ; Function Attrs: nounwind sspreq uwtable
 define internal fastcc void @"func_Foo.13<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !26 {
-fastSymCallIntrinsic_ResolvedSig_sig:
+functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -278,116 +276,116 @@ fastSymCallIntrinsic_ResolvedSig_sig:
   %14 = xor i32 %13, -1, !dbg !28
   %15 = and i32 %14, %11, !dbg !28
   %16 = icmp eq i32 %15, 0, !dbg !28
-  br i1 %16, label %afterSend, label %65, !dbg !28, !prof !31
+  br i1 %16, label %rb_vm_check_ints.exit1, label %17, !dbg !28, !prof !31
 
-afterSend:                                        ; preds = %65, %fastSymCallIntrinsic_ResolvedSig_sig
+17:                                               ; preds = %functionEntryInitializers
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !28
+  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !28, !tbaa !32
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !28
+  br label %rb_vm_check_ints.exit1, !dbg !28
+
+rb_vm_check_ints.exit1:                           ; preds = %functionEntryInitializers, %17
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !28, !tbaa !15
-  %17 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !32
-  %18 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !32, !tbaa !33
-  %needTakeSlowPath = icmp ne i64 %17, %18, !dbg !32
-  br i1 %needTakeSlowPath, label %19, label %20, !dbg !32, !prof !35
+  %21 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !33
+  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !34
+  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !33
+  br i1 %needTakeSlowPath, label %23, label %24, !dbg !33, !prof !36
 
-19:                                               ; preds = %afterSend
-  tail call void @"const_recompute_T::Sig"(), !dbg !32
-  br label %20, !dbg !32
+23:                                               ; preds = %rb_vm_check_ints.exit1
+  tail call void @"const_recompute_T::Sig"(), !dbg !33
+  br label %24, !dbg !33
 
-20:                                               ; preds = %afterSend, %19
-  %21 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !32
-  %22 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !32
-  %23 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !32, !tbaa !33
-  %guardUpdated = icmp eq i64 %22, %23, !dbg !32
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !32
-  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !32
-  %25 = load i64*, i64** %24, align 8, !dbg !32
-  store i64 %selfRaw, i64* %25, align 8, !dbg !32, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !32
-  store i64 %21, i64* %26, align 8, !dbg !32, !tbaa !6
-  %27 = getelementptr inbounds i64, i64* %26, i64 1, !dbg !32
-  store i64* %27, i64** %24, align 8, !dbg !32
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !32
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !32, !tbaa !15
-  %rubyId_bar40 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !36
-  %rawSym41 = tail call i64 @rb_id2sym(i64 %rubyId_bar40), !dbg !36
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !36
-  %rawSym42 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !36
-  %28 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !36
-  %29 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !36, !tbaa !33
-  %needTakeSlowPath2 = icmp ne i64 %28, %29, !dbg !36
-  br i1 %needTakeSlowPath2, label %30, label %31, !dbg !36, !prof !35
+24:                                               ; preds = %rb_vm_check_ints.exit1, %23
+  %25 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !33
+  %26 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !33
+  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !34
+  %guardUpdated = icmp eq i64 %26, %27, !dbg !33
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !33
+  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !33
+  %29 = load i64*, i64** %28, align 8, !dbg !33
+  store i64 %selfRaw, i64* %29, align 8, !dbg !33, !tbaa !6
+  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !33
+  store i64 %25, i64* %30, align 8, !dbg !33, !tbaa !6
+  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !33
+  store i64* %31, i64** %28, align 8, !dbg !33
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !33
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !33, !tbaa !15
+  %rubyId_bar37 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !37
+  %rawSym38 = tail call i64 @rb_id2sym(i64 %rubyId_bar37), !dbg !37
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !37
+  %rawSym39 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !37
+  %32 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !37
+  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !37, !tbaa !34
+  %needTakeSlowPath2 = icmp ne i64 %32, %33, !dbg !37
+  br i1 %needTakeSlowPath2, label %34, label %35, !dbg !37, !prof !36
 
-30:                                               ; preds = %20
-  tail call void @const_recompute_Foo(), !dbg !36
-  br label %31, !dbg !36
+34:                                               ; preds = %24
+  tail call void @const_recompute_Foo(), !dbg !37
+  br label %35, !dbg !37
 
-31:                                               ; preds = %20, %30
-  %32 = load i64, i64* @guarded_const_Foo, align 8, !dbg !36
-  %33 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !36
-  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !36, !tbaa !33
-  %guardUpdated3 = icmp eq i64 %33, %34, !dbg !36
-  tail call void @llvm.assume(i1 %guardUpdated3), !dbg !36
-  %stackFrame46 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8, !dbg !36
-  %35 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !36
-  %36 = bitcast i8* %35 to i16*, !dbg !36
-  %37 = load i16, i16* %36, align 8, !dbg !36
-  %38 = and i16 %37, -384, !dbg !36
-  %39 = or i16 %38, 65, !dbg !36
-  store i16 %39, i16* %36, align 8, !dbg !36
-  %40 = getelementptr inbounds i8, i8* %35, i64 8, !dbg !36
-  %41 = bitcast i8* %40 to i32*, !dbg !36
-  store i32 1, i32* %41, align 8, !dbg !36, !tbaa !37
-  %42 = getelementptr inbounds i8, i8* %35, i64 12, !dbg !36
-  %43 = bitcast i8* %42 to i32*, !dbg !36
-  %44 = getelementptr inbounds i8, i8* %35, i64 28, !dbg !36
-  %45 = bitcast i8* %44 to i32*, !dbg !36
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %42, i8 0, i64 16, i1 false), !dbg !36
-  store i32 1, i32* %45, align 4, !dbg !36, !tbaa !40
-  %46 = getelementptr inbounds i8, i8* %35, i64 4, !dbg !36
-  %47 = bitcast i8* %46 to i32*, !dbg !36
-  store i32 2, i32* %47, align 4, !dbg !36, !tbaa !41
-  %positional_table = alloca i64, i32 2, align 8, !dbg !36
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !36
-  store i64 %rubyId_x, i64* %positional_table, align 8, !dbg !36
-  %rubyId_blk = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !36
-  %48 = getelementptr i64, i64* %positional_table, i32 1, !dbg !36
-  store i64 %rubyId_blk, i64* %48, align 8, !dbg !36
-  %49 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !36
-  %50 = bitcast i64* %positional_table to i8*, !dbg !36
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %49, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %50, i64 noundef 16, i1 noundef false) #16, !dbg !36
-  %51 = getelementptr inbounds i8, i8* %35, i64 32, !dbg !36
-  %52 = bitcast i8* %51 to i8**, !dbg !36
-  store i8* %49, i8** %52, align 8, !dbg !36, !tbaa !42
-  tail call void @sorbet_vm_define_method(i64 %32, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Foo#3bar", i8* nonnull %35, %struct.rb_iseq_struct* %stackFrame46, i1 noundef zeroext false) #16, !dbg !36
-  %53 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !36, !tbaa !15
-  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 5, !dbg !36
-  %55 = load i32, i32* %54, align 8, !dbg !36, !tbaa !29
-  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 6, !dbg !36
-  %57 = load i32, i32* %56, align 4, !dbg !36, !tbaa !30
-  %58 = xor i32 %57, -1, !dbg !36
-  %59 = and i32 %58, %55, !dbg !36
-  %60 = icmp eq i32 %59, 0, !dbg !36
-  br i1 %60, label %rb_vm_check_ints.exit1, label %61, !dbg !36, !prof !31
+35:                                               ; preds = %24, %34
+  %36 = load i64, i64* @guarded_const_Foo, align 8, !dbg !37
+  %37 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !37
+  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !37, !tbaa !34
+  %guardUpdated3 = icmp eq i64 %37, %38, !dbg !37
+  tail call void @llvm.assume(i1 %guardUpdated3), !dbg !37
+  %stackFrame43 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8, !dbg !37
+  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !37
+  %40 = bitcast i8* %39 to i16*, !dbg !37
+  %41 = load i16, i16* %40, align 8, !dbg !37
+  %42 = and i16 %41, -384, !dbg !37
+  %43 = or i16 %42, 65, !dbg !37
+  store i16 %43, i16* %40, align 8, !dbg !37
+  %44 = getelementptr inbounds i8, i8* %39, i64 8, !dbg !37
+  %45 = bitcast i8* %44 to i32*, !dbg !37
+  store i32 1, i32* %45, align 8, !dbg !37, !tbaa !38
+  %46 = getelementptr inbounds i8, i8* %39, i64 12, !dbg !37
+  %47 = bitcast i8* %46 to i32*, !dbg !37
+  %48 = getelementptr inbounds i8, i8* %39, i64 28, !dbg !37
+  %49 = bitcast i8* %48 to i32*, !dbg !37
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 16, i1 false), !dbg !37
+  store i32 1, i32* %49, align 4, !dbg !37, !tbaa !41
+  %50 = getelementptr inbounds i8, i8* %39, i64 4, !dbg !37
+  %51 = bitcast i8* %50 to i32*, !dbg !37
+  store i32 2, i32* %51, align 4, !dbg !37, !tbaa !42
+  %positional_table = alloca i64, i32 2, align 8, !dbg !37
+  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !37
+  store i64 %rubyId_x, i64* %positional_table, align 8, !dbg !37
+  %rubyId_blk = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !37
+  %52 = getelementptr i64, i64* %positional_table, i32 1, !dbg !37
+  store i64 %rubyId_blk, i64* %52, align 8, !dbg !37
+  %53 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !37
+  %54 = bitcast i64* %positional_table to i8*, !dbg !37
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %53, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %54, i64 noundef 16, i1 noundef false) #16, !dbg !37
+  %55 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !37
+  %56 = bitcast i8* %55 to i8**, !dbg !37
+  store i8* %53, i8** %56, align 8, !dbg !37, !tbaa !43
+  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Foo#3bar", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame43, i1 noundef zeroext false) #16, !dbg !37
+  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !15
+  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 5, !dbg !37
+  %59 = load i32, i32* %58, align 8, !dbg !37, !tbaa !29
+  %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 6, !dbg !37
+  %61 = load i32, i32* %60, align 4, !dbg !37, !tbaa !30
+  %62 = xor i32 %61, -1, !dbg !37
+  %63 = and i32 %62, %59, !dbg !37
+  %64 = icmp eq i32 %63, 0, !dbg !37
+  br i1 %64, label %rb_vm_check_ints.exit, label %65, !dbg !37, !prof !31
 
-61:                                               ; preds = %31
-  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 8, !dbg !36
-  %63 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %62, align 8, !dbg !36, !tbaa !43
-  %64 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %63, i32 noundef 0) #16, !dbg !36
-  br label %rb_vm_check_ints.exit1, !dbg !36
+65:                                               ; preds = %35
+  %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 8, !dbg !37
+  %67 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %66, align 8, !dbg !37, !tbaa !32
+  %68 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %67, i32 noundef 0) #16, !dbg !37
+  br label %rb_vm_check_ints.exit, !dbg !37
 
-rb_vm_check_ints.exit1:                           ; preds = %31, %61
+rb_vm_check_ints.exit:                            ; preds = %35, %65
   ret void
-
-65:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig
-  %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !28
-  %67 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %66, align 8, !dbg !28, !tbaa !43
-  %68 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %67, i32 noundef 0) #16, !dbg !28
-  br label %afterSend, !dbg !28
 }
 
 ; Function Attrs: sspreq
 define void @Init_block_type_checking() local_unnamed_addr #9 {
 entry:
-  %locals.i18.i = alloca i64, i32 0, align 8
   %locals.i16.i = alloca i64, i32 0, align 8
+  %locals.i14.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %keywords.i = alloca i64, i32 2, align 8, !dbg !44
   %realpath = tail call i64 @sorbet_readRealpath()
@@ -408,160 +406,156 @@ entry:
   store i64 %7, i64* @"rubyIdPrecomputed_<class:Foo>", align 8
   %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @"str_block in <class:Foo>", i64 0, i64 0), i64 noundef 20) #16
   store i64 %8, i64* @"rubyIdPrecomputed_block in <class:Foo>", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i64 noundef 3) #16
-  store i64 %9, i64* @rubyIdPrecomputed_sig, align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #16
-  store i64 %10, i64* @rubyIdPrecomputed_x, align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_blk, i64 0, i64 0), i64 noundef 3) #16
-  store i64 %11, i64* @rubyIdPrecomputed_blk, align 8
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_proc, i64 0, i64 0), i64 noundef 4) #16
-  store i64 %12, i64* @rubyIdPrecomputed_proc, align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #16
-  store i64 %13, i64* @rubyIdPrecomputed_returns, align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #16
-  store i64 %14, i64* @rubyIdPrecomputed_params, align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #16
-  store i64 %15, i64* @rubyIdPrecomputed_extend, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
-  store i64 %16, i64* @rubyIdPrecomputed_normal, align 8
-  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #16
+  store i64 %9, i64* @rubyIdPrecomputed_x, align 8
+  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_blk, i64 0, i64 0), i64 noundef 3) #16
+  store i64 %10, i64* @rubyIdPrecomputed_blk, align 8
+  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_proc, i64 0, i64 0), i64 noundef 4) #16
+  store i64 %11, i64* @rubyIdPrecomputed_proc, align 8
+  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #16
+  store i64 %12, i64* @rubyIdPrecomputed_returns, align 8
+  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #16
+  store i64 %13, i64* @rubyIdPrecomputed_params, align 8
+  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #16
+  store i64 %14, i64* @rubyIdPrecomputed_extend, align 8
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
+  store i64 %15, i64* @rubyIdPrecomputed_normal, align 8
+  %16 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  tail call void @rb_gc_register_mark_object(i64 %16) #16
+  store i64 %16, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([46 x i8], [46 x i8]* @"str_test/testdata/compiler/block_type_checking.rb", i64 0, i64 0), i64 noundef 45) #16
   tail call void @rb_gc_register_mark_object(i64 %17) #16
-  store i64 %17, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([46 x i8], [46 x i8]* @"str_test/testdata/compiler/block_type_checking.rb", i64 0, i64 0), i64 noundef 45) #16
-  tail call void @rb_gc_register_mark_object(i64 %18) #16
-  store i64 %18, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
+  store i64 %17, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 19)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #16
-  call void @rb_gc_register_mark_object(i64 %20) #16
+  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #16
+  call void @rb_gc_register_mark_object(i64 %19) #16
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8
+  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i12.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
+  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i12.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !46
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !46
   %rubyId_bar.i = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !46
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
   %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !47
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
-  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #16
-  call void @rb_gc_register_mark_object(i64 %22) #16
+  %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #16
+  call void @rb_gc_register_mark_object(i64 %21) #16
   %rubyId_bar.i.i = load i64, i64* @rubyIdPrecomputed_bar, align 8
-  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8
-  %24 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Foo>", i64 0, i64 0), i64 noundef 11) #16
-  call void @rb_gc_register_mark_object(i64 %24) #16
+  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
+  %22 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i14.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %22, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8
+  %23 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Foo>", i64 0, i64 0), i64 noundef 11) #16
+  call void @rb_gc_register_mark_object(i64 %23) #16
   %"rubyId_<class:Foo>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:Foo>", align 8
-  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %24, i64 %"rubyId_<class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
-  %26 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @"str_block in <class:Foo>", i64 0, i64 0), i64 noundef 20) #16
-  call void @rb_gc_register_mark_object(i64 %26) #16
-  %stackFrame.i19.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
+  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
+  %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %23, i64 %"rubyId_<class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
+  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @"str_block in <class:Foo>", i64 0, i64 0), i64 noundef 20) #16
+  call void @rb_gc_register_mark_object(i64 %25) #16
+  %stackFrame.i17.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
   %"rubyId_block in <class:Foo>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:Foo>", align 8
-  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %26, i64 %"rubyId_block in <class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i19.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>$block_1", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !28
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !28
+  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
+  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %25, i64 %"rubyId_block in <class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i17.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>$block_1", align 8
   %rubyId_proc.i = load i64, i64* @rubyIdPrecomputed_proc, align 8, !dbg !48
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_proc, i64 %rubyId_proc.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !48
   %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !48
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !44
   %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !44
-  %28 = call i64 @rb_id2sym(i64 %rubyId_x.i) #16, !dbg !44
-  store i64 %28, i64* %keywords.i, align 8, !dbg !44
+  %27 = call i64 @rb_id2sym(i64 %rubyId_x.i) #16, !dbg !44
+  store i64 %27, i64* %keywords.i, align 8, !dbg !44
   %rubyId_blk.i = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !44
-  %29 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #16, !dbg !44
-  %30 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !44
-  store i64 %29, i64* %30, align 8, !dbg !44
+  %28 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #16, !dbg !44
+  %29 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !44
+  store i64 %28, i64* %29, align 8, !dbg !44
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords.i), !dbg !44
-  %rubyId_returns10.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.1, i64 %rubyId_returns10.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !44
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !32
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !32
+  %rubyId_returns8.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !44
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.1, i64 %rubyId_returns8.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !44
+  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !33
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !33
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %0)
-  %31 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
-  %32 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %31, i64 0, i32 18
-  %33 = load i64, i64* %32, align 8, !tbaa !49
-  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
-  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !17
+  %30 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %31 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %30, i64 0, i32 18
+  %32 = load i64, i64* %31, align 8, !tbaa !49
+  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 2
+  %35 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %34, align 8, !tbaa !17
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !21
-  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
-  %39 = load i64*, i64** %38, align 8, !tbaa !23
-  %40 = load i64, i64* %39, align 8, !tbaa !6
-  %41 = and i64 %40, -33
-  store i64 %41, i64* %39, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i) #16
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %42, align 8, !dbg !57, !tbaa !15
-  %43 = load i64, i64* @rb_cObject, align 8, !dbg !58
-  %44 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 %43) #16, !dbg !58
-  %45 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %44) #16, !dbg !58
-  call fastcc void @"func_Foo.13<static-init>L62"(i64 %44, %struct.rb_control_frame_struct* %45) #16, !dbg !58
+  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %36, align 8, !tbaa !21
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 4
+  %38 = load i64*, i64** %37, align 8, !tbaa !23
+  %39 = load i64, i64* %38, align 8, !tbaa !6
+  %40 = and i64 %39, -33
+  store i64 %40, i64* %38, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %33, %struct.rb_control_frame_struct* %35, %struct.rb_iseq_struct* %stackFrame.i) #16
+  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 0
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %41, align 8, !dbg !57, !tbaa !15
+  %42 = load i64, i64* @rb_cObject, align 8, !dbg !58
+  %43 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 %42) #16, !dbg !58
+  %44 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %43) #16, !dbg !58
+  call fastcc void @"func_Foo.13<static-init>L62"(i64 %43, %struct.rb_control_frame_struct* %44) #16, !dbg !58
   call void @sorbet_popFrame() #16, !dbg !58
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %42, align 8, !dbg !58, !tbaa !15
-  %46 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !46
-  %47 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !33
-  %needTakeSlowPath = icmp ne i64 %46, %47, !dbg !46
-  br i1 %needTakeSlowPath, label %48, label %49, !dbg !46, !prof !35
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %41, align 8, !dbg !58, !tbaa !15
+  %45 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !46
+  %46 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !34
+  %needTakeSlowPath = icmp ne i64 %45, %46, !dbg !46
+  br i1 %needTakeSlowPath, label %47, label %48, !dbg !46, !prof !36
 
-48:                                               ; preds = %entry
+47:                                               ; preds = %entry
   call void @const_recompute_Foo(), !dbg !46
-  br label %49, !dbg !46
+  br label %48, !dbg !46
 
-49:                                               ; preds = %entry, %48
-  %50 = load i64, i64* @guarded_const_Foo, align 8, !dbg !46
-  %51 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !46
-  %52 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !33
-  %guardUpdated = icmp eq i64 %51, %52, !dbg !46
+48:                                               ; preds = %entry, %47
+  %49 = load i64, i64* @guarded_const_Foo, align 8, !dbg !46
+  %50 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !46
+  %51 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !34
+  %guardUpdated = icmp eq i64 %50, %51, !dbg !46
   call void @llvm.assume(i1 %guardUpdated), !dbg !46
-  %53 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !46
-  %54 = load i64*, i64** %53, align 8, !dbg !46
-  store i64 %50, i64* %54, align 8, !dbg !46, !tbaa !6
-  %55 = getelementptr inbounds i64, i64* %54, i64 1, !dbg !46
-  store i64* %55, i64** %53, align 8, !dbg !46
+  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 1, !dbg !46
+  %53 = load i64*, i64** %52, align 8, !dbg !46
+  store i64 %49, i64* %53, align 8, !dbg !46, !tbaa !6
+  %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !46
+  store i64* %54, i64** %52, align 8, !dbg !46
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !46
-  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !46
-  %57 = load i64*, i64** %56, align 8, !dbg !46
-  store i64 %send, i64* %57, align 8, !dbg !46, !tbaa !6
+  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 1, !dbg !46
+  %56 = load i64*, i64** %55, align 8, !dbg !46
+  store i64 %send, i64* %56, align 8, !dbg !46, !tbaa !6
+  %57 = getelementptr inbounds i64, i64* %56, i64 1, !dbg !46
+  store i64 11, i64* %57, align 8, !dbg !46, !tbaa !6
   %58 = getelementptr inbounds i64, i64* %57, i64 1, !dbg !46
-  store i64 11, i64* %58, align 8, !dbg !46, !tbaa !6
-  %59 = getelementptr inbounds i64, i64* %58, i64 1, !dbg !46
-  store i64* %59, i64** %56, align 8, !dbg !46
-  %60 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !15
-  %61 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %60, i64 0, i32 2, !dbg !46
-  %62 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %61, align 8, !dbg !46, !tbaa !17
-  %63 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.17<static-init>$152$block_1", i8* null, i32 noundef 0, i32 noundef -1) #16, !dbg !46
-  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %62, i64 0, i32 3, !dbg !46
-  %65 = bitcast i64* %64 to %struct.rb_captured_block*, !dbg !46
-  %66 = getelementptr inbounds i64, i64* %64, i64 2, !dbg !46
-  %67 = bitcast i64* %66 to %struct.vm_ifunc**, !dbg !46
-  store %struct.vm_ifunc* %63, %struct.vm_ifunc** %67, align 8, !dbg !46, !tbaa !59
-  %68 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %60, i64 0, i32 17, !dbg !46
-  store i64 0, i64* %68, align 8, !dbg !46, !tbaa !60
+  store i64* %58, i64** %55, align 8, !dbg !46
+  %59 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !15
+  %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 2, !dbg !46
+  %61 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %60, align 8, !dbg !46, !tbaa !17
+  %62 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.17<static-init>$152$block_1", i8* null, i32 noundef 0, i32 noundef -1) #16, !dbg !46
+  %63 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %61, i64 0, i32 3, !dbg !46
+  %64 = bitcast i64* %63 to %struct.rb_captured_block*, !dbg !46
+  %65 = getelementptr inbounds i64, i64* %63, i64 2, !dbg !46
+  %66 = bitcast i64* %65 to %struct.vm_ifunc**, !dbg !46
+  store %struct.vm_ifunc* %62, %struct.vm_ifunc** %66, align 8, !dbg !46, !tbaa !59
+  %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 17, !dbg !46
+  store i64 0, i64* %67, align 8, !dbg !46, !tbaa !60
   call void @llvm.experimental.noalias.scope.decl(metadata !61) #16, !dbg !46
-  %69 = ptrtoint %struct.rb_captured_block* %65 to i64, !dbg !46
-  %70 = or i64 %69, 3, !dbg !46
-  %71 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %70) #16, !dbg !46
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %42, align 8, !dbg !46, !tbaa !15
-  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !47
-  %73 = load i64*, i64** %72, align 8, !dbg !47
-  store i64 %33, i64* %73, align 8, !dbg !47, !tbaa !6
+  %68 = ptrtoint %struct.rb_captured_block* %64 to i64, !dbg !46
+  %69 = or i64 %68, 3, !dbg !46
+  %70 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %69) #16, !dbg !46
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %41, align 8, !dbg !46, !tbaa !15
+  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 1, !dbg !47
+  %72 = load i64*, i64** %71, align 8, !dbg !47
+  store i64 %32, i64* %72, align 8, !dbg !47, !tbaa !6
+  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !47
+  store i64 %70, i64* %73, align 8, !dbg !47, !tbaa !6
   %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !47
-  store i64 %71, i64* %74, align 8, !dbg !47, !tbaa !6
-  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !47
-  store i64* %75, i64** %72, align 8, !dbg !47
+  store i64* %74, i64** %71, align 8, !dbg !47
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !47
   ret void
 }
@@ -663,7 +657,7 @@ sorbet_rb_int_plus.exit:                          ; preds = %29, %24, %33
 
 44:                                               ; preds = %sorbet_rb_int_plus.exit
   %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 8, !dbg !77
-  %46 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %45, align 8, !dbg !77, !tbaa !43
+  %46 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %45, align 8, !dbg !77, !tbaa !32
   %47 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %46, i32 noundef 0) #16, !dbg !77
   br label %rb_vm_check_ints.exit, !dbg !77
 
@@ -723,9 +717,9 @@ functionEntryInitializers:
   %rubyId_blk = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !80
   %rawSym19 = tail call i64 @rb_id2sym(i64 %rubyId_blk), !dbg !80
   %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !48
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !33
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !34
   %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !48
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !48, !prof !35
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !48, !prof !36
 
 13:                                               ; preds = %functionEntryInitializers
   tail call void @const_recompute_T(), !dbg !48
@@ -734,7 +728,7 @@ functionEntryInitializers:
 14:                                               ; preds = %functionEntryInitializers, %13
   %15 = load i64, i64* @guarded_const_T, align 8, !dbg !48
   %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !48
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !33
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !34
   %guardUpdated = icmp eq i64 %16, %17, !dbg !48
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !48
   %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !48
@@ -813,7 +807,7 @@ declare void @llvm.assume(i1 noundef) #14
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !33
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
@@ -822,7 +816,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #10 {
 define linkonce void @const_recompute_Foo() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 3)
   store i64 %1, i64* @guarded_const_Foo, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !33
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
   store i64 %2, i64* @guard_epoch_Foo, align 8
   ret void
 }
@@ -831,7 +825,7 @@ define linkonce void @const_recompute_Foo() local_unnamed_addr #10 {
 define linkonce void @const_recompute_T() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_T, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_T, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !33
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
   store i64 %2, i64* @guard_epoch_T, align 8
   ret void
 }
@@ -893,25 +887,25 @@ attributes #20 = { nounwind willreturn }
 !29 = !{!18, !19, i64 40}
 !30 = !{!18, !19, i64 44}
 !31 = !{!"branch_weights", i32 2000, i32 1}
-!32 = !DILocation(line: 6, column: 3, scope: !26)
-!33 = !{!34, !34, i64 0}
-!34 = !{!"long long", !8, i64 0}
-!35 = !{!"branch_weights", i32 1, i32 10000}
-!36 = !DILocation(line: 9, column: 3, scope: !26)
-!37 = !{!38, !19, i64 8}
-!38 = !{!"rb_sorbet_param_struct", !39, i64 0, !19, i64 4, !19, i64 8, !19, i64 12, !19, i64 16, !19, i64 20, !19, i64 24, !19, i64 28, !16, i64 32, !19, i64 40, !19, i64 44, !19, i64 48, !19, i64 52, !16, i64 56}
-!39 = !{!"", !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 1, !19, i64 1}
-!40 = !{!38, !19, i64 28}
-!41 = !{!38, !19, i64 4}
-!42 = !{!38, !16, i64 32}
-!43 = !{!18, !16, i64 56}
+!32 = !{!18, !16, i64 56}
+!33 = !DILocation(line: 6, column: 3, scope: !26)
+!34 = !{!35, !35, i64 0}
+!35 = !{!"long long", !8, i64 0}
+!36 = !{!"branch_weights", i32 1, i32 10000}
+!37 = !DILocation(line: 9, column: 3, scope: !26)
+!38 = !{!39, !19, i64 8}
+!39 = !{!"rb_sorbet_param_struct", !40, i64 0, !19, i64 4, !19, i64 8, !19, i64 12, !19, i64 16, !19, i64 20, !19, i64 24, !19, i64 28, !16, i64 32, !19, i64 40, !19, i64 44, !19, i64 48, !19, i64 52, !16, i64 56}
+!40 = !{!"", !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 1, !19, i64 1}
+!41 = !{!39, !19, i64 28}
+!42 = !{!39, !19, i64 4}
+!43 = !{!39, !16, i64 32}
 !44 = !DILocation(line: 8, column: 8, scope: !45)
 !45 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.13<static-init>L62$block_1", scope: !26, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !46 = !DILocation(line: 15, column: 10, scope: !11)
 !47 = !DILocation(line: 18, column: 1, scope: !11)
 !48 = !DILocation(line: 8, column: 32, scope: !45)
 !49 = !{!50, !7, i64 400}
-!50 = !{!"rb_vm_struct", !7, i64 0, !51, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !34, i64 216, !8, i64 224, !52, i64 264, !52, i64 280, !52, i64 296, !52, i64 312, !7, i64 328, !19, i64 336, !19, i64 340, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !54, i64 472, !55, i64 992, !16, i64 1016, !16, i64 1024, !19, i64 1032, !19, i64 1036, !52, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !19, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !19, i64 1192, !56, i64 1200, !8, i64 1232}
+!50 = !{!"rb_vm_struct", !7, i64 0, !51, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !35, i64 216, !8, i64 224, !52, i64 264, !52, i64 280, !52, i64 296, !52, i64 312, !7, i64 328, !19, i64 336, !19, i64 340, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !54, i64 472, !55, i64 992, !16, i64 1016, !16, i64 1024, !19, i64 1032, !19, i64 1036, !52, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !19, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !19, i64 1192, !56, i64 1200, !8, i64 1232}
 !51 = !{!"rb_global_vm_lock_struct", !16, i64 0, !8, i64 8, !52, i64 48, !16, i64 64, !19, i64 72, !8, i64 80, !8, i64 128, !19, i64 176, !19, i64 180}
 !52 = !{!"list_head", !53, i64 0}
 !53 = !{!"list_node", !16, i64 0, !16, i64 8}

--- a/test/testdata/compiler/float-intrinsics.llo.exp
+++ b/test/testdata/compiler/float-intrinsics.llo.exp
@@ -121,8 +121,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_2" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_3" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_4" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@ic_sig = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_sig = internal unnamed_addr global i64 0, align 8
 @rubyIdPrecomputed_x = internal unnamed_addr global i64 0, align 8
 @str_x = private unnamed_addr constant [2 x i8] c"x\00", align 1
 @rubyIdPrecomputed_y = internal unnamed_addr global i64 0, align 8
@@ -138,19 +136,16 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_returns = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_returns = internal unnamed_addr global i64 0, align 8
 @str_returns = private unnamed_addr constant [8 x i8] c"returns\00", align 1
-@ic_sig.2 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_untyped.3 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_params.4 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_untyped.5 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_returns.6 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_sig.7 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_untyped.8 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_params.9 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_returns.10 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_sig.11 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_untyped.12 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_params.13 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_returns.14 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_untyped.2 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_params.3 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_untyped.4 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_returns.5 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_untyped.6 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_params.7 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_returns.8 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_untyped.9 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_params.10 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_returns.11 = internal global %struct.FunctionInlineCache zeroinitializer
 @"str_T::Sig" = private unnamed_addr constant [7 x i8] c"T::Sig\00", align 1
 @ic_extend = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_extend = internal unnamed_addr global i64 0, align 8
@@ -162,59 +157,59 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @rubyIdPrecomputed_p = internal unnamed_addr global i64 0, align 8
 @str_p = private unnamed_addr constant [2 x i8] c"p\00", align 1
 @ic_minus = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.15 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.12 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lt = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.16 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lt.17 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.18 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.13 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lt.14 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.15 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lte = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.19 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lte.20 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.21 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lte.22 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.23 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_plus.24 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.25 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.16 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lte.17 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.18 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lte.19 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.20 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_plus.21 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.22 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_8.9 = internal unnamed_addr global i64 0, align 8
 @str_8.9 = private unnamed_addr constant [4 x i8] c"8.9\00", align 1
 @ic_Rational = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_Rational = internal unnamed_addr global i64 0, align 8
 @str_Rational = private unnamed_addr constant [9 x i8] c"Rational\00", align 1
-@ic_plus.26 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.27 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_plus.23 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.24 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_5 = internal unnamed_addr global i64 0, align 8
 @str_5 = private unnamed_addr constant [2 x i8] c"5\00", align 1
 @ic_Complex = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_Complex = internal unnamed_addr global i64 0, align 8
 @str_Complex = private unnamed_addr constant [8 x i8] c"Complex\00", align 1
-@ic_plus.28 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.29 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_minus.30 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.31 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_plus.25 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.26 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_minus.27 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.28 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_15.4 = internal unnamed_addr global i64 0, align 8
 @str_15.4 = private unnamed_addr constant [5 x i8] c"15.4\00", align 1
-@ic_Rational.32 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_minus.33 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.34 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_Rational.29 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_minus.30 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.31 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_18 = internal unnamed_addr global i64 0, align 8
 @str_18 = private unnamed_addr constant [3 x i8] c"18\00", align 1
-@ic_Complex.35 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_minus.36 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.37 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lt.38 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.39 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_Complex.32 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_minus.33 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.34 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lt.35 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.36 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_25.4 = internal unnamed_addr global i64 0, align 8
 @str_25.4 = private unnamed_addr constant [5 x i8] c"25.4\00", align 1
-@ic_Rational.40 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lt.41 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.42 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lte.43 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.44 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_Rational.37 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lt.38 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.39 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lte.40 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.41 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_5.923 = internal unnamed_addr global i64 0, align 8
 @str_5.923 = private unnamed_addr constant [6 x i8] c"5.923\00", align 1
-@ic_Rational.45 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_lte.46 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_p.47 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_Rational.42 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_lte.43 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_p.44 = internal global %struct.FunctionInlineCache zeroinitializer
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
@@ -582,7 +577,7 @@ codeRepl:                                         ; preds = %rb_vm_check_ints.ex
 
 ; Function Attrs: nounwind sspreq uwtable
 define internal fastcc void @"func_<root>.17<static-init>$152"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #6 !dbg !57 {
-fastSymCallIntrinsic_ResolvedSig_sig:
+functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -608,19 +603,19 @@ fastSymCallIntrinsic_ResolvedSig_sig:
   %14 = xor i32 %13, -1, !dbg !63
   %15 = and i32 %14, %11, !dbg !63
   %16 = icmp eq i32 %15, 0, !dbg !63
-  br i1 %16, label %fastSymCallIntrinsic_ResolvedSig_sig267, label %17, !dbg !63, !prof !21
+  br i1 %16, label %rb_vm_check_ints.exit3, label %17, !dbg !63, !prof !21
 
-17:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig
+17:                                               ; preds = %functionEntryInitializers
   %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !63
   %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !63, !tbaa !32
   %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !63
-  br label %fastSymCallIntrinsic_ResolvedSig_sig267, !dbg !63
+  br label %rb_vm_check_ints.exit3, !dbg !63
 
-fastSymCallIntrinsic_ResolvedSig_sig267:          ; preds = %fastSymCallIntrinsic_ResolvedSig_sig, %17
+rb_vm_check_ints.exit3:                           ; preds = %functionEntryInitializers, %17
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !63, !tbaa !14
   %rubyId_minus = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !64
-  %rawSym261 = tail call i64 @rb_id2sym(i64 %rubyId_minus), !dbg !64
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym261, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_2"), !dbg !64
+  %rawSym258 = tail call i64 @rb_id2sym(i64 %rubyId_minus), !dbg !64
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym258, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_2"), !dbg !64
   %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !64, !tbaa !14
   %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !64
   %23 = load i32, i32* %22, align 8, !dbg !64, !tbaa !27
@@ -629,19 +624,19 @@ fastSymCallIntrinsic_ResolvedSig_sig267:          ; preds = %fastSymCallIntrinsi
   %26 = xor i32 %25, -1, !dbg !64
   %27 = and i32 %26, %23, !dbg !64
   %28 = icmp eq i32 %27, 0, !dbg !64
-  br i1 %28, label %fastSymCallIntrinsic_ResolvedSig_sig286, label %29, !dbg !64, !prof !21
+  br i1 %28, label %rb_vm_check_ints.exit5, label %29, !dbg !64, !prof !21
 
-29:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig267
+29:                                               ; preds = %rb_vm_check_ints.exit3
   %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !64
   %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !64, !tbaa !32
   %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #15, !dbg !64
-  br label %fastSymCallIntrinsic_ResolvedSig_sig286, !dbg !64
+  br label %rb_vm_check_ints.exit5, !dbg !64
 
-fastSymCallIntrinsic_ResolvedSig_sig286:          ; preds = %fastSymCallIntrinsic_ResolvedSig_sig267, %29
+rb_vm_check_ints.exit5:                           ; preds = %rb_vm_check_ints.exit3, %29
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %8, align 8, !dbg !64, !tbaa !14
   %rubyId_lt = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !65
-  %rawSym280 = tail call i64 @rb_id2sym(i64 %rubyId_lt), !dbg !65
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym280, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_3"), !dbg !65
+  %rawSym272 = tail call i64 @rb_id2sym(i64 %rubyId_lt), !dbg !65
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym272, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_3"), !dbg !65
   %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !14
   %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 5, !dbg !65
   %35 = load i32, i32* %34, align 8, !dbg !65, !tbaa !27
@@ -650,648 +645,648 @@ fastSymCallIntrinsic_ResolvedSig_sig286:          ; preds = %fastSymCallIntrinsi
   %38 = xor i32 %37, -1, !dbg !65
   %39 = and i32 %38, %35, !dbg !65
   %40 = icmp eq i32 %39, 0, !dbg !65
-  br i1 %40, label %fastSymCallIntrinsic_ResolvedSig_sig305, label %41, !dbg !65, !prof !21
+  br i1 %40, label %rb_vm_check_ints.exit7, label %41, !dbg !65, !prof !21
 
-41:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig286
+41:                                               ; preds = %rb_vm_check_ints.exit5
   %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 8, !dbg !65
   %43 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %42, align 8, !dbg !65, !tbaa !32
   %44 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %43, i32 noundef 0) #15, !dbg !65
-  br label %fastSymCallIntrinsic_ResolvedSig_sig305, !dbg !65
+  br label %rb_vm_check_ints.exit7, !dbg !65
 
-afterSend302:                                     ; preds = %368, %fastSymCallIntrinsic_ResolvedSig_sig305
+rb_vm_check_ints.exit7:                           ; preds = %rb_vm_check_ints.exit5, %41
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %8, align 8, !dbg !65, !tbaa !14
+  %rubyId_lte = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !66
+  %rawSym286 = tail call i64 @rb_id2sym(i64 %rubyId_lte), !dbg !66
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym286, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_4"), !dbg !66
+  %45 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !14
+  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 5, !dbg !66
+  %47 = load i32, i32* %46, align 8, !dbg !66, !tbaa !27
+  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 6, !dbg !66
+  %49 = load i32, i32* %48, align 4, !dbg !66, !tbaa !31
+  %50 = xor i32 %49, -1, !dbg !66
+  %51 = and i32 %50, %47, !dbg !66
+  %52 = icmp eq i32 %51, 0, !dbg !66
+  br i1 %52, label %rb_vm_check_ints.exit6, label %53, !dbg !66, !prof !21
+
+53:                                               ; preds = %rb_vm_check_ints.exit7
+  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 8, !dbg !66
+  %55 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %54, align 8, !dbg !66, !tbaa !32
+  %56 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %55, i32 noundef 0) #15, !dbg !66
+  br label %rb_vm_check_ints.exit6, !dbg !66
+
+rb_vm_check_ints.exit6:                           ; preds = %rb_vm_check_ints.exit7, %53
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !66, !tbaa !14
-  %45 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !67
-  %46 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !68
-  %needTakeSlowPath = icmp ne i64 %45, %46, !dbg !67
-  br i1 %needTakeSlowPath, label %47, label %48, !dbg !67, !prof !70
+  %57 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !67
+  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !68
+  %needTakeSlowPath = icmp ne i64 %57, %58, !dbg !67
+  br i1 %needTakeSlowPath, label %59, label %60, !dbg !67, !prof !70
 
-47:                                               ; preds = %afterSend302
+59:                                               ; preds = %rb_vm_check_ints.exit6
   tail call void @"const_recompute_T::Sig"(), !dbg !67
-  br label %48, !dbg !67
+  br label %60, !dbg !67
 
-48:                                               ; preds = %afterSend302, %47
-  %49 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !67
-  %50 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !67
-  %51 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !68
-  %guardUpdated = icmp eq i64 %50, %51, !dbg !67
+60:                                               ; preds = %rb_vm_check_ints.exit6, %59
+  %61 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !67
+  %62 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !67
+  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !68
+  %guardUpdated = icmp eq i64 %62, %63, !dbg !67
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !67
-  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !67
-  %53 = load i64*, i64** %52, align 8, !dbg !67
-  store i64 %selfRaw, i64* %53, align 8, !dbg !67, !tbaa !6
-  %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !67
-  store i64 %49, i64* %54, align 8, !dbg !67, !tbaa !6
-  %55 = getelementptr inbounds i64, i64* %54, i64 1, !dbg !67
-  store i64* %55, i64** %52, align 8, !dbg !67
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !67
+  %65 = load i64*, i64** %64, align 8, !dbg !67
+  store i64 %selfRaw, i64* %65, align 8, !dbg !67, !tbaa !6
+  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !67
+  store i64 %61, i64* %66, align 8, !dbg !67, !tbaa !6
+  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !67
+  store i64* %67, i64** %64, align 8, !dbg !67
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !67
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !67, !tbaa !14
-  %rubyId_plus321 = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !71
-  %rawSym322 = tail call i64 @rb_id2sym(i64 %rubyId_plus321), !dbg !71
+  %rubyId_plus303 = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !71
+  %rawSym304 = tail call i64 @rb_id2sym(i64 %rubyId_plus303), !dbg !71
   %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !71
-  %rawSym323 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !71
-  %56 = load i64, i64* @rb_cObject, align 8, !dbg !71
-  %stackFrame327 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8, !dbg !71
-  %57 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !71
-  %58 = bitcast i8* %57 to i16*, !dbg !71
-  %59 = load i16, i16* %58, align 8, !dbg !71
-  %60 = and i16 %59, -384, !dbg !71
-  %61 = or i16 %60, 1, !dbg !71
-  store i16 %61, i16* %58, align 8, !dbg !71
-  %62 = getelementptr inbounds i8, i8* %57, i64 8, !dbg !71
-  %63 = bitcast i8* %62 to i32*, !dbg !71
-  store i32 2, i32* %63, align 8, !dbg !71, !tbaa !72
-  %64 = getelementptr inbounds i8, i8* %57, i64 12, !dbg !71
-  %65 = bitcast i8* %64 to i32*, !dbg !71
-  %66 = getelementptr inbounds i8, i8* %57, i64 4, !dbg !71
-  %67 = bitcast i8* %66 to i32*, !dbg !71
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %64, i8 0, i64 20, i1 false), !dbg !71
-  store i32 2, i32* %67, align 4, !dbg !71, !tbaa !75
+  %rawSym305 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !71
+  %68 = load i64, i64* @rb_cObject, align 8, !dbg !71
+  %stackFrame309 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8, !dbg !71
+  %69 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !71
+  %70 = bitcast i8* %69 to i16*, !dbg !71
+  %71 = load i16, i16* %70, align 8, !dbg !71
+  %72 = and i16 %71, -384, !dbg !71
+  %73 = or i16 %72, 1, !dbg !71
+  store i16 %73, i16* %70, align 8, !dbg !71
+  %74 = getelementptr inbounds i8, i8* %69, i64 8, !dbg !71
+  %75 = bitcast i8* %74 to i32*, !dbg !71
+  store i32 2, i32* %75, align 8, !dbg !71, !tbaa !72
+  %76 = getelementptr inbounds i8, i8* %69, i64 12, !dbg !71
+  %77 = bitcast i8* %76 to i32*, !dbg !71
+  %78 = getelementptr inbounds i8, i8* %69, i64 4, !dbg !71
+  %79 = bitcast i8* %78 to i32*, !dbg !71
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 20, i1 false), !dbg !71
+  store i32 2, i32* %79, align 4, !dbg !71, !tbaa !75
   %positional_table = alloca i64, i32 2, align 8, !dbg !71
   %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !71
   store i64 %rubyId_x, i64* %positional_table, align 8, !dbg !71
   %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !71
-  %68 = getelementptr i64, i64* %positional_table, i32 1, !dbg !71
-  store i64 %rubyId_y, i64* %68, align 8, !dbg !71
-  %69 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !71
-  %70 = bitcast i64* %positional_table to i8*, !dbg !71
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %69, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %70, i64 noundef 16, i1 noundef false) #15, !dbg !71
-  %71 = getelementptr inbounds i8, i8* %57, i64 32, !dbg !71
-  %72 = bitcast i8* %71 to i8**, !dbg !71
-  store i8* %69, i8** %72, align 8, !dbg !71, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %56, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#4plus", i8* nonnull %57, %struct.rb_iseq_struct* %stackFrame327, i1 noundef zeroext false) #15, !dbg !71
-  %73 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !71, !tbaa !14
-  %74 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %73, i64 0, i32 5, !dbg !71
-  %75 = load i32, i32* %74, align 8, !dbg !71, !tbaa !27
-  %76 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %73, i64 0, i32 6, !dbg !71
-  %77 = load i32, i32* %76, align 4, !dbg !71, !tbaa !31
-  %78 = xor i32 %77, -1, !dbg !71
-  %79 = and i32 %78, %75, !dbg !71
-  %80 = icmp eq i32 %79, 0, !dbg !71
-  br i1 %80, label %rb_vm_check_ints.exit5, label %81, !dbg !71, !prof !21
+  %80 = getelementptr i64, i64* %positional_table, i32 1, !dbg !71
+  store i64 %rubyId_y, i64* %80, align 8, !dbg !71
+  %81 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !71
+  %82 = bitcast i64* %positional_table to i8*, !dbg !71
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %81, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %82, i64 noundef 16, i1 noundef false) #15, !dbg !71
+  %83 = getelementptr inbounds i8, i8* %69, i64 32, !dbg !71
+  %84 = bitcast i8* %83 to i8**, !dbg !71
+  store i8* %81, i8** %84, align 8, !dbg !71, !tbaa !76
+  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#4plus", i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame309, i1 noundef zeroext false) #15, !dbg !71
+  %85 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !71, !tbaa !14
+  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 5, !dbg !71
+  %87 = load i32, i32* %86, align 8, !dbg !71, !tbaa !27
+  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 6, !dbg !71
+  %89 = load i32, i32* %88, align 4, !dbg !71, !tbaa !31
+  %90 = xor i32 %89, -1, !dbg !71
+  %91 = and i32 %90, %87, !dbg !71
+  %92 = icmp eq i32 %91, 0, !dbg !71
+  br i1 %92, label %rb_vm_check_ints.exit4, label %93, !dbg !71, !prof !21
 
-81:                                               ; preds = %48
-  %82 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %73, i64 0, i32 8, !dbg !71
-  %83 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %82, align 8, !dbg !71, !tbaa !32
-  %84 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %83, i32 noundef 0) #15, !dbg !71
-  br label %rb_vm_check_ints.exit5, !dbg !71
+93:                                               ; preds = %60
+  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 8, !dbg !71
+  %95 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %94, align 8, !dbg !71, !tbaa !32
+  %96 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %95, i32 noundef 0) #15, !dbg !71
+  br label %rb_vm_check_ints.exit4, !dbg !71
 
-rb_vm_check_ints.exit5:                           ; preds = %48, %81
+rb_vm_check_ints.exit4:                           ; preds = %60, %93
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !71, !tbaa !14
-  %rubyId_minus329 = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !77
-  %rawSym330 = tail call i64 @rb_id2sym(i64 %rubyId_minus329), !dbg !77
-  %rubyId_normal331 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !77
-  %rawSym332 = tail call i64 @rb_id2sym(i64 %rubyId_normal331), !dbg !77
-  %stackFrame337 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8, !dbg !77
-  %85 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !77
-  %86 = bitcast i8* %85 to i16*, !dbg !77
-  %87 = load i16, i16* %86, align 8, !dbg !77
-  %88 = and i16 %87, -384, !dbg !77
-  %89 = or i16 %88, 1, !dbg !77
-  store i16 %89, i16* %86, align 8, !dbg !77
-  %90 = getelementptr inbounds i8, i8* %85, i64 8, !dbg !77
-  %91 = bitcast i8* %90 to i32*, !dbg !77
-  store i32 2, i32* %91, align 8, !dbg !77, !tbaa !72
-  %92 = getelementptr inbounds i8, i8* %85, i64 12, !dbg !77
-  %93 = bitcast i8* %92 to i32*, !dbg !77
-  %94 = getelementptr inbounds i8, i8* %85, i64 4, !dbg !77
-  %95 = bitcast i8* %94 to i32*, !dbg !77
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %92, i8 0, i64 20, i1 false), !dbg !77
-  store i32 2, i32* %95, align 4, !dbg !77, !tbaa !75
-  %positional_table339 = alloca i64, i32 2, align 8, !dbg !77
-  %rubyId_x340 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !77
-  store i64 %rubyId_x340, i64* %positional_table339, align 8, !dbg !77
-  %rubyId_y341 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !77
-  %96 = getelementptr i64, i64* %positional_table339, i32 1, !dbg !77
-  store i64 %rubyId_y341, i64* %96, align 8, !dbg !77
-  %97 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !77
-  %98 = bitcast i64* %positional_table339 to i8*, !dbg !77
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %97, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %98, i64 noundef 16, i1 noundef false) #15, !dbg !77
-  %99 = getelementptr inbounds i8, i8* %85, i64 32, !dbg !77
-  %100 = bitcast i8* %99 to i8**, !dbg !77
-  store i8* %97, i8** %100, align 8, !dbg !77, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %56, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#5minus", i8* nonnull %85, %struct.rb_iseq_struct* %stackFrame337, i1 noundef zeroext false) #15, !dbg !77
-  %101 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !77, !tbaa !14
-  %102 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 5, !dbg !77
-  %103 = load i32, i32* %102, align 8, !dbg !77, !tbaa !27
-  %104 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 6, !dbg !77
-  %105 = load i32, i32* %104, align 4, !dbg !77, !tbaa !31
-  %106 = xor i32 %105, -1, !dbg !77
-  %107 = and i32 %106, %103, !dbg !77
-  %108 = icmp eq i32 %107, 0, !dbg !77
-  br i1 %108, label %rb_vm_check_ints.exit3, label %109, !dbg !77, !prof !21
+  %rubyId_minus311 = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !77
+  %rawSym312 = tail call i64 @rb_id2sym(i64 %rubyId_minus311), !dbg !77
+  %rubyId_normal313 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !77
+  %rawSym314 = tail call i64 @rb_id2sym(i64 %rubyId_normal313), !dbg !77
+  %stackFrame319 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8, !dbg !77
+  %97 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !77
+  %98 = bitcast i8* %97 to i16*, !dbg !77
+  %99 = load i16, i16* %98, align 8, !dbg !77
+  %100 = and i16 %99, -384, !dbg !77
+  %101 = or i16 %100, 1, !dbg !77
+  store i16 %101, i16* %98, align 8, !dbg !77
+  %102 = getelementptr inbounds i8, i8* %97, i64 8, !dbg !77
+  %103 = bitcast i8* %102 to i32*, !dbg !77
+  store i32 2, i32* %103, align 8, !dbg !77, !tbaa !72
+  %104 = getelementptr inbounds i8, i8* %97, i64 12, !dbg !77
+  %105 = bitcast i8* %104 to i32*, !dbg !77
+  %106 = getelementptr inbounds i8, i8* %97, i64 4, !dbg !77
+  %107 = bitcast i8* %106 to i32*, !dbg !77
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %104, i8 0, i64 20, i1 false), !dbg !77
+  store i32 2, i32* %107, align 4, !dbg !77, !tbaa !75
+  %positional_table321 = alloca i64, i32 2, align 8, !dbg !77
+  %rubyId_x322 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !77
+  store i64 %rubyId_x322, i64* %positional_table321, align 8, !dbg !77
+  %rubyId_y323 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !77
+  %108 = getelementptr i64, i64* %positional_table321, i32 1, !dbg !77
+  store i64 %rubyId_y323, i64* %108, align 8, !dbg !77
+  %109 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !77
+  %110 = bitcast i64* %positional_table321 to i8*, !dbg !77
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %109, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %110, i64 noundef 16, i1 noundef false) #15, !dbg !77
+  %111 = getelementptr inbounds i8, i8* %97, i64 32, !dbg !77
+  %112 = bitcast i8* %111 to i8**, !dbg !77
+  store i8* %109, i8** %112, align 8, !dbg !77, !tbaa !76
+  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#5minus", i8* nonnull %97, %struct.rb_iseq_struct* %stackFrame319, i1 noundef zeroext false) #15, !dbg !77
+  %113 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !77, !tbaa !14
+  %114 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 5, !dbg !77
+  %115 = load i32, i32* %114, align 8, !dbg !77, !tbaa !27
+  %116 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 6, !dbg !77
+  %117 = load i32, i32* %116, align 4, !dbg !77, !tbaa !31
+  %118 = xor i32 %117, -1, !dbg !77
+  %119 = and i32 %118, %115, !dbg !77
+  %120 = icmp eq i32 %119, 0, !dbg !77
+  br i1 %120, label %rb_vm_check_ints.exit2, label %121, !dbg !77, !prof !21
 
-109:                                              ; preds = %rb_vm_check_ints.exit5
-  %110 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 8, !dbg !77
-  %111 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %110, align 8, !dbg !77, !tbaa !32
-  %112 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %111, i32 noundef 0) #15, !dbg !77
-  br label %rb_vm_check_ints.exit3, !dbg !77
+121:                                              ; preds = %rb_vm_check_ints.exit4
+  %122 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 8, !dbg !77
+  %123 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %122, align 8, !dbg !77, !tbaa !32
+  %124 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %123, i32 noundef 0) #15, !dbg !77
+  br label %rb_vm_check_ints.exit2, !dbg !77
 
-rb_vm_check_ints.exit3:                           ; preds = %rb_vm_check_ints.exit5, %109
+rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.exit4, %121
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !dbg !77, !tbaa !14
-  %rubyId_lt343 = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !78
-  %rawSym344 = tail call i64 @rb_id2sym(i64 %rubyId_lt343), !dbg !78
-  %rubyId_normal345 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !78
-  %rawSym346 = tail call i64 @rb_id2sym(i64 %rubyId_normal345), !dbg !78
-  %stackFrame351 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8, !dbg !78
-  %113 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !78
-  %114 = bitcast i8* %113 to i16*, !dbg !78
-  %115 = load i16, i16* %114, align 8, !dbg !78
-  %116 = and i16 %115, -384, !dbg !78
-  %117 = or i16 %116, 1, !dbg !78
-  store i16 %117, i16* %114, align 8, !dbg !78
-  %118 = getelementptr inbounds i8, i8* %113, i64 8, !dbg !78
-  %119 = bitcast i8* %118 to i32*, !dbg !78
-  store i32 2, i32* %119, align 8, !dbg !78, !tbaa !72
-  %120 = getelementptr inbounds i8, i8* %113, i64 12, !dbg !78
-  %121 = bitcast i8* %120 to i32*, !dbg !78
-  %122 = getelementptr inbounds i8, i8* %113, i64 4, !dbg !78
-  %123 = bitcast i8* %122 to i32*, !dbg !78
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %120, i8 0, i64 20, i1 false), !dbg !78
-  store i32 2, i32* %123, align 4, !dbg !78, !tbaa !75
-  %positional_table353 = alloca i64, i32 2, align 8, !dbg !78
-  %rubyId_x354 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !78
-  store i64 %rubyId_x354, i64* %positional_table353, align 8, !dbg !78
-  %rubyId_y355 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !78
-  %124 = getelementptr i64, i64* %positional_table353, i32 1, !dbg !78
-  store i64 %rubyId_y355, i64* %124, align 8, !dbg !78
-  %125 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !78
-  %126 = bitcast i64* %positional_table353 to i8*, !dbg !78
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %125, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %126, i64 noundef 16, i1 noundef false) #15, !dbg !78
-  %127 = getelementptr inbounds i8, i8* %113, i64 32, !dbg !78
-  %128 = bitcast i8* %127 to i8**, !dbg !78
-  store i8* %125, i8** %128, align 8, !dbg !78, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %56, i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#2lt", i8* nonnull %113, %struct.rb_iseq_struct* %stackFrame351, i1 noundef zeroext false) #15, !dbg !78
-  %129 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !14
-  %130 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %129, i64 0, i32 5, !dbg !78
-  %131 = load i32, i32* %130, align 8, !dbg !78, !tbaa !27
-  %132 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %129, i64 0, i32 6, !dbg !78
-  %133 = load i32, i32* %132, align 4, !dbg !78, !tbaa !31
-  %134 = xor i32 %133, -1, !dbg !78
-  %135 = and i32 %134, %131, !dbg !78
-  %136 = icmp eq i32 %135, 0, !dbg !78
-  br i1 %136, label %rb_vm_check_ints.exit2, label %137, !dbg !78, !prof !21
+  %rubyId_lt325 = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !78
+  %rawSym326 = tail call i64 @rb_id2sym(i64 %rubyId_lt325), !dbg !78
+  %rubyId_normal327 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !78
+  %rawSym328 = tail call i64 @rb_id2sym(i64 %rubyId_normal327), !dbg !78
+  %stackFrame333 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8, !dbg !78
+  %125 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !78
+  %126 = bitcast i8* %125 to i16*, !dbg !78
+  %127 = load i16, i16* %126, align 8, !dbg !78
+  %128 = and i16 %127, -384, !dbg !78
+  %129 = or i16 %128, 1, !dbg !78
+  store i16 %129, i16* %126, align 8, !dbg !78
+  %130 = getelementptr inbounds i8, i8* %125, i64 8, !dbg !78
+  %131 = bitcast i8* %130 to i32*, !dbg !78
+  store i32 2, i32* %131, align 8, !dbg !78, !tbaa !72
+  %132 = getelementptr inbounds i8, i8* %125, i64 12, !dbg !78
+  %133 = bitcast i8* %132 to i32*, !dbg !78
+  %134 = getelementptr inbounds i8, i8* %125, i64 4, !dbg !78
+  %135 = bitcast i8* %134 to i32*, !dbg !78
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %132, i8 0, i64 20, i1 false), !dbg !78
+  store i32 2, i32* %135, align 4, !dbg !78, !tbaa !75
+  %positional_table335 = alloca i64, i32 2, align 8, !dbg !78
+  %rubyId_x336 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !78
+  store i64 %rubyId_x336, i64* %positional_table335, align 8, !dbg !78
+  %rubyId_y337 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !78
+  %136 = getelementptr i64, i64* %positional_table335, i32 1, !dbg !78
+  store i64 %rubyId_y337, i64* %136, align 8, !dbg !78
+  %137 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !78
+  %138 = bitcast i64* %positional_table335 to i8*, !dbg !78
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %137, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %138, i64 noundef 16, i1 noundef false) #15, !dbg !78
+  %139 = getelementptr inbounds i8, i8* %125, i64 32, !dbg !78
+  %140 = bitcast i8* %139 to i8**, !dbg !78
+  store i8* %137, i8** %140, align 8, !dbg !78, !tbaa !76
+  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#2lt", i8* nonnull %125, %struct.rb_iseq_struct* %stackFrame333, i1 noundef zeroext false) #15, !dbg !78
+  %141 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !14
+  %142 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 5, !dbg !78
+  %143 = load i32, i32* %142, align 8, !dbg !78, !tbaa !27
+  %144 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 6, !dbg !78
+  %145 = load i32, i32* %144, align 4, !dbg !78, !tbaa !31
+  %146 = xor i32 %145, -1, !dbg !78
+  %147 = and i32 %146, %143, !dbg !78
+  %148 = icmp eq i32 %147, 0, !dbg !78
+  br i1 %148, label %rb_vm_check_ints.exit1, label %149, !dbg !78, !prof !21
 
-137:                                              ; preds = %rb_vm_check_ints.exit3
-  %138 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %129, i64 0, i32 8, !dbg !78
-  %139 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %138, align 8, !dbg !78, !tbaa !32
-  %140 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %139, i32 noundef 0) #15, !dbg !78
-  br label %rb_vm_check_ints.exit2, !dbg !78
+149:                                              ; preds = %rb_vm_check_ints.exit2
+  %150 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 8, !dbg !78
+  %151 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %150, align 8, !dbg !78, !tbaa !32
+  %152 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %151, i32 noundef 0) #15, !dbg !78
+  br label %rb_vm_check_ints.exit1, !dbg !78
 
-rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.exit3, %137
+rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.exit2, %149
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %8, align 8, !dbg !78, !tbaa !14
-  %rubyId_lte357 = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !79
-  %rawSym358 = tail call i64 @rb_id2sym(i64 %rubyId_lte357), !dbg !79
-  %rubyId_normal359 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !79
-  %rawSym360 = tail call i64 @rb_id2sym(i64 %rubyId_normal359), !dbg !79
-  %stackFrame365 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8, !dbg !79
-  %141 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !79
-  %142 = bitcast i8* %141 to i16*, !dbg !79
-  %143 = load i16, i16* %142, align 8, !dbg !79
-  %144 = and i16 %143, -384, !dbg !79
-  %145 = or i16 %144, 1, !dbg !79
-  store i16 %145, i16* %142, align 8, !dbg !79
-  %146 = getelementptr inbounds i8, i8* %141, i64 8, !dbg !79
-  %147 = bitcast i8* %146 to i32*, !dbg !79
-  store i32 2, i32* %147, align 8, !dbg !79, !tbaa !72
-  %148 = getelementptr inbounds i8, i8* %141, i64 12, !dbg !79
-  %149 = bitcast i8* %148 to i32*, !dbg !79
-  %150 = getelementptr inbounds i8, i8* %141, i64 4, !dbg !79
-  %151 = bitcast i8* %150 to i32*, !dbg !79
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %148, i8 0, i64 20, i1 false), !dbg !79
-  store i32 2, i32* %151, align 4, !dbg !79, !tbaa !75
-  %positional_table367 = alloca i64, i32 2, align 8, !dbg !79
-  %rubyId_x368 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !79
-  store i64 %rubyId_x368, i64* %positional_table367, align 8, !dbg !79
-  %rubyId_y369 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !79
-  %152 = getelementptr i64, i64* %positional_table367, i32 1, !dbg !79
-  store i64 %rubyId_y369, i64* %152, align 8, !dbg !79
-  %153 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !79
-  %154 = bitcast i64* %positional_table367 to i8*, !dbg !79
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %153, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %154, i64 noundef 16, i1 noundef false) #15, !dbg !79
-  %155 = getelementptr inbounds i8, i8* %141, i64 32, !dbg !79
-  %156 = bitcast i8* %155 to i8**, !dbg !79
-  store i8* %153, i8** %156, align 8, !dbg !79, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %56, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#3lte", i8* nonnull %141, %struct.rb_iseq_struct* %stackFrame365, i1 noundef zeroext false) #15, !dbg !79
-  %157 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !79, !tbaa !14
-  %158 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %157, i64 0, i32 5, !dbg !79
-  %159 = load i32, i32* %158, align 8, !dbg !79, !tbaa !27
-  %160 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %157, i64 0, i32 6, !dbg !79
-  %161 = load i32, i32* %160, align 4, !dbg !79, !tbaa !31
-  %162 = xor i32 %161, -1, !dbg !79
-  %163 = and i32 %162, %159, !dbg !79
-  %164 = icmp eq i32 %163, 0, !dbg !79
-  br i1 %164, label %rb_vm_check_ints.exit1, label %165, !dbg !79, !prof !21
+  %rubyId_lte339 = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !79
+  %rawSym340 = tail call i64 @rb_id2sym(i64 %rubyId_lte339), !dbg !79
+  %rubyId_normal341 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !79
+  %rawSym342 = tail call i64 @rb_id2sym(i64 %rubyId_normal341), !dbg !79
+  %stackFrame347 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8, !dbg !79
+  %153 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !79
+  %154 = bitcast i8* %153 to i16*, !dbg !79
+  %155 = load i16, i16* %154, align 8, !dbg !79
+  %156 = and i16 %155, -384, !dbg !79
+  %157 = or i16 %156, 1, !dbg !79
+  store i16 %157, i16* %154, align 8, !dbg !79
+  %158 = getelementptr inbounds i8, i8* %153, i64 8, !dbg !79
+  %159 = bitcast i8* %158 to i32*, !dbg !79
+  store i32 2, i32* %159, align 8, !dbg !79, !tbaa !72
+  %160 = getelementptr inbounds i8, i8* %153, i64 12, !dbg !79
+  %161 = bitcast i8* %160 to i32*, !dbg !79
+  %162 = getelementptr inbounds i8, i8* %153, i64 4, !dbg !79
+  %163 = bitcast i8* %162 to i32*, !dbg !79
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %160, i8 0, i64 20, i1 false), !dbg !79
+  store i32 2, i32* %163, align 4, !dbg !79, !tbaa !75
+  %positional_table349 = alloca i64, i32 2, align 8, !dbg !79
+  %rubyId_x350 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !79
+  store i64 %rubyId_x350, i64* %positional_table349, align 8, !dbg !79
+  %rubyId_y351 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !79
+  %164 = getelementptr i64, i64* %positional_table349, i32 1, !dbg !79
+  store i64 %rubyId_y351, i64* %164, align 8, !dbg !79
+  %165 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !79
+  %166 = bitcast i64* %positional_table349 to i8*, !dbg !79
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %165, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %166, i64 noundef 16, i1 noundef false) #15, !dbg !79
+  %167 = getelementptr inbounds i8, i8* %153, i64 32, !dbg !79
+  %168 = bitcast i8* %167 to i8**, !dbg !79
+  store i8* %165, i8** %168, align 8, !dbg !79, !tbaa !76
+  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_Object#3lte", i8* nonnull %153, %struct.rb_iseq_struct* %stackFrame347, i1 noundef zeroext false) #15, !dbg !79
+  %169 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !79, !tbaa !14
+  %170 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %169, i64 0, i32 5, !dbg !79
+  %171 = load i32, i32* %170, align 8, !dbg !79, !tbaa !27
+  %172 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %169, i64 0, i32 6, !dbg !79
+  %173 = load i32, i32* %172, align 4, !dbg !79, !tbaa !31
+  %174 = xor i32 %173, -1, !dbg !79
+  %175 = and i32 %174, %171, !dbg !79
+  %176 = icmp eq i32 %175, 0, !dbg !79
+  br i1 %176, label %rb_vm_check_ints.exit, label %177, !dbg !79, !prof !21
 
-165:                                              ; preds = %rb_vm_check_ints.exit2
-  %166 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %157, i64 0, i32 8, !dbg !79
-  %167 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %166, align 8, !dbg !79, !tbaa !32
-  %168 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %167, i32 noundef 0) #15, !dbg !79
-  br label %rb_vm_check_ints.exit1, !dbg !79
+177:                                              ; preds = %rb_vm_check_ints.exit1
+  %178 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %169, i64 0, i32 8, !dbg !79
+  %179 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %178, align 8, !dbg !79, !tbaa !32
+  %180 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %179, i32 noundef 0) #15, !dbg !79
+  br label %rb_vm_check_ints.exit, !dbg !79
 
-rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.exit2, %165
+rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.exit1, %177
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %8, align 8, !dbg !79, !tbaa !14
-  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !80
-  %170 = load i64*, i64** %169, align 8, !dbg !80
-  store i64 %selfRaw, i64* %170, align 8, !dbg !80, !tbaa !6
-  %171 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !80
-  %172 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !80
-  %173 = bitcast i64* %171 to <2 x i64>*, !dbg !80
-  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %173, align 8, !dbg !80, !tbaa !6
-  %174 = getelementptr inbounds i64, i64* %172, i64 1, !dbg !80
-  store i64* %174, i64** %169, align 8, !dbg !80
+  %181 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !80
+  %182 = load i64*, i64** %181, align 8, !dbg !80
+  store i64 %selfRaw, i64* %182, align 8, !dbg !80, !tbaa !6
+  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !80
+  %184 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !80
+  %185 = bitcast i64* %183 to <2 x i64>*, !dbg !80
+  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %185, align 8, !dbg !80, !tbaa !6
+  %186 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !80
+  store i64* %186, i64** %181, align 8, !dbg !80
   %send9 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus, i64 0), !dbg !80
-  %175 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !81
-  %176 = load i64*, i64** %175, align 8, !dbg !81
-  store i64 %selfRaw, i64* %176, align 8, !dbg !81, !tbaa !6
-  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !81
-  store i64 %send9, i64* %177, align 8, !dbg !81, !tbaa !6
-  %178 = getelementptr inbounds i64, i64* %177, i64 1, !dbg !81
-  store i64* %178, i64** %175, align 8, !dbg !81
+  %187 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !81
+  %188 = load i64*, i64** %187, align 8, !dbg !81
+  store i64 %selfRaw, i64* %188, align 8, !dbg !81, !tbaa !6
+  %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !81
+  store i64 %send9, i64* %189, align 8, !dbg !81, !tbaa !6
+  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !81
+  store i64* %190, i64** %187, align 8, !dbg !81
   %send11 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !81
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %8, align 8, !dbg !81, !tbaa !14
-  %179 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !82
-  %180 = load i64*, i64** %179, align 8, !dbg !82
-  store i64 %selfRaw, i64* %180, align 8, !dbg !82, !tbaa !6
-  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !82
-  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !82
-  %183 = bitcast i64* %181 to <2 x i64>*, !dbg !82
-  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %183, align 8, !dbg !82, !tbaa !6
-  %184 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !82
-  store i64* %184, i64** %179, align 8, !dbg !82
+  %191 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !82
+  %192 = load i64*, i64** %191, align 8, !dbg !82
+  store i64 %selfRaw, i64* %192, align 8, !dbg !82, !tbaa !6
+  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !82
+  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !82
+  %195 = bitcast i64* %193 to <2 x i64>*, !dbg !82
+  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %195, align 8, !dbg !82, !tbaa !6
+  %196 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !82
+  store i64* %196, i64** %191, align 8, !dbg !82
   %send13 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus, i64 0), !dbg !82
-  %185 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !83
-  %186 = load i64*, i64** %185, align 8, !dbg !83
-  store i64 %selfRaw, i64* %186, align 8, !dbg !83, !tbaa !6
-  %187 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !83
-  store i64 %send13, i64* %187, align 8, !dbg !83, !tbaa !6
-  %188 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !83
-  store i64* %188, i64** %185, align 8, !dbg !83
-  %send15 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.15, i64 0), !dbg !83
+  %197 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !83
+  %198 = load i64*, i64** %197, align 8, !dbg !83
+  store i64 %selfRaw, i64* %198, align 8, !dbg !83, !tbaa !6
+  %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !83
+  store i64 %send13, i64* %199, align 8, !dbg !83, !tbaa !6
+  %200 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !83
+  store i64* %200, i64** %197, align 8, !dbg !83
+  %send15 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.12, i64 0), !dbg !83
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %8, align 8, !dbg !83, !tbaa !14
-  %189 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !84
-  %190 = load i64*, i64** %189, align 8, !dbg !84
-  store i64 %selfRaw, i64* %190, align 8, !dbg !84, !tbaa !6
-  %191 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !84
-  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !84
-  %193 = bitcast i64* %191 to <2 x i64>*, !dbg !84
-  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %193, align 8, !dbg !84, !tbaa !6
-  %194 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !84
-  store i64* %194, i64** %189, align 8, !dbg !84
+  %201 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !84
+  %202 = load i64*, i64** %201, align 8, !dbg !84
+  store i64 %selfRaw, i64* %202, align 8, !dbg !84, !tbaa !6
+  %203 = getelementptr inbounds i64, i64* %202, i64 1, !dbg !84
+  %204 = getelementptr inbounds i64, i64* %203, i64 1, !dbg !84
+  %205 = bitcast i64* %203 to <2 x i64>*, !dbg !84
+  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %205, align 8, !dbg !84, !tbaa !6
+  %206 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !84
+  store i64* %206, i64** %201, align 8, !dbg !84
   %send17 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt, i64 0), !dbg !84
-  %195 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !85
-  %196 = load i64*, i64** %195, align 8, !dbg !85
-  store i64 %selfRaw, i64* %196, align 8, !dbg !85, !tbaa !6
-  %197 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !85
-  store i64 %send17, i64* %197, align 8, !dbg !85, !tbaa !6
-  %198 = getelementptr inbounds i64, i64* %197, i64 1, !dbg !85
-  store i64* %198, i64** %195, align 8, !dbg !85
-  %send19 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.16, i64 0), !dbg !85
+  %207 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !85
+  %208 = load i64*, i64** %207, align 8, !dbg !85
+  store i64 %selfRaw, i64* %208, align 8, !dbg !85, !tbaa !6
+  %209 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !85
+  store i64 %send17, i64* %209, align 8, !dbg !85, !tbaa !6
+  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !85
+  store i64* %210, i64** %207, align 8, !dbg !85
+  %send19 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.13, i64 0), !dbg !85
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %8, align 8, !dbg !85, !tbaa !14
-  %199 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !86
-  %200 = load i64*, i64** %199, align 8, !dbg !86
-  store i64 %selfRaw, i64* %200, align 8, !dbg !86, !tbaa !6
-  %201 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !86
-  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !86
-  %203 = bitcast i64* %201 to <2 x i64>*, !dbg !86
-  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %203, align 8, !dbg !86, !tbaa !6
-  %204 = getelementptr inbounds i64, i64* %202, i64 1, !dbg !86
-  store i64* %204, i64** %199, align 8, !dbg !86
-  %send21 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.17, i64 0), !dbg !86
-  %205 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !87
-  %206 = load i64*, i64** %205, align 8, !dbg !87
-  store i64 %selfRaw, i64* %206, align 8, !dbg !87, !tbaa !6
-  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !87
-  store i64 %send21, i64* %207, align 8, !dbg !87, !tbaa !6
-  %208 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !87
-  store i64* %208, i64** %205, align 8, !dbg !87
-  %send23 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.18, i64 0), !dbg !87
+  %211 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !86
+  %212 = load i64*, i64** %211, align 8, !dbg !86
+  store i64 %selfRaw, i64* %212, align 8, !dbg !86, !tbaa !6
+  %213 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !86
+  %214 = getelementptr inbounds i64, i64* %213, i64 1, !dbg !86
+  %215 = bitcast i64* %213 to <2 x i64>*, !dbg !86
+  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %215, align 8, !dbg !86, !tbaa !6
+  %216 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !86
+  store i64* %216, i64** %211, align 8, !dbg !86
+  %send21 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.14, i64 0), !dbg !86
+  %217 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !87
+  %218 = load i64*, i64** %217, align 8, !dbg !87
+  store i64 %selfRaw, i64* %218, align 8, !dbg !87, !tbaa !6
+  %219 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !87
+  store i64 %send21, i64* %219, align 8, !dbg !87, !tbaa !6
+  %220 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !87
+  store i64* %220, i64** %217, align 8, !dbg !87
+  %send23 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.15, i64 0), !dbg !87
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 31), i64** %8, align 8, !dbg !87, !tbaa !14
-  %209 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !88
-  %210 = load i64*, i64** %209, align 8, !dbg !88
-  store i64 %selfRaw, i64* %210, align 8, !dbg !88, !tbaa !6
-  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !88
-  %212 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !88
-  %213 = bitcast i64* %211 to <2 x i64>*, !dbg !88
-  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %213, align 8, !dbg !88, !tbaa !6
-  %214 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !88
-  store i64* %214, i64** %209, align 8, !dbg !88
+  %221 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !88
+  %222 = load i64*, i64** %221, align 8, !dbg !88
+  store i64 %selfRaw, i64* %222, align 8, !dbg !88, !tbaa !6
+  %223 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !88
+  %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !88
+  %225 = bitcast i64* %223 to <2 x i64>*, !dbg !88
+  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %225, align 8, !dbg !88, !tbaa !6
+  %226 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !88
+  store i64* %226, i64** %221, align 8, !dbg !88
   %send25 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte, i64 0), !dbg !88
-  %215 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !89
-  %216 = load i64*, i64** %215, align 8, !dbg !89
-  store i64 %selfRaw, i64* %216, align 8, !dbg !89, !tbaa !6
-  %217 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !89
-  store i64 %send25, i64* %217, align 8, !dbg !89, !tbaa !6
-  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !89
-  store i64* %218, i64** %215, align 8, !dbg !89
-  %send27 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.19, i64 0), !dbg !89
+  %227 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !89
+  %228 = load i64*, i64** %227, align 8, !dbg !89
+  store i64 %selfRaw, i64* %228, align 8, !dbg !89, !tbaa !6
+  %229 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !89
+  store i64 %send25, i64* %229, align 8, !dbg !89, !tbaa !6
+  %230 = getelementptr inbounds i64, i64* %229, i64 1, !dbg !89
+  store i64* %230, i64** %227, align 8, !dbg !89
+  %send27 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.16, i64 0), !dbg !89
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 32), i64** %8, align 8, !dbg !89, !tbaa !14
-  %219 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !90
-  %220 = load i64*, i64** %219, align 8, !dbg !90
-  store i64 %selfRaw, i64* %220, align 8, !dbg !90, !tbaa !6
-  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !90
-  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !90
-  %223 = bitcast i64* %221 to <2 x i64>*, !dbg !90
-  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %223, align 8, !dbg !90, !tbaa !6
-  %224 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !90
-  store i64* %224, i64** %219, align 8, !dbg !90
-  %send29 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.20, i64 0), !dbg !90
-  %225 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !91
-  %226 = load i64*, i64** %225, align 8, !dbg !91
-  store i64 %selfRaw, i64* %226, align 8, !dbg !91, !tbaa !6
-  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !91
-  store i64 %send29, i64* %227, align 8, !dbg !91, !tbaa !6
-  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !91
-  store i64* %228, i64** %225, align 8, !dbg !91
-  %send31 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.21, i64 0), !dbg !91
+  %231 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !90
+  %232 = load i64*, i64** %231, align 8, !dbg !90
+  store i64 %selfRaw, i64* %232, align 8, !dbg !90, !tbaa !6
+  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !90
+  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !90
+  %235 = bitcast i64* %233 to <2 x i64>*, !dbg !90
+  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %235, align 8, !dbg !90, !tbaa !6
+  %236 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !90
+  store i64* %236, i64** %231, align 8, !dbg !90
+  %send29 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.17, i64 0), !dbg !90
+  %237 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !91
+  %238 = load i64*, i64** %237, align 8, !dbg !91
+  store i64 %selfRaw, i64* %238, align 8, !dbg !91, !tbaa !6
+  %239 = getelementptr inbounds i64, i64* %238, i64 1, !dbg !91
+  store i64 %send29, i64* %239, align 8, !dbg !91, !tbaa !6
+  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !91
+  store i64* %240, i64** %237, align 8, !dbg !91
+  %send31 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.18, i64 0), !dbg !91
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 33), i64** %8, align 8, !dbg !91, !tbaa !14
-  %229 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !92
-  %230 = load i64*, i64** %229, align 8, !dbg !92
-  store i64 %selfRaw, i64* %230, align 8, !dbg !92, !tbaa !6
-  %231 = getelementptr inbounds i64, i64* %230, i64 1, !dbg !92
-  %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !92
-  %233 = bitcast i64* %231 to <2 x i64>*, !dbg !92
-  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %233, align 8, !dbg !92, !tbaa !6
-  %234 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !92
-  store i64* %234, i64** %229, align 8, !dbg !92
-  %send33 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.22, i64 0), !dbg !92
-  %235 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !93
-  %236 = load i64*, i64** %235, align 8, !dbg !93
-  store i64 %selfRaw, i64* %236, align 8, !dbg !93, !tbaa !6
-  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !93
-  store i64 %send33, i64* %237, align 8, !dbg !93, !tbaa !6
-  %238 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !93
-  store i64* %238, i64** %235, align 8, !dbg !93
-  %send35 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.23, i64 0), !dbg !93
+  %241 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !92
+  %242 = load i64*, i64** %241, align 8, !dbg !92
+  store i64 %selfRaw, i64* %242, align 8, !dbg !92, !tbaa !6
+  %243 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !92
+  %244 = getelementptr inbounds i64, i64* %243, i64 1, !dbg !92
+  %245 = bitcast i64* %243 to <2 x i64>*, !dbg !92
+  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %245, align 8, !dbg !92, !tbaa !6
+  %246 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !92
+  store i64* %246, i64** %241, align 8, !dbg !92
+  %send33 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.19, i64 0), !dbg !92
+  %247 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !93
+  %248 = load i64*, i64** %247, align 8, !dbg !93
+  store i64 %selfRaw, i64* %248, align 8, !dbg !93, !tbaa !6
+  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !93
+  store i64 %send33, i64* %249, align 8, !dbg !93, !tbaa !6
+  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !93
+  store i64* %250, i64** %247, align 8, !dbg !93
+  %send35 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.20, i64 0), !dbg !93
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 36), i64** %8, align 8, !dbg !93, !tbaa !14
-  %239 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !94
-  %240 = load i64*, i64** %239, align 8, !dbg !94
-  store i64 %selfRaw, i64* %240, align 8, !dbg !94, !tbaa !6
-  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !94
-  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !94
-  %243 = bitcast i64* %241 to <2 x i64>*, !dbg !94
-  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %243, align 8, !dbg !94, !tbaa !6
-  %244 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !94
-  store i64* %244, i64** %239, align 8, !dbg !94
-  %send37 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.24, i64 0), !dbg !94
-  %245 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !95
-  %246 = load i64*, i64** %245, align 8, !dbg !95
-  store i64 %selfRaw, i64* %246, align 8, !dbg !95, !tbaa !6
-  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !95
-  store i64 %send37, i64* %247, align 8, !dbg !95, !tbaa !6
-  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !95
-  store i64* %248, i64** %245, align 8, !dbg !95
-  %send39 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.25, i64 0), !dbg !95
+  %251 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !94
+  %252 = load i64*, i64** %251, align 8, !dbg !94
+  store i64 %selfRaw, i64* %252, align 8, !dbg !94, !tbaa !6
+  %253 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !94
+  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !94
+  %255 = bitcast i64* %253 to <2 x i64>*, !dbg !94
+  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %255, align 8, !dbg !94, !tbaa !6
+  %256 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !94
+  store i64* %256, i64** %251, align 8, !dbg !94
+  %send37 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.21, i64 0), !dbg !94
+  %257 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !95
+  %258 = load i64*, i64** %257, align 8, !dbg !95
+  store i64 %selfRaw, i64* %258, align 8, !dbg !95, !tbaa !6
+  %259 = getelementptr inbounds i64, i64* %258, i64 1, !dbg !95
+  store i64 %send37, i64* %259, align 8, !dbg !95, !tbaa !6
+  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !95
+  store i64* %260, i64** %257, align 8, !dbg !95
+  %send39 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.22, i64 0), !dbg !95
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 37), i64** %8, align 8, !dbg !95, !tbaa !14
   %rubyStr_8.9 = load i64, i64* @rubyStrFrozen_8.9, align 8, !dbg !96
-  %249 = load i64, i64* @rb_mKernel, align 8, !dbg !96
-  %250 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !96
-  %251 = load i64*, i64** %250, align 8, !dbg !96
-  store i64 %249, i64* %251, align 8, !dbg !96, !tbaa !6
-  %252 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !96
-  store i64 %rubyStr_8.9, i64* %252, align 8, !dbg !96, !tbaa !6
-  %253 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !96
-  store i64* %253, i64** %250, align 8, !dbg !96
+  %261 = load i64, i64* @rb_mKernel, align 8, !dbg !96
+  %262 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !96
+  %263 = load i64*, i64** %262, align 8, !dbg !96
+  store i64 %261, i64* %263, align 8, !dbg !96, !tbaa !6
+  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !96
+  store i64 %rubyStr_8.9, i64* %264, align 8, !dbg !96, !tbaa !6
+  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !96
+  store i64* %265, i64** %262, align 8, !dbg !96
   %send41 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational, i64 0), !dbg !96
-  %254 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !97
-  %255 = load i64*, i64** %254, align 8, !dbg !97
-  store i64 %selfRaw, i64* %255, align 8, !dbg !97, !tbaa !6
-  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !97
-  store i64 36028797018963970, i64* %256, align 8, !dbg !97, !tbaa !6
-  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !97
-  store i64 %send41, i64* %257, align 8, !dbg !97, !tbaa !6
-  %258 = getelementptr inbounds i64, i64* %257, i64 1, !dbg !97
-  store i64* %258, i64** %254, align 8, !dbg !97
-  %send43 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.26, i64 0), !dbg !97
-  %259 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !98
-  %260 = load i64*, i64** %259, align 8, !dbg !98
-  store i64 %selfRaw, i64* %260, align 8, !dbg !98, !tbaa !6
-  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !98
-  store i64 %send43, i64* %261, align 8, !dbg !98, !tbaa !6
-  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !98
-  store i64* %262, i64** %259, align 8, !dbg !98
-  %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.27, i64 0), !dbg !98
+  %266 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !97
+  %267 = load i64*, i64** %266, align 8, !dbg !97
+  store i64 %selfRaw, i64* %267, align 8, !dbg !97, !tbaa !6
+  %268 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !97
+  store i64 36028797018963970, i64* %268, align 8, !dbg !97, !tbaa !6
+  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !97
+  store i64 %send41, i64* %269, align 8, !dbg !97, !tbaa !6
+  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !97
+  store i64* %270, i64** %266, align 8, !dbg !97
+  %send43 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.23, i64 0), !dbg !97
+  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !98
+  %272 = load i64*, i64** %271, align 8, !dbg !98
+  store i64 %selfRaw, i64* %272, align 8, !dbg !98, !tbaa !6
+  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !98
+  store i64 %send43, i64* %273, align 8, !dbg !98, !tbaa !6
+  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !98
+  store i64* %274, i64** %271, align 8, !dbg !98
+  %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.24, i64 0), !dbg !98
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 38), i64** %8, align 8, !dbg !98, !tbaa !14
   %rubyStr_5 = load i64, i64* @rubyStrFrozen_5, align 8, !dbg !99
-  %263 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !99
-  %264 = load i64*, i64** %263, align 8, !dbg !99
-  store i64 %249, i64* %264, align 8, !dbg !99, !tbaa !6
-  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !99
-  store i64 1, i64* %265, align 8, !dbg !99, !tbaa !6
-  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !99
-  store i64 %rubyStr_5, i64* %266, align 8, !dbg !99, !tbaa !6
-  %267 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !99
-  store i64* %267, i64** %263, align 8, !dbg !99
+  %275 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !99
+  %276 = load i64*, i64** %275, align 8, !dbg !99
+  store i64 %261, i64* %276, align 8, !dbg !99, !tbaa !6
+  %277 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !99
+  store i64 1, i64* %277, align 8, !dbg !99, !tbaa !6
+  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !99
+  store i64 %rubyStr_5, i64* %278, align 8, !dbg !99, !tbaa !6
+  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !99
+  store i64* %279, i64** %275, align 8, !dbg !99
   %send47 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex, i64 0), !dbg !99
-  %268 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !100
-  %269 = load i64*, i64** %268, align 8, !dbg !100
-  store i64 %selfRaw, i64* %269, align 8, !dbg !100, !tbaa !6
-  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !100
-  store i64 36028797018963970, i64* %270, align 8, !dbg !100, !tbaa !6
-  %271 = getelementptr inbounds i64, i64* %270, i64 1, !dbg !100
-  store i64 %send47, i64* %271, align 8, !dbg !100, !tbaa !6
-  %272 = getelementptr inbounds i64, i64* %271, i64 1, !dbg !100
-  store i64* %272, i64** %268, align 8, !dbg !100
-  %send49 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.28, i64 0), !dbg !100
-  %273 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !101
-  %274 = load i64*, i64** %273, align 8, !dbg !101
-  store i64 %selfRaw, i64* %274, align 8, !dbg !101, !tbaa !6
-  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !101
-  store i64 %send49, i64* %275, align 8, !dbg !101, !tbaa !6
-  %276 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !101
-  store i64* %276, i64** %273, align 8, !dbg !101
-  %send51 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.29, i64 0), !dbg !101
+  %280 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !100
+  %281 = load i64*, i64** %280, align 8, !dbg !100
+  store i64 %selfRaw, i64* %281, align 8, !dbg !100, !tbaa !6
+  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !100
+  store i64 36028797018963970, i64* %282, align 8, !dbg !100, !tbaa !6
+  %283 = getelementptr inbounds i64, i64* %282, i64 1, !dbg !100
+  store i64 %send47, i64* %283, align 8, !dbg !100, !tbaa !6
+  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !100
+  store i64* %284, i64** %280, align 8, !dbg !100
+  %send49 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.25, i64 0), !dbg !100
+  %285 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !101
+  %286 = load i64*, i64** %285, align 8, !dbg !101
+  store i64 %selfRaw, i64* %286, align 8, !dbg !101, !tbaa !6
+  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !101
+  store i64 %send49, i64* %287, align 8, !dbg !101, !tbaa !6
+  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !101
+  store i64* %288, i64** %285, align 8, !dbg !101
+  %send51 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.26, i64 0), !dbg !101
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 40), i64** %8, align 8, !dbg !101, !tbaa !14
-  %277 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !102
-  %278 = load i64*, i64** %277, align 8, !dbg !102
-  store i64 %selfRaw, i64* %278, align 8, !dbg !102, !tbaa !6
-  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !102
-  %280 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !102
-  %281 = bitcast i64* %279 to <2 x i64>*, !dbg !102
-  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %281, align 8, !dbg !102, !tbaa !6
-  %282 = getelementptr inbounds i64, i64* %280, i64 1, !dbg !102
-  store i64* %282, i64** %277, align 8, !dbg !102
-  %send53 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.30, i64 0), !dbg !102
-  %283 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !103
-  %284 = load i64*, i64** %283, align 8, !dbg !103
-  store i64 %selfRaw, i64* %284, align 8, !dbg !103, !tbaa !6
-  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !103
-  store i64 %send53, i64* %285, align 8, !dbg !103, !tbaa !6
-  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !103
-  store i64* %286, i64** %283, align 8, !dbg !103
-  %send55 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.31, i64 0), !dbg !103
+  %289 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !102
+  %290 = load i64*, i64** %289, align 8, !dbg !102
+  store i64 %selfRaw, i64* %290, align 8, !dbg !102, !tbaa !6
+  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !102
+  %292 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !102
+  %293 = bitcast i64* %291 to <2 x i64>*, !dbg !102
+  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %293, align 8, !dbg !102, !tbaa !6
+  %294 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !102
+  store i64* %294, i64** %289, align 8, !dbg !102
+  %send53 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.27, i64 0), !dbg !102
+  %295 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !103
+  %296 = load i64*, i64** %295, align 8, !dbg !103
+  store i64 %selfRaw, i64* %296, align 8, !dbg !103, !tbaa !6
+  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !103
+  store i64 %send53, i64* %297, align 8, !dbg !103, !tbaa !6
+  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !103
+  store i64* %298, i64** %295, align 8, !dbg !103
+  %send55 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.28, i64 0), !dbg !103
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 41), i64** %8, align 8, !dbg !103, !tbaa !14
   %rubyStr_15.4 = load i64, i64* @rubyStrFrozen_15.4, align 8, !dbg !104
-  %287 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !104
-  %288 = load i64*, i64** %287, align 8, !dbg !104
-  store i64 %249, i64* %288, align 8, !dbg !104, !tbaa !6
-  %289 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !104
-  store i64 %rubyStr_15.4, i64* %289, align 8, !dbg !104, !tbaa !6
-  %290 = getelementptr inbounds i64, i64* %289, i64 1, !dbg !104
-  store i64* %290, i64** %287, align 8, !dbg !104
-  %send57 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.32, i64 0), !dbg !104
-  %291 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !105
-  %292 = load i64*, i64** %291, align 8, !dbg !105
-  store i64 %selfRaw, i64* %292, align 8, !dbg !105, !tbaa !6
-  %293 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !105
-  store i64 199622053483197234, i64* %293, align 8, !dbg !105, !tbaa !6
-  %294 = getelementptr inbounds i64, i64* %293, i64 1, !dbg !105
-  store i64 %send57, i64* %294, align 8, !dbg !105, !tbaa !6
-  %295 = getelementptr inbounds i64, i64* %294, i64 1, !dbg !105
-  store i64* %295, i64** %291, align 8, !dbg !105
-  %send59 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.33, i64 0), !dbg !105
-  %296 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !106
-  %297 = load i64*, i64** %296, align 8, !dbg !106
-  store i64 %selfRaw, i64* %297, align 8, !dbg !106, !tbaa !6
-  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !106
-  store i64 %send59, i64* %298, align 8, !dbg !106, !tbaa !6
-  %299 = getelementptr inbounds i64, i64* %298, i64 1, !dbg !106
-  store i64* %299, i64** %296, align 8, !dbg !106
-  %send61 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.34, i64 0), !dbg !106
+  %299 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !104
+  %300 = load i64*, i64** %299, align 8, !dbg !104
+  store i64 %261, i64* %300, align 8, !dbg !104, !tbaa !6
+  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !104
+  store i64 %rubyStr_15.4, i64* %301, align 8, !dbg !104, !tbaa !6
+  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !104
+  store i64* %302, i64** %299, align 8, !dbg !104
+  %send57 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.29, i64 0), !dbg !104
+  %303 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !105
+  %304 = load i64*, i64** %303, align 8, !dbg !105
+  store i64 %selfRaw, i64* %304, align 8, !dbg !105, !tbaa !6
+  %305 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !105
+  store i64 199622053483197234, i64* %305, align 8, !dbg !105, !tbaa !6
+  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !105
+  store i64 %send57, i64* %306, align 8, !dbg !105, !tbaa !6
+  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !105
+  store i64* %307, i64** %303, align 8, !dbg !105
+  %send59 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.30, i64 0), !dbg !105
+  %308 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !106
+  %309 = load i64*, i64** %308, align 8, !dbg !106
+  store i64 %selfRaw, i64* %309, align 8, !dbg !106, !tbaa !6
+  %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !106
+  store i64 %send59, i64* %310, align 8, !dbg !106, !tbaa !6
+  %311 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !106
+  store i64* %311, i64** %308, align 8, !dbg !106
+  %send61 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.31, i64 0), !dbg !106
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 42), i64** %8, align 8, !dbg !106, !tbaa !14
   %rubyStr_18 = load i64, i64* @rubyStrFrozen_18, align 8, !dbg !107
-  %300 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !107
-  %301 = load i64*, i64** %300, align 8, !dbg !107
-  store i64 %249, i64* %301, align 8, !dbg !107, !tbaa !6
-  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !107
-  store i64 1, i64* %302, align 8, !dbg !107, !tbaa !6
-  %303 = getelementptr inbounds i64, i64* %302, i64 1, !dbg !107
-  store i64 %rubyStr_18, i64* %303, align 8, !dbg !107, !tbaa !6
-  %304 = getelementptr inbounds i64, i64* %303, i64 1, !dbg !107
-  store i64* %304, i64** %300, align 8, !dbg !107
-  %send63 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex.35, i64 0), !dbg !107
-  %305 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !108
-  %306 = load i64*, i64** %305, align 8, !dbg !108
-  store i64 %selfRaw, i64* %306, align 8, !dbg !108, !tbaa !6
-  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !108
-  store i64 199565758487855106, i64* %307, align 8, !dbg !108, !tbaa !6
-  %308 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !108
-  store i64 %send63, i64* %308, align 8, !dbg !108, !tbaa !6
-  %309 = getelementptr inbounds i64, i64* %308, i64 1, !dbg !108
-  store i64* %309, i64** %305, align 8, !dbg !108
-  %send65 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.36, i64 0), !dbg !108
-  %310 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !109
-  %311 = load i64*, i64** %310, align 8, !dbg !109
-  store i64 %selfRaw, i64* %311, align 8, !dbg !109, !tbaa !6
-  %312 = getelementptr inbounds i64, i64* %311, i64 1, !dbg !109
-  store i64 %send65, i64* %312, align 8, !dbg !109, !tbaa !6
-  %313 = getelementptr inbounds i64, i64* %312, i64 1, !dbg !109
-  store i64* %313, i64** %310, align 8, !dbg !109
-  %send67 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.37, i64 0), !dbg !109
+  %312 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !107
+  %313 = load i64*, i64** %312, align 8, !dbg !107
+  store i64 %261, i64* %313, align 8, !dbg !107, !tbaa !6
+  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !107
+  store i64 1, i64* %314, align 8, !dbg !107, !tbaa !6
+  %315 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !107
+  store i64 %rubyStr_18, i64* %315, align 8, !dbg !107, !tbaa !6
+  %316 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !107
+  store i64* %316, i64** %312, align 8, !dbg !107
+  %send63 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex.32, i64 0), !dbg !107
+  %317 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !108
+  %318 = load i64*, i64** %317, align 8, !dbg !108
+  store i64 %selfRaw, i64* %318, align 8, !dbg !108, !tbaa !6
+  %319 = getelementptr inbounds i64, i64* %318, i64 1, !dbg !108
+  store i64 199565758487855106, i64* %319, align 8, !dbg !108, !tbaa !6
+  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !108
+  store i64 %send63, i64* %320, align 8, !dbg !108, !tbaa !6
+  %321 = getelementptr inbounds i64, i64* %320, i64 1, !dbg !108
+  store i64* %321, i64** %317, align 8, !dbg !108
+  %send65 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.33, i64 0), !dbg !108
+  %322 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !109
+  %323 = load i64*, i64** %322, align 8, !dbg !109
+  store i64 %selfRaw, i64* %323, align 8, !dbg !109, !tbaa !6
+  %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !109
+  store i64 %send65, i64* %324, align 8, !dbg !109, !tbaa !6
+  %325 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !109
+  store i64* %325, i64** %322, align 8, !dbg !109
+  %send67 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.34, i64 0), !dbg !109
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 44), i64** %8, align 8, !dbg !109, !tbaa !14
-  %314 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !110
-  %315 = load i64*, i64** %314, align 8, !dbg !110
-  store i64 %selfRaw, i64* %315, align 8, !dbg !110, !tbaa !6
-  %316 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !110
-  %317 = getelementptr inbounds i64, i64* %316, i64 1, !dbg !110
-  %318 = bitcast i64* %316 to <2 x i64>*, !dbg !110
-  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %318, align 8, !dbg !110, !tbaa !6
-  %319 = getelementptr inbounds i64, i64* %317, i64 1, !dbg !110
-  store i64* %319, i64** %314, align 8, !dbg !110
-  %send69 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.38, i64 0), !dbg !110
-  %320 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !111
-  %321 = load i64*, i64** %320, align 8, !dbg !111
-  store i64 %selfRaw, i64* %321, align 8, !dbg !111, !tbaa !6
-  %322 = getelementptr inbounds i64, i64* %321, i64 1, !dbg !111
-  store i64 %send69, i64* %322, align 8, !dbg !111, !tbaa !6
-  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !111
-  store i64* %323, i64** %320, align 8, !dbg !111
-  %send71 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.39, i64 0), !dbg !111
+  %326 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !110
+  %327 = load i64*, i64** %326, align 8, !dbg !110
+  store i64 %selfRaw, i64* %327, align 8, !dbg !110, !tbaa !6
+  %328 = getelementptr inbounds i64, i64* %327, i64 1, !dbg !110
+  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !110
+  %330 = bitcast i64* %328 to <2 x i64>*, !dbg !110
+  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %330, align 8, !dbg !110, !tbaa !6
+  %331 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !110
+  store i64* %331, i64** %326, align 8, !dbg !110
+  %send69 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.35, i64 0), !dbg !110
+  %332 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !111
+  %333 = load i64*, i64** %332, align 8, !dbg !111
+  store i64 %selfRaw, i64* %333, align 8, !dbg !111, !tbaa !6
+  %334 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !111
+  store i64 %send69, i64* %334, align 8, !dbg !111, !tbaa !6
+  %335 = getelementptr inbounds i64, i64* %334, i64 1, !dbg !111
+  store i64* %335, i64** %332, align 8, !dbg !111
+  %send71 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.36, i64 0), !dbg !111
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 45), i64** %8, align 8, !dbg !111, !tbaa !14
   %rubyStr_25.4 = load i64, i64* @rubyStrFrozen_25.4, align 8, !dbg !112
-  %324 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !112
-  %325 = load i64*, i64** %324, align 8, !dbg !112
-  store i64 %249, i64* %325, align 8, !dbg !112, !tbaa !6
-  %326 = getelementptr inbounds i64, i64* %325, i64 1, !dbg !112
-  store i64 %rubyStr_25.4, i64* %326, align 8, !dbg !112, !tbaa !6
-  %327 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !112
-  store i64* %327, i64** %324, align 8, !dbg !112
-  %send73 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.40, i64 0), !dbg !112
-  %328 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !113
-  %329 = load i64*, i64** %328, align 8, !dbg !113
-  store i64 %selfRaw, i64* %329, align 8, !dbg !113, !tbaa !6
-  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !113
-  store i64 113040350646999450, i64* %330, align 8, !dbg !113, !tbaa !6
-  %331 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !113
-  store i64 %send73, i64* %331, align 8, !dbg !113, !tbaa !6
-  %332 = getelementptr inbounds i64, i64* %331, i64 1, !dbg !113
-  store i64* %332, i64** %328, align 8, !dbg !113
-  %send75 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.41, i64 0), !dbg !113
-  %333 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !114
-  %334 = load i64*, i64** %333, align 8, !dbg !114
-  store i64 %selfRaw, i64* %334, align 8, !dbg !114, !tbaa !6
-  %335 = getelementptr inbounds i64, i64* %334, i64 1, !dbg !114
-  store i64 %send75, i64* %335, align 8, !dbg !114, !tbaa !6
-  %336 = getelementptr inbounds i64, i64* %335, i64 1, !dbg !114
-  store i64* %336, i64** %333, align 8, !dbg !114
-  %send77 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.42, i64 0), !dbg !114
+  %336 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !112
+  %337 = load i64*, i64** %336, align 8, !dbg !112
+  store i64 %261, i64* %337, align 8, !dbg !112, !tbaa !6
+  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !112
+  store i64 %rubyStr_25.4, i64* %338, align 8, !dbg !112, !tbaa !6
+  %339 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !112
+  store i64* %339, i64** %336, align 8, !dbg !112
+  %send73 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.37, i64 0), !dbg !112
+  %340 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !113
+  %341 = load i64*, i64** %340, align 8, !dbg !113
+  store i64 %selfRaw, i64* %341, align 8, !dbg !113, !tbaa !6
+  %342 = getelementptr inbounds i64, i64* %341, i64 1, !dbg !113
+  store i64 113040350646999450, i64* %342, align 8, !dbg !113, !tbaa !6
+  %343 = getelementptr inbounds i64, i64* %342, i64 1, !dbg !113
+  store i64 %send73, i64* %343, align 8, !dbg !113, !tbaa !6
+  %344 = getelementptr inbounds i64, i64* %343, i64 1, !dbg !113
+  store i64* %344, i64** %340, align 8, !dbg !113
+  %send75 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.38, i64 0), !dbg !113
+  %345 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !114
+  %346 = load i64*, i64** %345, align 8, !dbg !114
+  store i64 %selfRaw, i64* %346, align 8, !dbg !114, !tbaa !6
+  %347 = getelementptr inbounds i64, i64* %346, i64 1, !dbg !114
+  store i64 %send75, i64* %347, align 8, !dbg !114, !tbaa !6
+  %348 = getelementptr inbounds i64, i64* %347, i64 1, !dbg !114
+  store i64* %348, i64** %345, align 8, !dbg !114
+  %send77 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.39, i64 0), !dbg !114
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 47), i64** %8, align 8, !dbg !114, !tbaa !14
-  %337 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !115
-  %338 = load i64*, i64** %337, align 8, !dbg !115
-  store i64 %selfRaw, i64* %338, align 8, !dbg !115, !tbaa !6
-  %339 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !115
-  %340 = getelementptr inbounds i64, i64* %339, i64 1, !dbg !115
-  %341 = bitcast i64* %339 to <2 x i64>*, !dbg !115
-  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %341, align 8, !dbg !115, !tbaa !6
-  %342 = getelementptr inbounds i64, i64* %340, i64 1, !dbg !115
-  store i64* %342, i64** %337, align 8, !dbg !115
-  %send79 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.43, i64 0), !dbg !115
-  %343 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !116
-  %344 = load i64*, i64** %343, align 8, !dbg !116
-  store i64 %selfRaw, i64* %344, align 8, !dbg !116, !tbaa !6
-  %345 = getelementptr inbounds i64, i64* %344, i64 1, !dbg !116
-  store i64 %send79, i64* %345, align 8, !dbg !116, !tbaa !6
-  %346 = getelementptr inbounds i64, i64* %345, i64 1, !dbg !116
-  store i64* %346, i64** %343, align 8, !dbg !116
-  %send81 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.44, i64 0), !dbg !116
+  %349 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !115
+  %350 = load i64*, i64** %349, align 8, !dbg !115
+  store i64 %selfRaw, i64* %350, align 8, !dbg !115, !tbaa !6
+  %351 = getelementptr inbounds i64, i64* %350, i64 1, !dbg !115
+  %352 = getelementptr inbounds i64, i64* %351, i64 1, !dbg !115
+  %353 = bitcast i64* %351 to <2 x i64>*, !dbg !115
+  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %353, align 8, !dbg !115, !tbaa !6
+  %354 = getelementptr inbounds i64, i64* %352, i64 1, !dbg !115
+  store i64* %354, i64** %349, align 8, !dbg !115
+  %send79 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.40, i64 0), !dbg !115
+  %355 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !116
+  %356 = load i64*, i64** %355, align 8, !dbg !116
+  store i64 %selfRaw, i64* %356, align 8, !dbg !116, !tbaa !6
+  %357 = getelementptr inbounds i64, i64* %356, i64 1, !dbg !116
+  store i64 %send79, i64* %357, align 8, !dbg !116, !tbaa !6
+  %358 = getelementptr inbounds i64, i64* %357, i64 1, !dbg !116
+  store i64* %358, i64** %355, align 8, !dbg !116
+  %send81 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.41, i64 0), !dbg !116
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 48), i64** %8, align 8, !dbg !116, !tbaa !14
   %rubyStr_5.923 = load i64, i64* @rubyStrFrozen_5.923, align 8, !dbg !117
-  %347 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !117
-  %348 = load i64*, i64** %347, align 8, !dbg !117
-  store i64 %249, i64* %348, align 8, !dbg !117, !tbaa !6
-  %349 = getelementptr inbounds i64, i64* %348, i64 1, !dbg !117
-  store i64 %rubyStr_5.923, i64* %349, align 8, !dbg !117, !tbaa !6
-  %350 = getelementptr inbounds i64, i64* %349, i64 1, !dbg !117
-  store i64* %350, i64** %347, align 8, !dbg !117
-  %send83 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.45, i64 0), !dbg !117
-  %351 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !118
-  %352 = load i64*, i64** %351, align 8, !dbg !118
-  store i64 %selfRaw, i64* %352, align 8, !dbg !118, !tbaa !6
-  %353 = getelementptr inbounds i64, i64* %352, i64 1, !dbg !118
-  store i64 113040350646999450, i64* %353, align 8, !dbg !118, !tbaa !6
-  %354 = getelementptr inbounds i64, i64* %353, i64 1, !dbg !118
-  store i64 %send83, i64* %354, align 8, !dbg !118, !tbaa !6
-  %355 = getelementptr inbounds i64, i64* %354, i64 1, !dbg !118
-  store i64* %355, i64** %351, align 8, !dbg !118
-  %send85 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.46, i64 0), !dbg !118
-  %356 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !119
-  %357 = load i64*, i64** %356, align 8, !dbg !119
-  store i64 %selfRaw, i64* %357, align 8, !dbg !119, !tbaa !6
-  %358 = getelementptr inbounds i64, i64* %357, i64 1, !dbg !119
-  store i64 %send85, i64* %358, align 8, !dbg !119, !tbaa !6
-  %359 = getelementptr inbounds i64, i64* %358, i64 1, !dbg !119
-  store i64* %359, i64** %356, align 8, !dbg !119
-  %send87 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.47, i64 0), !dbg !119
+  %359 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !117
+  %360 = load i64*, i64** %359, align 8, !dbg !117
+  store i64 %261, i64* %360, align 8, !dbg !117, !tbaa !6
+  %361 = getelementptr inbounds i64, i64* %360, i64 1, !dbg !117
+  store i64 %rubyStr_5.923, i64* %361, align 8, !dbg !117, !tbaa !6
+  %362 = getelementptr inbounds i64, i64* %361, i64 1, !dbg !117
+  store i64* %362, i64** %359, align 8, !dbg !117
+  %send83 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.42, i64 0), !dbg !117
+  %363 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !118
+  %364 = load i64*, i64** %363, align 8, !dbg !118
+  store i64 %selfRaw, i64* %364, align 8, !dbg !118, !tbaa !6
+  %365 = getelementptr inbounds i64, i64* %364, i64 1, !dbg !118
+  store i64 113040350646999450, i64* %365, align 8, !dbg !118, !tbaa !6
+  %366 = getelementptr inbounds i64, i64* %365, i64 1, !dbg !118
+  store i64 %send83, i64* %366, align 8, !dbg !118, !tbaa !6
+  %367 = getelementptr inbounds i64, i64* %366, i64 1, !dbg !118
+  store i64* %367, i64** %363, align 8, !dbg !118
+  %send85 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.43, i64 0), !dbg !118
+  %368 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !119
+  %369 = load i64*, i64** %368, align 8, !dbg !119
+  store i64 %selfRaw, i64* %369, align 8, !dbg !119, !tbaa !6
+  %370 = getelementptr inbounds i64, i64* %369, i64 1, !dbg !119
+  store i64 %send85, i64* %370, align 8, !dbg !119, !tbaa !6
+  %371 = getelementptr inbounds i64, i64* %370, i64 1, !dbg !119
+  store i64* %371, i64** %368, align 8, !dbg !119
+  %send87 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.44, i64 0), !dbg !119
   ret void
-
-fastSymCallIntrinsic_ResolvedSig_sig305:          ; preds = %fastSymCallIntrinsic_ResolvedSig_sig286, %41
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %8, align 8, !dbg !65, !tbaa !14
-  %rubyId_lte = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !66
-  %rawSym299 = tail call i64 @rb_id2sym(i64 %rubyId_lte), !dbg !66
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym299, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_4"), !dbg !66
-  %360 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !14
-  %361 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 5, !dbg !66
-  %362 = load i32, i32* %361, align 8, !dbg !66, !tbaa !27
-  %363 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 6, !dbg !66
-  %364 = load i32, i32* %363, align 4, !dbg !66, !tbaa !31
-  %365 = xor i32 %364, -1, !dbg !66
-  %366 = and i32 %365, %362, !dbg !66
-  %367 = icmp eq i32 %366, 0, !dbg !66
-  br i1 %367, label %afterSend302, label %368, !dbg !66, !prof !21
-
-368:                                              ; preds = %fastSymCallIntrinsic_ResolvedSig_sig305
-  %369 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %360, i64 0, i32 8, !dbg !66
-  %370 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %369, align 8, !dbg !66, !tbaa !32
-  %371 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %370, i32 noundef 0) #15, !dbg !66
-  br label %afterSend302, !dbg !66
 }
 
 ; Function Attrs: ssp
@@ -1407,7 +1402,7 @@ functionEntryInitializers:
   store i64 %15, i64* %19, align 8, !dbg !131, !tbaa !6
   %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !131
   store i64* %20, i64** %18, align 8, !dbg !131
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.3, i64 0), !dbg !131
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.2, i64 0), !dbg !131
   %21 = load i64, i64* @rb_cFloat, align 8, !dbg !132
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !132
   %23 = load i64*, i64** %22, align 8, !dbg !132
@@ -1418,13 +1413,13 @@ functionEntryInitializers:
   store i64 %send, i64* %25, align 8, !dbg !132, !tbaa !6
   %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !132
   store i64* %26, i64** %22, align 8, !dbg !132
-  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.4, i64 0), !dbg !132
+  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.3, i64 0), !dbg !132
   %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !133
   %28 = load i64*, i64** %27, align 8, !dbg !133
   store i64 %15, i64* %28, align 8, !dbg !133, !tbaa !6
   %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !133
   store i64* %29, i64** %27, align 8, !dbg !133
-  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.5, i64 0), !dbg !133
+  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.4, i64 0), !dbg !133
   %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !132
   %31 = load i64*, i64** %30, align 8, !dbg !132
   store i64 %send38, i64* %31, align 8, !dbg !132, !tbaa !6
@@ -1432,7 +1427,7 @@ functionEntryInitializers:
   store i64 %send40, i64* %32, align 8, !dbg !132, !tbaa !6
   %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !132
   store i64* %33, i64** %30, align 8, !dbg !132
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.6, i64 0), !dbg !132
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.5, i64 0), !dbg !132
   ret i64 %send42, !dbg !134
 }
 
@@ -1478,7 +1473,7 @@ functionEntryInitializers:
   store i64 %15, i64* %19, align 8, !dbg !138, !tbaa !6
   %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !138
   store i64* %20, i64** %18, align 8, !dbg !138
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.8, i64 0), !dbg !138
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.6, i64 0), !dbg !138
   %21 = load i64, i64* @rb_cFloat, align 8, !dbg !139
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !139
   %23 = load i64*, i64** %22, align 8, !dbg !139
@@ -1489,7 +1484,7 @@ functionEntryInitializers:
   store i64 %send, i64* %25, align 8, !dbg !139, !tbaa !6
   %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !139
   store i64* %26, i64** %22, align 8, !dbg !139
-  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.9, i64 0), !dbg !139
+  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.7, i64 0), !dbg !139
   %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !139
   %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !139, !tbaa !68
   %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !139
@@ -1512,7 +1507,7 @@ functionEntryInitializers:
   store i64 %31, i64* %36, align 8, !dbg !139, !tbaa !6
   %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !139
   store i64* %37, i64** %34, align 8, !dbg !139
-  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.10, i64 0), !dbg !139
+  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.8, i64 0), !dbg !139
   ret i64 %send36, !dbg !140
 }
 
@@ -1558,7 +1553,7 @@ functionEntryInitializers:
   store i64 %15, i64* %19, align 8, !dbg !144, !tbaa !6
   %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !144
   store i64* %20, i64** %18, align 8, !dbg !144
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.12, i64 0), !dbg !144
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.9, i64 0), !dbg !144
   %21 = load i64, i64* @rb_cFloat, align 8, !dbg !145
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !145
   %23 = load i64*, i64** %22, align 8, !dbg !145
@@ -1569,7 +1564,7 @@ functionEntryInitializers:
   store i64 %send, i64* %25, align 8, !dbg !145, !tbaa !6
   %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !145
   store i64* %26, i64** %22, align 8, !dbg !145
-  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.13, i64 0), !dbg !145
+  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.10, i64 0), !dbg !145
   %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !145
   %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !145, !tbaa !68
   %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !145
@@ -1592,30 +1587,30 @@ functionEntryInitializers:
   store i64 %31, i64* %36, align 8, !dbg !145, !tbaa !6
   %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !145
   store i64* %37, i64** %34, align 8, !dbg !145
-  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.14, i64 0), !dbg !145
+  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.11, i64 0), !dbg !145
   ret i64 %send36, !dbg !146
 }
 
 ; Function Attrs: ssp
 define void @Init_float-intrinsics() local_unnamed_addr #7 {
 entry:
-  %locals.i174.i = alloca i64, align 8
-  %locals.i172.i = alloca i64, i32 0, align 8
-  %locals.i170.i = alloca i64, i32 0, align 8
-  %locals.i168.i = alloca i64, i32 0, align 8
+  %locals.i163.i = alloca i64, align 8
+  %locals.i161.i = alloca i64, i32 0, align 8
+  %locals.i159.i = alloca i64, i32 0, align 8
+  %locals.i157.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %keywords.i = alloca i64, i32 2, align 8, !dbg !125
-  %keywords17.i = alloca i64, i32 2, align 8, !dbg !132
-  %keywords34.i = alloca i64, i32 2, align 8, !dbg !139
-  %keywords49.i = alloca i64, i32 2, align 8, !dbg !145
+  %keywords12.i = alloca i64, i32 2, align 8, !dbg !132
+  %keywords26.i = alloca i64, i32 2, align 8, !dbg !139
+  %keywords38.i = alloca i64, i32 2, align 8, !dbg !145
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %0)
-  %1 = bitcast i64* %keywords17.i to i8*
+  %1 = bitcast i64* %keywords12.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %1)
-  %2 = bitcast i64* %keywords34.i to i8*
+  %2 = bitcast i64* %keywords26.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %2)
-  %3 = bitcast i64* %keywords49.i to i8*
+  %3 = bitcast i64* %keywords38.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %3)
   %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #15
   store i64 %4, i64* @rubyIdPrecomputed_plus, align 8
@@ -1636,161 +1631,151 @@ entry:
   store i64 %13, i64* @"rubyIdPrecomputed_<block-call>", align 8
   %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #15
   store i64 %14, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i64 noundef 3) #15
-  store i64 %15, i64* @rubyIdPrecomputed_sig, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #15
-  store i64 %16, i64* @rubyIdPrecomputed_x, align 8
-  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_y, i64 0, i64 0), i64 noundef 1) #15
-  store i64 %17, i64* @rubyIdPrecomputed_y, align 8
-  %18 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_untyped, i64 0, i64 0), i64 noundef 7) #15
-  store i64 %18, i64* @rubyIdPrecomputed_untyped, align 8
-  %19 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %19, i64* @rubyIdPrecomputed_params, align 8
-  %20 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #15
-  store i64 %20, i64* @rubyIdPrecomputed_returns, align 8
-  %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %21, i64* @rubyIdPrecomputed_extend, align 8
-  %22 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %22, i64* @rubyIdPrecomputed_normal, align 8
-  %23 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #15
-  store i64 %23, i64* @rubyIdPrecomputed_p, align 8
-  %24 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_Rational, i64 0, i64 0), i64 noundef 8) #15
-  store i64 %24, i64* @rubyIdPrecomputed_Rational, align 8
-  %25 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Complex, i64 0, i64 0), i64 noundef 7) #15
-  store i64 %25, i64* @rubyIdPrecomputed_Complex, align 8
-  %26 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #15
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #15
+  store i64 %15, i64* @rubyIdPrecomputed_x, align 8
+  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_y, i64 0, i64 0), i64 noundef 1) #15
+  store i64 %16, i64* @rubyIdPrecomputed_y, align 8
+  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_untyped, i64 0, i64 0), i64 noundef 7) #15
+  store i64 %17, i64* @rubyIdPrecomputed_untyped, align 8
+  %18 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #15
+  store i64 %18, i64* @rubyIdPrecomputed_params, align 8
+  %19 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #15
+  store i64 %19, i64* @rubyIdPrecomputed_returns, align 8
+  %20 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #15
+  store i64 %20, i64* @rubyIdPrecomputed_extend, align 8
+  %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
+  store i64 %21, i64* @rubyIdPrecomputed_normal, align 8
+  %22 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #15
+  store i64 %22, i64* @rubyIdPrecomputed_p, align 8
+  %23 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_Rational, i64 0, i64 0), i64 noundef 8) #15
+  store i64 %23, i64* @rubyIdPrecomputed_Rational, align 8
+  %24 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Complex, i64 0, i64 0), i64 noundef 7) #15
+  store i64 %24, i64* @rubyIdPrecomputed_Complex, align 8
+  %25 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #15
+  tail call void @rb_gc_register_mark_object(i64 %25) #15
+  store i64 %25, i64* @rubyStrFrozen_plus, align 8
+  %26 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/float-intrinsics.rb", i64 0, i64 0), i64 noundef 42) #15
   tail call void @rb_gc_register_mark_object(i64 %26) #15
-  store i64 %26, i64* @rubyStrFrozen_plus, align 8
-  %27 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/float-intrinsics.rb", i64 0, i64 0), i64 noundef 42) #15
-  tail call void @rb_gc_register_mark_object(i64 %27) #15
-  store i64 %27, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  store i64 %26, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 49)
   %rubyId_plus.i.i = load i64, i64* @rubyIdPrecomputed_plus, align 8
   %rubyStr_plus.i.i = load i64, i64* @rubyStrFrozen_plus, align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_plus.i.i, i64 %rubyId_plus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8
-  %29 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #15
-  call void @rb_gc_register_mark_object(i64 %29) #15
+  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_plus.i.i, i64 %rubyId_plus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8
+  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #15
+  call void @rb_gc_register_mark_object(i64 %28) #15
   %rubyId_minus.i.i = load i64, i64* @rubyIdPrecomputed_minus, align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i167.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %29, i64 %rubyId_minus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i167.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i168.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i156.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %29 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %28, i64 %rubyId_minus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i156.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i157.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %29, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8
   %rubyId_-.i = load i64, i64* @rubyIdPrecomputed_-, align 8, !dbg !37
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_-, i64 %rubyId_-.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !37
-  %31 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #15
-  call void @rb_gc_register_mark_object(i64 %31) #15
+  %30 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #15
+  call void @rb_gc_register_mark_object(i64 %30) #15
   %rubyId_lt.i.i = load i64, i64* @rubyIdPrecomputed_lt, align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i169.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %32 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %31, i64 %rubyId_lt.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i169.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 18, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i170.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %32, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8
-  %33 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #15
-  call void @rb_gc_register_mark_object(i64 %33) #15
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i158.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %31 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %30, i64 %rubyId_lt.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i158.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 18, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i159.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %31, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8
+  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #15
+  call void @rb_gc_register_mark_object(i64 %32) #15
   %rubyId_lte.i.i = load i64, i64* @rubyIdPrecomputed_lte, align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i171.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %34 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %33, i64 %rubyId_lte.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i171.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 23, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i172.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %34, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8
-  %35 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
-  call void @rb_gc_register_mark_object(i64 %35) #15
-  %36 = bitcast i64* %locals.i174.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %36)
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i160.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %33 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %32, i64 %rubyId_lte.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i160.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 23, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i161.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %33, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8
+  %34 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  call void @rb_gc_register_mark_object(i64 %34) #15
+  %35 = bitcast i64* %locals.i163.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i173.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i162.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %"rubyId_<block-call>.i.i" = load i64, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  store i64 %"rubyId_<block-call>.i.i", i64* %locals.i174.i, align 8
-  %37 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %35, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i173.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i174.i, i32 noundef 1, i32 noundef 4)
-  store %struct.rb_iseq_struct* %37, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %36)
-  %38 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #15
-  call void @rb_gc_register_mark_object(i64 %38) #15
-  store i64 %38, i64* @"rubyStrFrozen_block in <top (required)>", align 8
+  store i64 %"rubyId_<block-call>.i.i", i64* %locals.i163.i, align 8
+  %36 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %34, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i162.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i163.i, i32 noundef 1, i32 noundef 4)
+  store %struct.rb_iseq_struct* %36, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35)
+  %37 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #15
+  call void @rb_gc_register_mark_object(i64 %37) #15
+  store i64 %37, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i175.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %39 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %38, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i175.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %39, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8
-  %stackFrame.i176.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %"rubyId_block in <top (required)>.i177.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %"rubyStr_block in <top (required)>.i178.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i179.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i178.i", i64 %"rubyId_block in <top (required)>.i177.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i179.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i176.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_2", align 8
-  %stackFrame.i180.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %"rubyId_block in <top (required)>.i181.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %"rubyStr_block in <top (required)>.i182.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i183.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %41 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i182.i", i64 %"rubyId_block in <top (required)>.i181.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i183.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i180.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %41, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_3", align 8
-  %stackFrame.i184.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %"rubyId_block in <top (required)>.i185.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %"rubyStr_block in <top (required)>.i186.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i187.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %42 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i186.i", i64 %"rubyId_block in <top (required)>.i185.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i187.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i184.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %42, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_4", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !63
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !63
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i164.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %37, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i164.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %38, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8
+  %stackFrame.i165.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %"rubyId_block in <top (required)>.i166.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
+  %"rubyStr_block in <top (required)>.i167.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i168.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %39 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i167.i", i64 %"rubyId_block in <top (required)>.i166.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i168.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i165.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %39, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_2", align 8
+  %stackFrame.i169.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %"rubyId_block in <top (required)>.i170.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
+  %"rubyStr_block in <top (required)>.i171.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i172.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i171.i", i64 %"rubyId_block in <top (required)>.i170.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i172.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i169.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_3", align 8
+  %stackFrame.i173.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %"rubyId_block in <top (required)>.i174.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
+  %"rubyStr_block in <top (required)>.i175.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i176.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %41 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i175.i", i64 %"rubyId_block in <top (required)>.i174.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i176.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i173.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %41, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_4", align 8
   %rubyId_untyped.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !124
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !124
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !125
   %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !125
-  %43 = call i64 @rb_id2sym(i64 %rubyId_x.i) #15, !dbg !125
-  store i64 %43, i64* %keywords.i, align 8, !dbg !125
+  %42 = call i64 @rb_id2sym(i64 %rubyId_x.i) #15, !dbg !125
+  store i64 %42, i64* %keywords.i, align 8, !dbg !125
   %rubyId_y.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !125
-  %44 = call i64 @rb_id2sym(i64 %rubyId_y.i) #15, !dbg !125
-  %45 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !125
-  store i64 %44, i64* %45, align 8, !dbg !125
+  %43 = call i64 @rb_id2sym(i64 %rubyId_y.i) #15, !dbg !125
+  %44 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !125
+  store i64 %43, i64* %44, align 8, !dbg !125
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords.i), !dbg !125
-  %rubyId_untyped8.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !126
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped8.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !126
+  %rubyId_untyped6.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !126
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped6.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !126
   %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !125
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !125
-  %rubyId_sig11.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !64
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.2, i64 %rubyId_sig11.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !64
-  %rubyId_untyped14.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !131
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.3, i64 %rubyId_untyped14.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !131
-  %rubyId_params16.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !132
-  %rubyId_x18.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !132
-  %46 = call i64 @rb_id2sym(i64 %rubyId_x18.i) #15, !dbg !132
-  store i64 %46, i64* %keywords17.i, align 8, !dbg !132
-  %rubyId_y20.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !132
-  %47 = call i64 @rb_id2sym(i64 %rubyId_y20.i) #15, !dbg !132
-  %48 = getelementptr i64, i64* %keywords17.i, i32 1, !dbg !132
-  store i64 %47, i64* %48, align 8, !dbg !132
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.4, i64 %rubyId_params16.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords17.i), !dbg !132
-  %rubyId_untyped24.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !133
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.5, i64 %rubyId_untyped24.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !133
-  %rubyId_returns26.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !132
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.6, i64 %rubyId_returns26.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !132
-  %rubyId_sig28.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !65
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.7, i64 %rubyId_sig28.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !65
-  %rubyId_untyped31.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !138
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.8, i64 %rubyId_untyped31.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !138
-  %rubyId_params33.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !139
-  %rubyId_x35.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !139
-  %49 = call i64 @rb_id2sym(i64 %rubyId_x35.i) #15, !dbg !139
-  store i64 %49, i64* %keywords34.i, align 8, !dbg !139
-  %rubyId_y37.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !139
-  %50 = call i64 @rb_id2sym(i64 %rubyId_y37.i) #15, !dbg !139
-  %51 = getelementptr i64, i64* %keywords34.i, i32 1, !dbg !139
-  store i64 %50, i64* %51, align 8, !dbg !139
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.9, i64 %rubyId_params33.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords34.i), !dbg !139
-  %rubyId_returns41.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !139
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.10, i64 %rubyId_returns41.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !139
-  %rubyId_sig43.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !66
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.11, i64 %rubyId_sig43.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !66
-  %rubyId_untyped46.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !144
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.12, i64 %rubyId_untyped46.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !144
-  %rubyId_params48.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !145
-  %rubyId_x50.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !145
-  %52 = call i64 @rb_id2sym(i64 %rubyId_x50.i) #15, !dbg !145
-  store i64 %52, i64* %keywords49.i, align 8, !dbg !145
-  %rubyId_y52.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !145
-  %53 = call i64 @rb_id2sym(i64 %rubyId_y52.i) #15, !dbg !145
-  %54 = getelementptr i64, i64* %keywords49.i, i32 1, !dbg !145
-  store i64 %53, i64* %54, align 8, !dbg !145
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.13, i64 %rubyId_params48.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords49.i), !dbg !145
-  %rubyId_returns56.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !145
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.14, i64 %rubyId_returns56.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !145
+  %rubyId_untyped9.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !131
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.2, i64 %rubyId_untyped9.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !131
+  %rubyId_params11.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !132
+  %rubyId_x13.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !132
+  %45 = call i64 @rb_id2sym(i64 %rubyId_x13.i) #15, !dbg !132
+  store i64 %45, i64* %keywords12.i, align 8, !dbg !132
+  %rubyId_y15.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !132
+  %46 = call i64 @rb_id2sym(i64 %rubyId_y15.i) #15, !dbg !132
+  %47 = getelementptr i64, i64* %keywords12.i, i32 1, !dbg !132
+  store i64 %46, i64* %47, align 8, !dbg !132
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.3, i64 %rubyId_params11.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords12.i), !dbg !132
+  %rubyId_untyped19.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !133
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.4, i64 %rubyId_untyped19.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !133
+  %rubyId_returns21.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !132
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.5, i64 %rubyId_returns21.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !132
+  %rubyId_untyped23.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !138
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.6, i64 %rubyId_untyped23.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !138
+  %rubyId_params25.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !139
+  %rubyId_x27.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !139
+  %48 = call i64 @rb_id2sym(i64 %rubyId_x27.i) #15, !dbg !139
+  store i64 %48, i64* %keywords26.i, align 8, !dbg !139
+  %rubyId_y29.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !139
+  %49 = call i64 @rb_id2sym(i64 %rubyId_y29.i) #15, !dbg !139
+  %50 = getelementptr i64, i64* %keywords26.i, i32 1, !dbg !139
+  store i64 %49, i64* %50, align 8, !dbg !139
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.7, i64 %rubyId_params25.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords26.i), !dbg !139
+  %rubyId_returns33.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !139
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.8, i64 %rubyId_returns33.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !139
+  %rubyId_untyped35.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !144
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.9, i64 %rubyId_untyped35.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !144
+  %rubyId_params37.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !145
+  %rubyId_x39.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !145
+  %51 = call i64 @rb_id2sym(i64 %rubyId_x39.i) #15, !dbg !145
+  store i64 %51, i64* %keywords38.i, align 8, !dbg !145
+  %rubyId_y41.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !145
+  %52 = call i64 @rb_id2sym(i64 %rubyId_y41.i) #15, !dbg !145
+  %53 = getelementptr i64, i64* %keywords38.i, i32 1, !dbg !145
+  store i64 %52, i64* %53, align 8, !dbg !145
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.10, i64 %rubyId_params37.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords38.i), !dbg !145
+  %rubyId_returns45.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !145
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.11, i64 %rubyId_returns45.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !145
   %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !67
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !67
   %rubyId_plus.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !80
@@ -1799,109 +1784,109 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !81
   %rubyId_minus.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !82
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus, i64 %rubyId_minus.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !82
-  %rubyId_p66.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !83
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.15, i64 %rubyId_p66.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !83
+  %rubyId_p55.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !83
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p55.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !83
   %rubyId_lt.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !84
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt, i64 %rubyId_lt.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !84
-  %rubyId_p71.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !85
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.16, i64 %rubyId_p71.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !85
-  %rubyId_lt74.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !86
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.17, i64 %rubyId_lt74.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !86
-  %rubyId_p77.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !87
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.18, i64 %rubyId_p77.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !87
+  %rubyId_p60.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !85
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p60.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !85
+  %rubyId_lt63.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !86
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.14, i64 %rubyId_lt63.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !86
+  %rubyId_p66.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !87
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.15, i64 %rubyId_p66.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !87
   %rubyId_lte.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !88
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte, i64 %rubyId_lte.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !88
-  %rubyId_p82.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !89
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.19, i64 %rubyId_p82.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !89
-  %rubyId_lte85.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !90
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.20, i64 %rubyId_lte85.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !90
-  %rubyId_p88.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !91
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.21, i64 %rubyId_p88.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !91
-  %rubyId_lte91.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !92
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.22, i64 %rubyId_lte91.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !92
-  %rubyId_p94.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !93
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.23, i64 %rubyId_p94.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !93
-  %rubyId_plus97.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !94
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.24, i64 %rubyId_plus97.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !94
-  %rubyId_p100.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !95
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.25, i64 %rubyId_p100.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !95
-  %55 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_8.9, i64 0, i64 0), i64 noundef 3) #15
-  call void @rb_gc_register_mark_object(i64 %55) #15
-  store i64 %55, i64* @rubyStrFrozen_8.9, align 8
+  %rubyId_p71.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !89
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.16, i64 %rubyId_p71.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !89
+  %rubyId_lte74.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !90
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.17, i64 %rubyId_lte74.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !90
+  %rubyId_p77.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !91
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.18, i64 %rubyId_p77.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !91
+  %rubyId_lte80.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !92
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.19, i64 %rubyId_lte80.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !92
+  %rubyId_p83.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !93
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.20, i64 %rubyId_p83.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !93
+  %rubyId_plus86.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !94
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.21, i64 %rubyId_plus86.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !94
+  %rubyId_p89.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !95
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.22, i64 %rubyId_p89.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !95
+  %54 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_8.9, i64 0, i64 0), i64 noundef 3) #15
+  call void @rb_gc_register_mark_object(i64 %54) #15
+  store i64 %54, i64* @rubyStrFrozen_8.9, align 8
   %rubyId_Rational.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !96
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !96
-  %rubyId_plus104.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !97
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.26, i64 %rubyId_plus104.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !97
-  %rubyId_p107.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !98
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.27, i64 %rubyId_p107.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !98
-  %56 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_5, i64 0, i64 0), i64 noundef 1) #15
-  call void @rb_gc_register_mark_object(i64 %56) #15
-  store i64 %56, i64* @rubyStrFrozen_5, align 8
+  %rubyId_plus93.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !97
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.23, i64 %rubyId_plus93.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !97
+  %rubyId_p96.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !98
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.24, i64 %rubyId_p96.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !98
+  %55 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_5, i64 0, i64 0), i64 noundef 1) #15
+  call void @rb_gc_register_mark_object(i64 %55) #15
+  store i64 %55, i64* @rubyStrFrozen_5, align 8
   %rubyId_Complex.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !99
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex, i64 %rubyId_Complex.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !99
-  %rubyId_plus111.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !100
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.28, i64 %rubyId_plus111.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !100
-  %rubyId_p114.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !101
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.29, i64 %rubyId_p114.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !101
-  %rubyId_minus117.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !102
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.30, i64 %rubyId_minus117.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !102
-  %rubyId_p120.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !103
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.31, i64 %rubyId_p120.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !103
-  %57 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_15.4, i64 0, i64 0), i64 noundef 4) #15
+  %rubyId_plus100.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !100
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.25, i64 %rubyId_plus100.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !100
+  %rubyId_p103.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !101
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.26, i64 %rubyId_p103.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !101
+  %rubyId_minus106.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !102
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.27, i64 %rubyId_minus106.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !102
+  %rubyId_p109.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !103
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.28, i64 %rubyId_p109.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !103
+  %56 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_15.4, i64 0, i64 0), i64 noundef 4) #15
+  call void @rb_gc_register_mark_object(i64 %56) #15
+  store i64 %56, i64* @rubyStrFrozen_15.4, align 8
+  %rubyId_Rational112.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !104
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.29, i64 %rubyId_Rational112.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
+  %rubyId_minus114.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !105
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.30, i64 %rubyId_minus114.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !105
+  %rubyId_p117.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !106
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.31, i64 %rubyId_p117.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !106
+  %57 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_18, i64 0, i64 0), i64 noundef 2) #15
   call void @rb_gc_register_mark_object(i64 %57) #15
-  store i64 %57, i64* @rubyStrFrozen_15.4, align 8
-  %rubyId_Rational123.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !104
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.32, i64 %rubyId_Rational123.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
-  %rubyId_minus125.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !105
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.33, i64 %rubyId_minus125.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !105
-  %rubyId_p128.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !106
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.34, i64 %rubyId_p128.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !106
-  %58 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_18, i64 0, i64 0), i64 noundef 2) #15
+  store i64 %57, i64* @rubyStrFrozen_18, align 8
+  %rubyId_Complex120.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !107
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.32, i64 %rubyId_Complex120.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !107
+  %rubyId_minus122.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !108
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.33, i64 %rubyId_minus122.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !108
+  %rubyId_p125.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !109
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.34, i64 %rubyId_p125.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !109
+  %rubyId_lt128.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !110
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.35, i64 %rubyId_lt128.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !110
+  %rubyId_p131.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !111
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.36, i64 %rubyId_p131.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !111
+  %58 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_25.4, i64 0, i64 0), i64 noundef 4) #15
   call void @rb_gc_register_mark_object(i64 %58) #15
-  store i64 %58, i64* @rubyStrFrozen_18, align 8
-  %rubyId_Complex131.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !107
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.35, i64 %rubyId_Complex131.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !107
-  %rubyId_minus133.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !108
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.36, i64 %rubyId_minus133.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !108
-  %rubyId_p136.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !109
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.37, i64 %rubyId_p136.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !109
-  %rubyId_lt139.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !110
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.38, i64 %rubyId_lt139.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !110
-  %rubyId_p142.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !111
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.39, i64 %rubyId_p142.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !111
-  %59 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_25.4, i64 0, i64 0), i64 noundef 4) #15
+  store i64 %58, i64* @rubyStrFrozen_25.4, align 8
+  %rubyId_Rational134.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !112
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.37, i64 %rubyId_Rational134.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
+  %rubyId_lt136.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !113
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.38, i64 %rubyId_lt136.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !113
+  %rubyId_p139.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !114
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.39, i64 %rubyId_p139.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !114
+  %rubyId_lte142.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !115
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.40, i64 %rubyId_lte142.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !115
+  %rubyId_p145.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !116
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.41, i64 %rubyId_p145.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !116
+  %59 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_5.923, i64 0, i64 0), i64 noundef 5) #15
   call void @rb_gc_register_mark_object(i64 %59) #15
-  store i64 %59, i64* @rubyStrFrozen_25.4, align 8
-  %rubyId_Rational145.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !112
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.40, i64 %rubyId_Rational145.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
-  %rubyId_lt147.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !113
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.41, i64 %rubyId_lt147.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !113
-  %rubyId_p150.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !114
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.42, i64 %rubyId_p150.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !114
-  %rubyId_lte153.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !115
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.43, i64 %rubyId_lte153.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !115
-  %rubyId_p156.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !116
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.44, i64 %rubyId_p156.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !116
-  %60 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_5.923, i64 0, i64 0), i64 noundef 5) #15
-  call void @rb_gc_register_mark_object(i64 %60) #15
-  store i64 %60, i64* @rubyStrFrozen_5.923, align 8
-  %rubyId_Rational159.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !117
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.45, i64 %rubyId_Rational159.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !117
-  %rubyId_lte161.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !118
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.46, i64 %rubyId_lte161.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !118
-  %rubyId_p164.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !119
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.47, i64 %rubyId_p164.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !119
+  store i64 %59, i64* @rubyStrFrozen_5.923, align 8
+  %rubyId_Rational148.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !117
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.42, i64 %rubyId_Rational148.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !117
+  %rubyId_lte150.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !118
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.43, i64 %rubyId_lte150.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !118
+  %rubyId_p153.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !119
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.44, i64 %rubyId_p153.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !119
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %3)
-  %61 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %62 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %61, i64 0, i32 18
-  %63 = load i64, i64* %62, align 8, !tbaa !147
-  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2
-  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !tbaa !58
-  call fastcc void @"func_<root>.17<static-init>$152"(i64 %63, %struct.rb_control_frame_struct* %66) #15
+  %60 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %61 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %60, i64 0, i32 18
+  %62 = load i64, i64* %61, align 8, !tbaa !147
+  %63 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %64 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %63, i64 0, i32 2
+  %65 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %64, align 8, !tbaa !58
+  call fastcc void @"func_<root>.17<static-init>$152"(i64 %62, %struct.rb_control_frame_struct* %65) #15
   ret void
 }
 

--- a/test/testdata/compiler/sig_rewriter.llo.exp
+++ b/test/testdata/compiler/sig_rewriter.llo.exp
@@ -106,9 +106,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_A.13<static-init>$block_1" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_block in <class:A>" = internal unnamed_addr global i64 0, align 8
 @"str_block in <class:A>" = private unnamed_addr constant [19 x i8] c"block in <class:A>\00", align 1
-@ic_sig = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_sig = internal unnamed_addr global i64 0, align 8
-@str_sig = private unnamed_addr constant [4 x i8] c"sig\00", align 1
 @ic_returns = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_returns = internal unnamed_addr global i64 0, align 8
 @str_returns = private unnamed_addr constant [8 x i8] c"returns\00", align 1
@@ -185,8 +182,8 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
 ; Function Attrs: sspreq
 define void @Init_sig_rewriter() local_unnamed_addr #4 {
 entry:
-  %locals.i12.i = alloca i64, i32 0, align 8
   %locals.i10.i = alloca i64, i32 0, align 8
+  %locals.i8.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
@@ -201,251 +198,247 @@ entry:
   store i64 %4, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #10
   store i64 %5, i64* @"rubyIdPrecomputed_block in <class:A>", align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i64 noundef 3) #10
-  store i64 %6, i64* @rubyIdPrecomputed_sig, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #10
-  store i64 %7, i64* @rubyIdPrecomputed_returns, align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #10
-  store i64 %8, i64* @rubyIdPrecomputed_extend, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #10
-  store i64 %9, i64* @rubyIdPrecomputed_normal, align 8
-  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #10
+  store i64 %6, i64* @rubyIdPrecomputed_returns, align 8
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #10
+  store i64 %7, i64* @rubyIdPrecomputed_extend, align 8
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #10
+  store i64 %8, i64* @rubyIdPrecomputed_normal, align 8
+  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
+  tail call void @rb_gc_register_mark_object(i64 %9) #10
+  store i64 %9, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/sig_rewriter.rb", i64 0, i64 0), i64 noundef 38) #10
   tail call void @rb_gc_register_mark_object(i64 %10) #10
-  store i64 %10, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/sig_rewriter.rb", i64 0, i64 0), i64 noundef 38) #10
-  tail call void @rb_gc_register_mark_object(i64 %11) #10
-  store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
+  store i64 %10, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 14)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !10
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !10
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #10
-  call void @rb_gc_register_mark_object(i64 %13) #10
+  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #10
+  call void @rb_gc_register_mark_object(i64 %12) #10
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
-  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i10.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
-  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #10
-  call void @rb_gc_register_mark_object(i64 %15) #10
+  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i7.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
+  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %12, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i7.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
+  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #10
+  call void @rb_gc_register_mark_object(i64 %14) #10
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #10
-  call void @rb_gc_register_mark_object(i64 %17) #10
+  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
+  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i10.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #10
+  call void @rb_gc_register_mark_object(i64 %16) #10
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
   %"rubyId_block in <class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:A>", align 8
-  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %"rubyId_block in <class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>$block_1", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !16
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !16
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !18
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %19 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !21
-  %20 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %19, i64 0, i32 18
-  %21 = load i64, i64* %20, align 8, !tbaa !23
-  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !21
-  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
-  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !33
+  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
+  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %"rubyId_block in <class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>$block_1", align 8
+  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !16
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
+  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  %18 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !20
+  %19 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %18, i64 0, i32 18
+  %20 = load i64, i64* %19, align 8, !tbaa !22
+  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 2
+  %23 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %22, align 8, !tbaa !32
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !36
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
-  %27 = load i64*, i64** %26, align 8, !tbaa !38
-  %28 = load i64, i64* %27, align 8, !tbaa !6
-  %29 = and i64 %28, -33
-  store i64 %29, i64* %27, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i) #10
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !39, !tbaa !21
-  %31 = load i64, i64* @rb_cObject, align 8, !dbg !40
-  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %31) #10, !dbg !40
-  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #10, !dbg !40
+  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %24, align 8, !tbaa !35
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 4
+  %26 = load i64*, i64** %25, align 8, !tbaa !37
+  %27 = load i64, i64* %26, align 8, !tbaa !6
+  %28 = and i64 %27, -33
+  store i64 %28, i64* %26, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %21, %struct.rb_control_frame_struct* %23, %struct.rb_iseq_struct* %stackFrame.i) #10
+  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 0
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %29, align 8, !dbg !38, !tbaa !20
+  %30 = load i64, i64* @rb_cObject, align 8, !dbg !39
+  %31 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %30) #10, !dbg !39
+  %32 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %31) #10, !dbg !39
   %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !21
-  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
-  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !33
-  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %37, align 8, !tbaa !36
-  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
-  %39 = load i64*, i64** %38, align 8, !tbaa !38
-  %40 = load i64, i64* %39, align 8, !tbaa !6
-  %41 = and i64 %40, -33
-  store i64 %41, i64* %39, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i.i1) #10
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %42, align 8, !dbg !41, !tbaa !21
-  %rubyId_foo.i.i2 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !43
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_foo.i.i2) #10, !dbg !43
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %32, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.13<static-init>L62$block_1") #10, !dbg !43
-  %43 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !43, !tbaa !21
-  %44 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 5, !dbg !43
-  %45 = load i32, i32* %44, align 8, !dbg !43, !tbaa !44
-  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 6, !dbg !43
-  %47 = load i32, i32* %46, align 4, !dbg !43, !tbaa !45
-  %48 = xor i32 %47, -1, !dbg !43
-  %49 = and i32 %48, %45, !dbg !43
-  %50 = icmp eq i32 %49, 0, !dbg !43
-  br i1 %50, label %afterSend.i.i, label %86, !dbg !43, !prof !46
+  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
+  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 2
+  %35 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %34, align 8, !tbaa !32
+  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %36, align 8, !tbaa !35
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 4
+  %38 = load i64*, i64** %37, align 8, !tbaa !37
+  %39 = load i64, i64* %38, align 8, !tbaa !6
+  %40 = and i64 %39, -33
+  store i64 %40, i64* %38, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %33, %struct.rb_control_frame_struct* %35, %struct.rb_iseq_struct* %stackFrame.i.i1) #10
+  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 0
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %41, align 8, !dbg !40, !tbaa !20
+  %rubyId_foo.i.i2 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !42
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_foo.i.i2) #10, !dbg !42
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %31, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.13<static-init>L62$block_1") #10, !dbg !42
+  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !42, !tbaa !20
+  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 5, !dbg !42
+  %44 = load i32, i32* %43, align 8, !dbg !42, !tbaa !43
+  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 6, !dbg !42
+  %46 = load i32, i32* %45, align 4, !dbg !42, !tbaa !44
+  %47 = xor i32 %46, -1, !dbg !42
+  %48 = and i32 %47, %44, !dbg !42
+  %49 = icmp eq i32 %48, 0, !dbg !42
+  br i1 %49, label %rb_vm_check_ints.exit1.i.i, label %50, !dbg !42, !prof !45
 
-afterSend.i.i:                                    ; preds = %86, %entry
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !43, !tbaa !21
-  %51 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !47
-  %52 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !47, !tbaa !48
-  %needTakeSlowPath = icmp ne i64 %51, %52, !dbg !47
-  br i1 %needTakeSlowPath, label %53, label %54, !dbg !47, !prof !49
+50:                                               ; preds = %entry
+  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 8, !dbg !42
+  %52 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %51, align 8, !dbg !42, !tbaa !46
+  %53 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %52, i32 noundef 0) #10, !dbg !42
+  br label %rb_vm_check_ints.exit1.i.i, !dbg !42
 
-53:                                               ; preds = %afterSend.i.i
+rb_vm_check_ints.exit1.i.i:                       ; preds = %50, %entry
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %41, align 8, !dbg !42, !tbaa !20
+  %54 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !47
+  %55 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !47, !tbaa !48
+  %needTakeSlowPath = icmp ne i64 %54, %55, !dbg !47
+  br i1 %needTakeSlowPath, label %56, label %57, !dbg !47, !prof !49
+
+56:                                               ; preds = %rb_vm_check_ints.exit1.i.i
   call void @"const_recompute_T::Sig"(), !dbg !47
-  br label %54, !dbg !47
+  br label %57, !dbg !47
 
-54:                                               ; preds = %afterSend.i.i, %53
-  %55 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !47
-  %56 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !47
-  %57 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !47, !tbaa !48
-  %guardUpdated = icmp eq i64 %56, %57, !dbg !47
+57:                                               ; preds = %rb_vm_check_ints.exit1.i.i, %56
+  %58 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !47
+  %59 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !47
+  %60 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !47, !tbaa !48
+  %guardUpdated = icmp eq i64 %59, %60, !dbg !47
   call void @llvm.assume(i1 %guardUpdated), !dbg !47
-  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !47
-  %59 = load i64*, i64** %58, align 8, !dbg !47
-  store i64 %32, i64* %59, align 8, !dbg !47, !tbaa !6
-  %60 = getelementptr inbounds i64, i64* %59, i64 1, !dbg !47
-  store i64 %55, i64* %60, align 8, !dbg !47, !tbaa !6
-  %61 = getelementptr inbounds i64, i64* %60, i64 1, !dbg !47
-  store i64* %61, i64** %58, align 8, !dbg !47
+  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !47
+  %62 = load i64*, i64** %61, align 8, !dbg !47
+  store i64 %31, i64* %62, align 8, !dbg !47, !tbaa !6
+  %63 = getelementptr inbounds i64, i64* %62, i64 1, !dbg !47
+  store i64 %58, i64* %63, align 8, !dbg !47, !tbaa !6
+  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !47
+  store i64* %64, i64** %61, align 8, !dbg !47
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !47
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %42, align 8, !dbg !47, !tbaa !21
-  %rubyId_foo40.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !50
-  %rawSym41.i.i = call i64 @rb_id2sym(i64 %rubyId_foo40.i.i) #10, !dbg !50
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %41, align 8, !dbg !47, !tbaa !20
+  %rubyId_foo37.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !50
+  %rawSym38.i.i = call i64 @rb_id2sym(i64 %rubyId_foo37.i.i) #10, !dbg !50
   %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !50
-  %rawSym42.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #10, !dbg !50
-  %62 = load i64, i64* @guard_epoch_A, align 8, !dbg !50
-  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !48
-  %needTakeSlowPath3 = icmp ne i64 %62, %63, !dbg !50
-  br i1 %needTakeSlowPath3, label %64, label %65, !dbg !50, !prof !49
+  %rawSym39.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #10, !dbg !50
+  %65 = load i64, i64* @guard_epoch_A, align 8, !dbg !50
+  %66 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !48
+  %needTakeSlowPath3 = icmp ne i64 %65, %66, !dbg !50
+  br i1 %needTakeSlowPath3, label %67, label %68, !dbg !50, !prof !49
 
-64:                                               ; preds = %54
+67:                                               ; preds = %57
   call void @const_recompute_A(), !dbg !50
-  br label %65, !dbg !50
+  br label %68, !dbg !50
 
-65:                                               ; preds = %54, %64
-  %66 = load i64, i64* @guarded_const_A, align 8, !dbg !50
-  %67 = load i64, i64* @guard_epoch_A, align 8, !dbg !50
-  %68 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !48
-  %guardUpdated4 = icmp eq i64 %67, %68, !dbg !50
+68:                                               ; preds = %57, %67
+  %69 = load i64, i64* @guarded_const_A, align 8, !dbg !50
+  %70 = load i64, i64* @guard_epoch_A, align 8, !dbg !50
+  %71 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !48
+  %guardUpdated4 = icmp eq i64 %70, %71, !dbg !50
   call void @llvm.assume(i1 %guardUpdated4), !dbg !50
-  %stackFrame46.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8, !dbg !50
-  %69 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !50
-  %70 = bitcast i8* %69 to i16*, !dbg !50
-  %71 = load i16, i16* %70, align 8, !dbg !50
-  %72 = and i16 %71, -384, !dbg !50
-  store i16 %72, i16* %70, align 8, !dbg !50
-  %73 = getelementptr inbounds i8, i8* %69, i64 4, !dbg !50
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %73, i8 0, i64 28, i1 false) #10, !dbg !50
-  call void @sorbet_vm_define_method(i64 %66, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#3foo", i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame46.i.i, i1 noundef zeroext false) #10, !dbg !50
-  %74 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !50, !tbaa !21
-  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 5, !dbg !50
-  %76 = load i32, i32* %75, align 8, !dbg !50, !tbaa !44
-  %77 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 6, !dbg !50
-  %78 = load i32, i32* %77, align 4, !dbg !50, !tbaa !45
-  %79 = xor i32 %78, -1, !dbg !50
-  %80 = and i32 %79, %76, !dbg !50
-  %81 = icmp eq i32 %80, 0, !dbg !50
-  br i1 %81, label %"func_<root>.17<static-init>$152.exit", label %82, !dbg !50, !prof !46
+  %stackFrame43.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8, !dbg !50
+  %72 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !50
+  %73 = bitcast i8* %72 to i16*, !dbg !50
+  %74 = load i16, i16* %73, align 8, !dbg !50
+  %75 = and i16 %74, -384, !dbg !50
+  store i16 %75, i16* %73, align 8, !dbg !50
+  %76 = getelementptr inbounds i8, i8* %72, i64 4, !dbg !50
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 28, i1 false) #10, !dbg !50
+  call void @sorbet_vm_define_method(i64 %69, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_A#3foo", i8* nonnull %72, %struct.rb_iseq_struct* %stackFrame43.i.i, i1 noundef zeroext false) #10, !dbg !50
+  %77 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !50, !tbaa !20
+  %78 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 5, !dbg !50
+  %79 = load i32, i32* %78, align 8, !dbg !50, !tbaa !43
+  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 6, !dbg !50
+  %81 = load i32, i32* %80, align 4, !dbg !50, !tbaa !44
+  %82 = xor i32 %81, -1, !dbg !50
+  %83 = and i32 %82, %79, !dbg !50
+  %84 = icmp eq i32 %83, 0, !dbg !50
+  br i1 %84, label %"func_<root>.17<static-init>$152.exit", label %85, !dbg !50, !prof !45
 
-82:                                               ; preds = %65
-  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %74, i64 0, i32 8, !dbg !50
-  %84 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %83, align 8, !dbg !50, !tbaa !51
-  %85 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %84, i32 noundef 0) #10, !dbg !50
+85:                                               ; preds = %68
+  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 8, !dbg !50
+  %87 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %86, align 8, !dbg !50, !tbaa !46
+  %88 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %87, i32 noundef 0) #10, !dbg !50
   br label %"func_<root>.17<static-init>$152.exit", !dbg !50
 
-86:                                               ; preds = %entry
-  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 8, !dbg !43
-  %88 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %87, align 8, !dbg !43, !tbaa !51
-  %89 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %88, i32 noundef 0) #10, !dbg !43
-  br label %afterSend.i.i, !dbg !43
-
-"func_<root>.17<static-init>$152.exit":           ; preds = %65, %82
-  call void @sorbet_popFrame() #10, !dbg !40
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %30, align 8, !dbg !40, !tbaa !21
-  %90 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
-  %91 = load i64*, i64** %90, align 8, !dbg !10
-  store i64 %66, i64* %91, align 8, !dbg !10, !tbaa !6
-  %92 = getelementptr inbounds i64, i64* %91, i64 1, !dbg !10
-  store i64* %92, i64** %90, align 8, !dbg !10
+"func_<root>.17<static-init>$152.exit":           ; preds = %68, %85
+  call void @sorbet_popFrame() #10, !dbg !39
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %29, align 8, !dbg !39, !tbaa !20
+  %89 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !10
+  %90 = load i64*, i64** %89, align 8, !dbg !10
+  store i64 %69, i64* %90, align 8, !dbg !10, !tbaa !6
+  %91 = getelementptr inbounds i64, i64* %90, i64 1, !dbg !10
+  store i64* %91, i64** %89, align 8, !dbg !10
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !10
-  %93 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
-  %94 = load i64*, i64** %93, align 8, !dbg !10
-  store i64 %send6, i64* %94, align 8, !dbg !10, !tbaa !6
-  %95 = getelementptr inbounds i64, i64* %94, i64 1, !dbg !10
-  store i64* %95, i64** %93, align 8, !dbg !10
+  %92 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !10
+  %93 = load i64*, i64** %92, align 8, !dbg !10
+  store i64 %send6, i64* %93, align 8, !dbg !10, !tbaa !6
+  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !10
+  store i64* %94, i64** %92, align 8, !dbg !10
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !10
-  %96 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !15
-  %97 = load i64*, i64** %96, align 8, !dbg !15
-  store i64 %21, i64* %97, align 8, !dbg !15, !tbaa !6
+  %95 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !15
+  %96 = load i64*, i64** %95, align 8, !dbg !15
+  store i64 %20, i64* %96, align 8, !dbg !15, !tbaa !6
+  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !15
+  store i64 %send8, i64* %97, align 8, !dbg !15, !tbaa !6
   %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !15
-  store i64 %send8, i64* %98, align 8, !dbg !15, !tbaa !6
-  %99 = getelementptr inbounds i64, i64* %98, i64 1, !dbg !15
-  store i64* %99, i64** %96, align 8, !dbg !15
+  store i64* %98, i64** %95, align 8, !dbg !15
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define noundef i64 @"func_A#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #5 !dbg !52 {
+define noundef i64 @"func_A#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp) #5 !dbg !51 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !21
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !53
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !53, !prof !54
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !20
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !52
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !52, !prof !53
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #12, !dbg !53
-  unreachable, !dbg !53
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #12, !dbg !52
+  unreachable, !dbg !52
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !55, !tbaa !21
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !54, !tbaa !20
   ret i64 183
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_A.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #6 !dbg !19 {
+define internal i64 @"func_A.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #6 !dbg !17 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !21
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !33
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !32
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !56
+  %4 = load i64, i64* %3, align 8, !tbaa !55
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>$block_1", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !36
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !35
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !38
+  %7 = load i64*, i64** %6, align 8, !tbaa !37
   %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !21
-  %11 = load i64, i64* @rb_cInteger, align 8, !dbg !18
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !18
-  %13 = load i64*, i64** %12, align 8, !dbg !18
-  store i64 %4, i64* %13, align 8, !dbg !18, !tbaa !6
-  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !18
-  store i64 %11, i64* %14, align 8, !dbg !18, !tbaa !6
-  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !18
-  store i64* %15, i64** %12, align 8, !dbg !18
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !18
-  ret i64 %send, !dbg !57
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !20
+  %11 = load i64, i64* @rb_cInteger, align 8, !dbg !16
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !16
+  %13 = load i64*, i64** %12, align 8, !dbg !16
+  store i64 %4, i64* %13, align 8, !dbg !16, !tbaa !6
+  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !16
+  store i64 %11, i64* %14, align 8, !dbg !16, !tbaa !6
+  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !16
+  store i64* %15, i64** %12, align 8, !dbg !16
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !16
+  ret i64 %send, !dbg !56
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
@@ -505,45 +498,44 @@ attributes #12 = { noreturn }
 !13 = !{!14}
 !14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
 !15 = !DILocation(line: 13, column: 1, scope: !11)
-!16 = !DILocation(line: 7, column: 3, scope: !17)
-!17 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.13<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!18 = !DILocation(line: 7, column: 8, scope: !19)
-!19 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.13<static-init>L62$block_1", scope: !17, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!20 = !DILocation(line: 6, column: 3, scope: !17)
-!21 = !{!22, !22, i64 0}
-!22 = !{!"any pointer", !8, i64 0}
-!23 = !{!24, !7, i64 400}
-!24 = !{!"rb_vm_struct", !7, i64 0, !25, i64 8, !22, i64 192, !22, i64 200, !22, i64 208, !29, i64 216, !8, i64 224, !26, i64 264, !26, i64 280, !26, i64 296, !26, i64 312, !7, i64 328, !28, i64 336, !28, i64 340, !28, i64 344, !28, i64 344, !28, i64 344, !28, i64 344, !28, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !22, i64 456, !22, i64 464, !30, i64 472, !31, i64 992, !22, i64 1016, !22, i64 1024, !28, i64 1032, !28, i64 1036, !26, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !28, i64 1136, !22, i64 1144, !22, i64 1152, !22, i64 1160, !22, i64 1168, !22, i64 1176, !22, i64 1184, !28, i64 1192, !32, i64 1200, !8, i64 1232}
-!25 = !{!"rb_global_vm_lock_struct", !22, i64 0, !8, i64 8, !26, i64 48, !22, i64 64, !28, i64 72, !8, i64 80, !8, i64 128, !28, i64 176, !28, i64 180}
-!26 = !{!"list_head", !27, i64 0}
-!27 = !{!"list_node", !22, i64 0, !22, i64 8}
-!28 = !{!"int", !8, i64 0}
-!29 = !{!"long long", !8, i64 0}
-!30 = !{!"", !8, i64 0}
-!31 = !{!"rb_hook_list_struct", !22, i64 0, !28, i64 8, !28, i64 12, !28, i64 16}
-!32 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!33 = !{!34, !22, i64 16}
-!34 = !{!"rb_execution_context_struct", !22, i64 0, !7, i64 8, !22, i64 16, !22, i64 24, !22, i64 32, !28, i64 40, !28, i64 44, !22, i64 48, !22, i64 56, !22, i64 64, !7, i64 72, !7, i64 80, !22, i64 88, !7, i64 96, !22, i64 104, !22, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !35, i64 152}
-!35 = !{!"", !22, i64 0, !22, i64 8, !7, i64 16, !8, i64 24}
-!36 = !{!37, !22, i64 16}
-!37 = !{!"rb_control_frame_struct", !22, i64 0, !22, i64 8, !22, i64 16, !7, i64 24, !22, i64 32, !22, i64 40, !22, i64 48}
-!38 = !{!37, !22, i64 32}
-!39 = !DILocation(line: 0, scope: !11)
-!40 = !DILocation(line: 5, column: 1, scope: !11)
-!41 = !DILocation(line: 0, scope: !17, inlinedAt: !42)
-!42 = distinct !DILocation(line: 5, column: 1, scope: !11)
-!43 = !DILocation(line: 7, column: 3, scope: !17, inlinedAt: !42)
-!44 = !{!34, !28, i64 40}
-!45 = !{!34, !28, i64 44}
-!46 = !{!"branch_weights", i32 2000, i32 1}
-!47 = !DILocation(line: 6, column: 3, scope: !17, inlinedAt: !42)
-!48 = !{!29, !29, i64 0}
+!16 = !DILocation(line: 7, column: 8, scope: !17)
+!17 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.13<static-init>L62$block_1", scope: !18, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!18 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.13<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!19 = !DILocation(line: 6, column: 3, scope: !18)
+!20 = !{!21, !21, i64 0}
+!21 = !{!"any pointer", !8, i64 0}
+!22 = !{!23, !7, i64 400}
+!23 = !{!"rb_vm_struct", !7, i64 0, !24, i64 8, !21, i64 192, !21, i64 200, !21, i64 208, !28, i64 216, !8, i64 224, !25, i64 264, !25, i64 280, !25, i64 296, !25, i64 312, !7, i64 328, !27, i64 336, !27, i64 340, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !21, i64 456, !21, i64 464, !29, i64 472, !30, i64 992, !21, i64 1016, !21, i64 1024, !27, i64 1032, !27, i64 1036, !25, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !27, i64 1136, !21, i64 1144, !21, i64 1152, !21, i64 1160, !21, i64 1168, !21, i64 1176, !21, i64 1184, !27, i64 1192, !31, i64 1200, !8, i64 1232}
+!24 = !{!"rb_global_vm_lock_struct", !21, i64 0, !8, i64 8, !25, i64 48, !21, i64 64, !27, i64 72, !8, i64 80, !8, i64 128, !27, i64 176, !27, i64 180}
+!25 = !{!"list_head", !26, i64 0}
+!26 = !{!"list_node", !21, i64 0, !21, i64 8}
+!27 = !{!"int", !8, i64 0}
+!28 = !{!"long long", !8, i64 0}
+!29 = !{!"", !8, i64 0}
+!30 = !{!"rb_hook_list_struct", !21, i64 0, !27, i64 8, !27, i64 12, !27, i64 16}
+!31 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!32 = !{!33, !21, i64 16}
+!33 = !{!"rb_execution_context_struct", !21, i64 0, !7, i64 8, !21, i64 16, !21, i64 24, !21, i64 32, !27, i64 40, !27, i64 44, !21, i64 48, !21, i64 56, !21, i64 64, !7, i64 72, !7, i64 80, !21, i64 88, !7, i64 96, !21, i64 104, !21, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !34, i64 152}
+!34 = !{!"", !21, i64 0, !21, i64 8, !7, i64 16, !8, i64 24}
+!35 = !{!36, !21, i64 16}
+!36 = !{!"rb_control_frame_struct", !21, i64 0, !21, i64 8, !21, i64 16, !7, i64 24, !21, i64 32, !21, i64 40, !21, i64 48}
+!37 = !{!36, !21, i64 32}
+!38 = !DILocation(line: 0, scope: !11)
+!39 = !DILocation(line: 5, column: 1, scope: !11)
+!40 = !DILocation(line: 0, scope: !18, inlinedAt: !41)
+!41 = distinct !DILocation(line: 5, column: 1, scope: !11)
+!42 = !DILocation(line: 7, column: 3, scope: !18, inlinedAt: !41)
+!43 = !{!33, !27, i64 40}
+!44 = !{!33, !27, i64 44}
+!45 = !{!"branch_weights", i32 2000, i32 1}
+!46 = !{!33, !21, i64 56}
+!47 = !DILocation(line: 6, column: 3, scope: !18, inlinedAt: !41)
+!48 = !{!28, !28, i64 0}
 !49 = !{!"branch_weights", i32 1, i32 10000}
-!50 = !DILocation(line: 8, column: 3, scope: !17, inlinedAt: !42)
-!51 = !{!34, !22, i64 56}
-!52 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#3foo", scope: null, file: !4, line: 8, type: !12, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!53 = !DILocation(line: 8, column: 3, scope: !52)
-!54 = !{!"branch_weights", i32 1, i32 2000}
-!55 = !DILocation(line: 0, scope: !52)
-!56 = !{!37, !7, i64 24}
-!57 = !DILocation(line: 7, column: 3, scope: !19)
+!50 = !DILocation(line: 8, column: 3, scope: !18, inlinedAt: !41)
+!51 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#3foo", scope: null, file: !4, line: 8, type: !12, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!52 = !DILocation(line: 8, column: 3, scope: !51)
+!53 = !{!"branch_weights", i32 1, i32 2000}
+!54 = !DILocation(line: 0, scope: !51)
+!55 = !{!36, !7, i64 24}
+!56 = !DILocation(line: 7, column: 3, scope: !17)

--- a/test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.llo.exp
@@ -126,8 +126,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>$block_1" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_block in <class:AttrReaderNoSig>" = internal unnamed_addr global i64 0, align 8
 @"str_block in <class:AttrReaderNoSig>" = private unnamed_addr constant [33 x i8] c"block in <class:AttrReaderNoSig>\00", align 1
-@ic_sig = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_sig = internal unnamed_addr global i64 0, align 8
 @ic_params = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_params = internal unnamed_addr global i64 0, align 8
 @str_params = private unnamed_addr constant [7 x i8] c"params\00", align 1
@@ -240,7 +238,7 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
 
 ; Function Attrs: nounwind sspreq uwtable
 define internal fastcc void @"func_AttrReaderNoSig.13<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !10 {
-fastSymCallIntrinsic_ResolvedSig_sig:
+functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -266,138 +264,138 @@ fastSymCallIntrinsic_ResolvedSig_sig:
   %14 = xor i32 %13, -1, !dbg !24
   %15 = and i32 %14, %11, !dbg !24
   %16 = icmp eq i32 %15, 0, !dbg !24
-  br i1 %16, label %afterSend, label %79, !dbg !24, !prof !27
+  br i1 %16, label %rb_vm_check_ints.exit2, label %17, !dbg !24, !prof !27
 
-afterSend:                                        ; preds = %79, %fastSymCallIntrinsic_ResolvedSig_sig
+17:                                               ; preds = %functionEntryInitializers
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
+  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !24, !tbaa !28
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !24
+  br label %rb_vm_check_ints.exit2, !dbg !24
+
+rb_vm_check_ints.exit2:                           ; preds = %functionEntryInitializers, %17
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !24, !tbaa !14
-  %17 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !28
-  %18 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !28, !tbaa !29
-  %needTakeSlowPath = icmp ne i64 %17, %18, !dbg !28
-  br i1 %needTakeSlowPath, label %19, label %20, !dbg !28, !prof !31
+  %21 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !29
+  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !29, !tbaa !30
+  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !29
+  br i1 %needTakeSlowPath, label %23, label %24, !dbg !29, !prof !32
 
-19:                                               ; preds = %afterSend
-  tail call void @"const_recompute_T::Sig"(), !dbg !28
-  br label %20, !dbg !28
+23:                                               ; preds = %rb_vm_check_ints.exit2
+  tail call void @"const_recompute_T::Sig"(), !dbg !29
+  br label %24, !dbg !29
 
-20:                                               ; preds = %afterSend, %19
-  %21 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !28
-  %22 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !28
-  %23 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !28, !tbaa !29
-  %guardUpdated = icmp eq i64 %22, %23, !dbg !28
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !28
-  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !28
-  %25 = load i64*, i64** %24, align 8, !dbg !28
-  store i64 %selfRaw, i64* %25, align 8, !dbg !28, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !28
-  store i64 %21, i64* %26, align 8, !dbg !28, !tbaa !6
-  %27 = getelementptr inbounds i64, i64* %26, i64 1, !dbg !28
-  store i64* %27, i64** %24, align 8, !dbg !28
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !28
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !28, !tbaa !14
-  %rubyId_initialize48 = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !32
-  %rawSym49 = tail call i64 @rb_id2sym(i64 %rubyId_initialize48), !dbg !32
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !32
-  %rawSym50 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !32
-  %28 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !32
-  %29 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !32, !tbaa !29
-  %needTakeSlowPath3 = icmp ne i64 %28, %29, !dbg !32
-  br i1 %needTakeSlowPath3, label %30, label %31, !dbg !32, !prof !31
+24:                                               ; preds = %rb_vm_check_ints.exit2, %23
+  %25 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !29
+  %26 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !29
+  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !29, !tbaa !30
+  %guardUpdated = icmp eq i64 %26, %27, !dbg !29
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !29
+  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !29
+  %29 = load i64*, i64** %28, align 8, !dbg !29
+  store i64 %selfRaw, i64* %29, align 8, !dbg !29, !tbaa !6
+  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !29
+  store i64 %25, i64* %30, align 8, !dbg !29, !tbaa !6
+  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !29
+  store i64* %31, i64** %28, align 8, !dbg !29
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !29
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !29, !tbaa !14
+  %rubyId_initialize45 = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !33
+  %rawSym46 = tail call i64 @rb_id2sym(i64 %rubyId_initialize45), !dbg !33
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !33
+  %rawSym47 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !33
+  %32 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !33
+  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !30
+  %needTakeSlowPath3 = icmp ne i64 %32, %33, !dbg !33
+  br i1 %needTakeSlowPath3, label %34, label %35, !dbg !33, !prof !32
 
-30:                                               ; preds = %20
-  tail call void @const_recompute_AttrReaderNoSig(), !dbg !32
-  br label %31, !dbg !32
+34:                                               ; preds = %24
+  tail call void @const_recompute_AttrReaderNoSig(), !dbg !33
+  br label %35, !dbg !33
 
-31:                                               ; preds = %20, %30
-  %32 = load i64, i64* @guarded_const_AttrReaderNoSig, align 8, !dbg !32
-  %33 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !32
-  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !32, !tbaa !29
-  %guardUpdated4 = icmp eq i64 %33, %34, !dbg !32
-  tail call void @llvm.assume(i1 %guardUpdated4), !dbg !32
-  %stackFrame54 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig#10initialize", align 8, !dbg !32
-  %35 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !32
-  %36 = bitcast i8* %35 to i16*, !dbg !32
-  %37 = load i16, i16* %36, align 8, !dbg !32
-  %38 = and i16 %37, -384, !dbg !32
-  %39 = or i16 %38, 1, !dbg !32
-  store i16 %39, i16* %36, align 8, !dbg !32
-  %40 = getelementptr inbounds i8, i8* %35, i64 8, !dbg !32
-  %41 = bitcast i8* %40 to i32*, !dbg !32
-  store i32 1, i32* %41, align 8, !dbg !32, !tbaa !33
-  %42 = getelementptr inbounds i8, i8* %35, i64 12, !dbg !32
-  %43 = bitcast i8* %42 to i32*, !dbg !32
-  %44 = getelementptr inbounds i8, i8* %35, i64 4, !dbg !32
-  %45 = bitcast i8* %44 to i32*, !dbg !32
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %42, i8 0, i64 20, i1 false), !dbg !32
-  store i32 1, i32* %45, align 4, !dbg !32, !tbaa !36
-  %positional_table = alloca i64, align 8, !dbg !32
-  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !32
-  store i64 %rubyId_foo, i64* %positional_table, align 8, !dbg !32
-  %46 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !32
-  %47 = bitcast i64* %positional_table to i8*, !dbg !32
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %46, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %47, i64 noundef 8, i1 noundef false) #15, !dbg !32
-  %48 = getelementptr inbounds i8, i8* %35, i64 32, !dbg !32
-  %49 = bitcast i8* %48 to i8**, !dbg !32
-  store i8* %46, i8** %49, align 8, !dbg !32, !tbaa !37
-  tail call void @sorbet_vm_define_method(i64 %32, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderNoSig#10initialize", i8* nonnull %35, %struct.rb_iseq_struct* %stackFrame54, i1 noundef zeroext false) #15, !dbg !32
-  %50 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !32, !tbaa !14
-  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %50, i64 0, i32 5, !dbg !32
-  %52 = load i32, i32* %51, align 8, !dbg !32, !tbaa !25
-  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %50, i64 0, i32 6, !dbg !32
-  %54 = load i32, i32* %53, align 4, !dbg !32, !tbaa !26
-  %55 = xor i32 %54, -1, !dbg !32
-  %56 = and i32 %55, %52, !dbg !32
-  %57 = icmp eq i32 %56, 0, !dbg !32
-  br i1 %57, label %rb_vm_check_ints.exit2, label %58, !dbg !32, !prof !27
+35:                                               ; preds = %24, %34
+  %36 = load i64, i64* @guarded_const_AttrReaderNoSig, align 8, !dbg !33
+  %37 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !33
+  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !30
+  %guardUpdated4 = icmp eq i64 %37, %38, !dbg !33
+  tail call void @llvm.assume(i1 %guardUpdated4), !dbg !33
+  %stackFrame51 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig#10initialize", align 8, !dbg !33
+  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !33
+  %40 = bitcast i8* %39 to i16*, !dbg !33
+  %41 = load i16, i16* %40, align 8, !dbg !33
+  %42 = and i16 %41, -384, !dbg !33
+  %43 = or i16 %42, 1, !dbg !33
+  store i16 %43, i16* %40, align 8, !dbg !33
+  %44 = getelementptr inbounds i8, i8* %39, i64 8, !dbg !33
+  %45 = bitcast i8* %44 to i32*, !dbg !33
+  store i32 1, i32* %45, align 8, !dbg !33, !tbaa !34
+  %46 = getelementptr inbounds i8, i8* %39, i64 12, !dbg !33
+  %47 = bitcast i8* %46 to i32*, !dbg !33
+  %48 = getelementptr inbounds i8, i8* %39, i64 4, !dbg !33
+  %49 = bitcast i8* %48 to i32*, !dbg !33
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 20, i1 false), !dbg !33
+  store i32 1, i32* %49, align 4, !dbg !33, !tbaa !37
+  %positional_table = alloca i64, align 8, !dbg !33
+  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !33
+  store i64 %rubyId_foo, i64* %positional_table, align 8, !dbg !33
+  %50 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !33
+  %51 = bitcast i64* %positional_table to i8*, !dbg !33
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %50, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %51, i64 noundef 8, i1 noundef false) #15, !dbg !33
+  %52 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !33
+  %53 = bitcast i8* %52 to i8**, !dbg !33
+  store i8* %50, i8** %53, align 8, !dbg !33, !tbaa !38
+  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderNoSig#10initialize", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame51, i1 noundef zeroext false) #15, !dbg !33
+  %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !33, !tbaa !14
+  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 5, !dbg !33
+  %56 = load i32, i32* %55, align 8, !dbg !33, !tbaa !25
+  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 6, !dbg !33
+  %58 = load i32, i32* %57, align 4, !dbg !33, !tbaa !26
+  %59 = xor i32 %58, -1, !dbg !33
+  %60 = and i32 %59, %56, !dbg !33
+  %61 = icmp eq i32 %60, 0, !dbg !33
+  br i1 %61, label %rb_vm_check_ints.exit1, label %62, !dbg !33, !prof !27
 
-58:                                               ; preds = %31
-  %59 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %50, i64 0, i32 8, !dbg !32
-  %60 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %59, align 8, !dbg !32, !tbaa !38
-  %61 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %60, i32 noundef 0) #15, !dbg !32
-  br label %rb_vm_check_ints.exit2, !dbg !32
+62:                                               ; preds = %35
+  %63 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 8, !dbg !33
+  %64 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %63, align 8, !dbg !33, !tbaa !28
+  %65 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %64, i32 noundef 0) #15, !dbg !33
+  br label %rb_vm_check_ints.exit1, !dbg !33
 
-rb_vm_check_ints.exit2:                           ; preds = %31, %58
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !32, !tbaa !14
-  %rubyId_foo56 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !39
-  %rawSym57 = tail call i64 @rb_id2sym(i64 %rubyId_foo56), !dbg !39
+rb_vm_check_ints.exit1:                           ; preds = %35, %62
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !33, !tbaa !14
+  %rubyId_foo53 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !39
+  %rawSym54 = tail call i64 @rb_id2sym(i64 %rubyId_foo53), !dbg !39
   %rubyId_attr_reader = load i64, i64* @rubyIdPrecomputed_attr_reader, align 8, !dbg !39
-  %rawSym58 = tail call i64 @rb_id2sym(i64 %rubyId_attr_reader), !dbg !39
-  %62 = tail call i64 @rb_intern(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0)) #15, !dbg !39
-  %63 = tail call i64 @rb_id2str(i64 %62) #15, !dbg !39
-  %64 = tail call i64 (i8*, ...) @rb_sprintf(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i64 %63) #15, !dbg !39
-  %65 = tail call i64 @rb_intern_str(i64 %64) #15, !dbg !39
-  %66 = inttoptr i64 %65 to i8*, !dbg !39
-  tail call void @rb_add_method(i64 %32, i64 %62, i32 noundef 4, i8* %66, i32 noundef 1) #15, !dbg !39
-  %67 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !39, !tbaa !14
-  %68 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %67, i64 0, i32 5, !dbg !39
-  %69 = load i32, i32* %68, align 8, !dbg !39, !tbaa !25
-  %70 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %67, i64 0, i32 6, !dbg !39
-  %71 = load i32, i32* %70, align 4, !dbg !39, !tbaa !26
-  %72 = xor i32 %71, -1, !dbg !39
-  %73 = and i32 %72, %69, !dbg !39
-  %74 = icmp eq i32 %73, 0, !dbg !39
-  br i1 %74, label %rb_vm_check_ints.exit1, label %75, !dbg !39, !prof !27
+  %rawSym55 = tail call i64 @rb_id2sym(i64 %rubyId_attr_reader), !dbg !39
+  %66 = tail call i64 @rb_intern(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0)) #15, !dbg !39
+  %67 = tail call i64 @rb_id2str(i64 %66) #15, !dbg !39
+  %68 = tail call i64 (i8*, ...) @rb_sprintf(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i64 %67) #15, !dbg !39
+  %69 = tail call i64 @rb_intern_str(i64 %68) #15, !dbg !39
+  %70 = inttoptr i64 %69 to i8*, !dbg !39
+  tail call void @rb_add_method(i64 %36, i64 %66, i32 noundef 4, i8* %70, i32 noundef 1) #15, !dbg !39
+  %71 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !39, !tbaa !14
+  %72 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 5, !dbg !39
+  %73 = load i32, i32* %72, align 8, !dbg !39, !tbaa !25
+  %74 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 6, !dbg !39
+  %75 = load i32, i32* %74, align 4, !dbg !39, !tbaa !26
+  %76 = xor i32 %75, -1, !dbg !39
+  %77 = and i32 %76, %73, !dbg !39
+  %78 = icmp eq i32 %77, 0, !dbg !39
+  br i1 %78, label %rb_vm_check_ints.exit, label %79, !dbg !39, !prof !27
 
-75:                                               ; preds = %rb_vm_check_ints.exit2
-  %76 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %67, i64 0, i32 8, !dbg !39
-  %77 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %76, align 8, !dbg !39, !tbaa !38
-  %78 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %77, i32 noundef 0) #15, !dbg !39
-  br label %rb_vm_check_ints.exit1, !dbg !39
+79:                                               ; preds = %rb_vm_check_ints.exit1
+  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 8, !dbg !39
+  %81 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %80, align 8, !dbg !39, !tbaa !28
+  %82 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %81, i32 noundef 0) #15, !dbg !39
+  br label %rb_vm_check_ints.exit, !dbg !39
 
-rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.exit2, %75
+rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.exit1, %79
   ret void
-
-79:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig
-  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
-  %81 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %80, align 8, !dbg !24, !tbaa !38
-  %82 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %81, i32 noundef 0) #15, !dbg !24
-  br label %afterSend, !dbg !24
 }
 
 ; Function Attrs: sspreq
 define void @Init_no_sig() local_unnamed_addr #8 {
 entry:
-  %locals.i20.i = alloca i64, i32 0, align 8
   %locals.i18.i = alloca i64, i32 0, align 8
+  %locals.i16.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %keywords.i = alloca i64, align 8, !dbg !40
   %realpath = tail call i64 @sorbet_readRealpath()
@@ -423,30 +421,28 @@ entry:
   store i64 %9, i64* @"rubyIdPrecomputed_<class:AttrReaderNoSig>", align 8
   %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([33 x i8], [33 x i8]* @"str_block in <class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 32) #15
   store i64 %10, i64* @"rubyIdPrecomputed_block in <class:AttrReaderNoSig>", align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i64 noundef 3) #15
-  store i64 %11, i64* @rubyIdPrecomputed_sig, align 8
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %12, i64* @rubyIdPrecomputed_params, align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_void, i64 0, i64 0), i64 noundef 4) #15
-  store i64 %13, i64* @rubyIdPrecomputed_void, align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %14, i64* @rubyIdPrecomputed_extend, align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %15, i64* @rubyIdPrecomputed_normal, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @str_attr_reader, i64 0, i64 0), i64 noundef 11) #15
-  store i64 %16, i64* @rubyIdPrecomputed_attr_reader, align 8
-  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #15
+  store i64 %11, i64* @rubyIdPrecomputed_params, align 8
+  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_void, i64 0, i64 0), i64 noundef 4) #15
+  store i64 %12, i64* @rubyIdPrecomputed_void, align 8
+  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #15
+  store i64 %13, i64* @rubyIdPrecomputed_extend, align 8
+  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
+  store i64 %14, i64* @rubyIdPrecomputed_normal, align 8
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @str_attr_reader, i64 0, i64 0), i64 noundef 11) #15
+  store i64 %15, i64* @rubyIdPrecomputed_attr_reader, align 8
+  %16 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  tail call void @rb_gc_register_mark_object(i64 %16) #15
+  store i64 %16, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([58 x i8], [58 x i8]* @"str_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", i64 0, i64 0), i64 noundef 57) #15
   tail call void @rb_gc_register_mark_object(i64 %17) #15
-  store i64 %17, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([58 x i8], [58 x i8]* @"str_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", i64 0, i64 0), i64 noundef 57) #15
-  tail call void @rb_gc_register_mark_object(i64 %18) #15
-  store i64 %18, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
+  store i64 %17, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !42
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !42
   %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !44
@@ -461,255 +457,253 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !48
   %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !49
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
-  call void @rb_gc_register_mark_object(i64 %20) #15
+  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
+  call void @rb_gc_register_mark_object(i64 %19) #15
   %rubyId_initialize.i.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %rubyId_initialize.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig#10initialize", align 8
-  %22 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #15
-  store i64 %22, i64* @"<void-singleton>", align 8
-  %23 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_<class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 23) #15
-  call void @rb_gc_register_mark_object(i64 %23) #15
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
+  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %rubyId_initialize.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig#10initialize", align 8
+  %21 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #15
+  store i64 %21, i64* @"<void-singleton>", align 8
+  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_<class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 23) #15
+  call void @rb_gc_register_mark_object(i64 %22) #15
   %"rubyId_<class:AttrReaderNoSig>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:AttrReaderNoSig>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i19.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
-  %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %23, i64 %"rubyId_<class:AttrReaderNoSig>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i19.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i20.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>", align 8
-  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([33 x i8], [33 x i8]* @"str_block in <class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 32) #15
-  call void @rb_gc_register_mark_object(i64 %25) #15
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
+  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %"rubyId_<class:AttrReaderNoSig>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>", align 8
+  %24 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([33 x i8], [33 x i8]* @"str_block in <class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 32) #15
+  call void @rb_gc_register_mark_object(i64 %24) #15
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>", align 8
   %"rubyId_block in <class:AttrReaderNoSig>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:AttrReaderNoSig>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i21.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
-  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %25, i64 %"rubyId_block in <class:AttrReaderNoSig>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>$block_1", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i19.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
+  %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %24, i64 %"rubyId_block in <class:AttrReaderNoSig>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i19.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>$block_1", align 8
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !40
-  %rubyId_foo12.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
-  %27 = call i64 @rb_id2sym(i64 %rubyId_foo12.i) #15, !dbg !40
-  store i64 %27, i64* %keywords.i, align 8, !dbg !40
+  %rubyId_foo10.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
+  %26 = call i64 @rb_id2sym(i64 %rubyId_foo10.i) #15, !dbg !40
+  store i64 %26, i64* %keywords.i, align 8, !dbg !40
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !40
   %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !40
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !40
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !28
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
+  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !29
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
-  %28 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %29 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %28, i64 0, i32 18
-  %30 = load i64, i64* %29, align 8, !tbaa !50
-  %31 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 2
-  %33 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %32, align 8, !tbaa !16
+  %27 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %28 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %27, i64 0, i32 18
+  %29 = load i64, i64* %28, align 8, !tbaa !50
+  %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 2
+  %32 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %31, align 8, !tbaa !16
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %34, align 8, !tbaa !20
-  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 4
-  %36 = load i64*, i64** %35, align 8, !tbaa !22
-  %37 = load i64, i64* %36, align 8, !tbaa !6
-  %38 = and i64 %37, -33
-  store i64 %38, i64* %36, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %31, %struct.rb_control_frame_struct* %33, %struct.rb_iseq_struct* %stackFrame.i) #15
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %39, align 8, !dbg !58, !tbaa !14
-  %40 = load i64, i64* @rb_cObject, align 8, !dbg !59
-  %41 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([16 x i8], [16 x i8]* @str_AttrReaderNoSig, i64 0, i64 0), i64 %40) #15, !dbg !59
-  %42 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %41) #15, !dbg !59
-  call fastcc void @"func_AttrReaderNoSig.13<static-init>L62"(i64 %41, %struct.rb_control_frame_struct* %42) #15, !dbg !59
+  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %33, align 8, !tbaa !20
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 4
+  %35 = load i64*, i64** %34, align 8, !tbaa !22
+  %36 = load i64, i64* %35, align 8, !tbaa !6
+  %37 = and i64 %36, -33
+  store i64 %37, i64* %35, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %30, %struct.rb_control_frame_struct* %32, %struct.rb_iseq_struct* %stackFrame.i) #15
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %38, align 8, !dbg !58, !tbaa !14
+  %39 = load i64, i64* @rb_cObject, align 8, !dbg !59
+  %40 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([16 x i8], [16 x i8]* @str_AttrReaderNoSig, i64 0, i64 0), i64 %39) #15, !dbg !59
+  %41 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %40) #15, !dbg !59
+  call fastcc void @"func_AttrReaderNoSig.13<static-init>L62"(i64 %40, %struct.rb_control_frame_struct* %41) #15, !dbg !59
   call void @sorbet_popFrame() #15, !dbg !59
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %39, align 8, !dbg !59, !tbaa !14
-  %43 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !42
-  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !42, !tbaa !29
-  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !42
-  br i1 %needTakeSlowPath, label %45, label %46, !dbg !42, !prof !31
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %38, align 8, !dbg !59, !tbaa !14
+  %42 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !42
+  %43 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !42, !tbaa !30
+  %needTakeSlowPath = icmp ne i64 %42, %43, !dbg !42
+  br i1 %needTakeSlowPath, label %44, label %45, !dbg !42, !prof !32
 
-45:                                               ; preds = %entry
+44:                                               ; preds = %entry
   call void @const_recompute_AttrReaderNoSig(), !dbg !42
-  br label %46, !dbg !42
+  br label %45, !dbg !42
 
-46:                                               ; preds = %entry, %45
-  %47 = load i64, i64* @guarded_const_AttrReaderNoSig, align 8, !dbg !42
-  %48 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !42
-  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !42, !tbaa !29
-  %guardUpdated = icmp eq i64 %48, %49, !dbg !42
+45:                                               ; preds = %entry, %44
+  %46 = load i64, i64* @guarded_const_AttrReaderNoSig, align 8, !dbg !42
+  %47 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !42
+  %48 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !42, !tbaa !30
+  %guardUpdated = icmp eq i64 %47, %48, !dbg !42
   call void @llvm.assume(i1 %guardUpdated), !dbg !42
-  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !42
-  %51 = load i64*, i64** %50, align 8, !dbg !42
-  store i64 %47, i64* %51, align 8, !dbg !42, !tbaa !6
+  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !42
+  %50 = load i64*, i64** %49, align 8, !dbg !42
+  store i64 %46, i64* %50, align 8, !dbg !42, !tbaa !6
+  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !42
+  store i64 2497, i64* %51, align 8, !dbg !42, !tbaa !6
   %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !42
-  store i64 2497, i64* %52, align 8, !dbg !42, !tbaa !6
-  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !42
-  store i64* %53, i64** %50, align 8, !dbg !42
+  store i64* %52, i64** %49, align 8, !dbg !42
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !42
   br label %BB2.i, !dbg !60
 
-BB2.i:                                            ; preds = %BB2.i.backedge, %46
-  %i.sroa.0.0.i = phi i64 [ 1, %46 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !58
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %39, align 8, !tbaa !14
-  %54 = and i64 %i.sroa.0.0.i, 1, !dbg !44
-  %55 = icmp eq i64 %54, 0, !dbg !44
-  br i1 %55, label %56, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !44, !prof !61
+BB2.i:                                            ; preds = %BB2.i.backedge, %45
+  %i.sroa.0.0.i = phi i64 [ 1, %45 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !58
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %38, align 8, !tbaa !14
+  %53 = and i64 %i.sroa.0.0.i, 1, !dbg !44
+  %54 = icmp eq i64 %53, 0, !dbg !44
+  br i1 %54, label %55, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !44, !prof !61
 
-56:                                               ; preds = %BB2.i
-  %57 = and i64 %i.sroa.0.0.i, 7, !dbg !44
-  %58 = icmp ne i64 %57, 0, !dbg !44
-  %59 = and i64 %i.sroa.0.0.i, -9, !dbg !44
-  %60 = icmp eq i64 %59, 0, !dbg !44
-  %61 = or i1 %58, %60, !dbg !44
-  br i1 %61, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !44, !prof !62
+55:                                               ; preds = %BB2.i
+  %56 = and i64 %i.sroa.0.0.i, 7, !dbg !44
+  %57 = icmp ne i64 %56, 0, !dbg !44
+  %58 = and i64 %i.sroa.0.0.i, -9, !dbg !44
+  %59 = icmp eq i64 %58, 0, !dbg !44
+  %60 = or i1 %57, %59, !dbg !44
+  br i1 %60, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !44, !prof !62
 
-sorbet_isa_Integer.exit:                          ; preds = %56
-  %62 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !44
-  %63 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %62, i64 0, i32 0, !dbg !44
-  %64 = load i64, i64* %63, align 8, !dbg !44, !tbaa !63
-  %65 = and i64 %64, 31, !dbg !44
-  %66 = icmp eq i64 %65, 10, !dbg !44
-  br i1 %66, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !44, !prof !27
+sorbet_isa_Integer.exit:                          ; preds = %55
+  %61 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !44
+  %62 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %61, i64 0, i32 0, !dbg !44
+  %63 = load i64, i64* %62, align 8, !dbg !44, !tbaa !63
+  %64 = and i64 %63, 31, !dbg !44
+  %65 = icmp eq i64 %64, 10, !dbg !44
+  br i1 %65, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !44, !prof !27
 
 BB5.i:                                            ; preds = %afterSend37.i
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %39, align 8, !tbaa !14
-  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !45
-  %68 = load i64*, i64** %67, align 8, !dbg !45
-  store i64 %send, i64* %68, align 8, !dbg !45, !tbaa !6
-  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !45
-  store i64* %69, i64** %67, align 8, !dbg !45
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %38, align 8, !tbaa !14
+  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !45
+  %67 = load i64*, i64** %66, align 8, !dbg !45
+  store i64 %send, i64* %67, align 8, !dbg !45, !tbaa !6
+  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !45
+  store i64* %68, i64** %66, align 8, !dbg !45
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !45
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %39, align 8, !dbg !45, !tbaa !14
-  br i1 %70, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !46
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %38, align 8, !dbg !45, !tbaa !14
+  br i1 %69, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !46
 
-afterSend37.i:                                    ; preds = %95, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
-  %70 = phi i1 [ %73, %"alternativeCallIntrinsic_Integer_<.i" ], [ %78, %sorbet_rb_int_lt.exit.i ], [ %78, %95 ]
-  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send4, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult89.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult89.i, %95 ], !dbg !44
-  %71 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !44
-  %72 = icmp ne i64 %71, 0, !dbg !44
-  br i1 %72, label %BB5.i, label %"func_<root>.17<static-init>$152.exit", !dbg !44
+afterSend37.i:                                    ; preds = %94, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
+  %69 = phi i1 [ %72, %"alternativeCallIntrinsic_Integer_<.i" ], [ %77, %sorbet_rb_int_lt.exit.i ], [ %77, %94 ]
+  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send4, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult89.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult89.i, %94 ], !dbg !44
+  %70 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !44
+  %71 = icmp ne i64 %70, 0, !dbg !44
+  br i1 %71, label %BB5.i, label %"func_<root>.17<static-init>$152.exit", !dbg !44
 
-"alternativeCallIntrinsic_Integer_<.i":           ; preds = %56, %sorbet_isa_Integer.exit
-  %73 = phi i1 [ %66, %sorbet_isa_Integer.exit ], [ false, %56 ]
-  %74 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !44
-  %75 = load i64*, i64** %74, align 8, !dbg !44
-  store i64 %i.sroa.0.0.i, i64* %75, align 8, !dbg !44, !tbaa !6
+"alternativeCallIntrinsic_Integer_<.i":           ; preds = %55, %sorbet_isa_Integer.exit
+  %72 = phi i1 [ %65, %sorbet_isa_Integer.exit ], [ false, %55 ]
+  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !44
+  %74 = load i64*, i64** %73, align 8, !dbg !44
+  store i64 %i.sroa.0.0.i, i64* %74, align 8, !dbg !44, !tbaa !6
+  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !44
+  store i64 20000001, i64* %75, align 8, !dbg !44, !tbaa !6
   %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !44
-  store i64 20000001, i64* %76, align 8, !dbg !44, !tbaa !6
-  %77 = getelementptr inbounds i64, i64* %76, i64 1, !dbg !44
-  store i64* %77, i64** %74, align 8, !dbg !44
+  store i64* %76, i64** %73, align 8, !dbg !44
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !44
   br label %afterSend37.i, !dbg !44
 
 "fastSymCallIntrinsic_Integer_<.i":               ; preds = %BB2.i, %sorbet_isa_Integer.exit
-  %78 = phi i1 [ %66, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
+  %77 = phi i1 [ %65, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
   call void @llvm.experimental.noalias.scope.decl(metadata !65) #15, !dbg !44
-  %79 = and i64 %i.sroa.0.0.i, 1, !dbg !44
-  %80 = icmp eq i64 %79, 0, !dbg !44
-  br i1 %80, label %85, label %81, !dbg !44, !prof !68
+  %78 = and i64 %i.sroa.0.0.i, 1, !dbg !44
+  %79 = icmp eq i64 %78, 0, !dbg !44
+  br i1 %79, label %84, label %80, !dbg !44, !prof !68
 
-81:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %82 = ashr i64 %i.sroa.0.0.i, 1, !dbg !44
-  %83 = icmp slt i64 %82, 10000000, !dbg !44
-  %84 = select i1 %83, i64 20, i64 0, !dbg !44
+80:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
+  %81 = ashr i64 %i.sroa.0.0.i, 1, !dbg !44
+  %82 = icmp slt i64 %81, 10000000, !dbg !44
+  %83 = select i1 %82, i64 20, i64 0, !dbg !44
   br label %sorbet_rb_int_lt.exit.i, !dbg !44
 
-85:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %86 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !44, !noalias !65
+84:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
+  %85 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !44, !noalias !65
   br label %sorbet_rb_int_lt.exit.i, !dbg !44
 
-sorbet_rb_int_lt.exit.i:                          ; preds = %85, %81
-  %rawSendResult89.i = phi i64 [ %84, %81 ], [ %86, %85 ]
-  %87 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !44, !tbaa !14
-  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 5, !dbg !44
-  %89 = load i32, i32* %88, align 8, !dbg !44, !tbaa !25
-  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 6, !dbg !44
-  %91 = load i32, i32* %90, align 4, !dbg !44, !tbaa !26
-  %92 = xor i32 %91, -1, !dbg !44
-  %93 = and i32 %92, %89, !dbg !44
-  %94 = icmp eq i32 %93, 0, !dbg !44
-  br i1 %94, label %afterSend37.i, label %95, !dbg !44, !prof !27
+sorbet_rb_int_lt.exit.i:                          ; preds = %84, %80
+  %rawSendResult89.i = phi i64 [ %83, %80 ], [ %85, %84 ]
+  %86 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !44, !tbaa !14
+  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %86, i64 0, i32 5, !dbg !44
+  %88 = load i32, i32* %87, align 8, !dbg !44, !tbaa !25
+  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %86, i64 0, i32 6, !dbg !44
+  %90 = load i32, i32* %89, align 4, !dbg !44, !tbaa !26
+  %91 = xor i32 %90, -1, !dbg !44
+  %92 = and i32 %91, %88, !dbg !44
+  %93 = icmp eq i32 %92, 0, !dbg !44
+  br i1 %93, label %afterSend37.i, label %94, !dbg !44, !prof !27
 
-95:                                               ; preds = %sorbet_rb_int_lt.exit.i
-  %96 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 8, !dbg !44
-  %97 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %96, align 8, !dbg !44, !tbaa !38
-  %98 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %97, i32 noundef 0) #15, !dbg !44
+94:                                               ; preds = %sorbet_rb_int_lt.exit.i
+  %95 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %86, i64 0, i32 8, !dbg !44
+  %96 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %95, align 8, !dbg !44, !tbaa !28
+  %97 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %96, i32 noundef 0) #15, !dbg !44
   br label %afterSend37.i, !dbg !44
 
 "alternativeCallIntrinsic_Integer_+.i":           ; preds = %BB5.i
-  %99 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !46
-  %100 = load i64*, i64** %99, align 8, !dbg !46
-  store i64 %i.sroa.0.0.i, i64* %100, align 8, !dbg !46, !tbaa !6
+  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !46
+  %99 = load i64*, i64** %98, align 8, !dbg !46
+  store i64 %i.sroa.0.0.i, i64* %99, align 8, !dbg !46, !tbaa !6
+  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !46
+  store i64 3, i64* %100, align 8, !dbg !46, !tbaa !6
   %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !46
-  store i64 3, i64* %101, align 8, !dbg !46, !tbaa !6
-  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !46
-  store i64* %102, i64** %99, align 8, !dbg !46
+  store i64* %101, i64** %98, align 8, !dbg !46
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !46
   br label %BB2.i.backedge, !dbg !46
 
 "fastSymCallIntrinsic_Integer_+.i":               ; preds = %BB5.i
   call void @llvm.experimental.noalias.scope.decl(metadata !69) #15, !dbg !46
-  %103 = and i64 %i.sroa.0.0.i, 1, !dbg !46
-  %104 = icmp eq i64 %103, 0, !dbg !46
-  br i1 %104, label %113, label %105, !dbg !46, !prof !68
+  %102 = and i64 %i.sroa.0.0.i, 1, !dbg !46
+  %103 = icmp eq i64 %102, 0, !dbg !46
+  br i1 %103, label %112, label %104, !dbg !46, !prof !68
 
-105:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %106 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !46
-  %107 = extractvalue { i64, i1 } %106, 1, !dbg !46
-  %108 = extractvalue { i64, i1 } %106, 0, !dbg !46
-  br i1 %107, label %109, label %sorbet_rb_int_plus.exit.i, !dbg !46
+104:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
+  %105 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !46
+  %106 = extractvalue { i64, i1 } %105, 1, !dbg !46
+  %107 = extractvalue { i64, i1 } %105, 0, !dbg !46
+  br i1 %106, label %108, label %sorbet_rb_int_plus.exit.i, !dbg !46
 
-109:                                              ; preds = %105
-  %110 = ashr i64 %108, 1, !dbg !46
-  %111 = xor i64 %110, -9223372036854775808, !dbg !46
-  %112 = call i64 @rb_int2big(i64 %111) #15, !dbg !46
+108:                                              ; preds = %104
+  %109 = ashr i64 %107, 1, !dbg !46
+  %110 = xor i64 %109, -9223372036854775808, !dbg !46
+  %111 = call i64 @rb_int2big(i64 %110) #15, !dbg !46
   br label %sorbet_rb_int_plus.exit.i, !dbg !46
 
-113:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %114 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !46, !noalias !69
+112:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
+  %113 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !46, !noalias !69
   br label %sorbet_rb_int_plus.exit.i, !dbg !46
 
-sorbet_rb_int_plus.exit.i:                        ; preds = %113, %109, %105
-  %115 = phi i64 [ %114, %113 ], [ %112, %109 ], [ %108, %105 ], !dbg !46
-  %116 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !14
-  %117 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %116, i64 0, i32 5, !dbg !46
-  %118 = load i32, i32* %117, align 8, !dbg !46, !tbaa !25
-  %119 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %116, i64 0, i32 6, !dbg !46
-  %120 = load i32, i32* %119, align 4, !dbg !46, !tbaa !26
-  %121 = xor i32 %120, -1, !dbg !46
-  %122 = and i32 %121, %118, !dbg !46
-  %123 = icmp eq i32 %122, 0, !dbg !46
-  br i1 %123, label %BB2.i.backedge, label %124, !dbg !46, !prof !27
+sorbet_rb_int_plus.exit.i:                        ; preds = %112, %108, %104
+  %114 = phi i64 [ %113, %112 ], [ %111, %108 ], [ %107, %104 ], !dbg !46
+  %115 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !14
+  %116 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %115, i64 0, i32 5, !dbg !46
+  %117 = load i32, i32* %116, align 8, !dbg !46, !tbaa !25
+  %118 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %115, i64 0, i32 6, !dbg !46
+  %119 = load i32, i32* %118, align 4, !dbg !46, !tbaa !26
+  %120 = xor i32 %119, -1, !dbg !46
+  %121 = and i32 %120, %117, !dbg !46
+  %122 = icmp eq i32 %121, 0, !dbg !46
+  br i1 %122, label %BB2.i.backedge, label %123, !dbg !46, !prof !27
 
-124:                                              ; preds = %sorbet_rb_int_plus.exit.i
-  %125 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %116, i64 0, i32 8, !dbg !46
-  %126 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %125, align 8, !dbg !46, !tbaa !38
-  %127 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %126, i32 noundef 0) #15, !dbg !46
+123:                                              ; preds = %sorbet_rb_int_plus.exit.i
+  %124 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %115, i64 0, i32 8, !dbg !46
+  %125 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %124, align 8, !dbg !46, !tbaa !28
+  %126 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %125, i32 noundef 0) #15, !dbg !46
   br label %BB2.i.backedge, !dbg !46
 
-BB2.i.backedge:                                   ; preds = %124, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
-  %i.sroa.0.0.i.be = phi i64 [ %send6, %"alternativeCallIntrinsic_Integer_+.i" ], [ %115, %sorbet_rb_int_plus.exit.i ], [ %115, %124 ]
+BB2.i.backedge:                                   ; preds = %123, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
+  %i.sroa.0.0.i.be = phi i64 [ %send6, %"alternativeCallIntrinsic_Integer_+.i" ], [ %114, %sorbet_rb_int_plus.exit.i ], [ %114, %123 ]
   br label %BB2.i
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %afterSend37.i
   %i.sroa.0.0.i.lcssa = phi i64 [ %i.sroa.0.0.i, %afterSend37.i ], !dbg !58
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %39, align 8, !tbaa !14
-  %128 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !47
-  %129 = load i64*, i64** %128, align 8, !dbg !47
-  store i64 %30, i64* %129, align 8, !dbg !47, !tbaa !6
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %38, align 8, !tbaa !14
+  %127 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !47
+  %128 = load i64*, i64** %127, align 8, !dbg !47
+  store i64 %29, i64* %128, align 8, !dbg !47, !tbaa !6
+  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !47
+  store i64 %i.sroa.0.0.i.lcssa, i64* %129, align 8, !dbg !47, !tbaa !6
   %130 = getelementptr inbounds i64, i64* %129, i64 1, !dbg !47
-  store i64 %i.sroa.0.0.i.lcssa, i64* %130, align 8, !dbg !47, !tbaa !6
-  %131 = getelementptr inbounds i64, i64* %130, i64 1, !dbg !47
-  store i64* %131, i64** %128, align 8, !dbg !47
+  store i64* %130, i64** %127, align 8, !dbg !47
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !47
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %39, align 8, !dbg !47, !tbaa !14
-  %132 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !48
-  %133 = load i64*, i64** %132, align 8, !dbg !48
-  store i64 %send, i64* %133, align 8, !dbg !48, !tbaa !6
-  %134 = getelementptr inbounds i64, i64* %133, i64 1, !dbg !48
-  store i64* %134, i64** %132, align 8, !dbg !48
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %38, align 8, !dbg !47, !tbaa !14
+  %131 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !48
+  %132 = load i64*, i64** %131, align 8, !dbg !48
+  store i64 %send, i64* %132, align 8, !dbg !48, !tbaa !6
+  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !48
+  store i64* %133, i64** %131, align 8, !dbg !48
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !48
-  %135 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !49
-  %136 = load i64*, i64** %135, align 8, !dbg !49
-  store i64 %30, i64* %136, align 8, !dbg !49, !tbaa !6
+  %134 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !49
+  %135 = load i64*, i64** %134, align 8, !dbg !49
+  store i64 %29, i64* %135, align 8, !dbg !49, !tbaa !6
+  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !49
+  store i64 %send10, i64* %136, align 8, !dbg !49, !tbaa !6
   %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !49
-  store i64 %send10, i64* %137, align 8, !dbg !49, !tbaa !6
-  %138 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !49
-  store i64* %138, i64** %135, align 8, !dbg !49
+  store i64* %137, i64** %134, align 8, !dbg !49
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !49
   ret void
 }
@@ -828,7 +822,7 @@ declare void @llvm.assume(i1 noundef) #13
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !29
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !30
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
@@ -837,7 +831,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #9 {
 define linkonce void @const_recompute_AttrReaderNoSig() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @str_AttrReaderNoSig, i64 0, i64 0), i64 15)
   store i64 %1, i64* @guarded_const_AttrReaderNoSig, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !29
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !30
   store i64 %2, i64* @guard_epoch_AttrReaderNoSig, align 8
   ret void
 }
@@ -894,17 +888,17 @@ attributes #19 = { noinline }
 !25 = !{!17, !18, i64 40}
 !26 = !{!17, !18, i64 44}
 !27 = !{!"branch_weights", i32 2000, i32 1}
-!28 = !DILocation(line: 6, column: 3, scope: !10)
-!29 = !{!30, !30, i64 0}
-!30 = !{!"long long", !8, i64 0}
-!31 = !{!"branch_weights", i32 1, i32 10000}
-!32 = !DILocation(line: 8, column: 3, scope: !10)
-!33 = !{!34, !18, i64 8}
-!34 = !{!"rb_sorbet_param_struct", !35, i64 0, !18, i64 4, !18, i64 8, !18, i64 12, !18, i64 16, !18, i64 20, !18, i64 24, !18, i64 28, !15, i64 32, !18, i64 40, !18, i64 44, !18, i64 48, !18, i64 52, !15, i64 56}
-!35 = !{!"", !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 1, !18, i64 1}
-!36 = !{!34, !18, i64 4}
-!37 = !{!34, !15, i64 32}
-!38 = !{!17, !15, i64 56}
+!28 = !{!17, !15, i64 56}
+!29 = !DILocation(line: 6, column: 3, scope: !10)
+!30 = !{!31, !31, i64 0}
+!31 = !{!"long long", !8, i64 0}
+!32 = !{!"branch_weights", i32 1, i32 10000}
+!33 = !DILocation(line: 8, column: 3, scope: !10)
+!34 = !{!35, !18, i64 8}
+!35 = !{!"rb_sorbet_param_struct", !36, i64 0, !18, i64 4, !18, i64 8, !18, i64 12, !18, i64 16, !18, i64 20, !18, i64 24, !18, i64 28, !15, i64 32, !18, i64 40, !18, i64 44, !18, i64 48, !18, i64 52, !15, i64 56}
+!36 = !{!"", !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 1, !18, i64 1}
+!37 = !{!35, !18, i64 4}
+!38 = !{!35, !15, i64 32}
 !39 = !DILocation(line: 13, column: 3, scope: !10)
 !40 = !DILocation(line: 7, column: 8, scope: !41)
 !41 = distinct !DISubprogram(name: "AttrReaderNoSig.<static-init>", linkageName: "func_AttrReaderNoSig.13<static-init>L62$block_1", scope: !10, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
@@ -917,7 +911,7 @@ attributes #19 = { noinline }
 !48 = !DILocation(line: 27, column: 6, scope: !43)
 !49 = !DILocation(line: 27, column: 1, scope: !43)
 !50 = !{!51, !7, i64 400}
-!51 = !{!"rb_vm_struct", !7, i64 0, !52, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !30, i64 216, !8, i64 224, !53, i64 264, !53, i64 280, !53, i64 296, !53, i64 312, !7, i64 328, !18, i64 336, !18, i64 340, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !55, i64 472, !56, i64 992, !15, i64 1016, !15, i64 1024, !18, i64 1032, !18, i64 1036, !53, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !18, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !18, i64 1192, !57, i64 1200, !8, i64 1232}
+!51 = !{!"rb_vm_struct", !7, i64 0, !52, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !31, i64 216, !8, i64 224, !53, i64 264, !53, i64 280, !53, i64 296, !53, i64 312, !7, i64 328, !18, i64 336, !18, i64 340, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 344, !18, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !55, i64 472, !56, i64 992, !15, i64 1016, !15, i64 1024, !18, i64 1032, !18, i64 1036, !53, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !18, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !18, i64 1192, !57, i64 1200, !8, i64 1232}
 !52 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !53, i64 48, !15, i64 64, !18, i64 72, !8, i64 80, !8, i64 128, !18, i64 176, !18, i64 180}
 !53 = !{!"list_head", !54, i64 0}
 !54 = !{!"list_node", !15, i64 0, !15, i64 8}

--- a/test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.llo.exp
@@ -132,15 +132,12 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"str_block in <class:AttrReaderSigChecked>" = private unnamed_addr constant [38 x i8] c"block in <class:AttrReaderSigChecked>\00", align 1
 @"rubyStrFrozen_block in <class:AttrReaderSigChecked>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>$block_2" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@ic_sig = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_sig = internal unnamed_addr global i64 0, align 8
 @ic_params = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_params = internal unnamed_addr global i64 0, align 8
 @str_params = private unnamed_addr constant [7 x i8] c"params\00", align 1
 @ic_void = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_void = internal unnamed_addr global i64 0, align 8
 @str_void = private unnamed_addr constant [5 x i8] c"void\00", align 1
-@ic_sig.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_returns = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_returns = internal unnamed_addr global i64 0, align 8
 @str_returns = private unnamed_addr constant [8 x i8] c"returns\00", align 1
@@ -238,7 +235,7 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
 
 ; Function Attrs: nounwind sspreq uwtable
 define internal fastcc void @"func_AttrReaderSigChecked.13<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !10 {
-fastSymCallIntrinsic_ResolvedSig_sig:
+functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -264,164 +261,164 @@ fastSymCallIntrinsic_ResolvedSig_sig:
   %14 = xor i32 %13, -1, !dbg !24
   %15 = and i32 %14, %11, !dbg !24
   %16 = icmp eq i32 %15, 0, !dbg !24
-  br i1 %16, label %fastSymCallIntrinsic_ResolvedSig_sig63, label %17, !dbg !24, !prof !27
+  br i1 %16, label %rb_vm_check_ints.exit3, label %17, !dbg !24, !prof !27
 
-17:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig
+17:                                               ; preds = %functionEntryInitializers
   %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
   %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !24, !tbaa !28
   %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !24
-  br label %fastSymCallIntrinsic_ResolvedSig_sig63, !dbg !24
+  br label %rb_vm_check_ints.exit3, !dbg !24
 
-afterSend60:                                      ; preds = %92, %fastSymCallIntrinsic_ResolvedSig_sig63
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !29, !tbaa !14
-  %21 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !30
-  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
-  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !30
-  br i1 %needTakeSlowPath, label %23, label %24, !dbg !30, !prof !33
-
-23:                                               ; preds = %afterSend60
-  tail call void @"const_recompute_T::Sig"(), !dbg !30
-  br label %24, !dbg !30
-
-24:                                               ; preds = %afterSend60, %23
-  %25 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !30
-  %26 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !30
-  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
-  %guardUpdated = icmp eq i64 %26, %27, !dbg !30
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !30
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !30
-  %29 = load i64*, i64** %28, align 8, !dbg !30
-  store i64 %selfRaw, i64* %29, align 8, !dbg !30, !tbaa !6
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !30
-  store i64 %25, i64* %30, align 8, !dbg !30, !tbaa !6
-  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !30
-  store i64* %31, i64** %28, align 8, !dbg !30
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !30
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !30, !tbaa !14
-  %rubyId_initialize79 = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !34
-  %rawSym80 = tail call i64 @rb_id2sym(i64 %rubyId_initialize79), !dbg !34
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !34
-  %rawSym81 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !34
-  %32 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !34
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !34, !tbaa !31
-  %needTakeSlowPath4 = icmp ne i64 %32, %33, !dbg !34
-  br i1 %needTakeSlowPath4, label %34, label %35, !dbg !34, !prof !33
-
-34:                                               ; preds = %24
-  tail call void @const_recompute_AttrReaderSigChecked(), !dbg !34
-  br label %35, !dbg !34
-
-35:                                               ; preds = %24, %34
-  %36 = load i64, i64* @guarded_const_AttrReaderSigChecked, align 8, !dbg !34
-  %37 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !34
-  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !34, !tbaa !31
-  %guardUpdated5 = icmp eq i64 %37, %38, !dbg !34
-  tail call void @llvm.assume(i1 %guardUpdated5), !dbg !34
-  %stackFrame85 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#10initialize", align 8, !dbg !34
-  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !34
-  %40 = bitcast i8* %39 to i16*, !dbg !34
-  %41 = load i16, i16* %40, align 8, !dbg !34
-  %42 = and i16 %41, -384, !dbg !34
-  %43 = or i16 %42, 1, !dbg !34
-  store i16 %43, i16* %40, align 8, !dbg !34
-  %44 = getelementptr inbounds i8, i8* %39, i64 8, !dbg !34
-  %45 = bitcast i8* %44 to i32*, !dbg !34
-  store i32 1, i32* %45, align 8, !dbg !34, !tbaa !35
-  %46 = getelementptr inbounds i8, i8* %39, i64 12, !dbg !34
-  %47 = bitcast i8* %46 to i32*, !dbg !34
-  %48 = getelementptr inbounds i8, i8* %39, i64 4, !dbg !34
-  %49 = bitcast i8* %48 to i32*, !dbg !34
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 20, i1 false), !dbg !34
-  store i32 1, i32* %49, align 4, !dbg !34, !tbaa !38
-  %positional_table = alloca i64, align 8, !dbg !34
-  %rubyId_foo86 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !34
-  store i64 %rubyId_foo86, i64* %positional_table, align 8, !dbg !34
-  %50 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !34
-  %51 = bitcast i64* %positional_table to i8*, !dbg !34
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %50, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %51, i64 noundef 8, i1 noundef false) #15, !dbg !34
-  %52 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !34
-  %53 = bitcast i8* %52 to i8**, !dbg !34
-  store i8* %50, i8** %53, align 8, !dbg !34, !tbaa !39
-  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderSigChecked#10initialize", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame85, i1 noundef zeroext false) #15, !dbg !34
-  %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !34, !tbaa !14
-  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 5, !dbg !34
-  %56 = load i32, i32* %55, align 8, !dbg !34, !tbaa !25
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 6, !dbg !34
-  %58 = load i32, i32* %57, align 4, !dbg !34, !tbaa !26
-  %59 = xor i32 %58, -1, !dbg !34
-  %60 = and i32 %59, %56, !dbg !34
-  %61 = icmp eq i32 %60, 0, !dbg !34
-  br i1 %61, label %rb_vm_check_ints.exit2, label %62, !dbg !34, !prof !27
-
-62:                                               ; preds = %35
-  %63 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 8, !dbg !34
-  %64 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %63, align 8, !dbg !34, !tbaa !28
-  %65 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %64, i32 noundef 0) #15, !dbg !34
-  br label %rb_vm_check_ints.exit2, !dbg !34
-
-rb_vm_check_ints.exit2:                           ; preds = %35, %62
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !34, !tbaa !14
-  %rubyId_foo88 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
-  %rawSym89 = tail call i64 @rb_id2sym(i64 %rubyId_foo88), !dbg !40
-  %rubyId_normal90 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !40
-  %rawSym91 = tail call i64 @rb_id2sym(i64 %rubyId_normal90), !dbg !40
-  %stackFrame96 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#3foo", align 8, !dbg !40
-  %66 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !40
-  %67 = bitcast i8* %66 to i16*, !dbg !40
-  %68 = load i16, i16* %67, align 8, !dbg !40
-  %69 = and i16 %68, -384, !dbg !40
-  store i16 %69, i16* %67, align 8, !dbg !40
-  %70 = getelementptr inbounds i8, i8* %66, i64 4, !dbg !40
-  %71 = bitcast i8* %70 to i32*, !dbg !40
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %70, i8 0, i64 28, i1 false), !dbg !40
-  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderSigChecked#3foo", i8* nonnull %66, %struct.rb_iseq_struct* %stackFrame96, i1 noundef zeroext false) #15, !dbg !40
-  %72 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !14
-  %73 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 5, !dbg !40
-  %74 = load i32, i32* %73, align 8, !dbg !40, !tbaa !25
-  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 6, !dbg !40
-  %76 = load i32, i32* %75, align 4, !dbg !40, !tbaa !26
-  %77 = xor i32 %76, -1, !dbg !40
-  %78 = and i32 %77, %74, !dbg !40
-  %79 = icmp eq i32 %78, 0, !dbg !40
-  br i1 %79, label %rb_vm_check_ints.exit1, label %80, !dbg !40, !prof !27
-
-80:                                               ; preds = %rb_vm_check_ints.exit2
-  %81 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 8, !dbg !40
-  %82 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %81, align 8, !dbg !40, !tbaa !28
-  %83 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %82, i32 noundef 0) #15, !dbg !40
-  br label %rb_vm_check_ints.exit1, !dbg !40
-
-rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.exit2, %80
-  ret void
-
-fastSymCallIntrinsic_ResolvedSig_sig63:           ; preds = %fastSymCallIntrinsic_ResolvedSig_sig, %17
+rb_vm_check_ints.exit3:                           ; preds = %functionEntryInitializers, %17
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !24, !tbaa !14
   %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !29
-  %rawSym57 = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !29
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym57, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_AttrReaderSigChecked.13<static-init>L62$block_2"), !dbg !29
-  %84 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
-  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 5, !dbg !29
-  %86 = load i32, i32* %85, align 8, !dbg !29, !tbaa !25
-  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 6, !dbg !29
-  %88 = load i32, i32* %87, align 4, !dbg !29, !tbaa !26
-  %89 = xor i32 %88, -1, !dbg !29
-  %90 = and i32 %89, %86, !dbg !29
-  %91 = icmp eq i32 %90, 0, !dbg !29
-  br i1 %91, label %afterSend60, label %92, !dbg !29, !prof !27
+  %rawSym54 = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !29
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym54, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_AttrReaderSigChecked.13<static-init>L62$block_2"), !dbg !29
+  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !29
+  %23 = load i32, i32* %22, align 8, !dbg !29, !tbaa !25
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 6, !dbg !29
+  %25 = load i32, i32* %24, align 4, !dbg !29, !tbaa !26
+  %26 = xor i32 %25, -1, !dbg !29
+  %27 = and i32 %26, %23, !dbg !29
+  %28 = icmp eq i32 %27, 0, !dbg !29
+  br i1 %28, label %rb_vm_check_ints.exit2, label %29, !dbg !29, !prof !27
 
-92:                                               ; preds = %fastSymCallIntrinsic_ResolvedSig_sig63
-  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 8, !dbg !29
-  %94 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %93, align 8, !dbg !29, !tbaa !28
-  %95 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #15, !dbg !29
-  br label %afterSend60, !dbg !29
+29:                                               ; preds = %rb_vm_check_ints.exit3
+  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !29
+  %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !29, !tbaa !28
+  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #15, !dbg !29
+  br label %rb_vm_check_ints.exit2, !dbg !29
+
+rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.exit3, %29
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !29, !tbaa !14
+  %33 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !30
+  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
+  %needTakeSlowPath = icmp ne i64 %33, %34, !dbg !30
+  br i1 %needTakeSlowPath, label %35, label %36, !dbg !30, !prof !33
+
+35:                                               ; preds = %rb_vm_check_ints.exit2
+  tail call void @"const_recompute_T::Sig"(), !dbg !30
+  br label %36, !dbg !30
+
+36:                                               ; preds = %rb_vm_check_ints.exit2, %35
+  %37 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !30
+  %38 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !30
+  %39 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
+  %guardUpdated = icmp eq i64 %38, %39, !dbg !30
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !30
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !30
+  %41 = load i64*, i64** %40, align 8, !dbg !30
+  store i64 %selfRaw, i64* %41, align 8, !dbg !30, !tbaa !6
+  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !30
+  store i64 %37, i64* %42, align 8, !dbg !30, !tbaa !6
+  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !30
+  store i64* %43, i64** %40, align 8, !dbg !30
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !30
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !30, !tbaa !14
+  %rubyId_initialize71 = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !34
+  %rawSym72 = tail call i64 @rb_id2sym(i64 %rubyId_initialize71), !dbg !34
+  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !34
+  %rawSym73 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !34
+  %44 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !34
+  %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !34, !tbaa !31
+  %needTakeSlowPath4 = icmp ne i64 %44, %45, !dbg !34
+  br i1 %needTakeSlowPath4, label %46, label %47, !dbg !34, !prof !33
+
+46:                                               ; preds = %36
+  tail call void @const_recompute_AttrReaderSigChecked(), !dbg !34
+  br label %47, !dbg !34
+
+47:                                               ; preds = %36, %46
+  %48 = load i64, i64* @guarded_const_AttrReaderSigChecked, align 8, !dbg !34
+  %49 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !34
+  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !34, !tbaa !31
+  %guardUpdated5 = icmp eq i64 %49, %50, !dbg !34
+  tail call void @llvm.assume(i1 %guardUpdated5), !dbg !34
+  %stackFrame77 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#10initialize", align 8, !dbg !34
+  %51 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !34
+  %52 = bitcast i8* %51 to i16*, !dbg !34
+  %53 = load i16, i16* %52, align 8, !dbg !34
+  %54 = and i16 %53, -384, !dbg !34
+  %55 = or i16 %54, 1, !dbg !34
+  store i16 %55, i16* %52, align 8, !dbg !34
+  %56 = getelementptr inbounds i8, i8* %51, i64 8, !dbg !34
+  %57 = bitcast i8* %56 to i32*, !dbg !34
+  store i32 1, i32* %57, align 8, !dbg !34, !tbaa !35
+  %58 = getelementptr inbounds i8, i8* %51, i64 12, !dbg !34
+  %59 = bitcast i8* %58 to i32*, !dbg !34
+  %60 = getelementptr inbounds i8, i8* %51, i64 4, !dbg !34
+  %61 = bitcast i8* %60 to i32*, !dbg !34
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %58, i8 0, i64 20, i1 false), !dbg !34
+  store i32 1, i32* %61, align 4, !dbg !34, !tbaa !38
+  %positional_table = alloca i64, align 8, !dbg !34
+  %rubyId_foo78 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !34
+  store i64 %rubyId_foo78, i64* %positional_table, align 8, !dbg !34
+  %62 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !34
+  %63 = bitcast i64* %positional_table to i8*, !dbg !34
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %63, i64 noundef 8, i1 noundef false) #15, !dbg !34
+  %64 = getelementptr inbounds i8, i8* %51, i64 32, !dbg !34
+  %65 = bitcast i8* %64 to i8**, !dbg !34
+  store i8* %62, i8** %65, align 8, !dbg !34, !tbaa !39
+  tail call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderSigChecked#10initialize", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame77, i1 noundef zeroext false) #15, !dbg !34
+  %66 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !34, !tbaa !14
+  %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 5, !dbg !34
+  %68 = load i32, i32* %67, align 8, !dbg !34, !tbaa !25
+  %69 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 6, !dbg !34
+  %70 = load i32, i32* %69, align 4, !dbg !34, !tbaa !26
+  %71 = xor i32 %70, -1, !dbg !34
+  %72 = and i32 %71, %68, !dbg !34
+  %73 = icmp eq i32 %72, 0, !dbg !34
+  br i1 %73, label %rb_vm_check_ints.exit1, label %74, !dbg !34, !prof !27
+
+74:                                               ; preds = %47
+  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 8, !dbg !34
+  %76 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %75, align 8, !dbg !34, !tbaa !28
+  %77 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %76, i32 noundef 0) #15, !dbg !34
+  br label %rb_vm_check_ints.exit1, !dbg !34
+
+rb_vm_check_ints.exit1:                           ; preds = %47, %74
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !34, !tbaa !14
+  %rubyId_foo80 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
+  %rawSym81 = tail call i64 @rb_id2sym(i64 %rubyId_foo80), !dbg !40
+  %rubyId_normal82 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !40
+  %rawSym83 = tail call i64 @rb_id2sym(i64 %rubyId_normal82), !dbg !40
+  %stackFrame88 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#3foo", align 8, !dbg !40
+  %78 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !40
+  %79 = bitcast i8* %78 to i16*, !dbg !40
+  %80 = load i16, i16* %79, align 8, !dbg !40
+  %81 = and i16 %80, -384, !dbg !40
+  store i16 %81, i16* %79, align 8, !dbg !40
+  %82 = getelementptr inbounds i8, i8* %78, i64 4, !dbg !40
+  %83 = bitcast i8* %82 to i32*, !dbg !40
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %82, i8 0, i64 28, i1 false), !dbg !40
+  tail call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*)* noundef @"func_AttrReaderSigChecked#3foo", i8* nonnull %78, %struct.rb_iseq_struct* %stackFrame88, i1 noundef zeroext false) #15, !dbg !40
+  %84 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !14
+  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 5, !dbg !40
+  %86 = load i32, i32* %85, align 8, !dbg !40, !tbaa !25
+  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 6, !dbg !40
+  %88 = load i32, i32* %87, align 4, !dbg !40, !tbaa !26
+  %89 = xor i32 %88, -1, !dbg !40
+  %90 = and i32 %89, %86, !dbg !40
+  %91 = icmp eq i32 %90, 0, !dbg !40
+  br i1 %91, label %rb_vm_check_ints.exit, label %92, !dbg !40, !prof !27
+
+92:                                               ; preds = %rb_vm_check_ints.exit1
+  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 8, !dbg !40
+  %94 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %93, align 8, !dbg !40, !tbaa !28
+  %95 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #15, !dbg !40
+  br label %rb_vm_check_ints.exit, !dbg !40
+
+rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.exit1, %92
+  ret void
 }
 
 ; Function Attrs: sspreq
 define void @Init_sig_checked() local_unnamed_addr #8 {
 entry:
-  %locals.i27.i = alloca i64, align 8
-  %locals.i25.i = alloca i64, i32 0, align 8
-  %locals.i23.i = alloca i64, i32 0, align 8
+  %locals.i22.i = alloca i64, align 8
+  %locals.i20.i = alloca i64, i32 0, align 8
+  %locals.i18.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %keywords.i = alloca i64, align 8, !dbg !41
   %realpath = tail call i64 @sorbet_readRealpath()
@@ -449,30 +446,28 @@ entry:
   store i64 %10, i64* @"rubyIdPrecomputed_<block-call>", align 8
   %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_block in <class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 37) #15
   store i64 %11, i64* @"rubyIdPrecomputed_block in <class:AttrReaderSigChecked>", align 8
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i64 noundef 3) #15
-  store i64 %12, i64* @rubyIdPrecomputed_sig, align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %13, i64* @rubyIdPrecomputed_params, align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_void, i64 0, i64 0), i64 noundef 4) #15
-  store i64 %14, i64* @rubyIdPrecomputed_void, align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #15
-  store i64 %15, i64* @rubyIdPrecomputed_returns, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %16, i64* @rubyIdPrecomputed_extend, align 8
-  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %17, i64* @rubyIdPrecomputed_normal, align 8
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #15
+  store i64 %12, i64* @rubyIdPrecomputed_params, align 8
+  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_void, i64 0, i64 0), i64 noundef 4) #15
+  store i64 %13, i64* @rubyIdPrecomputed_void, align 8
+  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #15
+  store i64 %14, i64* @rubyIdPrecomputed_returns, align 8
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #15
+  store i64 %15, i64* @rubyIdPrecomputed_extend, align 8
+  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
+  store i64 %16, i64* @rubyIdPrecomputed_normal, align 8
+  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  tail call void @rb_gc_register_mark_object(i64 %17) #15
+  store i64 %17, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([63 x i8], [63 x i8]* @"str_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", i64 0, i64 0), i64 noundef 62) #15
   tail call void @rb_gc_register_mark_object(i64 %18) #15
-  store i64 %18, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([63 x i8], [63 x i8]* @"str_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", i64 0, i64 0), i64 noundef 62) #15
-  tail call void @rb_gc_register_mark_object(i64 %19) #15
-  store i64 %19, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
+  store i64 %18, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
-  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !43
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !43
   %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !45
@@ -487,277 +482,273 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !49
   %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !50
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
-  %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
-  call void @rb_gc_register_mark_object(i64 %21) #15
+  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
+  call void @rb_gc_register_mark_object(i64 %20) #15
   %rubyId_initialize.i.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
-  %22 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %rubyId_initialize.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %22, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#10initialize", align 8
-  %23 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #15
-  store i64 %23, i64* @"<void-singleton>", align 8
-  %24 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #15
-  call void @rb_gc_register_mark_object(i64 %24) #15
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
+  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %rubyId_initialize.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#10initialize", align 8
+  %22 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #15
+  store i64 %22, i64* @"<void-singleton>", align 8
+  %23 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #15
+  call void @rb_gc_register_mark_object(i64 %23) #15
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
-  %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %24, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#3foo", align 8
-  %26 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([29 x i8], [29 x i8]* @"str_<class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 28) #15
-  call void @rb_gc_register_mark_object(i64 %26) #15
-  %27 = bitcast i64* %locals.i27.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %27)
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i19.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
+  %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %23, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i19.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i20.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#3foo", align 8
+  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([29 x i8], [29 x i8]* @"str_<class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 28) #15
+  call void @rb_gc_register_mark_object(i64 %25) #15
+  %26 = bitcast i64* %locals.i22.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %26)
   %"rubyId_<class:AttrReaderSigChecked>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:AttrReaderSigChecked>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i21.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
   %"rubyId_<block-call>.i.i" = load i64, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  store i64 %"rubyId_<block-call>.i.i", i64* %locals.i27.i, align 8
-  %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %26, i64 %"rubyId_<class:AttrReaderSigChecked>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i27.i, i32 noundef 1, i32 noundef 4)
-  store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %27)
-  %29 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_block in <class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 37) #15
-  call void @rb_gc_register_mark_object(i64 %29) #15
-  store i64 %29, i64* @"rubyStrFrozen_block in <class:AttrReaderSigChecked>", align 8
+  store i64 %"rubyId_<block-call>.i.i", i64* %locals.i22.i, align 8
+  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %25, i64 %"rubyId_<class:AttrReaderSigChecked>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i22.i, i32 noundef 1, i32 noundef 4)
+  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %26)
+  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_block in <class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 37) #15
+  call void @rb_gc_register_mark_object(i64 %28) #15
+  store i64 %28, i64* @"rubyStrFrozen_block in <class:AttrReaderSigChecked>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
   %"rubyId_block in <class:AttrReaderSigChecked>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:AttrReaderSigChecked>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
-  %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %29, i64 %"rubyId_block in <class:AttrReaderSigChecked>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>$block_1", align 8
-  %stackFrame.i29.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
-  %"rubyId_block in <class:AttrReaderSigChecked>.i30.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:AttrReaderSigChecked>", align 8
-  %"rubyStr_block in <class:AttrReaderSigChecked>.i31.i" = load i64, i64* @"rubyStrFrozen_block in <class:AttrReaderSigChecked>", align 8
-  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i32.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
-  %31 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <class:AttrReaderSigChecked>.i31.i", i64 %"rubyId_block in <class:AttrReaderSigChecked>.i30.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i32.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i29.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %31, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>$block_2", align 8
-  %rubyId_sig.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig, i64 %rubyId_sig.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !24
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i23.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
+  %29 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %28, i64 %"rubyId_block in <class:AttrReaderSigChecked>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i23.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %29, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>$block_1", align 8
+  %stackFrame.i24.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
+  %"rubyId_block in <class:AttrReaderSigChecked>.i25.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:AttrReaderSigChecked>", align 8
+  %"rubyStr_block in <class:AttrReaderSigChecked>.i26.i" = load i64, i64* @"rubyStrFrozen_block in <class:AttrReaderSigChecked>", align 8
+  %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i27.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
+  %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <class:AttrReaderSigChecked>.i26.i", i64 %"rubyId_block in <class:AttrReaderSigChecked>.i25.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i27.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i24.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>$block_2", align 8
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !41
-  %rubyId_foo12.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !41
-  %32 = call i64 @rb_id2sym(i64 %rubyId_foo12.i) #15, !dbg !41
-  store i64 %32, i64* %keywords.i, align 8, !dbg !41
+  %rubyId_foo10.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !41
+  %31 = call i64 @rb_id2sym(i64 %rubyId_foo10.i) #15, !dbg !41
+  store i64 %31, i64* %keywords.i, align 8, !dbg !41
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !41
   %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !41
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !41
-  %rubyId_sig15.i = load i64, i64* @rubyIdPrecomputed_sig, align 8, !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_sig.5, i64 %rubyId_sig15.i, i32 noundef 20, i32 noundef 3, i32 noundef 0, i64* noundef null), !dbg !29
   %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !51
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !51
   %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !30
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
-  %33 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %34 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %33, i64 0, i32 18
-  %35 = load i64, i64* %34, align 8, !tbaa !53
-  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2
-  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !tbaa !16
+  %32 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %33 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %32, i64 0, i32 18
+  %34 = load i64, i64* %33, align 8, !tbaa !53
+  %35 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %35, i64 0, i32 2
+  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %36, align 8, !tbaa !16
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %39, align 8, !tbaa !20
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 4
-  %41 = load i64*, i64** %40, align 8, !tbaa !22
-  %42 = load i64, i64* %41, align 8, !tbaa !6
-  %43 = and i64 %42, -33
-  store i64 %43, i64* %41, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %36, %struct.rb_control_frame_struct* %38, %struct.rb_iseq_struct* %stackFrame.i) #15
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %44, align 8, !dbg !61, !tbaa !14
-  %45 = load i64, i64* @rb_cObject, align 8, !dbg !62
-  %46 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @str_AttrReaderSigChecked, i64 0, i64 0), i64 %45) #15, !dbg !62
-  %47 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %46) #15, !dbg !62
-  call fastcc void @"func_AttrReaderSigChecked.13<static-init>L62"(i64 %46, %struct.rb_control_frame_struct* %47) #15, !dbg !62
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %38, align 8, !tbaa !20
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 4
+  %40 = load i64*, i64** %39, align 8, !tbaa !22
+  %41 = load i64, i64* %40, align 8, !tbaa !6
+  %42 = and i64 %41, -33
+  store i64 %42, i64* %40, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %35, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i) #15
+  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %43, align 8, !dbg !61, !tbaa !14
+  %44 = load i64, i64* @rb_cObject, align 8, !dbg !62
+  %45 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @str_AttrReaderSigChecked, i64 0, i64 0), i64 %44) #15, !dbg !62
+  %46 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %45) #15, !dbg !62
+  call fastcc void @"func_AttrReaderSigChecked.13<static-init>L62"(i64 %45, %struct.rb_control_frame_struct* %46) #15, !dbg !62
   call void @sorbet_popFrame() #15, !dbg !62
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %44, align 8, !dbg !62, !tbaa !14
-  %48 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !43
-  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !31
-  %needTakeSlowPath = icmp ne i64 %48, %49, !dbg !43
-  br i1 %needTakeSlowPath, label %50, label %51, !dbg !43, !prof !33
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %43, align 8, !dbg !62, !tbaa !14
+  %47 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !43
+  %48 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !31
+  %needTakeSlowPath = icmp ne i64 %47, %48, !dbg !43
+  br i1 %needTakeSlowPath, label %49, label %50, !dbg !43, !prof !33
 
-50:                                               ; preds = %entry
+49:                                               ; preds = %entry
   call void @const_recompute_AttrReaderSigChecked(), !dbg !43
-  br label %51, !dbg !43
+  br label %50, !dbg !43
 
-51:                                               ; preds = %entry, %50
-  %52 = load i64, i64* @guarded_const_AttrReaderSigChecked, align 8, !dbg !43
-  %53 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !43
-  %54 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !31
-  %guardUpdated = icmp eq i64 %53, %54, !dbg !43
+50:                                               ; preds = %entry, %49
+  %51 = load i64, i64* @guarded_const_AttrReaderSigChecked, align 8, !dbg !43
+  %52 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !43
+  %53 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !31
+  %guardUpdated = icmp eq i64 %52, %53, !dbg !43
   call void @llvm.assume(i1 %guardUpdated), !dbg !43
-  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !43
-  %56 = load i64*, i64** %55, align 8, !dbg !43
-  store i64 %52, i64* %56, align 8, !dbg !43, !tbaa !6
+  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !43
+  %55 = load i64*, i64** %54, align 8, !dbg !43
+  store i64 %51, i64* %55, align 8, !dbg !43, !tbaa !6
+  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !43
+  store i64 2497, i64* %56, align 8, !dbg !43, !tbaa !6
   %57 = getelementptr inbounds i64, i64* %56, i64 1, !dbg !43
-  store i64 2497, i64* %57, align 8, !dbg !43, !tbaa !6
-  %58 = getelementptr inbounds i64, i64* %57, i64 1, !dbg !43
-  store i64* %58, i64** %55, align 8, !dbg !43
+  store i64* %57, i64** %54, align 8, !dbg !43
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !43
   br label %BB2.i, !dbg !63
 
-BB2.i:                                            ; preds = %BB2.i.backedge, %51
-  %i.sroa.0.0.i = phi i64 [ 1, %51 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !61
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %44, align 8, !tbaa !14
-  %59 = and i64 %i.sroa.0.0.i, 1, !dbg !45
-  %60 = icmp eq i64 %59, 0, !dbg !45
-  br i1 %60, label %61, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !45, !prof !64
+BB2.i:                                            ; preds = %BB2.i.backedge, %50
+  %i.sroa.0.0.i = phi i64 [ 1, %50 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !61
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %43, align 8, !tbaa !14
+  %58 = and i64 %i.sroa.0.0.i, 1, !dbg !45
+  %59 = icmp eq i64 %58, 0, !dbg !45
+  br i1 %59, label %60, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !45, !prof !64
 
-61:                                               ; preds = %BB2.i
-  %62 = and i64 %i.sroa.0.0.i, 7, !dbg !45
-  %63 = icmp ne i64 %62, 0, !dbg !45
-  %64 = and i64 %i.sroa.0.0.i, -9, !dbg !45
-  %65 = icmp eq i64 %64, 0, !dbg !45
-  %66 = or i1 %63, %65, !dbg !45
-  br i1 %66, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !45, !prof !65
+60:                                               ; preds = %BB2.i
+  %61 = and i64 %i.sroa.0.0.i, 7, !dbg !45
+  %62 = icmp ne i64 %61, 0, !dbg !45
+  %63 = and i64 %i.sroa.0.0.i, -9, !dbg !45
+  %64 = icmp eq i64 %63, 0, !dbg !45
+  %65 = or i1 %62, %64, !dbg !45
+  br i1 %65, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !45, !prof !65
 
-sorbet_isa_Integer.exit:                          ; preds = %61
-  %67 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !45
-  %68 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %67, i64 0, i32 0, !dbg !45
-  %69 = load i64, i64* %68, align 8, !dbg !45, !tbaa !66
-  %70 = and i64 %69, 31, !dbg !45
-  %71 = icmp eq i64 %70, 10, !dbg !45
-  br i1 %71, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !45, !prof !27
+sorbet_isa_Integer.exit:                          ; preds = %60
+  %66 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !45
+  %67 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %66, i64 0, i32 0, !dbg !45
+  %68 = load i64, i64* %67, align 8, !dbg !45, !tbaa !66
+  %69 = and i64 %68, 31, !dbg !45
+  %70 = icmp eq i64 %69, 10, !dbg !45
+  br i1 %70, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !45, !prof !27
 
 BB5.i:                                            ; preds = %afterSend37.i
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %44, align 8, !tbaa !14
-  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !46
-  %73 = load i64*, i64** %72, align 8, !dbg !46
-  store i64 %send, i64* %73, align 8, !dbg !46, !tbaa !6
-  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !46
-  store i64* %74, i64** %72, align 8, !dbg !46
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %43, align 8, !tbaa !14
+  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !46
+  %72 = load i64*, i64** %71, align 8, !dbg !46
+  store i64 %send, i64* %72, align 8, !dbg !46, !tbaa !6
+  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !46
+  store i64* %73, i64** %71, align 8, !dbg !46
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !46
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %44, align 8, !dbg !46, !tbaa !14
-  br i1 %75, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !47
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %43, align 8, !dbg !46, !tbaa !14
+  br i1 %74, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !47
 
-afterSend37.i:                                    ; preds = %100, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
-  %75 = phi i1 [ %78, %"alternativeCallIntrinsic_Integer_<.i" ], [ %83, %sorbet_rb_int_lt.exit.i ], [ %83, %100 ]
-  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send4, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult89.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult89.i, %100 ], !dbg !45
-  %76 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !45
-  %77 = icmp ne i64 %76, 0, !dbg !45
-  br i1 %77, label %BB5.i, label %"func_<root>.17<static-init>$152.exit", !dbg !45
+afterSend37.i:                                    ; preds = %99, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
+  %74 = phi i1 [ %77, %"alternativeCallIntrinsic_Integer_<.i" ], [ %82, %sorbet_rb_int_lt.exit.i ], [ %82, %99 ]
+  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send4, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult89.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult89.i, %99 ], !dbg !45
+  %75 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !45
+  %76 = icmp ne i64 %75, 0, !dbg !45
+  br i1 %76, label %BB5.i, label %"func_<root>.17<static-init>$152.exit", !dbg !45
 
-"alternativeCallIntrinsic_Integer_<.i":           ; preds = %61, %sorbet_isa_Integer.exit
-  %78 = phi i1 [ %71, %sorbet_isa_Integer.exit ], [ false, %61 ]
-  %79 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !45
-  %80 = load i64*, i64** %79, align 8, !dbg !45
-  store i64 %i.sroa.0.0.i, i64* %80, align 8, !dbg !45, !tbaa !6
+"alternativeCallIntrinsic_Integer_<.i":           ; preds = %60, %sorbet_isa_Integer.exit
+  %77 = phi i1 [ %70, %sorbet_isa_Integer.exit ], [ false, %60 ]
+  %78 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !45
+  %79 = load i64*, i64** %78, align 8, !dbg !45
+  store i64 %i.sroa.0.0.i, i64* %79, align 8, !dbg !45, !tbaa !6
+  %80 = getelementptr inbounds i64, i64* %79, i64 1, !dbg !45
+  store i64 20000001, i64* %80, align 8, !dbg !45, !tbaa !6
   %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !45
-  store i64 20000001, i64* %81, align 8, !dbg !45, !tbaa !6
-  %82 = getelementptr inbounds i64, i64* %81, i64 1, !dbg !45
-  store i64* %82, i64** %79, align 8, !dbg !45
+  store i64* %81, i64** %78, align 8, !dbg !45
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !45
   br label %afterSend37.i, !dbg !45
 
 "fastSymCallIntrinsic_Integer_<.i":               ; preds = %BB2.i, %sorbet_isa_Integer.exit
-  %83 = phi i1 [ %71, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
+  %82 = phi i1 [ %70, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
   call void @llvm.experimental.noalias.scope.decl(metadata !68) #15, !dbg !45
-  %84 = and i64 %i.sroa.0.0.i, 1, !dbg !45
-  %85 = icmp eq i64 %84, 0, !dbg !45
-  br i1 %85, label %90, label %86, !dbg !45, !prof !71
+  %83 = and i64 %i.sroa.0.0.i, 1, !dbg !45
+  %84 = icmp eq i64 %83, 0, !dbg !45
+  br i1 %84, label %89, label %85, !dbg !45, !prof !71
 
-86:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %87 = ashr i64 %i.sroa.0.0.i, 1, !dbg !45
-  %88 = icmp slt i64 %87, 10000000, !dbg !45
-  %89 = select i1 %88, i64 20, i64 0, !dbg !45
+85:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
+  %86 = ashr i64 %i.sroa.0.0.i, 1, !dbg !45
+  %87 = icmp slt i64 %86, 10000000, !dbg !45
+  %88 = select i1 %87, i64 20, i64 0, !dbg !45
   br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
-90:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %91 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !45, !noalias !68
+89:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
+  %90 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !45, !noalias !68
   br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
-sorbet_rb_int_lt.exit.i:                          ; preds = %90, %86
-  %rawSendResult89.i = phi i64 [ %89, %86 ], [ %91, %90 ]
-  %92 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !14
-  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %92, i64 0, i32 5, !dbg !45
-  %94 = load i32, i32* %93, align 8, !dbg !45, !tbaa !25
-  %95 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %92, i64 0, i32 6, !dbg !45
-  %96 = load i32, i32* %95, align 4, !dbg !45, !tbaa !26
-  %97 = xor i32 %96, -1, !dbg !45
-  %98 = and i32 %97, %94, !dbg !45
-  %99 = icmp eq i32 %98, 0, !dbg !45
-  br i1 %99, label %afterSend37.i, label %100, !dbg !45, !prof !27
+sorbet_rb_int_lt.exit.i:                          ; preds = %89, %85
+  %rawSendResult89.i = phi i64 [ %88, %85 ], [ %90, %89 ]
+  %91 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !14
+  %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %91, i64 0, i32 5, !dbg !45
+  %93 = load i32, i32* %92, align 8, !dbg !45, !tbaa !25
+  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %91, i64 0, i32 6, !dbg !45
+  %95 = load i32, i32* %94, align 4, !dbg !45, !tbaa !26
+  %96 = xor i32 %95, -1, !dbg !45
+  %97 = and i32 %96, %93, !dbg !45
+  %98 = icmp eq i32 %97, 0, !dbg !45
+  br i1 %98, label %afterSend37.i, label %99, !dbg !45, !prof !27
 
-100:                                              ; preds = %sorbet_rb_int_lt.exit.i
-  %101 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %92, i64 0, i32 8, !dbg !45
-  %102 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %101, align 8, !dbg !45, !tbaa !28
-  %103 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %102, i32 noundef 0) #15, !dbg !45
+99:                                               ; preds = %sorbet_rb_int_lt.exit.i
+  %100 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %91, i64 0, i32 8, !dbg !45
+  %101 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %100, align 8, !dbg !45, !tbaa !28
+  %102 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %101, i32 noundef 0) #15, !dbg !45
   br label %afterSend37.i, !dbg !45
 
 "alternativeCallIntrinsic_Integer_+.i":           ; preds = %BB5.i
-  %104 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !47
-  %105 = load i64*, i64** %104, align 8, !dbg !47
-  store i64 %i.sroa.0.0.i, i64* %105, align 8, !dbg !47, !tbaa !6
+  %103 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !47
+  %104 = load i64*, i64** %103, align 8, !dbg !47
+  store i64 %i.sroa.0.0.i, i64* %104, align 8, !dbg !47, !tbaa !6
+  %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !47
+  store i64 3, i64* %105, align 8, !dbg !47, !tbaa !6
   %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !47
-  store i64 3, i64* %106, align 8, !dbg !47, !tbaa !6
-  %107 = getelementptr inbounds i64, i64* %106, i64 1, !dbg !47
-  store i64* %107, i64** %104, align 8, !dbg !47
+  store i64* %106, i64** %103, align 8, !dbg !47
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !47
   br label %BB2.i.backedge, !dbg !47
 
 "fastSymCallIntrinsic_Integer_+.i":               ; preds = %BB5.i
   call void @llvm.experimental.noalias.scope.decl(metadata !72) #15, !dbg !47
-  %108 = and i64 %i.sroa.0.0.i, 1, !dbg !47
-  %109 = icmp eq i64 %108, 0, !dbg !47
-  br i1 %109, label %118, label %110, !dbg !47, !prof !71
+  %107 = and i64 %i.sroa.0.0.i, 1, !dbg !47
+  %108 = icmp eq i64 %107, 0, !dbg !47
+  br i1 %108, label %117, label %109, !dbg !47, !prof !71
 
-110:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %111 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !47
-  %112 = extractvalue { i64, i1 } %111, 1, !dbg !47
-  %113 = extractvalue { i64, i1 } %111, 0, !dbg !47
-  br i1 %112, label %114, label %sorbet_rb_int_plus.exit.i, !dbg !47
+109:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
+  %110 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !47
+  %111 = extractvalue { i64, i1 } %110, 1, !dbg !47
+  %112 = extractvalue { i64, i1 } %110, 0, !dbg !47
+  br i1 %111, label %113, label %sorbet_rb_int_plus.exit.i, !dbg !47
 
-114:                                              ; preds = %110
-  %115 = ashr i64 %113, 1, !dbg !47
-  %116 = xor i64 %115, -9223372036854775808, !dbg !47
-  %117 = call i64 @rb_int2big(i64 %116) #15, !dbg !47
+113:                                              ; preds = %109
+  %114 = ashr i64 %112, 1, !dbg !47
+  %115 = xor i64 %114, -9223372036854775808, !dbg !47
+  %116 = call i64 @rb_int2big(i64 %115) #15, !dbg !47
   br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
-118:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %119 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !47, !noalias !72
+117:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
+  %118 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !47, !noalias !72
   br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
-sorbet_rb_int_plus.exit.i:                        ; preds = %118, %114, %110
-  %120 = phi i64 [ %119, %118 ], [ %117, %114 ], [ %113, %110 ], !dbg !47
-  %121 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !14
-  %122 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %121, i64 0, i32 5, !dbg !47
-  %123 = load i32, i32* %122, align 8, !dbg !47, !tbaa !25
-  %124 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %121, i64 0, i32 6, !dbg !47
-  %125 = load i32, i32* %124, align 4, !dbg !47, !tbaa !26
-  %126 = xor i32 %125, -1, !dbg !47
-  %127 = and i32 %126, %123, !dbg !47
-  %128 = icmp eq i32 %127, 0, !dbg !47
-  br i1 %128, label %BB2.i.backedge, label %129, !dbg !47, !prof !27
+sorbet_rb_int_plus.exit.i:                        ; preds = %117, %113, %109
+  %119 = phi i64 [ %118, %117 ], [ %116, %113 ], [ %112, %109 ], !dbg !47
+  %120 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !14
+  %121 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 5, !dbg !47
+  %122 = load i32, i32* %121, align 8, !dbg !47, !tbaa !25
+  %123 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 6, !dbg !47
+  %124 = load i32, i32* %123, align 4, !dbg !47, !tbaa !26
+  %125 = xor i32 %124, -1, !dbg !47
+  %126 = and i32 %125, %122, !dbg !47
+  %127 = icmp eq i32 %126, 0, !dbg !47
+  br i1 %127, label %BB2.i.backedge, label %128, !dbg !47, !prof !27
 
-129:                                              ; preds = %sorbet_rb_int_plus.exit.i
-  %130 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %121, i64 0, i32 8, !dbg !47
-  %131 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %130, align 8, !dbg !47, !tbaa !28
-  %132 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %131, i32 noundef 0) #15, !dbg !47
+128:                                              ; preds = %sorbet_rb_int_plus.exit.i
+  %129 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 8, !dbg !47
+  %130 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %129, align 8, !dbg !47, !tbaa !28
+  %131 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %130, i32 noundef 0) #15, !dbg !47
   br label %BB2.i.backedge, !dbg !47
 
-BB2.i.backedge:                                   ; preds = %129, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
-  %i.sroa.0.0.i.be = phi i64 [ %send6, %"alternativeCallIntrinsic_Integer_+.i" ], [ %120, %sorbet_rb_int_plus.exit.i ], [ %120, %129 ]
+BB2.i.backedge:                                   ; preds = %128, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
+  %i.sroa.0.0.i.be = phi i64 [ %send6, %"alternativeCallIntrinsic_Integer_+.i" ], [ %119, %sorbet_rb_int_plus.exit.i ], [ %119, %128 ]
   br label %BB2.i
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %afterSend37.i
   %i.sroa.0.0.i.lcssa = phi i64 [ %i.sroa.0.0.i, %afterSend37.i ], !dbg !61
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %44, align 8, !tbaa !14
-  %133 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !48
-  %134 = load i64*, i64** %133, align 8, !dbg !48
-  store i64 %35, i64* %134, align 8, !dbg !48, !tbaa !6
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %43, align 8, !tbaa !14
+  %132 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !48
+  %133 = load i64*, i64** %132, align 8, !dbg !48
+  store i64 %34, i64* %133, align 8, !dbg !48, !tbaa !6
+  %134 = getelementptr inbounds i64, i64* %133, i64 1, !dbg !48
+  store i64 %i.sroa.0.0.i.lcssa, i64* %134, align 8, !dbg !48, !tbaa !6
   %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !48
-  store i64 %i.sroa.0.0.i.lcssa, i64* %135, align 8, !dbg !48, !tbaa !6
-  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !48
-  store i64* %136, i64** %133, align 8, !dbg !48
+  store i64* %135, i64** %132, align 8, !dbg !48
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !48
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %44, align 8, !dbg !48, !tbaa !14
-  %137 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !49
-  %138 = load i64*, i64** %137, align 8, !dbg !49
-  store i64 %send, i64* %138, align 8, !dbg !49, !tbaa !6
-  %139 = getelementptr inbounds i64, i64* %138, i64 1, !dbg !49
-  store i64* %139, i64** %137, align 8, !dbg !49
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %43, align 8, !dbg !48, !tbaa !14
+  %136 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !49
+  %137 = load i64*, i64** %136, align 8, !dbg !49
+  store i64 %send, i64* %137, align 8, !dbg !49, !tbaa !6
+  %138 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !49
+  store i64* %138, i64** %136, align 8, !dbg !49
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !49
-  %140 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !50
-  %141 = load i64*, i64** %140, align 8, !dbg !50
-  store i64 %35, i64* %141, align 8, !dbg !50, !tbaa !6
+  %139 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !50
+  %140 = load i64*, i64** %139, align 8, !dbg !50
+  store i64 %34, i64* %140, align 8, !dbg !50, !tbaa !6
+  %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !50
+  store i64 %send10, i64* %141, align 8, !dbg !50, !tbaa !6
   %142 = getelementptr inbounds i64, i64* %141, i64 1, !dbg !50
-  store i64 %send10, i64* %142, align 8, !dbg !50, !tbaa !6
-  %143 = getelementptr inbounds i64, i64* %142, i64 1, !dbg !50
-  store i64* %143, i64** %140, align 8, !dbg !50
+  store i64* %142, i64** %139, align 8, !dbg !50
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !50
   ret void
 }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We don't need to have type tests for this, following the rationale for not having type tests for `Sorbet::Private::Static` in #4645.  This makes the generated LLVM IR smaller and generally more pleasant to read.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
