### PR TITLE
optimize Thread.current and Thread.current[:constant_sym]

### DIFF
--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -274,6 +274,7 @@ const vector<pair<core::ClassOrModuleRef, string>> optimizedTypeTests = {
     {core::Symbols::Regexp(), "sorbet_i_isa_Regexp"},
     {core::Symbols::String(), "sorbet_i_isa_String"},
     {core::Symbols::Symbol(), "sorbet_i_isa_Symbol"},
+    {core::Symbols::Thread(), "sorbet_i_isa_Thread"},
     {core::Symbols::rootSingleton(), "sorbet_i_isa_RootSingleton"},
 };
 

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -58,7 +58,7 @@ struct SorbetLineNumberInfo {
     extern rettype name rest;             \
     KEEP_ALIVE(name)
 
-SORBET_ALIVE(VALUE, rb_id2sym, (ID));
+SORBET_ALIVE(VALUE, rb_id2sym, (ID) SORBET_ATTRIBUTE(const));
 SORBET_ALIVE(VALUE, rb_errinfo, ());
 SORBET_ALIVE(VALUE, rb_obj_is_kind_of, (VALUE, VALUE) __attribute__((const)));
 

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -58,7 +58,7 @@ struct SorbetLineNumberInfo {
     extern rettype name rest;             \
     KEEP_ALIVE(name)
 
-SORBET_ALIVE(VALUE, rb_id2sym, (ID) SORBET_ATTRIBUTE(const));
+SORBET_ALIVE(VALUE, rb_id2sym, (ID)SORBET_ATTRIBUTE(const));
 SORBET_ALIVE(VALUE, rb_errinfo, ());
 SORBET_ALIVE(VALUE, rb_obj_is_kind_of, (VALUE, VALUE) __attribute__((const)));
 

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -142,6 +142,7 @@ SORBET_ALIVE(_Bool, sorbet_i_isa_Array, (VALUE) __attribute__((const)));
 SORBET_ALIVE(_Bool, sorbet_i_isa_Regexp, (VALUE) __attribute__((const)));
 SORBET_ALIVE(_Bool, sorbet_i_isa_String, (VALUE) __attribute__((const)));
 SORBET_ALIVE(_Bool, sorbet_i_isa_Proc, (VALUE) __attribute__((const)));
+SORBET_ALIVE(_Bool, sorbet_i_isa_Thread, (VALUE) __attribute__((const)));
 SORBET_ALIVE(_Bool, sorbet_i_isa_RootSingleton, (VALUE) __attribute__((const)));
 
 SORBET_ALIVE(long, sorbet_globalConstRegister, (VALUE val));
@@ -330,6 +331,12 @@ _Bool sorbet_isa_Proc(VALUE obj) {
     return rb_obj_is_proc(obj) == Qtrue;
 }
 KEEP_ALIVE(sorbet_isa_Proc);
+
+SORBET_ATTRIBUTE(const)
+_Bool sorbet_isa_Thread(VALUE obj) {
+    return rb_obj_is_kind_of(obj, rb_cThread) == Qtrue;
+}
+KEEP_ALIVE(sorbet_isa_Thread);
 
 SORBET_ATTRIBUTE(const)
 _Bool sorbet_isa_RootSingleton(VALUE obj) {

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -815,6 +815,11 @@ VALUE sorbet_Thread_square_br_eq(VALUE recv, ID fun, int argc, const VALUE *cons
     return rb_thread_local_aset(recv, rb_to_id(id), val);
 }
 
+SORBET_INLINE
+VALUE sorbet_Thread_square_br_eq_symarg(VALUE recv, ID id, VALUE val) {
+    return rb_thread_local_aset(recv, id, val);
+}
+
 // https://github.com/ruby/ruby/blob/5445e0435260b449decf2ac16f9d09bae3cafe72/thread.c#L3386-L3390
 SORBET_INLINE
 VALUE sorbet_rb_obj_is_kind_of(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -800,6 +800,11 @@ VALUE sorbet_Thread_square_br(VALUE recv, ID fun, int argc, const VALUE *const r
     return rb_thread_local_aref(recv, id);
 }
 
+SORBET_INLINE
+VALUE sorbet_Thread_square_br_symarg(VALUE recv, ID id) {
+    return rb_thread_local_aref(recv, id);
+}
+
 // https://github.com/ruby/ruby/blob/5445e0435260b449decf2ac16f9d09bae3cafe72/thread.c#L3386-L3390
 SORBET_INLINE
 VALUE sorbet_Thread_square_br_eq(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -785,8 +785,7 @@ public:
 
         auto *recv = mcctx.varGetRecv();
         auto *id = Payload::idIntern(cs, builder, symit->second);
-        return builder.CreateCall(cs.getFunction("sorbet_Thread_square_br_symarg"),
-                                  {recv, id});
+        return builder.CreateCall(cs.getFunction("sorbet_Thread_square_br_symarg"), {recv, id});
     }
 } Thread_squareBrackets;
 
@@ -812,9 +811,9 @@ public:
 
         auto *recv = mcctx.varGetRecv();
         auto *id = Payload::idIntern(cs, builder, symit->second);
-        return builder.CreateCall(cs.getFunction("sorbet_Thread_square_br_eq_symarg"),
-                                  {recv, id, Payload::varGet(cs, send->args[1].variable, builder, irctx,
-                                                             mcctx.rubyBlockId)});
+        return builder.CreateCall(
+            cs.getFunction("sorbet_Thread_square_br_eq_symarg"),
+            {recv, id, Payload::varGet(cs, send->args[1].variable, builder, irctx, mcctx.rubyBlockId)});
     }
 } Thread_squareBracketsEq;
 

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -763,6 +763,33 @@ public:
     };
 } TPrivateCompiler_compilerVersion;
 
+class Thread_squareBrackets : public CallCMethod {
+public:
+    Thread_squareBrackets() : CallCMethod(core::Symbols::Thread(), "[]"sv, CMethod{"sorbet_Thread_square_br"}) {}
+
+    virtual llvm::Value *makeCall(MethodCallContext &mcctx) const override {
+        auto &cs = mcctx.cs;
+        auto &builder = mcctx.builder;
+        auto &irctx = mcctx.irctx;
+        auto *send = mcctx.send;
+
+        if (send->args.size() != 1 || send->numPosArgs != 1) {
+            return CallCMethod::makeCall(mcctx);
+        }
+
+        auto &arg = send->args[0];
+        auto symit = irctx.symbols.find(arg.variable);
+        if (symit == irctx.symbols.end()) {
+            return CallCMethod::makeCall(mcctx);
+        }
+
+        auto *recv = mcctx.varGetRecv();
+        auto *id = Payload::idIntern(cs, builder, symit->second);
+        return builder.CreateCall(cs.getFunction("sorbet_Thread_square_br_symarg"),
+                                  {recv, id});
+    }
+} Thread_squareBrackets;
+
 class CallCMethodSingleton : public CallCMethod {
 public:
     CallCMethodSingleton(core::ClassOrModuleRef rubyClass, string_view rubyMethod, CMethod cMethod)
@@ -865,7 +892,6 @@ static const vector<CallCMethod> knownCMethodsInstance{
      CMethod{"sorbet_rb_int_dotimes_withBlock", core::Symbols::Integer()}},
     {core::Symbols::Symbol(), "==", CMethod{"sorbet_rb_sym_equal"}},
     {core::Symbols::Symbol(), "===", CMethod{"sorbet_rb_sym_equal"}},
-    {core::Symbols::Thread(), "[]", CMethod{"sorbet_Thread_square_br"}},
     {core::Symbols::Thread(), "[]=", CMethod{"sorbet_Thread_square_br_eq"}},
     {core::Symbols::Kernel(), "is_a?", CMethod{"sorbet_rb_obj_is_kind_of"}, nullopt, {"rb_obj_is_kind_of"}},
     {core::Symbols::Kernel(), "kind_of?", CMethod{"sorbet_rb_obj_is_kind_of"}, nullopt, {"rb_obj_is_kind_of"}},
@@ -889,6 +915,7 @@ vector<const SymbolBasedIntrinsicMethod *> getKnownCMethodPtrs(const core::Globa
         &TEnum_abstract,
         &TPrivateCompiler_runningCompiled_p,
         &TPrivateCompiler_compilerVersion,
+        &Thread_squareBrackets,
     };
     for (auto &method : knownCMethodsInstance) {
         if (debug_mode) {

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -765,6 +765,9 @@ public:
 
 class Thread_squareBrackets : public CallCMethod {
 public:
+    // This sorbet_Thread_square_br is a slower version that will do arity checking and convert the
+    // argument to a symbol. If our `makeCall` fast path doesn't apply, we'll fall back to calling
+    // the slow version (via super class `makeCall`).
     Thread_squareBrackets() : CallCMethod(core::Symbols::Thread(), "[]"sv, CMethod{"sorbet_Thread_square_br"}) {}
 
     virtual llvm::Value *makeCall(MethodCallContext &mcctx) const override {
@@ -791,6 +794,9 @@ public:
 
 class Thread_squareBracketsEq : public CallCMethod {
 public:
+    // This sorbet_Thread_square_br_eq is a slower version that will do arity checking and convert the
+    // argument to a symbol. If our `makeCall` fast path doesn't apply, we'll fall back to calling
+    // the slow version (via super class).
     Thread_squareBracketsEq() : CallCMethod(core::Symbols::Thread(), "[]="sv, CMethod{"sorbet_Thread_square_br_eq"}) {}
 
     virtual llvm::Value *makeCall(MethodCallContext &mcctx) const override {

--- a/compiler/Passes/Lowerings.cc
+++ b/compiler/Passes/Lowerings.cc
@@ -278,13 +278,20 @@ public:
 } TypeTest;
 
 const vector<pair<llvm::StringRef, llvm::StringRef>> TypeTest::intrinsicMap{
-    {"sorbet_i_isa_Array", "sorbet_isa_Array"},         {"sorbet_i_isa_Integer", "sorbet_isa_Integer"},
-    {"sorbet_i_isa_TrueClass", "sorbet_isa_TrueClass"}, {"sorbet_i_isa_FalseClass", "sorbet_isa_FalseClass"},
-    {"sorbet_i_isa_NilClass", "sorbet_isa_NilClass"},   {"sorbet_i_isa_Symbol", "sorbet_isa_Symbol"},
-    {"sorbet_i_isa_Float", "sorbet_isa_Float"},         {"sorbet_i_isa_Untyped", "sorbet_isa_Untyped"},
-    {"sorbet_i_isa_Hash", "sorbet_isa_Hash"},           {"sorbet_i_isa_Array", "sorbet_isa_Array"},
-    {"sorbet_i_isa_Regexp", "sorbet_isa_Regexp"},       {"sorbet_i_isa_String", "sorbet_isa_String"},
-    {"sorbet_i_isa_Proc", "sorbet_isa_Proc"},           {"sorbet_i_isa_Thread", "sorbet_isa_Thread" },
+    {"sorbet_i_isa_Array", "sorbet_isa_Array"},
+    {"sorbet_i_isa_Integer", "sorbet_isa_Integer"},
+    {"sorbet_i_isa_TrueClass", "sorbet_isa_TrueClass"},
+    {"sorbet_i_isa_FalseClass", "sorbet_isa_FalseClass"},
+    {"sorbet_i_isa_NilClass", "sorbet_isa_NilClass"},
+    {"sorbet_i_isa_Symbol", "sorbet_isa_Symbol"},
+    {"sorbet_i_isa_Float", "sorbet_isa_Float"},
+    {"sorbet_i_isa_Untyped", "sorbet_isa_Untyped"},
+    {"sorbet_i_isa_Hash", "sorbet_isa_Hash"},
+    {"sorbet_i_isa_Array", "sorbet_isa_Array"},
+    {"sorbet_i_isa_Regexp", "sorbet_isa_Regexp"},
+    {"sorbet_i_isa_String", "sorbet_isa_String"},
+    {"sorbet_i_isa_Proc", "sorbet_isa_Proc"},
+    {"sorbet_i_isa_Thread", "sorbet_isa_Thread"},
     {"sorbet_i_isa_RootSingleton", "sorbet_isa_RootSingleton"},
 };
 

--- a/compiler/Passes/Lowerings.cc
+++ b/compiler/Passes/Lowerings.cc
@@ -284,7 +284,8 @@ const vector<pair<llvm::StringRef, llvm::StringRef>> TypeTest::intrinsicMap{
     {"sorbet_i_isa_Float", "sorbet_isa_Float"},         {"sorbet_i_isa_Untyped", "sorbet_isa_Untyped"},
     {"sorbet_i_isa_Hash", "sorbet_isa_Hash"},           {"sorbet_i_isa_Array", "sorbet_isa_Array"},
     {"sorbet_i_isa_Regexp", "sorbet_isa_Regexp"},       {"sorbet_i_isa_String", "sorbet_isa_String"},
-    {"sorbet_i_isa_Proc", "sorbet_isa_Proc"},           {"sorbet_i_isa_RootSingleton", "sorbet_isa_RootSingleton"},
+    {"sorbet_i_isa_Proc", "sorbet_isa_Proc"},           {"sorbet_i_isa_Thread", "sorbet_isa_Thread" },
+    {"sorbet_i_isa_RootSingleton", "sorbet_isa_RootSingleton"},
 };
 
 class SorbetSend : public IRIntrinsic {

--- a/test/testdata/compiler/all_arguments.llo.exp
+++ b/test/testdata/compiler/all_arguments.llo.exp
@@ -103,7 +103,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
 @str_a = private unnamed_addr constant [2 x i8] c"a\00", align 1
@@ -140,6 +139,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_take_arguments.20 = internal global %struct.FunctionInlineCache zeroinitializer
 @rb_cObject = external local_unnamed_addr constant i64
 
+; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
@@ -148,72 +148,72 @@ declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #1
 ; Function Attrs: noreturn
 declare void @sorbet_raiseMissingKeywords(i64) local_unnamed_addr #1
 
-declare i64 @sorbet_addMissingKWArg(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_addMissingKWArg(i64, i64) local_unnamed_addr #2
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #2
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #2
 
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
+declare i64 @sorbet_readRealpath() local_unnamed_addr #2
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #2
 
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #2
 
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #2
 
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #2
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #2
 
-declare i32 @rb_block_given_p() local_unnamed_addr #0
+declare i32 @rb_block_given_p() local_unnamed_addr #2
 
-declare i64 @rb_block_proc() local_unnamed_addr #0
+declare i64 @rb_block_proc() local_unnamed_addr #2
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #2
 
-declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #0
+declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #2
 
-declare i64 @rb_hash_new() local_unnamed_addr #0
+declare i64 @rb_hash_new() local_unnamed_addr #2
 
-declare i64 @rb_hash_dup(i64) local_unnamed_addr #0
+declare i64 @rb_hash_dup(i64) local_unnamed_addr #2
 
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #2
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
 
-declare i64 @rb_ary_new() local_unnamed_addr #0
+declare i64 @rb_ary_new() local_unnamed_addr #2
 
-declare i64 @rb_hash_delete_entry(i64, i64) local_unnamed_addr #0
+declare i64 @rb_hash_delete_entry(i64, i64) local_unnamed_addr #2
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
-
-; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #2
 
 ; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xmalloc2(i64, i64) local_unnamed_addr #2
+declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #3
+
+; Function Attrs: allocsize(0,1)
+declare noalias nonnull i8* @ruby_xmalloc2(i64, i64) local_unnamed_addr #3
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #3
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #4
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #5 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #8
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #5 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #8
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#14take_arguments"(i32 %argc, i64* %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #5 !dbg !10 {
+define i64 @"func_Object#14take_arguments"(i32 %argc, i64* %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #6 !dbg !10 {
 functionEntryInitializers:
   %callArgs = alloca [8 x i64], align 8
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
@@ -244,7 +244,7 @@ sorbet_isa_Hash.exit:                             ; preds = %argCountSecondCheck
   br label %fillRequiredArgs, !dbg !16
 
 argCountFailBlock:                                ; preds = %argCountSecondCheckBlock
-  tail call void @sorbet_raiseArity(i32 noundef 0, i32 noundef 1, i32 noundef -1) #9, !dbg !16
+  tail call void @sorbet_raiseArity(i32 noundef 0, i32 noundef 1, i32 noundef -1) #10, !dbg !16
   unreachable, !dbg !16
 
 argCountSecondCheckBlock:                         ; preds = %functionEntryInitializers
@@ -260,14 +260,14 @@ fillFromDefaultBlockDone1:                        ; preds = %sorbet_getMethodBlo
 fillFromDefaultBlockDone1.thread:                 ; preds = %sorbet_getMethodBlockAsProc.exit, %fillFromDefaultBlockDone1
   %"<argPresent>.sroa.0.093" = phi i64 [ 20, %fillFromDefaultBlockDone1 ], [ 0, %sorbet_getMethodBlockAsProc.exit ]
   %b.sroa.0.191 = phi i64 [ %rawArg_b, %fillFromDefaultBlockDone1 ], [ 8, %sorbet_getMethodBlockAsProc.exit ]
-  %15 = tail call i64 @rb_ary_new() #10, !dbg !16
+  %15 = tail call i64 @rb_ary_new() #11, !dbg !16
   br label %sorbet_readRestArgs.exit, !dbg !16
 
 16:                                               ; preds = %fillFromDefaultBlockDone1
   %17 = sub nuw nsw i32 %argcPhi87, 2, !dbg !16
   %18 = zext i32 %17 to i64
   %19 = getelementptr inbounds i64, i64* %argArray, i64 2, !dbg !16
-  %20 = tail call i64 @rb_ary_new_from_values(i64 %18, i64* nonnull %19) #10, !dbg !16
+  %20 = tail call i64 @rb_ary_new_from_values(i64 %18, i64* nonnull %19) #11, !dbg !16
   br label %sorbet_readRestArgs.exit, !dbg !16
 
 sorbet_readRestArgs.exit:                         ; preds = %fillFromDefaultBlockDone1.thread, %16
@@ -280,7 +280,7 @@ sorbet_readRestArgs.exit:                         ; preds = %fillFromDefaultBloc
   br i1 %22, label %kwArgContinue, label %sorbet_removeKWArg.exit79, !dbg !16
 
 sorbet_removeKWArg.exit79:                        ; preds = %sorbet_readRestArgs.exit
-  %23 = tail call i64 @rb_hash_delete_entry(i64 %hashArgsPhi84, i64 %rawSym) #10, !dbg !16
+  %23 = tail call i64 @rb_hash_delete_entry(i64 %hashArgsPhi84, i64 %rawSym) #11, !dbg !16
   %24 = icmp eq i64 %23, 52, !dbg !16
   br i1 %24, label %kwArgContinue, label %kwArgContinue.thread, !dbg !16
 
@@ -293,12 +293,12 @@ fillRequiredArgs:                                 ; preds = %.thread, %sorbet_is
   %argcPhi87 = phi i32 [ 1, %argCountSecondCheckBlock ], [ %argc, %.thread ], [ %argsWithoutHashCount, %sorbet_isa_Hash.exit ]
   %hashArgsPhi84 = phi i64 [ 52, %argCountSecondCheckBlock ], [ 52, %.thread ], [ %KWArgHash, %sorbet_isa_Hash.exit ]
   %rawArg_a = load i64, i64* %argArray, align 8, !dbg !16
-  %25 = tail call i32 @rb_block_given_p() #10, !dbg !16
+  %25 = tail call i32 @rb_block_given_p() #11, !dbg !16
   %26 = icmp eq i32 %25, 0, !dbg !16
   br i1 %26, label %sorbet_getMethodBlockAsProc.exit, label %27, !dbg !16
 
 27:                                               ; preds = %fillRequiredArgs
-  %28 = tail call i64 @rb_block_proc() #10, !dbg !16
+  %28 = tail call i64 @rb_block_proc() #11, !dbg !16
   br label %sorbet_getMethodBlockAsProc.exit, !dbg !16
 
 sorbet_getMethodBlockAsProc.exit:                 ; preds = %fillRequiredArgs, %27
@@ -320,7 +320,7 @@ sorbet_removeKWArg.exit.thread:                   ; preds = %kwArgContinue, %kwA
   %rawSym21107 = phi i64 [ %rawSym21101, %kwArgContinue.thread ], [ %rawSym21, %kwArgContinue ]
   %missingArgsPhi105 = phi i64 [ 52, %kwArgContinue.thread ], [ %30, %kwArgContinue ]
   %d.sroa.0.0103 = phi i64 [ %23, %kwArgContinue.thread ], [ 8, %kwArgContinue ]
-  %32 = tail call i64 @rb_hash_delete_entry(i64 %hashArgsPhi84, i64 %rawSym21107) #10, !dbg !16
+  %32 = tail call i64 @rb_hash_delete_entry(i64 %hashArgsPhi84, i64 %rawSym21107) #11, !dbg !16
   %33 = icmp eq i64 %32, 52, !dbg !16
   %e.sroa.0.1111 = select i1 %33, i64 8, i64 %32, !dbg !16
   %"<argPresent>9.sroa.0.0112" = select i1 %33, i64 0, i64 20, !dbg !16
@@ -329,18 +329,18 @@ sorbet_removeKWArg.exit.thread:                   ; preds = %kwArgContinue, %kwA
 
 35:                                               ; preds = %sorbet_removeKWArg.exit.thread, %sorbet_removeKWArg.exit
   %missingArgsPhi106113 = phi i64 [ %missingArgsPhi105, %sorbet_removeKWArg.exit.thread ], [ %30, %sorbet_removeKWArg.exit ]
-  tail call void @sorbet_raiseMissingKeywords(i64 %missingArgsPhi106113) #8, !dbg !16
+  tail call void @sorbet_raiseMissingKeywords(i64 %missingArgsPhi106113) #9, !dbg !16
   unreachable, !dbg !16
 
 sorbet_readKWRestArgs.exit.thread:                ; preds = %sorbet_removeKWArg.exit
-  %36 = tail call i64 @rb_hash_new() #10, !dbg !16
+  %36 = tail call i64 @rb_hash_new() #11, !dbg !16
   %37 = and i64 %"<argPresent>.sroa.0.092", -9, !dbg !21
   %38 = icmp ne i64 %37, 0, !dbg !21
   %b.sroa.0.0138 = select i1 %38, i64 %b.sroa.0.190, i64 3, !dbg !21
   br label %44, !dbg !22
 
 sorbet_readKWRestArgs.exit:                       ; preds = %sorbet_removeKWArg.exit.thread
-  %39 = tail call i64 @rb_hash_dup(i64 %hashArgsPhi84) #10, !dbg !16
+  %39 = tail call i64 @rb_hash_dup(i64 %hashArgsPhi84) #11, !dbg !16
   %40 = and i64 %"<argPresent>.sroa.0.092", -9, !dbg !21
   %41 = icmp ne i64 %40, 0, !dbg !21
   %b.sroa.0.0 = select i1 %41, i64 %b.sroa.0.190, i64 3, !dbg !21
@@ -371,8 +371,8 @@ sorbet_readKWRestArgs.exit:                       ; preds = %sorbet_removeKWArg.
   %callArgs6Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 6, !dbg !24
   store i64 %29, i64* %callArgs6Addr, align 8, !dbg !24
   %47 = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 0, !dbg !24
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !25) #11, !dbg !24
-  %48 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull %47) #10, !dbg !24
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !25) #12, !dbg !24
+  %48 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull %47) #11, !dbg !24
   %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !24
   %50 = load i64*, i64** %49, align 8, !dbg !24
   store i64 %48, i64* %50, align 8, !dbg !24, !tbaa !6
@@ -391,7 +391,7 @@ sorbet_readKWRestArgs.exit:                       ; preds = %sorbet_removeKWArg.
 }
 
 ; Function Attrs: sspreq
-define void @Init_all_arguments() local_unnamed_addr #6 {
+define void @Init_all_arguments() local_unnamed_addr #7 {
 entry:
   %positional_table.i = alloca i64, i32 4, align 8, !dbg !29
   %keyword_table.i = alloca i64, i32 3, align 8, !dbg !29
@@ -461,38 +461,37 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %19)
   %20 = bitcast i64* %keywords154.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %20)
-  %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 noundef 14) #10
+  %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 noundef 14) #11
   store i64 %21, i64* @rubyIdPrecomputed_take_arguments, align 8
-  %22 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_d, i64 0, i64 0), i64 noundef 1) #10
+  %22 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_d, i64 0, i64 0), i64 noundef 1) #11
   store i64 %22, i64* @rubyIdPrecomputed_d, align 8
-  %23 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_e, i64 0, i64 0), i64 noundef 1) #10
+  %23 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_e, i64 0, i64 0), i64 noundef 1) #11
   store i64 %23, i64* @rubyIdPrecomputed_e, align 8
-  %24 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #10
-  %25 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_inspect, i64 0, i64 0), i64 noundef 7) #10
+  %24 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #11
+  %25 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_inspect, i64 0, i64 0), i64 noundef 7) #11
   store i64 %25, i64* @rubyIdPrecomputed_inspect, align 8
-  %26 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #10
+  %26 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
   store i64 %26, i64* @rubyIdPrecomputed_puts, align 8
-  %27 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
+  %27 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
   store i64 %27, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %28 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #10
-  store i64 %28, i64* @rubyIdPrecomputed_normal, align 8
-  %29 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #10
+  %28 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
+  %29 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #11
   store i64 %29, i64* @rubyIdPrecomputed_a, align 8
-  %30 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_b, i64 0, i64 0), i64 noundef 1) #10
+  %30 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_b, i64 0, i64 0), i64 noundef 1) #11
   store i64 %30, i64* @rubyIdPrecomputed_b, align 8
-  %31 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_c, i64 0, i64 0), i64 noundef 1) #10
+  %31 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_c, i64 0, i64 0), i64 noundef 1) #11
   store i64 %31, i64* @rubyIdPrecomputed_c, align 8
-  %32 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_g, i64 0, i64 0), i64 noundef 1) #10
+  %32 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_g, i64 0, i64 0), i64 noundef 1) #11
   store i64 %32, i64* @rubyIdPrecomputed_g, align 8
-  %33 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_f, i64 0, i64 0), i64 noundef 1) #10
+  %33 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_f, i64 0, i64 0), i64 noundef 1) #11
   store i64 %33, i64* @rubyIdPrecomputed_f, align 8
-  %34 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_baz, i64 0, i64 0), i64 noundef 3) #10
+  %34 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_baz, i64 0, i64 0), i64 noundef 3) #11
   store i64 %34, i64* @rubyIdPrecomputed_baz, align 8
-  %35 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 noundef 14) #10
-  tail call void @rb_gc_register_mark_object(i64 %35) #10
+  %35 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 noundef 14) #11
+  tail call void @rb_gc_register_mark_object(i64 %35) #11
   store i64 %35, i64* @rubyStrFrozen_take_arguments, align 8
-  %36 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([40 x i8], [40 x i8]* @"str_test/testdata/compiler/all_arguments.rb", i64 0, i64 0), i64 noundef 39) #10
-  tail call void @rb_gc_register_mark_object(i64 %36) #10
+  %36 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([40 x i8], [40 x i8]* @"str_test/testdata/compiler/all_arguments.rb", i64 0, i64 0), i64 noundef 39) #11
+  tail call void @rb_gc_register_mark_object(i64 %36) #11
   store i64 %36, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 32)
   %rubyId_take_arguments.i.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8
@@ -504,201 +503,201 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_inspect, i64 %rubyId_inspect.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !28
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  %38 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
-  call void @rb_gc_register_mark_object(i64 %38) #10
+  %38 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  call void @rb_gc_register_mark_object(i64 %38) #11
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/all_arguments.rb.i163.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
   %39 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %38, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i163.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i164.i, i32 noundef 0, i32 noundef 11)
   store %struct.rb_iseq_struct* %39, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_take_arguments.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !31
   %rubyId_d.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !31
-  %40 = call i64 @rb_id2sym(i64 %rubyId_d.i) #10, !dbg !31
+  %40 = call i64 @rb_id2sym(i64 %rubyId_d.i) #13, !dbg !31
   store i64 %40, i64* %keywords.i, align 8, !dbg !31
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments.i, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !31
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments.i, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64* noundef nonnull align 8 %keywords.i), !dbg !31
   %rubyId_take_arguments3.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !32
   %rubyId_d5.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !32
-  %41 = call i64 @rb_id2sym(i64 %rubyId_d5.i) #10, !dbg !32
+  %41 = call i64 @rb_id2sym(i64 %rubyId_d5.i) #13, !dbg !32
   store i64 %41, i64* %keywords4.i, align 8, !dbg !32
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments3.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull %keywords4.i), !dbg !32
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments3.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull align 8 %keywords4.i), !dbg !32
   %rubyId_take_arguments9.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !33
   %rubyId_d11.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !33
-  %42 = call i64 @rb_id2sym(i64 %rubyId_d11.i) #10, !dbg !33
+  %42 = call i64 @rb_id2sym(i64 %rubyId_d11.i) #13, !dbg !33
   store i64 %42, i64* %keywords10.i, align 8, !dbg !33
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments9.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull %keywords10.i), !dbg !33
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments9.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull align 8 %keywords10.i), !dbg !33
   %rubyId_take_arguments15.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !34
   %rubyId_d17.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !34
-  %43 = call i64 @rb_id2sym(i64 %rubyId_d17.i) #10, !dbg !34
+  %43 = call i64 @rb_id2sym(i64 %rubyId_d17.i) #13, !dbg !34
   store i64 %43, i64* %keywords16.i, align 8, !dbg !34
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments15.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull %keywords16.i), !dbg !34
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments15.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull align 8 %keywords16.i), !dbg !34
   %rubyId_take_arguments21.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !35
   %rubyId_d23.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !35
-  %44 = call i64 @rb_id2sym(i64 %rubyId_d23.i) #10, !dbg !35
+  %44 = call i64 @rb_id2sym(i64 %rubyId_d23.i) #13, !dbg !35
   store i64 %44, i64* %keywords22.i, align 8, !dbg !35
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments21.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull %keywords22.i), !dbg !35
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments21.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull align 8 %keywords22.i), !dbg !35
   %rubyId_take_arguments27.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !36
   %rubyId_d29.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !36
-  %45 = call i64 @rb_id2sym(i64 %rubyId_d29.i) #10, !dbg !36
+  %45 = call i64 @rb_id2sym(i64 %rubyId_d29.i) #13, !dbg !36
   store i64 %45, i64* %keywords28.i, align 8, !dbg !36
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments27.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull %keywords28.i), !dbg !36
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments27.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull align 8 %keywords28.i), !dbg !36
   %rubyId_take_arguments33.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !37
   %rubyId_d35.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !37
-  %46 = call i64 @rb_id2sym(i64 %rubyId_d35.i) #10, !dbg !37
+  %46 = call i64 @rb_id2sym(i64 %rubyId_d35.i) #13, !dbg !37
   store i64 %46, i64* %keywords34.i, align 8, !dbg !37
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments33.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull %keywords34.i), !dbg !37
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments33.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull align 8 %keywords34.i), !dbg !37
   %rubyId_take_arguments39.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !38
   %rubyId_d41.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !38
-  %47 = call i64 @rb_id2sym(i64 %rubyId_d41.i) #10, !dbg !38
+  %47 = call i64 @rb_id2sym(i64 %rubyId_d41.i) #13, !dbg !38
   store i64 %47, i64* %keywords40.i, align 8, !dbg !38
   %rubyId_e.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !38
-  %48 = call i64 @rb_id2sym(i64 %rubyId_e.i) #10, !dbg !38
+  %48 = call i64 @rb_id2sym(i64 %rubyId_e.i) #13, !dbg !38
   %49 = getelementptr i64, i64* %keywords40.i, i32 1, !dbg !38
   store i64 %48, i64* %49, align 8, !dbg !38
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments39.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull %keywords40.i), !dbg !38
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments39.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull align 8 %keywords40.i), !dbg !38
   %rubyId_take_arguments46.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !39
   %rubyId_d48.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !39
-  %50 = call i64 @rb_id2sym(i64 %rubyId_d48.i) #10, !dbg !39
+  %50 = call i64 @rb_id2sym(i64 %rubyId_d48.i) #13, !dbg !39
   store i64 %50, i64* %keywords47.i, align 8, !dbg !39
   %rubyId_e50.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !39
-  %51 = call i64 @rb_id2sym(i64 %rubyId_e50.i) #10, !dbg !39
+  %51 = call i64 @rb_id2sym(i64 %rubyId_e50.i) #13, !dbg !39
   %52 = getelementptr i64, i64* %keywords47.i, i32 1, !dbg !39
   store i64 %51, i64* %52, align 8, !dbg !39
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments46.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull %keywords47.i), !dbg !39
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments46.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull align 8 %keywords47.i), !dbg !39
   %rubyId_take_arguments54.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !40
   %rubyId_d56.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !40
-  %53 = call i64 @rb_id2sym(i64 %rubyId_d56.i) #10, !dbg !40
+  %53 = call i64 @rb_id2sym(i64 %rubyId_d56.i) #13, !dbg !40
   store i64 %53, i64* %keywords55.i, align 8, !dbg !40
   %rubyId_e58.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !40
-  %54 = call i64 @rb_id2sym(i64 %rubyId_e58.i) #10, !dbg !40
+  %54 = call i64 @rb_id2sym(i64 %rubyId_e58.i) #13, !dbg !40
   %55 = getelementptr i64, i64* %keywords55.i, i32 1, !dbg !40
   store i64 %54, i64* %55, align 8, !dbg !40
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments54.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull %keywords55.i), !dbg !40
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments54.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull align 8 %keywords55.i), !dbg !40
   %rubyId_take_arguments62.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !41
   %rubyId_d64.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !41
-  %56 = call i64 @rb_id2sym(i64 %rubyId_d64.i) #10, !dbg !41
+  %56 = call i64 @rb_id2sym(i64 %rubyId_d64.i) #13, !dbg !41
   store i64 %56, i64* %keywords63.i, align 8, !dbg !41
   %rubyId_e66.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !41
-  %57 = call i64 @rb_id2sym(i64 %rubyId_e66.i) #10, !dbg !41
+  %57 = call i64 @rb_id2sym(i64 %rubyId_e66.i) #13, !dbg !41
   %58 = getelementptr i64, i64* %keywords63.i, i32 1, !dbg !41
   store i64 %57, i64* %58, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments62.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull %keywords63.i), !dbg !41
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments62.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull align 8 %keywords63.i), !dbg !41
   %rubyId_take_arguments70.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !42
   %rubyId_d72.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !42
-  %59 = call i64 @rb_id2sym(i64 %rubyId_d72.i) #10, !dbg !42
+  %59 = call i64 @rb_id2sym(i64 %rubyId_d72.i) #13, !dbg !42
   store i64 %59, i64* %keywords71.i, align 8, !dbg !42
   %rubyId_e74.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !42
-  %60 = call i64 @rb_id2sym(i64 %rubyId_e74.i) #10, !dbg !42
+  %60 = call i64 @rb_id2sym(i64 %rubyId_e74.i) #13, !dbg !42
   %61 = getelementptr i64, i64* %keywords71.i, i32 1, !dbg !42
   store i64 %60, i64* %61, align 8, !dbg !42
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments70.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull %keywords71.i), !dbg !42
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments70.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull align 8 %keywords71.i), !dbg !42
   %rubyId_take_arguments78.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !43
   %rubyId_d80.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !43
-  %62 = call i64 @rb_id2sym(i64 %rubyId_d80.i) #10, !dbg !43
+  %62 = call i64 @rb_id2sym(i64 %rubyId_d80.i) #13, !dbg !43
   store i64 %62, i64* %keywords79.i, align 8, !dbg !43
   %rubyId_e82.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !43
-  %63 = call i64 @rb_id2sym(i64 %rubyId_e82.i) #10, !dbg !43
+  %63 = call i64 @rb_id2sym(i64 %rubyId_e82.i) #13, !dbg !43
   %64 = getelementptr i64, i64* %keywords79.i, i32 1, !dbg !43
   store i64 %63, i64* %64, align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments78.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull %keywords79.i), !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments78.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull align 8 %keywords79.i), !dbg !43
   %rubyId_take_arguments86.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !44
   %rubyId_d88.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !44
-  %65 = call i64 @rb_id2sym(i64 %rubyId_d88.i) #10, !dbg !44
+  %65 = call i64 @rb_id2sym(i64 %rubyId_d88.i) #13, !dbg !44
   store i64 %65, i64* %keywords87.i, align 8, !dbg !44
   %rubyId_e90.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !44
-  %66 = call i64 @rb_id2sym(i64 %rubyId_e90.i) #10, !dbg !44
+  %66 = call i64 @rb_id2sym(i64 %rubyId_e90.i) #13, !dbg !44
   %67 = getelementptr i64, i64* %keywords87.i, i32 1, !dbg !44
   store i64 %66, i64* %67, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments86.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull %keywords87.i), !dbg !44
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments86.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull align 8 %keywords87.i), !dbg !44
   %rubyId_take_arguments94.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !45
   %rubyId_d96.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !45
-  %68 = call i64 @rb_id2sym(i64 %rubyId_d96.i) #10, !dbg !45
+  %68 = call i64 @rb_id2sym(i64 %rubyId_d96.i) #13, !dbg !45
   store i64 %68, i64* %keywords95.i, align 8, !dbg !45
   %rubyId_e98.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !45
-  %69 = call i64 @rb_id2sym(i64 %rubyId_e98.i) #10, !dbg !45
+  %69 = call i64 @rb_id2sym(i64 %rubyId_e98.i) #13, !dbg !45
   %70 = getelementptr i64, i64* %keywords95.i, i32 1, !dbg !45
   store i64 %69, i64* %70, align 8, !dbg !45
   %rubyId_baz.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !45
-  %71 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #10, !dbg !45
+  %71 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #13, !dbg !45
   %72 = getelementptr i64, i64* %keywords95.i, i32 2, !dbg !45
   store i64 %71, i64* %72, align 8, !dbg !45
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments94.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull %keywords95.i), !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments94.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull align 8 %keywords95.i), !dbg !45
   %rubyId_take_arguments103.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !46
   %rubyId_d105.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !46
-  %73 = call i64 @rb_id2sym(i64 %rubyId_d105.i) #10, !dbg !46
+  %73 = call i64 @rb_id2sym(i64 %rubyId_d105.i) #13, !dbg !46
   store i64 %73, i64* %keywords104.i, align 8, !dbg !46
   %rubyId_e107.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !46
-  %74 = call i64 @rb_id2sym(i64 %rubyId_e107.i) #10, !dbg !46
+  %74 = call i64 @rb_id2sym(i64 %rubyId_e107.i) #13, !dbg !46
   %75 = getelementptr i64, i64* %keywords104.i, i32 1, !dbg !46
   store i64 %74, i64* %75, align 8, !dbg !46
   %rubyId_baz109.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !46
-  %76 = call i64 @rb_id2sym(i64 %rubyId_baz109.i) #10, !dbg !46
+  %76 = call i64 @rb_id2sym(i64 %rubyId_baz109.i) #13, !dbg !46
   %77 = getelementptr i64, i64* %keywords104.i, i32 2, !dbg !46
   store i64 %76, i64* %77, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments103.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull %keywords104.i), !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments103.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull align 8 %keywords104.i), !dbg !46
   %rubyId_take_arguments113.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !47
   %rubyId_d115.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !47
-  %78 = call i64 @rb_id2sym(i64 %rubyId_d115.i) #10, !dbg !47
+  %78 = call i64 @rb_id2sym(i64 %rubyId_d115.i) #13, !dbg !47
   store i64 %78, i64* %keywords114.i, align 8, !dbg !47
   %rubyId_e117.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !47
-  %79 = call i64 @rb_id2sym(i64 %rubyId_e117.i) #10, !dbg !47
+  %79 = call i64 @rb_id2sym(i64 %rubyId_e117.i) #13, !dbg !47
   %80 = getelementptr i64, i64* %keywords114.i, i32 1, !dbg !47
   store i64 %79, i64* %80, align 8, !dbg !47
   %rubyId_baz119.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !47
-  %81 = call i64 @rb_id2sym(i64 %rubyId_baz119.i) #10, !dbg !47
+  %81 = call i64 @rb_id2sym(i64 %rubyId_baz119.i) #13, !dbg !47
   %82 = getelementptr i64, i64* %keywords114.i, i32 2, !dbg !47
   store i64 %81, i64* %82, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments113.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull %keywords114.i), !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments113.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull align 8 %keywords114.i), !dbg !47
   %rubyId_take_arguments123.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !48
   %rubyId_d125.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !48
-  %83 = call i64 @rb_id2sym(i64 %rubyId_d125.i) #10, !dbg !48
+  %83 = call i64 @rb_id2sym(i64 %rubyId_d125.i) #13, !dbg !48
   store i64 %83, i64* %keywords124.i, align 8, !dbg !48
   %rubyId_e127.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !48
-  %84 = call i64 @rb_id2sym(i64 %rubyId_e127.i) #10, !dbg !48
+  %84 = call i64 @rb_id2sym(i64 %rubyId_e127.i) #13, !dbg !48
   %85 = getelementptr i64, i64* %keywords124.i, i32 1, !dbg !48
   store i64 %84, i64* %85, align 8, !dbg !48
   %rubyId_baz129.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !48
-  %86 = call i64 @rb_id2sym(i64 %rubyId_baz129.i) #10, !dbg !48
+  %86 = call i64 @rb_id2sym(i64 %rubyId_baz129.i) #13, !dbg !48
   %87 = getelementptr i64, i64* %keywords124.i, i32 2, !dbg !48
   store i64 %86, i64* %87, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments123.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull %keywords124.i), !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments123.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull align 8 %keywords124.i), !dbg !48
   %rubyId_take_arguments133.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !49
   %rubyId_d135.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !49
-  %88 = call i64 @rb_id2sym(i64 %rubyId_d135.i) #10, !dbg !49
+  %88 = call i64 @rb_id2sym(i64 %rubyId_d135.i) #13, !dbg !49
   store i64 %88, i64* %keywords134.i, align 8, !dbg !49
   %rubyId_e137.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !49
-  %89 = call i64 @rb_id2sym(i64 %rubyId_e137.i) #10, !dbg !49
+  %89 = call i64 @rb_id2sym(i64 %rubyId_e137.i) #13, !dbg !49
   %90 = getelementptr i64, i64* %keywords134.i, i32 1, !dbg !49
   store i64 %89, i64* %90, align 8, !dbg !49
   %rubyId_baz139.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !49
-  %91 = call i64 @rb_id2sym(i64 %rubyId_baz139.i) #10, !dbg !49
+  %91 = call i64 @rb_id2sym(i64 %rubyId_baz139.i) #13, !dbg !49
   %92 = getelementptr i64, i64* %keywords134.i, i32 2, !dbg !49
   store i64 %91, i64* %92, align 8, !dbg !49
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments133.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull %keywords134.i), !dbg !49
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments133.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull align 8 %keywords134.i), !dbg !49
   %rubyId_take_arguments143.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !50
   %rubyId_d145.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !50
-  %93 = call i64 @rb_id2sym(i64 %rubyId_d145.i) #10, !dbg !50
+  %93 = call i64 @rb_id2sym(i64 %rubyId_d145.i) #13, !dbg !50
   store i64 %93, i64* %keywords144.i, align 8, !dbg !50
   %rubyId_e147.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !50
-  %94 = call i64 @rb_id2sym(i64 %rubyId_e147.i) #10, !dbg !50
+  %94 = call i64 @rb_id2sym(i64 %rubyId_e147.i) #13, !dbg !50
   %95 = getelementptr i64, i64* %keywords144.i, i32 1, !dbg !50
   store i64 %94, i64* %95, align 8, !dbg !50
   %rubyId_baz149.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !50
-  %96 = call i64 @rb_id2sym(i64 %rubyId_baz149.i) #10, !dbg !50
+  %96 = call i64 @rb_id2sym(i64 %rubyId_baz149.i) #13, !dbg !50
   %97 = getelementptr i64, i64* %keywords144.i, i32 2, !dbg !50
   store i64 %96, i64* %97, align 8, !dbg !50
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments143.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull %keywords144.i), !dbg !50
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments143.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull align 8 %keywords144.i), !dbg !50
   %rubyId_take_arguments153.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !51
   %rubyId_d155.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !51
-  %98 = call i64 @rb_id2sym(i64 %rubyId_d155.i) #10, !dbg !51
+  %98 = call i64 @rb_id2sym(i64 %rubyId_d155.i) #13, !dbg !51
   store i64 %98, i64* %keywords154.i, align 8, !dbg !51
   %rubyId_e157.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !51
-  %99 = call i64 @rb_id2sym(i64 %rubyId_e157.i) #10, !dbg !51
+  %99 = call i64 @rb_id2sym(i64 %rubyId_e157.i) #13, !dbg !51
   %100 = getelementptr i64, i64* %keywords154.i, i32 1, !dbg !51
   store i64 %99, i64* %100, align 8, !dbg !51
   %rubyId_baz159.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !51
-  %101 = call i64 @rb_id2sym(i64 %rubyId_baz159.i) #10, !dbg !51
+  %101 = call i64 @rb_id2sym(i64 %rubyId_baz159.i) #13, !dbg !51
   %102 = getelementptr i64, i64* %keywords154.i, i32 2, !dbg !51
   store i64 %101, i64* %102, align 8, !dbg !51
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments153.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull %keywords154.i), !dbg !51
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments153.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull align 8 %keywords154.i), !dbg !51
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %2)
@@ -738,16 +737,12 @@ entry:
   %114 = load i64, i64* %113, align 8, !tbaa !6
   %115 = and i64 %114, -33
   store i64 %115, i64* %113, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %106, %struct.rb_control_frame_struct* %108, %struct.rb_iseq_struct* %stackFrame.i) #10
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %106, %struct.rb_control_frame_struct* %108, %struct.rb_iseq_struct* %stackFrame.i) #11
   %116 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 0
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %116, align 8, !dbg !68, !tbaa !14
-  %rubyId_take_arguments.i1 = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !29
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_take_arguments.i1) #10, !dbg !29
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !29
-  %rawSym386.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #10, !dbg !29
   %117 = load i64, i64* @rb_cObject, align 8, !dbg !29
   %stackFrame387.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8, !dbg !29
-  %118 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !29
+  %118 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #14, !dbg !29
   %119 = bitcast i8* %118 to i16*, !dbg !29
   %120 = load i16, i16* %119, align 8, !dbg !29
   %121 = and i16 %120, -384, !dbg !29
@@ -782,16 +777,16 @@ entry:
   %rubyId_g.i = load i64, i64* @rubyIdPrecomputed_g, align 8, !dbg !29
   %139 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !29
   store i64 %rubyId_g.i, i64* %139, align 8, !dbg !29
-  %140 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #12, !dbg !29
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %140, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %109, i64 noundef 32, i1 noundef false) #10, !dbg !29
+  %140 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #14, !dbg !29
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %140, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %109, i64 noundef 32, i1 noundef false) #11, !dbg !29
   %141 = getelementptr inbounds i8, i8* %118, i64 32, !dbg !29
   %142 = bitcast i8* %141 to i8**, !dbg !29
   store i8* %140, i8** %142, align 8, !dbg !29, !tbaa !75
-  %rubyId_d.i2 = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !29
-  store i64 %rubyId_d.i2, i64* %keyword_table.i, align 8, !dbg !29
-  %rubyId_e.i3 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !29
+  %rubyId_d.i1 = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !29
+  store i64 %rubyId_d.i1, i64* %keyword_table.i, align 8, !dbg !29
+  %rubyId_e.i2 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !29
   %143 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !29
-  store i64 %rubyId_e.i3, i64* %143, align 8, !dbg !29
+  store i64 %rubyId_e.i2, i64* %143, align 8, !dbg !29
   %rubyId_f.i = load i64, i64* @rubyIdPrecomputed_f, align 8, !dbg !29
   %144 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !29
   store i64 %rubyId_f.i, i64* %144, align 8, !dbg !29
@@ -821,12 +816,12 @@ entry:
   br label %sorbet_setupParamKeywords.exit.i, !dbg !29
 
 sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
-  %162 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #12, !dbg !29
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %162, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %110, i64 noundef 24, i1 noundef false) #10, !dbg !29
+  %162 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #14, !dbg !29
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %162, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %110, i64 noundef 24, i1 noundef false) #11, !dbg !29
   %163 = getelementptr inbounds i8, i8* %118, i64 56, !dbg !29
   %164 = bitcast i8* %163 to i8**, !dbg !29
   store i8* %162, i8** %164, align 8, !dbg !29, !tbaa !82
-  call void @sorbet_vm_define_method(i64 %117, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Object#14take_arguments", i8* nonnull %118, %struct.rb_iseq_struct* %stackFrame387.i, i1 noundef zeroext false) #10, !dbg !29
+  call void @sorbet_vm_define_method(i64 %117, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Object#14take_arguments", i8* nonnull %118, %struct.rb_iseq_struct* %stackFrame387.i, i1 noundef zeroext false) #11, !dbg !29
   %165 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
   %166 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %165, i64 0, i32 5, !dbg !29
   %167 = load i32, i32* %166, align 8, !dbg !29, !tbaa !83
@@ -840,13 +835,11 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
 173:                                              ; preds = %sorbet_setupParamKeywords.exit.i
   %174 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %165, i64 0, i32 8, !dbg !29
   %175 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %174, align 8, !dbg !29, !tbaa !85
-  %176 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %175, i32 noundef 0) #10, !dbg !29
+  %176 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %175, i32 noundef 0) #11, !dbg !29
   br label %"func_<root>.17<static-init>$152.exit", !dbg !29
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %sorbet_setupParamKeywords.exit.i, %173
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %116, align 8, !dbg !29, !tbaa !14
-  %rubyId_d395.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !86
-  %rawSym396.i = call i64 @rb_id2sym(i64 %rubyId_d395.i) #10, !dbg !86
   %177 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !31
   %178 = load i64*, i64** %177, align 8, !dbg !31
   store i64 %105, i64* %178, align 8, !dbg !31, !tbaa !6
@@ -868,8 +861,6 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64* %189, i64** %177, align 8, !dbg !31
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments, i64 0), !dbg !31
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %116, align 8, !dbg !31, !tbaa !14
-  %rubyId_d416.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !87
-  %rawSym417.i = call i64 @rb_id2sym(i64 %rubyId_d416.i) #10, !dbg !87
   %190 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !32
   %191 = load i64*, i64** %190, align 8, !dbg !32
   store i64 %105, i64* %191, align 8, !dbg !32, !tbaa !6
@@ -887,10 +878,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64 -15, i64* %200, align 8, !dbg !32, !tbaa !6
   %201 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !32
   store i64* %201, i64** %190, align 8, !dbg !32
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !32
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !32
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %116, align 8, !dbg !32, !tbaa !14
-  %rubyId_d436.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !88
-  %rawSym437.i = call i64 @rb_id2sym(i64 %rubyId_d436.i) #10, !dbg !88
   %202 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !33
   %203 = load i64*, i64** %202, align 8, !dbg !33
   store i64 %105, i64* %203, align 8, !dbg !33, !tbaa !6
@@ -906,10 +895,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %211, align 8, !dbg !33, !tbaa !6
   %212 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !33
   store i64* %212, i64** %202, align 8, !dbg !33
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !33
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !33
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %116, align 8, !dbg !33, !tbaa !14
-  %rubyId_d454.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !89
-  %rawSym455.i = call i64 @rb_id2sym(i64 %rubyId_d454.i) #10, !dbg !89
   %213 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !34
   %214 = load i64*, i64** %213, align 8, !dbg !34
   store i64 %105, i64* %214, align 8, !dbg !34, !tbaa !6
@@ -923,10 +910,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64 -15, i64* %220, align 8, !dbg !34, !tbaa !6
   %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !34
   store i64* %221, i64** %213, align 8, !dbg !34
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !34
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !34
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %116, align 8, !dbg !34, !tbaa !14
-  %rubyId_d470.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !90
-  %rawSym471.i = call i64 @rb_id2sym(i64 %rubyId_d470.i) #10, !dbg !90
   %222 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !35
   %223 = load i64*, i64** %222, align 8, !dbg !35
   store i64 %105, i64* %223, align 8, !dbg !35, !tbaa !6
@@ -938,10 +923,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %228, align 8, !dbg !35, !tbaa !6
   %229 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !35
   store i64* %229, i64** %222, align 8, !dbg !35
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !35
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !35
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %116, align 8, !dbg !35, !tbaa !14
-  %rubyId_d484.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !91
-  %rawSym485.i = call i64 @rb_id2sym(i64 %rubyId_d484.i) #10, !dbg !91
   %230 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !36
   %231 = load i64*, i64** %230, align 8, !dbg !36
   store i64 %105, i64* %231, align 8, !dbg !36, !tbaa !6
@@ -953,10 +936,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64 -15, i64* %235, align 8, !dbg !36, !tbaa !6
   %236 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !36
   store i64* %236, i64** %230, align 8, !dbg !36
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !36
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !36
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %116, align 8, !dbg !36, !tbaa !14
-  %rubyId_d496.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !92
-  %rawSym497.i = call i64 @rb_id2sym(i64 %rubyId_d496.i) #10, !dbg !92
   %237 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !37
   %238 = load i64*, i64** %237, align 8, !dbg !37
   store i64 %105, i64* %238, align 8, !dbg !37, !tbaa !6
@@ -966,12 +947,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %241, align 8, !dbg !37, !tbaa !6
   %242 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !37
   store i64* %242, i64** %237, align 8, !dbg !37
-  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !37
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !37
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %116, align 8, !dbg !37, !tbaa !14
-  %rubyId_d513.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !93
-  %rawSym514.i = call i64 @rb_id2sym(i64 %rubyId_d513.i) #10, !dbg !93
-  %rubyId_e516.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !94
-  %rawSym517.i = call i64 @rb_id2sym(i64 %rubyId_e516.i) #10, !dbg !94
   %243 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !38
   %244 = load i64*, i64** %243, align 8, !dbg !38
   store i64 %105, i64* %244, align 8, !dbg !38, !tbaa !6
@@ -993,12 +970,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64 -17, i64* %255, align 8, !dbg !38, !tbaa !6
   %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !38
   store i64* %256, i64** %243, align 8, !dbg !38
-  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !38
+  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !38
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %116, align 8, !dbg !38, !tbaa !14
-  %rubyId_d539.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !95
-  %rawSym540.i = call i64 @rb_id2sym(i64 %rubyId_d539.i) #10, !dbg !95
-  %rubyId_e542.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !96
-  %rawSym543.i = call i64 @rb_id2sym(i64 %rubyId_e542.i) #10, !dbg !96
   %257 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !39
   %258 = load i64*, i64** %257, align 8, !dbg !39
   store i64 %105, i64* %258, align 8, !dbg !39, !tbaa !6
@@ -1018,12 +991,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64 -17, i64* %268, align 8, !dbg !39, !tbaa !6
   %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !39
   store i64* %269, i64** %257, align 8, !dbg !39
-  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !39
+  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !39
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %116, align 8, !dbg !39, !tbaa !14
-  %rubyId_d563.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !97
-  %rawSym564.i = call i64 @rb_id2sym(i64 %rubyId_d563.i) #10, !dbg !97
-  %rubyId_e566.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !98
-  %rawSym567.i = call i64 @rb_id2sym(i64 %rubyId_e566.i) #10, !dbg !98
   %270 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !40
   %271 = load i64*, i64** %270, align 8, !dbg !40
   store i64 %105, i64* %271, align 8, !dbg !40, !tbaa !6
@@ -1041,12 +1010,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64 -17, i64* %280, align 8, !dbg !40, !tbaa !6
   %281 = getelementptr inbounds i64, i64* %280, i64 1, !dbg !40
   store i64* %281, i64** %270, align 8, !dbg !40
-  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !40
+  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !40
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %116, align 8, !dbg !40, !tbaa !14
-  %rubyId_d585.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !99
-  %rawSym586.i = call i64 @rb_id2sym(i64 %rubyId_d585.i) #10, !dbg !99
-  %rubyId_e588.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !100
-  %rawSym589.i = call i64 @rb_id2sym(i64 %rubyId_e588.i) #10, !dbg !100
   %282 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !41
   %283 = load i64*, i64** %282, align 8, !dbg !41
   store i64 %105, i64* %283, align 8, !dbg !41, !tbaa !6
@@ -1062,12 +1027,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %291, align 8, !dbg !41, !tbaa !6
   %292 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !41
   store i64* %292, i64** %282, align 8, !dbg !41
-  %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !41
+  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !41
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %116, align 8, !dbg !41, !tbaa !14
-  %rubyId_d605.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !101
-  %rawSym606.i = call i64 @rb_id2sym(i64 %rubyId_d605.i) #10, !dbg !101
-  %rubyId_e608.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !102
-  %rawSym609.i = call i64 @rb_id2sym(i64 %rubyId_e608.i) #10, !dbg !102
   %293 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !42
   %294 = load i64*, i64** %293, align 8, !dbg !42
   store i64 %105, i64* %294, align 8, !dbg !42, !tbaa !6
@@ -1081,12 +1042,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64 -17, i64* %300, align 8, !dbg !42, !tbaa !6
   %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !42
   store i64* %301, i64** %293, align 8, !dbg !42
-  %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !42
+  %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !42
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %116, align 8, !dbg !42, !tbaa !14
-  %rubyId_d623.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !103
-  %rawSym624.i = call i64 @rb_id2sym(i64 %rubyId_d623.i) #10, !dbg !103
-  %rubyId_e626.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !104
-  %rawSym627.i = call i64 @rb_id2sym(i64 %rubyId_e626.i) #10, !dbg !104
   %302 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !43
   %303 = load i64*, i64** %302, align 8, !dbg !43
   store i64 %105, i64* %303, align 8, !dbg !43, !tbaa !6
@@ -1098,12 +1055,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %308, align 8, !dbg !43, !tbaa !6
   %309 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !43
   store i64* %309, i64** %302, align 8, !dbg !43
-  %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !43
+  %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !43
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %116, align 8, !dbg !43, !tbaa !14
-  %rubyId_d639.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !105
-  %rawSym640.i = call i64 @rb_id2sym(i64 %rubyId_d639.i) #10, !dbg !105
-  %rubyId_e642.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !106
-  %rawSym643.i = call i64 @rb_id2sym(i64 %rubyId_e642.i) #10, !dbg !106
   %310 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !44
   %311 = load i64*, i64** %310, align 8, !dbg !44
   store i64 %105, i64* %311, align 8, !dbg !44, !tbaa !6
@@ -1115,14 +1068,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64 -17, i64* %315, align 8, !dbg !44, !tbaa !6
   %316 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !44
   store i64* %316, i64** %310, align 8, !dbg !44
-  %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !44
+  %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !44
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %116, align 8, !dbg !44, !tbaa !14
-  %rubyId_d660.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !107
-  %rawSym661.i = call i64 @rb_id2sym(i64 %rubyId_d660.i) #10, !dbg !107
-  %rubyId_e663.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !108
-  %rawSym664.i = call i64 @rb_id2sym(i64 %rubyId_e663.i) #10, !dbg !108
-  %rubyId_baz.i4 = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !109
-  %rawSym666.i = call i64 @rb_id2sym(i64 %rubyId_baz.i4) #10, !dbg !109
   %317 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !45
   %318 = load i64*, i64** %317, align 8, !dbg !45
   store i64 %105, i64* %318, align 8, !dbg !45, !tbaa !6
@@ -1146,14 +1093,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64 -19, i64* %330, align 8, !dbg !45, !tbaa !6
   %331 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !45
   store i64* %331, i64** %317, align 8, !dbg !45
-  %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !45
+  %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !45
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %116, align 8, !dbg !45, !tbaa !14
-  %rubyId_d689.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !110
-  %rawSym690.i = call i64 @rb_id2sym(i64 %rubyId_d689.i) #10, !dbg !110
-  %rubyId_e692.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !111
-  %rawSym693.i = call i64 @rb_id2sym(i64 %rubyId_e692.i) #10, !dbg !111
-  %rubyId_baz695.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !112
-  %rawSym696.i = call i64 @rb_id2sym(i64 %rubyId_baz695.i) #10, !dbg !112
   %332 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !46
   %333 = load i64*, i64** %332, align 8, !dbg !46
   store i64 %105, i64* %333, align 8, !dbg !46, !tbaa !6
@@ -1175,14 +1116,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64 -19, i64* %344, align 8, !dbg !46, !tbaa !6
   %345 = getelementptr inbounds i64, i64* %344, i64 1, !dbg !46
   store i64* %345, i64** %332, align 8, !dbg !46
-  %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !46
+  %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !46
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %116, align 8, !dbg !46, !tbaa !14
-  %rubyId_d717.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !113
-  %rawSym718.i = call i64 @rb_id2sym(i64 %rubyId_d717.i) #10, !dbg !113
-  %rubyId_e720.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !114
-  %rawSym721.i = call i64 @rb_id2sym(i64 %rubyId_e720.i) #10, !dbg !114
-  %rubyId_baz723.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !115
-  %rawSym724.i = call i64 @rb_id2sym(i64 %rubyId_baz723.i) #10, !dbg !115
   %346 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !47
   %347 = load i64*, i64** %346, align 8, !dbg !47
   store i64 %105, i64* %347, align 8, !dbg !47, !tbaa !6
@@ -1202,14 +1137,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64 -19, i64* %357, align 8, !dbg !47, !tbaa !6
   %358 = getelementptr inbounds i64, i64* %357, i64 1, !dbg !47
   store i64* %358, i64** %346, align 8, !dbg !47
-  %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !47
+  %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !47
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %116, align 8, !dbg !47, !tbaa !14
-  %rubyId_d743.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !116
-  %rawSym744.i = call i64 @rb_id2sym(i64 %rubyId_d743.i) #10, !dbg !116
-  %rubyId_e746.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !117
-  %rawSym747.i = call i64 @rb_id2sym(i64 %rubyId_e746.i) #10, !dbg !117
-  %rubyId_baz749.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !118
-  %rawSym750.i = call i64 @rb_id2sym(i64 %rubyId_baz749.i) #10, !dbg !118
   %359 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !48
   %360 = load i64*, i64** %359, align 8, !dbg !48
   store i64 %105, i64* %360, align 8, !dbg !48, !tbaa !6
@@ -1227,14 +1156,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64 -19, i64* %369, align 8, !dbg !48, !tbaa !6
   %370 = getelementptr inbounds i64, i64* %369, i64 1, !dbg !48
   store i64* %370, i64** %359, align 8, !dbg !48
-  %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !48
+  %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !48
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %116, align 8, !dbg !48, !tbaa !14
-  %rubyId_d767.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !119
-  %rawSym768.i = call i64 @rb_id2sym(i64 %rubyId_d767.i) #10, !dbg !119
-  %rubyId_e770.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !120
-  %rawSym771.i = call i64 @rb_id2sym(i64 %rubyId_e770.i) #10, !dbg !120
-  %rubyId_baz773.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !121
-  %rawSym774.i = call i64 @rb_id2sym(i64 %rubyId_baz773.i) #10, !dbg !121
   %371 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !49
   %372 = load i64*, i64** %371, align 8, !dbg !49
   store i64 %105, i64* %372, align 8, !dbg !49, !tbaa !6
@@ -1250,14 +1173,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %380, align 8, !dbg !49, !tbaa !6
   %381 = getelementptr inbounds i64, i64* %379, i64 1, !dbg !49
   store i64* %381, i64** %371, align 8, !dbg !49
-  %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !49
+  %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !49
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %116, align 8, !dbg !49, !tbaa !14
-  %rubyId_d789.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !122
-  %rawSym790.i = call i64 @rb_id2sym(i64 %rubyId_d789.i) #10, !dbg !122
-  %rubyId_e792.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !123
-  %rawSym793.i = call i64 @rb_id2sym(i64 %rubyId_e792.i) #10, !dbg !123
-  %rubyId_baz795.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !124
-  %rawSym796.i = call i64 @rb_id2sym(i64 %rubyId_baz795.i) #10, !dbg !124
   %382 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !50
   %383 = load i64*, i64** %382, align 8, !dbg !50
   store i64 %105, i64* %383, align 8, !dbg !50, !tbaa !6
@@ -1271,14 +1188,8 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store i64 -19, i64* %389, align 8, !dbg !50, !tbaa !6
   %390 = getelementptr inbounds i64, i64* %389, i64 1, !dbg !50
   store i64* %390, i64** %382, align 8, !dbg !50
-  %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !50
+  %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !50
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %116, align 8, !dbg !50, !tbaa !14
-  %rubyId_d809.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !125
-  %rawSym810.i = call i64 @rb_id2sym(i64 %rubyId_d809.i) #10, !dbg !125
-  %rubyId_e812.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !126
-  %rawSym813.i = call i64 @rb_id2sym(i64 %rubyId_e812.i) #10, !dbg !126
-  %rubyId_baz815.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !127
-  %rawSym816.i = call i64 @rb_id2sym(i64 %rubyId_baz815.i) #10, !dbg !127
   %391 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !51
   %392 = load i64*, i64** %391, align 8, !dbg !51
   store i64 %105, i64* %392, align 8, !dbg !51, !tbaa !6
@@ -1290,34 +1201,36 @@ sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
   store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %397, align 8, !dbg !51, !tbaa !6
   %398 = getelementptr inbounds i64, i64* %396, i64 1, !dbg !51
   store i64* %398, i64** %391, align 8, !dbg !51
-  %send44 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !51
+  %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !51
   call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %109)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %110)
   ret void
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare void @llvm.experimental.noalias.scope.decl(metadata) #7
+declare void @llvm.experimental.noalias.scope.decl(metadata) #8
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #3
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #4
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #3
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #4
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { argmemonly nofree nosync nounwind willreturn }
-attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #5 = { nounwind sspreq uwtable }
-attributes #6 = { sspreq }
-attributes #7 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #8 = { noreturn nounwind }
-attributes #9 = { noreturn }
-attributes #10 = { nounwind }
-attributes #11 = { willreturn }
-attributes #12 = { nounwind allocsize(0,1) }
+attributes #2 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { argmemonly nofree nosync nounwind willreturn }
+attributes #5 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #6 = { nounwind sspreq uwtable }
+attributes #7 = { sspreq }
+attributes #8 = { inaccessiblememonly nofree nosync nounwind willreturn }
+attributes #9 = { noreturn nounwind }
+attributes #10 = { noreturn }
+attributes #11 = { nounwind }
+attributes #12 = { willreturn }
+attributes #13 = { nounwind readnone willreturn }
+attributes #14 = { nounwind allocsize(0,1) }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -1408,45 +1321,3 @@ attributes #12 = { nounwind allocsize(0,1) }
 !83 = !{!63, !57, i64 40}
 !84 = !{!63, !57, i64 44}
 !85 = !{!63, !15, i64 56}
-!86 = !DILocation(line: 8, column: 44, scope: !30)
-!87 = !DILocation(line: 9, column: 40, scope: !30)
-!88 = !DILocation(line: 10, column: 36, scope: !30)
-!89 = !DILocation(line: 11, column: 32, scope: !30)
-!90 = !DILocation(line: 12, column: 28, scope: !30)
-!91 = !DILocation(line: 13, column: 24, scope: !30)
-!92 = !DILocation(line: 14, column: 20, scope: !30)
-!93 = !DILocation(line: 16, column: 44, scope: !30)
-!94 = !DILocation(line: 16, column: 51, scope: !30)
-!95 = !DILocation(line: 17, column: 40, scope: !30)
-!96 = !DILocation(line: 17, column: 47, scope: !30)
-!97 = !DILocation(line: 18, column: 36, scope: !30)
-!98 = !DILocation(line: 18, column: 43, scope: !30)
-!99 = !DILocation(line: 19, column: 32, scope: !30)
-!100 = !DILocation(line: 19, column: 39, scope: !30)
-!101 = !DILocation(line: 20, column: 28, scope: !30)
-!102 = !DILocation(line: 20, column: 35, scope: !30)
-!103 = !DILocation(line: 21, column: 24, scope: !30)
-!104 = !DILocation(line: 21, column: 31, scope: !30)
-!105 = !DILocation(line: 22, column: 20, scope: !30)
-!106 = !DILocation(line: 22, column: 27, scope: !30)
-!107 = !DILocation(line: 24, column: 44, scope: !30)
-!108 = !DILocation(line: 24, column: 51, scope: !30)
-!109 = !DILocation(line: 24, column: 58, scope: !30)
-!110 = !DILocation(line: 25, column: 40, scope: !30)
-!111 = !DILocation(line: 25, column: 47, scope: !30)
-!112 = !DILocation(line: 25, column: 54, scope: !30)
-!113 = !DILocation(line: 26, column: 36, scope: !30)
-!114 = !DILocation(line: 26, column: 43, scope: !30)
-!115 = !DILocation(line: 26, column: 50, scope: !30)
-!116 = !DILocation(line: 27, column: 32, scope: !30)
-!117 = !DILocation(line: 27, column: 39, scope: !30)
-!118 = !DILocation(line: 27, column: 46, scope: !30)
-!119 = !DILocation(line: 28, column: 28, scope: !30)
-!120 = !DILocation(line: 28, column: 35, scope: !30)
-!121 = !DILocation(line: 28, column: 42, scope: !30)
-!122 = !DILocation(line: 29, column: 24, scope: !30)
-!123 = !DILocation(line: 29, column: 31, scope: !30)
-!124 = !DILocation(line: 29, column: 38, scope: !30)
-!125 = !DILocation(line: 30, column: 20, scope: !30)
-!126 = !DILocation(line: 30, column: 27, scope: !30)
-!127 = !DILocation(line: 30, column: 34, scope: !30)

--- a/test/testdata/compiler/block_arg_expand.llo.exp
+++ b/test/testdata/compiler/block_arg_expand.llo.exp
@@ -129,73 +129,74 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_p.12 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.13 = internal global %struct.FunctionInlineCache zeroinitializer
 
+; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 ; Function Attrs: cold noreturn
 declare void @sorbet_cast_failure(i64, i8*, i8*) local_unnamed_addr #1
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #2
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #2
 
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
+declare i64 @sorbet_readRealpath() local_unnamed_addr #2
 
-declare void @sorbet_pushBlockFrame(%struct.rb_captured_block*) local_unnamed_addr #0
+declare void @sorbet_pushBlockFrame(%struct.rb_captured_block*) local_unnamed_addr #2
 
-declare void @sorbet_popFrame() local_unnamed_addr #0
+declare void @sorbet_popFrame() local_unnamed_addr #2
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #2
 
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #2
 
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #2
 
-declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #2
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #3
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #3
 
-declare void @rb_ary_detransient(i64) local_unnamed_addr #0
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #2
 
-declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #0
+declare void @rb_ary_detransient(i64) local_unnamed_addr #2
 
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #2
+
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #2
 
 ; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #3
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #4
 
-declare i64 @rb_int2big(i64) local_unnamed_addr #0
+declare i64 @rb_int2big(i64) local_unnamed_addr #2
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #4
+declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #5
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #2
 
-declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*, i32, i32) local_unnamed_addr #0
+declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*, i32, i32) local_unnamed_addr #2
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #5 {
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #11
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #12
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #5 {
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #11
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #12
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$152$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !10 {
+define internal i64 @"func_<root>.17<static-init>$152$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #7 !dbg !10 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -239,7 +240,7 @@ argArrayExpand:                                   ; preds = %sorbet_isa_Array.ex
   br i1 %23, label %25, label %24, !dbg !24
 
 24:                                               ; preds = %argArrayExpand
-  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #12, !dbg !24
+  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #13, !dbg !24
   br label %25, !dbg !24
 
 25:                                               ; preds = %24, %argArrayExpand
@@ -339,12 +340,12 @@ sorbet_isa_Integer.exit39:                        ; preds = %58
 
 codeRepl38:                                       ; preds = %45, %sorbet_isa_Integer.exit
   %el1.sroa.0.147 = phi i64 [ %el1.sroa.0.146, %45 ], [ %el1.sroa.0.146, %sorbet_isa_Integer.exit ]
-  tail call fastcc void @"func_<root>.17<static-init>$152$block_1.cold.1"(i64 %el1.sroa.0.147) #13, !dbg !30
+  tail call fastcc void @"func_<root>.17<static-init>$152$block_1.cold.1"(i64 %el1.sroa.0.147) #14, !dbg !30
   unreachable
 
 codeRepl:                                         ; preds = %58, %sorbet_isa_Integer.exit39
   %el2.sroa.0.044 = phi i64 [ %el2.sroa.0.042, %58 ], [ %el2.sroa.0.042, %sorbet_isa_Integer.exit39 ]
-  tail call fastcc void @"func_<root>.17<static-init>$152$block_1.cold.1"(i64 %el2.sroa.0.044) #13, !dbg !32
+  tail call fastcc void @"func_<root>.17<static-init>$152$block_1.cold.1"(i64 %el2.sroa.0.044) #14, !dbg !32
   unreachable
 
 "fastSymCallIntrinsic_Integer_+":                 ; preds = %typeTestSuccess, %sorbet_isa_Integer.exit39
@@ -356,7 +357,7 @@ codeRepl:                                         ; preds = %58, %sorbet_isa_Int
 
 72:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
   %73 = add nsw i64 %el2.sroa.0.042, -1, !dbg !30
-  %74 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %el1.sroa.0.145, i64 %73) #14, !dbg !30
+  %74 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %el1.sroa.0.145, i64 %73) #15, !dbg !30
   %75 = extractvalue { i64, i1 } %74, 1, !dbg !30
   %76 = extractvalue { i64, i1 } %74, 0, !dbg !30
   br i1 %75, label %77, label %sorbet_rb_int_plus.exit, !dbg !30
@@ -364,11 +365,11 @@ codeRepl:                                         ; preds = %58, %sorbet_isa_Int
 77:                                               ; preds = %72
   %78 = ashr i64 %76, 1, !dbg !30
   %79 = xor i64 %78, -9223372036854775808, !dbg !30
-  %80 = tail call i64 @rb_int2big(i64 %79) #12, !dbg !30, !noalias !33
+  %80 = tail call i64 @rb_int2big(i64 %79) #13, !dbg !30, !noalias !33
   br label %sorbet_rb_int_plus.exit, !dbg !30
 
 81:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %82 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %el1.sroa.0.145, i64 %el2.sroa.0.042) #12, !dbg !30, !noalias !33
+  %82 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %el1.sroa.0.145, i64 %el2.sroa.0.042) #13, !dbg !30, !noalias !33
   br label %sorbet_rb_int_plus.exit, !dbg !30
 
 sorbet_rb_int_plus.exit:                          ; preds = %77, %72, %81
@@ -386,7 +387,7 @@ sorbet_rb_int_plus.exit:                          ; preds = %77, %72, %81
 92:                                               ; preds = %sorbet_rb_int_plus.exit
   %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 8, !dbg !30
   %94 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %93, align 8, !dbg !30, !tbaa !39
-  %95 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #12, !dbg !30
+  %95 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #13, !dbg !30
   br label %rb_vm_check_ints.exit, !dbg !30
 
 rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.exit, %92
@@ -395,7 +396,7 @@ rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$152$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !41 {
+define internal i64 @"func_<root>.17<static-init>$152$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #7 !dbg !41 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -435,7 +436,7 @@ fillFromDefaultBlockDone1:                        ; preds = %functionEntryInitia
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$152$block_3"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !47 {
+define internal i64 @"func_<root>.17<static-init>$152$block_3"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #7 !dbg !47 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -482,7 +483,7 @@ BB16:                                             ; preds = %BB15, %BB14
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$152$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !54 {
+define internal i64 @"func_<root>.17<static-init>$152$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #7 !dbg !54 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -505,7 +506,12 @@ functionEntryInitializers:
 BB23.thread:                                      ; preds = %fillRequiredArgs
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %10, align 8, !tbaa !15
   %rubyId_default = load i64, i64* @rubyIdPrecomputed_default, align 8, !dbg !56
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_default), !dbg !56
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_default) #16, !dbg !56
+  br label %BB25, !dbg !57
+
+BB23.thread62:                                    ; preds = %argArrayExpandArrayTest, %sorbet_isa_Array.exit, %fillFromArgBlock0
+  %x.sroa.0.2.ph.ph = phi i64 [ %rawArg_x, %fillFromArgBlock0 ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ]
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %10, align 8, !tbaa !15
   br label %BB25, !dbg !57
 
 BB24:                                             ; preds = %fillFromArgBlock0
@@ -514,11 +520,11 @@ BB24:                                             ; preds = %fillFromArgBlock0
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %10, align 8, !tbaa !15
   br label %BB26, !dbg !57
 
-BB25:                                             ; preds = %argArrayExpandArrayTest, %fillFromArgBlock0, %sorbet_isa_Array.exit, %BB23.thread
-  %x.sroa.0.061 = phi i64 [ %rawSym, %BB23.thread ], [ %rawArg_x, %fillFromArgBlock0 ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ]
+BB25:                                             ; preds = %BB23.thread62, %BB23.thread
+  %x.sroa.0.061 = phi i64 [ %rawSym, %BB23.thread ], [ %x.sroa.0.2.ph.ph, %BB23.thread62 ]
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %10, align 8, !tbaa !15
   %rubyId_something = load i64, i64* @rubyIdPrecomputed_something, align 8, !dbg !58
-  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_something), !dbg !58
+  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_something) #16, !dbg !58
   br label %BB26, !dbg !58
 
 BB26:                                             ; preds = %BB25, %BB24
@@ -552,7 +558,7 @@ argArrayExpandArrayTest:                          ; preds = %functionEntryInitia
   %22 = and i64 %arg1_maybeExpandToFullArgs, -9, !dbg !55
   %23 = icmp eq i64 %22, 0, !dbg !55
   %24 = or i1 %21, %23, !dbg !55
-  br i1 %24, label %BB25, label %sorbet_isa_Array.exit, !dbg !55
+  br i1 %24, label %BB23.thread62, label %sorbet_isa_Array.exit, !dbg !55
 
 sorbet_isa_Array.exit:                            ; preds = %argArrayExpandArrayTest
   %25 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !55
@@ -560,7 +566,7 @@ sorbet_isa_Array.exit:                            ; preds = %argArrayExpandArray
   %27 = load i64, i64* %26, align 8, !dbg !55, !tbaa !25
   %28 = and i64 %27, 31, !dbg !55
   %29 = icmp eq i64 %28, 7, !dbg !55
-  br i1 %29, label %argArrayExpand, label %BB25, !dbg !55
+  br i1 %29, label %argArrayExpand, label %BB23.thread62, !dbg !55
 
 argArrayExpand:                                   ; preds = %sorbet_isa_Array.exit
   %30 = inttoptr i64 %arg1_maybeExpandToFullArgs to %struct.iseq_inline_iv_cache_entry*, !dbg !55
@@ -571,7 +577,7 @@ argArrayExpand:                                   ; preds = %sorbet_isa_Array.ex
   br i1 %34, label %36, label %35, !dbg !55
 
 35:                                               ; preds = %argArrayExpand
-  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #12, !dbg !55
+  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #13, !dbg !55
   br label %36, !dbg !55
 
 36:                                               ; preds = %35, %argArrayExpand
@@ -603,7 +609,7 @@ rb_array_len.exit:                                ; preds = %41, %45
 fillFromArgBlock0:                                ; preds = %fillRequiredArgs
   %rawArg_x = load i64, i64* %argArrayPhi, align 8, !dbg !55
   %default1 = icmp eq i32 %argcPhi, 1, !dbg !55
-  br i1 %default1, label %BB25, label %BB24, !dbg !55, !prof !28
+  br i1 %default1, label %BB23.thread62, label %BB24, !dbg !55, !prof !28
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers, %rb_array_len.exit
   %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %52, %rb_array_len.exit ], !dbg !55
@@ -613,7 +619,7 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$152$block_5"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #6 !dbg !63 {
+define internal i64 @"func_<root>.17<static-init>$152$block_5"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture readonly %argArray, i64 %blockArg) #7 !dbg !63 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -643,7 +649,7 @@ BB32:                                             ; preds = %argArrayExpandArray
   %x.sroa.0.1.ph = phi i64 [ 8, %fillRequiredArgs ], [ %rawArg_x, %fillFromArgBlock0 ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ]
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %10, align 8, !tbaa !15
   %rubyId_something = load i64, i64* @rubyIdPrecomputed_something, align 8, !dbg !66
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_something), !dbg !66
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_something) #16, !dbg !66
   br label %BB33, !dbg !66
 
 BB33:                                             ; preds = %BB32, %BB31
@@ -696,7 +702,7 @@ argArrayExpand:                                   ; preds = %sorbet_isa_Array.ex
   br i1 %34, label %36, label %35, !dbg !64
 
 35:                                               ; preds = %argArrayExpand
-  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #12, !dbg !64
+  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #13, !dbg !64
   br label %36, !dbg !64
 
 36:                                               ; preds = %35, %argArrayExpand
@@ -738,7 +744,7 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
 }
 
 ; Function Attrs: sspreq
-define void @Init_block_arg_expand() local_unnamed_addr #7 {
+define void @Init_block_arg_expand() local_unnamed_addr #8 {
 entry:
   %0 = alloca i64, align 8
   %1 = alloca i64, align 8
@@ -751,30 +757,30 @@ entry:
   %callArgs.i = alloca [3 x i64], align 8
   %locals.i.i = alloca i64, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #13
   store i64 %8, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #12
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #13
   store i64 %9, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #12
+  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #13
   store i64 %10, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #12
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_each, i64 0, i64 0), i64 noundef 4) #12
+  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #13
+  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_each, i64 0, i64 0), i64 noundef 4) #13
   store i64 %12, i64* @rubyIdPrecomputed_each, align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #12
+  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #13
   store i64 %13, i64* @"rubyIdPrecomputed_+", align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #12
+  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #13
   store i64 %14, i64* @rubyIdPrecomputed_p, align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #12
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #13
   store i64 %15, i64* @rubyIdPrecomputed_x, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_default, i64 0, i64 0), i64 noundef 7) #12
+  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_default, i64 0, i64 0), i64 noundef 7) #13
   store i64 %16, i64* @rubyIdPrecomputed_default, align 8
-  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @str_something, i64 0, i64 0), i64 noundef 9) #12
+  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @str_something, i64 0, i64 0), i64 noundef 9) #13
   store i64 %17, i64* @rubyIdPrecomputed_something, align 8
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
-  tail call void @rb_gc_register_mark_object(i64 %18) #12
+  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #13
+  tail call void @rb_gc_register_mark_object(i64 %18) #13
   store i64 %18, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/block_arg_expand.rb", i64 0, i64 0), i64 noundef 42) #12
-  tail call void @rb_gc_register_mark_object(i64 %19) #12
+  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/block_arg_expand.rb", i64 0, i64 0), i64 noundef 42) #13
+  tail call void @rb_gc_register_mark_object(i64 %19) #13
   store i64 %19, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 32)
   %20 = bitcast i64* %locals.i.i to i8*
@@ -787,8 +793,8 @@ entry:
   %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 3)
   store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %20)
-  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #12
-  call void @rb_gc_register_mark_object(i64 %22) #12
+  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #13
+  call void @rb_gc_register_mark_object(i64 %22) #13
   store i64 %22, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
@@ -847,22 +853,22 @@ entry:
   %36 = load i64, i64* %35, align 8, !tbaa !6
   %37 = and i64 %36, -33
   store i64 %37, i64* %35, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %28, %struct.rb_control_frame_struct* %32, %struct.rb_iseq_struct* %stackFrame.i) #12
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %28, %struct.rb_control_frame_struct* %32, %struct.rb_iseq_struct* %stackFrame.i) #13
   %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 0
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %38, align 8, !dbg !71, !tbaa !15
   %callArgs0Addr.i = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i32 0, i64 0, !dbg !72
   %39 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !72
   store <2 x i64> <i64 3, i64 5>, <2 x i64>* %39, align 8, !dbg !72
   %40 = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i64 0, i64 0, !dbg !72
-  call void @llvm.experimental.noalias.scope.decl(metadata !73) #12, !dbg !72
-  %41 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %40) #12, !dbg !72
+  call void @llvm.experimental.noalias.scope.decl(metadata !73) #13, !dbg !72
+  %41 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %40) #13, !dbg !72
   store i64 %41, i64* %callArgs0Addr.i, align 8, !dbg !76
-  call void @llvm.experimental.noalias.scope.decl(metadata !77) #12, !dbg !76
-  %42 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %40) #12, !dbg !76
+  call void @llvm.experimental.noalias.scope.decl(metadata !77) #13, !dbg !76
+  %42 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %40) #13, !dbg !76
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %38, align 8, !dbg !76, !tbaa !15
   %rubyId_each.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !80
   %43 = bitcast %struct.sorbet_inlineIntrinsicEnv* %6 to i8*, !dbg !80
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %43) #12, !dbg !80
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %43) #13, !dbg !80
   %44 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 0, !dbg !80
   store i64 %42, i64* %44, align 8, !dbg !80, !tbaa !81
   %45 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 1, !dbg !80
@@ -871,17 +877,17 @@ entry:
   store i32 0, i32* %46, align 8, !dbg !80, !tbaa !84
   %47 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 3, !dbg !80
   %48 = bitcast i64** %47 to i8*, !dbg !80
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %48, i8 0, i64 16, i1 false) #12, !dbg !80
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %48, i8 0, i64 16, i1 false) #13, !dbg !80
   %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
   %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 2, !dbg !80
   %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !80, !tbaa !17
-  %52 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_1", i8* noundef null, i32 noundef 2, i32 noundef 2) #12, !dbg !80
+  %52 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_1", i8* noundef null, i32 noundef 2, i32 noundef 2) #13, !dbg !80
   %53 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 3, !dbg !80
   %54 = bitcast i64* %53 to %struct.rb_captured_block*, !dbg !80
   %55 = getelementptr inbounds i64, i64* %53, i64 2, !dbg !80
   %56 = bitcast i64* %55 to %struct.vm_ifunc**, !dbg !80
   store %struct.vm_ifunc* %52, %struct.vm_ifunc** %56, align 8, !dbg !80, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !85) #12, !dbg !80
+  call void @llvm.experimental.noalias.scope.decl(metadata !85) #13, !dbg !80
   %57 = ptrtoint %struct.rb_captured_block* %54 to i64, !dbg !80
   %58 = or i64 %57, 3, !dbg !80
   %59 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 17, !dbg !80
@@ -892,7 +898,7 @@ entry:
   %63 = and i64 %62, -4, !dbg !89
   %64 = inttoptr i64 %63 to %struct.rb_captured_block*, !dbg !89
   store i64 0, i64* %61, align 8, !dbg !89, !tbaa !88
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %64) #12, !dbg !89
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %64) #13, !dbg !89
   %65 = inttoptr i64 %42 to %struct.iseq_inline_iv_cache_entry*, !dbg !89
   %66 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %65, i64 0, i32 0, !dbg !89
   %67 = load i64, i64* %66, align 8, !dbg !89, !tbaa !25
@@ -925,7 +931,7 @@ rb_array_len.exit1.i3.i:                          ; preds = %73, %70
 
 84:                                               ; preds = %rb_array_len.exit.i5.i, %79
   %85 = phi i64 [ 0, %79 ], [ %95, %rb_array_len.exit.i5.i ], !dbg !89
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %80) #12, !dbg !89
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %80) #13, !dbg !89
   %86 = load i64, i64* %66, align 8, !dbg !89, !tbaa !25
   %87 = and i64 %86, 8192, !dbg !89
   %88 = icmp eq i64 %87, 0, !dbg !89
@@ -940,8 +946,8 @@ rb_array_const_ptr_transient.exit.i4.i:           ; preds = %89, %84
   %92 = getelementptr inbounds i64, i64* %91, i64 %85, !dbg !89
   %93 = load i64, i64* %92, align 8, !dbg !89, !tbaa !6
   store i64 %93, i64* %1, align 8, !dbg !89, !tbaa !6
-  %94 = call i64 @"func_<root>.17<static-init>$152$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %1, i64 undef) #12, !dbg !89
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %80) #12, !dbg !89
+  %94 = call i64 @"func_<root>.17<static-init>$152$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %1, i64 undef) #13, !dbg !89
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %80) #13, !dbg !89
   %95 = add nuw nsw i64 %85, 1, !dbg !89
   %96 = load i64, i64* %66, align 8, !dbg !89, !tbaa !25
   %97 = and i64 %96, 8192, !dbg !89
@@ -963,8 +969,8 @@ rb_array_len.exit.i5.i:                           ; preds = %102, %99
   br i1 %105, label %84, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !89, !llvm.loop !91
 
 forward_sorbet_rb_array_each_withBlock.exit.i:    ; preds = %rb_array_len.exit.i5.i, %rb_array_len.exit1.i3.i
-  call void @sorbet_popFrame() #12, !dbg !89
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %43) #12, !dbg !80
+  call void @sorbet_popFrame() #13, !dbg !89
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %43) #13, !dbg !80
   %106 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
   %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 5, !dbg !80
   %108 = load i32, i32* %107, align 8, !dbg !80, !tbaa !37
@@ -978,14 +984,14 @@ forward_sorbet_rb_array_each_withBlock.exit.i:    ; preds = %rb_array_len.exit.i
 114:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.exit.i
   %115 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 8, !dbg !80
   %116 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %115, align 8, !dbg !80, !tbaa !39
-  %117 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %116, i32 noundef 0) #12, !dbg !80
+  %117 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %116, i32 noundef 0) #13, !dbg !80
   br label %rb_check_arity.1.exit.i8.i, !dbg !80
 
 rb_check_arity.1.exit.i8.i:                       ; preds = %114, %forward_sorbet_rb_array_each_withBlock.exit.i
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %38, align 8, !dbg !80, !tbaa !15
   %rubyId_each66.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !93
   %118 = bitcast %struct.sorbet_inlineIntrinsicEnv* %5 to i8*, !dbg !93
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %118) #12, !dbg !93
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %118) #13, !dbg !93
   %119 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 0, !dbg !93
   store i64 %42, i64* %119, align 8, !dbg !93, !tbaa !81
   %120 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 1, !dbg !93
@@ -994,17 +1000,17 @@ rb_check_arity.1.exit.i8.i:                       ; preds = %114, %forward_sorbe
   store i32 0, i32* %121, align 8, !dbg !93, !tbaa !84
   %122 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 3, !dbg !93
   %123 = bitcast i64** %122 to i8*, !dbg !93
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %123, i8 0, i64 16, i1 false) #12, !dbg !93
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %123, i8 0, i64 16, i1 false) #13, !dbg !93
   %124 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15
   %125 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %124, i64 0, i32 2, !dbg !93
   %126 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %125, align 8, !dbg !93, !tbaa !17
-  %127 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_2", i8* noundef null, i32 noundef 1, i32 noundef 1) #12, !dbg !93
+  %127 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_2", i8* noundef null, i32 noundef 1, i32 noundef 1) #13, !dbg !93
   %128 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %126, i64 0, i32 3, !dbg !93
   %129 = bitcast i64* %128 to %struct.rb_captured_block*, !dbg !93
   %130 = getelementptr inbounds i64, i64* %128, i64 2, !dbg !93
   %131 = bitcast i64* %130 to %struct.vm_ifunc**, !dbg !93
   store %struct.vm_ifunc* %127, %struct.vm_ifunc** %131, align 8, !dbg !93, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !94) #12, !dbg !93
+  call void @llvm.experimental.noalias.scope.decl(metadata !94) #13, !dbg !93
   %132 = ptrtoint %struct.rb_captured_block* %129 to i64, !dbg !93
   %133 = or i64 %132, 3, !dbg !93
   %134 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %124, i64 0, i32 17, !dbg !93
@@ -1015,7 +1021,7 @@ rb_check_arity.1.exit.i8.i:                       ; preds = %114, %forward_sorbe
   %138 = and i64 %137, -4, !dbg !97
   %139 = inttoptr i64 %138 to %struct.rb_captured_block*, !dbg !97
   store i64 0, i64* %136, align 8, !dbg !97, !tbaa !88
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %139) #12, !dbg !97
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %139) #13, !dbg !97
   %140 = load i64, i64* %66, align 8, !dbg !97, !tbaa !25
   %141 = and i64 %140, 8192, !dbg !97
   %142 = icmp eq i64 %141, 0, !dbg !97
@@ -1058,7 +1064,7 @@ rb_array_const_ptr_transient.exit.i10.i:          ; preds = %161, %156
   %163 = phi i64* [ %162, %161 ], [ %154, %156 ], !dbg !97
   %164 = getelementptr inbounds i64, i64* %163, i64 %157, !dbg !97
   %165 = load i64, i64* %164, align 8, !dbg !97, !tbaa !6
-  call void @llvm.experimental.noalias.scope.decl(metadata !99) #12, !dbg !97
+  call void @llvm.experimental.noalias.scope.decl(metadata !99) #13, !dbg !97
   %166 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15, !noalias !99
   %167 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 2, !dbg !93
   %168 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %167, align 8, !dbg !93, !tbaa !17, !noalias !99
@@ -1104,8 +1110,8 @@ rb_array_len.exit.i11.i:                          ; preds = %188, %185
   br i1 %191, label %156, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !97, !llvm.loop !105
 
 forward_sorbet_rb_array_each_withBlock.1.exit.i:  ; preds = %rb_array_len.exit.i11.i, %rb_array_len.exit1.i9.i
-  call void @sorbet_popFrame() #12, !dbg !97
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %118) #12, !dbg !93
+  call void @sorbet_popFrame() #13, !dbg !97
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %118) #13, !dbg !93
   %192 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15
   %193 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %192, i64 0, i32 5, !dbg !93
   %194 = load i32, i32* %193, align 8, !dbg !93, !tbaa !37
@@ -1119,14 +1125,14 @@ forward_sorbet_rb_array_each_withBlock.1.exit.i:  ; preds = %rb_array_len.exit.i
 200:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.1.exit.i
   %201 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %192, i64 0, i32 8, !dbg !93
   %202 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %201, align 8, !dbg !93, !tbaa !39
-  %203 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %202, i32 noundef 0) #12, !dbg !93
+  %203 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %202, i32 noundef 0) #13, !dbg !93
   br label %rb_check_arity.1.exit.i14.i, !dbg !93
 
 rb_check_arity.1.exit.i14.i:                      ; preds = %200, %forward_sorbet_rb_array_each_withBlock.1.exit.i
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %38, align 8, !dbg !93, !tbaa !15
   %rubyId_each78.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !106
   %204 = bitcast %struct.sorbet_inlineIntrinsicEnv* %4 to i8*, !dbg !106
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %204) #12, !dbg !106
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %204) #13, !dbg !106
   %205 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 0, !dbg !106
   store i64 %42, i64* %205, align 8, !dbg !106, !tbaa !81
   %206 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 1, !dbg !106
@@ -1135,17 +1141,17 @@ rb_check_arity.1.exit.i14.i:                      ; preds = %200, %forward_sorbe
   store i32 0, i32* %207, align 8, !dbg !106, !tbaa !84
   %208 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 3, !dbg !106
   %209 = bitcast i64** %208 to i8*, !dbg !106
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %209, i8 0, i64 16, i1 false) #12, !dbg !106
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %209, i8 0, i64 16, i1 false) #13, !dbg !106
   %210 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15
   %211 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %210, i64 0, i32 2, !dbg !106
   %212 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %211, align 8, !dbg !106, !tbaa !17
-  %213 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_3", i8* noundef null, i32 noundef 0, i32 noundef 1) #12, !dbg !106
+  %213 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_3", i8* noundef null, i32 noundef 0, i32 noundef 1) #13, !dbg !106
   %214 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %212, i64 0, i32 3, !dbg !106
   %215 = bitcast i64* %214 to %struct.rb_captured_block*, !dbg !106
   %216 = getelementptr inbounds i64, i64* %214, i64 2, !dbg !106
   %217 = bitcast i64* %216 to %struct.vm_ifunc**, !dbg !106
   store %struct.vm_ifunc* %213, %struct.vm_ifunc** %217, align 8, !dbg !106, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !107) #12, !dbg !106
+  call void @llvm.experimental.noalias.scope.decl(metadata !107) #13, !dbg !106
   %218 = ptrtoint %struct.rb_captured_block* %215 to i64, !dbg !106
   %219 = or i64 %218, 3, !dbg !106
   %220 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %210, i64 0, i32 17, !dbg !106
@@ -1156,7 +1162,7 @@ rb_check_arity.1.exit.i14.i:                      ; preds = %200, %forward_sorbe
   %224 = and i64 %223, -4, !dbg !110
   %225 = inttoptr i64 %224 to %struct.rb_captured_block*, !dbg !110
   store i64 0, i64* %222, align 8, !dbg !110, !tbaa !88
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %225) #12, !dbg !110
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %225) #13, !dbg !110
   %226 = load i64, i64* %66, align 8, !dbg !110, !tbaa !25
   %227 = and i64 %226, 8192, !dbg !110
   %228 = icmp eq i64 %227, 0, !dbg !110
@@ -1199,7 +1205,7 @@ rb_array_const_ptr_transient.exit.i17.i:          ; preds = %247, %242
   %249 = phi i64* [ %248, %247 ], [ %240, %242 ], !dbg !110
   %250 = getelementptr inbounds i64, i64* %249, i64 %243, !dbg !110
   %251 = load i64, i64* %250, align 8, !dbg !110, !tbaa !6
-  call void @llvm.experimental.noalias.scope.decl(metadata !112) #12, !dbg !110
+  call void @llvm.experimental.noalias.scope.decl(metadata !112) #13, !dbg !110
   %252 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15, !noalias !112
   %253 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %252, i64 0, i32 2, !dbg !106
   %254 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %253, align 8, !dbg !106, !tbaa !17, !noalias !112
@@ -1245,8 +1251,8 @@ rb_array_len.exit.i18.i:                          ; preds = %274, %271
   br i1 %277, label %242, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !110, !llvm.loop !117
 
 forward_sorbet_rb_array_each_withBlock.3.exit.i:  ; preds = %rb_array_len.exit.i18.i, %rb_array_len.exit1.i15.i
-  call void @sorbet_popFrame() #12, !dbg !110
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %204) #12, !dbg !106
+  call void @sorbet_popFrame() #13, !dbg !110
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %204) #13, !dbg !106
   %278 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15
   %279 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %278, i64 0, i32 5, !dbg !106
   %280 = load i32, i32* %279, align 8, !dbg !106, !tbaa !37
@@ -1260,14 +1266,14 @@ forward_sorbet_rb_array_each_withBlock.3.exit.i:  ; preds = %rb_array_len.exit.i
 286:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.3.exit.i
   %287 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %278, i64 0, i32 8, !dbg !106
   %288 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %287, align 8, !dbg !106, !tbaa !39
-  %289 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %288, i32 noundef 0) #12, !dbg !106
+  %289 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %288, i32 noundef 0) #13, !dbg !106
   br label %rb_check_arity.1.exit.i21.i, !dbg !106
 
 rb_check_arity.1.exit.i21.i:                      ; preds = %286, %forward_sorbet_rb_array_each_withBlock.3.exit.i
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %38, align 8, !dbg !106, !tbaa !15
   %rubyId_each90.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !118
   %290 = bitcast %struct.sorbet_inlineIntrinsicEnv* %3 to i8*, !dbg !118
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %290) #12, !dbg !118
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %290) #13, !dbg !118
   %291 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 0, !dbg !118
   store i64 %42, i64* %291, align 8, !dbg !118, !tbaa !81
   %292 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 1, !dbg !118
@@ -1276,17 +1282,17 @@ rb_check_arity.1.exit.i21.i:                      ; preds = %286, %forward_sorbe
   store i32 0, i32* %293, align 8, !dbg !118, !tbaa !84
   %294 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 3, !dbg !118
   %295 = bitcast i64** %294 to i8*, !dbg !118
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %295, i8 0, i64 16, i1 false) #12, !dbg !118
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %295, i8 0, i64 16, i1 false) #13, !dbg !118
   %296 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !118, !tbaa !15
   %297 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %296, i64 0, i32 2, !dbg !118
   %298 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %297, align 8, !dbg !118, !tbaa !17
-  %299 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_4", i8* noundef null, i32 noundef 0, i32 noundef 2) #12, !dbg !118
+  %299 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_4", i8* noundef null, i32 noundef 0, i32 noundef 2) #13, !dbg !118
   %300 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %298, i64 0, i32 3, !dbg !118
   %301 = bitcast i64* %300 to %struct.rb_captured_block*, !dbg !118
   %302 = getelementptr inbounds i64, i64* %300, i64 2, !dbg !118
   %303 = bitcast i64* %302 to %struct.vm_ifunc**, !dbg !118
   store %struct.vm_ifunc* %299, %struct.vm_ifunc** %303, align 8, !dbg !118, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !119) #12, !dbg !118
+  call void @llvm.experimental.noalias.scope.decl(metadata !119) #13, !dbg !118
   %304 = ptrtoint %struct.rb_captured_block* %301 to i64, !dbg !118
   %305 = or i64 %304, 3, !dbg !118
   %306 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %296, i64 0, i32 17, !dbg !118
@@ -1297,7 +1303,7 @@ rb_check_arity.1.exit.i21.i:                      ; preds = %286, %forward_sorbe
   %310 = and i64 %309, -4, !dbg !122
   %311 = inttoptr i64 %310 to %struct.rb_captured_block*, !dbg !122
   store i64 0, i64* %308, align 8, !dbg !122, !tbaa !88
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %311) #12, !dbg !122
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %311) #13, !dbg !122
   %312 = load i64, i64* %66, align 8, !dbg !122, !tbaa !25
   %313 = and i64 %312, 8192, !dbg !122
   %314 = icmp eq i64 %313, 0, !dbg !122
@@ -1328,7 +1334,7 @@ rb_array_len.exit1.i22.i:                         ; preds = %318, %315
 
 329:                                              ; preds = %rb_array_len.exit.i24.i, %324
   %330 = phi i64 [ 0, %324 ], [ %340, %rb_array_len.exit.i24.i ], !dbg !122
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %325) #12, !dbg !122
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %325) #13, !dbg !122
   %331 = load i64, i64* %66, align 8, !dbg !122, !tbaa !25
   %332 = and i64 %331, 8192, !dbg !122
   %333 = icmp eq i64 %332, 0, !dbg !122
@@ -1343,8 +1349,8 @@ rb_array_const_ptr_transient.exit.i23.i:          ; preds = %334, %329
   %337 = getelementptr inbounds i64, i64* %336, i64 %330, !dbg !122
   %338 = load i64, i64* %337, align 8, !dbg !122, !tbaa !6
   store i64 %338, i64* %0, align 8, !dbg !122, !tbaa !6
-  %339 = call i64 @"func_<root>.17<static-init>$152$block_4"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #12, !dbg !122
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %325) #12, !dbg !122
+  %339 = call i64 @"func_<root>.17<static-init>$152$block_4"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #13, !dbg !122
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %325) #13, !dbg !122
   %340 = add nuw nsw i64 %330, 1, !dbg !122
   %341 = load i64, i64* %66, align 8, !dbg !122, !tbaa !25
   %342 = and i64 %341, 8192, !dbg !122
@@ -1366,8 +1372,8 @@ rb_array_len.exit.i24.i:                          ; preds = %347, %344
   br i1 %350, label %329, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !122, !llvm.loop !124
 
 forward_sorbet_rb_array_each_withBlock.6.exit.i:  ; preds = %rb_array_len.exit.i24.i, %rb_array_len.exit1.i22.i
-  call void @sorbet_popFrame() #12, !dbg !122
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %290) #12, !dbg !118
+  call void @sorbet_popFrame() #13, !dbg !122
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %290) #13, !dbg !118
   %351 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !118, !tbaa !15
   %352 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %351, i64 0, i32 5, !dbg !118
   %353 = load i32, i32* %352, align 8, !dbg !118, !tbaa !37
@@ -1381,14 +1387,14 @@ forward_sorbet_rb_array_each_withBlock.6.exit.i:  ; preds = %rb_array_len.exit.i
 359:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.6.exit.i
   %360 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %351, i64 0, i32 8, !dbg !118
   %361 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %360, align 8, !dbg !118, !tbaa !39
-  %362 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %361, i32 noundef 0) #12, !dbg !118
+  %362 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %361, i32 noundef 0) #13, !dbg !118
   br label %rb_check_arity.1.exit.i.i, !dbg !118
 
 rb_check_arity.1.exit.i.i:                        ; preds = %359, %forward_sorbet_rb_array_each_withBlock.6.exit.i
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %38, align 8, !dbg !118, !tbaa !15
   %rubyId_each102.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !125
   %363 = bitcast %struct.sorbet_inlineIntrinsicEnv* %7 to i8*, !dbg !125
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %363) #12, !dbg !125
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %363) #13, !dbg !125
   %364 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 0, !dbg !125
   store i64 %42, i64* %364, align 8, !dbg !125, !tbaa !81
   %365 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 1, !dbg !125
@@ -1397,17 +1403,17 @@ rb_check_arity.1.exit.i.i:                        ; preds = %359, %forward_sorbe
   store i32 0, i32* %366, align 8, !dbg !125, !tbaa !84
   %367 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 3, !dbg !125
   %368 = bitcast i64** %367 to i8*, !dbg !125
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %368, i8 0, i64 16, i1 false) #12, !dbg !125
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %368, i8 0, i64 16, i1 false) #13, !dbg !125
   %369 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !125, !tbaa !15
   %370 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %369, i64 0, i32 2, !dbg !125
   %371 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %370, align 8, !dbg !125, !tbaa !17
-  %372 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_5", i8* noundef null, i32 noundef 1, i32 noundef 2) #12, !dbg !125
+  %372 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_5", i8* noundef null, i32 noundef 1, i32 noundef 2) #13, !dbg !125
   %373 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %371, i64 0, i32 3, !dbg !125
   %374 = bitcast i64* %373 to %struct.rb_captured_block*, !dbg !125
   %375 = getelementptr inbounds i64, i64* %373, i64 2, !dbg !125
   %376 = bitcast i64* %375 to %struct.vm_ifunc**, !dbg !125
   store %struct.vm_ifunc* %372, %struct.vm_ifunc** %376, align 8, !dbg !125, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !126) #12, !dbg !125
+  call void @llvm.experimental.noalias.scope.decl(metadata !126) #13, !dbg !125
   %377 = ptrtoint %struct.rb_captured_block* %374 to i64, !dbg !125
   %378 = or i64 %377, 3, !dbg !125
   %379 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %369, i64 0, i32 17, !dbg !125
@@ -1418,7 +1424,7 @@ rb_check_arity.1.exit.i.i:                        ; preds = %359, %forward_sorbe
   %383 = and i64 %382, -4, !dbg !129
   %384 = inttoptr i64 %383 to %struct.rb_captured_block*, !dbg !129
   store i64 0, i64* %381, align 8, !dbg !129, !tbaa !88
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %384) #12, !dbg !129
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %384) #13, !dbg !129
   %385 = load i64, i64* %66, align 8, !dbg !129, !tbaa !25
   %386 = and i64 %385, 8192, !dbg !129
   %387 = icmp eq i64 %386, 0, !dbg !129
@@ -1449,7 +1455,7 @@ rb_array_len.exit1.i.i:                           ; preds = %391, %388
 
 402:                                              ; preds = %rb_array_len.exit.i.i, %397
   %403 = phi i64 [ 0, %397 ], [ %413, %rb_array_len.exit.i.i ], !dbg !129
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %398) #12, !dbg !129
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %398) #13, !dbg !129
   %404 = load i64, i64* %66, align 8, !dbg !129, !tbaa !25
   %405 = and i64 %404, 8192, !dbg !129
   %406 = icmp eq i64 %405, 0, !dbg !129
@@ -1464,8 +1470,8 @@ rb_array_const_ptr_transient.exit.i.i:            ; preds = %407, %402
   %410 = getelementptr inbounds i64, i64* %409, i64 %403, !dbg !129
   %411 = load i64, i64* %410, align 8, !dbg !129, !tbaa !6
   store i64 %411, i64* %2, align 8, !dbg !129, !tbaa !6
-  %412 = call i64 @"func_<root>.17<static-init>$152$block_5"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %2, i64 undef) #12, !dbg !129
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %398) #12, !dbg !129
+  %412 = call i64 @"func_<root>.17<static-init>$152$block_5"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %2, i64 undef) #13, !dbg !129
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %398) #13, !dbg !129
   %413 = add nuw nsw i64 %403, 1, !dbg !129
   %414 = load i64, i64* %66, align 8, !dbg !129, !tbaa !25
   %415 = and i64 %414, 8192, !dbg !129
@@ -1487,8 +1493,8 @@ rb_array_len.exit.i.i:                            ; preds = %420, %417
   br i1 %423, label %402, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !129, !llvm.loop !131
 
 forward_sorbet_rb_array_each_withBlock.10.exit.i: ; preds = %rb_array_len.exit.i.i, %rb_array_len.exit1.i.i
-  call void @sorbet_popFrame() #12, !dbg !129
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %363) #12, !dbg !125
+  call void @sorbet_popFrame() #13, !dbg !129
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %363) #13, !dbg !125
   %424 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !125, !tbaa !15
   %425 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %424, i64 0, i32 5, !dbg !125
   %426 = load i32, i32* %425, align 8, !dbg !125, !tbaa !37
@@ -1502,7 +1508,7 @@ forward_sorbet_rb_array_each_withBlock.10.exit.i: ; preds = %rb_array_len.exit.i
 432:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i
   %433 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %424, i64 0, i32 8, !dbg !125
   %434 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %433, align 8, !dbg !125, !tbaa !39
-  %435 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %434, i32 noundef 0) #12, !dbg !125
+  %435 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %434, i32 noundef 0) #13, !dbg !125
   br label %"func_<root>.17<static-init>$152.exit", !dbg !125
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i, %432
@@ -1512,34 +1518,36 @@ forward_sorbet_rb_array_each_withBlock.10.exit.i: ; preds = %rb_array_len.exit.i
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare void @llvm.experimental.noalias.scope.decl(metadata) #8
+declare void @llvm.experimental.noalias.scope.decl(metadata) #9
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #9
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #10
 
 ; Function Attrs: cold minsize noreturn ssp
-define internal fastcc void @"func_<root>.17<static-init>$152$block_1.cold.1"(i64 %el2.sroa.0.0) unnamed_addr #10 !dbg !132 {
+define internal fastcc void @"func_<root>.17<static-init>$152$block_1.cold.1"(i64 %el2.sroa.0.0) unnamed_addr #11 !dbg !132 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %el2.sroa.0.0, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_T.let, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #15, !dbg !134
+  tail call void @sorbet_cast_failure(i64 %el2.sroa.0.0, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_T.let, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #17, !dbg !134
   unreachable, !dbg !134
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { argmemonly nofree nosync nounwind willreturn }
-attributes #3 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #4 = { nofree nosync nounwind readnone speculatable willreturn }
-attributes #5 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #6 = { ssp }
-attributes #7 = { sspreq }
-attributes #8 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #9 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #10 = { cold minsize noreturn ssp }
-attributes #11 = { noreturn nounwind }
-attributes #12 = { nounwind }
-attributes #13 = { noinline }
-attributes #14 = { nounwind willreturn }
-attributes #15 = { noreturn }
+attributes #2 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { argmemonly nofree nosync nounwind willreturn }
+attributes #4 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #5 = { nofree nosync nounwind readnone speculatable willreturn }
+attributes #6 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #7 = { ssp }
+attributes #8 = { sspreq }
+attributes #9 = { inaccessiblememonly nofree nosync nounwind willreturn }
+attributes #10 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #11 = { cold minsize noreturn ssp }
+attributes #12 = { noreturn nounwind }
+attributes #13 = { nounwind }
+attributes #14 = { noinline }
+attributes #15 = { nounwind willreturn }
+attributes #16 = { willreturn }
+attributes #17 = { noreturn }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}

--- a/test/testdata/compiler/block_no_args_captures_constant.llo.exp
+++ b/test/testdata/compiler/block_no_args_captures_constant.llo.exp
@@ -106,7 +106,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @rubyStrFrozen_hi = internal unnamed_addr global i64 0, align 8
 @str_hi = private unnamed_addr constant [3 x i8] c"hi\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
@@ -114,45 +113,43 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @rb_mKernel = external local_unnamed_addr constant i64
 @rb_cObject = external local_unnamed_addr constant i64
 
-declare i64 @rb_id2sym(i64) local_unnamed_addr #0
+; Function Attrs: noreturn
+declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #0
+
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #1
+
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #1
+
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #1
+
+declare i64 @sorbet_setConstant(i64, i8*, i64, i64) local_unnamed_addr #1
+
+declare i64 @sorbet_readRealpath() local_unnamed_addr #1
+
+declare void @sorbet_pushBlockFrame(%struct.rb_captured_block*) local_unnamed_addr #1
+
+declare void @sorbet_popFrame() local_unnamed_addr #1
+
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
+
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
+
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
+
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
+
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #1
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
-
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
-
-declare i64 @sorbet_setConstant(i64, i8*, i64, i64) local_unnamed_addr #0
-
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
-
-declare void @sorbet_pushBlockFrame(%struct.rb_captured_block*) local_unnamed_addr #0
-
-declare void @sorbet_popFrame() local_unnamed_addr #0
-
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
-
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
-
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
-
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
-
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
-
-; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
-
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
-
-declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*, i32, i32) local_unnamed_addr #0
+declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*, i32, i32) local_unnamed_addr #1
 
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
@@ -344,7 +341,6 @@ entry:
   %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
   store i64 %4, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #12
-  store i64 %5, i64* @rubyIdPrecomputed_normal, align 8
   %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #12
   tail call void @rb_gc_register_mark_object(i64 %6) #12
   store i64 %6, i64* @rubyStrFrozen_foo, align 8
@@ -400,10 +396,6 @@ entry:
   %26 = load i64, i64* @rb_cObject, align 8, !dbg !61
   %27 = call i64 @sorbet_setConstant(i64 %26, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 noundef 1, i64 %rubyStr_hi.i) #12, !dbg !61
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %25, align 8, !dbg !61, !tbaa !14
-  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !62
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #12, !dbg !62
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !62
-  %rawSym12.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #12, !dbg !62
   %stackFrame13.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !62
   %28 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !62
   %29 = bitcast i8* %28 to i16*, !dbg !62
@@ -458,8 +450,8 @@ define linkonce void @const_recompute_A() local_unnamed_addr #5 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #4 = { nounwind sspreq uwtable }

--- a/test/testdata/compiler/block_type_checking.llo.exp
+++ b/test/testdata/compiler/block_type_checking.llo.exp
@@ -137,7 +137,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_extend = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_extend = internal unnamed_addr global i64 0, align 8
 @str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
@@ -148,6 +147,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @guarded_const_T = linkonce local_unnamed_addr global i64 0
 @rb_cInteger = external local_unnamed_addr constant i64
 
+; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 ; Function Attrs: cold noreturn
@@ -156,81 +156,81 @@ declare void @sorbet_cast_failure(i64, i8*, i8*) local_unnamed_addr #1
 ; Function Attrs: noreturn
 declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #2
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #3
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #3
 
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
+declare i64 @sorbet_readRealpath() local_unnamed_addr #3
 
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #3
 
-declare void @sorbet_popFrame() local_unnamed_addr #0
+declare void @sorbet_popFrame() local_unnamed_addr #3
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #3
 
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #3
 
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #3
 
-declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #3
 
-declare void @sorbet_vm_register_sig(i64, i64, i64, i64, i64 (i64, i64, i32, i64*, i64)*) local_unnamed_addr #0
+declare void @sorbet_vm_register_sig(i64, i64, i64, i64, i64 (i64, i64, i32, i64*, i64)*) local_unnamed_addr #3
 
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_callBlock(%struct.rb_control_frame_struct*, i32, i64* nocapture, i32) local_unnamed_addr #0
+declare i64 @sorbet_vm_callBlock(%struct.rb_control_frame_struct*, i32, i64* nocapture, i32) local_unnamed_addr #3
 
-declare i32 @rb_block_given_p() local_unnamed_addr #0
+declare i32 @rb_block_given_p() local_unnamed_addr #3
 
-declare i64 @rb_block_proc() local_unnamed_addr #0
+declare i64 @rb_block_proc() local_unnamed_addr #3
 
-declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #3
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #3
 
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #3
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
 
-declare i64 @rb_int2big(i64) local_unnamed_addr #0
+declare i64 @rb_int2big(i64) local_unnamed_addr #3
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #3
+declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #4
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #3
 
-declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*, i32, i32) local_unnamed_addr #0
-
-; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #4
+declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*, i32, i32) local_unnamed_addr #3
 
 ; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xmalloc2(i64, i64) local_unnamed_addr #4
+declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #5
+
+; Function Attrs: allocsize(0,1)
+declare noalias nonnull i8* @ruby_xmalloc2(i64, i64) local_unnamed_addr #5
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #5
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #6
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #15
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #16
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #15
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #16
   unreachable
 }
 
 ; Function Attrs: nofree nosync nounwind ssp willreturn
-define internal noundef i64 @"func_<root>.17<static-init>$152$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !10 {
+define internal noundef i64 @"func_<root>.17<static-init>$152$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !10 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -249,7 +249,7 @@ functionEntryInitializers:
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_Foo.13<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !26 {
+define internal fastcc void @"func_Foo.13<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #9 !dbg !26 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
@@ -262,7 +262,7 @@ functionEntryInitializers:
   %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
   store i64 %7, i64* %5, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #16
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #17
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !27, !tbaa !15
   %rubyId_bar = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !28
@@ -281,7 +281,7 @@ functionEntryInitializers:
 17:                                               ; preds = %functionEntryInitializers
   %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !28
   %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !28, !tbaa !32
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !28
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #17, !dbg !28
   br label %rb_vm_check_ints.exit1, !dbg !28
 
 rb_vm_check_ints.exit1:                           ; preds = %functionEntryInitializers, %17
@@ -310,10 +310,6 @@ rb_vm_check_ints.exit1:                           ; preds = %functionEntryInitia
   store i64* %31, i64** %28, align 8, !dbg !33
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !33
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !33, !tbaa !15
-  %rubyId_bar37 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !37
-  %rawSym38 = tail call i64 @rb_id2sym(i64 %rubyId_bar37), !dbg !37
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !37
-  %rawSym39 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !37
   %32 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !37
   %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !37, !tbaa !34
   %needTakeSlowPath2 = icmp ne i64 %32, %33, !dbg !37
@@ -330,7 +326,7 @@ rb_vm_check_ints.exit1:                           ; preds = %functionEntryInitia
   %guardUpdated3 = icmp eq i64 %37, %38, !dbg !37
   tail call void @llvm.assume(i1 %guardUpdated3), !dbg !37
   %stackFrame43 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8, !dbg !37
-  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !37
+  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !37
   %40 = bitcast i8* %39 to i16*, !dbg !37
   %41 = load i16, i16* %40, align 8, !dbg !37
   %42 = and i16 %41, -384, !dbg !37
@@ -354,13 +350,13 @@ rb_vm_check_ints.exit1:                           ; preds = %functionEntryInitia
   %rubyId_blk = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !37
   %52 = getelementptr i64, i64* %positional_table, i32 1, !dbg !37
   store i64 %rubyId_blk, i64* %52, align 8, !dbg !37
-  %53 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !37
+  %53 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #18, !dbg !37
   %54 = bitcast i64* %positional_table to i8*, !dbg !37
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %53, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %54, i64 noundef 16, i1 noundef false) #16, !dbg !37
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %53, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %54, i64 noundef 16, i1 noundef false) #17, !dbg !37
   %55 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !37
   %56 = bitcast i8* %55 to i8**, !dbg !37
   store i8* %53, i8** %56, align 8, !dbg !37, !tbaa !43
-  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Foo#3bar", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame43, i1 noundef zeroext false) #16, !dbg !37
+  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Foo#3bar", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame43, i1 noundef zeroext false) #17, !dbg !37
   %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !15
   %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 5, !dbg !37
   %59 = load i32, i32* %58, align 8, !dbg !37, !tbaa !29
@@ -374,7 +370,7 @@ rb_vm_check_ints.exit1:                           ; preds = %functionEntryInitia
 65:                                               ; preds = %35
   %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 8, !dbg !37
   %67 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %66, align 8, !dbg !37, !tbaa !32
-  %68 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %67, i32 noundef 0) #16, !dbg !37
+  %68 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %67, i32 noundef 0) #17, !dbg !37
   br label %rb_vm_check_ints.exit, !dbg !37
 
 rb_vm_check_ints.exit:                            ; preds = %35, %65
@@ -382,7 +378,7 @@ rb_vm_check_ints.exit:                            ; preds = %35, %65
 }
 
 ; Function Attrs: sspreq
-define void @Init_block_type_checking() local_unnamed_addr #9 {
+define void @Init_block_type_checking() local_unnamed_addr #10 {
 entry:
   %locals.i16.i = alloca i64, i32 0, align 8
   %locals.i14.i = alloca i64, i32 0, align 8
@@ -391,40 +387,39 @@ entry:
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %0)
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
   store i64 %1, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #16
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #17
   store i64 %2, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #16
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #17
   store i64 %3, i64* @rubyIdPrecomputed_new, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #16
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #17
   store i64 %4, i64* @rubyIdPrecomputed_bar, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #16
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #17
   store i64 %5, i64* @rubyIdPrecomputed_p, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #16
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Foo>", i64 0, i64 0), i64 noundef 11) #16
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #17
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Foo>", i64 0, i64 0), i64 noundef 11) #17
   store i64 %7, i64* @"rubyIdPrecomputed_<class:Foo>", align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @"str_block in <class:Foo>", i64 0, i64 0), i64 noundef 20) #16
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @"str_block in <class:Foo>", i64 0, i64 0), i64 noundef 20) #17
   store i64 %8, i64* @"rubyIdPrecomputed_block in <class:Foo>", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #16
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #17
   store i64 %9, i64* @rubyIdPrecomputed_x, align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_blk, i64 0, i64 0), i64 noundef 3) #16
+  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_blk, i64 0, i64 0), i64 noundef 3) #17
   store i64 %10, i64* @rubyIdPrecomputed_blk, align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_proc, i64 0, i64 0), i64 noundef 4) #16
+  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_proc, i64 0, i64 0), i64 noundef 4) #17
   store i64 %11, i64* @rubyIdPrecomputed_proc, align 8
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #16
+  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #17
   store i64 %12, i64* @rubyIdPrecomputed_returns, align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #16
+  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #17
   store i64 %13, i64* @rubyIdPrecomputed_params, align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #16
+  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #17
   store i64 %14, i64* @rubyIdPrecomputed_extend, align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
-  store i64 %15, i64* @rubyIdPrecomputed_normal, align 8
-  %16 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
-  tail call void @rb_gc_register_mark_object(i64 %16) #16
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #17
+  %16 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
+  tail call void @rb_gc_register_mark_object(i64 %16) #17
   store i64 %16, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([46 x i8], [46 x i8]* @"str_test/testdata/compiler/block_type_checking.rb", i64 0, i64 0), i64 noundef 45) #16
-  tail call void @rb_gc_register_mark_object(i64 %17) #16
+  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([46 x i8], [46 x i8]* @"str_test/testdata/compiler/block_type_checking.rb", i64 0, i64 0), i64 noundef 45) #17
+  tail call void @rb_gc_register_mark_object(i64 %17) #17
   store i64 %17, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 19)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -432,8 +427,8 @@ entry:
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #16
-  call void @rb_gc_register_mark_object(i64 %19) #16
+  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #17
+  call void @rb_gc_register_mark_object(i64 %19) #17
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i12.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
@@ -445,20 +440,20 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
   %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !47
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
-  %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #16
-  call void @rb_gc_register_mark_object(i64 %21) #16
+  %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #17
+  call void @rb_gc_register_mark_object(i64 %21) #17
   %rubyId_bar.i.i = load i64, i64* @rubyIdPrecomputed_bar, align 8
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   %22 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i14.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %22, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8
-  %23 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Foo>", i64 0, i64 0), i64 noundef 11) #16
-  call void @rb_gc_register_mark_object(i64 %23) #16
+  %23 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Foo>", i64 0, i64 0), i64 noundef 11) #17
+  call void @rb_gc_register_mark_object(i64 %23) #17
   %"rubyId_<class:Foo>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:Foo>", align 8
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %23, i64 %"rubyId_<class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
-  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @"str_block in <class:Foo>", i64 0, i64 0), i64 noundef 20) #16
-  call void @rb_gc_register_mark_object(i64 %25) #16
+  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @"str_block in <class:Foo>", i64 0, i64 0), i64 noundef 20) #17
+  call void @rb_gc_register_mark_object(i64 %25) #17
   %stackFrame.i17.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
   %"rubyId_block in <class:Foo>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:Foo>", align 8
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
@@ -470,13 +465,13 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !44
   %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !44
-  %27 = call i64 @rb_id2sym(i64 %rubyId_x.i) #16, !dbg !44
+  %27 = call i64 @rb_id2sym(i64 %rubyId_x.i) #19, !dbg !44
   store i64 %27, i64* %keywords.i, align 8, !dbg !44
   %rubyId_blk.i = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !44
-  %28 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #16, !dbg !44
+  %28 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #19, !dbg !44
   %29 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !44
   store i64 %28, i64* %29, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords.i), !dbg !44
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords.i), !dbg !44
   %rubyId_returns8.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !44
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.1, i64 %rubyId_returns8.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !44
   %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !33
@@ -496,14 +491,14 @@ entry:
   %39 = load i64, i64* %38, align 8, !tbaa !6
   %40 = and i64 %39, -33
   store i64 %40, i64* %38, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %33, %struct.rb_control_frame_struct* %35, %struct.rb_iseq_struct* %stackFrame.i) #16
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %33, %struct.rb_control_frame_struct* %35, %struct.rb_iseq_struct* %stackFrame.i) #17
   %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 0
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %41, align 8, !dbg !57, !tbaa !15
   %42 = load i64, i64* @rb_cObject, align 8, !dbg !58
-  %43 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 %42) #16, !dbg !58
-  %44 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %43) #16, !dbg !58
-  call fastcc void @"func_Foo.13<static-init>L62"(i64 %43, %struct.rb_control_frame_struct* %44) #16, !dbg !58
-  call void @sorbet_popFrame() #16, !dbg !58
+  %43 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 %42) #17, !dbg !58
+  %44 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %43) #17, !dbg !58
+  call fastcc void @"func_Foo.13<static-init>L62"(i64 %43, %struct.rb_control_frame_struct* %44) #17, !dbg !58
+  call void @sorbet_popFrame() #17, !dbg !58
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %41, align 8, !dbg !58, !tbaa !15
   %45 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !46
   %46 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !34
@@ -536,7 +531,7 @@ entry:
   %59 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !15
   %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 2, !dbg !46
   %61 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %60, align 8, !dbg !46, !tbaa !17
-  %62 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.17<static-init>$152$block_1", i8* null, i32 0, i32 0) #16, !dbg !46
+  %62 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.17<static-init>$152$block_1", i8* null, i32 0, i32 0) #17, !dbg !46
   %63 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %61, i64 0, i32 3, !dbg !46
   %64 = bitcast i64* %63 to %struct.rb_captured_block*, !dbg !46
   %65 = getelementptr inbounds i64, i64* %63, i64 2, !dbg !46
@@ -544,10 +539,10 @@ entry:
   store %struct.vm_ifunc* %62, %struct.vm_ifunc** %66, align 8, !dbg !46, !tbaa !59
   %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 17, !dbg !46
   store i64 0, i64* %67, align 8, !dbg !46, !tbaa !60
-  call void @llvm.experimental.noalias.scope.decl(metadata !61) #16, !dbg !46
+  call void @llvm.experimental.noalias.scope.decl(metadata !61) #17, !dbg !46
   %68 = ptrtoint %struct.rb_captured_block* %64 to i64, !dbg !46
   %69 = or i64 %68, 3, !dbg !46
-  %70 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %69) #16, !dbg !46
+  %70 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %69) #17, !dbg !46
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %41, align 8, !dbg !46, !tbaa !15
   %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 1, !dbg !47
   %72 = load i64*, i64** %71, align 8, !dbg !47
@@ -561,7 +556,7 @@ entry:
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Foo#3bar"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #8 !dbg !64 {
+define i64 @"func_Foo#3bar"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #9 !dbg !64 {
 functionEntryInitializers:
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %1, align 8, !tbaa !15
@@ -571,17 +566,17 @@ functionEntryInitializers:
   br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !65, !prof !66
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #18, !dbg !65
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #20, !dbg !65
   unreachable, !dbg !65
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
   %rawArg_x = load i64, i64* %argArray, align 8, !dbg !65
-  %2 = tail call i32 @rb_block_given_p() #16, !dbg !65
+  %2 = tail call i32 @rb_block_given_p() #17, !dbg !65
   %3 = icmp eq i32 %2, 0, !dbg !65
   br i1 %3, label %sorbet_getMethodBlockAsProc.exit, label %4, !dbg !65
 
 4:                                                ; preds = %fillRequiredArgs
-  %5 = tail call i64 @rb_block_proc() #16, !dbg !65
+  %5 = tail call i64 @rb_block_proc() #17, !dbg !65
   br label %sorbet_getMethodBlockAsProc.exit, !dbg !65
 
 sorbet_getMethodBlockAsProc.exit:                 ; preds = %fillRequiredArgs, %4
@@ -608,12 +603,12 @@ sorbet_isa_Integer.exit:                          ; preds = %9
   br i1 %19, label %typeTestSuccess, label %codeRepl25, !dbg !68, !prof !31
 
 typeTestSuccess:                                  ; preds = %sorbet_getMethodBlockAsProc.exit, %sorbet_isa_Integer.exit
-  %20 = tail call i32 @rb_block_given_p() #16, !dbg !72
+  %20 = tail call i32 @rb_block_given_p() #17, !dbg !72
   %21 = icmp ne i32 %20, 0, !dbg !72
   br i1 %21, label %typeTestSuccess7, label %codeRepl24, !dbg !72, !prof !31
 
 codeRepl25:                                       ; preds = %9, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_Foo#3bar.cold.3"(i64 %rawArg_x) #19, !dbg !68
+  tail call fastcc void @"func_Foo#3bar.cold.3"(i64 %rawArg_x) #21, !dbg !68
   unreachable
 
 typeTestSuccess7:                                 ; preds = %typeTestSuccess
@@ -628,7 +623,7 @@ typeTestSuccess7:                                 ; preds = %typeTestSuccess
 
 25:                                               ; preds = %typeTestSuccess7
   %26 = add nsw i64 %rawBlockSendResult, -1, !dbg !77
-  %27 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_x, i64 %26) #20, !dbg !77
+  %27 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_x, i64 %26) #22, !dbg !77
   %28 = extractvalue { i64, i1 } %27, 1, !dbg !77
   %29 = extractvalue { i64, i1 } %27, 0, !dbg !77
   br i1 %28, label %30, label %sorbet_rb_int_plus.exit, !dbg !77
@@ -636,11 +631,11 @@ typeTestSuccess7:                                 ; preds = %typeTestSuccess
 30:                                               ; preds = %25
   %31 = ashr i64 %29, 1, !dbg !77
   %32 = xor i64 %31, -9223372036854775808, !dbg !77
-  %33 = tail call i64 @rb_int2big(i64 %32) #16, !dbg !77, !noalias !74
+  %33 = tail call i64 @rb_int2big(i64 %32) #17, !dbg !77, !noalias !74
   br label %sorbet_rb_int_plus.exit, !dbg !77
 
 34:                                               ; preds = %typeTestSuccess7
-  %35 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_x, i64 %rawBlockSendResult) #16, !dbg !77, !noalias !74
+  %35 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_x, i64 %rawBlockSendResult) #17, !dbg !77, !noalias !74
   br label %sorbet_rb_int_plus.exit, !dbg !77
 
 sorbet_rb_int_plus.exit:                          ; preds = %30, %25, %34
@@ -658,7 +653,7 @@ sorbet_rb_int_plus.exit:                          ; preds = %30, %25, %34
 45:                                               ; preds = %sorbet_rb_int_plus.exit
   %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %37, i64 0, i32 8, !dbg !77
   %47 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %46, align 8, !dbg !77, !tbaa !32
-  %48 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %47, i32 noundef 0) #16, !dbg !77
+  %48 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %47, i32 noundef 0) #17, !dbg !77
   br label %rb_vm_check_ints.exit, !dbg !77
 
 rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.exit, %45
@@ -683,19 +678,19 @@ sorbet_isa_Integer.exit26:                        ; preds = %51
   br i1 %61, label %typeTestSuccess17, label %codeRepl, !prof !31
 
 codeRepl24:                                       ; preds = %typeTestSuccess
-  tail call fastcc void @"func_Foo#3bar.cold.2"(i64 %6) #19, !dbg !72
+  tail call fastcc void @"func_Foo#3bar.cold.2"(i64 %6) #21, !dbg !72
   unreachable
 
 typeTestSuccess17:                                ; preds = %rb_vm_check_ints.exit, %sorbet_isa_Integer.exit26
   ret i64 %36
 
 codeRepl:                                         ; preds = %51, %sorbet_isa_Integer.exit26
-  tail call fastcc void @"func_Foo#3bar.cold.1"(i64 %36) #19, !dbg !67
+  tail call fastcc void @"func_Foo#3bar.cold.1"(i64 %36) #21, !dbg !67
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_Foo.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #10 !dbg !45 {
+define internal i64 @"func_Foo.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #11 !dbg !45 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -712,10 +707,6 @@ functionEntryInitializers:
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %10, align 8, !tbaa !15
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !79
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !79
-  %rubyId_blk = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !80
-  %rawSym19 = tail call i64 @rb_id2sym(i64 %rubyId_blk), !dbg !80
   %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !48
   %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !34
   %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !48
@@ -764,47 +755,47 @@ functionEntryInitializers:
   %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !44
   store i64* %34, i64** %31, align 8, !dbg !44
   %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.1, i64 0), !dbg !44
-  ret i64 %send45, !dbg !81
+  ret i64 %send45, !dbg !79
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare void @llvm.experimental.noalias.scope.decl(metadata) #11
+declare void @llvm.experimental.noalias.scope.decl(metadata) #12
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #12
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #13
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #6
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #6
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Foo#3bar.cold.1"(i64 %0) unnamed_addr #13 !dbg !82 {
+define internal fastcc void @"func_Foo#3bar.cold.1"(i64 %0) unnamed_addr #14 !dbg !80 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18
+  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20
   unreachable
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Foo#3bar.cold.2"(i64 %0) unnamed_addr #13 !dbg !84 {
+define internal fastcc void @"func_Foo#3bar.cold.2"(i64 %0) unnamed_addr #14 !dbg !82 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_T.proc.returns(Integer)", i64 0, i64 0)) #18, !dbg !85
-  unreachable, !dbg !85
+  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_T.proc.returns(Integer)", i64 0, i64 0)) #20, !dbg !83
+  unreachable, !dbg !83
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Foo#3bar.cold.3"(i64 %rawArg_x) unnamed_addr #13 !dbg !86 {
+define internal fastcc void @"func_Foo#3bar.cold.3"(i64 %rawArg_x) unnamed_addr #14 !dbg !84 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !87
-  unreachable, !dbg !87
+  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !85
+  unreachable, !dbg !85
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #14
+declare void @llvm.assume(i1 noundef) #15
 
 ; Function Attrs: ssp
-define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #10 {
+define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #11 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
@@ -813,7 +804,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #10 {
 }
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_Foo() local_unnamed_addr #10 {
+define linkonce void @const_recompute_Foo() local_unnamed_addr #11 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 3)
   store i64 %1, i64* @guarded_const_Foo, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
@@ -822,7 +813,7 @@ define linkonce void @const_recompute_Foo() local_unnamed_addr #10 {
 }
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_T() local_unnamed_addr #10 {
+define linkonce void @const_recompute_T() local_unnamed_addr #11 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_T, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_T, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
@@ -830,27 +821,29 @@ define linkonce void @const_recompute_T() local_unnamed_addr #10 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nofree nosync nounwind readnone speculatable willreturn }
-attributes #4 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #5 = { argmemonly nofree nosync nounwind willreturn }
-attributes #6 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #7 = { nofree nosync nounwind ssp willreturn }
-attributes #8 = { nounwind sspreq uwtable }
-attributes #9 = { sspreq }
-attributes #10 = { ssp }
-attributes #11 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #12 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #13 = { cold minsize noreturn nounwind sspreq uwtable }
-attributes #14 = { nofree nosync nounwind willreturn }
-attributes #15 = { noreturn nounwind }
-attributes #16 = { nounwind }
-attributes #17 = { nounwind allocsize(0,1) }
-attributes #18 = { noreturn }
-attributes #19 = { noinline }
-attributes #20 = { nounwind willreturn }
+attributes #3 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { nofree nosync nounwind readnone speculatable willreturn }
+attributes #5 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #6 = { argmemonly nofree nosync nounwind willreturn }
+attributes #7 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #8 = { nofree nosync nounwind ssp willreturn }
+attributes #9 = { nounwind sspreq uwtable }
+attributes #10 = { sspreq }
+attributes #11 = { ssp }
+attributes #12 = { inaccessiblememonly nofree nosync nounwind willreturn }
+attributes #13 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #14 = { cold minsize noreturn nounwind sspreq uwtable }
+attributes #15 = { nofree nosync nounwind willreturn }
+attributes #16 = { noreturn nounwind }
+attributes #17 = { nounwind }
+attributes #18 = { nounwind allocsize(0,1) }
+attributes #19 = { nounwind readnone willreturn }
+attributes #20 = { noreturn }
+attributes #21 = { noinline }
+attributes #22 = { nounwind willreturn }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -934,12 +927,10 @@ attributes #20 = { nounwind willreturn }
 !76 = distinct !{!76, !"sorbet_rb_int_plus"}
 !77 = !DILocation(line: 11, column: 5, scope: !64)
 !78 = !{!22, !7, i64 24}
-!79 = !DILocation(line: 8, column: 15, scope: !45)
-!80 = !DILocation(line: 8, column: 27, scope: !45)
-!81 = !DILocation(line: 8, column: 3, scope: !45)
-!82 = distinct !DISubprogram(name: "func_Foo#3bar.cold.1", linkageName: "func_Foo#3bar.cold.1", scope: null, file: !4, type: !83, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!83 = !DISubroutineType(types: !5)
-!84 = distinct !DISubprogram(name: "func_Foo#3bar.cold.2", linkageName: "func_Foo#3bar.cold.2", scope: null, file: !4, type: !83, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!85 = !DILocation(line: 9, column: 15, scope: !84)
-!86 = distinct !DISubprogram(name: "func_Foo#3bar.cold.3", linkageName: "func_Foo#3bar.cold.3", scope: null, file: !4, type: !83, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!87 = !DILocation(line: 9, column: 11, scope: !86)
+!79 = !DILocation(line: 8, column: 3, scope: !45)
+!80 = distinct !DISubprogram(name: "func_Foo#3bar.cold.1", linkageName: "func_Foo#3bar.cold.1", scope: null, file: !4, type: !81, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!81 = !DISubroutineType(types: !5)
+!82 = distinct !DISubprogram(name: "func_Foo#3bar.cold.2", linkageName: "func_Foo#3bar.cold.2", scope: null, file: !4, type: !81, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!83 = !DILocation(line: 9, column: 15, scope: !82)
+!84 = distinct !DISubprogram(name: "func_Foo#3bar.cold.3", linkageName: "func_Foo#3bar.cold.3", scope: null, file: !4, type: !81, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!85 = !DILocation(line: 9, column: 11, scope: !84)

--- a/test/testdata/compiler/casts.llo.exp
+++ b/test/testdata/compiler/casts.llo.exp
@@ -111,7 +111,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_arg = internal unnamed_addr global i64 0, align 8
 @str_arg = private unnamed_addr constant [4 x i8] c"arg\00", align 1
@@ -131,50 +130,48 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @rb_mKernel = external local_unnamed_addr constant i64
 @rb_cObject = external local_unnamed_addr constant i64
 
-declare i64 @rb_id2sym(i64) local_unnamed_addr #0
-
 ; Function Attrs: nounwind readnone willreturn
-declare i64 @rb_obj_is_kind_of(i64, i64) local_unnamed_addr #1
+declare i64 @rb_obj_is_kind_of(i64, i64) local_unnamed_addr #0
 
 ; Function Attrs: cold noreturn
-declare void @sorbet_cast_failure(i64, i8*, i8*) local_unnamed_addr #2
+declare void @sorbet_cast_failure(i64, i8*, i8*) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #3
+declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #2
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #3
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #3
 
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
+declare i64 @sorbet_readRealpath() local_unnamed_addr #3
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #3
 
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #3
 
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #3
 
-declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #3
 
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #3
 
-declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #0
+declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #3
 
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #3
 
 ; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #3
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
 
-declare i64 @rb_int2big(i64) local_unnamed_addr #0
+declare i64 @rb_int2big(i64) local_unnamed_addr #3
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
 declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #4
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #3
 
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #5
@@ -505,10 +502,6 @@ functionEntryInitializers:
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #17
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !54, !tbaa !14
-  %rubyId_fooAll = load i64, i64* @rubyIdPrecomputed_fooAll, align 8, !dbg !55
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_fooAll), !dbg !55
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !55
-  %rawSym73 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !55
   %9 = load i64, i64* @rb_cObject, align 8, !dbg !55
   %stackFrame74 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8, !dbg !55
   %10 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !55
@@ -554,10 +547,6 @@ functionEntryInitializers:
 
 rb_vm_check_ints.exit4:                           ; preds = %functionEntryInitializers, %33
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !55, !tbaa !14
-  %rubyId_fooAny1 = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8, !dbg !61
-  %rawSym76 = tail call i64 @rb_id2sym(i64 %rubyId_fooAny1), !dbg !61
-  %rubyId_normal77 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !61
-  %rawSym78 = tail call i64 @rb_id2sym(i64 %rubyId_normal77), !dbg !61
   %stackFrame83 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8, !dbg !61
   %37 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !61
   %38 = bitcast i8* %37 to i16*, !dbg !61
@@ -602,10 +591,6 @@ rb_vm_check_ints.exit4:                           ; preds = %functionEntryInitia
 
 rb_vm_check_ints.exit3:                           ; preds = %rb_vm_check_ints.exit4, %60
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !61, !tbaa !14
-  %rubyId_fooAny2 = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8, !dbg !62
-  %rawSym88 = tail call i64 @rb_id2sym(i64 %rubyId_fooAny2), !dbg !62
-  %rubyId_normal89 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !62
-  %rawSym90 = tail call i64 @rb_id2sym(i64 %rubyId_normal89), !dbg !62
   %stackFrame95 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8, !dbg !62
   %64 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !62
   %65 = bitcast i8* %64 to i16*, !dbg !62
@@ -650,10 +635,6 @@ rb_vm_check_ints.exit3:                           ; preds = %rb_vm_check_ints.ex
 
 rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.exit3, %87
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %8, align 8, !dbg !62, !tbaa !14
-  %rubyId_fooInt = load i64, i64* @rubyIdPrecomputed_fooInt, align 8, !dbg !63
-  %rawSym100 = tail call i64 @rb_id2sym(i64 %rubyId_fooInt), !dbg !63
-  %rubyId_normal101 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !63
-  %rawSym102 = tail call i64 @rb_id2sym(i64 %rubyId_normal101), !dbg !63
   %stackFrame107 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8, !dbg !63
   %91 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !63
   %92 = bitcast i8* %91 to i16*, !dbg !63
@@ -698,10 +679,6 @@ rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.ex
 
 rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.exit2, %114
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %8, align 8, !dbg !63, !tbaa !14
-  %rubyId_fooArray = load i64, i64* @rubyIdPrecomputed_fooArray, align 8, !dbg !64
-  %rawSym112 = tail call i64 @rb_id2sym(i64 %rubyId_fooArray), !dbg !64
-  %rubyId_normal113 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !64
-  %rawSym114 = tail call i64 @rb_id2sym(i64 %rubyId_normal113), !dbg !64
   %stackFrame119 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8, !dbg !64
   %118 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !64
   %119 = bitcast i8* %118 to i16*, !dbg !64
@@ -862,7 +839,6 @@ entry:
   %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
   store i64 %6, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #17
-  store i64 %7, i64* @rubyIdPrecomputed_normal, align 8
   %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_arg, i64 0, i64 0), i64 noundef 3) #17
   store i64 %8, i64* @rubyIdPrecomputed_arg, align 8
   %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #17
@@ -981,10 +957,10 @@ newFuncRoot:
   unreachable, !dbg !98
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #4 = { nofree nosync nounwind readnone speculatable willreturn }
 attributes #5 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #6 = { argmemonly nofree nosync nounwind willreturn }

--- a/test/testdata/compiler/classfields.llo.exp
+++ b/test/testdata/compiler/classfields.llo.exp
@@ -114,7 +114,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_B.13<static-init>" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:B>" = internal unnamed_addr global i64 0, align 8
 @"str_<class:B>" = private unnamed_addr constant [10 x i8] c"<class:B>\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
 @str_a = private unnamed_addr constant [2 x i8] c"a\00", align 1
@@ -122,47 +121,45 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @guard_epoch_B = linkonce local_unnamed_addr global i64 0
 @guarded_const_B = linkonce local_unnamed_addr global i64 0
 
-declare i64 @rb_id2sym(i64) local_unnamed_addr #0
+; Function Attrs: noreturn
+declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #0
+
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #1
+
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #1
+
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #1
+
+declare i64 @sorbet_readRealpath() local_unnamed_addr #1
+
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #1
+
+declare void @sorbet_popFrame() local_unnamed_addr #1
+
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
+
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
+
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
+
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+
+declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #1
+
+declare i64 @rb_cvar_get(i64, i64) local_unnamed_addr #1
+
+declare void @rb_cvar_set(i64, i64, i64) local_unnamed_addr #1
+
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
+
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #1
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
-
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
-
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
-
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
-
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
-
-declare void @sorbet_popFrame() local_unnamed_addr #0
-
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
-
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
-
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
-
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
-
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_cvar_get(i64, i64) local_unnamed_addr #0
-
-declare void @rb_cvar_set(i64, i64, i64) local_unnamed_addr #0
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
-
-; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
-
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
 
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
@@ -212,7 +209,6 @@ entry:
   %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:B>", i64 0, i64 0), i64 noundef 9) #11
   store i64 %6, i64* @"rubyIdPrecomputed_<class:B>", align 8
   %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  store i64 %7, i64* @rubyIdPrecomputed_normal, align 8
   %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #11
   store i64 %8, i64* @rubyIdPrecomputed_a, align 8
   %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
@@ -301,10 +297,6 @@ entry:
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %35, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i.i) #11
   %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
   store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %43, align 8, !dbg !42, !tbaa !22
-  %rubyId_write.i.i1 = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !10
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_write.i.i1) #11, !dbg !10
-  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !10
-  %rawSym25.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !10
   %44 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
   %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !43
   %needTakeSlowPath = icmp ne i64 %44, %45, !dbg !10
@@ -361,10 +353,6 @@ entry:
 
 rb_vm_check_ints.exit2.i.i:                       ; preds = %72, %47
   store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %43, align 8, !dbg !10, !tbaa !22
-  %rubyId_read.i.i2 = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !54
-  %rawSym28.i.i = call i64 @rb_id2sym(i64 %rubyId_read.i.i2) #11, !dbg !54
-  %rubyId_normal29.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !54
-  %rawSym30.i.i = call i64 @rb_id2sym(i64 %rubyId_normal29.i.i) #11, !dbg !54
   %stackFrame35.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8, !dbg !54
   %76 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !54
   %77 = bitcast i8* %76 to i16*, !dbg !54
@@ -392,10 +380,6 @@ rb_vm_check_ints.exit2.i.i:                       ; preds = %72, %47
 
 rb_vm_check_ints.exit1.i.i:                       ; preds = %89, %rb_vm_check_ints.exit2.i.i
   store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %43, align 8, !dbg !54, !tbaa !22
-  %rubyId_read38.i.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !55
-  %rawSym39.i.i = call i64 @rb_id2sym(i64 %rubyId_read38.i.i) #11, !dbg !55
-  %rubyId_normal40.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !55
-  %rawSym41.i.i = call i64 @rb_id2sym(i64 %rubyId_normal40.i.i) #11, !dbg !55
   %stackFrame45.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8, !dbg !55
   %93 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !55
   %94 = bitcast i8* %93 to i16*, !dbg !55
@@ -438,43 +422,43 @@ rb_vm_check_ints.exit1.i.i:                       ; preds = %89, %rb_vm_check_in
   store i64 3, i64* %115, align 8, !dbg !17, !tbaa !6
   %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !17
   store i64* %116, i64** %113, align 8, !dbg !17
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !17
+  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !17
   store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %30, align 8, !dbg !17, !tbaa !22
   %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !18
   %118 = load i64*, i64** %117, align 8, !dbg !18
   store i64 %48, i64* %118, align 8, !dbg !18, !tbaa !6
   %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !18
   store i64* %119, i64** %117, align 8, !dbg !18
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
   %120 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !19
   %121 = load i64*, i64** %120, align 8, !dbg !19
   store i64 %21, i64* %121, align 8, !dbg !19, !tbaa !6
   %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !19
-  store i64 %send6, i64* %122, align 8, !dbg !19, !tbaa !6
+  store i64 %send4, i64* %122, align 8, !dbg !19, !tbaa !6
   %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !19
   store i64* %123, i64** %120, align 8, !dbg !19
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
   store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %30, align 8, !dbg !19, !tbaa !22
   %124 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !20
   %125 = load i64*, i64** %124, align 8, !dbg !20
   store i64 %48, i64* %125, align 8, !dbg !20, !tbaa !6
   %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !20
   store i64* %126, i64** %124, align 8, !dbg !20
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new.1, i64 0), !dbg !20
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new.1, i64 0), !dbg !20
   %127 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !20
   %128 = load i64*, i64** %127, align 8, !dbg !20
-  store i64 %send10, i64* %128, align 8, !dbg !20, !tbaa !6
+  store i64 %send8, i64* %128, align 8, !dbg !20, !tbaa !6
   %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !20
   store i64* %129, i64** %127, align 8, !dbg !20
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.2, i64 0), !dbg !20
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.2, i64 0), !dbg !20
   %130 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !21
   %131 = load i64*, i64** %130, align 8, !dbg !21
   store i64 %21, i64* %131, align 8, !dbg !21, !tbaa !6
   %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !21
-  store i64 %send12, i64* %132, align 8, !dbg !21, !tbaa !6
+  store i64 %send10, i64* %132, align 8, !dbg !21, !tbaa !6
   %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !21
   store i64* %133, i64** %130, align 8, !dbg !21
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !21
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !21
   ret void
 }
 
@@ -606,8 +590,8 @@ define linkonce void @const_recompute_B() local_unnamed_addr #9 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #3 = { argmemonly nofree nosync nounwind willreturn }
 attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/testdata/compiler/constant_cache.llo.exp
+++ b/test/testdata/compiler/constant_cache.llo.exp
@@ -99,7 +99,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_A.13<static-init>" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
@@ -109,43 +108,41 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
 
-declare i64 @rb_id2sym(i64) local_unnamed_addr #0
+; Function Attrs: noreturn
+declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #0
+
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #1
+
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #1
+
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #1
+
+declare i64 @sorbet_readRealpath() local_unnamed_addr #1
+
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #1
+
+declare void @sorbet_popFrame() local_unnamed_addr #1
+
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
+
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
+
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
+
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+
+declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #1
+
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
+
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #1
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
-
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
-
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
-
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
-
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
-
-declare void @sorbet_popFrame() local_unnamed_addr #0
-
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
-
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
-
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
-
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
-
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
-
-; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
-
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
 
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
@@ -245,7 +242,6 @@ entry:
   %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
   store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  store i64 %3, i64* @rubyIdPrecomputed_normal, align 8
   %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
   store i64 %4, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
@@ -318,10 +314,6 @@ entry:
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %35, align 8, !dbg !45, !tbaa !14
   call void @sorbet_popFrame() #11, !dbg !44
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %23, align 8, !dbg !44, !tbaa !14
-  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !48
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #11, !dbg !48
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !48
-  %rawSym18.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #11, !dbg !48
   %stackFrame22.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !48
   %36 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !48
   %37 = bitcast i8* %36 to i16*, !dbg !48
@@ -373,8 +365,8 @@ define linkonce void @const_recompute_A() local_unnamed_addr #8 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #4 = { nounwind sspreq uwtable }

--- a/test/testdata/compiler/custom_plus.llo.exp
+++ b/test/testdata/compiler/custom_plus.llo.exp
@@ -110,7 +110,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
 @str_new = private unnamed_addr constant [4 x i8] c"new\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
 @str_a = private unnamed_addr constant [2 x i8] c"a\00", align 1
@@ -125,43 +124,41 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 
-declare i64 @rb_id2sym(i64) local_unnamed_addr #0
+; Function Attrs: noreturn
+declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #0
+
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #1
+
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #1
+
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #1
+
+declare i64 @sorbet_readRealpath() local_unnamed_addr #1
+
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #1
+
+declare void @sorbet_popFrame() local_unnamed_addr #1
+
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
+
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
+
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
+
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+
+declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #1
+
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
+
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #1
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
-
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
-
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
-
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
-
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
-
-declare void @sorbet_popFrame() local_unnamed_addr #0
-
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
-
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
-
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
-
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
-
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
-
-; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
-
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
 
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
@@ -275,10 +272,6 @@ functionEntryInitializers:
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #11
   %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %21, align 8, !dbg !34, !tbaa !14
-  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !22
-  %rawSym.i = tail call i64 @rb_id2sym(i64 %"rubyId_+.i") #11, !dbg !22
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !22
-  %rawSym7.i = tail call i64 @rb_id2sym(i64 %rubyId_normal.i) #11, !dbg !22
   %22 = load i64, i64* @guard_epoch_A, align 8, !dbg !22
   %23 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !35
   %needTakeSlowPath = icmp ne i64 %22, %23, !dbg !22
@@ -344,10 +337,6 @@ functionEntryInitializers:
   store i64* %56, i64** %54, align 8, !dbg !47
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !47
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !47, !tbaa !14
-  %rubyId_delegate = load i64, i64* @rubyIdPrecomputed_delegate, align 8, !dbg !48
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_delegate), !dbg !48
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !48
-  %rawSym24 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !48
   %stackFrame28 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8delegate", align 8, !dbg !48
   %57 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !48
   %58 = bitcast i8* %57 to i16*, !dbg !48
@@ -424,7 +413,6 @@ entry:
   %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
   store i64 %5, i64* @rubyIdPrecomputed_new, align 8
   %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  store i64 %6, i64* @rubyIdPrecomputed_normal, align 8
   %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #11
   store i64 %7, i64* @rubyIdPrecomputed_a, align 8
   %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
@@ -529,8 +517,8 @@ define linkonce void @const_recompute_A() local_unnamed_addr #6 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #3 = { argmemonly nofree nosync nounwind willreturn }
 attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/testdata/compiler/direct_call.llo.exp
+++ b/test/testdata/compiler/direct_call.llo.exp
@@ -95,7 +95,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @ic_bar = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
@@ -103,35 +102,33 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 
-declare i64 @rb_id2sym(i64) local_unnamed_addr #0
+; Function Attrs: noreturn
+declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #0
+
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #1
+
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #1
+
+declare i64 @sorbet_readRealpath() local_unnamed_addr #1
+
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
+
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
+
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
+
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
+
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #1
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
-
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
-
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
-
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
-
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
-
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
-
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
-
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
-
-; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
-
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
 
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
@@ -204,7 +201,6 @@ entry:
   %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #9
   store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #9
-  store i64 %3, i64* @rubyIdPrecomputed_normal, align 8
   %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #9
   store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
   %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #9
@@ -254,10 +250,6 @@ entry:
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %15, %struct.rb_control_frame_struct* %17, %struct.rb_iseq_struct* %stackFrame.i) #9
   %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 0
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %23, align 8, !dbg !42, !tbaa !14
-  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !43
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #9, !dbg !43
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !43
-  %rawSym21.i = call i64 @rb_id2sym(i64 %rubyId_normal.i) #9, !dbg !43
   %24 = load i64, i64* @rb_cObject, align 8, !dbg !43
   %stackFrame22.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !43
   %25 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !43
@@ -286,10 +278,6 @@ entry:
 
 rb_vm_check_ints.exit1.i:                         ; preds = %38, %entry
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %23, align 8, !dbg !43, !tbaa !14
-  %rubyId_bar.i2 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !48
-  %rawSym24.i = call i64 @rb_id2sym(i64 %rubyId_bar.i2) #9, !dbg !48
-  %rubyId_normal25.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !48
-  %rawSym26.i = call i64 @rb_id2sym(i64 %rubyId_normal25.i) #9, !dbg !48
   %stackFrame31.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8, !dbg !48
   %42 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !48
   %43 = bitcast i8* %42 to i16*, !dbg !48
@@ -330,15 +318,15 @@ rb_vm_check_ints.exit1.i:                         ; preds = %38, %entry
   store i64 %send, i64* %64, align 8, !dbg !25, !tbaa !6
   %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !25
   store i64* %65, i64** %62, align 8, !dbg !25
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !25
+  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !25
   ret void
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #6
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #4 = { nounwind sspreq uwtable }

--- a/test/testdata/compiler/exceptions/basic.llo.exp
+++ b/test/testdata/compiler/exceptions/basic.llo.exp
@@ -143,56 +143,53 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_A.13<static-init>" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
 @"str_<class:A>" = private unnamed_addr constant [10 x i8] c"<class:A>\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_eStandardError = external local_unnamed_addr constant i64
 
-declare i64 @rb_id2sym(i64) local_unnamed_addr #0
+; Function Attrs: noreturn
+declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #0
+
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #1
+
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #1
+
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #1
+
+declare i64 @sorbet_readRealpath() local_unnamed_addr #1
+
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #1
+
+declare void @sorbet_popFrame() local_unnamed_addr #1
+
+declare void @sorbet_vm_env_write_slowpath(i64*, i32, i64) local_unnamed_addr #1
+
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
+
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
+
+declare void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
+
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
+
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+
+declare i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64**, i64, %struct.rb_control_frame_struct*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64, i64, i64) local_unnamed_addr #1
+
+declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #1
+
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
+
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #1
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
-
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
-
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
-
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
-
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
-
-declare void @sorbet_popFrame() local_unnamed_addr #0
-
-declare void @sorbet_vm_env_write_slowpath(i64*, i32, i64) local_unnamed_addr #0
-
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
-
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
-
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
-
-declare void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
-
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
-
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64**, i64, %struct.rb_control_frame_struct*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64, i64, i64) local_unnamed_addr #0
-
-declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
-
-; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
-
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
 
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
@@ -252,7 +249,6 @@ entry:
   %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
   store i64 %12, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  store i64 %13, i64* @rubyIdPrecomputed_normal, align 8
   %14 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
   tail call void @rb_gc_register_mark_object(i64 %14) #11
   store i64 %14, i64* @"rubyStrFrozen_<top (required)>", align 8
@@ -386,10 +382,6 @@ entry:
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %53, %struct.rb_control_frame_struct* %55, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
   %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %61, align 8, !dbg !53, !tbaa !33
-  %rubyId_test.i.i2 = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !10
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_test.i.i2) #11, !dbg !10
-  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !10
-  %rawSym7.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !10
   %62 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
   %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !54
   %needTakeSlowPath = icmp ne i64 %62, %63, !dbg !10
@@ -420,8 +412,8 @@ entry:
   %78 = bitcast i8* %77 to i32*, !dbg !10
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 20, i1 false) #11, !dbg !10
   store i32 1, i32* %78, align 4, !dbg !10, !tbaa !59
-  %rubyId_x.i.i3 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !10
-  store i64 %rubyId_x.i.i3, i64* %positional_table.i.i, align 8, !dbg !10
+  %rubyId_x.i.i2 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !10
+  store i64 %rubyId_x.i.i2, i64* %positional_table.i.i, align 8, !dbg !10
   %79 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %79, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %52, i64 noundef 8, i1 noundef false) #11, !dbg !10
   %80 = getelementptr inbounds i8, i8* %69, i64 32, !dbg !10
@@ -465,7 +457,7 @@ entry:
   store i64 0, i64* %100, align 8, !dbg !18, !tbaa !6
   %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !18
   store i64* %101, i64** %98, align 8, !dbg !18
-  %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !18
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !18
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %48, align 8, !dbg !18, !tbaa !33
   %"rubyStr_=== raise ===.i" = load i64, i64* @"rubyStrFrozen_=== raise ===", align 8, !dbg !66
   %102 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !19
@@ -475,7 +467,7 @@ entry:
   store i64 %"rubyStr_=== raise ===.i", i64* %104, align 8, !dbg !19, !tbaa !6
   %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !19
   store i64* %105, i64** %102, align 8, !dbg !19
-  %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !19
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !19
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %48, align 8, !dbg !19, !tbaa !33
   %106 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !20
   %107 = load i64*, i64** %106, align 8, !dbg !20
@@ -484,7 +476,7 @@ entry:
   store i64 20, i64* %108, align 8, !dbg !20, !tbaa !6
   %109 = getelementptr inbounds i64, i64* %108, i64 1, !dbg !20
   store i64* %109, i64** %106, align 8, !dbg !20
-  %send9 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test.2, i64 0), !dbg !20
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test.2, i64 0), !dbg !20
   ret void
 }
 
@@ -828,8 +820,8 @@ define linkonce void @const_recompute_A() local_unnamed_addr #7 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #3 = { argmemonly nofree nosync nounwind willreturn }
 attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/testdata/compiler/float-intrinsics.llo.exp
+++ b/test/testdata/compiler/float-intrinsics.llo.exp
@@ -150,7 +150,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_extend = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_extend = internal unnamed_addr global i64 0, align 8
 @str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @ic_plus = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p = internal global %struct.FunctionInlineCache zeroinitializer
@@ -226,13 +225,14 @@ declare i64 @sorbet_flo_lt(i64, i64) local_unnamed_addr #0
 
 declare i64 @sorbet_flo_le(i64, i64) local_unnamed_addr #0
 
-declare i64 @rb_id2sym(i64) local_unnamed_addr #0
+; Function Attrs: nounwind readnone willreturn
+declare i64 @rb_id2sym(i64) local_unnamed_addr #1
 
 ; Function Attrs: cold noreturn
-declare void @sorbet_cast_failure(i64, i8*, i8*) local_unnamed_addr #1
+declare void @sorbet_cast_failure(i64, i8*, i8*) local_unnamed_addr #2
 
 ; Function Attrs: noreturn
-declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #2
+declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #3
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -259,35 +259,35 @@ declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #3
 
 declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
 
 ; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #3
+declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #4
 
 ; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xmalloc2(i64, i64) local_unnamed_addr #3
+declare noalias nonnull i8* @ruby_xmalloc2(i64, i64) local_unnamed_addr #4
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #4
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #5
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #5 {
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #12
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #13
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #5 {
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #12
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #13
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#4plus"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #6 !dbg !10 {
+define i64 @"func_Object#4plus"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #7 !dbg !10 {
 functionEntryInitializers:
   %callArgs = alloca [2 x i64], align 8
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
@@ -298,7 +298,7 @@ functionEntryInitializers:
   br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !16, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #13, !dbg !16
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #14, !dbg !16
   unreachable, !dbg !16
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
@@ -326,7 +326,7 @@ sorbet_isa_Float.exit:                            ; preds = %5
   br i1 %15, label %typeTestSuccess7, label %codeRepl22, !dbg !18, !prof !21
 
 codeRepl22:                                       ; preds = %5, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #14, !dbg !18
+  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #15, !dbg !18
   unreachable
 
 typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
@@ -336,7 +336,7 @@ typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %
   %16 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !23
   tail call void @llvm.experimental.noalias.scope.decl(metadata !24), !dbg !23
   %17 = load i64, i64* %16, align 8, !dbg !23, !tbaa !6, !alias.scope !24
-  %18 = tail call i64 @rb_float_plus(i64 %rawArg_x, i64 %17) #15, !dbg !23, !noalias !24
+  %18 = tail call i64 @rb_float_plus(i64 %rawArg_x, i64 %17) #16, !dbg !23, !noalias !24
   %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !14
   %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 5, !dbg !23
   %21 = load i32, i32* %20, align 8, !dbg !23, !tbaa !27
@@ -350,7 +350,7 @@ typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %
 27:                                               ; preds = %typeTestSuccess7
   %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 8, !dbg !23
   %29 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %28, align 8, !dbg !23, !tbaa !32
-  %30 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %29, i32 noundef 0) #15, !dbg !23
+  %30 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %29, i32 noundef 0) #16, !dbg !23
   br label %typeTestSuccess14, !dbg !23
 
 typeTestSuccess14:                                ; preds = %27, %typeTestSuccess7
@@ -358,7 +358,7 @@ typeTestSuccess14:                                ; preds = %27, %typeTestSucces
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#5minus"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #6 !dbg !33 {
+define i64 @"func_Object#5minus"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #7 !dbg !33 {
 functionEntryInitializers:
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %1, align 8, !tbaa !14
@@ -368,7 +368,7 @@ functionEntryInitializers:
   br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !34, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #13, !dbg !34
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #14, !dbg !34
   unreachable, !dbg !34
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
@@ -397,7 +397,7 @@ sorbet_isa_Float.exit:                            ; preds = %8
   br i1 %18, label %typeTestSuccess7, label %codeRepl20, !dbg !35, !prof !21
 
 codeRepl20:                                       ; preds = %8, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %5) #14, !dbg !35
+  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %5) #15, !dbg !35
   unreachable
 
 typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
@@ -414,7 +414,7 @@ typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#2lt"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #6 !dbg !38 {
+define i64 @"func_Object#2lt"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #7 !dbg !38 {
 functionEntryInitializers:
   %callArgs = alloca [2 x i64], align 8
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
@@ -425,7 +425,7 @@ functionEntryInitializers:
   br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !39, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #13, !dbg !39
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #14, !dbg !39
   unreachable, !dbg !39
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
@@ -453,7 +453,7 @@ sorbet_isa_Float.exit:                            ; preds = %5
   br i1 %15, label %typeTestSuccess7, label %codeRepl22, !dbg !40, !prof !21
 
 codeRepl22:                                       ; preds = %5, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #14, !dbg !40
+  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #15, !dbg !40
   unreachable
 
 typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
@@ -463,7 +463,7 @@ typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %
   %16 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !42
   tail call void @llvm.experimental.noalias.scope.decl(metadata !43), !dbg !42
   %17 = load i64, i64* %16, align 8, !dbg !42, !tbaa !6, !alias.scope !43
-  %18 = tail call i64 @sorbet_flo_lt(i64 %rawArg_x, i64 %17) #15, !dbg !42, !noalias !43
+  %18 = tail call i64 @sorbet_flo_lt(i64 %rawArg_x, i64 %17) #16, !dbg !42, !noalias !43
   %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !42, !tbaa !14
   %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 5, !dbg !42
   %21 = load i32, i32* %20, align 8, !dbg !42, !tbaa !27
@@ -477,7 +477,7 @@ typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %
 27:                                               ; preds = %typeTestSuccess7
   %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 8, !dbg !42
   %29 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %28, align 8, !dbg !42, !tbaa !32
-  %30 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %29, i32 noundef 0) #15, !dbg !42
+  %30 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %29, i32 noundef 0) #16, !dbg !42
   br label %rb_vm_check_ints.exit, !dbg !42
 
 rb_vm_check_ints.exit:                            ; preds = %typeTestSuccess7, %27
@@ -490,12 +490,12 @@ typeTestSuccess14:                                ; preds = %rb_vm_check_ints.ex
   ret i64 %18
 
 codeRepl:                                         ; preds = %rb_vm_check_ints.exit
-  tail call fastcc void @"func_Object#2lt.cold.1"(i64 %18) #14, !dbg !47
+  tail call fastcc void @"func_Object#2lt.cold.1"(i64 %18) #15, !dbg !47
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_Object#3lte"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #6 !dbg !48 {
+define i64 @"func_Object#3lte"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #7 !dbg !48 {
 functionEntryInitializers:
   %callArgs = alloca [2 x i64], align 8
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
@@ -506,7 +506,7 @@ functionEntryInitializers:
   br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !49, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #13, !dbg !49
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #14, !dbg !49
   unreachable, !dbg !49
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
@@ -534,7 +534,7 @@ sorbet_isa_Float.exit:                            ; preds = %5
   br i1 %15, label %typeTestSuccess7, label %codeRepl22, !dbg !50, !prof !21
 
 codeRepl22:                                       ; preds = %5, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #14, !dbg !50
+  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #15, !dbg !50
   unreachable
 
 typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
@@ -544,7 +544,7 @@ typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %
   %16 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !52
   tail call void @llvm.experimental.noalias.scope.decl(metadata !53), !dbg !52
   %17 = load i64, i64* %16, align 8, !dbg !52, !tbaa !6, !alias.scope !53
-  %18 = tail call i64 @sorbet_flo_le(i64 %rawArg_x, i64 %17) #15, !dbg !52, !noalias !53
+  %18 = tail call i64 @sorbet_flo_le(i64 %rawArg_x, i64 %17) #16, !dbg !52, !noalias !53
   %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !14
   %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 5, !dbg !52
   %21 = load i32, i32* %20, align 8, !dbg !52, !tbaa !27
@@ -558,7 +558,7 @@ typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %
 27:                                               ; preds = %typeTestSuccess7
   %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 8, !dbg !52
   %29 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %28, align 8, !dbg !52, !tbaa !32
-  %30 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %29, i32 noundef 0) #15, !dbg !52
+  %30 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %29, i32 noundef 0) #16, !dbg !52
   br label %rb_vm_check_ints.exit, !dbg !52
 
 rb_vm_check_ints.exit:                            ; preds = %typeTestSuccess7, %27
@@ -571,12 +571,12 @@ typeTestSuccess14:                                ; preds = %rb_vm_check_ints.ex
   ret i64 %18
 
 codeRepl:                                         ; preds = %rb_vm_check_ints.exit
-  tail call fastcc void @"func_Object#2lt.cold.1"(i64 %18) #14, !dbg !56
+  tail call fastcc void @"func_Object#2lt.cold.1"(i64 %18) #15, !dbg !56
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_<root>.17<static-init>$152"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #6 !dbg !57 {
+define internal fastcc void @"func_<root>.17<static-init>$152"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !57 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
@@ -589,7 +589,7 @@ functionEntryInitializers:
   %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
   store i64 %7, i64* %5, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #15
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #16
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !62, !tbaa !14
   %rubyId_plus = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !63
@@ -608,7 +608,7 @@ functionEntryInitializers:
 17:                                               ; preds = %functionEntryInitializers
   %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !63
   %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !63, !tbaa !32
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !63
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !63
   br label %rb_vm_check_ints.exit3, !dbg !63
 
 rb_vm_check_ints.exit3:                           ; preds = %functionEntryInitializers, %17
@@ -629,7 +629,7 @@ rb_vm_check_ints.exit3:                           ; preds = %functionEntryInitia
 29:                                               ; preds = %rb_vm_check_ints.exit3
   %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !64
   %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !64, !tbaa !32
-  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #15, !dbg !64
+  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #16, !dbg !64
   br label %rb_vm_check_ints.exit5, !dbg !64
 
 rb_vm_check_ints.exit5:                           ; preds = %rb_vm_check_ints.exit3, %29
@@ -650,7 +650,7 @@ rb_vm_check_ints.exit5:                           ; preds = %rb_vm_check_ints.ex
 41:                                               ; preds = %rb_vm_check_ints.exit5
   %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 8, !dbg !65
   %43 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %42, align 8, !dbg !65, !tbaa !32
-  %44 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %43, i32 noundef 0) #15, !dbg !65
+  %44 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %43, i32 noundef 0) #16, !dbg !65
   br label %rb_vm_check_ints.exit7, !dbg !65
 
 rb_vm_check_ints.exit7:                           ; preds = %rb_vm_check_ints.exit5, %41
@@ -671,7 +671,7 @@ rb_vm_check_ints.exit7:                           ; preds = %rb_vm_check_ints.ex
 53:                                               ; preds = %rb_vm_check_ints.exit7
   %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 8, !dbg !66
   %55 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %54, align 8, !dbg !66, !tbaa !32
-  %56 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %55, i32 noundef 0) #15, !dbg !66
+  %56 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %55, i32 noundef 0) #16, !dbg !66
   br label %rb_vm_check_ints.exit6, !dbg !66
 
 rb_vm_check_ints.exit6:                           ; preds = %rb_vm_check_ints.exit7, %53
@@ -700,13 +700,9 @@ rb_vm_check_ints.exit6:                           ; preds = %rb_vm_check_ints.ex
   store i64* %67, i64** %64, align 8, !dbg !67
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !67
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !67, !tbaa !14
-  %rubyId_plus303 = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !71
-  %rawSym304 = tail call i64 @rb_id2sym(i64 %rubyId_plus303), !dbg !71
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !71
-  %rawSym305 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !71
   %68 = load i64, i64* @rb_cObject, align 8, !dbg !71
   %stackFrame309 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8, !dbg !71
-  %69 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !71
+  %69 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !71
   %70 = bitcast i8* %69 to i16*, !dbg !71
   %71 = load i16, i16* %70, align 8, !dbg !71
   %72 = and i16 %71, -384, !dbg !71
@@ -727,13 +723,13 @@ rb_vm_check_ints.exit6:                           ; preds = %rb_vm_check_ints.ex
   %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !71
   %80 = getelementptr i64, i64* %positional_table, i32 1, !dbg !71
   store i64 %rubyId_y, i64* %80, align 8, !dbg !71
-  %81 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !71
+  %81 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !71
   %82 = bitcast i64* %positional_table to i8*, !dbg !71
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %81, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %82, i64 noundef 16, i1 noundef false) #15, !dbg !71
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %81, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %82, i64 noundef 16, i1 noundef false) #16, !dbg !71
   %83 = getelementptr inbounds i8, i8* %69, i64 32, !dbg !71
   %84 = bitcast i8* %83 to i8**, !dbg !71
   store i8* %81, i8** %84, align 8, !dbg !71, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Object#4plus", i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame309, i1 noundef zeroext false) #15, !dbg !71
+  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Object#4plus", i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame309, i1 noundef zeroext false) #16, !dbg !71
   %85 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !71, !tbaa !14
   %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 5, !dbg !71
   %87 = load i32, i32* %86, align 8, !dbg !71, !tbaa !27
@@ -747,17 +743,13 @@ rb_vm_check_ints.exit6:                           ; preds = %rb_vm_check_ints.ex
 93:                                               ; preds = %60
   %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 8, !dbg !71
   %95 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %94, align 8, !dbg !71, !tbaa !32
-  %96 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %95, i32 noundef 0) #15, !dbg !71
+  %96 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %95, i32 noundef 0) #16, !dbg !71
   br label %rb_vm_check_ints.exit4, !dbg !71
 
 rb_vm_check_ints.exit4:                           ; preds = %60, %93
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !71, !tbaa !14
-  %rubyId_minus311 = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !77
-  %rawSym312 = tail call i64 @rb_id2sym(i64 %rubyId_minus311), !dbg !77
-  %rubyId_normal313 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !77
-  %rawSym314 = tail call i64 @rb_id2sym(i64 %rubyId_normal313), !dbg !77
   %stackFrame319 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8, !dbg !77
-  %97 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !77
+  %97 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !77
   %98 = bitcast i8* %97 to i16*, !dbg !77
   %99 = load i16, i16* %98, align 8, !dbg !77
   %100 = and i16 %99, -384, !dbg !77
@@ -778,13 +770,13 @@ rb_vm_check_ints.exit4:                           ; preds = %60, %93
   %rubyId_y323 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !77
   %108 = getelementptr i64, i64* %positional_table321, i32 1, !dbg !77
   store i64 %rubyId_y323, i64* %108, align 8, !dbg !77
-  %109 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !77
+  %109 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !77
   %110 = bitcast i64* %positional_table321 to i8*, !dbg !77
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %109, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %110, i64 noundef 16, i1 noundef false) #15, !dbg !77
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %109, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %110, i64 noundef 16, i1 noundef false) #16, !dbg !77
   %111 = getelementptr inbounds i8, i8* %97, i64 32, !dbg !77
   %112 = bitcast i8* %111 to i8**, !dbg !77
   store i8* %109, i8** %112, align 8, !dbg !77, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Object#5minus", i8* nonnull %97, %struct.rb_iseq_struct* %stackFrame319, i1 noundef zeroext false) #15, !dbg !77
+  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Object#5minus", i8* nonnull %97, %struct.rb_iseq_struct* %stackFrame319, i1 noundef zeroext false) #16, !dbg !77
   %113 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !77, !tbaa !14
   %114 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 5, !dbg !77
   %115 = load i32, i32* %114, align 8, !dbg !77, !tbaa !27
@@ -798,17 +790,13 @@ rb_vm_check_ints.exit4:                           ; preds = %60, %93
 121:                                              ; preds = %rb_vm_check_ints.exit4
   %122 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 8, !dbg !77
   %123 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %122, align 8, !dbg !77, !tbaa !32
-  %124 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %123, i32 noundef 0) #15, !dbg !77
+  %124 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %123, i32 noundef 0) #16, !dbg !77
   br label %rb_vm_check_ints.exit2, !dbg !77
 
 rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.exit4, %121
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !dbg !77, !tbaa !14
-  %rubyId_lt325 = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !78
-  %rawSym326 = tail call i64 @rb_id2sym(i64 %rubyId_lt325), !dbg !78
-  %rubyId_normal327 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !78
-  %rawSym328 = tail call i64 @rb_id2sym(i64 %rubyId_normal327), !dbg !78
   %stackFrame333 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8, !dbg !78
-  %125 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !78
+  %125 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !78
   %126 = bitcast i8* %125 to i16*, !dbg !78
   %127 = load i16, i16* %126, align 8, !dbg !78
   %128 = and i16 %127, -384, !dbg !78
@@ -829,13 +817,13 @@ rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.ex
   %rubyId_y337 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !78
   %136 = getelementptr i64, i64* %positional_table335, i32 1, !dbg !78
   store i64 %rubyId_y337, i64* %136, align 8, !dbg !78
-  %137 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !78
+  %137 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !78
   %138 = bitcast i64* %positional_table335 to i8*, !dbg !78
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %137, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %138, i64 noundef 16, i1 noundef false) #15, !dbg !78
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %137, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %138, i64 noundef 16, i1 noundef false) #16, !dbg !78
   %139 = getelementptr inbounds i8, i8* %125, i64 32, !dbg !78
   %140 = bitcast i8* %139 to i8**, !dbg !78
   store i8* %137, i8** %140, align 8, !dbg !78, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Object#2lt", i8* nonnull %125, %struct.rb_iseq_struct* %stackFrame333, i1 noundef zeroext false) #15, !dbg !78
+  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Object#2lt", i8* nonnull %125, %struct.rb_iseq_struct* %stackFrame333, i1 noundef zeroext false) #16, !dbg !78
   %141 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !14
   %142 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 5, !dbg !78
   %143 = load i32, i32* %142, align 8, !dbg !78, !tbaa !27
@@ -849,17 +837,13 @@ rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.ex
 149:                                              ; preds = %rb_vm_check_ints.exit2
   %150 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 8, !dbg !78
   %151 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %150, align 8, !dbg !78, !tbaa !32
-  %152 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %151, i32 noundef 0) #15, !dbg !78
+  %152 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %151, i32 noundef 0) #16, !dbg !78
   br label %rb_vm_check_ints.exit1, !dbg !78
 
 rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.exit2, %149
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %8, align 8, !dbg !78, !tbaa !14
-  %rubyId_lte339 = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !79
-  %rawSym340 = tail call i64 @rb_id2sym(i64 %rubyId_lte339), !dbg !79
-  %rubyId_normal341 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !79
-  %rawSym342 = tail call i64 @rb_id2sym(i64 %rubyId_normal341), !dbg !79
   %stackFrame347 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8, !dbg !79
-  %153 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !79
+  %153 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !79
   %154 = bitcast i8* %153 to i16*, !dbg !79
   %155 = load i16, i16* %154, align 8, !dbg !79
   %156 = and i16 %155, -384, !dbg !79
@@ -880,13 +864,13 @@ rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.ex
   %rubyId_y351 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !79
   %164 = getelementptr i64, i64* %positional_table349, i32 1, !dbg !79
   store i64 %rubyId_y351, i64* %164, align 8, !dbg !79
-  %165 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #16, !dbg !79
+  %165 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !79
   %166 = bitcast i64* %positional_table349 to i8*, !dbg !79
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %165, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %166, i64 noundef 16, i1 noundef false) #15, !dbg !79
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %165, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %166, i64 noundef 16, i1 noundef false) #16, !dbg !79
   %167 = getelementptr inbounds i8, i8* %153, i64 32, !dbg !79
   %168 = bitcast i8* %167 to i8**, !dbg !79
   store i8* %165, i8** %168, align 8, !dbg !79, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Object#3lte", i8* nonnull %153, %struct.rb_iseq_struct* %stackFrame347, i1 noundef zeroext false) #15, !dbg !79
+  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Object#3lte", i8* nonnull %153, %struct.rb_iseq_struct* %stackFrame347, i1 noundef zeroext false) #16, !dbg !79
   %169 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !79, !tbaa !14
   %170 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %169, i64 0, i32 5, !dbg !79
   %171 = load i32, i32* %170, align 8, !dbg !79, !tbaa !27
@@ -900,7 +884,7 @@ rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.ex
 177:                                              ; preds = %rb_vm_check_ints.exit1
   %178 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %169, i64 0, i32 8, !dbg !79
   %179 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %178, align 8, !dbg !79, !tbaa !32
-  %180 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %179, i32 noundef 0) #15, !dbg !79
+  %180 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %179, i32 noundef 0) #16, !dbg !79
   br label %rb_vm_check_ints.exit, !dbg !79
 
 rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.exit1, %177
@@ -1290,7 +1274,7 @@ rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.ex
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$152$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !120 {
+define internal i64 @"func_<root>.17<static-init>$152$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !120 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -1307,61 +1291,57 @@ functionEntryInitializers:
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !14
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !122
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !122
-  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !123
-  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_y), !dbg !123
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !124
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !124, !tbaa !68
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !124
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !124, !prof !70
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !122
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !122, !tbaa !68
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !122
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !122, !prof !70
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !124
-  br label %14, !dbg !124
+  tail call void @const_recompute_T(), !dbg !122
+  br label %14, !dbg !122
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !124
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !124
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !124, !tbaa !68
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !124
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !124
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !124
-  %19 = load i64*, i64** %18, align 8, !dbg !124
-  store i64 %15, i64* %19, align 8, !dbg !124, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !124
-  store i64* %20, i64** %18, align 8, !dbg !124
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped, i64 0), !dbg !124
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !125
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !125
-  %23 = load i64*, i64** %22, align 8, !dbg !125
-  store i64 %4, i64* %23, align 8, !dbg !125, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !125
-  store i64 %21, i64* %24, align 8, !dbg !125, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !125
-  store i64 %send, i64* %25, align 8, !dbg !125, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !125
-  store i64* %26, i64** %22, align 8, !dbg !125
-  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !125
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !126
-  %28 = load i64*, i64** %27, align 8, !dbg !126
-  store i64 %15, i64* %28, align 8, !dbg !126, !tbaa !6
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !126
-  store i64* %29, i64** %27, align 8, !dbg !126
-  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.1, i64 0), !dbg !126
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !125
-  %31 = load i64*, i64** %30, align 8, !dbg !125
-  store i64 %send38, i64* %31, align 8, !dbg !125, !tbaa !6
-  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !125
-  store i64 %send40, i64* %32, align 8, !dbg !125, !tbaa !6
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !125
-  store i64* %33, i64** %30, align 8, !dbg !125
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !125
-  ret i64 %send42, !dbg !127
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !122
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !122
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !122, !tbaa !68
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !122
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !122
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !122
+  %19 = load i64*, i64** %18, align 8, !dbg !122
+  store i64 %15, i64* %19, align 8, !dbg !122, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !122
+  store i64* %20, i64** %18, align 8, !dbg !122
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped, i64 0), !dbg !122
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !123
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !123
+  %23 = load i64*, i64** %22, align 8, !dbg !123
+  store i64 %4, i64* %23, align 8, !dbg !123, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !123
+  store i64 %21, i64* %24, align 8, !dbg !123, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !123
+  store i64 %send, i64* %25, align 8, !dbg !123, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !123
+  store i64* %26, i64** %22, align 8, !dbg !123
+  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !123
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !124
+  %28 = load i64*, i64** %27, align 8, !dbg !124
+  store i64 %15, i64* %28, align 8, !dbg !124, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !124
+  store i64* %29, i64** %27, align 8, !dbg !124
+  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.1, i64 0), !dbg !124
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !123
+  %31 = load i64*, i64** %30, align 8, !dbg !123
+  store i64 %send38, i64* %31, align 8, !dbg !123, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !123
+  store i64 %send40, i64* %32, align 8, !dbg !123, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !123
+  store i64* %33, i64** %30, align 8, !dbg !123
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !123
+  ret i64 %send42, !dbg !125
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$152$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !128 {
+define internal i64 @"func_<root>.17<static-init>$152$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !126 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -1378,61 +1358,57 @@ functionEntryInitializers:
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %10, align 8, !tbaa !14
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !129
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !129
-  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !130
-  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_y), !dbg !130
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !131
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !131, !tbaa !68
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !131
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !131, !prof !70
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !127
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !127, !tbaa !68
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !127
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !127, !prof !70
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !131
-  br label %14, !dbg !131
+  tail call void @const_recompute_T(), !dbg !127
+  br label %14, !dbg !127
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !131
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !131
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !131, !tbaa !68
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !131
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !131
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !131
-  %19 = load i64*, i64** %18, align 8, !dbg !131
-  store i64 %15, i64* %19, align 8, !dbg !131, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !131
-  store i64* %20, i64** %18, align 8, !dbg !131
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.2, i64 0), !dbg !131
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !132
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !132
-  %23 = load i64*, i64** %22, align 8, !dbg !132
-  store i64 %4, i64* %23, align 8, !dbg !132, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !132
-  store i64 %21, i64* %24, align 8, !dbg !132, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !132
-  store i64 %send, i64* %25, align 8, !dbg !132, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !132
-  store i64* %26, i64** %22, align 8, !dbg !132
-  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.3, i64 0), !dbg !132
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !133
-  %28 = load i64*, i64** %27, align 8, !dbg !133
-  store i64 %15, i64* %28, align 8, !dbg !133, !tbaa !6
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !133
-  store i64* %29, i64** %27, align 8, !dbg !133
-  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.4, i64 0), !dbg !133
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !132
-  %31 = load i64*, i64** %30, align 8, !dbg !132
-  store i64 %send38, i64* %31, align 8, !dbg !132, !tbaa !6
-  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !132
-  store i64 %send40, i64* %32, align 8, !dbg !132, !tbaa !6
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !132
-  store i64* %33, i64** %30, align 8, !dbg !132
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.5, i64 0), !dbg !132
-  ret i64 %send42, !dbg !134
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !127
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !127
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !127, !tbaa !68
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !127
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !127
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !127
+  %19 = load i64*, i64** %18, align 8, !dbg !127
+  store i64 %15, i64* %19, align 8, !dbg !127, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !127
+  store i64* %20, i64** %18, align 8, !dbg !127
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.2, i64 0), !dbg !127
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !128
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !128
+  %23 = load i64*, i64** %22, align 8, !dbg !128
+  store i64 %4, i64* %23, align 8, !dbg !128, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !128
+  store i64 %21, i64* %24, align 8, !dbg !128, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !128
+  store i64 %send, i64* %25, align 8, !dbg !128, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !128
+  store i64* %26, i64** %22, align 8, !dbg !128
+  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.3, i64 0), !dbg !128
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !129
+  %28 = load i64*, i64** %27, align 8, !dbg !129
+  store i64 %15, i64* %28, align 8, !dbg !129, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !129
+  store i64* %29, i64** %27, align 8, !dbg !129
+  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.4, i64 0), !dbg !129
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !128
+  %31 = load i64*, i64** %30, align 8, !dbg !128
+  store i64 %send38, i64* %31, align 8, !dbg !128, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !128
+  store i64 %send40, i64* %32, align 8, !dbg !128, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !128
+  store i64* %33, i64** %30, align 8, !dbg !128
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.5, i64 0), !dbg !128
+  ret i64 %send42, !dbg !130
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$152$block_3"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !135 {
+define internal i64 @"func_<root>.17<static-init>$152$block_3"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !131 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -1449,70 +1425,66 @@ functionEntryInitializers:
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %10, align 8, !tbaa !14
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !136
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !136
-  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !137
-  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_y), !dbg !137
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !138
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !138, !tbaa !68
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !138
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !138, !prof !70
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !132
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !132, !tbaa !68
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !132
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !132, !prof !70
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !138
-  br label %14, !dbg !138
+  tail call void @const_recompute_T(), !dbg !132
+  br label %14, !dbg !132
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !138
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !138
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !138, !tbaa !68
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !138
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !138
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !138
-  %19 = load i64*, i64** %18, align 8, !dbg !138
-  store i64 %15, i64* %19, align 8, !dbg !138, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !138
-  store i64* %20, i64** %18, align 8, !dbg !138
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.6, i64 0), !dbg !138
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !139
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !139
-  %23 = load i64*, i64** %22, align 8, !dbg !139
-  store i64 %4, i64* %23, align 8, !dbg !139, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !139
-  store i64 %21, i64* %24, align 8, !dbg !139, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !139
-  store i64 %send, i64* %25, align 8, !dbg !139, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !139
-  store i64* %26, i64** %22, align 8, !dbg !139
-  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.7, i64 0), !dbg !139
-  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !139
-  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !139, !tbaa !68
-  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !139
-  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !139, !prof !70
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !132
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !132
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !132, !tbaa !68
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !132
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !132
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !132
+  %19 = load i64*, i64** %18, align 8, !dbg !132
+  store i64 %15, i64* %19, align 8, !dbg !132, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !132
+  store i64* %20, i64** %18, align 8, !dbg !132
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.6, i64 0), !dbg !132
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !133
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !133
+  %23 = load i64*, i64** %22, align 8, !dbg !133
+  store i64 %4, i64* %23, align 8, !dbg !133, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !133
+  store i64 %21, i64* %24, align 8, !dbg !133, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !133
+  store i64 %send, i64* %25, align 8, !dbg !133, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !133
+  store i64* %26, i64** %22, align 8, !dbg !133
+  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.7, i64 0), !dbg !133
+  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !133
+  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !133, !tbaa !68
+  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !133
+  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !133, !prof !70
 
 29:                                               ; preds = %14
-  tail call void @"const_recompute_T::Boolean"(), !dbg !139
-  br label %30, !dbg !139
+  tail call void @"const_recompute_T::Boolean"(), !dbg !133
+  br label %30, !dbg !133
 
 30:                                               ; preds = %14, %29
-  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !139
-  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !139
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !139, !tbaa !68
-  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !139
-  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !139
-  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !139
-  %35 = load i64*, i64** %34, align 8, !dbg !139
-  store i64 %send34, i64* %35, align 8, !dbg !139, !tbaa !6
-  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !139
-  store i64 %31, i64* %36, align 8, !dbg !139, !tbaa !6
-  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !139
-  store i64* %37, i64** %34, align 8, !dbg !139
-  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.8, i64 0), !dbg !139
-  ret i64 %send36, !dbg !140
+  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !133
+  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !133
+  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !133, !tbaa !68
+  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !133
+  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !133
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !133
+  %35 = load i64*, i64** %34, align 8, !dbg !133
+  store i64 %send34, i64* %35, align 8, !dbg !133, !tbaa !6
+  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !133
+  store i64 %31, i64* %36, align 8, !dbg !133, !tbaa !6
+  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !133
+  store i64* %37, i64** %34, align 8, !dbg !133
+  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.8, i64 0), !dbg !133
+  ret i64 %send36, !dbg !134
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$152$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !141 {
+define internal i64 @"func_<root>.17<static-init>$152$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !135 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -1529,80 +1501,76 @@ functionEntryInitializers:
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %10, align 8, !tbaa !14
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !142
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x), !dbg !142
-  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !143
-  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_y), !dbg !143
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !144
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !144, !tbaa !68
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !144
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !144, !prof !70
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !136
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !136, !tbaa !68
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !136
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !136, !prof !70
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !144
-  br label %14, !dbg !144
+  tail call void @const_recompute_T(), !dbg !136
+  br label %14, !dbg !136
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !144
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !144
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !144, !tbaa !68
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !144
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !144
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !144
-  %19 = load i64*, i64** %18, align 8, !dbg !144
-  store i64 %15, i64* %19, align 8, !dbg !144, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !144
-  store i64* %20, i64** %18, align 8, !dbg !144
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.9, i64 0), !dbg !144
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !145
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !145
-  %23 = load i64*, i64** %22, align 8, !dbg !145
-  store i64 %4, i64* %23, align 8, !dbg !145, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !145
-  store i64 %21, i64* %24, align 8, !dbg !145, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !145
-  store i64 %send, i64* %25, align 8, !dbg !145, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !145
-  store i64* %26, i64** %22, align 8, !dbg !145
-  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.10, i64 0), !dbg !145
-  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !145
-  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !145, !tbaa !68
-  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !145
-  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !145, !prof !70
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !136
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !136
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !136, !tbaa !68
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !136
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !136
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !136
+  %19 = load i64*, i64** %18, align 8, !dbg !136
+  store i64 %15, i64* %19, align 8, !dbg !136, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !136
+  store i64* %20, i64** %18, align 8, !dbg !136
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.9, i64 0), !dbg !136
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !137
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !137
+  %23 = load i64*, i64** %22, align 8, !dbg !137
+  store i64 %4, i64* %23, align 8, !dbg !137, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !137
+  store i64 %21, i64* %24, align 8, !dbg !137, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !137
+  store i64 %send, i64* %25, align 8, !dbg !137, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !137
+  store i64* %26, i64** %22, align 8, !dbg !137
+  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.10, i64 0), !dbg !137
+  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !137
+  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !137, !tbaa !68
+  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !137
+  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !137, !prof !70
 
 29:                                               ; preds = %14
-  tail call void @"const_recompute_T::Boolean"(), !dbg !145
-  br label %30, !dbg !145
+  tail call void @"const_recompute_T::Boolean"(), !dbg !137
+  br label %30, !dbg !137
 
 30:                                               ; preds = %14, %29
-  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !145
-  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !145
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !145, !tbaa !68
-  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !145
-  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !145
-  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !145
-  %35 = load i64*, i64** %34, align 8, !dbg !145
-  store i64 %send34, i64* %35, align 8, !dbg !145, !tbaa !6
-  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !145
-  store i64 %31, i64* %36, align 8, !dbg !145, !tbaa !6
-  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !145
-  store i64* %37, i64** %34, align 8, !dbg !145
-  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.11, i64 0), !dbg !145
-  ret i64 %send36, !dbg !146
+  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !137
+  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !137
+  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !137, !tbaa !68
+  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !137
+  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !137
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !137
+  %35 = load i64*, i64** %34, align 8, !dbg !137
+  store i64 %send34, i64* %35, align 8, !dbg !137, !tbaa !6
+  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !137
+  store i64 %31, i64* %36, align 8, !dbg !137, !tbaa !6
+  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !137
+  store i64* %37, i64** %34, align 8, !dbg !137
+  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.11, i64 0), !dbg !137
+  ret i64 %send36, !dbg !138
 }
 
 ; Function Attrs: ssp
-define void @Init_float-intrinsics() local_unnamed_addr #7 {
+define void @Init_float-intrinsics() local_unnamed_addr #8 {
 entry:
   %locals.i163.i = alloca i64, align 8
   %locals.i161.i = alloca i64, i32 0, align 8
   %locals.i159.i = alloca i64, i32 0, align 8
   %locals.i157.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, i32 2, align 8, !dbg !125
-  %keywords12.i = alloca i64, i32 2, align 8, !dbg !132
-  %keywords26.i = alloca i64, i32 2, align 8, !dbg !139
-  %keywords38.i = alloca i64, i32 2, align 8, !dbg !145
+  %keywords.i = alloca i64, i32 2, align 8, !dbg !123
+  %keywords12.i = alloca i64, i32 2, align 8, !dbg !128
+  %keywords26.i = alloca i64, i32 2, align 8, !dbg !133
+  %keywords38.i = alloca i64, i32 2, align 8, !dbg !137
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %0)
@@ -1612,50 +1580,49 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %2)
   %3 = bitcast i64* %keywords38.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %3)
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #15
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #16
   store i64 %4, i64* @rubyIdPrecomputed_plus, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #15
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #15
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #16
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #16
   store i64 %6, i64* @rubyIdPrecomputed_minus, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_-, i64 0, i64 0), i64 noundef 1) #15
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_-, i64 0, i64 0), i64 noundef 1) #16
   store i64 %7, i64* @rubyIdPrecomputed_-, align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #15
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #16
   store i64 %8, i64* @rubyIdPrecomputed_lt, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_<", i64 0, i64 0), i64 noundef 1) #15
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #15
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_<", i64 0, i64 0), i64 noundef 1) #16
+  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #16
   store i64 %10, i64* @rubyIdPrecomputed_lte, align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @"str_<=", i64 0, i64 0), i64 noundef 2) #15
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @"str_<=", i64 0, i64 0), i64 noundef 2) #16
+  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
   store i64 %12, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #15
+  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #16
   store i64 %13, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #15
+  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #16
   store i64 %14, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #15
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #16
   store i64 %15, i64* @rubyIdPrecomputed_x, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_y, i64 0, i64 0), i64 noundef 1) #15
+  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_y, i64 0, i64 0), i64 noundef 1) #16
   store i64 %16, i64* @rubyIdPrecomputed_y, align 8
-  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_untyped, i64 0, i64 0), i64 noundef 7) #15
+  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_untyped, i64 0, i64 0), i64 noundef 7) #16
   store i64 %17, i64* @rubyIdPrecomputed_untyped, align 8
-  %18 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #15
+  %18 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #16
   store i64 %18, i64* @rubyIdPrecomputed_params, align 8
-  %19 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #15
+  %19 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #16
   store i64 %19, i64* @rubyIdPrecomputed_returns, align 8
-  %20 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #15
+  %20 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #16
   store i64 %20, i64* @rubyIdPrecomputed_extend, align 8
-  %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %21, i64* @rubyIdPrecomputed_normal, align 8
-  %22 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #15
+  %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
+  %22 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #16
   store i64 %22, i64* @rubyIdPrecomputed_p, align 8
-  %23 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_Rational, i64 0, i64 0), i64 noundef 8) #15
+  %23 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_Rational, i64 0, i64 0), i64 noundef 8) #16
   store i64 %23, i64* @rubyIdPrecomputed_Rational, align 8
-  %24 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Complex, i64 0, i64 0), i64 noundef 7) #15
+  %24 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Complex, i64 0, i64 0), i64 noundef 7) #16
   store i64 %24, i64* @rubyIdPrecomputed_Complex, align 8
-  %25 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #15
-  tail call void @rb_gc_register_mark_object(i64 %25) #15
+  %25 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #16
+  tail call void @rb_gc_register_mark_object(i64 %25) #16
   store i64 %25, i64* @rubyStrFrozen_plus, align 8
-  %26 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/float-intrinsics.rb", i64 0, i64 0), i64 noundef 42) #15
-  tail call void @rb_gc_register_mark_object(i64 %26) #15
+  %26 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/float-intrinsics.rb", i64 0, i64 0), i64 noundef 42) #16
+  tail call void @rb_gc_register_mark_object(i64 %26) #16
   store i64 %26, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 49)
   %rubyId_plus.i.i = load i64, i64* @rubyIdPrecomputed_plus, align 8
@@ -1663,28 +1630,28 @@ entry:
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_plus.i.i, i64 %rubyId_plus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8
-  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #15
-  call void @rb_gc_register_mark_object(i64 %28) #15
+  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #16
+  call void @rb_gc_register_mark_object(i64 %28) #16
   %rubyId_minus.i.i = load i64, i64* @rubyIdPrecomputed_minus, align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i156.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %29 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %28, i64 %rubyId_minus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i156.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i157.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %29, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8
   %rubyId_-.i = load i64, i64* @rubyIdPrecomputed_-, align 8, !dbg !37
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_-, i64 %rubyId_-.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !37
-  %30 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #15
-  call void @rb_gc_register_mark_object(i64 %30) #15
+  %30 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #16
+  call void @rb_gc_register_mark_object(i64 %30) #16
   %rubyId_lt.i.i = load i64, i64* @rubyIdPrecomputed_lt, align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i158.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %31 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %30, i64 %rubyId_lt.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i158.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 18, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i159.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %31, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8
-  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #15
-  call void @rb_gc_register_mark_object(i64 %32) #15
+  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #16
+  call void @rb_gc_register_mark_object(i64 %32) #16
   %rubyId_lte.i.i = load i64, i64* @rubyIdPrecomputed_lte, align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i160.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %33 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %32, i64 %rubyId_lte.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i160.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 23, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i161.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %33, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8
-  %34 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
-  call void @rb_gc_register_mark_object(i64 %34) #15
+  %34 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  call void @rb_gc_register_mark_object(i64 %34) #16
   %35 = bitcast i64* %locals.i163.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -1694,8 +1661,8 @@ entry:
   %36 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %34, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i162.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i163.i, i32 noundef 1, i32 noundef 4)
   store %struct.rb_iseq_struct* %36, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35)
-  %37 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #15
-  call void @rb_gc_register_mark_object(i64 %37) #15
+  %37 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #16
+  call void @rb_gc_register_mark_object(i64 %37) #16
   store i64 %37, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
@@ -1720,62 +1687,62 @@ entry:
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i176.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %41 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i175.i", i64 %"rubyId_block in <top (required)>.i174.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i176.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i173.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %41, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_4", align 8
-  %rubyId_untyped.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !124
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !124
-  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !125
-  %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !125
-  %42 = call i64 @rb_id2sym(i64 %rubyId_x.i) #15, !dbg !125
-  store i64 %42, i64* %keywords.i, align 8, !dbg !125
-  %rubyId_y.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !125
-  %43 = call i64 @rb_id2sym(i64 %rubyId_y.i) #15, !dbg !125
-  %44 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !125
-  store i64 %43, i64* %44, align 8, !dbg !125
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords.i), !dbg !125
-  %rubyId_untyped6.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !126
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped6.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !126
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !125
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !125
-  %rubyId_untyped9.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !131
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.2, i64 %rubyId_untyped9.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !131
-  %rubyId_params11.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !132
-  %rubyId_x13.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !132
-  %45 = call i64 @rb_id2sym(i64 %rubyId_x13.i) #15, !dbg !132
-  store i64 %45, i64* %keywords12.i, align 8, !dbg !132
-  %rubyId_y15.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !132
-  %46 = call i64 @rb_id2sym(i64 %rubyId_y15.i) #15, !dbg !132
-  %47 = getelementptr i64, i64* %keywords12.i, i32 1, !dbg !132
-  store i64 %46, i64* %47, align 8, !dbg !132
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.3, i64 %rubyId_params11.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords12.i), !dbg !132
-  %rubyId_untyped19.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !133
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.4, i64 %rubyId_untyped19.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !133
-  %rubyId_returns21.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !132
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.5, i64 %rubyId_returns21.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !132
-  %rubyId_untyped23.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !138
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.6, i64 %rubyId_untyped23.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !138
-  %rubyId_params25.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !139
-  %rubyId_x27.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !139
-  %48 = call i64 @rb_id2sym(i64 %rubyId_x27.i) #15, !dbg !139
-  store i64 %48, i64* %keywords26.i, align 8, !dbg !139
-  %rubyId_y29.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !139
-  %49 = call i64 @rb_id2sym(i64 %rubyId_y29.i) #15, !dbg !139
-  %50 = getelementptr i64, i64* %keywords26.i, i32 1, !dbg !139
-  store i64 %49, i64* %50, align 8, !dbg !139
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.7, i64 %rubyId_params25.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords26.i), !dbg !139
-  %rubyId_returns33.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !139
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.8, i64 %rubyId_returns33.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !139
-  %rubyId_untyped35.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !144
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.9, i64 %rubyId_untyped35.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !144
-  %rubyId_params37.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !145
-  %rubyId_x39.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !145
-  %51 = call i64 @rb_id2sym(i64 %rubyId_x39.i) #15, !dbg !145
-  store i64 %51, i64* %keywords38.i, align 8, !dbg !145
-  %rubyId_y41.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !145
-  %52 = call i64 @rb_id2sym(i64 %rubyId_y41.i) #15, !dbg !145
-  %53 = getelementptr i64, i64* %keywords38.i, i32 1, !dbg !145
-  store i64 %52, i64* %53, align 8, !dbg !145
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.10, i64 %rubyId_params37.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull %keywords38.i), !dbg !145
-  %rubyId_returns45.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !145
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.11, i64 %rubyId_returns45.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !145
+  %rubyId_untyped.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !122
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !122
+  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !123
+  %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !123
+  %42 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !123
+  store i64 %42, i64* %keywords.i, align 8, !dbg !123
+  %rubyId_y.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !123
+  %43 = call i64 @rb_id2sym(i64 %rubyId_y.i) #18, !dbg !123
+  %44 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !123
+  store i64 %43, i64* %44, align 8, !dbg !123
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords.i), !dbg !123
+  %rubyId_untyped6.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !124
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped6.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !124
+  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !123
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !123
+  %rubyId_untyped9.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !127
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.2, i64 %rubyId_untyped9.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !127
+  %rubyId_params11.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !128
+  %rubyId_x13.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !128
+  %45 = call i64 @rb_id2sym(i64 %rubyId_x13.i) #18, !dbg !128
+  store i64 %45, i64* %keywords12.i, align 8, !dbg !128
+  %rubyId_y15.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !128
+  %46 = call i64 @rb_id2sym(i64 %rubyId_y15.i) #18, !dbg !128
+  %47 = getelementptr i64, i64* %keywords12.i, i32 1, !dbg !128
+  store i64 %46, i64* %47, align 8, !dbg !128
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.3, i64 %rubyId_params11.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords12.i), !dbg !128
+  %rubyId_untyped19.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !129
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.4, i64 %rubyId_untyped19.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !129
+  %rubyId_returns21.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !128
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.5, i64 %rubyId_returns21.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !128
+  %rubyId_untyped23.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !132
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.6, i64 %rubyId_untyped23.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !132
+  %rubyId_params25.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !133
+  %rubyId_x27.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !133
+  %48 = call i64 @rb_id2sym(i64 %rubyId_x27.i) #18, !dbg !133
+  store i64 %48, i64* %keywords26.i, align 8, !dbg !133
+  %rubyId_y29.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !133
+  %49 = call i64 @rb_id2sym(i64 %rubyId_y29.i) #18, !dbg !133
+  %50 = getelementptr i64, i64* %keywords26.i, i32 1, !dbg !133
+  store i64 %49, i64* %50, align 8, !dbg !133
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.7, i64 %rubyId_params25.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords26.i), !dbg !133
+  %rubyId_returns33.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !133
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.8, i64 %rubyId_returns33.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !133
+  %rubyId_untyped35.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !136
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.9, i64 %rubyId_untyped35.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !136
+  %rubyId_params37.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !137
+  %rubyId_x39.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !137
+  %51 = call i64 @rb_id2sym(i64 %rubyId_x39.i) #18, !dbg !137
+  store i64 %51, i64* %keywords38.i, align 8, !dbg !137
+  %rubyId_y41.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !137
+  %52 = call i64 @rb_id2sym(i64 %rubyId_y41.i) #18, !dbg !137
+  %53 = getelementptr i64, i64* %keywords38.i, i32 1, !dbg !137
+  store i64 %52, i64* %53, align 8, !dbg !137
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.10, i64 %rubyId_params37.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords38.i), !dbg !137
+  %rubyId_returns45.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !137
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.11, i64 %rubyId_returns45.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !137
   %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !67
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !67
   %rubyId_plus.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !80
@@ -1810,8 +1777,8 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.21, i64 %rubyId_plus86.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !94
   %rubyId_p89.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !95
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.22, i64 %rubyId_p89.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !95
-  %54 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_8.9, i64 0, i64 0), i64 noundef 3) #15
-  call void @rb_gc_register_mark_object(i64 %54) #15
+  %54 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_8.9, i64 0, i64 0), i64 noundef 3) #16
+  call void @rb_gc_register_mark_object(i64 %54) #16
   store i64 %54, i64* @rubyStrFrozen_8.9, align 8
   %rubyId_Rational.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !96
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !96
@@ -1819,8 +1786,8 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.23, i64 %rubyId_plus93.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !97
   %rubyId_p96.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !98
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.24, i64 %rubyId_p96.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !98
-  %55 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_5, i64 0, i64 0), i64 noundef 1) #15
-  call void @rb_gc_register_mark_object(i64 %55) #15
+  %55 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_5, i64 0, i64 0), i64 noundef 1) #16
+  call void @rb_gc_register_mark_object(i64 %55) #16
   store i64 %55, i64* @rubyStrFrozen_5, align 8
   %rubyId_Complex.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !99
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex, i64 %rubyId_Complex.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !99
@@ -1832,8 +1799,8 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.27, i64 %rubyId_minus106.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !102
   %rubyId_p109.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !103
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.28, i64 %rubyId_p109.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !103
-  %56 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_15.4, i64 0, i64 0), i64 noundef 4) #15
-  call void @rb_gc_register_mark_object(i64 %56) #15
+  %56 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_15.4, i64 0, i64 0), i64 noundef 4) #16
+  call void @rb_gc_register_mark_object(i64 %56) #16
   store i64 %56, i64* @rubyStrFrozen_15.4, align 8
   %rubyId_Rational112.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !104
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.29, i64 %rubyId_Rational112.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
@@ -1841,8 +1808,8 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.30, i64 %rubyId_minus114.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !105
   %rubyId_p117.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !106
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.31, i64 %rubyId_p117.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !106
-  %57 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_18, i64 0, i64 0), i64 noundef 2) #15
-  call void @rb_gc_register_mark_object(i64 %57) #15
+  %57 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_18, i64 0, i64 0), i64 noundef 2) #16
+  call void @rb_gc_register_mark_object(i64 %57) #16
   store i64 %57, i64* @rubyStrFrozen_18, align 8
   %rubyId_Complex120.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !107
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.32, i64 %rubyId_Complex120.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !107
@@ -1854,8 +1821,8 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.35, i64 %rubyId_lt128.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !110
   %rubyId_p131.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !111
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.36, i64 %rubyId_p131.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !111
-  %58 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_25.4, i64 0, i64 0), i64 noundef 4) #15
-  call void @rb_gc_register_mark_object(i64 %58) #15
+  %58 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_25.4, i64 0, i64 0), i64 noundef 4) #16
+  call void @rb_gc_register_mark_object(i64 %58) #16
   store i64 %58, i64* @rubyStrFrozen_25.4, align 8
   %rubyId_Rational134.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !112
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.37, i64 %rubyId_Rational134.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
@@ -1867,8 +1834,8 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.40, i64 %rubyId_lte142.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !115
   %rubyId_p145.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !116
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.41, i64 %rubyId_p145.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !116
-  %59 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_5.923, i64 0, i64 0), i64 noundef 5) #15
-  call void @rb_gc_register_mark_object(i64 %59) #15
+  %59 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_5.923, i64 0, i64 0), i64 noundef 5) #16
+  call void @rb_gc_register_mark_object(i64 %59) #16
   store i64 %59, i64* @rubyStrFrozen_5.923, align 8
   %rubyId_Rational148.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !117
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.42, i64 %rubyId_Rational148.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !117
@@ -1882,45 +1849,45 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %3)
   %60 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %61 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %60, i64 0, i32 18
-  %62 = load i64, i64* %61, align 8, !tbaa !147
+  %62 = load i64, i64* %61, align 8, !tbaa !139
   %63 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %64 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %63, i64 0, i32 2
   %65 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %64, align 8, !tbaa !58
-  call fastcc void @"func_<root>.17<static-init>$152"(i64 %62, %struct.rb_control_frame_struct* %65) #15
+  call fastcc void @"func_<root>.17<static-init>$152"(i64 %62, %struct.rb_control_frame_struct* %65) #16
   ret void
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare void @llvm.experimental.noalias.scope.decl(metadata) #8
+declare void @llvm.experimental.noalias.scope.decl(metadata) #9
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #4
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #4
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #9
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #10
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#2lt.cold.1"(i64 %0) unnamed_addr #10 !dbg !155 {
+define internal fastcc void @"func_Object#2lt.cold.1"(i64 %0) unnamed_addr #11 !dbg !147 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @"str_T::Boolean", i64 0, i64 0)) #13
+  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @"str_T::Boolean", i64 0, i64 0)) #14
   unreachable
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) unnamed_addr #10 !dbg !157 {
+define internal fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) unnamed_addr #11 !dbg !149 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_Float, i64 0, i64 0)) #13, !dbg !158
-  unreachable, !dbg !158
+  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_Float, i64 0, i64 0)) #14, !dbg !150
+  unreachable, !dbg !150
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #11
+declare void @llvm.assume(i1 noundef) #12
 
 ; Function Attrs: ssp
-define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #7 {
+define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !68
@@ -1929,7 +1896,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #7 {
 }
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_T() local_unnamed_addr #7 {
+define linkonce void @const_recompute_T() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_T, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_T, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !68
@@ -1938,7 +1905,7 @@ define linkonce void @const_recompute_T() local_unnamed_addr #7 {
 }
 
 ; Function Attrs: ssp
-define linkonce void @"const_recompute_T::Boolean"() local_unnamed_addr #7 {
+define linkonce void @"const_recompute_T::Boolean"() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"str_T::Boolean", i64 0, i64 0), i64 10)
   store i64 %1, i64* @"guarded_const_T::Boolean", align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !68
@@ -1947,22 +1914,24 @@ define linkonce void @"const_recompute_T::Boolean"() local_unnamed_addr #7 {
 }
 
 attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #4 = { argmemonly nofree nosync nounwind willreturn }
-attributes #5 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #6 = { nounwind sspreq uwtable }
-attributes #7 = { ssp }
-attributes #8 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #9 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #10 = { cold minsize noreturn nounwind sspreq uwtable }
-attributes #11 = { nofree nosync nounwind willreturn }
-attributes #12 = { noreturn nounwind }
-attributes #13 = { noreturn }
-attributes #14 = { noinline }
-attributes #15 = { nounwind }
-attributes #16 = { nounwind allocsize(0,1) }
+attributes #1 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #5 = { argmemonly nofree nosync nounwind willreturn }
+attributes #6 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #7 = { nounwind sspreq uwtable }
+attributes #8 = { ssp }
+attributes #9 = { inaccessiblememonly nofree nosync nounwind willreturn }
+attributes #10 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #11 = { cold minsize noreturn nounwind sspreq uwtable }
+attributes #12 = { nofree nosync nounwind willreturn }
+attributes #13 = { noreturn nounwind }
+attributes #14 = { noreturn }
+attributes #15 = { noinline }
+attributes #16 = { nounwind }
+attributes #17 = { nounwind allocsize(0,1) }
+attributes #18 = { nounwind readnone willreturn }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -2089,40 +2058,32 @@ attributes #16 = { nounwind allocsize(0,1) }
 !119 = !DILocation(line: 48, column: 1, scope: !57)
 !120 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_1", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !121 = !{!60, !7, i64 24}
-!122 = !DILocation(line: 7, column: 13, scope: !120)
-!123 = !DILocation(line: 7, column: 23, scope: !120)
-!124 = !DILocation(line: 7, column: 26, scope: !120)
-!125 = !DILocation(line: 7, column: 6, scope: !120)
-!126 = !DILocation(line: 7, column: 45, scope: !120)
-!127 = !DILocation(line: 7, column: 1, scope: !120)
-!128 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_2", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!129 = !DILocation(line: 12, column: 13, scope: !128)
-!130 = !DILocation(line: 12, column: 23, scope: !128)
-!131 = !DILocation(line: 12, column: 26, scope: !128)
-!132 = !DILocation(line: 12, column: 6, scope: !128)
-!133 = !DILocation(line: 12, column: 45, scope: !128)
-!134 = !DILocation(line: 12, column: 1, scope: !128)
-!135 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_3", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!136 = !DILocation(line: 17, column: 13, scope: !135)
-!137 = !DILocation(line: 17, column: 23, scope: !135)
-!138 = !DILocation(line: 17, column: 26, scope: !135)
-!139 = !DILocation(line: 17, column: 6, scope: !135)
-!140 = !DILocation(line: 17, column: 1, scope: !135)
-!141 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_4", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!142 = !DILocation(line: 22, column: 13, scope: !141)
-!143 = !DILocation(line: 22, column: 23, scope: !141)
-!144 = !DILocation(line: 22, column: 26, scope: !141)
-!145 = !DILocation(line: 22, column: 6, scope: !141)
-!146 = !DILocation(line: 22, column: 1, scope: !141)
-!147 = !{!148, !7, i64 400}
-!148 = !{!"rb_vm_struct", !7, i64 0, !149, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !69, i64 216, !8, i64 224, !150, i64 264, !150, i64 280, !150, i64 296, !150, i64 312, !7, i64 328, !29, i64 336, !29, i64 340, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !152, i64 472, !153, i64 992, !15, i64 1016, !15, i64 1024, !29, i64 1032, !29, i64 1036, !150, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !29, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !29, i64 1192, !154, i64 1200, !8, i64 1232}
-!149 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !150, i64 48, !15, i64 64, !29, i64 72, !8, i64 80, !8, i64 128, !29, i64 176, !29, i64 180}
-!150 = !{!"list_head", !151, i64 0}
-!151 = !{!"list_node", !15, i64 0, !15, i64 8}
-!152 = !{!"", !8, i64 0}
-!153 = !{!"rb_hook_list_struct", !15, i64 0, !29, i64 8, !29, i64 12, !29, i64 16}
-!154 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!155 = distinct !DISubprogram(name: "func_Object#2lt.cold.1", linkageName: "func_Object#2lt.cold.1", scope: null, file: !4, type: !156, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!156 = !DISubroutineType(types: !5)
-!157 = distinct !DISubprogram(name: "func_Object#2lt.cold.3", linkageName: "func_Object#2lt.cold.3", scope: null, file: !4, type: !156, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!158 = !DILocation(line: 18, column: 8, scope: !157)
+!122 = !DILocation(line: 7, column: 26, scope: !120)
+!123 = !DILocation(line: 7, column: 6, scope: !120)
+!124 = !DILocation(line: 7, column: 45, scope: !120)
+!125 = !DILocation(line: 7, column: 1, scope: !120)
+!126 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_2", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!127 = !DILocation(line: 12, column: 26, scope: !126)
+!128 = !DILocation(line: 12, column: 6, scope: !126)
+!129 = !DILocation(line: 12, column: 45, scope: !126)
+!130 = !DILocation(line: 12, column: 1, scope: !126)
+!131 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_3", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!132 = !DILocation(line: 17, column: 26, scope: !131)
+!133 = !DILocation(line: 17, column: 6, scope: !131)
+!134 = !DILocation(line: 17, column: 1, scope: !131)
+!135 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_4", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!136 = !DILocation(line: 22, column: 26, scope: !135)
+!137 = !DILocation(line: 22, column: 6, scope: !135)
+!138 = !DILocation(line: 22, column: 1, scope: !135)
+!139 = !{!140, !7, i64 400}
+!140 = !{!"rb_vm_struct", !7, i64 0, !141, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !69, i64 216, !8, i64 224, !142, i64 264, !142, i64 280, !142, i64 296, !142, i64 312, !7, i64 328, !29, i64 336, !29, i64 340, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !144, i64 472, !145, i64 992, !15, i64 1016, !15, i64 1024, !29, i64 1032, !29, i64 1036, !142, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !29, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !29, i64 1192, !146, i64 1200, !8, i64 1232}
+!141 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !142, i64 48, !15, i64 64, !29, i64 72, !8, i64 80, !8, i64 128, !29, i64 176, !29, i64 180}
+!142 = !{!"list_head", !143, i64 0}
+!143 = !{!"list_node", !15, i64 0, !15, i64 8}
+!144 = !{!"", !8, i64 0}
+!145 = !{!"rb_hook_list_struct", !15, i64 0, !29, i64 8, !29, i64 12, !29, i64 16}
+!146 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!147 = distinct !DISubprogram(name: "func_Object#2lt.cold.1", linkageName: "func_Object#2lt.cold.1", scope: null, file: !4, type: !148, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!148 = !DISubroutineType(types: !5)
+!149 = distinct !DISubprogram(name: "func_Object#2lt.cold.3", linkageName: "func_Object#2lt.cold.3", scope: null, file: !4, type: !148, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!150 = !DILocation(line: 18, column: 8, scope: !149)

--- a/test/testdata/compiler/globalfields.llo.exp
+++ b/test/testdata/compiler/globalfields.llo.exp
@@ -117,7 +117,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_A.13<static-init>" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
 @"str_<class:A>" = private unnamed_addr constant [10 x i8] c"<class:A>\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_v = internal unnamed_addr global i64 0, align 8
 @str_v = private unnamed_addr constant [2 x i8] c"v\00", align 1
@@ -125,51 +124,49 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 
-declare i64 @rb_id2sym(i64) local_unnamed_addr #0
+; Function Attrs: noreturn
+declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #0
+
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #1
+
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #1
+
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #1
+
+declare i64 @sorbet_setConstant(i64, i8*, i64, i64) local_unnamed_addr #1
+
+declare i64 @sorbet_readRealpath() local_unnamed_addr #1
+
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #1
+
+declare void @sorbet_popFrame() local_unnamed_addr #1
+
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
+
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
+
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
+
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+
+declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #1
+
+declare %struct.rb_global_entry* @rb_global_entry(i64) local_unnamed_addr #1
+
+declare i64 @rb_gvar_get(%struct.rb_global_entry*) local_unnamed_addr #1
+
+declare i64 @rb_gvar_set(%struct.rb_global_entry*, i64) local_unnamed_addr #1
+
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
+
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #1
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
-
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
-
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
-
-declare i64 @sorbet_setConstant(i64, i8*, i64, i64) local_unnamed_addr #0
-
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
-
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
-
-declare void @sorbet_popFrame() local_unnamed_addr #0
-
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
-
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
-
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
-
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
-
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
-
-declare %struct.rb_global_entry* @rb_global_entry(i64) local_unnamed_addr #0
-
-declare i64 @rb_gvar_get(%struct.rb_global_entry*) local_unnamed_addr #0
-
-declare i64 @rb_gvar_set(%struct.rb_global_entry*, i64) local_unnamed_addr #0
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
-
-; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
-
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
 
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
@@ -218,7 +215,6 @@ entry:
   %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
   store i64 %6, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  store i64 %7, i64* @rubyIdPrecomputed_normal, align 8
   %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_v, i64 0, i64 0), i64 noundef 1) #11
   store i64 %8, i64* @rubyIdPrecomputed_v, align 8
   %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
@@ -304,10 +300,6 @@ entry:
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %35, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i.i) #11
   %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %43, align 8, !dbg !44, !tbaa !24
-  %rubyId_write.i.i1 = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !10
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_write.i.i1) #11, !dbg !10
-  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !10
-  %rawSym17.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !10
   %44 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
   %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !45
   %needTakeSlowPath = icmp ne i64 %44, %45, !dbg !10
@@ -364,10 +356,6 @@ entry:
 
 rb_vm_check_ints.exit1.i.i:                       ; preds = %72, %47
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %43, align 8, !dbg !10, !tbaa !24
-  %rubyId_read.i.i2 = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !56
-  %rawSym20.i.i = call i64 @rb_id2sym(i64 %rubyId_read.i.i2) #11, !dbg !56
-  %rubyId_normal21.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !56
-  %rawSym22.i.i = call i64 @rb_id2sym(i64 %rubyId_normal21.i.i) #11, !dbg !56
   %stackFrame27.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8, !dbg !56
   %76 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !56
   %77 = bitcast i8* %76 to i16*, !dbg !56
@@ -409,15 +397,15 @@ rb_vm_check_ints.exit1.i.i:                       ; preds = %72, %47
   store i64 %send, i64* %97, align 8, !dbg !18, !tbaa !6
   %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !18
   store i64* %98, i64** %96, align 8, !dbg !18
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
+  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
   %99 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !19
   %100 = load i64*, i64** %99, align 8, !dbg !19
   store i64 %21, i64* %100, align 8, !dbg !19, !tbaa !6
   %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !19
-  store i64 %send4, i64* %101, align 8, !dbg !19, !tbaa !6
+  store i64 %send2, i64* %101, align 8, !dbg !19, !tbaa !6
   %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !19
   store i64* %102, i64** %99, align 8, !dbg !19
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %30, align 8, !dbg !19, !tbaa !24
   %rubyStr_value.i = load i64, i64* @rubyStrFrozen_value, align 8, !dbg !57
   %103 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !20
@@ -427,22 +415,22 @@ rb_vm_check_ints.exit1.i.i:                       ; preds = %72, %47
   store i64 %rubyStr_value.i, i64* %105, align 8, !dbg !20, !tbaa !6
   %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !20
   store i64* %106, i64** %103, align 8, !dbg !20
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !20
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !20
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %30, align 8, !dbg !20, !tbaa !24
   %107 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !21
   %108 = load i64*, i64** %107, align 8, !dbg !21
   store i64 %send, i64* %108, align 8, !dbg !21, !tbaa !6
   %109 = getelementptr inbounds i64, i64* %108, i64 1, !dbg !21
   store i64* %109, i64** %107, align 8, !dbg !21
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.1, i64 0), !dbg !21
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.1, i64 0), !dbg !21
   %110 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !22
   %111 = load i64*, i64** %110, align 8, !dbg !22
   store i64 %21, i64* %111, align 8, !dbg !22, !tbaa !6
   %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !22
-  store i64 %send10, i64* %112, align 8, !dbg !22, !tbaa !6
+  store i64 %send8, i64* %112, align 8, !dbg !22, !tbaa !6
   %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !22
   store i64* %113, i64** %110, align 8, !dbg !22
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !22
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !22
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %30, align 8, !dbg !22, !tbaa !24
   %"rubyId_$f.i" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !23
   %114 = call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f.i") #11, !dbg !23
@@ -454,7 +442,7 @@ rb_vm_check_ints.exit1.i.i:                       ; preds = %72, %47
   store i64 %115, i64* %118, align 8, !dbg !23, !tbaa !6
   %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !23
   store i64* %119, i64** %116, align 8, !dbg !23
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !23
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !23
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %30, align 8, !dbg !23, !tbaa !24
   %120 = call i64 @sorbet_setConstant(i64 %31, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_F, i64 0, i64 0), i64 noundef 1, i64 noundef 3) #11, !dbg !58
   ret void
@@ -527,8 +515,8 @@ define linkonce void @const_recompute_A() local_unnamed_addr #9 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #3 = { argmemonly nofree nosync nounwind willreturn }
 attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/testdata/compiler/intrinsics/bang.llo.exp
+++ b/test/testdata/compiler/intrinsics/bang.llo.exp
@@ -105,7 +105,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_Bad.13<static-init>" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:Bad>" = internal unnamed_addr global i64 0, align 8
 @"str_<class:Bad>" = private unnamed_addr constant [12 x i8] c"<class:Bad>\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @stackFramePrecomputed_func_Main.4test = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -127,47 +126,45 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @guard_epoch_Main = linkonce local_unnamed_addr global i64 0
 @guarded_const_Main = linkonce local_unnamed_addr global i64 0
 
-declare i64 @rb_id2sym(i64) local_unnamed_addr #0
+; Function Attrs: noreturn
+declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #0
+
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #1
+
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #1
+
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #1
+
+declare i64 @sorbet_readRealpath() local_unnamed_addr #1
+
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #1
+
+declare void @sorbet_popFrame() local_unnamed_addr #1
+
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
+
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
+
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
+
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+
+declare i64 @rb_define_module(i8*) local_unnamed_addr #1
+
+declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #1
+
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
+
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #1
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare i64 @rb_funcallv_with_cc(%struct.rb_call_data*, i64, i64, i32, i64*) local_unnamed_addr #1
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
-
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
-
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
-
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
-
-declare void @sorbet_popFrame() local_unnamed_addr #0
-
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
-
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
-
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
-
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
-
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_define_module(i8*) local_unnamed_addr #0
-
-declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
-
-; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
-
-declare i64 @rb_funcallv_with_cc(%struct.rb_call_data*, i64, i64, i32, i64*) local_unnamed_addr #0
-
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
 
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
@@ -206,7 +203,6 @@ entry:
   %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Bad>", i64 0, i64 0), i64 noundef 11) #11
   store i64 %4, i64* @"rubyIdPrecomputed_<class:Bad>", align 8
   %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  store i64 %5, i64* @rubyIdPrecomputed_normal, align 8
   %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
   store i64 %6, i64* @rubyIdPrecomputed_new, align 8
   %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #11
@@ -300,10 +296,6 @@ entry:
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %33, %struct.rb_control_frame_struct* %35, %struct.rb_iseq_struct* %stackFrame.i1.i) #11
   %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 0
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %41, align 8, !dbg !35, !tbaa !24
-  %"rubyId_!.i.i1" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !38
-  %rawSym.i2.i = call i64 @rb_id2sym(i64 %"rubyId_!.i.i1") #11, !dbg !38
-  %rubyId_normal.i3.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !38
-  %rawSym7.i4.i = call i64 @rb_id2sym(i64 %rubyId_normal.i3.i) #11, !dbg !38
   %42 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !38
   %43 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !39
   %needTakeSlowPath = icmp ne i64 %42, %43, !dbg !38
@@ -319,7 +311,7 @@ entry:
   %48 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !39
   %guardUpdated = icmp eq i64 %47, %48, !dbg !38
   call void @llvm.assume(i1 %guardUpdated), !dbg !38
-  %stackFrame8.i5.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8, !dbg !38
+  %stackFrame8.i2.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8, !dbg !38
   %49 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !38
   %50 = bitcast i8* %49 to i16*, !dbg !38
   %51 = load i16, i16* %50, align 8, !dbg !38
@@ -327,7 +319,7 @@ entry:
   store i16 %52, i16* %50, align 8, !dbg !38
   %53 = getelementptr inbounds i8, i8* %49, i64 4, !dbg !38
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %53, i8 0, i64 28, i1 false) #11, !dbg !38
-  call void @sorbet_vm_define_method(i64 %46, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Bad#1!", i8* nonnull %49, %struct.rb_iseq_struct* %stackFrame8.i5.i, i1 noundef zeroext false) #11, !dbg !38
+  call void @sorbet_vm_define_method(i64 %46, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_Bad#1!", i8* nonnull %49, %struct.rb_iseq_struct* %stackFrame8.i2.i, i1 noundef zeroext false) #11, !dbg !38
   %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !38, !tbaa !24
   %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 5, !dbg !38
   %56 = load i32, i32* %55, align 8, !dbg !38, !tbaa !42
@@ -363,14 +355,10 @@ entry:
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %68, %struct.rb_control_frame_struct* %70, %struct.rb_iseq_struct* %stackFrame.i.i) #11
   %76 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %67, i64 0, i32 0
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %76, align 8, !dbg !47, !tbaa !24
-  %rubyId_test.i.i2 = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !50
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_test.i.i2) #11, !dbg !50
-  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !50
-  %rawSym7.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #11, !dbg !50
   %77 = load i64, i64* @guard_epoch_Main, align 8, !dbg !50
   %78 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !39
-  %needTakeSlowPath3 = icmp ne i64 %77, %78, !dbg !50
-  br i1 %needTakeSlowPath3, label %79, label %80, !dbg !50, !prof !41
+  %needTakeSlowPath1 = icmp ne i64 %77, %78, !dbg !50
+  br i1 %needTakeSlowPath1, label %79, label %80, !dbg !50, !prof !41
 
 79:                                               ; preds = %"func_Bad.13<static-init>L62.exit.i"
   call void @const_recompute_Main(), !dbg !50
@@ -380,8 +368,8 @@ entry:
   %81 = load i64, i64* @guarded_const_Main, align 8, !dbg !50
   %82 = load i64, i64* @guard_epoch_Main, align 8, !dbg !50
   %83 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !39
-  %guardUpdated4 = icmp eq i64 %82, %83, !dbg !50
-  call void @llvm.assume(i1 %guardUpdated4), !dbg !50
+  %guardUpdated2 = icmp eq i64 %82, %83, !dbg !50
+  call void @llvm.assume(i1 %guardUpdated2), !dbg !50
   %stackFrame8.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8, !dbg !50
   %84 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !50
   %85 = bitcast i8* %84 to i16*, !dbg !50
@@ -591,8 +579,8 @@ define linkonce void @const_recompute_Main() local_unnamed_addr #9 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #4 = { sspreq }

--- a/test/testdata/compiler/intrinsics/t_must.llo.exp
+++ b/test/testdata/compiler/intrinsics/t_must.llo.exp
@@ -116,9 +116,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"rubyIdPrecomputed_ensure in test_known_nil" = internal unnamed_addr global i64 0, align 8
 @"str_ensure in test_known_nil" = private unnamed_addr constant [25 x i8] c"ensure in test_known_nil\00", align 1
 @"<retry-singleton>" = internal unnamed_addr global i64 0
-@rubyIdPrecomputed_must = internal unnamed_addr global i64 0, align 8
 @str_must = private unnamed_addr constant [5 x i8] c"must\00", align 1
-@ic_must = internal global %struct.FunctionInlineCache zeroinitializer
 @"ic_is_a?" = internal global %struct.FunctionInlineCache zeroinitializer
 @"rubyIdPrecomputed_is_a?" = internal unnamed_addr global i64 0, align 8
 @"str_is_a?" = private unnamed_addr constant [6 x i8] c"is_a?\00", align 1
@@ -134,68 +132,64 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_ensure in test_nilable_arg" = internal unnamed_addr global i64 0, align 8
 @"str_ensure in test_nilable_arg" = private unnamed_addr constant [27 x i8] c"ensure in test_nilable_arg\00", align 1
-@ic_must.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @"rubyStrFrozen_ wasn't nil" = internal unnamed_addr global i64 0, align 8
 @"str_ wasn't nil" = private unnamed_addr constant [12 x i8] c" wasn't nil\00", align 1
 @"rubyIdPrecomputed_<string-interpolate>" = internal unnamed_addr global i64 0, align 8
 @"str_<string-interpolate>" = private unnamed_addr constant [21 x i8] c"<string-interpolate>\00", align 1
-@ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
-@"ic_is_a?.5" = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_puts.6 = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
+@"ic_is_a?.4" = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_Test.13<static-init>" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<module:Test>" = internal unnamed_addr global i64 0, align 8
 @"str_<module:Test>" = private unnamed_addr constant [14 x i8] c"<module:Test>\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @guard_epoch_Test = linkonce local_unnamed_addr global i64 0
 @guarded_const_Test = linkonce local_unnamed_addr global i64 0
 @rb_eStandardError = external local_unnamed_addr constant i64
 
-declare i64 @rb_id2sym(i64) local_unnamed_addr #0
+; Function Attrs: noreturn
+declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #0
+
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #1
+
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #1
+
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #1
+
+declare i64 @sorbet_readRealpath() local_unnamed_addr #1
+
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #1
+
+declare void @sorbet_popFrame() local_unnamed_addr #1
+
+declare void @sorbet_vm_env_write_slowpath(i64*, i32, i64) local_unnamed_addr #1
+
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
+
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
+
+declare void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
+
+declare i64 @sorbet_stringInterpolate(i64, i64, i32, i64*, i64 (i64, i64, i32, i64*, i64)*, i64) local_unnamed_addr #1
+
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
+
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+
+declare i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64**, i64, %struct.rb_control_frame_struct*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64, i64, i64) local_unnamed_addr #1
+
+declare i64 @rb_define_module(i8*) local_unnamed_addr #1
+
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
+
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #1
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
-
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
-
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
-
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
-
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
-
-declare void @sorbet_popFrame() local_unnamed_addr #0
-
-declare void @sorbet_vm_env_write_slowpath(i64*, i32, i64) local_unnamed_addr #0
-
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
-
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
-
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
-
-declare void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
-
-declare i64 @sorbet_stringInterpolate(i64, i64, i32, i64*, i64 (i64, i64, i32, i64*, i64)*, i64) local_unnamed_addr #0
-
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
-
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64**, i64, %struct.rb_control_frame_struct*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64, i64, i64) local_unnamed_addr #0
-
-declare i64 @rb_define_module(i8*) local_unnamed_addr #0
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
-
-; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
-
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
 
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
@@ -237,10 +231,6 @@ functionEntryInitializers:
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #14
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !23, !tbaa !14
-  %rubyId_test_known_nil = load i64, i64* @rubyIdPrecomputed_test_known_nil, align 8, !dbg !24
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_test_known_nil), !dbg !24
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !24
-  %rawSym17 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !24
   %9 = load i64, i64* @guard_epoch_Test, align 8, !dbg !24
   %10 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !25
   %needTakeSlowPath = icmp ne i64 %9, %10, !dbg !24
@@ -284,10 +274,6 @@ functionEntryInitializers:
 
 rb_vm_check_ints.exit1:                           ; preds = %12, %30
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !24, !tbaa !14
-  %rubyId_test_nilable_arg = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !32
-  %rawSym20 = tail call i64 @rb_id2sym(i64 %rubyId_test_nilable_arg), !dbg !32
-  %rubyId_normal21 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !32
-  %rawSym22 = tail call i64 @rb_id2sym(i64 %rubyId_normal21), !dbg !32
   %stackFrame27 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8, !dbg !32
   %34 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !32
   %35 = bitcast i8* %34 to i16*, !dbg !32
@@ -337,9 +323,9 @@ rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.ex
 ; Function Attrs: sspreq
 define void @Init_t_must() local_unnamed_addr #6 {
 entry:
-  %locals.i35.i = alloca i64, i32 0, align 8
-  %locals.i25.i = alloca i64, i32 5, align 8
-  %locals.i20.i = alloca i64, i32 4, align 8
+  %locals.i32.i = alloca i64, i32 0, align 8
+  %locals.i22.i = alloca i64, i32 5, align 8
+  %locals.i17.i = alloca i64, i32 4, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #14
@@ -361,7 +347,6 @@ entry:
   %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @"str_ensure in test_known_nil", i64 0, i64 0), i64 noundef 24) #14
   store i64 %8, i64* @"rubyIdPrecomputed_ensure in test_known_nil", align 8
   %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_must, i64 0, i64 0), i64 noundef 4) #14
-  store i64 %9, i64* @rubyIdPrecomputed_must, align 8
   %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @"str_is_a?", i64 0, i64 0), i64 noundef 5) #14
   store i64 %10, i64* @"rubyIdPrecomputed_is_a?", align 8
   %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #14
@@ -377,7 +362,6 @@ entry:
   %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Test>", i64 0, i64 0), i64 noundef 13) #14
   store i64 %16, i64* @"rubyIdPrecomputed_<module:Test>", align 8
   %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #14
-  store i64 %17, i64* @rubyIdPrecomputed_normal, align 8
   %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #14
   tail call void @rb_gc_register_mark_object(i64 %18) #14
   store i64 %18, i64* @"rubyStrFrozen_<top (required)>", align 8
@@ -400,99 +384,95 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.2, i64 %rubyId_test_nilable_arg4.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !42
   %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_test_known_nil, i64 0, i64 0), i64 noundef 14) #14
   call void @rb_gc_register_mark_object(i64 %21) #14
-  %22 = bitcast i64* %locals.i20.i to i8*
+  %22 = bitcast i64* %locals.i17.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %22)
   %rubyId_test_known_nil.i.i = load i64, i64* @rubyIdPrecomputed_test_known_nil, align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i19.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
   %"rubyId_<exceptionValue>.i.i" = load i64, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
-  store i64 %"rubyId_<exceptionValue>.i.i", i64* %locals.i20.i, align 8
+  store i64 %"rubyId_<exceptionValue>.i.i", i64* %locals.i17.i, align 8
   %"rubyId_<magic>.i.i" = load i64, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %23 = getelementptr i64, i64* %locals.i20.i, i32 1
+  %23 = getelementptr i64, i64* %locals.i17.i, i32 1
   store i64 %"rubyId_<magic>.i.i", i64* %23, align 8
   %"rubyId_<returnMethodTemp>.i.i" = load i64, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %24 = getelementptr i64, i64* %locals.i20.i, i32 2
+  %24 = getelementptr i64, i64* %locals.i17.i, i32 2
   store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %24, align 8
   %"rubyId_<gotoDeadTemp>.i.i" = load i64, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %25 = getelementptr i64, i64* %locals.i20.i, i32 3
+  %25 = getelementptr i64, i64* %locals.i17.i, i32 3
   store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %25, align 8
-  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %rubyId_test_known_nil.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i19.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i20.i, i32 noundef 4, i32 noundef 2)
+  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %rubyId_test_known_nil.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i17.i, i32 noundef 4, i32 noundef 2)
   store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
   call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %22)
   %27 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @"str_rescue in test_known_nil", i64 0, i64 0), i64 noundef 24) #14
   call void @rb_gc_register_mark_object(i64 %27) #14
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
   %"rubyId_rescue in test_known_nil.i.i" = load i64, i64* @"rubyIdPrecomputed_rescue in test_known_nil", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i21.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %27, i64 %"rubyId_rescue in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %27, i64 %"rubyId_rescue in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_2", align 8
   %29 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @"str_ensure in test_known_nil", i64 0, i64 0), i64 noundef 24) #14
   call void @rb_gc_register_mark_object(i64 %29) #14
-  %stackFrame.i22.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
+  %stackFrame.i19.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
   %"rubyId_ensure in test_known_nil.i.i" = load i64, i64* @"rubyIdPrecomputed_ensure in test_known_nil", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i23.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %29, i64 %"rubyId_ensure in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i23.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i22.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %29, i64 %"rubyId_ensure in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i19.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_3", align 8
   %31 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #14
   store i64 %31, i64* @"<retry-singleton>", align 8
-  %rubyId_must.i = load i64, i64* @rubyIdPrecomputed_must, align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_must, i64 %rubyId_must.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !43
-  %"rubyId_is_a?.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
+  %"rubyId_is_a?.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !43
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
   %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 noundef 16) #14
   call void @rb_gc_register_mark_object(i64 %32) #14
-  %33 = bitcast i64* %locals.i25.i to i8*
+  %33 = bitcast i64* %locals.i22.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %33)
   %rubyId_test_nilable_arg.i.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %"rubyId_<exceptionValue>.i26.i" = load i64, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
-  store i64 %"rubyId_<exceptionValue>.i26.i", i64* %locals.i25.i, align 8
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i21.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %"rubyId_<exceptionValue>.i23.i" = load i64, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
+  store i64 %"rubyId_<exceptionValue>.i23.i", i64* %locals.i22.i, align 8
   %rubyId_arg.i.i = load i64, i64* @rubyIdPrecomputed_arg, align 8
-  %34 = getelementptr i64, i64* %locals.i25.i, i32 1
+  %34 = getelementptr i64, i64* %locals.i22.i, i32 1
   store i64 %rubyId_arg.i.i, i64* %34, align 8
-  %"rubyId_<magic>.i27.i" = load i64, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %35 = getelementptr i64, i64* %locals.i25.i, i32 2
-  store i64 %"rubyId_<magic>.i27.i", i64* %35, align 8
-  %"rubyId_<returnMethodTemp>.i28.i" = load i64, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %36 = getelementptr i64, i64* %locals.i25.i, i32 3
-  store i64 %"rubyId_<returnMethodTemp>.i28.i", i64* %36, align 8
-  %"rubyId_<gotoDeadTemp>.i29.i" = load i64, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %37 = getelementptr i64, i64* %locals.i25.i, i32 4
-  store i64 %"rubyId_<gotoDeadTemp>.i29.i", i64* %37, align 8
-  %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %32, i64 %rubyId_test_nilable_arg.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i25.i, i32 noundef 5, i32 noundef 3)
+  %"rubyId_<magic>.i24.i" = load i64, i64* @"rubyIdPrecomputed_<magic>", align 8
+  %35 = getelementptr i64, i64* %locals.i22.i, i32 2
+  store i64 %"rubyId_<magic>.i24.i", i64* %35, align 8
+  %"rubyId_<returnMethodTemp>.i25.i" = load i64, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
+  %36 = getelementptr i64, i64* %locals.i22.i, i32 3
+  store i64 %"rubyId_<returnMethodTemp>.i25.i", i64* %36, align 8
+  %"rubyId_<gotoDeadTemp>.i26.i" = load i64, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
+  %37 = getelementptr i64, i64* %locals.i22.i, i32 4
+  store i64 %"rubyId_<gotoDeadTemp>.i26.i", i64* %37, align 8
+  %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %32, i64 %rubyId_test_nilable_arg.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i22.i, i32 noundef 5, i32 noundef 3)
   store %struct.rb_iseq_struct* %38, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
   call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %33)
   %39 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([27 x i8], [27 x i8]* @"str_rescue in test_nilable_arg", i64 0, i64 0), i64 noundef 26) #14
   call void @rb_gc_register_mark_object(i64 %39) #14
-  %stackFrame.i30.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
+  %stackFrame.i27.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
   %"rubyId_rescue in test_nilable_arg.i.i" = load i64, i64* @"rubyIdPrecomputed_rescue in test_nilable_arg", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %39, i64 %"rubyId_rescue in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i30.i, i32 noundef 4, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %39, i64 %"rubyId_rescue in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i27.i, i32 noundef 4, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
   store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_2", align 8
   %41 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([27 x i8], [27 x i8]* @"str_ensure in test_nilable_arg", i64 0, i64 0), i64 noundef 26) #14
   call void @rb_gc_register_mark_object(i64 %41) #14
-  %stackFrame.i32.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
+  %stackFrame.i29.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
   %"rubyId_ensure in test_nilable_arg.i.i" = load i64, i64* @"rubyIdPrecomputed_ensure in test_nilable_arg", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i33.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %42 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %41, i64 %"rubyId_ensure in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i33.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i32.i, i32 noundef 5, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %42 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %41, i64 %"rubyId_ensure in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i29.i, i32 noundef 5, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
   store %struct.rb_iseq_struct* %42, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3", align 8
-  %rubyId_must9.i = load i64, i64* @rubyIdPrecomputed_must, align 8, !dbg !49
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_must.3, i64 %rubyId_must9.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
   %43 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_ wasn't nil", i64 0, i64 0), i64 noundef 11) #14
   call void @rb_gc_register_mark_object(i64 %43) #14
   store i64 %43, i64* @"rubyStrFrozen_ wasn't nil", align 8
-  %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !52
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !52
-  %"rubyId_is_a?14.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !53
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?.5", i64 %"rubyId_is_a?14.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !53
-  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !55
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !55
+  %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
+  %"rubyId_is_a?11.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !50
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?.4", i64 %"rubyId_is_a?11.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
+  %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !52
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !52
   %44 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Test>", i64 0, i64 0), i64 noundef 13) #14
   call void @rb_gc_register_mark_object(i64 %44) #14
   %"rubyId_<module:Test>.i.i" = load i64, i64* @"rubyIdPrecomputed_<module:Test>", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i34.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %45 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %44, i64 %"rubyId_<module:Test>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i34.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i35.i, i32 noundef 0, i32 noundef 4)
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %45 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %44, i64 %"rubyId_<module:Test>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i32.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %45, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
   %46 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2
@@ -507,12 +487,12 @@ entry:
   store i64 %53, i64* %51, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %46, %struct.rb_control_frame_struct* %48, %struct.rb_iseq_struct* %stackFrame.i) #14
   %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %54, align 8, !dbg !56, !tbaa !14
-  %55 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Test, i64 0, i64 0)) #14, !dbg !57
-  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #14, !dbg !57
-  call fastcc void @"func_Test.13<static-init>L62"(%struct.rb_control_frame_struct* nocapture writeonly %56) #14, !dbg !57
-  call void @sorbet_popFrame() #14, !dbg !57
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %54, align 8, !dbg !57, !tbaa !14
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %54, align 8, !dbg !53, !tbaa !14
+  %55 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Test, i64 0, i64 0)) #14, !dbg !54
+  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #14, !dbg !54
+  call fastcc void @"func_Test.13<static-init>L62"(%struct.rb_control_frame_struct* nocapture writeonly %56) #14, !dbg !54
+  call void @sorbet_popFrame() #14, !dbg !54
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %54, align 8, !dbg !54, !tbaa !14
   %57 = load i64, i64* @guard_epoch_Test, align 8, !dbg !38
   %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !25
   %needTakeSlowPath = icmp ne i64 %57, %58, !dbg !38
@@ -569,52 +549,52 @@ define i64 @func_Test.14test_known_nil(i32 %argc, i64* nocapture nofree readnone
 functionEntryInitializers:
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %1, align 8, !tbaa !14
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !58
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !58, !prof !59
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !55
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !55, !prof !56
 
 postProcess:                                      ; preds = %fillRequiredArgs, %exception-continue
-  %"<returnValue>.sroa.0.0" = phi i64 [ %7, %exception-continue ], [ %3, %fillRequiredArgs ], !dbg !60
+  %"<returnValue>.sroa.0.0" = phi i64 [ %7, %exception-continue ], [ %3, %fillRequiredArgs ], !dbg !57
   ret i64 %"<returnValue>.sroa.0.0"
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #16, !dbg !58
-  unreachable, !dbg !58
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #16, !dbg !55
+  unreachable, !dbg !55
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %1, align 8, !dbg !60, !tbaa !14
-  %2 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !61, !tbaa !14
-  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !61
-  %3 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %2, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_1", i64** nonnull align 8 dereferenceable(8) %1, i64 noundef 0, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !61
-  %ensureReturnValue = icmp ne i64 %3, 52, !dbg !61
-  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !61
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %1, align 8, !dbg !57, !tbaa !14
+  %2 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !58, !tbaa !14
+  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !58
+  %3 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %2, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_1", i64** nonnull align 8 dereferenceable(8) %1, i64 noundef 0, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !58
+  %ensureReturnValue = icmp ne i64 %3, 52, !dbg !58
+  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !58
 
 exception-continue:                               ; preds = %fillRequiredArgs
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %1, align 8, !tbaa !14
-  %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !62
-  %5 = load i64*, i64** %4, align 8, !dbg !62, !tbaa !22
-  %6 = getelementptr inbounds i64, i64* %5, i64 -5, !dbg !62
-  %7 = load i64, i64* %6, align 8, !dbg !62, !tbaa !6
-  br label %postProcess, !dbg !62
+  %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !59
+  %5 = load i64*, i64** %4, align 8, !dbg !59, !tbaa !22
+  %6 = getelementptr inbounds i64, i64* %5, i64 -5, !dbg !59
+  %7 = load i64, i64* %6, align 8, !dbg !59, !tbaa !6
+  br label %postProcess, !dbg !59
 }
 
 ; Function Attrs: noreturn nounwind ssp
-define internal noundef i64 @"func_Test.14test_known_nil$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* %cfp) #7 !dbg !44 {
-fastSymCallIntrinsic_T_must:
+define internal i64 @"func_Test.14test_known_nil$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #7 !dbg !60 {
+functionEntryInitializers:
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !14
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !63), !dbg !43
-  %0 = load i64, i64* @rb_eTypeError, align 8, !dbg !43, !tbaa !6, !noalias !63
-  tail call void (i64, i8*, ...) @rb_raise(i64 %0, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #13, !dbg !43, !noalias !63
-  unreachable, !dbg !43
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !61) #17, !dbg !64
+  %0 = load i64, i64* @rb_eTypeError, align 8, !dbg !64, !tbaa !6, !noalias !61
+  tail call void (i64, i8*, ...) @rb_raise(i64 %0, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #13, !dbg !64, !noalias !61
+  unreachable, !dbg !64
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.14test_known_nil$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !47 {
+define internal noundef i64 @"func_Test.14test_known_nil$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !44 {
 vm_get_ep.exit34:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !66
+  %4 = load i64, i64* %3, align 8, !tbaa !65
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_2", align 8
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #14
   %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
@@ -622,122 +602,122 @@ vm_get_ep.exit34:
   %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !16
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !tbaa !14
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !14
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !46
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !46, !tbaa !16
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !46
-  %13 = load i64*, i64** %12, align 8, !dbg !46
-  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !46
-  %15 = load i64, i64* %14, align 8, !dbg !46, !tbaa !6
-  %16 = and i64 %15, -4, !dbg !46
-  %17 = inttoptr i64 %16 to i64*, !dbg !46
-  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !46
-  %19 = load i64, i64* %18, align 8, !dbg !46, !tbaa !6
-  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !46
-  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !46
-  %22 = load i64*, i64** %21, align 8, !dbg !46
-  store i64 %19, i64* %22, align 8, !dbg !46, !tbaa !6
-  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !46
-  store i64 %20, i64* %23, align 8, !dbg !46, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !46
-  store i64* %24, i64** %21, align 8, !dbg !46
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_is_a?", i64 0), !dbg !46
-  %25 = and i64 %send, -9, !dbg !46
-  %26 = icmp ne i64 %25, 0, !dbg !46
-  br i1 %26, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !46
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !43, !tbaa !14
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !43
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !43, !tbaa !16
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !43
+  %13 = load i64*, i64** %12, align 8, !dbg !43
+  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !43
+  %15 = load i64, i64* %14, align 8, !dbg !43, !tbaa !6
+  %16 = and i64 %15, -4, !dbg !43
+  %17 = inttoptr i64 %16 to i64*, !dbg !43
+  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !43
+  %19 = load i64, i64* %18, align 8, !dbg !43, !tbaa !6
+  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !43
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !43
+  %22 = load i64*, i64** %21, align 8, !dbg !43
+  store i64 %19, i64* %22, align 8, !dbg !43, !tbaa !6
+  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !43
+  store i64 %20, i64* %23, align 8, !dbg !43, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !43
+  store i64* %24, i64** %21, align 8, !dbg !43
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_is_a?", i64 0), !dbg !43
+  %25 = and i64 %send, -9, !dbg !43
+  %26 = icmp ne i64 %25, 0, !dbg !43
+  br i1 %26, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !43
 
 blockExit:                                        ; preds = %78, %76, %63, %61
   tail call void @sorbet_popFrame()
   ret i64 52
 
 vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
-  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !67, !tbaa !14
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2, !dbg !67
-  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !dbg !67, !tbaa !16
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4, !dbg !67
-  %31 = load i64*, i64** %30, align 8, !dbg !67
-  %32 = getelementptr inbounds i64, i64* %31, i64 -1, !dbg !67
-  %33 = load i64, i64* %32, align 8, !dbg !67, !tbaa !6
-  %34 = and i64 %33, -4, !dbg !67
-  %35 = inttoptr i64 %34 to i64*, !dbg !67
-  %36 = load i64, i64* %35, align 8, !dbg !67, !tbaa !6
-  %37 = and i64 %36, 8, !dbg !67
-  %38 = icmp eq i64 %37, 0, !dbg !67
-  br i1 %38, label %39, label %41, !dbg !67, !prof !30
+  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !14
+  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2, !dbg !66
+  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !dbg !66, !tbaa !16
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4, !dbg !66
+  %31 = load i64*, i64** %30, align 8, !dbg !66
+  %32 = getelementptr inbounds i64, i64* %31, i64 -1, !dbg !66
+  %33 = load i64, i64* %32, align 8, !dbg !66, !tbaa !6
+  %34 = and i64 %33, -4, !dbg !66
+  %35 = inttoptr i64 %34 to i64*, !dbg !66
+  %36 = load i64, i64* %35, align 8, !dbg !66, !tbaa !6
+  %37 = and i64 %36, 8, !dbg !66
+  %38 = icmp eq i64 %37, 0, !dbg !66
+  br i1 %38, label %39, label %41, !dbg !66, !prof !30
 
 39:                                               ; preds = %vm_get_ep.exit32
-  %40 = getelementptr inbounds i64, i64* %35, i64 -3, !dbg !67
-  store i64 8, i64* %40, align 8, !dbg !67, !tbaa !6
-  br label %vm_get_ep.exit30, !dbg !67
+  %40 = getelementptr inbounds i64, i64* %35, i64 -3, !dbg !66
+  store i64 8, i64* %40, align 8, !dbg !66, !tbaa !6
+  br label %vm_get_ep.exit30, !dbg !66
 
 41:                                               ; preds = %vm_get_ep.exit32
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %35, i32 noundef -3, i64 noundef 8) #14, !dbg !67
-  br label %vm_get_ep.exit30, !dbg !67
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %35, i32 noundef -3, i64 noundef 8) #14, !dbg !66
+  br label %vm_get_ep.exit30, !dbg !66
 
 vm_get_ep.exit30:                                 ; preds = %39, %41
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %8, align 8, !dbg !68, !tbaa !14
-  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !48, !tbaa !14
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !48
-  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !48, !tbaa !16
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !48
-  %46 = load i64*, i64** %45, align 8, !dbg !48
-  store i64 %4, i64* %46, align 8, !dbg !48, !tbaa !6
-  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !48
-  store i64 %19, i64* %47, align 8, !dbg !48, !tbaa !6
-  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !48
-  store i64* %48, i64** %45, align 8, !dbg !48
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !48
-  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !48, !tbaa !14
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 2, !dbg !48
-  %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !48, !tbaa !16
-  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 4, !dbg !48
-  %53 = load i64*, i64** %52, align 8, !dbg !48
-  %54 = getelementptr inbounds i64, i64* %53, i64 -1, !dbg !48
-  %55 = load i64, i64* %54, align 8, !dbg !48, !tbaa !6
-  %56 = and i64 %55, -4, !dbg !48
-  %57 = inttoptr i64 %56 to i64*, !dbg !48
-  %58 = load i64, i64* %57, align 8, !dbg !48, !tbaa !6
-  %59 = and i64 %58, 8, !dbg !48
-  %60 = icmp eq i64 %59, 0, !dbg !48
-  br i1 %60, label %61, label %63, !dbg !48, !prof !30
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %8, align 8, !dbg !67, !tbaa !14
+  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !14
+  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !46
+  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !46, !tbaa !16
+  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !46
+  %46 = load i64*, i64** %45, align 8, !dbg !46
+  store i64 %4, i64* %46, align 8, !dbg !46, !tbaa !6
+  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !46
+  store i64 %19, i64* %47, align 8, !dbg !46, !tbaa !6
+  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !46
+  store i64* %48, i64** %45, align 8, !dbg !46
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !46
+  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !14
+  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 2, !dbg !46
+  %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !46, !tbaa !16
+  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 4, !dbg !46
+  %53 = load i64*, i64** %52, align 8, !dbg !46
+  %54 = getelementptr inbounds i64, i64* %53, i64 -1, !dbg !46
+  %55 = load i64, i64* %54, align 8, !dbg !46, !tbaa !6
+  %56 = and i64 %55, -4, !dbg !46
+  %57 = inttoptr i64 %56 to i64*, !dbg !46
+  %58 = load i64, i64* %57, align 8, !dbg !46, !tbaa !6
+  %59 = and i64 %58, 8, !dbg !46
+  %60 = icmp eq i64 %59, 0, !dbg !46
+  br i1 %60, label %61, label %63, !dbg !46, !prof !30
 
 61:                                               ; preds = %vm_get_ep.exit30
-  %62 = getelementptr inbounds i64, i64* %57, i64 -5, !dbg !48
-  store i64 %send42, i64* %62, align 8, !dbg !48, !tbaa !6
-  br label %blockExit, !dbg !48
+  %62 = getelementptr inbounds i64, i64* %57, i64 -5, !dbg !46
+  store i64 %send42, i64* %62, align 8, !dbg !46, !tbaa !6
+  br label %blockExit, !dbg !46
 
 63:                                               ; preds = %vm_get_ep.exit30
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %57, i32 noundef -5, i64 %send42) #14, !dbg !48
-  br label %blockExit, !dbg !48
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %57, i32 noundef -5, i64 %send42) #14, !dbg !46
+  br label %blockExit, !dbg !46
 
 vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !tbaa !14
-  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !69, !tbaa !14
-  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2, !dbg !69
-  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !dbg !69, !tbaa !16
-  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %66, i64 0, i32 4, !dbg !69
-  %68 = load i64*, i64** %67, align 8, !dbg !69
-  %69 = getelementptr inbounds i64, i64* %68, i64 -1, !dbg !69
-  %70 = load i64, i64* %69, align 8, !dbg !69, !tbaa !6
-  %71 = and i64 %70, -4, !dbg !69
-  %72 = inttoptr i64 %71 to i64*, !dbg !69
-  %73 = load i64, i64* %72, align 8, !dbg !69, !tbaa !6
-  %74 = and i64 %73, 8, !dbg !69
-  %75 = icmp eq i64 %74, 0, !dbg !69
-  br i1 %75, label %76, label %78, !dbg !69, !prof !30
+  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !68, !tbaa !14
+  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 2, !dbg !68
+  %66 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %65, align 8, !dbg !68, !tbaa !16
+  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %66, i64 0, i32 4, !dbg !68
+  %68 = load i64*, i64** %67, align 8, !dbg !68
+  %69 = getelementptr inbounds i64, i64* %68, i64 -1, !dbg !68
+  %70 = load i64, i64* %69, align 8, !dbg !68, !tbaa !6
+  %71 = and i64 %70, -4, !dbg !68
+  %72 = inttoptr i64 %71 to i64*, !dbg !68
+  %73 = load i64, i64* %72, align 8, !dbg !68, !tbaa !6
+  %74 = and i64 %73, 8, !dbg !68
+  %75 = icmp eq i64 %74, 0, !dbg !68
+  br i1 %75, label %76, label %78, !dbg !68, !prof !30
 
 76:                                               ; preds = %vm_get_ep.exit
-  %77 = getelementptr inbounds i64, i64* %72, i64 -6, !dbg !69
-  store i64 20, i64* %77, align 8, !dbg !69, !tbaa !6
-  br label %blockExit, !dbg !69
+  %77 = getelementptr inbounds i64, i64* %72, i64 -6, !dbg !68
+  store i64 20, i64* %77, align 8, !dbg !68, !tbaa !6
+  br label %blockExit, !dbg !68
 
 78:                                               ; preds = %vm_get_ep.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %72, i32 noundef -6, i64 noundef 20) #14, !dbg !69
-  br label %blockExit, !dbg !69
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %72, i32 noundef -6, i64 noundef 20) #14, !dbg !68
+  br label %blockExit, !dbg !68
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.14test_known_nil$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !70 {
+define internal noundef i64 @"func_Test.14test_known_nil$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !69 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_3", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
@@ -754,155 +734,155 @@ functionEntryInitializers:
 }
 
 ; Function Attrs: argmemonly nofree norecurse nosync nounwind ssp willreturn writeonly
-define internal noundef i64 @"func_Test.14test_known_nil$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !71 {
+define internal noundef i64 @"func_Test.14test_known_nil$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !70 {
 functionEntryInitializers:
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %pc, align 8, !tbaa !14
   ret i64 52
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @func_Test.16test_nilable_arg(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #5 !dbg !51 {
+define i64 @func_Test.16test_nilable_arg(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #5 !dbg !49 {
 functionEntryInitializers:
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %1, align 8, !tbaa !14
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !72
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !72
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !72
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !72, !prof !73
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !71
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !71
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !71
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !71, !prof !72
 
 postProcess:                                      ; preds = %sorbet_writeLocal.exit, %exception-continue
-  %"<returnValue>.sroa.0.0" = phi i64 [ %14, %exception-continue ], [ %11, %sorbet_writeLocal.exit ], !dbg !74
+  %"<returnValue>.sroa.0.0" = phi i64 [ %14, %exception-continue ], [ %11, %sorbet_writeLocal.exit ], !dbg !73
   ret i64 %"<returnValue>.sroa.0.0"
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #16, !dbg !72
-  unreachable, !dbg !72
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #16, !dbg !71
+  unreachable, !dbg !71
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !72
-  %2 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !72
-  %3 = load i64*, i64** %2, align 8, !dbg !72, !tbaa !22
-  %4 = load i64, i64* %3, align 8, !dbg !72, !tbaa !6
-  %5 = and i64 %4, 8, !dbg !72
-  %6 = icmp eq i64 %5, 0, !dbg !72
-  br i1 %6, label %7, label %9, !dbg !72, !prof !30
+  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !71
+  %2 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !71
+  %3 = load i64*, i64** %2, align 8, !dbg !71, !tbaa !22
+  %4 = load i64, i64* %3, align 8, !dbg !71, !tbaa !6
+  %5 = and i64 %4, 8, !dbg !71
+  %6 = icmp eq i64 %5, 0, !dbg !71
+  br i1 %6, label %7, label %9, !dbg !71, !prof !30
 
 7:                                                ; preds = %fillRequiredArgs
-  %8 = getelementptr inbounds i64, i64* %3, i64 -4, !dbg !72
-  store i64 %rawArg_arg, i64* %8, align 8, !dbg !72, !tbaa !6
-  br label %sorbet_writeLocal.exit, !dbg !72
+  %8 = getelementptr inbounds i64, i64* %3, i64 -4, !dbg !71
+  store i64 %rawArg_arg, i64* %8, align 8, !dbg !71, !tbaa !6
+  br label %sorbet_writeLocal.exit, !dbg !71
 
 9:                                                ; preds = %fillRequiredArgs
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %3, i32 noundef -4, i64 %rawArg_arg) #14, !dbg !72
-  br label %sorbet_writeLocal.exit, !dbg !72
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %3, i32 noundef -4, i64 %rawArg_arg) #14, !dbg !71
+  br label %sorbet_writeLocal.exit, !dbg !71
 
 sorbet_writeLocal.exit:                           ; preds = %7, %9
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %1, align 8, !dbg !74, !tbaa !14
-  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !75, !tbaa !14
-  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !75
-  %11 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %10, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_1", i64** nonnull %1, i64 noundef 0, %struct.rb_control_frame_struct* nonnull %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !75
-  %ensureReturnValue = icmp ne i64 %11, 52, !dbg !75
-  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !75
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %1, align 8, !dbg !73, !tbaa !14
+  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !74, !tbaa !14
+  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !74
+  %11 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %10, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_1", i64** nonnull %1, i64 noundef 0, %struct.rb_control_frame_struct* nonnull %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !74
+  %ensureReturnValue = icmp ne i64 %11, 52, !dbg !74
+  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !74
 
 exception-continue:                               ; preds = %sorbet_writeLocal.exit
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %1, align 8, !tbaa !14
-  %12 = load i64*, i64** %2, align 8, !dbg !76, !tbaa !22
-  %13 = getelementptr inbounds i64, i64* %12, i64 -6, !dbg !76
-  %14 = load i64, i64* %13, align 8, !dbg !76, !tbaa !6
-  br label %postProcess, !dbg !76
+  %12 = load i64*, i64** %2, align 8, !dbg !75, !tbaa !22
+  %13 = getelementptr inbounds i64, i64* %12, i64 -6, !dbg !75
+  %14 = load i64, i64* %13, align 8, !dbg !75, !tbaa !6
+  br label %postProcess, !dbg !75
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.16test_nilable_arg$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(40) %cfp) #8 !dbg !50 {
-fastSymCallIntrinsic_T_must:
+define internal noundef i64 @"func_Test.16test_nilable_arg$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(40) %cfp) #8 !dbg !48 {
+functionEntryInitializers:
   %callArgs = alloca [3 x i64], align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !66
+  %4 = load i64, i64* %3, align 8, !tbaa !65
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !tbaa !14
-  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !49
-  %6 = load i64*, i64** %5, align 8, !dbg !49, !tbaa !22
-  %7 = getelementptr inbounds i64, i64* %6, i64 -4, !dbg !49
-  %8 = load i64, i64* %7, align 8, !dbg !49, !tbaa !6
-  %callArgs0Addr = getelementptr [3 x i64], [3 x i64]* %callArgs, i32 0, i64 0, !dbg !49
-  store i64 %8, i64* %callArgs0Addr, align 8, !dbg !49
-  %9 = getelementptr [3 x i64], [3 x i64]* %callArgs, i64 0, i64 0, !dbg !49
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !77), !dbg !49
-  %10 = load i64, i64* %9, align 8, !dbg !49, !tbaa !6, !alias.scope !77
-  %11 = icmp eq i64 %10, 8, !dbg !49
-  br i1 %11, label %26, label %sorbet_T_must.exit, !dbg !49, !prof !59
+  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !76
+  %6 = load i64*, i64** %5, align 8, !dbg !76, !tbaa !22
+  %7 = getelementptr inbounds i64, i64* %6, i64 -4, !dbg !76
+  %8 = load i64, i64* %7, align 8, !dbg !76, !tbaa !6
+  %callArgs0Addr = getelementptr [3 x i64], [3 x i64]* %callArgs, i32 0, i64 0, !dbg !76
+  store i64 %8, i64* %callArgs0Addr, align 8, !dbg !76
+  %9 = getelementptr [3 x i64], [3 x i64]* %callArgs, i64 0, i64 0, !dbg !76
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !77), !dbg !76
+  %10 = load i64, i64* %9, align 8, !dbg !76, !tbaa !6, !alias.scope !77
+  %11 = icmp eq i64 %10, 8, !dbg !76
+  br i1 %11, label %12, label %sorbet_T_must.exit, !dbg !76, !prof !56
 
-afterSend:                                        ; preds = %36, %sorbet_T_must.exit
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %pc, align 8, !dbg !49, !tbaa !14
+12:                                               ; preds = %functionEntryInitializers
+  %13 = load i64, i64* @rb_eTypeError, align 8, !dbg !76, !tbaa !6, !noalias !77
+  tail call void (i64, i8*, ...) @rb_raise(i64 %13, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #13, !dbg !76, !noalias !77
+  unreachable, !dbg !76
+
+sorbet_T_must.exit:                               ; preds = %functionEntryInitializers
+  %14 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !76, !tbaa !14
+  %15 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 5, !dbg !76
+  %16 = load i32, i32* %15, align 8, !dbg !76, !tbaa !28
+  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 6, !dbg !76
+  %18 = load i32, i32* %17, align 4, !dbg !76, !tbaa !29
+  %19 = xor i32 %18, -1, !dbg !76
+  %20 = and i32 %19, %16, !dbg !76
+  %21 = icmp eq i32 %20, 0, !dbg !76
+  br i1 %21, label %rb_vm_check_ints.exit, label %22, !dbg !76, !prof !30
+
+22:                                               ; preds = %sorbet_T_must.exit
+  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 8, !dbg !76
+  %24 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %23, align 8, !dbg !76, !tbaa !31
+  %25 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %24, i32 noundef 0) #14, !dbg !76
+  br label %rb_vm_check_ints.exit, !dbg !76
+
+rb_vm_check_ints.exit:                            ; preds = %sorbet_T_must.exit, %22
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %pc, align 8, !dbg !76, !tbaa !14
   %"rubyStr_ wasn't nil" = load i64, i64* @"rubyStrFrozen_ wasn't nil", align 8, !dbg !80
-  %12 = load i64*, i64** %5, align 8, !dbg !81, !tbaa !22
-  %13 = getelementptr inbounds i64, i64* %12, i64 -4, !dbg !81
-  %14 = load i64, i64* %13, align 8, !dbg !81, !tbaa !6
-  store i64 %14, i64* %callArgs0Addr, align 8, !dbg !81
+  %26 = load i64*, i64** %5, align 8, !dbg !81, !tbaa !22
+  %27 = getelementptr inbounds i64, i64* %26, i64 -4, !dbg !81
+  %28 = load i64, i64* %27, align 8, !dbg !81, !tbaa !6
+  store i64 %28, i64* %callArgs0Addr, align 8, !dbg !81
   %callArgs1Addr = getelementptr [3 x i64], [3 x i64]* %callArgs, i32 0, i64 1, !dbg !81
   store i64 %"rubyStr_ wasn't nil", i64* %callArgs1Addr, align 8, !dbg !81
   %"rubyId_<string-interpolate>" = load i64, i64* @"rubyIdPrecomputed_<string-interpolate>", align 8, !dbg !81
   %rawSendResult13 = call i64 @sorbet_stringInterpolate(i64 noundef 8, i64 %"rubyId_<string-interpolate>", i32 noundef 2, i64* noundef nonnull %9, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0), !dbg !81
-  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !52
-  %16 = load i64*, i64** %15, align 8, !dbg !52
-  store i64 %4, i64* %16, align 8, !dbg !52, !tbaa !6
-  %17 = getelementptr inbounds i64, i64* %16, i64 1, !dbg !52
-  store i64 %rawSendResult13, i64* %17, align 8, !dbg !52, !tbaa !6
-  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !52
-  store i64* %18, i64** %15, align 8, !dbg !52
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !52
-  %19 = load i64*, i64** %5, align 8, !dbg !52, !tbaa !22
-  %20 = load i64, i64* %19, align 8, !dbg !52, !tbaa !6
-  %21 = and i64 %20, 8, !dbg !52
-  %22 = icmp eq i64 %21, 0, !dbg !52
-  br i1 %22, label %23, label %25, !dbg !52, !prof !30
+  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !47
+  %30 = load i64*, i64** %29, align 8, !dbg !47
+  store i64 %4, i64* %30, align 8, !dbg !47, !tbaa !6
+  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !47
+  store i64 %rawSendResult13, i64* %31, align 8, !dbg !47, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !47
+  store i64* %32, i64** %29, align 8, !dbg !47
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !47
+  %33 = load i64*, i64** %5, align 8, !dbg !47, !tbaa !22
+  %34 = load i64, i64* %33, align 8, !dbg !47, !tbaa !6
+  %35 = and i64 %34, 8, !dbg !47
+  %36 = icmp eq i64 %35, 0, !dbg !47
+  br i1 %36, label %37, label %39, !dbg !47, !prof !30
 
-23:                                               ; preds = %afterSend
-  %24 = getelementptr inbounds i64, i64* %19, i64 -6, !dbg !52
-  store i64 %send, i64* %24, align 8, !dbg !52, !tbaa !6
-  br label %sorbet_writeLocal.exit, !dbg !52
+37:                                               ; preds = %rb_vm_check_ints.exit
+  %38 = getelementptr inbounds i64, i64* %33, i64 -6, !dbg !47
+  store i64 %send, i64* %38, align 8, !dbg !47, !tbaa !6
+  br label %sorbet_writeLocal.exit, !dbg !47
 
-25:                                               ; preds = %afterSend
-  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %19, i32 noundef -6, i64 %send) #14, !dbg !52
-  br label %sorbet_writeLocal.exit, !dbg !52
+39:                                               ; preds = %rb_vm_check_ints.exit
+  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %33, i32 noundef -6, i64 %send) #14, !dbg !47
+  br label %sorbet_writeLocal.exit, !dbg !47
 
-sorbet_writeLocal.exit:                           ; preds = %23, %25
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !dbg !52, !tbaa !14
+sorbet_writeLocal.exit:                           ; preds = %37, %39
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !dbg !47, !tbaa !14
   ret i64 52
-
-26:                                               ; preds = %fastSymCallIntrinsic_T_must
-  %27 = load i64, i64* @rb_eTypeError, align 8, !dbg !49, !tbaa !6, !noalias !77
-  tail call void (i64, i8*, ...) @rb_raise(i64 %27, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #13, !dbg !49, !noalias !77
-  unreachable, !dbg !49
-
-sorbet_T_must.exit:                               ; preds = %fastSymCallIntrinsic_T_must
-  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !14
-  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 5, !dbg !49
-  %30 = load i32, i32* %29, align 8, !dbg !49, !tbaa !28
-  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 6, !dbg !49
-  %32 = load i32, i32* %31, align 4, !dbg !49, !tbaa !29
-  %33 = xor i32 %32, -1, !dbg !49
-  %34 = and i32 %33, %30, !dbg !49
-  %35 = icmp eq i32 %34, 0, !dbg !49
-  br i1 %35, label %afterSend, label %36, !dbg !49, !prof !30
-
-36:                                               ; preds = %sorbet_T_must.exit
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 8, !dbg !49
-  %38 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %37, align 8, !dbg !49, !tbaa !31
-  %39 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %38, i32 noundef 0) #14, !dbg !49
-  br label %afterSend, !dbg !49
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.16test_nilable_arg$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !54 {
+define internal noundef i64 @"func_Test.16test_nilable_arg$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !51 {
 vm_get_ep.exit34:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !66
+  %4 = load i64, i64* %3, align 8, !tbaa !65
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_2", align 8
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #14
   %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
@@ -910,29 +890,29 @@ vm_get_ep.exit34:
   %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !16
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !tbaa !14
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !53, !tbaa !14
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !53
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !53, !tbaa !16
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !53
-  %13 = load i64*, i64** %12, align 8, !dbg !53
-  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !53
-  %15 = load i64, i64* %14, align 8, !dbg !53, !tbaa !6
-  %16 = and i64 %15, -4, !dbg !53
-  %17 = inttoptr i64 %16 to i64*, !dbg !53
-  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !53
-  %19 = load i64, i64* %18, align 8, !dbg !53, !tbaa !6
-  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !53
-  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !53
-  %22 = load i64*, i64** %21, align 8, !dbg !53
-  store i64 %19, i64* %22, align 8, !dbg !53, !tbaa !6
-  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !53
-  store i64 %20, i64* %23, align 8, !dbg !53, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !53
-  store i64* %24, i64** %21, align 8, !dbg !53
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_is_a?.5", i64 0), !dbg !53
-  %25 = and i64 %send, -9, !dbg !53
-  %26 = icmp ne i64 %25, 0, !dbg !53
-  br i1 %26, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !53
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !50, !tbaa !14
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !50
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !50, !tbaa !16
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !50
+  %13 = load i64*, i64** %12, align 8, !dbg !50
+  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !50
+  %15 = load i64, i64* %14, align 8, !dbg !50, !tbaa !6
+  %16 = and i64 %15, -4, !dbg !50
+  %17 = inttoptr i64 %16 to i64*, !dbg !50
+  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !50
+  %19 = load i64, i64* %18, align 8, !dbg !50, !tbaa !6
+  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !50
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !50
+  %22 = load i64*, i64** %21, align 8, !dbg !50
+  store i64 %19, i64* %22, align 8, !dbg !50, !tbaa !6
+  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !50
+  store i64 %20, i64* %23, align 8, !dbg !50, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !50
+  store i64* %24, i64** %21, align 8, !dbg !50
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_is_a?.4", i64 0), !dbg !50
+  %25 = and i64 %send, -9, !dbg !50
+  %26 = icmp ne i64 %25, 0, !dbg !50
+  br i1 %26, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !50
 
 blockExit:                                        ; preds = %78, %76, %63, %61
   tail call void @sorbet_popFrame()
@@ -964,39 +944,39 @@ vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
 
 vm_get_ep.exit30:                                 ; preds = %39, %41
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %8, align 8, !dbg !83, !tbaa !14
-  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !55, !tbaa !14
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !55
-  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !55, !tbaa !16
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !55
-  %46 = load i64*, i64** %45, align 8, !dbg !55
-  store i64 %4, i64* %46, align 8, !dbg !55, !tbaa !6
-  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !55
-  store i64 %19, i64* %47, align 8, !dbg !55, !tbaa !6
-  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !55
-  store i64* %48, i64** %45, align 8, !dbg !55
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !55
-  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !55, !tbaa !14
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 2, !dbg !55
-  %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !55, !tbaa !16
-  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 4, !dbg !55
-  %53 = load i64*, i64** %52, align 8, !dbg !55
-  %54 = getelementptr inbounds i64, i64* %53, i64 -1, !dbg !55
-  %55 = load i64, i64* %54, align 8, !dbg !55, !tbaa !6
-  %56 = and i64 %55, -4, !dbg !55
-  %57 = inttoptr i64 %56 to i64*, !dbg !55
-  %58 = load i64, i64* %57, align 8, !dbg !55, !tbaa !6
-  %59 = and i64 %58, 8, !dbg !55
-  %60 = icmp eq i64 %59, 0, !dbg !55
-  br i1 %60, label %61, label %63, !dbg !55, !prof !30
+  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !14
+  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !52
+  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !52, !tbaa !16
+  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !52
+  %46 = load i64*, i64** %45, align 8, !dbg !52
+  store i64 %4, i64* %46, align 8, !dbg !52, !tbaa !6
+  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !52
+  store i64 %19, i64* %47, align 8, !dbg !52, !tbaa !6
+  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !52
+  store i64* %48, i64** %45, align 8, !dbg !52
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !52
+  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !14
+  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 2, !dbg !52
+  %51 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %50, align 8, !dbg !52, !tbaa !16
+  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 4, !dbg !52
+  %53 = load i64*, i64** %52, align 8, !dbg !52
+  %54 = getelementptr inbounds i64, i64* %53, i64 -1, !dbg !52
+  %55 = load i64, i64* %54, align 8, !dbg !52, !tbaa !6
+  %56 = and i64 %55, -4, !dbg !52
+  %57 = inttoptr i64 %56 to i64*, !dbg !52
+  %58 = load i64, i64* %57, align 8, !dbg !52, !tbaa !6
+  %59 = and i64 %58, 8, !dbg !52
+  %60 = icmp eq i64 %59, 0, !dbg !52
+  br i1 %60, label %61, label %63, !dbg !52, !prof !30
 
 61:                                               ; preds = %vm_get_ep.exit30
-  %62 = getelementptr inbounds i64, i64* %57, i64 -6, !dbg !55
-  store i64 %send42, i64* %62, align 8, !dbg !55, !tbaa !6
-  br label %blockExit, !dbg !55
+  %62 = getelementptr inbounds i64, i64* %57, i64 -6, !dbg !52
+  store i64 %send42, i64* %62, align 8, !dbg !52, !tbaa !6
+  br label %blockExit, !dbg !52
 
 63:                                               ; preds = %vm_get_ep.exit30
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %57, i32 noundef -6, i64 %send42) #14, !dbg !55
-  br label %blockExit, !dbg !55
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %57, i32 noundef -6, i64 %send42) #14, !dbg !52
+  br label %blockExit, !dbg !52
 
 vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %8, align 8, !tbaa !14
@@ -1072,8 +1052,8 @@ define linkonce void @const_recompute_Test() local_unnamed_addr #8 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #3 = { argmemonly nofree nosync nounwind willreturn }
 attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
@@ -1089,6 +1069,7 @@ attributes #13 = { noreturn nounwind }
 attributes #14 = { nounwind }
 attributes #15 = { nounwind allocsize(0,1) }
 attributes #16 = { noreturn }
+attributes #17 = { willreturn }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -1136,47 +1117,47 @@ attributes #16 = { noreturn }
 !40 = !DILocation(line: 25, column: 1, scope: !39)
 !41 = !DILocation(line: 26, column: 1, scope: !39)
 !42 = !DILocation(line: 27, column: 1, scope: !39)
-!43 = !DILocation(line: 8, column: 7, scope: !44)
-!44 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_1", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!43 = !DILocation(line: 9, column: 15, scope: !44)
+!44 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_2", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !45 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil", scope: null, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!46 = !DILocation(line: 9, column: 15, scope: !47)
-!47 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_2", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!48 = !DILocation(line: 10, column: 7, scope: !47)
-!49 = !DILocation(line: 16, column: 7, scope: !50)
-!50 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_1", scope: !51, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!51 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg", scope: null, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!52 = !DILocation(line: 17, column: 7, scope: !50)
-!53 = !DILocation(line: 18, column: 15, scope: !54)
-!54 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_2", scope: !51, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!55 = !DILocation(line: 19, column: 7, scope: !54)
-!56 = !DILocation(line: 0, scope: !39)
-!57 = !DILocation(line: 5, column: 1, scope: !39)
-!58 = !DILocation(line: 6, column: 3, scope: !45)
-!59 = !{!"branch_weights", i32 1, i32 2000}
-!60 = !DILocation(line: 0, scope: !45)
-!61 = !DILocation(line: 8, column: 7, scope: !45)
-!62 = !DILocation(line: 12, column: 3, scope: !45)
-!63 = !{!64}
-!64 = distinct !{!64, !65, !"sorbet_T_must: argument 0"}
-!65 = distinct !{!65, !"sorbet_T_must"}
-!66 = !{!21, !7, i64 24}
-!67 = !DILocation(line: 0, scope: !47)
-!68 = !DILocation(line: 9, column: 5, scope: !47)
-!69 = !DILocation(line: 8, column: 7, scope: !47)
-!70 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_3", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!71 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_4", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!72 = !DILocation(line: 14, column: 3, scope: !51)
-!73 = !{!"branch_weights", i32 4001, i32 4000000}
-!74 = !DILocation(line: 0, scope: !51)
-!75 = !DILocation(line: 16, column: 7, scope: !51)
-!76 = !DILocation(line: 21, column: 3, scope: !51)
+!46 = !DILocation(line: 10, column: 7, scope: !44)
+!47 = !DILocation(line: 17, column: 7, scope: !48)
+!48 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_1", scope: !49, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!49 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg", scope: null, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!50 = !DILocation(line: 18, column: 15, scope: !51)
+!51 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_2", scope: !49, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!52 = !DILocation(line: 19, column: 7, scope: !51)
+!53 = !DILocation(line: 0, scope: !39)
+!54 = !DILocation(line: 5, column: 1, scope: !39)
+!55 = !DILocation(line: 6, column: 3, scope: !45)
+!56 = !{!"branch_weights", i32 1, i32 2000}
+!57 = !DILocation(line: 0, scope: !45)
+!58 = !DILocation(line: 8, column: 7, scope: !45)
+!59 = !DILocation(line: 12, column: 3, scope: !45)
+!60 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_1", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!61 = !{!62}
+!62 = distinct !{!62, !63, !"sorbet_T_must: argument 0"}
+!63 = distinct !{!63, !"sorbet_T_must"}
+!64 = !DILocation(line: 8, column: 7, scope: !60)
+!65 = !{!21, !7, i64 24}
+!66 = !DILocation(line: 0, scope: !44)
+!67 = !DILocation(line: 9, column: 5, scope: !44)
+!68 = !DILocation(line: 8, column: 7, scope: !44)
+!69 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_3", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!70 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_4", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!71 = !DILocation(line: 14, column: 3, scope: !49)
+!72 = !{!"branch_weights", i32 4001, i32 4000000}
+!73 = !DILocation(line: 0, scope: !49)
+!74 = !DILocation(line: 16, column: 7, scope: !49)
+!75 = !DILocation(line: 21, column: 3, scope: !49)
+!76 = !DILocation(line: 16, column: 7, scope: !48)
 !77 = !{!78}
 !78 = distinct !{!78, !79, !"sorbet_T_must: argument 0"}
 !79 = distinct !{!79, !"sorbet_T_must"}
-!80 = !DILocation(line: 17, column: 19, scope: !50)
-!81 = !DILocation(line: 17, column: 12, scope: !50)
-!82 = !DILocation(line: 0, scope: !54)
-!83 = !DILocation(line: 18, column: 5, scope: !54)
-!84 = !DILocation(line: 16, column: 7, scope: !54)
-!85 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_3", scope: !51, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!86 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_4", scope: !51, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!80 = !DILocation(line: 17, column: 19, scope: !48)
+!81 = !DILocation(line: 17, column: 12, scope: !48)
+!82 = !DILocation(line: 0, scope: !51)
+!83 = !DILocation(line: 18, column: 5, scope: !51)
+!84 = !DILocation(line: 16, column: 7, scope: !51)
+!85 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_3", scope: !49, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!86 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_4", scope: !49, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)

--- a/test/testdata/compiler/intrinsics/thread_aref_aset.rb
+++ b/test/testdata/compiler/intrinsics/thread_aref_aset.rb
@@ -1,14 +1,80 @@
 # frozen_string_literal: true
 # typed: true
 # compiled: true
+# run_filecheck: INITIAL OPT
 
-# TODO(jez) FileCheck assertions
+extend T::Sig
 
-current = Thread.current
+sig {returns(Thread)}
+def thread_current
+  Thread.current
+end
+
+# INITIAL-LABEL: define i64 @"func_Object#14thread_current
+# INITIAL-NOT: call i64 @sorbet_i_send
+# INITIAL: call i64 @sorbet_Thread_current
+# INITIAL-NOT: call i64 @sorbet_i_send
+# INITIAL{LITERAL}: }
+
+# OPT-LABEL: define i64 @"func_Object#14thread_current
+# OPT-NOT: call i64 @callFuncWithCache
+# OPT: call i64 @rb_thread_current
+# OPT-NOT: call i64 @callFuncWithCache
+# OPT{LITERAL}: }
+
+sig {params(thread: Thread).returns(T.untyped)}
+def thread_aref_constant(thread)
+  thread[:my_key]
+end
+
+# INITIAL-LABEL: define i64 @"func_Object#20thread_aref_constant
+# INITIAL: call i64 @sorbet_Thread_square_br_symarg
+# INITIAL{LITERAL}: }
+
+# OPT-LABEL: define i64 @"func_Object#20thread_aref_constant
+# OPT-NOT: call i64 @rb_id2sym
+# OPT: call i64 @rb_thread_local_aref
+# OPT-NOT: call i64 @rb_id2sym
+# OPT{LITERAL}: }
+
+sig {params(thread: Thread, key: T.untyped).returns(T.untyped)}
+def thread_aref(thread, key)
+  thread[key]
+end
+
+# INITIAL-LABEL: define i64 @"func_Object#11thread_aref
+# INITIAL: call i64 @sorbet_Thread_square_br
+# INITIAL{LITERAL}: }
+
+sig {params(thread: Thread, val: T.untyped).returns(T.untyped)}
+def thread_aset_constant(thread, val)
+  thread[:my_key] = val
+end
+
+# INITIAL-LABEL: define i64 @"func_Object#20thread_aset_constant
+# INITIAL: call i64 @sorbet_Thread_square_br_eq_symarg
+# INITIAL{LITERAL}: }
+
+# OPT-LABEL: define i64 @"func_Object#20thread_aset_constant
+# OPT-NOT: call i64 @rb_id2sym
+# OPT: call i64 @sorbet_Thread_square_br_eq_symarg
+# OPT-NOT: call i64 @rb_id2sym
+# OPT{LITERAL}: }
+
+sig {params(thread: Thread, key: T.untyped, val: T.untyped).returns(T.untyped)}
+def thread_aset(thread, key, val)
+  thread[key] = val
+end
+
+# INITIAL-LABEL: define i64 @"func_Object#11thread_aset
+# INITIAL: call i64 @sorbet_Thread_square_br_eq
+# INITIAL{LITERAL}: }
+
+current = thread_current
 p(current.class)
 
-p(current[:my_key] = 'my value')
-p(current['another key'] = 646)
+p(thread_aset_constant(current, 'my value'))
+p(thread_aset(current, 'another key', 646))
 
-p(current[:my_key])
-p(current['another key'])
+p(thread_aref_constant(current))
+p(thread_aref(current, 'another key'))

--- a/test/testdata/compiler/literal_hash.llo.exp
+++ b/test/testdata/compiler/literal_hash.llo.exp
@@ -104,7 +104,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @str_unknown = private unnamed_addr constant [8 x i8] c"unknown\00", align 1
 @rubyIdPrecomputed_do = internal unnamed_addr global i64 0, align 8
 @str_do = private unnamed_addr constant [3 x i8] c"do\00", align 1
-@rubyStrFrozen_magic = internal unnamed_addr global i64 0, align 8
 @str_magic = private unnamed_addr constant [6 x i8] c"magic\00", align 1
 @ruby_hashLiteral1 = internal unnamed_addr global i64 0, align 8
 @str_one = private unnamed_addr constant [4 x i8] c"one\00", align 1
@@ -119,77 +118,77 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ruby_hashLiteral6 = internal unnamed_addr global i64 0, align 8
 @rubyIdPrecomputed_symbol = internal unnamed_addr global i64 0, align 8
 @str_symbol = private unnamed_addr constant [7 x i8] c"symbol\00", align 1
-@rubyStrFrozen_symbol = internal unnamed_addr global i64 0, align 8
 @ruby_hashLiteral7 = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 
+; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #1
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #1
 
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
+declare i64 @sorbet_readRealpath() local_unnamed_addr #1
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
 
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
 
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
 
-declare i64 @sorbet_globalConstRegister(i64) local_unnamed_addr #0
+declare i64 @sorbet_globalConstRegister(i64) local_unnamed_addr #1
 
-declare i64 @sorbet_globalConstDupHash(i64) local_unnamed_addr #0
+declare i64 @sorbet_globalConstDupHash(i64) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
 
-declare i64 @rb_hash_new_with_size(i64) local_unnamed_addr #0
+declare i64 @rb_hash_new_with_size(i64) local_unnamed_addr #1
 
-declare void @rb_hash_bulk_insert(i64, i64*, i64) local_unnamed_addr #0
+declare void @rb_hash_bulk_insert(i64, i64*, i64) local_unnamed_addr #1
 
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #5
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #6
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #5
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #6
   unreachable
 }
 
 ; Function Attrs: sspreq
-define void @Init_literal_hash() local_unnamed_addr #3 {
+define void @Init_literal_hash() local_unnamed_addr #4 {
 entry:
   %argArray.i1.i = alloca [2 x i64], align 8
   %argArray.i.i = alloca [14 x i64], align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #7
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_do, i64 0, i64 0), i64 noundef 2) #6
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_do, i64 0, i64 0), i64 noundef 2) #7
   store i64 %1, i64* @rubyIdPrecomputed_do, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_symbol, i64 0, i64 0), i64 noundef 6) #6
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_symbol, i64 0, i64 0), i64 noundef 6) #7
   store i64 %2, i64* @rubyIdPrecomputed_symbol, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #6
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #7
   store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
-  tail call void @rb_gc_register_mark_object(i64 %4) #6
+  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #7
+  tail call void @rb_gc_register_mark_object(i64 %4) #7
   store i64 %4, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/literal_hash.rb", i64 0, i64 0), i64 noundef 38) #6
-  tail call void @rb_gc_register_mark_object(i64 %5) #6
+  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/literal_hash.rb", i64 0, i64 0), i64 noundef 38) #7
+  tail call void @rb_gc_register_mark_object(i64 %5) #7
   store i64 %5, i64* @"rubyStrFrozen_test/testdata/compiler/literal_hash.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 15)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -197,30 +196,29 @@ entry:
   %"rubyStr_test/testdata/compiler/literal_hash.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/literal_hash.rb", align 8
   %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/literal_hash.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 15)
   store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %7 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #6
-  call void @rb_gc_register_mark_object(i64 %7) #6
+  %7 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %7) #7
   store i64 %7, i64* @rubyStrFrozen_foo, align 8
-  %8 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #6
-  call void @rb_gc_register_mark_object(i64 %8) #6
+  %8 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %8) #7
   store i64 %8, i64* @rubyStrFrozen_bar, align 8
-  %9 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_baz, i64 0, i64 0), i64 noundef 3) #6
-  call void @rb_gc_register_mark_object(i64 %9) #6
+  %9 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_baz, i64 0, i64 0), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %9) #7
   store i64 %9, i64* @rubyStrFrozen_baz, align 8
-  %10 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_quux, i64 0, i64 0), i64 noundef 4) #6
-  call void @rb_gc_register_mark_object(i64 %10) #6
+  %10 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_quux, i64 0, i64 0), i64 noundef 4) #7
+  call void @rb_gc_register_mark_object(i64 %10) #7
   store i64 %10, i64* @rubyStrFrozen_quux, align 8
-  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_wat, i64 0, i64 0), i64 noundef 3) #6
-  call void @rb_gc_register_mark_object(i64 %11) #6
+  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_wat, i64 0, i64 0), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %11) #7
   store i64 %11, i64* @rubyStrFrozen_wat, align 8
-  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_how, i64 0, i64 0), i64 noundef 3) #6
-  call void @rb_gc_register_mark_object(i64 %12) #6
+  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_how, i64 0, i64 0), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %12) #7
   store i64 %12, i64* @rubyStrFrozen_how, align 8
-  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_unknown, i64 0, i64 0), i64 noundef 7) #6
-  call void @rb_gc_register_mark_object(i64 %13) #6
+  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_unknown, i64 0, i64 0), i64 noundef 7) #7
+  call void @rb_gc_register_mark_object(i64 %13) #7
   store i64 %13, i64* @rubyStrFrozen_unknown, align 8
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_magic, i64 0, i64 0), i64 noundef 5) #6
-  call void @rb_gc_register_mark_object(i64 %14) #6
-  store i64 %14, i64* @rubyStrFrozen_magic, align 8
+  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_magic, i64 0, i64 0), i64 noundef 5) #7
+  call void @rb_gc_register_mark_object(i64 %14) #7
   %15 = bitcast [14 x i64]* %argArray.i.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 112, i8* nonnull %15)
   %rubyStr_foo.i.i = load i64, i64* @rubyStrFrozen_foo, align 8
@@ -255,20 +253,19 @@ entry:
   %hashArgs11Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i32 0, i64 11
   store i64 %rubyStr_unknown.i.i, i64* %hashArgs11Addr.i.i, align 8
   %rubyId_do.i.i = load i64, i64* @rubyIdPrecomputed_do, align 8
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_do.i.i)
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_do.i.i) #8
   %hashArgs12Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i32 0, i64 12
   store i64 %rawSym.i.i, i64* %hashArgs12Addr.i.i, align 8
-  %rubyStr_magic.i.i = load i64, i64* @rubyStrFrozen_magic, align 8
   %hashArgs13Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i32 0, i64 13
-  store i64 %rubyStr_magic.i.i, i64* %hashArgs13Addr.i.i, align 8
+  store i64 %14, i64* %hashArgs13Addr.i.i, align 8
   %16 = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 0
-  %17 = call i64 @rb_hash_new_with_size(i64 noundef 7) #6
-  call void @rb_hash_bulk_insert(i64 noundef 14, i64* noundef nonnull %16, i64 %17) #6
-  %18 = call i64 @sorbet_globalConstRegister(i64 %17) #6
+  %17 = call i64 @rb_hash_new_with_size(i64 noundef 7) #7
+  call void @rb_hash_bulk_insert(i64 noundef 14, i64* noundef nonnull %16, i64 %17) #7
+  %18 = call i64 @sorbet_globalConstRegister(i64 %17) #7
   store i64 %18, i64* @ruby_hashLiteral1, align 8
   call void @llvm.lifetime.end.p0i8(i64 112, i8* nonnull %15)
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_one, i64 0, i64 0), i64 noundef 3) #6
-  call void @rb_gc_register_mark_object(i64 %19) #6
+  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_one, i64 0, i64 0), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %19) #7
   %20 = bitcast [2 x i64]* %argArray.i1.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %20)
   %hashArgs0Addr.i2.i = getelementptr [2 x i64], [2 x i64]* %argArray.i1.i, i32 0, i64 0
@@ -276,63 +273,61 @@ entry:
   %hashArgs1Addr.i3.i = getelementptr [2 x i64], [2 x i64]* %argArray.i1.i, i32 0, i64 1
   store i64 %19, i64* %hashArgs1Addr.i3.i, align 8
   %21 = getelementptr [2 x i64], [2 x i64]* %argArray.i1.i, i64 0, i64 0
-  %22 = call i64 @rb_hash_new_with_size(i64 noundef 1) #6
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %21, i64 %22) #6
-  %23 = call i64 @sorbet_globalConstRegister(i64 %22) #6
+  %22 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %21, i64 %22) #7
+  %23 = call i64 @sorbet_globalConstRegister(i64 %22) #7
   store i64 %23, i64* @ruby_hashLiteral2, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %20)
-  %24 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_two, i64 0, i64 0), i64 noundef 3) #6
-  call void @rb_gc_register_mark_object(i64 %24) #6
+  %24 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_two, i64 0, i64 0), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %24) #7
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %20)
   store i64 2, i64* %hashArgs0Addr.i2.i, align 8
   store i64 %24, i64* %hashArgs1Addr.i3.i, align 8
-  %25 = call i64 @rb_hash_new_with_size(i64 noundef 1) #6
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %21, i64 %25) #6
-  %26 = call i64 @sorbet_globalConstRegister(i64 %25) #6
+  %25 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %21, i64 %25) #7
+  %26 = call i64 @sorbet_globalConstRegister(i64 %25) #7
   store i64 %26, i64* @ruby_hashLiteral3, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %20)
-  %27 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_true, i64 0, i64 0), i64 noundef 4) #6
-  call void @rb_gc_register_mark_object(i64 %27) #6
+  %27 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_true, i64 0, i64 0), i64 noundef 4) #7
+  call void @rb_gc_register_mark_object(i64 %27) #7
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %20)
   store i64 20, i64* %hashArgs0Addr.i2.i, align 8
   store i64 %27, i64* %hashArgs1Addr.i3.i, align 8
-  %28 = call i64 @rb_hash_new_with_size(i64 noundef 1) #6
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %21, i64 %28) #6
-  %29 = call i64 @sorbet_globalConstRegister(i64 %28) #6
+  %28 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %21, i64 %28) #7
+  %29 = call i64 @sorbet_globalConstRegister(i64 %28) #7
   store i64 %29, i64* @ruby_hashLiteral4, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %20)
-  %30 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_false, i64 0, i64 0), i64 noundef 5) #6
-  call void @rb_gc_register_mark_object(i64 %30) #6
+  %30 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_false, i64 0, i64 0), i64 noundef 5) #7
+  call void @rb_gc_register_mark_object(i64 %30) #7
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %20)
   store i64 0, i64* %hashArgs0Addr.i2.i, align 8
   store i64 %30, i64* %hashArgs1Addr.i3.i, align 8
-  %31 = call i64 @rb_hash_new_with_size(i64 noundef 1) #6
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %21, i64 %31) #6
-  %32 = call i64 @sorbet_globalConstRegister(i64 %31) #6
+  %31 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %21, i64 %31) #7
+  %32 = call i64 @sorbet_globalConstRegister(i64 %31) #7
   store i64 %32, i64* @ruby_hashLiteral5, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %20)
-  %33 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_nil, i64 0, i64 0), i64 noundef 3) #6
-  call void @rb_gc_register_mark_object(i64 %33) #6
+  %33 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_nil, i64 0, i64 0), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %33) #7
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %20)
   store i64 8, i64* %hashArgs0Addr.i2.i, align 8
   store i64 %33, i64* %hashArgs1Addr.i3.i, align 8
-  %34 = call i64 @rb_hash_new_with_size(i64 noundef 1) #6
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %21, i64 %34) #6
-  %35 = call i64 @sorbet_globalConstRegister(i64 %34) #6
+  %34 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %21, i64 %34) #7
+  %35 = call i64 @sorbet_globalConstRegister(i64 %34) #7
   store i64 %35, i64* @ruby_hashLiteral6, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %20)
-  %36 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_symbol, i64 0, i64 0), i64 noundef 6) #6
-  call void @rb_gc_register_mark_object(i64 %36) #6
-  store i64 %36, i64* @rubyStrFrozen_symbol, align 8
+  %36 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_symbol, i64 0, i64 0), i64 noundef 6) #7
+  call void @rb_gc_register_mark_object(i64 %36) #7
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %20)
   %rubyId_symbol.i.i = load i64, i64* @rubyIdPrecomputed_symbol, align 8
-  %rawSym.i17.i = call i64 @rb_id2sym(i64 %rubyId_symbol.i.i)
+  %rawSym.i17.i = call i64 @rb_id2sym(i64 %rubyId_symbol.i.i) #8
   store i64 %rawSym.i17.i, i64* %hashArgs0Addr.i2.i, align 8
-  %rubyStr_symbol.i.i = load i64, i64* @rubyStrFrozen_symbol, align 8
-  store i64 %rubyStr_symbol.i.i, i64* %hashArgs1Addr.i3.i, align 8
-  %37 = call i64 @rb_hash_new_with_size(i64 noundef 1) #6
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %21, i64 %37) #6
-  %38 = call i64 @sorbet_globalConstRegister(i64 %37) #6
+  store i64 %36, i64* %hashArgs1Addr.i3.i, align 8
+  %37 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %21, i64 %37) #7
+  %38 = call i64 @sorbet_globalConstRegister(i64 %37) #7
   store i64 %38, i64* @ruby_hashLiteral7, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %20)
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10
@@ -351,34 +346,30 @@ entry:
   %48 = load i64, i64* %47, align 8, !tbaa !6
   %49 = and i64 %48, -33
   store i64 %49, i64* %47, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %42, %struct.rb_control_frame_struct* %44, %struct.rb_iseq_struct* %stackFrame.i) #6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %42, %struct.rb_control_frame_struct* %44, %struct.rb_iseq_struct* %stackFrame.i) #7
   %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 0
   store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %50, align 8, !dbg !33, !tbaa !15
-  %rubyId_do.i = load i64, i64* @rubyIdPrecomputed_do, align 8, !dbg !34
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_do.i) #6, !dbg !34
-  %hashLiteral.i = load i64, i64* @ruby_hashLiteral1, align 8, !dbg !35
-  %duplicatedHash.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral.i) #6, !dbg !35
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %50, align 8, !dbg !35, !tbaa !15
-  %hashLiteral81.i = load i64, i64* @ruby_hashLiteral2, align 8, !dbg !36
-  %duplicatedHash82.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral81.i) #6, !dbg !36
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %50, align 8, !dbg !36, !tbaa !15
-  %hashLiteral88.i = load i64, i64* @ruby_hashLiteral3, align 8, !dbg !37
-  %duplicatedHash89.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral88.i) #6, !dbg !37
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %50, align 8, !dbg !37, !tbaa !15
-  %hashLiteral95.i = load i64, i64* @ruby_hashLiteral4, align 8, !dbg !38
-  %duplicatedHash96.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral95.i) #6, !dbg !38
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %50, align 8, !dbg !38, !tbaa !15
-  %hashLiteral102.i = load i64, i64* @ruby_hashLiteral5, align 8, !dbg !39
-  %duplicatedHash103.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral102.i) #6, !dbg !39
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %50, align 8, !dbg !39, !tbaa !15
-  %hashLiteral109.i = load i64, i64* @ruby_hashLiteral6, align 8, !dbg !40
-  %duplicatedHash110.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral109.i) #6, !dbg !40
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %50, align 8, !dbg !40, !tbaa !15
-  %rubyId_symbol.i = load i64, i64* @rubyIdPrecomputed_symbol, align 8, !dbg !41
-  %rawSym111.i = call i64 @rb_id2sym(i64 %rubyId_symbol.i) #6, !dbg !41
-  %hashLiteral116.i = load i64, i64* @ruby_hashLiteral7, align 8, !dbg !42
-  %duplicatedHash117.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral116.i) #6, !dbg !42
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %50, align 8, !dbg !42, !tbaa !15
+  %hashLiteral.i = load i64, i64* @ruby_hashLiteral1, align 8, !dbg !34
+  %duplicatedHash.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral.i) #7, !dbg !34
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %50, align 8, !dbg !34, !tbaa !15
+  %hashLiteral81.i = load i64, i64* @ruby_hashLiteral2, align 8, !dbg !35
+  %duplicatedHash82.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral81.i) #7, !dbg !35
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %50, align 8, !dbg !35, !tbaa !15
+  %hashLiteral88.i = load i64, i64* @ruby_hashLiteral3, align 8, !dbg !36
+  %duplicatedHash89.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral88.i) #7, !dbg !36
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %50, align 8, !dbg !36, !tbaa !15
+  %hashLiteral95.i = load i64, i64* @ruby_hashLiteral4, align 8, !dbg !37
+  %duplicatedHash96.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral95.i) #7, !dbg !37
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %50, align 8, !dbg !37, !tbaa !15
+  %hashLiteral102.i = load i64, i64* @ruby_hashLiteral5, align 8, !dbg !38
+  %duplicatedHash103.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral102.i) #7, !dbg !38
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %50, align 8, !dbg !38, !tbaa !15
+  %hashLiteral109.i = load i64, i64* @ruby_hashLiteral6, align 8, !dbg !39
+  %duplicatedHash110.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral109.i) #7, !dbg !39
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %50, align 8, !dbg !39, !tbaa !15
+  %hashLiteral116.i = load i64, i64* @ruby_hashLiteral7, align 8, !dbg !40
+  %duplicatedHash117.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral116.i) #7, !dbg !40
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %50, align 8, !dbg !40, !tbaa !15
   %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 1, !dbg !10
   %52 = load i64*, i64** %51, align 8, !dbg !10
   store i64 %41, i64* %52, align 8, !dbg !10, !tbaa !6
@@ -403,18 +394,20 @@ entry:
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #4
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #4
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { sspreq }
-attributes #4 = { argmemonly nofree nosync nounwind willreturn }
-attributes #5 = { noreturn nounwind }
-attributes #6 = { nounwind }
+attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { sspreq }
+attributes #5 = { argmemonly nofree nosync nounwind willreturn }
+attributes #6 = { noreturn nounwind }
+attributes #7 = { nounwind }
+attributes #8 = { nounwind willreturn }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -453,12 +446,10 @@ attributes #6 = { nounwind }
 !31 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !7, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
 !32 = !{!31, !16, i64 32}
 !33 = !DILocation(line: 0, scope: !11)
-!34 = !DILocation(line: 6, column: 99, scope: !11)
-!35 = !DILocation(line: 6, column: 5, scope: !11)
-!36 = !DILocation(line: 8, column: 5, scope: !11)
-!37 = !DILocation(line: 9, column: 5, scope: !11)
-!38 = !DILocation(line: 10, column: 5, scope: !11)
-!39 = !DILocation(line: 11, column: 5, scope: !11)
-!40 = !DILocation(line: 12, column: 5, scope: !11)
-!41 = !DILocation(line: 13, column: 7, scope: !11)
-!42 = !DILocation(line: 13, column: 5, scope: !11)
+!34 = !DILocation(line: 6, column: 5, scope: !11)
+!35 = !DILocation(line: 8, column: 5, scope: !11)
+!36 = !DILocation(line: 9, column: 5, scope: !11)
+!37 = !DILocation(line: 10, column: 5, scope: !11)
+!38 = !DILocation(line: 11, column: 5, scope: !11)
+!39 = !DILocation(line: 12, column: 5, scope: !11)
+!40 = !DILocation(line: 13, column: 5, scope: !11)

--- a/test/testdata/compiler/literals.llo.exp
+++ b/test/testdata/compiler/literals.llo.exp
@@ -102,59 +102,60 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.6 = internal global %struct.FunctionInlineCache zeroinitializer
 
+; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #1
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #1
 
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
+declare i64 @sorbet_readRealpath() local_unnamed_addr #1
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
 
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
 
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
 
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #4
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #5
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #4
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #5
   unreachable
 }
 
 ; Function Attrs: sspreq
-define void @Init_literals() local_unnamed_addr #3 {
+define void @Init_literals() local_unnamed_addr #4 {
 entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #5
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #5
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #6
   store i64 %1, i64* @rubyIdPrecomputed_puts, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sym, i64 0, i64 0), i64 noundef 3) #5
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sym, i64 0, i64 0), i64 noundef 3) #6
   store i64 %2, i64* @rubyIdPrecomputed_sym, align 8
-  %3 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #5
-  tail call void @rb_gc_register_mark_object(i64 %3) #5
+  %3 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
+  tail call void @rb_gc_register_mark_object(i64 %3) #6
   store i64 %3, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([35 x i8], [35 x i8]* @"str_test/testdata/compiler/literals.rb", i64 0, i64 0), i64 noundef 34) #5
-  tail call void @rb_gc_register_mark_object(i64 %4) #5
+  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([35 x i8], [35 x i8]* @"str_test/testdata/compiler/literals.rb", i64 0, i64 0), i64 noundef 34) #6
+  tail call void @rb_gc_register_mark_object(i64 %4) #6
   store i64 %4, i64* @"rubyStrFrozen_test/testdata/compiler/literals.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 11)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -166,8 +167,8 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_puts1.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %6 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_str, i64 0, i64 0), i64 noundef 3) #5
-  call void @rb_gc_register_mark_object(i64 %6) #5
+  %6 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_str, i64 0, i64 0), i64 noundef 3) #6
+  call void @rb_gc_register_mark_object(i64 %6) #6
   store i64 %6, i64* @rubyStrFrozen_str, align 8
   %rubyId_puts4.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !16
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts4.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
@@ -193,7 +194,7 @@ entry:
   %16 = load i64, i64* %15, align 8, !tbaa !6
   %17 = and i64 %16, -33
   store i64 %17, i64* %15, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #5
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #6
   %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
   store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !39, !tbaa !21
   %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !10
@@ -225,7 +226,7 @@ entry:
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !16
   store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %18, align 8, !dbg !16, !tbaa !21
   %rubyId_sym.i = load i64, i64* @rubyIdPrecomputed_sym, align 8, !dbg !41
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_sym.i) #5, !dbg !41
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_sym.i) #6, !dbg !41
   %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !17
   %32 = load i64*, i64** %31, align 8, !dbg !17
   store i64 %9, i64* %32, align 8, !dbg !17, !tbaa !6
@@ -264,12 +265,13 @@ entry:
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { sspreq }
-attributes #4 = { noreturn nounwind }
-attributes #5 = { nounwind }
+attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { sspreq }
+attributes #5 = { noreturn nounwind }
+attributes #6 = { nounwind }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}

--- a/test/testdata/compiler/repeated_casts.llo.exp
+++ b/test/testdata/compiler/repeated_casts.llo.exp
@@ -97,7 +97,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
 @str_a = private unnamed_addr constant [2 x i8] c"a\00", align 1
@@ -109,49 +108,47 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
 
-declare i64 @rb_id2sym(i64) local_unnamed_addr #0
-
 ; Function Attrs: nounwind readnone willreturn
-declare i64 @rb_obj_is_kind_of(i64, i64) local_unnamed_addr #1
+declare i64 @rb_obj_is_kind_of(i64, i64) local_unnamed_addr #0
 
 ; Function Attrs: cold noreturn
-declare void @sorbet_cast_failure(i64, i8*, i8*) local_unnamed_addr #2
+declare void @sorbet_cast_failure(i64, i8*, i8*) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #3
+declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #2
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #3
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #3
 
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
+declare i64 @sorbet_readRealpath() local_unnamed_addr #3
 
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #3
 
-declare void @sorbet_popFrame() local_unnamed_addr #0
+declare void @sorbet_popFrame() local_unnamed_addr #3
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #3
 
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #3
 
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #3
 
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
 
-declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #3
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #3
 
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #3
 
 ; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #3
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #3
 
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #4
@@ -267,10 +264,6 @@ functionEntryInitializers:
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %12, %struct.rb_control_frame_struct* %14, %struct.rb_iseq_struct* %stackFrame.i) #15
   %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
   store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %20, align 8, !dbg !35, !tbaa !14
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !38
-  %rawSym.i = tail call i64 @rb_id2sym(i64 %rubyId_foo.i) #15, !dbg !38
-  %rubyId_normal.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !38
-  %rawSym7.i = tail call i64 @rb_id2sym(i64 %rubyId_normal.i) #15, !dbg !38
   %21 = load i64, i64* @guard_epoch_A, align 8, !dbg !38
   %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !20
   %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !38
@@ -314,10 +307,6 @@ functionEntryInitializers:
 "func_A.13<static-init>L61.exit":                 ; preds = %24, %41
   tail call void @sorbet_popFrame() #15, !dbg !34
   store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !34, !tbaa !14
-  %rubyId_doubleCast = load i64, i64* @rubyIdPrecomputed_doubleCast, align 8, !dbg !42
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_doubleCast), !dbg !42
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !42
-  %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !42
   %stackFrame20 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#10doubleCast", align 8, !dbg !42
   %45 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !42
   %46 = bitcast i8* %45 to i16*, !dbg !42
@@ -379,7 +368,6 @@ entry:
   %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
   store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %3, i64* @rubyIdPrecomputed_normal, align 8
   %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #15
   store i64 %4, i64* @rubyIdPrecomputed_a, align 8
   %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #15
@@ -464,10 +452,10 @@ define linkonce void @const_recompute_A() local_unnamed_addr #8 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #4 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #5 = { argmemonly nofree nosync nounwind willreturn }
 attributes #6 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/testdata/compiler/send_with_block_param.llo.exp
+++ b/test/testdata/compiler/send_with_block_param.llo.exp
@@ -91,9 +91,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @iseqEncodedArray = internal global [7 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ruby_hashLiteral1 = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_unsafe = internal unnamed_addr global i64 0, align 8
 @str_unsafe = private unnamed_addr constant [7 x i8] c"unsafe\00", align 1
-@ic_unsafe = internal global %struct.FunctionInlineCache zeroinitializer
 @"str_<build-array>" = private unnamed_addr constant [14 x i8] c"<build-array>\00", align 1
 @rubyIdPrecomputed_map = internal unnamed_addr global i64 0, align 8
 @str_map = private unnamed_addr constant [4 x i8] c"map\00", align 1
@@ -101,8 +99,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
-
-declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -163,7 +159,6 @@ entry:
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #7
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_unsafe, i64 0, i64 0), i64 noundef 6) #7
-  store i64 %1, i64* @rubyIdPrecomputed_unsafe, align 8
   %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #7
   %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_map, i64 0, i64 0), i64 noundef 3) #7
   store i64 %3, i64* @rubyIdPrecomputed_map, align 8
@@ -192,86 +187,82 @@ entry:
   %12 = call i64 @sorbet_globalConstRegister(i64 %11) #7
   store i64 %12, i64* @ruby_hashLiteral1, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %8)
-  %rubyId_unsafe.i = load i64, i64* @rubyIdPrecomputed_unsafe, align 8, !dbg !10
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_unsafe, i64 %rubyId_unsafe.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
-  %rubyId_map.i = load i64, i64* @rubyIdPrecomputed_map, align 8, !dbg !15
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %rubyId_map.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !15
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !16
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
-  %13 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !17
+  %rubyId_map.i = load i64, i64* @rubyIdPrecomputed_map, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %rubyId_map.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
+  %13 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !16
   %14 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %13, i64 0, i32 18
-  %15 = load i64, i64* %14, align 8, !tbaa !19
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !17
+  %15 = load i64, i64* %14, align 8, !tbaa !18
+  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !16
   %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2
-  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !29
+  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !28
   %19 = bitcast [4 x i64]* %callArgs.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %19)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %20 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !29
+  %20 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !28
   %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %21, align 8, !tbaa !32
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %21, align 8, !tbaa !31
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 4
-  %23 = load i64*, i64** %22, align 8, !tbaa !34
+  %23 = load i64*, i64** %22, align 8, !tbaa !33
   %24 = load i64, i64* %23, align 8, !tbaa !6
   %25 = and i64 %24, -33
   store i64 %25, i64* %23, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %16, %struct.rb_control_frame_struct* %20, %struct.rb_iseq_struct* %stackFrame.i) #7
   %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 0
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %26, align 8, !dbg !35, !tbaa !17
-  %hashLiteral.i = load i64, i64* @ruby_hashLiteral1, align 8, !dbg !36
-  %duplicatedHash.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral.i) #7, !dbg !36
-  %callArgs0Addr.i = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i32 0, i64 0, !dbg !10
-  store i64 %duplicatedHash.i, i64* %callArgs0Addr.i, align 8, !dbg !10
-  %27 = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i64 0, i64 0, !dbg !10
-  call void @llvm.experimental.noalias.scope.decl(metadata !37) #7, !dbg !10
-  %28 = load i64, i64* %27, align 8, !dbg !10, !tbaa !6, !alias.scope !37
-  %29 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !17
-  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 5, !dbg !10
-  %31 = load i32, i32* %30, align 8, !dbg !10, !tbaa !40
-  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 6, !dbg !10
-  %33 = load i32, i32* %32, align 4, !dbg !10, !tbaa !41
-  %34 = xor i32 %33, -1, !dbg !10
-  %35 = and i32 %34, %31, !dbg !10
-  %36 = icmp eq i32 %35, 0, !dbg !10
-  br i1 %36, label %afterSend26.i, label %42, !dbg !10, !prof !42
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %26, align 8, !dbg !34, !tbaa !16
+  %hashLiteral.i = load i64, i64* @ruby_hashLiteral1, align 8, !dbg !35
+  %duplicatedHash.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral.i) #7, !dbg !35
+  %callArgs0Addr.i = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i32 0, i64 0, !dbg !36
+  store i64 %duplicatedHash.i, i64* %callArgs0Addr.i, align 8, !dbg !36
+  %27 = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i64 0, i64 0, !dbg !36
+  call void @llvm.experimental.noalias.scope.decl(metadata !37) #7, !dbg !36
+  %28 = load i64, i64* %27, align 8, !dbg !36, !tbaa !6, !alias.scope !37
+  %29 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !36, !tbaa !16
+  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 5, !dbg !36
+  %31 = load i32, i32* %30, align 8, !dbg !36, !tbaa !40
+  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 6, !dbg !36
+  %33 = load i32, i32* %32, align 4, !dbg !36, !tbaa !41
+  %34 = xor i32 %33, -1, !dbg !36
+  %35 = and i32 %34, %31, !dbg !36
+  %36 = icmp eq i32 %35, 0, !dbg !36
+  br i1 %36, label %rb_vm_check_ints.exit.i, label %37, !dbg !36, !prof !42
 
-afterSend26.i:                                    ; preds = %42, %entry
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %26, align 8, !dbg !10, !tbaa !17
-  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !15
-  call void @llvm.experimental.noalias.scope.decl(metadata !43) #7, !dbg !15
-  %37 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %27) #7, !dbg !15
-  %rubyId_map.i1 = load i64, i64* @rubyIdPrecomputed_map, align 8, !dbg !15
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_map.i1) #7, !dbg !15
-  %38 = icmp eq i64 %28, 8, !dbg !15
-  br i1 %38, label %"func_<root>.17<static-init>$152.exit", label %39, !dbg !15
+37:                                               ; preds = %entry
+  %38 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 8, !dbg !36
+  %39 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %38, align 8, !dbg !36, !tbaa !43
+  %40 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %39, i32 noundef 0) #7, !dbg !36
+  br label %rb_vm_check_ints.exit.i, !dbg !36
 
-39:                                               ; preds = %afterSend26.i
-  %40 = call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @.str.6, i64 0, i64 0), i64 noundef 7) #7, !dbg !15
-  %41 = call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_makeBlockHandlerProc.rb_funcallv_data, i64 %28, i64 %40, i32 noundef 0, i64* noundef null) #7, !dbg !15
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !15
+rb_vm_check_ints.exit.i:                          ; preds = %37, %entry
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %26, align 8, !dbg !36, !tbaa !16
+  store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !10
+  call void @llvm.experimental.noalias.scope.decl(metadata !44) #7, !dbg !10
+  %41 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %27) #7, !dbg !10
+  %42 = icmp eq i64 %28, 8, !dbg !10
+  br i1 %42, label %"func_<root>.17<static-init>$152.exit", label %43, !dbg !10
 
-42:                                               ; preds = %entry
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 8, !dbg !10
-  %44 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %43, align 8, !dbg !10, !tbaa !46
-  %45 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %44, i32 noundef 0) #7, !dbg !10
-  br label %afterSend26.i, !dbg !10
+43:                                               ; preds = %rb_vm_check_ints.exit.i
+  %44 = call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @.str.6, i64 0, i64 0), i64 noundef 7) #7, !dbg !10
+  %45 = call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_makeBlockHandlerProc.rb_funcallv_data, i64 %28, i64 %44, i32 noundef 0, i64* noundef null) #7, !dbg !10
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !10
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %afterSend26.i, %39
-  %46 = phi i64 [ %41, %39 ], [ 0, %afterSend26.i ], !dbg !15
-  %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !15
-  %48 = load i64*, i64** %47, align 8, !dbg !15
-  store i64 %37, i64* %48, align 8, !dbg !15, !tbaa !6
-  %49 = getelementptr inbounds i64, i64* %48, i64 1, !dbg !15
-  store i64* %49, i64** %47, align 8, !dbg !15
-  %send.i = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %46) #7, !dbg !15
-  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !16
-  %51 = load i64*, i64** %50, align 8, !dbg !16
-  store i64 %15, i64* %51, align 8, !dbg !16, !tbaa !6
-  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !16
-  store i64 %send.i, i64* %52, align 8, !dbg !16, !tbaa !6
-  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !16
-  store i64* %53, i64** %50, align 8, !dbg !16
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !16
+"func_<root>.17<static-init>$152.exit":           ; preds = %rb_vm_check_ints.exit.i, %43
+  %46 = phi i64 [ %45, %43 ], [ 0, %rb_vm_check_ints.exit.i ], !dbg !10
+  %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !10
+  %48 = load i64*, i64** %47, align 8, !dbg !10
+  store i64 %41, i64* %48, align 8, !dbg !10, !tbaa !6
+  %49 = getelementptr inbounds i64, i64* %48, i64 1, !dbg !10
+  store i64* %49, i64** %47, align 8, !dbg !10
+  %send.i = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %46) #7, !dbg !10
+  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !15
+  %51 = load i64*, i64** %50, align 8, !dbg !15
+  store i64 %15, i64* %51, align 8, !dbg !15, !tbaa !6
+  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !15
+  store i64 %send.i, i64* %52, align 8, !dbg !15, !tbaa !6
+  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !15
+  store i64* %53, i64** %50, align 8, !dbg !15
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
   call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %19)
   ret void
 }
@@ -307,40 +298,40 @@ attributes #7 = { nounwind }
 !7 = !{!"long", !8, i64 0}
 !8 = !{!"omnipotent char", !9, i64 0}
 !9 = !{!"Simple C/C++ TBAA"}
-!10 = !DILocation(line: 4, column: 5, scope: !11)
+!10 = !DILocation(line: 6, column: 6, scope: !11)
 !11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !12 = !DISubroutineType(types: !13)
 !13 = !{!14}
 !14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!15 = !DILocation(line: 6, column: 6, scope: !11)
-!16 = !DILocation(line: 6, column: 1, scope: !11)
-!17 = !{!18, !18, i64 0}
-!18 = !{!"any pointer", !8, i64 0}
-!19 = !{!20, !7, i64 400}
-!20 = !{!"rb_vm_struct", !7, i64 0, !21, i64 8, !18, i64 192, !18, i64 200, !18, i64 208, !25, i64 216, !8, i64 224, !22, i64 264, !22, i64 280, !22, i64 296, !22, i64 312, !7, i64 328, !24, i64 336, !24, i64 340, !24, i64 344, !24, i64 344, !24, i64 344, !24, i64 344, !24, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !18, i64 456, !18, i64 464, !26, i64 472, !27, i64 992, !18, i64 1016, !18, i64 1024, !24, i64 1032, !24, i64 1036, !22, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !24, i64 1136, !18, i64 1144, !18, i64 1152, !18, i64 1160, !18, i64 1168, !18, i64 1176, !18, i64 1184, !24, i64 1192, !28, i64 1200, !8, i64 1232}
-!21 = !{!"rb_global_vm_lock_struct", !18, i64 0, !8, i64 8, !22, i64 48, !18, i64 64, !24, i64 72, !8, i64 80, !8, i64 128, !24, i64 176, !24, i64 180}
-!22 = !{!"list_head", !23, i64 0}
-!23 = !{!"list_node", !18, i64 0, !18, i64 8}
-!24 = !{!"int", !8, i64 0}
-!25 = !{!"long long", !8, i64 0}
-!26 = !{!"", !8, i64 0}
-!27 = !{!"rb_hook_list_struct", !18, i64 0, !24, i64 8, !24, i64 12, !24, i64 16}
-!28 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!29 = !{!30, !18, i64 16}
-!30 = !{!"rb_execution_context_struct", !18, i64 0, !7, i64 8, !18, i64 16, !18, i64 24, !18, i64 32, !24, i64 40, !24, i64 44, !18, i64 48, !18, i64 56, !18, i64 64, !7, i64 72, !7, i64 80, !18, i64 88, !7, i64 96, !18, i64 104, !18, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !31, i64 152}
-!31 = !{!"", !18, i64 0, !18, i64 8, !7, i64 16, !8, i64 24}
-!32 = !{!33, !18, i64 16}
-!33 = !{!"rb_control_frame_struct", !18, i64 0, !18, i64 8, !18, i64 16, !7, i64 24, !18, i64 32, !18, i64 40, !18, i64 48}
-!34 = !{!33, !18, i64 32}
-!35 = !DILocation(line: 0, scope: !11)
-!36 = !DILocation(line: 4, column: 14, scope: !11)
+!15 = !DILocation(line: 6, column: 1, scope: !11)
+!16 = !{!17, !17, i64 0}
+!17 = !{!"any pointer", !8, i64 0}
+!18 = !{!19, !7, i64 400}
+!19 = !{!"rb_vm_struct", !7, i64 0, !20, i64 8, !17, i64 192, !17, i64 200, !17, i64 208, !24, i64 216, !8, i64 224, !21, i64 264, !21, i64 280, !21, i64 296, !21, i64 312, !7, i64 328, !23, i64 336, !23, i64 340, !23, i64 344, !23, i64 344, !23, i64 344, !23, i64 344, !23, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !17, i64 456, !17, i64 464, !25, i64 472, !26, i64 992, !17, i64 1016, !17, i64 1024, !23, i64 1032, !23, i64 1036, !21, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !23, i64 1136, !17, i64 1144, !17, i64 1152, !17, i64 1160, !17, i64 1168, !17, i64 1176, !17, i64 1184, !23, i64 1192, !27, i64 1200, !8, i64 1232}
+!20 = !{!"rb_global_vm_lock_struct", !17, i64 0, !8, i64 8, !21, i64 48, !17, i64 64, !23, i64 72, !8, i64 80, !8, i64 128, !23, i64 176, !23, i64 180}
+!21 = !{!"list_head", !22, i64 0}
+!22 = !{!"list_node", !17, i64 0, !17, i64 8}
+!23 = !{!"int", !8, i64 0}
+!24 = !{!"long long", !8, i64 0}
+!25 = !{!"", !8, i64 0}
+!26 = !{!"rb_hook_list_struct", !17, i64 0, !23, i64 8, !23, i64 12, !23, i64 16}
+!27 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!28 = !{!29, !17, i64 16}
+!29 = !{!"rb_execution_context_struct", !17, i64 0, !7, i64 8, !17, i64 16, !17, i64 24, !17, i64 32, !23, i64 40, !23, i64 44, !17, i64 48, !17, i64 56, !17, i64 64, !7, i64 72, !7, i64 80, !17, i64 88, !7, i64 96, !17, i64 104, !17, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !30, i64 152}
+!30 = !{!"", !17, i64 0, !17, i64 8, !7, i64 16, !8, i64 24}
+!31 = !{!32, !17, i64 16}
+!32 = !{!"rb_control_frame_struct", !17, i64 0, !17, i64 8, !17, i64 16, !7, i64 24, !17, i64 32, !17, i64 40, !17, i64 48}
+!33 = !{!32, !17, i64 32}
+!34 = !DILocation(line: 0, scope: !11)
+!35 = !DILocation(line: 4, column: 14, scope: !11)
+!36 = !DILocation(line: 4, column: 5, scope: !11)
 !37 = !{!38}
 !38 = distinct !{!38, !39, !"sorbet_T_unsafe: argument 0"}
 !39 = distinct !{!39, !"sorbet_T_unsafe"}
-!40 = !{!30, !24, i64 40}
-!41 = !{!30, !24, i64 44}
+!40 = !{!29, !23, i64 40}
+!41 = !{!29, !23, i64 44}
 !42 = !{!"branch_weights", i32 2000, i32 1}
-!43 = !{!44}
-!44 = distinct !{!44, !45, !"sorbet_buildArrayIntrinsic: argument 0"}
-!45 = distinct !{!45, !"sorbet_buildArrayIntrinsic"}
-!46 = !{!30, !18, i64 56}
+!43 = !{!29, !17, i64 56}
+!44 = !{!45}
+!45 = distinct !{!45, !46, !"sorbet_buildArrayIntrinsic: argument 0"}
+!46 = distinct !{!46, !"sorbet_buildArrayIntrinsic"}

--- a/test/testdata/compiler/sig_rewriter.llo.exp
+++ b/test/testdata/compiler/sig_rewriter.llo.exp
@@ -113,7 +113,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_extend = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_extend = internal unnamed_addr global i64 0, align 8
 @str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
@@ -122,93 +121,93 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_cInteger = external local_unnamed_addr constant i64
 
+; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
 declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #1
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #2
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #2
 
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #2
 
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
+declare i64 @sorbet_readRealpath() local_unnamed_addr #2
 
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #2
 
-declare void @sorbet_popFrame() local_unnamed_addr #0
+declare void @sorbet_popFrame() local_unnamed_addr #2
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #2
 
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #2
 
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #2
 
-declare void @sorbet_vm_register_sig(i64, i64, i64, i64, i64 (i64, i64, i32, i64*, i64)*) local_unnamed_addr #0
+declare void @sorbet_vm_register_sig(i64, i64, i64, i64, i64 (i64, i64, i32, i64*, i64)*) local_unnamed_addr #2
 
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #2
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #2
 
-declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #2
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #2
 
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #2
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #2
 
 ; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
+declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #3
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: sspreq
-define void @Init_sig_rewriter() local_unnamed_addr #4 {
+define void @Init_sig_rewriter() local_unnamed_addr #5 {
 entry:
   %locals.i10.i = alloca i64, i32 0, align 8
   %locals.i8.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #10
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
   store i64 %1, i64* @rubyIdPrecomputed_new, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #10
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
   store i64 %2, i64* @rubyIdPrecomputed_foo, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #10
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
   store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #10
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
   store i64 %4, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #10
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #11
   store i64 %5, i64* @"rubyIdPrecomputed_block in <class:A>", align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #10
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #11
   store i64 %6, i64* @rubyIdPrecomputed_returns, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #10
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #11
   store i64 %7, i64* @rubyIdPrecomputed_extend, align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #10
-  store i64 %8, i64* @rubyIdPrecomputed_normal, align 8
-  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
-  tail call void @rb_gc_register_mark_object(i64 %9) #10
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
+  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %9) #11
   store i64 %9, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/sig_rewriter.rb", i64 0, i64 0), i64 noundef 38) #10
-  tail call void @rb_gc_register_mark_object(i64 %10) #10
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/sig_rewriter.rb", i64 0, i64 0), i64 noundef 38) #11
+  tail call void @rb_gc_register_mark_object(i64 %10) #11
   store i64 %10, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 14)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -222,20 +221,20 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #10
-  call void @rb_gc_register_mark_object(i64 %12) #10
+  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
+  call void @rb_gc_register_mark_object(i64 %12) #11
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i7.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
   %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %12, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i7.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #10
-  call void @rb_gc_register_mark_object(i64 %14) #10
+  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %14) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
   %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i10.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #10
-  call void @rb_gc_register_mark_object(i64 %16) #10
+  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #11
+  call void @rb_gc_register_mark_object(i64 %16) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
   %"rubyId_block in <class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:A>", align 8
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
@@ -259,12 +258,12 @@ entry:
   %27 = load i64, i64* %26, align 8, !tbaa !6
   %28 = and i64 %27, -33
   store i64 %28, i64* %26, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %21, %struct.rb_control_frame_struct* %23, %struct.rb_iseq_struct* %stackFrame.i) #10
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %21, %struct.rb_control_frame_struct* %23, %struct.rb_iseq_struct* %stackFrame.i) #11
   %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 0
   store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %29, align 8, !dbg !38, !tbaa !20
   %30 = load i64, i64* @rb_cObject, align 8, !dbg !39
-  %31 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %30) #10, !dbg !39
-  %32 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %31) #10, !dbg !39
+  %31 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %30) #11, !dbg !39
+  %32 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %31) #11, !dbg !39
   %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
   %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
   %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 2
@@ -276,12 +275,12 @@ entry:
   %39 = load i64, i64* %38, align 8, !tbaa !6
   %40 = and i64 %39, -33
   store i64 %40, i64* %38, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %33, %struct.rb_control_frame_struct* %35, %struct.rb_iseq_struct* %stackFrame.i.i1) #10
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %33, %struct.rb_control_frame_struct* %35, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
   %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 0
   store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %41, align 8, !dbg !40, !tbaa !20
   %rubyId_foo.i.i2 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !42
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_foo.i.i2) #10, !dbg !42
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %31, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.13<static-init>L62$block_1") #10, !dbg !42
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_foo.i.i2) #11, !dbg !42
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %31, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.13<static-init>L62$block_1") #11, !dbg !42
   %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !42, !tbaa !20
   %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 5, !dbg !42
   %44 = load i32, i32* %43, align 8, !dbg !42, !tbaa !43
@@ -295,7 +294,7 @@ entry:
 50:                                               ; preds = %entry
   %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 8, !dbg !42
   %52 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %51, align 8, !dbg !42, !tbaa !46
-  %53 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %52, i32 noundef 0) #10, !dbg !42
+  %53 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %52, i32 noundef 0) #11, !dbg !42
   br label %rb_vm_check_ints.exit1.i.i, !dbg !42
 
 rb_vm_check_ints.exit1.i.i:                       ; preds = %50, %entry
@@ -324,10 +323,6 @@ rb_vm_check_ints.exit1.i.i:                       ; preds = %50, %entry
   store i64* %64, i64** %61, align 8, !dbg !47
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !47
   store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %41, align 8, !dbg !47, !tbaa !20
-  %rubyId_foo37.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !50
-  %rawSym38.i.i = call i64 @rb_id2sym(i64 %rubyId_foo37.i.i) #10, !dbg !50
-  %rubyId_normal.i.i = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !50
-  %rawSym39.i.i = call i64 @rb_id2sym(i64 %rubyId_normal.i.i) #10, !dbg !50
   %65 = load i64, i64* @guard_epoch_A, align 8, !dbg !50
   %66 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !50, !tbaa !48
   %needTakeSlowPath3 = icmp ne i64 %65, %66, !dbg !50
@@ -344,14 +339,14 @@ rb_vm_check_ints.exit1.i.i:                       ; preds = %50, %entry
   %guardUpdated4 = icmp eq i64 %70, %71, !dbg !50
   call void @llvm.assume(i1 %guardUpdated4), !dbg !50
   %stackFrame43.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8, !dbg !50
-  %72 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !50
+  %72 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !50
   %73 = bitcast i8* %72 to i16*, !dbg !50
   %74 = load i16, i16* %73, align 8, !dbg !50
   %75 = and i16 %74, -384, !dbg !50
   store i16 %75, i16* %73, align 8, !dbg !50
   %76 = getelementptr inbounds i8, i8* %72, i64 4, !dbg !50
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 28, i1 false) #10, !dbg !50
-  call void @sorbet_vm_define_method(i64 %69, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_A#3foo", i8* nonnull %72, %struct.rb_iseq_struct* %stackFrame43.i.i, i1 noundef zeroext false) #10, !dbg !50
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 28, i1 false) #11, !dbg !50
+  call void @sorbet_vm_define_method(i64 %69, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_A#3foo", i8* nonnull %72, %struct.rb_iseq_struct* %stackFrame43.i.i, i1 noundef zeroext false) #11, !dbg !50
   %77 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !50, !tbaa !20
   %78 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 5, !dbg !50
   %79 = load i32, i32* %78, align 8, !dbg !50, !tbaa !43
@@ -365,11 +360,11 @@ rb_vm_check_ints.exit1.i.i:                       ; preds = %50, %entry
 85:                                               ; preds = %68
   %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 8, !dbg !50
   %87 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %86, align 8, !dbg !50, !tbaa !46
-  %88 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %87, i32 noundef 0) #10, !dbg !50
+  %88 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %87, i32 noundef 0) #11, !dbg !50
   br label %"func_<root>.17<static-init>$152.exit", !dbg !50
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %68, %85
-  call void @sorbet_popFrame() #10, !dbg !39
+  call void @sorbet_popFrame() #11, !dbg !39
   store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %29, align 8, !dbg !39, !tbaa !20
   %89 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !10
   %90 = load i64*, i64** %89, align 8, !dbg !10
@@ -395,7 +390,7 @@ rb_vm_check_ints.exit1.i.i:                       ; preds = %50, %entry
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define noundef i64 @"func_A#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #5 !dbg !51 {
+define noundef i64 @"func_A#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #6 !dbg !51 {
 functionEntryInitializers:
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %1, align 8, !tbaa !20
@@ -403,7 +398,7 @@ functionEntryInitializers:
   br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !52, !prof !53
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #12, !dbg !52
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !52
   unreachable, !dbg !52
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
@@ -412,7 +407,7 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_A.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #6 !dbg !17 {
+define internal i64 @"func_A.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !17 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -442,13 +437,13 @@ functionEntryInitializers:
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #7
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #8
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #8
+declare void @llvm.assume(i1 noundef) #9
 
 ; Function Attrs: ssp
-define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #6 {
+define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #7 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !48
@@ -457,7 +452,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #6 {
 }
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_A() local_unnamed_addr #6 {
+define linkonce void @const_recompute_A() local_unnamed_addr #7 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !48
@@ -465,19 +460,20 @@ define linkonce void @const_recompute_A() local_unnamed_addr #6 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #4 = { sspreq }
-attributes #5 = { nounwind sspreq uwtable }
-attributes #6 = { ssp }
-attributes #7 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #8 = { nofree nosync nounwind willreturn }
-attributes #9 = { noreturn nounwind }
-attributes #10 = { nounwind }
-attributes #11 = { nounwind allocsize(0,1) }
-attributes #12 = { noreturn }
+attributes #2 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #5 = { sspreq }
+attributes #6 = { nounwind sspreq uwtable }
+attributes #7 = { ssp }
+attributes #8 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #9 = { nofree nosync nounwind willreturn }
+attributes #10 = { noreturn nounwind }
+attributes #11 = { nounwind }
+attributes #12 = { nounwind allocsize(0,1) }
+attributes #13 = { noreturn }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}

--- a/test/testdata/compiler/unsafe.llo.exp
+++ b/test/testdata/compiler/unsafe.llo.exp
@@ -88,9 +88,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"str_test/testdata/compiler/unsafe.rb" = private unnamed_addr constant [33 x i8] c"test/testdata/compiler/unsafe.rb\00", align 1
 @iseqEncodedArray = internal global [5 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@rubyIdPrecomputed_unsafe = internal unnamed_addr global i64 0, align 8
 @str_unsafe = private unnamed_addr constant [7 x i8] c"unsafe\00", align 1
-@ic_unsafe = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
@@ -140,7 +138,6 @@ entry:
   %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_unsafe, i64 0, i64 0), i64 noundef 6) #6
-  store i64 %1, i64* @rubyIdPrecomputed_unsafe, align 8
   %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #6
   store i64 %2, i64* @rubyIdPrecomputed_puts, align 8
   %3 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
@@ -155,53 +152,51 @@ entry:
   %"rubyStr_test/testdata/compiler/unsafe.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/unsafe.rb", align 8
   %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/unsafe.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %rubyId_unsafe.i = load i64, i64* @rubyIdPrecomputed_unsafe, align 8, !dbg !10
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_unsafe, i64 %rubyId_unsafe.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %6 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !16
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
+  %6 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
   %7 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %6, i64 0, i32 18
-  %8 = load i64, i64* %7, align 8, !tbaa !18
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !16
+  %8 = load i64, i64* %7, align 8, !tbaa !17
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !28
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !27
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %12, align 8, !tbaa !31
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %12, align 8, !tbaa !30
   %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4
-  %14 = load i64*, i64** %13, align 8, !tbaa !33
+  %14 = load i64*, i64** %13, align 8, !tbaa !32
   %15 = load i64, i64* %14, align 8, !tbaa !6
   %16 = and i64 %15, -33
   store i64 %16, i64* %14, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %9, %struct.rb_control_frame_struct* %11, %struct.rb_iseq_struct* %stackFrame.i) #6
   %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %17, align 8, !dbg !34, !tbaa !16
-  call void @llvm.experimental.noalias.scope.decl(metadata !35) #6, !dbg !10
-  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !16
-  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 5, !dbg !10
-  %20 = load i32, i32* %19, align 8, !dbg !10, !tbaa !38
-  %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 6, !dbg !10
-  %22 = load i32, i32* %21, align 4, !dbg !10, !tbaa !39
-  %23 = xor i32 %22, -1, !dbg !10
-  %24 = and i32 %23, %20, !dbg !10
-  %25 = icmp eq i32 %24, 0, !dbg !10
-  br i1 %25, label %"func_<root>.17<static-init>$152.exit", label %26, !dbg !10, !prof !40
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %17, align 8, !dbg !33, !tbaa !15
+  call void @llvm.experimental.noalias.scope.decl(metadata !34) #6, !dbg !37
+  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !15
+  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 5, !dbg !37
+  %20 = load i32, i32* %19, align 8, !dbg !37, !tbaa !38
+  %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 6, !dbg !37
+  %22 = load i32, i32* %21, align 4, !dbg !37, !tbaa !39
+  %23 = xor i32 %22, -1, !dbg !37
+  %24 = and i32 %23, %20, !dbg !37
+  %25 = icmp eq i32 %24, 0, !dbg !37
+  br i1 %25, label %"func_<root>.17<static-init>$152.exit", label %26, !dbg !37, !prof !40
 
 26:                                               ; preds = %entry
-  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !10
-  %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !10, !tbaa !41
-  %29 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #6, !dbg !10
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !10
+  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !37
+  %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !37, !tbaa !41
+  %29 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #6, !dbg !37
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !37
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %entry, %26
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !15
-  %31 = load i64*, i64** %30, align 8, !dbg !15
-  store i64 %8, i64* %31, align 8, !dbg !15, !tbaa !6
-  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !15
-  store i64 3, i64* %32, align 8, !dbg !15, !tbaa !6
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !15
-  store i64* %33, i64** %30, align 8, !dbg !15
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !10
+  %31 = load i64*, i64** %30, align 8, !dbg !10
+  store i64 %8, i64* %31, align 8, !dbg !10, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !10
+  store i64 3, i64* %32, align 8, !dbg !10, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !10
+  store i64* %33, i64** %30, align 8, !dbg !10
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
   ret void
 }
 
@@ -229,35 +224,35 @@ attributes #6 = { nounwind }
 !7 = !{!"long", !8, i64 0}
 !8 = !{!"omnipotent char", !9, i64 0}
 !9 = !{!"Simple C/C++ TBAA"}
-!10 = !DILocation(line: 4, column: 6, scope: !11)
+!10 = !DILocation(line: 4, column: 1, scope: !11)
 !11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !12 = !DISubroutineType(types: !13)
 !13 = !{!14}
 !14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!15 = !DILocation(line: 4, column: 1, scope: !11)
-!16 = !{!17, !17, i64 0}
-!17 = !{!"any pointer", !8, i64 0}
-!18 = !{!19, !7, i64 400}
-!19 = !{!"rb_vm_struct", !7, i64 0, !20, i64 8, !17, i64 192, !17, i64 200, !17, i64 208, !24, i64 216, !8, i64 224, !21, i64 264, !21, i64 280, !21, i64 296, !21, i64 312, !7, i64 328, !23, i64 336, !23, i64 340, !23, i64 344, !23, i64 344, !23, i64 344, !23, i64 344, !23, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !17, i64 456, !17, i64 464, !25, i64 472, !26, i64 992, !17, i64 1016, !17, i64 1024, !23, i64 1032, !23, i64 1036, !21, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !23, i64 1136, !17, i64 1144, !17, i64 1152, !17, i64 1160, !17, i64 1168, !17, i64 1176, !17, i64 1184, !23, i64 1192, !27, i64 1200, !8, i64 1232}
-!20 = !{!"rb_global_vm_lock_struct", !17, i64 0, !8, i64 8, !21, i64 48, !17, i64 64, !23, i64 72, !8, i64 80, !8, i64 128, !23, i64 176, !23, i64 180}
-!21 = !{!"list_head", !22, i64 0}
-!22 = !{!"list_node", !17, i64 0, !17, i64 8}
-!23 = !{!"int", !8, i64 0}
-!24 = !{!"long long", !8, i64 0}
-!25 = !{!"", !8, i64 0}
-!26 = !{!"rb_hook_list_struct", !17, i64 0, !23, i64 8, !23, i64 12, !23, i64 16}
-!27 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!28 = !{!29, !17, i64 16}
-!29 = !{!"rb_execution_context_struct", !17, i64 0, !7, i64 8, !17, i64 16, !17, i64 24, !17, i64 32, !23, i64 40, !23, i64 44, !17, i64 48, !17, i64 56, !17, i64 64, !7, i64 72, !7, i64 80, !17, i64 88, !7, i64 96, !17, i64 104, !17, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !30, i64 152}
-!30 = !{!"", !17, i64 0, !17, i64 8, !7, i64 16, !8, i64 24}
-!31 = !{!32, !17, i64 16}
-!32 = !{!"rb_control_frame_struct", !17, i64 0, !17, i64 8, !17, i64 16, !7, i64 24, !17, i64 32, !17, i64 40, !17, i64 48}
-!33 = !{!32, !17, i64 32}
-!34 = !DILocation(line: 0, scope: !11)
-!35 = !{!36}
-!36 = distinct !{!36, !37, !"sorbet_T_unsafe: argument 0"}
-!37 = distinct !{!37, !"sorbet_T_unsafe"}
-!38 = !{!29, !23, i64 40}
-!39 = !{!29, !23, i64 44}
+!15 = !{!16, !16, i64 0}
+!16 = !{!"any pointer", !8, i64 0}
+!17 = !{!18, !7, i64 400}
+!18 = !{!"rb_vm_struct", !7, i64 0, !19, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !23, i64 216, !8, i64 224, !20, i64 264, !20, i64 280, !20, i64 296, !20, i64 312, !7, i64 328, !22, i64 336, !22, i64 340, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !24, i64 472, !25, i64 992, !16, i64 1016, !16, i64 1024, !22, i64 1032, !22, i64 1036, !20, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !22, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !22, i64 1192, !26, i64 1200, !8, i64 1232}
+!19 = !{!"rb_global_vm_lock_struct", !16, i64 0, !8, i64 8, !20, i64 48, !16, i64 64, !22, i64 72, !8, i64 80, !8, i64 128, !22, i64 176, !22, i64 180}
+!20 = !{!"list_head", !21, i64 0}
+!21 = !{!"list_node", !16, i64 0, !16, i64 8}
+!22 = !{!"int", !8, i64 0}
+!23 = !{!"long long", !8, i64 0}
+!24 = !{!"", !8, i64 0}
+!25 = !{!"rb_hook_list_struct", !16, i64 0, !22, i64 8, !22, i64 12, !22, i64 16}
+!26 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!27 = !{!28, !16, i64 16}
+!28 = !{!"rb_execution_context_struct", !16, i64 0, !7, i64 8, !16, i64 16, !16, i64 24, !16, i64 32, !22, i64 40, !22, i64 44, !16, i64 48, !16, i64 56, !16, i64 64, !7, i64 72, !7, i64 80, !16, i64 88, !7, i64 96, !16, i64 104, !16, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !29, i64 152}
+!29 = !{!"", !16, i64 0, !16, i64 8, !7, i64 16, !8, i64 24}
+!30 = !{!31, !16, i64 16}
+!31 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !7, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
+!32 = !{!31, !16, i64 32}
+!33 = !DILocation(line: 0, scope: !11)
+!34 = !{!35}
+!35 = distinct !{!35, !36, !"sorbet_T_unsafe: argument 0"}
+!36 = distinct !{!36, !"sorbet_T_unsafe"}
+!37 = !DILocation(line: 4, column: 6, scope: !11)
+!38 = !{!28, !22, i64 40}
+!39 = !{!28, !22, i64 44}
 !40 = !{!"branch_weights", i32 2000, i32 1}
-!41 = !{!29, !17, i64 56}
+!41 = !{!28, !16, i64 56}

--- a/test/testdata/ruby_benchmark/app_fib.llo.exp
+++ b/test/testdata/ruby_benchmark/app_fib.llo.exp
@@ -114,7 +114,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_HasFib.13<static-init>$block_1" = unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_block in <class:HasFib>" = internal unnamed_addr global i64 0, align 8
 @"str_block in <class:HasFib>" = private unnamed_addr constant [24 x i8] c"block in <class:HasFib>\00", align 1
-@rubyIdPrecomputed_final = internal unnamed_addr global i64 0, align 8
 @str_final = private unnamed_addr constant [6 x i8] c"final\00", align 1
 @rubyIdPrecomputed_n = internal unnamed_addr global i64 0, align 8
 @str_n = private unnamed_addr constant [2 x i8] c"n\00", align 1
@@ -124,68 +123,68 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_returns = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_returns = internal unnamed_addr global i64 0, align 8
 @str_returns = private unnamed_addr constant [8 x i8] c"returns\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @guard_epoch_HasFib = linkonce local_unnamed_addr global i64 0
 @guarded_const_HasFib = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
 
+; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 ; Function Attrs: nounwind readnone willreturn
-declare i64 @rb_obj_is_kind_of(i64, i64) local_unnamed_addr #1
+declare i64 @rb_obj_is_kind_of(i64, i64) local_unnamed_addr #0
 
 ; Function Attrs: cold noreturn
-declare void @sorbet_cast_failure(i64, i8*, i8*) local_unnamed_addr #2
+declare void @sorbet_cast_failure(i64, i8*, i8*) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
-declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #3
+declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #2
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #3
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #3
 
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
+declare i64 @sorbet_readRealpath() local_unnamed_addr #3
 
-declare %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache*, i64, %struct.rb_iseq_struct*) local_unnamed_addr #0
+declare %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache*, i64, %struct.rb_iseq_struct*) local_unnamed_addr #3
 
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #3
 
-declare void @sorbet_popFrame() local_unnamed_addr #0
+declare void @sorbet_popFrame() local_unnamed_addr #3
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #3
 
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #3
 
-declare void @sorbet_vmMethodSearch(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+declare void @sorbet_vmMethodSearch(%struct.FunctionInlineCache*, i64) local_unnamed_addr #3
 
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #3
 
-declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_rb_int_minus_slowpath(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_rb_int_minus_slowpath(i64, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_rb_int_lt_slowpath(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_rb_int_lt_slowpath(i64, i64) local_unnamed_addr #3
 
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
 
 ; Function Attrs: nounwind readnone willreturn
-declare i64 @rb_class_inherited_p(i64, i64) local_unnamed_addr #1
+declare i64 @rb_class_inherited_p(i64, i64) local_unnamed_addr #0
 
-declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #3
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #3
 
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #3
 
 ; Function Attrs: noreturn
-declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #3
+declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
 
-declare i64 @rb_int2big(i64) local_unnamed_addr #0
+declare i64 @rb_int2big(i64) local_unnamed_addr #3
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
 declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #4
@@ -193,7 +192,7 @@ declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #4
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
 declare { i64, i1 } @llvm.ssub.with.overflow.i64(i64, i64) #4
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #3
 
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #5
@@ -235,182 +234,176 @@ functionEntryInitializers:
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #16
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !23, !tbaa !14
-  %rubyId_final = load i64, i64* @rubyIdPrecomputed_final, align 8, !dbg !24
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_final), !dbg !24
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !25, !tbaa !14
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !25
-  %11 = load i32, i32* %10, align 8, !dbg !25, !tbaa !26
-  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !25
-  %13 = load i32, i32* %12, align 4, !dbg !25, !tbaa !27
-  %14 = xor i32 %13, -1, !dbg !25
-  %15 = and i32 %14, %11, !dbg !25
-  %16 = icmp eq i32 %15, 0, !dbg !25
-  br i1 %16, label %rb_vm_check_ints.exit1, label %17, !dbg !25, !prof !28
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !14
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !24
+  %11 = load i32, i32* %10, align 8, !dbg !24, !tbaa !25
+  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !24
+  %13 = load i32, i32* %12, align 4, !dbg !24, !tbaa !26
+  %14 = xor i32 %13, -1, !dbg !24
+  %15 = and i32 %14, %11, !dbg !24
+  %16 = icmp eq i32 %15, 0, !dbg !24
+  br i1 %16, label %rb_vm_check_ints.exit1, label %17, !dbg !24, !prof !27
 
 17:                                               ; preds = %functionEntryInitializers
-  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !25
-  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !25, !tbaa !29
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !25
-  br label %rb_vm_check_ints.exit1, !dbg !25
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
+  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !24, !tbaa !28
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !24
+  br label %rb_vm_check_ints.exit1, !dbg !24
 
 rb_vm_check_ints.exit1:                           ; preds = %functionEntryInitializers, %17
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !25, !tbaa !14
-  %rubyId_fib = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !30
-  %rawSym27 = tail call i64 @rb_id2sym(i64 %rubyId_fib), !dbg !30
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !30
-  %rawSym28 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !30
-  %21 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !30
-  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
-  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !30
-  br i1 %needTakeSlowPath, label %23, label %24, !dbg !30, !prof !33
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !24, !tbaa !14
+  %21 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !29
+  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !29, !tbaa !30
+  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !29
+  br i1 %needTakeSlowPath, label %23, label %24, !dbg !29, !prof !32
 
 23:                                               ; preds = %rb_vm_check_ints.exit1
-  tail call void @const_recompute_HasFib(), !dbg !30
-  br label %24, !dbg !30
+  tail call void @const_recompute_HasFib(), !dbg !29
+  br label %24, !dbg !29
 
 24:                                               ; preds = %rb_vm_check_ints.exit1, %23
-  %25 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !30
-  %26 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !30
-  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !31
-  %guardUpdated = icmp eq i64 %26, %27, !dbg !30
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !30
-  %stackFrame32 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8, !dbg !30
-  %28 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !30
-  %29 = bitcast i8* %28 to i16*, !dbg !30
-  %30 = load i16, i16* %29, align 8, !dbg !30
-  %31 = and i16 %30, -384, !dbg !30
-  %32 = or i16 %31, 1, !dbg !30
-  store i16 %32, i16* %29, align 8, !dbg !30
-  %33 = getelementptr inbounds i8, i8* %28, i64 8, !dbg !30
-  %34 = bitcast i8* %33 to i32*, !dbg !30
-  store i32 1, i32* %34, align 8, !dbg !30, !tbaa !34
-  %35 = getelementptr inbounds i8, i8* %28, i64 12, !dbg !30
-  %36 = bitcast i8* %35 to i32*, !dbg !30
-  %37 = getelementptr inbounds i8, i8* %28, i64 4, !dbg !30
-  %38 = bitcast i8* %37 to i32*, !dbg !30
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %35, i8 0, i64 20, i1 false), !dbg !30
-  store i32 1, i32* %38, align 4, !dbg !30, !tbaa !37
-  %positional_table = alloca i64, align 8, !dbg !30
-  %rubyId_n = load i64, i64* @rubyIdPrecomputed_n, align 8, !dbg !30
-  store i64 %rubyId_n, i64* %positional_table, align 8, !dbg !30
-  %39 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !30
-  %40 = bitcast i64* %positional_table to i8*, !dbg !30
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %39, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %40, i64 noundef 8, i1 noundef false) #16, !dbg !30
-  %41 = getelementptr inbounds i8, i8* %28, i64 32, !dbg !30
-  %42 = bitcast i8* %41 to i8**, !dbg !30
-  store i8* %39, i8** %42, align 8, !dbg !30, !tbaa !38
-  tail call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_fib, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @func_HasFib.3fib, i8* nonnull %28, %struct.rb_iseq_struct* %stackFrame32, i1 noundef zeroext true) #16, !dbg !30
-  %43 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !14
-  %44 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 5, !dbg !30
-  %45 = load i32, i32* %44, align 8, !dbg !30, !tbaa !26
-  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 6, !dbg !30
-  %47 = load i32, i32* %46, align 4, !dbg !30, !tbaa !27
-  %48 = xor i32 %47, -1, !dbg !30
-  %49 = and i32 %48, %45, !dbg !30
-  %50 = icmp eq i32 %49, 0, !dbg !30
-  br i1 %50, label %rb_vm_check_ints.exit, label %51, !dbg !30, !prof !28
+  %25 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !29
+  %26 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !29
+  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !29, !tbaa !30
+  %guardUpdated = icmp eq i64 %26, %27, !dbg !29
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !29
+  %stackFrame32 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8, !dbg !29
+  %28 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !29
+  %29 = bitcast i8* %28 to i16*, !dbg !29
+  %30 = load i16, i16* %29, align 8, !dbg !29
+  %31 = and i16 %30, -384, !dbg !29
+  %32 = or i16 %31, 1, !dbg !29
+  store i16 %32, i16* %29, align 8, !dbg !29
+  %33 = getelementptr inbounds i8, i8* %28, i64 8, !dbg !29
+  %34 = bitcast i8* %33 to i32*, !dbg !29
+  store i32 1, i32* %34, align 8, !dbg !29, !tbaa !33
+  %35 = getelementptr inbounds i8, i8* %28, i64 12, !dbg !29
+  %36 = bitcast i8* %35 to i32*, !dbg !29
+  %37 = getelementptr inbounds i8, i8* %28, i64 4, !dbg !29
+  %38 = bitcast i8* %37 to i32*, !dbg !29
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %35, i8 0, i64 20, i1 false), !dbg !29
+  store i32 1, i32* %38, align 4, !dbg !29, !tbaa !36
+  %positional_table = alloca i64, align 8, !dbg !29
+  %rubyId_n = load i64, i64* @rubyIdPrecomputed_n, align 8, !dbg !29
+  store i64 %rubyId_n, i64* %positional_table, align 8, !dbg !29
+  %39 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !29
+  %40 = bitcast i64* %positional_table to i8*, !dbg !29
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %39, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %40, i64 noundef 8, i1 noundef false) #16, !dbg !29
+  %41 = getelementptr inbounds i8, i8* %28, i64 32, !dbg !29
+  %42 = bitcast i8* %41 to i8**, !dbg !29
+  store i8* %39, i8** %42, align 8, !dbg !29, !tbaa !37
+  tail call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_fib, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @func_HasFib.3fib, i8* nonnull %28, %struct.rb_iseq_struct* %stackFrame32, i1 noundef zeroext true) #16, !dbg !29
+  %43 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
+  %44 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 5, !dbg !29
+  %45 = load i32, i32* %44, align 8, !dbg !29, !tbaa !25
+  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 6, !dbg !29
+  %47 = load i32, i32* %46, align 4, !dbg !29, !tbaa !26
+  %48 = xor i32 %47, -1, !dbg !29
+  %49 = and i32 %48, %45, !dbg !29
+  %50 = icmp eq i32 %49, 0, !dbg !29
+  br i1 %50, label %rb_vm_check_ints.exit, label %51, !dbg !29, !prof !27
 
 51:                                               ; preds = %24
-  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 8, !dbg !30
-  %53 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %52, align 8, !dbg !30, !tbaa !29
-  %54 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %53, i32 noundef 0) #16, !dbg !30
-  br label %rb_vm_check_ints.exit, !dbg !30
+  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 8, !dbg !29
+  %53 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %52, align 8, !dbg !29, !tbaa !28
+  %54 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %53, i32 noundef 0) #16, !dbg !29
+  br label %rb_vm_check_ints.exit, !dbg !29
 
 rb_vm_check_ints.exit:                            ; preds = %24, %51
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @func_HasFib.3fib(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %callData) #8 !dbg !39 {
+define i64 @func_HasFib.3fib(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %callData) #8 !dbg !38 {
 functionEntryInitializers:
   %callArgs = alloca [2 x i64], align 8
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !14
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !40
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !40
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !40
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !40, !prof !41
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !39
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !39
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !39
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !39, !prof !40
 
 BB3:                                              ; preds = %rb_vm_check_ints.exit98
   store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %0, align 8, !tbaa !14
-  store i64 3, i64* %callArgs0Addr, align 8, !dbg !42
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !43), !dbg !42
-  %1 = load i64, i64* %68, align 8, !dbg !42, !tbaa !6, !alias.scope !43
-  %2 = and i64 %1, %70, !dbg !42
-  %3 = icmp eq i64 %2, 0, !dbg !42
-  br i1 %3, label %13, label %4, !dbg !42, !prof !41
+  store i64 3, i64* %callArgs0Addr, align 8, !dbg !41
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !42), !dbg !41
+  %1 = load i64, i64* %68, align 8, !dbg !41, !tbaa !6, !alias.scope !42
+  %2 = and i64 %1, %70, !dbg !41
+  %3 = icmp eq i64 %2, 0, !dbg !41
+  br i1 %3, label %13, label %4, !dbg !41, !prof !40
 
 4:                                                ; preds = %BB3
-  %5 = add nsw i64 %1, -1, !dbg !42
-  %6 = tail call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 %rawArg_n, i64 %5) #18, !dbg !42
-  %7 = extractvalue { i64, i1 } %6, 1, !dbg !42
-  %8 = extractvalue { i64, i1 } %6, 0, !dbg !42
-  br i1 %7, label %9, label %sorbet_rb_int_minus.exit, !dbg !42
+  %5 = add nsw i64 %1, -1, !dbg !41
+  %6 = tail call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 %rawArg_n, i64 %5) #18, !dbg !41
+  %7 = extractvalue { i64, i1 } %6, 1, !dbg !41
+  %8 = extractvalue { i64, i1 } %6, 0, !dbg !41
+  br i1 %7, label %9, label %sorbet_rb_int_minus.exit, !dbg !41
 
 9:                                                ; preds = %4
-  %10 = ashr i64 %8, 1, !dbg !42
-  %11 = xor i64 %10, -9223372036854775808, !dbg !42
-  %12 = tail call i64 @rb_int2big(i64 %11) #16, !dbg !42, !noalias !43
-  br label %sorbet_rb_int_minus.exit, !dbg !42
+  %10 = ashr i64 %8, 1, !dbg !41
+  %11 = xor i64 %10, -9223372036854775808, !dbg !41
+  %12 = tail call i64 @rb_int2big(i64 %11) #16, !dbg !41, !noalias !42
+  br label %sorbet_rb_int_minus.exit, !dbg !41
 
 13:                                               ; preds = %BB3
-  %14 = tail call i64 @sorbet_rb_int_minus_slowpath(i64 %rawArg_n, i64 %1) #16, !dbg !42, !noalias !43
-  br label %sorbet_rb_int_minus.exit, !dbg !42
+  %14 = tail call i64 @sorbet_rb_int_minus_slowpath(i64 %rawArg_n, i64 %1) #16, !dbg !41, !noalias !42
+  br label %sorbet_rb_int_minus.exit, !dbg !41
 
 sorbet_rb_int_minus.exit:                         ; preds = %9, %4, %13
-  %15 = phi i64 [ %14, %13 ], [ %12, %9 ], [ %8, %4 ], !dbg !42
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !42, !tbaa !14
-  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 5, !dbg !42
-  %18 = load i32, i32* %17, align 8, !dbg !42, !tbaa !26
-  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 6, !dbg !42
-  %20 = load i32, i32* %19, align 4, !dbg !42, !tbaa !27
-  %21 = xor i32 %20, -1, !dbg !42
-  %22 = and i32 %21, %18, !dbg !42
-  %23 = icmp eq i32 %22, 0, !dbg !42
-  br i1 %23, label %rb_vm_check_ints.exit, label %24, !dbg !42, !prof !28
+  %15 = phi i64 [ %14, %13 ], [ %12, %9 ], [ %8, %4 ], !dbg !41
+  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !41, !tbaa !14
+  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 5, !dbg !41
+  %18 = load i32, i32* %17, align 8, !dbg !41, !tbaa !25
+  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 6, !dbg !41
+  %20 = load i32, i32* %19, align 4, !dbg !41, !tbaa !26
+  %21 = xor i32 %20, -1, !dbg !41
+  %22 = and i32 %21, %18, !dbg !41
+  %23 = icmp eq i32 %22, 0, !dbg !41
+  br i1 %23, label %rb_vm_check_ints.exit, label %24, !dbg !41, !prof !27
 
 24:                                               ; preds = %sorbet_rb_int_minus.exit
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 8, !dbg !42
-  %26 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %25, align 8, !dbg !42, !tbaa !29
-  %27 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %26, i32 noundef 0) #16, !dbg !42
-  br label %rb_vm_check_ints.exit, !dbg !42
+  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 8, !dbg !41
+  %26 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %25, align 8, !dbg !41, !tbaa !28
+  %27 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %26, i32 noundef 0) #16, !dbg !41
+  br label %rb_vm_check_ints.exit, !dbg !41
 
 rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_minus.exit, %24
-  %28 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !46
-  %29 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !31
-  %needTakeSlowPath = icmp ne i64 %28, %29, !dbg !46
-  br i1 %needTakeSlowPath, label %30, label %31, !dbg !46, !prof !33
+  %28 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !45
+  %29 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !45, !tbaa !30
+  %needTakeSlowPath = icmp ne i64 %28, %29, !dbg !45
+  br i1 %needTakeSlowPath, label %30, label %31, !dbg !45, !prof !32
 
 30:                                               ; preds = %rb_vm_check_ints.exit
-  tail call void @const_recompute_HasFib(), !dbg !46
-  br label %31, !dbg !46
+  tail call void @const_recompute_HasFib(), !dbg !45
+  br label %31, !dbg !45
 
 31:                                               ; preds = %rb_vm_check_ints.exit, %30
-  %32 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !46
-  %33 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !46
-  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !31
-  %guardUpdated = icmp eq i64 %33, %34, !dbg !46
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !46
-  %35 = icmp eq i64 %selfRaw, %32, !dbg !46
-  br i1 %35, label %fastFinalCall_fib, label %36, !dbg !46
+  %32 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !45
+  %33 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !45
+  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !45, !tbaa !30
+  %guardUpdated = icmp eq i64 %33, %34, !dbg !45
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !45
+  %35 = icmp eq i64 %selfRaw, %32, !dbg !45
+  br i1 %35, label %fastFinalCall_fib, label %36, !dbg !45
 
 36:                                               ; preds = %31
-  %37 = load i64, i64* @rb_cModule, align 8, !dbg !46, !tbaa !6
-  %38 = tail call i64 @rb_obj_is_kind_of(i64 %selfRaw, i64 %37), !dbg !46
-  %39 = icmp eq i64 %38, 0, !dbg !46
-  br i1 %39, label %slowFinalCall_fib, label %sorbet_isa_class_of.exit, !dbg !46, !prof !47
+  %37 = load i64, i64* @rb_cModule, align 8, !dbg !45, !tbaa !6
+  %38 = tail call i64 @rb_obj_is_kind_of(i64 %selfRaw, i64 %37), !dbg !45
+  %39 = icmp eq i64 %38, 0, !dbg !45
+  br i1 %39, label %slowFinalCall_fib, label %sorbet_isa_class_of.exit, !dbg !45, !prof !46
 
 sorbet_isa_class_of.exit:                         ; preds = %36
-  %40 = tail call i64 @rb_class_inherited_p(i64 %selfRaw, i64 %32) #19, !dbg !46
-  %41 = icmp ne i64 %40, 0, !dbg !46
-  br i1 %41, label %fastFinalCall_fib, label %slowFinalCall_fib, !dbg !46, !prof !28
+  %40 = tail call i64 @rb_class_inherited_p(i64 %selfRaw, i64 %32) #19, !dbg !45
+  %41 = icmp ne i64 %40, 0, !dbg !45
+  br i1 %41, label %fastFinalCall_fib, label %slowFinalCall_fib, !dbg !45, !prof !27
 
 BB4:                                              ; preds = %183, %sorbet_rb_int_plus.exit, %"alternativeCallIntrinsic_Integer_+"
-  %"<returnMethodTemp>.sroa.0.0" = phi i64 [ %send107, %"alternativeCallIntrinsic_Integer_+" ], [ %174, %sorbet_rb_int_plus.exit ], [ %174, %183 ], !dbg !48
+  %"<returnMethodTemp>.sroa.0.0" = phi i64 [ %send107, %"alternativeCallIntrinsic_Integer_+" ], [ %174, %sorbet_rb_int_plus.exit ], [ %174, %183 ], !dbg !47
   store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !14
   %42 = and i64 %"<returnMethodTemp>.sroa.0.0", 1
   %43 = icmp eq i64 %42, 0
-  br i1 %43, label %44, label %typeTestSuccess77, !prof !49
+  br i1 %43, label %44, label %typeTestSuccess77, !prof !48
 
 44:                                               ; preds = %BB4
   %45 = and i64 %"<returnMethodTemp>.sroa.0.0", 7
@@ -423,271 +416,271 @@ BB4:                                              ; preds = %183, %sorbet_rb_int
 sorbet_isa_Integer.exit:                          ; preds = %44
   %50 = inttoptr i64 %"<returnMethodTemp>.sroa.0.0" to %struct.iseq_inline_iv_cache_entry*
   %51 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %50, i64 0, i32 0
-  %52 = load i64, i64* %51, align 8, !tbaa !50
+  %52 = load i64, i64* %51, align 8, !tbaa !49
   %53 = and i64 %52, 31
   %54 = icmp eq i64 %53, 10
-  br i1 %54, label %typeTestSuccess77, label %codeRepl, !prof !28
+  br i1 %54, label %typeTestSuccess77, label %codeRepl, !prof !27
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #20, !dbg !40
-  unreachable, !dbg !40
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #20, !dbg !39
+  unreachable, !dbg !39
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_n = load i64, i64* %argArray, align 8, !dbg !40
-  %55 = and i64 %rawArg_n, 1, !dbg !52
-  %56 = icmp eq i64 %55, 0, !dbg !52
-  br i1 %56, label %57, label %typeTestSuccess, !dbg !52, !prof !49
+  %rawArg_n = load i64, i64* %argArray, align 8, !dbg !39
+  %55 = and i64 %rawArg_n, 1, !dbg !51
+  %56 = icmp eq i64 %55, 0, !dbg !51
+  br i1 %56, label %57, label %typeTestSuccess, !dbg !51, !prof !48
 
 57:                                               ; preds = %fillRequiredArgs
-  %58 = and i64 %rawArg_n, 7, !dbg !52
-  %59 = icmp ne i64 %58, 0, !dbg !52
-  %60 = and i64 %rawArg_n, -9, !dbg !52
-  %61 = icmp eq i64 %60, 0, !dbg !52
-  %62 = or i1 %59, %61, !dbg !52
-  br i1 %62, label %codeRepl103, label %sorbet_isa_Integer.exit109, !dbg !52
+  %58 = and i64 %rawArg_n, 7, !dbg !51
+  %59 = icmp ne i64 %58, 0, !dbg !51
+  %60 = and i64 %rawArg_n, -9, !dbg !51
+  %61 = icmp eq i64 %60, 0, !dbg !51
+  %62 = or i1 %59, %61, !dbg !51
+  br i1 %62, label %codeRepl103, label %sorbet_isa_Integer.exit109, !dbg !51
 
 sorbet_isa_Integer.exit109:                       ; preds = %57
-  %63 = inttoptr i64 %rawArg_n to %struct.iseq_inline_iv_cache_entry*, !dbg !52
-  %64 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %63, i64 0, i32 0, !dbg !52
-  %65 = load i64, i64* %64, align 8, !dbg !52, !tbaa !50
-  %66 = and i64 %65, 31, !dbg !52
-  %67 = icmp eq i64 %66, 10, !dbg !52
-  br i1 %67, label %typeTestSuccess, label %codeRepl103, !dbg !52, !prof !28
+  %63 = inttoptr i64 %rawArg_n to %struct.iseq_inline_iv_cache_entry*, !dbg !51
+  %64 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %63, i64 0, i32 0, !dbg !51
+  %65 = load i64, i64* %64, align 8, !dbg !51, !tbaa !49
+  %66 = and i64 %65, 31, !dbg !51
+  %67 = icmp eq i64 %66, 10, !dbg !51
+  br i1 %67, label %typeTestSuccess, label %codeRepl103, !dbg !51, !prof !27
 
 typeTestSuccess:                                  ; preds = %fillRequiredArgs, %sorbet_isa_Integer.exit109
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !52, !tbaa !14
-  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !53
-  store i64 7, i64* %callArgs0Addr, align 8, !dbg !53
-  %68 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !53
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !54), !dbg !53
-  %69 = load i64, i64* %68, align 8, !dbg !53, !tbaa !6, !alias.scope !54
-  %70 = and i64 %rawArg_n, 1, !dbg !53
-  %71 = and i64 %69, %70, !dbg !53
-  %72 = icmp eq i64 %71, 0, !dbg !53
-  br i1 %72, label %78, label %73, !dbg !53, !prof !41
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !51, !tbaa !14
+  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !52
+  store i64 7, i64* %callArgs0Addr, align 8, !dbg !52
+  %68 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !52
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !53), !dbg !52
+  %69 = load i64, i64* %68, align 8, !dbg !52, !tbaa !6, !alias.scope !53
+  %70 = and i64 %rawArg_n, 1, !dbg !52
+  %71 = and i64 %69, %70, !dbg !52
+  %72 = icmp eq i64 %71, 0, !dbg !52
+  br i1 %72, label %78, label %73, !dbg !52, !prof !40
 
 73:                                               ; preds = %typeTestSuccess
-  %74 = ashr i64 %rawArg_n, 1, !dbg !53
-  %75 = ashr i64 %69, 1, !dbg !53
-  %76 = icmp slt i64 %74, %75, !dbg !53
-  %77 = select i1 %76, i64 20, i64 0, !dbg !53
-  br label %sorbet_rb_int_lt.exit, !dbg !53
+  %74 = ashr i64 %rawArg_n, 1, !dbg !52
+  %75 = ashr i64 %69, 1, !dbg !52
+  %76 = icmp slt i64 %74, %75, !dbg !52
+  %77 = select i1 %76, i64 20, i64 0, !dbg !52
+  br label %sorbet_rb_int_lt.exit, !dbg !52
 
 78:                                               ; preds = %typeTestSuccess
-  %79 = tail call i64 @sorbet_rb_int_lt_slowpath(i64 %rawArg_n, i64 %69) #16, !dbg !53, !noalias !54
-  br label %sorbet_rb_int_lt.exit, !dbg !53
+  %79 = tail call i64 @sorbet_rb_int_lt_slowpath(i64 %rawArg_n, i64 %69) #16, !dbg !52, !noalias !53
+  br label %sorbet_rb_int_lt.exit, !dbg !52
 
 sorbet_rb_int_lt.exit:                            ; preds = %78, %73
   %rawSendResult95 = phi i64 [ %77, %73 ], [ %79, %78 ]
-  %80 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !53, !tbaa !14
-  %81 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 5, !dbg !53
-  %82 = load i32, i32* %81, align 8, !dbg !53, !tbaa !26
-  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 6, !dbg !53
-  %84 = load i32, i32* %83, align 4, !dbg !53, !tbaa !27
-  %85 = xor i32 %84, -1, !dbg !53
-  %86 = and i32 %85, %82, !dbg !53
-  %87 = icmp eq i32 %86, 0, !dbg !53
-  br i1 %87, label %rb_vm_check_ints.exit98, label %88, !dbg !53, !prof !28
+  %80 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !14
+  %81 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 5, !dbg !52
+  %82 = load i32, i32* %81, align 8, !dbg !52, !tbaa !25
+  %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 6, !dbg !52
+  %84 = load i32, i32* %83, align 4, !dbg !52, !tbaa !26
+  %85 = xor i32 %84, -1, !dbg !52
+  %86 = and i32 %85, %82, !dbg !52
+  %87 = icmp eq i32 %86, 0, !dbg !52
+  br i1 %87, label %rb_vm_check_ints.exit98, label %88, !dbg !52, !prof !27
 
 88:                                               ; preds = %sorbet_rb_int_lt.exit
-  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 8, !dbg !53
-  %90 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %89, align 8, !dbg !53, !tbaa !29
-  %91 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %90, i32 noundef 0) #16, !dbg !53
-  br label %rb_vm_check_ints.exit98, !dbg !53
+  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %80, i64 0, i32 8, !dbg !52
+  %90 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %89, align 8, !dbg !52, !tbaa !28
+  %91 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %90, i32 noundef 0) #16, !dbg !52
+  br label %rb_vm_check_ints.exit98, !dbg !52
 
 rb_vm_check_ints.exit98:                          ; preds = %sorbet_rb_int_lt.exit, %88
-  %92 = and i64 %rawSendResult95, -9, !dbg !53
-  %93 = icmp ne i64 %92, 0, !dbg !53
-  br i1 %93, label %BB4.thread, label %BB3, !dbg !53
+  %92 = and i64 %rawSendResult95, -9, !dbg !52
+  %93 = icmp ne i64 %92, 0, !dbg !52
+  br i1 %93, label %BB4.thread, label %BB3, !dbg !52
 
 BB4.thread:                                       ; preds = %rb_vm_check_ints.exit98
   store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !14
   br label %typeTestSuccess77
 
 codeRepl103:                                      ; preds = %57, %sorbet_isa_Integer.exit109
-  tail call fastcc void @func_HasFib.3fib.cold.2(i64 %rawArg_n) #21, !dbg !52
+  tail call fastcc void @func_HasFib.3fib.cold.2(i64 %rawArg_n) #21, !dbg !51
   unreachable
 
 fastFinalCall_fib:                                ; preds = %31, %sorbet_isa_class_of.exit
-  store i64 %15, i64* %callArgs0Addr, align 8, !dbg !46
-  %94 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8, !dbg !46
-  %95 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.3, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !46, !tbaa !57
-  %96 = icmp eq %struct.rb_callable_method_entry_struct* %95, null, !dbg !46
-  br i1 %96, label %97, label %sorbet_callFuncDirect.exit96, !dbg !46, !prof !49
+  store i64 %15, i64* %callArgs0Addr, align 8, !dbg !45
+  %94 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8, !dbg !45
+  %95 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.3, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !45, !tbaa !56
+  %96 = icmp eq %struct.rb_callable_method_entry_struct* %95, null, !dbg !45
+  br i1 %96, label %97, label %sorbet_callFuncDirect.exit96, !dbg !45, !prof !48
 
 97:                                               ; preds = %fastFinalCall_fib
-  tail call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.3, i64 %selfRaw) #16, !dbg !46
-  br label %sorbet_callFuncDirect.exit96, !dbg !46
+  tail call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.3, i64 %selfRaw) #16, !dbg !45
+  br label %sorbet_callFuncDirect.exit96, !dbg !45
 
 sorbet_callFuncDirect.exit96:                     ; preds = %fastFinalCall_fib, %97
-  %98 = tail call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.3, i64 %selfRaw, %struct.rb_iseq_struct* %94) #16, !dbg !46
-  %99 = call i64 @func_HasFib.3fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %68, i64 %selfRaw, %struct.rb_control_frame_struct* align 8 %98, i8* noalias nocapture nofree nonnull readnone align 16 dereferenceable(88) undef) #16, !dbg !46
-  tail call void @sorbet_popFrame() #16, !dbg !46
-  br label %afterFinalCall_fib, !dbg !46
+  %98 = tail call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.3, i64 %selfRaw, %struct.rb_iseq_struct* %94) #16, !dbg !45
+  %99 = call i64 @func_HasFib.3fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %68, i64 %selfRaw, %struct.rb_control_frame_struct* align 8 %98, i8* noalias nocapture nofree nonnull readnone align 16 dereferenceable(88) undef) #16, !dbg !45
+  tail call void @sorbet_popFrame() #16, !dbg !45
+  br label %afterFinalCall_fib, !dbg !45
 
 slowFinalCall_fib:                                ; preds = %36, %sorbet_isa_class_of.exit
-  %100 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !46
-  %101 = load i64*, i64** %100, align 8, !dbg !46
-  store i64 %selfRaw, i64* %101, align 8, !dbg !46, !tbaa !6
-  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !46
-  store i64 %15, i64* %102, align 8, !dbg !46, !tbaa !6
-  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !46
-  store i64* %103, i64** %100, align 8, !dbg !46
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fib.4, i64 0), !dbg !46
-  br label %afterFinalCall_fib, !dbg !46
+  %100 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !45
+  %101 = load i64*, i64** %100, align 8, !dbg !45
+  store i64 %selfRaw, i64* %101, align 8, !dbg !45, !tbaa !6
+  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !45
+  store i64 %15, i64* %102, align 8, !dbg !45, !tbaa !6
+  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !45
+  store i64* %103, i64** %100, align 8, !dbg !45
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fib.4, i64 0), !dbg !45
+  br label %afterFinalCall_fib, !dbg !45
 
 afterFinalCall_fib:                               ; preds = %slowFinalCall_fib, %sorbet_callFuncDirect.exit96
   %104 = phi i1 [ true, %sorbet_callFuncDirect.exit96 ], [ false, %slowFinalCall_fib ]
-  %finalCallResult_fib = phi i64 [ %99, %sorbet_callFuncDirect.exit96 ], [ %send, %slowFinalCall_fib ], !dbg !46
-  store i64 5, i64* %callArgs0Addr, align 8, !dbg !63
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !64), !dbg !63
-  %105 = load i64, i64* %68, align 8, !dbg !63, !tbaa !6, !alias.scope !64
-  %106 = and i64 %105, %70, !dbg !63
-  %107 = icmp eq i64 %106, 0, !dbg !63
-  br i1 %107, label %117, label %108, !dbg !63, !prof !41
+  %finalCallResult_fib = phi i64 [ %99, %sorbet_callFuncDirect.exit96 ], [ %send, %slowFinalCall_fib ], !dbg !45
+  store i64 5, i64* %callArgs0Addr, align 8, !dbg !62
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !63), !dbg !62
+  %105 = load i64, i64* %68, align 8, !dbg !62, !tbaa !6, !alias.scope !63
+  %106 = and i64 %105, %70, !dbg !62
+  %107 = icmp eq i64 %106, 0, !dbg !62
+  br i1 %107, label %117, label %108, !dbg !62, !prof !40
 
 108:                                              ; preds = %afterFinalCall_fib
-  %109 = add nsw i64 %105, -1, !dbg !63
-  %110 = tail call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 %rawArg_n, i64 %109) #18, !dbg !63
-  %111 = extractvalue { i64, i1 } %110, 1, !dbg !63
-  %112 = extractvalue { i64, i1 } %110, 0, !dbg !63
-  br i1 %111, label %113, label %sorbet_rb_int_minus.exit97, !dbg !63
+  %109 = add nsw i64 %105, -1, !dbg !62
+  %110 = tail call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 %rawArg_n, i64 %109) #18, !dbg !62
+  %111 = extractvalue { i64, i1 } %110, 1, !dbg !62
+  %112 = extractvalue { i64, i1 } %110, 0, !dbg !62
+  br i1 %111, label %113, label %sorbet_rb_int_minus.exit97, !dbg !62
 
 113:                                              ; preds = %108
-  %114 = ashr i64 %112, 1, !dbg !63
-  %115 = xor i64 %114, -9223372036854775808, !dbg !63
-  %116 = tail call i64 @rb_int2big(i64 %115) #16, !dbg !63, !noalias !64
-  br label %sorbet_rb_int_minus.exit97, !dbg !63
+  %114 = ashr i64 %112, 1, !dbg !62
+  %115 = xor i64 %114, -9223372036854775808, !dbg !62
+  %116 = tail call i64 @rb_int2big(i64 %115) #16, !dbg !62, !noalias !63
+  br label %sorbet_rb_int_minus.exit97, !dbg !62
 
 117:                                              ; preds = %afterFinalCall_fib
-  %118 = tail call i64 @sorbet_rb_int_minus_slowpath(i64 %rawArg_n, i64 %105) #16, !dbg !63, !noalias !64
-  br label %sorbet_rb_int_minus.exit97, !dbg !63
+  %118 = tail call i64 @sorbet_rb_int_minus_slowpath(i64 %rawArg_n, i64 %105) #16, !dbg !62, !noalias !63
+  br label %sorbet_rb_int_minus.exit97, !dbg !62
 
 sorbet_rb_int_minus.exit97:                       ; preds = %113, %108, %117
-  %119 = phi i64 [ %118, %117 ], [ %116, %113 ], [ %112, %108 ], !dbg !63
-  %120 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !63, !tbaa !14
-  %121 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 5, !dbg !63
-  %122 = load i32, i32* %121, align 8, !dbg !63, !tbaa !26
-  %123 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 6, !dbg !63
-  %124 = load i32, i32* %123, align 4, !dbg !63, !tbaa !27
-  %125 = xor i32 %124, -1, !dbg !63
-  %126 = and i32 %125, %122, !dbg !63
-  %127 = icmp eq i32 %126, 0, !dbg !63
-  br i1 %127, label %rb_vm_check_ints.exit101, label %128, !dbg !63, !prof !28
+  %119 = phi i64 [ %118, %117 ], [ %116, %113 ], [ %112, %108 ], !dbg !62
+  %120 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !62, !tbaa !14
+  %121 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 5, !dbg !62
+  %122 = load i32, i32* %121, align 8, !dbg !62, !tbaa !25
+  %123 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 6, !dbg !62
+  %124 = load i32, i32* %123, align 4, !dbg !62, !tbaa !26
+  %125 = xor i32 %124, -1, !dbg !62
+  %126 = and i32 %125, %122, !dbg !62
+  %127 = icmp eq i32 %126, 0, !dbg !62
+  br i1 %127, label %rb_vm_check_ints.exit101, label %128, !dbg !62, !prof !27
 
 128:                                              ; preds = %sorbet_rb_int_minus.exit97
-  %129 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 8, !dbg !63
-  %130 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %129, align 8, !dbg !63, !tbaa !29
-  %131 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %130, i32 noundef 0) #16, !dbg !63
-  br label %rb_vm_check_ints.exit101, !dbg !63
+  %129 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 8, !dbg !62
+  %130 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %129, align 8, !dbg !62, !tbaa !28
+  %131 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %130, i32 noundef 0) #16, !dbg !62
+  br label %rb_vm_check_ints.exit101, !dbg !62
 
 rb_vm_check_ints.exit101:                         ; preds = %sorbet_rb_int_minus.exit97, %128
-  br i1 %104, label %fastFinalCall_fib59, label %slowFinalCall_fib60, !dbg !67
+  br i1 %104, label %fastFinalCall_fib59, label %slowFinalCall_fib60, !dbg !66
 
 fastFinalCall_fib59:                              ; preds = %rb_vm_check_ints.exit101
-  store i64 %119, i64* %callArgs0Addr, align 8, !dbg !67
-  %132 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8, !dbg !67
-  %133 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.6, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !67, !tbaa !57
-  %134 = icmp eq %struct.rb_callable_method_entry_struct* %133, null, !dbg !67
-  br i1 %134, label %135, label %sorbet_callFuncDirect.exit, !dbg !67, !prof !49
+  store i64 %119, i64* %callArgs0Addr, align 8, !dbg !66
+  %132 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8, !dbg !66
+  %133 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.6, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !66, !tbaa !56
+  %134 = icmp eq %struct.rb_callable_method_entry_struct* %133, null, !dbg !66
+  br i1 %134, label %135, label %sorbet_callFuncDirect.exit, !dbg !66, !prof !48
 
 135:                                              ; preds = %fastFinalCall_fib59
-  tail call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.6, i64 %selfRaw) #16, !dbg !67
-  br label %sorbet_callFuncDirect.exit, !dbg !67
+  tail call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.6, i64 %selfRaw) #16, !dbg !66
+  br label %sorbet_callFuncDirect.exit, !dbg !66
 
 sorbet_callFuncDirect.exit:                       ; preds = %fastFinalCall_fib59, %135
-  %136 = tail call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.6, i64 %selfRaw, %struct.rb_iseq_struct* %132) #16, !dbg !67
-  %137 = call i64 @func_HasFib.3fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %68, i64 %selfRaw, %struct.rb_control_frame_struct* align 8 %136, i8* noalias nocapture nofree nonnull readnone align 16 dereferenceable(88) undef) #16, !dbg !67
-  tail call void @sorbet_popFrame() #16, !dbg !67
-  br label %afterFinalCall_fib61, !dbg !67
+  %136 = tail call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.6, i64 %selfRaw, %struct.rb_iseq_struct* %132) #16, !dbg !66
+  %137 = call i64 @func_HasFib.3fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %68, i64 %selfRaw, %struct.rb_control_frame_struct* align 8 %136, i8* noalias nocapture nofree nonnull readnone align 16 dereferenceable(88) undef) #16, !dbg !66
+  tail call void @sorbet_popFrame() #16, !dbg !66
+  br label %afterFinalCall_fib61, !dbg !66
 
 slowFinalCall_fib60:                              ; preds = %rb_vm_check_ints.exit101
-  %138 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !67
-  %139 = load i64*, i64** %138, align 8, !dbg !67
-  store i64 %selfRaw, i64* %139, align 8, !dbg !67, !tbaa !6
-  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !67
-  store i64 %119, i64* %140, align 8, !dbg !67, !tbaa !6
-  %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !67
-  store i64* %141, i64** %138, align 8, !dbg !67
-  %send105 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fib.7, i64 0), !dbg !67
-  br label %afterFinalCall_fib61, !dbg !67
+  %138 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !66
+  %139 = load i64*, i64** %138, align 8, !dbg !66
+  store i64 %selfRaw, i64* %139, align 8, !dbg !66, !tbaa !6
+  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !66
+  store i64 %119, i64* %140, align 8, !dbg !66, !tbaa !6
+  %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !66
+  store i64* %141, i64** %138, align 8, !dbg !66
+  %send105 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fib.7, i64 0), !dbg !66
+  br label %afterFinalCall_fib61, !dbg !66
 
 afterFinalCall_fib61:                             ; preds = %slowFinalCall_fib60, %sorbet_callFuncDirect.exit
-  %finalCallResult_fib66 = phi i64 [ %137, %sorbet_callFuncDirect.exit ], [ %send105, %slowFinalCall_fib60 ], !dbg !67
-  %142 = and i64 %finalCallResult_fib, 1, !dbg !46
-  %143 = icmp eq i64 %142, 0, !dbg !46
-  br i1 %143, label %144, label %"fastSymCallIntrinsic_Integer_+", !dbg !46, !prof !49
+  %finalCallResult_fib66 = phi i64 [ %137, %sorbet_callFuncDirect.exit ], [ %send105, %slowFinalCall_fib60 ], !dbg !66
+  %142 = and i64 %finalCallResult_fib, 1, !dbg !45
+  %143 = icmp eq i64 %142, 0, !dbg !45
+  br i1 %143, label %144, label %"fastSymCallIntrinsic_Integer_+", !dbg !45, !prof !48
 
 144:                                              ; preds = %afterFinalCall_fib61
-  %145 = and i64 %finalCallResult_fib, 7, !dbg !46
-  %146 = icmp ne i64 %145, 0, !dbg !46
-  %147 = and i64 %finalCallResult_fib, -9, !dbg !46
-  %148 = icmp eq i64 %147, 0, !dbg !46
-  %149 = or i1 %146, %148, !dbg !46
-  br i1 %149, label %"alternativeCallIntrinsic_Integer_+", label %sorbet_isa_Integer.exit108, !dbg !46
+  %145 = and i64 %finalCallResult_fib, 7, !dbg !45
+  %146 = icmp ne i64 %145, 0, !dbg !45
+  %147 = and i64 %finalCallResult_fib, -9, !dbg !45
+  %148 = icmp eq i64 %147, 0, !dbg !45
+  %149 = or i1 %146, %148, !dbg !45
+  br i1 %149, label %"alternativeCallIntrinsic_Integer_+", label %sorbet_isa_Integer.exit108, !dbg !45
 
 sorbet_isa_Integer.exit108:                       ; preds = %144
-  %150 = inttoptr i64 %finalCallResult_fib to %struct.iseq_inline_iv_cache_entry*, !dbg !46
-  %151 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %150, i64 0, i32 0, !dbg !46
-  %152 = load i64, i64* %151, align 8, !dbg !46, !tbaa !50
-  %153 = and i64 %152, 31, !dbg !46
-  %154 = icmp eq i64 %153, 10, !dbg !46
-  br i1 %154, label %"fastSymCallIntrinsic_Integer_+", label %"alternativeCallIntrinsic_Integer_+", !dbg !46, !prof !28
+  %150 = inttoptr i64 %finalCallResult_fib to %struct.iseq_inline_iv_cache_entry*, !dbg !45
+  %151 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %150, i64 0, i32 0, !dbg !45
+  %152 = load i64, i64* %151, align 8, !dbg !45, !tbaa !49
+  %153 = and i64 %152, 31, !dbg !45
+  %154 = icmp eq i64 %153, 10, !dbg !45
+  br i1 %154, label %"fastSymCallIntrinsic_Integer_+", label %"alternativeCallIntrinsic_Integer_+", !dbg !45, !prof !27
 
 "alternativeCallIntrinsic_Integer_+":             ; preds = %144, %sorbet_isa_Integer.exit108
-  %155 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !46
-  %156 = load i64*, i64** %155, align 8, !dbg !46
-  store i64 %finalCallResult_fib, i64* %156, align 8, !dbg !46, !tbaa !6
-  %157 = getelementptr inbounds i64, i64* %156, i64 1, !dbg !46
-  store i64 %finalCallResult_fib66, i64* %157, align 8, !dbg !46, !tbaa !6
-  %158 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !46
-  store i64* %158, i64** %155, align 8, !dbg !46
-  %send107 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !46
-  br label %BB4, !dbg !46
+  %155 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !45
+  %156 = load i64*, i64** %155, align 8, !dbg !45
+  store i64 %finalCallResult_fib, i64* %156, align 8, !dbg !45, !tbaa !6
+  %157 = getelementptr inbounds i64, i64* %156, i64 1, !dbg !45
+  store i64 %finalCallResult_fib66, i64* %157, align 8, !dbg !45, !tbaa !6
+  %158 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !45
+  store i64* %158, i64** %155, align 8, !dbg !45
+  %send107 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !45
+  br label %BB4, !dbg !45
 
 "fastSymCallIntrinsic_Integer_+":                 ; preds = %afterFinalCall_fib61, %sorbet_isa_Integer.exit108
-  store i64 %finalCallResult_fib66, i64* %callArgs0Addr, align 8, !dbg !46
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !68), !dbg !46
-  %159 = load i64, i64* %68, align 8, !dbg !46, !tbaa !6, !alias.scope !68
-  %160 = and i64 %finalCallResult_fib, 1, !dbg !46
-  %161 = and i64 %160, %159, !dbg !46
-  %162 = icmp eq i64 %161, 0, !dbg !46
-  br i1 %162, label %172, label %163, !dbg !46, !prof !41
+  store i64 %finalCallResult_fib66, i64* %callArgs0Addr, align 8, !dbg !45
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !67), !dbg !45
+  %159 = load i64, i64* %68, align 8, !dbg !45, !tbaa !6, !alias.scope !67
+  %160 = and i64 %finalCallResult_fib, 1, !dbg !45
+  %161 = and i64 %160, %159, !dbg !45
+  %162 = icmp eq i64 %161, 0, !dbg !45
+  br i1 %162, label %172, label %163, !dbg !45, !prof !40
 
 163:                                              ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %164 = add nsw i64 %159, -1, !dbg !46
-  %165 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %finalCallResult_fib, i64 %164) #18, !dbg !46
-  %166 = extractvalue { i64, i1 } %165, 1, !dbg !46
-  %167 = extractvalue { i64, i1 } %165, 0, !dbg !46
-  br i1 %166, label %168, label %sorbet_rb_int_plus.exit, !dbg !46
+  %164 = add nsw i64 %159, -1, !dbg !45
+  %165 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %finalCallResult_fib, i64 %164) #18, !dbg !45
+  %166 = extractvalue { i64, i1 } %165, 1, !dbg !45
+  %167 = extractvalue { i64, i1 } %165, 0, !dbg !45
+  br i1 %166, label %168, label %sorbet_rb_int_plus.exit, !dbg !45
 
 168:                                              ; preds = %163
-  %169 = ashr i64 %167, 1, !dbg !46
-  %170 = xor i64 %169, -9223372036854775808, !dbg !46
-  %171 = tail call i64 @rb_int2big(i64 %170) #16, !dbg !46, !noalias !68
-  br label %sorbet_rb_int_plus.exit, !dbg !46
+  %169 = ashr i64 %167, 1, !dbg !45
+  %170 = xor i64 %169, -9223372036854775808, !dbg !45
+  %171 = tail call i64 @rb_int2big(i64 %170) #16, !dbg !45, !noalias !67
+  br label %sorbet_rb_int_plus.exit, !dbg !45
 
 172:                                              ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %173 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %finalCallResult_fib, i64 %159) #16, !dbg !46, !noalias !68
-  br label %sorbet_rb_int_plus.exit, !dbg !46
+  %173 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %finalCallResult_fib, i64 %159) #16, !dbg !45, !noalias !67
+  br label %sorbet_rb_int_plus.exit, !dbg !45
 
 sorbet_rb_int_plus.exit:                          ; preds = %168, %163, %172
-  %174 = phi i64 [ %173, %172 ], [ %171, %168 ], [ %167, %163 ], !dbg !46
-  %175 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !14
-  %176 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 5, !dbg !46
-  %177 = load i32, i32* %176, align 8, !dbg !46, !tbaa !26
-  %178 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 6, !dbg !46
-  %179 = load i32, i32* %178, align 4, !dbg !46, !tbaa !27
-  %180 = xor i32 %179, -1, !dbg !46
-  %181 = and i32 %180, %177, !dbg !46
-  %182 = icmp eq i32 %181, 0, !dbg !46
-  br i1 %182, label %BB4, label %183, !dbg !46, !prof !28
+  %174 = phi i64 [ %173, %172 ], [ %171, %168 ], [ %167, %163 ], !dbg !45
+  %175 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !14
+  %176 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 5, !dbg !45
+  %177 = load i32, i32* %176, align 8, !dbg !45, !tbaa !25
+  %178 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 6, !dbg !45
+  %179 = load i32, i32* %178, align 4, !dbg !45, !tbaa !26
+  %180 = xor i32 %179, -1, !dbg !45
+  %181 = and i32 %180, %177, !dbg !45
+  %182 = icmp eq i32 %181, 0, !dbg !45
+  br i1 %182, label %BB4, label %183, !dbg !45, !prof !27
 
 183:                                              ; preds = %sorbet_rb_int_plus.exit
-  %184 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 8, !dbg !46
-  %185 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %184, align 8, !dbg !46, !tbaa !29
-  %186 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %185, i32 noundef 0) #16, !dbg !46
-  br label %BB4, !dbg !46
+  %184 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %175, i64 0, i32 8, !dbg !45
+  %185 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %184, align 8, !dbg !45, !tbaa !28
+  %186 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %185, i32 noundef 0) #16, !dbg !45
+  br label %BB4, !dbg !45
 
 typeTestSuccess77:                                ; preds = %BB4.thread, %BB4, %sorbet_isa_Integer.exit
   %"<returnMethodTemp>.sroa.0.0111" = phi i64 [ 3, %BB4.thread ], [ %"<returnMethodTemp>.sroa.0.0", %BB4 ], [ %"<returnMethodTemp>.sroa.0.0", %sorbet_isa_Integer.exit ]
@@ -695,7 +688,7 @@ typeTestSuccess77:                                ; preds = %BB4.thread, %BB4, %
 
 codeRepl:                                         ; preds = %44, %sorbet_isa_Integer.exit
   %"<returnMethodTemp>.sroa.0.0112" = phi i64 [ %"<returnMethodTemp>.sroa.0.0", %44 ], [ %"<returnMethodTemp>.sroa.0.0", %sorbet_isa_Integer.exit ]
-  tail call fastcc void @func_HasFib.3fib.cold.1(i64 %"<returnMethodTemp>.sroa.0.0112") #21, !dbg !48
+  tail call fastcc void @func_HasFib.3fib.cold.1(i64 %"<returnMethodTemp>.sroa.0.0112") #21, !dbg !47
   unreachable
 }
 
@@ -706,7 +699,7 @@ entry:
   %locals.i23.i = alloca i64, i32 0, align 8
   %locals.i21.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, align 8, !dbg !71
+  %keywords.i = alloca i64, align 8, !dbg !70
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
@@ -723,7 +716,6 @@ entry:
   %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_block in <class:HasFib>", i64 0, i64 0), i64 noundef 23) #16
   store i64 %7, i64* @"rubyIdPrecomputed_block in <class:HasFib>", align 8
   %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_final, i64 0, i64 0), i64 noundef 5) #16
-  store i64 %8, i64* @rubyIdPrecomputed_final, align 8
   %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_n, i64 0, i64 0), i64 noundef 1) #16
   store i64 %9, i64* @rubyIdPrecomputed_n, align 8
   %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #16
@@ -731,7 +723,6 @@ entry:
   %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #16
   store i64 %11, i64* @rubyIdPrecomputed_returns, align 8
   %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
-  store i64 %12, i64* @rubyIdPrecomputed_normal, align 8
   %13 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
   tail call void @rb_gc_register_mark_object(i64 %13) #16
   store i64 %13, i64* @"rubyStrFrozen_<top (required)>", align 8
@@ -744,26 +735,26 @@ entry:
   %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
   %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %rubyId_fib1.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !73
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %rubyId_fib1.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !73
-  %rubyId_fib2.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !73
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.2, i64 %rubyId_fib2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !73
+  %rubyId_fib1.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !72
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %rubyId_fib1.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !72
+  %rubyId_fib2.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !72
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.2, i64 %rubyId_fib2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !72
   %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_fib, i64 0, i64 0), i64 noundef 3) #16
   call void @rb_gc_register_mark_object(i64 %16) #16
   %rubyId_fib.i.i = load i64, i64* @rubyIdPrecomputed_fib, align 8
   %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
   %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %rubyId_fib.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i21.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8
-  %rubyId_fib6.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.3, i64 %rubyId_fib6.i, i32 noundef 4, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !46
-  %rubyId_fib7.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.4, i64 %rubyId_fib7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
-  %rubyId_fib12.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !67
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.6, i64 %rubyId_fib12.i, i32 noundef 4, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !67
-  %rubyId_fib14.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !67
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.7, i64 %rubyId_fib14.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !67
-  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
+  %rubyId_fib6.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.3, i64 %rubyId_fib6.i, i32 noundef 4, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !45
+  %rubyId_fib7.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.4, i64 %rubyId_fib7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
+  %rubyId_fib12.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !66
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.6, i64 %rubyId_fib12.i, i32 noundef 4, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !66
+  %rubyId_fib14.i = load i64, i64* @rubyIdPrecomputed_fib, align 8, !dbg !66
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fib.7, i64 %rubyId_fib14.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !66
+  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
   %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_<class:HasFib>", i64 0, i64 0), i64 noundef 14) #16
   call void @rb_gc_register_mark_object(i64 %18) #16
   %"rubyId_<class:HasFib>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:HasFib>", align 8
@@ -777,13 +768,13 @@ entry:
   %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/app_fib.rb", align 8
   %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_block in <class:HasFib>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/app_fib.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_HasFib.13<static-init>$block_1", align 8
-  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !71
-  %rubyId_n.i = load i64, i64* @rubyIdPrecomputed_n, align 8, !dbg !71
-  %22 = call i64 @rb_id2sym(i64 %rubyId_n.i) #16, !dbg !71
-  store i64 %22, i64* %keywords.i, align 8, !dbg !71
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !71
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !71
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !71
+  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !70
+  %rubyId_n.i = load i64, i64* @rubyIdPrecomputed_n, align 8, !dbg !70
+  %22 = call i64 @rb_id2sym(i64 %rubyId_n.i) #19, !dbg !70
+  store i64 %22, i64* %keywords.i, align 8, !dbg !70
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull align 8 %keywords.i), !dbg !70
+  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !70
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !70
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
   %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
@@ -800,44 +791,44 @@ entry:
   store i64 %31, i64* %29, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %23, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #16
   %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %32, align 8, !dbg !75, !tbaa !14
-  %33 = load i64, i64* @rb_cObject, align 8, !dbg !76
-  %34 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_HasFib, i64 0, i64 0), i64 %33) #16, !dbg !76
-  %35 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %34) #16, !dbg !76
-  call fastcc void @"func_HasFib.13<static-init>L64"(%struct.rb_control_frame_struct* nocapture writeonly %35) #16, !dbg !76
-  call void @sorbet_popFrame() #16, !dbg !76
-  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %32, align 8, !dbg !76, !tbaa !14
-  %36 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !73
-  %37 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !73, !tbaa !31
-  %needTakeSlowPath = icmp ne i64 %36, %37, !dbg !73
-  br i1 %needTakeSlowPath, label %38, label %39, !dbg !73, !prof !33
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %32, align 8, !dbg !74, !tbaa !14
+  %33 = load i64, i64* @rb_cObject, align 8, !dbg !75
+  %34 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_HasFib, i64 0, i64 0), i64 %33) #16, !dbg !75
+  %35 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %34) #16, !dbg !75
+  call fastcc void @"func_HasFib.13<static-init>L64"(%struct.rb_control_frame_struct* nocapture writeonly %35) #16, !dbg !75
+  call void @sorbet_popFrame() #16, !dbg !75
+  store i64* getelementptr inbounds ([18 x i64], [18 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %32, align 8, !dbg !75, !tbaa !14
+  %36 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !72
+  %37 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !72, !tbaa !30
+  %needTakeSlowPath = icmp ne i64 %36, %37, !dbg !72
+  br i1 %needTakeSlowPath, label %38, label %39, !dbg !72, !prof !32
 
 38:                                               ; preds = %entry
-  call void @const_recompute_HasFib(), !dbg !73
-  br label %39, !dbg !73
+  call void @const_recompute_HasFib(), !dbg !72
+  br label %39, !dbg !72
 
 39:                                               ; preds = %entry, %38
-  %40 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !73
-  %41 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !73
-  %42 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !73, !tbaa !31
-  %guardUpdated = icmp eq i64 %41, %42, !dbg !73
-  call void @llvm.assume(i1 %guardUpdated), !dbg !73
-  %callArgs0Addr.i = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i32 0, i64 0, !dbg !73
-  store i64 69, i64* %callArgs0Addr.i, align 8, !dbg !73
-  %43 = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i64 0, i64 0, !dbg !73
-  %44 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8, !dbg !73
-  %45 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.1, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !73, !tbaa !57
-  %46 = icmp eq %struct.rb_callable_method_entry_struct* %45, null, !dbg !73
-  br i1 %46, label %47, label %"func_<root>.17<static-init>$152.exit", !dbg !73, !prof !49
+  %40 = load i64, i64* @guarded_const_HasFib, align 8, !dbg !72
+  %41 = load i64, i64* @guard_epoch_HasFib, align 8, !dbg !72
+  %42 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !72, !tbaa !30
+  %guardUpdated = icmp eq i64 %41, %42, !dbg !72
+  call void @llvm.assume(i1 %guardUpdated), !dbg !72
+  %callArgs0Addr.i = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i32 0, i64 0, !dbg !72
+  store i64 69, i64* %callArgs0Addr.i, align 8, !dbg !72
+  %43 = getelementptr [2 x i64], [2 x i64]* %callArgs.i, i64 0, i64 0, !dbg !72
+  %44 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_HasFib.3fib, align 8, !dbg !72
+  %45 = load %struct.rb_callable_method_entry_struct*, %struct.rb_callable_method_entry_struct** getelementptr inbounds (%struct.FunctionInlineCache, %struct.FunctionInlineCache* @ic_fib.1, i64 0, i32 0, i32 0, i32 2), align 16, !dbg !72, !tbaa !56
+  %46 = icmp eq %struct.rb_callable_method_entry_struct* %45, null, !dbg !72
+  br i1 %46, label %47, label %"func_<root>.17<static-init>$152.exit", !dbg !72, !prof !48
 
 47:                                               ; preds = %39
-  call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %40) #16, !dbg !73
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !73
+  call void @sorbet_vmMethodSearch(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %40) #16, !dbg !72
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !72
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %39, %47
-  %48 = call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %40, %struct.rb_iseq_struct* %44) #16, !dbg !73
-  %49 = call i64 @func_HasFib.3fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %43, i64 %40, %struct.rb_control_frame_struct* align 8 %48, i8* noalias nocapture nofree nonnull readnone align 16 dereferenceable(88) undef) #16, !dbg !73
-  call void @sorbet_popFrame() #16, !dbg !73
+  %48 = call %struct.rb_control_frame_struct* @sorbet_pushCfuncFrame(%struct.FunctionInlineCache* noundef @ic_fib.1, i64 %40, %struct.rb_iseq_struct* %44) #16, !dbg !72
+  %49 = call i64 @func_HasFib.3fib(i32 noundef 1, i64* nocapture noundef nonnull readonly align 8 dereferenceable(16) %43, i64 %40, %struct.rb_control_frame_struct* align 8 %48, i8* noalias nocapture nofree nonnull readnone align 16 dereferenceable(88) undef) #16, !dbg !72
+  call void @sorbet_popFrame() #16, !dbg !72
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %26)
   ret void
 }
@@ -855,17 +846,17 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #6
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #6
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @func_HasFib.3fib.cold.1(i64 %"<returnMethodTemp>.sroa.0.0") unnamed_addr #12 !dbg !77 {
+define internal fastcc void @func_HasFib.3fib.cold.1(i64 %"<returnMethodTemp>.sroa.0.0") unnamed_addr #12 !dbg !76 {
 newFuncRoot:
   tail call void @sorbet_cast_failure(i64 %"<returnMethodTemp>.sroa.0.0", i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20
   unreachable
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @func_HasFib.3fib.cold.2(i64 %rawArg_n) unnamed_addr #12 !dbg !79 {
+define internal fastcc void @func_HasFib.3fib.cold.2(i64 %rawArg_n) unnamed_addr #12 !dbg !78 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_n, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !80
-  unreachable, !dbg !80
+  tail call void @sorbet_cast_failure(i64 %rawArg_n, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !79
+  unreachable, !dbg !79
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
@@ -875,15 +866,15 @@ declare void @llvm.assume(i1 noundef) #13
 define linkonce void @const_recompute_HasFib() local_unnamed_addr #14 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @str_HasFib, i64 0, i64 0), i64 6)
   store i64 %1, i64* @guarded_const_HasFib, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !31
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !30
   store i64 %2, i64* @guard_epoch_HasFib, align 8
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #4 = { nofree nosync nounwind readnone speculatable willreturn }
 attributes #5 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #6 = { argmemonly nofree nosync nounwind willreturn }
@@ -930,60 +921,59 @@ attributes #21 = { noinline }
 !21 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
 !22 = !{!21, !15, i64 32}
 !23 = !DILocation(line: 0, scope: !10)
-!24 = !DILocation(line: 6, column: 30, scope: !10)
-!25 = !DILocation(line: 6, column: 3, scope: !10)
-!26 = !{!17, !18, i64 40}
-!27 = !{!17, !18, i64 44}
-!28 = !{!"branch_weights", i32 2000, i32 1}
-!29 = !{!17, !15, i64 56}
-!30 = !DILocation(line: 7, column: 3, scope: !10)
-!31 = !{!32, !32, i64 0}
-!32 = !{!"long long", !8, i64 0}
-!33 = !{!"branch_weights", i32 1, i32 10000}
-!34 = !{!35, !18, i64 8}
-!35 = !{!"rb_sorbet_param_struct", !36, i64 0, !18, i64 4, !18, i64 8, !18, i64 12, !18, i64 16, !18, i64 20, !18, i64 24, !18, i64 28, !15, i64 32, !18, i64 40, !18, i64 44, !18, i64 48, !18, i64 52, !15, i64 56}
-!36 = !{!"", !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 1, !18, i64 1}
-!37 = !{!35, !18, i64 4}
-!38 = !{!35, !15, i64 32}
-!39 = distinct !DISubprogram(name: "HasFib.fib", linkageName: "func_HasFib.3fib", scope: null, file: !4, line: 7, type: !11, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!40 = !DILocation(line: 7, column: 3, scope: !39)
-!41 = !{!"branch_weights", i32 4001, i32 4000000}
-!42 = !DILocation(line: 11, column: 11, scope: !39)
-!43 = !{!44}
-!44 = distinct !{!44, !45, !"sorbet_rb_int_minus: argument 0"}
-!45 = distinct !{!45, !"sorbet_rb_int_minus"}
-!46 = !DILocation(line: 11, column: 7, scope: !39)
-!47 = !{!"branch_weights", i32 1073205, i32 2146410443}
-!48 = !DILocation(line: 0, scope: !39)
-!49 = !{!"branch_weights", i32 1, i32 2000}
-!50 = !{!51, !7, i64 0}
-!51 = !{!"RBasic", !7, i64 0, !7, i64 8}
-!52 = !DILocation(line: 7, column: 16, scope: !39)
-!53 = !DILocation(line: 8, column: 8, scope: !39)
-!54 = !{!55}
-!55 = distinct !{!55, !56, !"sorbet_rb_int_lt: argument 0"}
-!56 = distinct !{!56, !"sorbet_rb_int_lt"}
-!57 = !{!58, !15, i64 32}
-!58 = !{!"FunctionInlineCache", !59, i64 0}
-!59 = !{!"rb_kwarg_call_data", !60, i64 0, !61, i64 64}
-!60 = !{!"rb_call_cache", !32, i64 0, !8, i64 8, !15, i64 32, !7, i64 40, !15, i64 48, !8, i64 56}
-!61 = !{!"rb_call_info_with_kwarg", !62, i64 0, !15, i64 16}
-!62 = !{!"rb_call_info", !7, i64 0, !18, i64 8, !18, i64 12}
-!63 = !DILocation(line: 11, column: 22, scope: !39)
-!64 = !{!65}
-!65 = distinct !{!65, !66, !"sorbet_rb_int_minus: argument 0"}
-!66 = distinct !{!66, !"sorbet_rb_int_minus"}
-!67 = !DILocation(line: 11, column: 18, scope: !39)
-!68 = !{!69}
-!69 = distinct !{!69, !70, !"sorbet_rb_int_plus: argument 0"}
-!70 = distinct !{!70, !"sorbet_rb_int_plus"}
-!71 = !DILocation(line: 6, column: 39, scope: !72)
-!72 = distinct !DISubprogram(name: "HasFib.<static-init>", linkageName: "func_HasFib.13<static-init>L64$block_1", scope: !10, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!73 = !DILocation(line: 16, column: 1, scope: !74)
-!74 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!75 = !DILocation(line: 0, scope: !74)
-!76 = !DILocation(line: 5, column: 1, scope: !74)
-!77 = distinct !DISubprogram(name: "func_HasFib.3fib.cold.1", linkageName: "func_HasFib.3fib.cold.1", scope: null, file: !4, type: !78, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!78 = !DISubroutineType(types: !5)
-!79 = distinct !DISubprogram(name: "func_HasFib.3fib.cold.2", linkageName: "func_HasFib.3fib.cold.2", scope: null, file: !4, type: !78, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!80 = !DILocation(line: 7, column: 16, scope: !79)
+!24 = !DILocation(line: 6, column: 3, scope: !10)
+!25 = !{!17, !18, i64 40}
+!26 = !{!17, !18, i64 44}
+!27 = !{!"branch_weights", i32 2000, i32 1}
+!28 = !{!17, !15, i64 56}
+!29 = !DILocation(line: 7, column: 3, scope: !10)
+!30 = !{!31, !31, i64 0}
+!31 = !{!"long long", !8, i64 0}
+!32 = !{!"branch_weights", i32 1, i32 10000}
+!33 = !{!34, !18, i64 8}
+!34 = !{!"rb_sorbet_param_struct", !35, i64 0, !18, i64 4, !18, i64 8, !18, i64 12, !18, i64 16, !18, i64 20, !18, i64 24, !18, i64 28, !15, i64 32, !18, i64 40, !18, i64 44, !18, i64 48, !18, i64 52, !15, i64 56}
+!35 = !{!"", !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 1, !18, i64 1}
+!36 = !{!34, !18, i64 4}
+!37 = !{!34, !15, i64 32}
+!38 = distinct !DISubprogram(name: "HasFib.fib", linkageName: "func_HasFib.3fib", scope: null, file: !4, line: 7, type: !11, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!39 = !DILocation(line: 7, column: 3, scope: !38)
+!40 = !{!"branch_weights", i32 4001, i32 4000000}
+!41 = !DILocation(line: 11, column: 11, scope: !38)
+!42 = !{!43}
+!43 = distinct !{!43, !44, !"sorbet_rb_int_minus: argument 0"}
+!44 = distinct !{!44, !"sorbet_rb_int_minus"}
+!45 = !DILocation(line: 11, column: 7, scope: !38)
+!46 = !{!"branch_weights", i32 1073205, i32 2146410443}
+!47 = !DILocation(line: 0, scope: !38)
+!48 = !{!"branch_weights", i32 1, i32 2000}
+!49 = !{!50, !7, i64 0}
+!50 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!51 = !DILocation(line: 7, column: 16, scope: !38)
+!52 = !DILocation(line: 8, column: 8, scope: !38)
+!53 = !{!54}
+!54 = distinct !{!54, !55, !"sorbet_rb_int_lt: argument 0"}
+!55 = distinct !{!55, !"sorbet_rb_int_lt"}
+!56 = !{!57, !15, i64 32}
+!57 = !{!"FunctionInlineCache", !58, i64 0}
+!58 = !{!"rb_kwarg_call_data", !59, i64 0, !60, i64 64}
+!59 = !{!"rb_call_cache", !31, i64 0, !8, i64 8, !15, i64 32, !7, i64 40, !15, i64 48, !8, i64 56}
+!60 = !{!"rb_call_info_with_kwarg", !61, i64 0, !15, i64 16}
+!61 = !{!"rb_call_info", !7, i64 0, !18, i64 8, !18, i64 12}
+!62 = !DILocation(line: 11, column: 22, scope: !38)
+!63 = !{!64}
+!64 = distinct !{!64, !65, !"sorbet_rb_int_minus: argument 0"}
+!65 = distinct !{!65, !"sorbet_rb_int_minus"}
+!66 = !DILocation(line: 11, column: 18, scope: !38)
+!67 = !{!68}
+!68 = distinct !{!68, !69, !"sorbet_rb_int_plus: argument 0"}
+!69 = distinct !{!69, !"sorbet_rb_int_plus"}
+!70 = !DILocation(line: 6, column: 39, scope: !71)
+!71 = distinct !DISubprogram(name: "HasFib.<static-init>", linkageName: "func_HasFib.13<static-init>L64$block_1", scope: !10, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!72 = !DILocation(line: 16, column: 1, scope: !73)
+!73 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!74 = !DILocation(line: 0, scope: !73)
+!75 = !DILocation(line: 5, column: 1, scope: !73)
+!76 = distinct !DISubprogram(name: "func_HasFib.3fib.cold.1", linkageName: "func_HasFib.3fib.cold.1", scope: null, file: !4, type: !77, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!77 = !DISubroutineType(types: !5)
+!78 = distinct !DISubprogram(name: "func_HasFib.3fib.cold.2", linkageName: "func_HasFib.3fib.cold.2", scope: null, file: !4, type: !77, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!79 = !DILocation(line: 7, column: 16, scope: !78)

--- a/test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.llo.exp
@@ -136,9 +136,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_extend = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_extend = internal unnamed_addr global i64 0, align 8
 @str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
-@rubyIdPrecomputed_attr_reader = internal unnamed_addr global i64 0, align 8
 @str_attr_reader = private unnamed_addr constant [12 x i8] c"attr_reader\00", align 1
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
@@ -147,6 +145,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @rb_cObject = external local_unnamed_addr constant i64
 @rb_cInteger = external local_unnamed_addr constant i64
 
+; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 ; Function Attrs: cold noreturn
@@ -155,89 +154,89 @@ declare void @sorbet_cast_failure(i64, i8*, i8*) local_unnamed_addr #1
 ; Function Attrs: noreturn
 declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #2
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #3
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #3
 
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
+declare i64 @sorbet_readRealpath() local_unnamed_addr #3
 
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #3
 
-declare void @sorbet_popFrame() local_unnamed_addr #0
+declare void @sorbet_popFrame() local_unnamed_addr #3
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #3
 
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #3
 
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #3
 
-declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_rb_int_lt_slowpath(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_rb_int_lt_slowpath(i64, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_getivar(i64, i64, %struct.iseq_inline_iv_cache_entry*) local_unnamed_addr #0
+declare i64 @sorbet_vm_getivar(i64, i64, %struct.iseq_inline_iv_cache_entry*) local_unnamed_addr #3
 
-declare void @sorbet_vm_setivar(i64, i64, i64, %struct.iseq_inline_iv_cache_entry*) local_unnamed_addr #0
+declare void @sorbet_vm_setivar(i64, i64, i64, %struct.iseq_inline_iv_cache_entry*) local_unnamed_addr #3
 
-declare void @sorbet_vm_register_sig(i64, i64, i64, i64, i64 (i64, i64, i32, i64*, i64)*) local_unnamed_addr #0
+declare void @sorbet_vm_register_sig(i64, i64, i64, i64, i64 (i64, i64, i32, i64*, i64)*) local_unnamed_addr #3
 
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
 
-declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #3
 
-declare i64 @rb_intern(i8*) local_unnamed_addr #0
+declare i64 @rb_intern(i8*) local_unnamed_addr #3
 
-declare i64 @rb_id2str(i64) local_unnamed_addr #0
+declare i64 @rb_id2str(i64) local_unnamed_addr #3
 
-declare i64 @rb_sprintf(i8*, ...) local_unnamed_addr #0
+declare i64 @rb_sprintf(i8*, ...) local_unnamed_addr #3
 
-declare i64 @rb_intern_str(i64) local_unnamed_addr #0
+declare i64 @rb_intern_str(i64) local_unnamed_addr #3
 
-declare void @rb_add_method(i64, i64, i32, i8*, i32) local_unnamed_addr #0
+declare void @rb_add_method(i64, i64, i32, i8*, i32) local_unnamed_addr #3
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #3
 
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #3
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
 
-declare i64 @rb_int2big(i64) local_unnamed_addr #0
+declare i64 @rb_int2big(i64) local_unnamed_addr #3
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #3
+declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #4
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
-
-; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #4
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #3
 
 ; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xmalloc2(i64, i64) local_unnamed_addr #4
+declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #5
+
+; Function Attrs: allocsize(0,1)
+declare noalias nonnull i8* @ruby_xmalloc2(i64, i64) local_unnamed_addr #5
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #5
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #6
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #14
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #14
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_AttrReaderNoSig.13<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !10 {
+define internal fastcc void @"func_AttrReaderNoSig.13<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !10 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
@@ -250,7 +249,7 @@ functionEntryInitializers:
   %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
   store i64 %7, i64* %5, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #15
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #16
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !23, !tbaa !14
   %rubyId_initialize = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !24
@@ -269,7 +268,7 @@ functionEntryInitializers:
 17:                                               ; preds = %functionEntryInitializers
   %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
   %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !24, !tbaa !28
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !24
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !24
   br label %rb_vm_check_ints.exit2, !dbg !24
 
 rb_vm_check_ints.exit2:                           ; preds = %functionEntryInitializers, %17
@@ -298,10 +297,6 @@ rb_vm_check_ints.exit2:                           ; preds = %functionEntryInitia
   store i64* %31, i64** %28, align 8, !dbg !29
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !29
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !29, !tbaa !14
-  %rubyId_initialize45 = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !33
-  %rawSym46 = tail call i64 @rb_id2sym(i64 %rubyId_initialize45), !dbg !33
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !33
-  %rawSym47 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !33
   %32 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !33
   %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !30
   %needTakeSlowPath3 = icmp ne i64 %32, %33, !dbg !33
@@ -318,7 +313,7 @@ rb_vm_check_ints.exit2:                           ; preds = %functionEntryInitia
   %guardUpdated4 = icmp eq i64 %37, %38, !dbg !33
   tail call void @llvm.assume(i1 %guardUpdated4), !dbg !33
   %stackFrame51 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig#10initialize", align 8, !dbg !33
-  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !33
+  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !33
   %40 = bitcast i8* %39 to i16*, !dbg !33
   %41 = load i16, i16* %40, align 8, !dbg !33
   %42 = and i16 %41, -384, !dbg !33
@@ -336,13 +331,13 @@ rb_vm_check_ints.exit2:                           ; preds = %functionEntryInitia
   %positional_table = alloca i64, align 8, !dbg !33
   %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !33
   store i64 %rubyId_foo, i64* %positional_table, align 8, !dbg !33
-  %50 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !33
+  %50 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !33
   %51 = bitcast i64* %positional_table to i8*, !dbg !33
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %50, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %51, i64 noundef 8, i1 noundef false) #15, !dbg !33
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %50, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %51, i64 noundef 8, i1 noundef false) #16, !dbg !33
   %52 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !33
   %53 = bitcast i8* %52 to i8**, !dbg !33
   store i8* %50, i8** %53, align 8, !dbg !33, !tbaa !38
-  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_AttrReaderNoSig#10initialize", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame51, i1 noundef zeroext false) #15, !dbg !33
+  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_AttrReaderNoSig#10initialize", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame51, i1 noundef zeroext false) #16, !dbg !33
   %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !33, !tbaa !14
   %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 5, !dbg !33
   %56 = load i32, i32* %55, align 8, !dbg !33, !tbaa !25
@@ -356,21 +351,17 @@ rb_vm_check_ints.exit2:                           ; preds = %functionEntryInitia
 62:                                               ; preds = %35
   %63 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 8, !dbg !33
   %64 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %63, align 8, !dbg !33, !tbaa !28
-  %65 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %64, i32 noundef 0) #15, !dbg !33
+  %65 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %64, i32 noundef 0) #16, !dbg !33
   br label %rb_vm_check_ints.exit1, !dbg !33
 
 rb_vm_check_ints.exit1:                           ; preds = %35, %62
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !33, !tbaa !14
-  %rubyId_foo53 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !39
-  %rawSym54 = tail call i64 @rb_id2sym(i64 %rubyId_foo53), !dbg !39
-  %rubyId_attr_reader = load i64, i64* @rubyIdPrecomputed_attr_reader, align 8, !dbg !39
-  %rawSym55 = tail call i64 @rb_id2sym(i64 %rubyId_attr_reader), !dbg !39
-  %66 = tail call i64 @rb_intern(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0)) #15, !dbg !39
-  %67 = tail call i64 @rb_id2str(i64 %66) #15, !dbg !39
-  %68 = tail call i64 (i8*, ...) @rb_sprintf(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i64 %67) #15, !dbg !39
-  %69 = tail call i64 @rb_intern_str(i64 %68) #15, !dbg !39
+  %66 = tail call i64 @rb_intern(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0)) #16, !dbg !39
+  %67 = tail call i64 @rb_id2str(i64 %66) #16, !dbg !39
+  %68 = tail call i64 (i8*, ...) @rb_sprintf(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i64 %67) #16, !dbg !39
+  %69 = tail call i64 @rb_intern_str(i64 %68) #16, !dbg !39
   %70 = inttoptr i64 %69 to i8*, !dbg !39
-  tail call void @rb_add_method(i64 %36, i64 %66, i32 noundef 4, i8* %70, i32 noundef 1) #15, !dbg !39
+  tail call void @rb_add_method(i64 %36, i64 %66, i32 noundef 4, i8* %70, i32 noundef 1) #16, !dbg !39
   %71 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !39, !tbaa !14
   %72 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 5, !dbg !39
   %73 = load i32, i32* %72, align 8, !dbg !39, !tbaa !25
@@ -384,7 +375,7 @@ rb_vm_check_ints.exit1:                           ; preds = %35, %62
 79:                                               ; preds = %rb_vm_check_ints.exit1
   %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 8, !dbg !39
   %81 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %80, align 8, !dbg !39, !tbaa !28
-  %82 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %81, i32 noundef 0) #15, !dbg !39
+  %82 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %81, i32 noundef 0) #16, !dbg !39
   br label %rb_vm_check_ints.exit, !dbg !39
 
 rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.exit1, %79
@@ -392,7 +383,7 @@ rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.ex
 }
 
 ; Function Attrs: sspreq
-define void @Init_no_sig() local_unnamed_addr #8 {
+define void @Init_no_sig() local_unnamed_addr #9 {
 entry:
   %locals.i18.i = alloca i64, i32 0, align 8
   %locals.i16.i = alloca i64, i32 0, align 8
@@ -401,41 +392,39 @@ entry:
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
   store i64 %1, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #15
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #16
   store i64 %2, i64* @rubyIdPrecomputed_new, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_<", i64 0, i64 0), i64 noundef 1) #15
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_<", i64 0, i64 0), i64 noundef 1) #16
   store i64 %3, i64* @"rubyIdPrecomputed_<", align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #15
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #16
   store i64 %4, i64* @rubyIdPrecomputed_foo, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #15
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #16
   store i64 %5, i64* @"rubyIdPrecomputed_+", align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #15
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #16
   store i64 %6, i64* @rubyIdPrecomputed_puts, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #16
   store i64 %7, i64* @rubyIdPrecomputed_initialize, align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @"str_@foo", i64 0, i64 0), i64 noundef 4) #15
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @"str_@foo", i64 0, i64 0), i64 noundef 4) #16
   store i64 %8, i64* @"rubyIdPrecomputed_@foo", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_<class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 23) #15
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_<class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 23) #16
   store i64 %9, i64* @"rubyIdPrecomputed_<class:AttrReaderNoSig>", align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([33 x i8], [33 x i8]* @"str_block in <class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 32) #15
+  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([33 x i8], [33 x i8]* @"str_block in <class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 32) #16
   store i64 %10, i64* @"rubyIdPrecomputed_block in <class:AttrReaderNoSig>", align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #15
+  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #16
   store i64 %11, i64* @rubyIdPrecomputed_params, align 8
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_void, i64 0, i64 0), i64 noundef 4) #15
+  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_void, i64 0, i64 0), i64 noundef 4) #16
   store i64 %12, i64* @rubyIdPrecomputed_void, align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #15
+  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #16
   store i64 %13, i64* @rubyIdPrecomputed_extend, align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %14, i64* @rubyIdPrecomputed_normal, align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @str_attr_reader, i64 0, i64 0), i64 noundef 11) #15
-  store i64 %15, i64* @rubyIdPrecomputed_attr_reader, align 8
-  %16 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
-  tail call void @rb_gc_register_mark_object(i64 %16) #15
+  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @str_attr_reader, i64 0, i64 0), i64 noundef 11) #16
+  %16 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  tail call void @rb_gc_register_mark_object(i64 %16) #16
   store i64 %16, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([58 x i8], [58 x i8]* @"str_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", i64 0, i64 0), i64 noundef 57) #15
-  tail call void @rb_gc_register_mark_object(i64 %17) #15
+  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([58 x i8], [58 x i8]* @"str_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", i64 0, i64 0), i64 noundef 57) #16
+  tail call void @rb_gc_register_mark_object(i64 %17) #16
   store i64 %17, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -457,22 +446,22 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !48
   %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !49
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
-  call void @rb_gc_register_mark_object(i64 %19) #15
+  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #16
+  call void @rb_gc_register_mark_object(i64 %19) #16
   %rubyId_initialize.i.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8
   %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
   %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %rubyId_initialize.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig#10initialize", align 8
-  %21 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #15
+  %21 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #16
   store i64 %21, i64* @"<void-singleton>", align 8
-  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_<class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 23) #15
-  call void @rb_gc_register_mark_object(i64 %22) #15
+  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_<class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 23) #16
+  call void @rb_gc_register_mark_object(i64 %22) #16
   %"rubyId_<class:AttrReaderNoSig>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:AttrReaderNoSig>", align 8
   %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
   %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %"rubyId_<class:AttrReaderNoSig>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>", align 8
-  %24 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([33 x i8], [33 x i8]* @"str_block in <class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 32) #15
-  call void @rb_gc_register_mark_object(i64 %24) #15
+  %24 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([33 x i8], [33 x i8]* @"str_block in <class:AttrReaderNoSig>", i64 0, i64 0), i64 noundef 32) #16
+  call void @rb_gc_register_mark_object(i64 %24) #16
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>", align 8
   %"rubyId_block in <class:AttrReaderNoSig>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:AttrReaderNoSig>", align 8
   %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb.i19.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/no_sig.rb", align 8
@@ -480,9 +469,9 @@ entry:
   store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderNoSig.13<static-init>$block_1", align 8
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !40
   %rubyId_foo10.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
-  %26 = call i64 @rb_id2sym(i64 %rubyId_foo10.i) #15, !dbg !40
+  %26 = call i64 @rb_id2sym(i64 %rubyId_foo10.i) #18, !dbg !40
   store i64 %26, i64* %keywords.i, align 8, !dbg !40
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !40
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull align 8 %keywords.i), !dbg !40
   %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !40
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !40
   %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !29
@@ -502,14 +491,14 @@ entry:
   %36 = load i64, i64* %35, align 8, !tbaa !6
   %37 = and i64 %36, -33
   store i64 %37, i64* %35, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %30, %struct.rb_control_frame_struct* %32, %struct.rb_iseq_struct* %stackFrame.i) #15
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %30, %struct.rb_control_frame_struct* %32, %struct.rb_iseq_struct* %stackFrame.i) #16
   %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %38, align 8, !dbg !58, !tbaa !14
   %39 = load i64, i64* @rb_cObject, align 8, !dbg !59
-  %40 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([16 x i8], [16 x i8]* @str_AttrReaderNoSig, i64 0, i64 0), i64 %39) #15, !dbg !59
-  %41 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %40) #15, !dbg !59
-  call fastcc void @"func_AttrReaderNoSig.13<static-init>L62"(i64 %40, %struct.rb_control_frame_struct* %41) #15, !dbg !59
-  call void @sorbet_popFrame() #15, !dbg !59
+  %40 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([16 x i8], [16 x i8]* @str_AttrReaderNoSig, i64 0, i64 0), i64 %39) #16, !dbg !59
+  %41 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %40) #16, !dbg !59
+  call fastcc void @"func_AttrReaderNoSig.13<static-init>L62"(i64 %40, %struct.rb_control_frame_struct* %41) #16, !dbg !59
+  call void @sorbet_popFrame() #16, !dbg !59
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %38, align 8, !dbg !59, !tbaa !14
   %42 = load i64, i64* @guard_epoch_AttrReaderNoSig, align 8, !dbg !42
   %43 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !42, !tbaa !30
@@ -591,7 +580,7 @@ afterSend37.i:                                    ; preds = %94, %sorbet_rb_int_
 
 "fastSymCallIntrinsic_Integer_<.i":               ; preds = %BB2.i, %sorbet_isa_Integer.exit
   %77 = phi i1 [ %65, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
-  call void @llvm.experimental.noalias.scope.decl(metadata !65) #15, !dbg !44
+  call void @llvm.experimental.noalias.scope.decl(metadata !65) #16, !dbg !44
   %78 = and i64 %i.sroa.0.0.i, 1, !dbg !44
   %79 = icmp eq i64 %78, 0, !dbg !44
   br i1 %79, label %84, label %80, !dbg !44, !prof !68
@@ -603,7 +592,7 @@ afterSend37.i:                                    ; preds = %94, %sorbet_rb_int_
   br label %sorbet_rb_int_lt.exit.i, !dbg !44
 
 84:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %85 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !44, !noalias !65
+  %85 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #16, !dbg !44, !noalias !65
   br label %sorbet_rb_int_lt.exit.i, !dbg !44
 
 sorbet_rb_int_lt.exit.i:                          ; preds = %84, %80
@@ -621,7 +610,7 @@ sorbet_rb_int_lt.exit.i:                          ; preds = %84, %80
 94:                                               ; preds = %sorbet_rb_int_lt.exit.i
   %95 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %86, i64 0, i32 8, !dbg !44
   %96 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %95, align 8, !dbg !44, !tbaa !28
-  %97 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %96, i32 noundef 0) #15, !dbg !44
+  %97 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %96, i32 noundef 0) #16, !dbg !44
   br label %afterSend37.i, !dbg !44
 
 "alternativeCallIntrinsic_Integer_+.i":           ; preds = %BB5.i
@@ -636,13 +625,13 @@ sorbet_rb_int_lt.exit.i:                          ; preds = %84, %80
   br label %BB2.i.backedge, !dbg !46
 
 "fastSymCallIntrinsic_Integer_+.i":               ; preds = %BB5.i
-  call void @llvm.experimental.noalias.scope.decl(metadata !69) #15, !dbg !46
+  call void @llvm.experimental.noalias.scope.decl(metadata !69) #16, !dbg !46
   %102 = and i64 %i.sroa.0.0.i, 1, !dbg !46
   %103 = icmp eq i64 %102, 0, !dbg !46
   br i1 %103, label %112, label %104, !dbg !46, !prof !68
 
 104:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %105 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !46
+  %105 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #19, !dbg !46
   %106 = extractvalue { i64, i1 } %105, 1, !dbg !46
   %107 = extractvalue { i64, i1 } %105, 0, !dbg !46
   br i1 %106, label %108, label %sorbet_rb_int_plus.exit.i, !dbg !46
@@ -650,11 +639,11 @@ sorbet_rb_int_lt.exit.i:                          ; preds = %84, %80
 108:                                              ; preds = %104
   %109 = ashr i64 %107, 1, !dbg !46
   %110 = xor i64 %109, -9223372036854775808, !dbg !46
-  %111 = call i64 @rb_int2big(i64 %110) #15, !dbg !46
+  %111 = call i64 @rb_int2big(i64 %110) #16, !dbg !46
   br label %sorbet_rb_int_plus.exit.i, !dbg !46
 
 112:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %113 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !46, !noalias !69
+  %113 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #16, !dbg !46, !noalias !69
   br label %sorbet_rb_int_plus.exit.i, !dbg !46
 
 sorbet_rb_int_plus.exit.i:                        ; preds = %112, %108, %104
@@ -672,7 +661,7 @@ sorbet_rb_int_plus.exit.i:                        ; preds = %112, %108, %104
 123:                                              ; preds = %sorbet_rb_int_plus.exit.i
   %124 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %115, i64 0, i32 8, !dbg !46
   %125 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %124, align 8, !dbg !46, !tbaa !28
-  %126 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %125, i32 noundef 0) #15, !dbg !46
+  %126 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %125, i32 noundef 0) #16, !dbg !46
   br label %BB2.i.backedge, !dbg !46
 
 BB2.i.backedge:                                   ; preds = %123, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
@@ -709,7 +698,7 @@ BB2.i.backedge:                                   ; preds = %123, %sorbet_rb_int
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_AttrReaderNoSig#10initialize"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #7 !dbg !72 {
+define i64 @"func_AttrReaderNoSig#10initialize"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #8 !dbg !72 {
 functionEntryInitializers:
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %1, align 8, !tbaa !14
@@ -719,7 +708,7 @@ functionEntryInitializers:
   br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !73, !prof !68
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #18, !dbg !73
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #20, !dbg !73
   unreachable, !dbg !73
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
@@ -747,19 +736,19 @@ sorbet_isa_Integer.exit:                          ; preds = %4
 typeTestSuccess:                                  ; preds = %fillRequiredArgs, %sorbet_isa_Integer.exit
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %1, align 8, !dbg !74, !tbaa !14
   %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !75
-  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %rawArg_foo, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #15, !dbg !75
+  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %rawArg_foo, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #16, !dbg !75
   %"rubyId_@foo13" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !76
-  %15 = tail call i64 @sorbet_vm_getivar(i64 %selfRaw, i64 %"rubyId_@foo13", %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo.3") #15, !dbg !76
+  %15 = tail call i64 @sorbet_vm_getivar(i64 %selfRaw, i64 %"rubyId_@foo13", %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo.3") #16, !dbg !76
   %"<void-singleton>" = load i64, i64* @"<void-singleton>", align 8
   ret i64 %"<void-singleton>"
 
 codeRepl:                                         ; preds = %4, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_AttrReaderNoSig#10initialize.cold.1"(i64 %rawArg_foo) #19, !dbg !74
+  tail call fastcc void @"func_AttrReaderNoSig#10initialize.cold.1"(i64 %rawArg_foo) #21, !dbg !74
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_AttrReaderNoSig.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #9 !dbg !41 {
+define internal i64 @"func_AttrReaderNoSig.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #10 !dbg !41 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -776,8 +765,6 @@ functionEntryInitializers:
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !14
-  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !78
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !78
   %11 = load i64, i64* @rb_cInteger, align 8, !dbg !40
   %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !40
   %13 = load i64*, i64** %12, align 8, !dbg !40
@@ -793,33 +780,33 @@ functionEntryInitializers:
   %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !40
   store i64* %18, i64** %16, align 8, !dbg !40
   %send17 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_void, i64 0), !dbg !40
-  ret i64 %send17, !dbg !79
+  ret i64 %send17, !dbg !78
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare void @llvm.experimental.noalias.scope.decl(metadata) #10
+declare void @llvm.experimental.noalias.scope.decl(metadata) #11
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #11
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #12
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #6
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #6
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_AttrReaderNoSig#10initialize.cold.1"(i64 %rawArg_foo) unnamed_addr #12 !dbg !80 {
+define internal fastcc void @"func_AttrReaderNoSig#10initialize.cold.1"(i64 %rawArg_foo) unnamed_addr #13 !dbg !79 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_foo, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !82
-  unreachable, !dbg !82
+  tail call void @sorbet_cast_failure(i64 %rawArg_foo, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !81
+  unreachable, !dbg !81
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #13
+declare void @llvm.assume(i1 noundef) #14
 
 ; Function Attrs: ssp
-define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #9 {
+define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !30
@@ -828,7 +815,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #9 {
 }
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_AttrReaderNoSig() local_unnamed_addr #9 {
+define linkonce void @const_recompute_AttrReaderNoSig() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @str_AttrReaderNoSig, i64 0, i64 0), i64 15)
   store i64 %1, i64* @guarded_const_AttrReaderNoSig, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !30
@@ -836,26 +823,28 @@ define linkonce void @const_recompute_AttrReaderNoSig() local_unnamed_addr #9 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nofree nosync nounwind readnone speculatable willreturn }
-attributes #4 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #5 = { argmemonly nofree nosync nounwind willreturn }
-attributes #6 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #7 = { nounwind sspreq uwtable }
-attributes #8 = { sspreq }
-attributes #9 = { ssp }
-attributes #10 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #11 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #12 = { cold minsize noreturn nounwind sspreq uwtable }
-attributes #13 = { nofree nosync nounwind willreturn }
-attributes #14 = { noreturn nounwind }
-attributes #15 = { nounwind }
-attributes #16 = { nounwind allocsize(0,1) }
-attributes #17 = { nounwind willreturn }
-attributes #18 = { noreturn }
-attributes #19 = { noinline }
+attributes #3 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { nofree nosync nounwind readnone speculatable willreturn }
+attributes #5 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #6 = { argmemonly nofree nosync nounwind willreturn }
+attributes #7 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #8 = { nounwind sspreq uwtable }
+attributes #9 = { sspreq }
+attributes #10 = { ssp }
+attributes #11 = { inaccessiblememonly nofree nosync nounwind willreturn }
+attributes #12 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #13 = { cold minsize noreturn nounwind sspreq uwtable }
+attributes #14 = { nofree nosync nounwind willreturn }
+attributes #15 = { noreturn nounwind }
+attributes #16 = { nounwind }
+attributes #17 = { nounwind allocsize(0,1) }
+attributes #18 = { nounwind readnone willreturn }
+attributes #19 = { nounwind willreturn }
+attributes #20 = { noreturn }
+attributes #21 = { noinline }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -938,8 +927,7 @@ attributes #19 = { noinline }
 !75 = !DILocation(line: 9, column: 12, scope: !72)
 !76 = !DILocation(line: 9, column: 5, scope: !72)
 !77 = !{!21, !7, i64 24}
-!78 = !DILocation(line: 7, column: 15, scope: !41)
-!79 = !DILocation(line: 7, column: 3, scope: !41)
-!80 = distinct !DISubprogram(name: "func_AttrReaderNoSig#10initialize.cold.1", linkageName: "func_AttrReaderNoSig#10initialize.cold.1", scope: null, file: !4, type: !81, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!81 = !DISubroutineType(types: !5)
-!82 = !DILocation(line: 8, column: 18, scope: !80)
+!78 = !DILocation(line: 7, column: 3, scope: !41)
+!79 = distinct !DISubprogram(name: "func_AttrReaderNoSig#10initialize.cold.1", linkageName: "func_AttrReaderNoSig#10initialize.cold.1", scope: null, file: !4, type: !80, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!80 = !DISubroutineType(types: !5)
+!81 = !DILocation(line: 8, column: 18, scope: !79)

--- a/test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.llo.exp
@@ -145,7 +145,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_extend = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_extend = internal unnamed_addr global i64 0, align 8
 @str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
@@ -154,6 +153,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @rb_cObject = external local_unnamed_addr constant i64
 @rb_cInteger = external local_unnamed_addr constant i64
 
+; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 ; Function Attrs: cold noreturn
@@ -162,79 +162,79 @@ declare void @sorbet_cast_failure(i64, i8*, i8*) local_unnamed_addr #1
 ; Function Attrs: noreturn
 declare void @sorbet_raiseArity(i32, i32, i32) local_unnamed_addr #2
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #3
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #3
 
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
+declare i64 @sorbet_readRealpath() local_unnamed_addr #3
 
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #3
 
-declare void @sorbet_popFrame() local_unnamed_addr #0
+declare void @sorbet_popFrame() local_unnamed_addr #3
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #3
 
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #3
 
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #3
 
-declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_rb_int_lt_slowpath(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_rb_int_lt_slowpath(i64, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_getivar(i64, i64, %struct.iseq_inline_iv_cache_entry*) local_unnamed_addr #0
+declare i64 @sorbet_vm_getivar(i64, i64, %struct.iseq_inline_iv_cache_entry*) local_unnamed_addr #3
 
-declare void @sorbet_vm_setivar(i64, i64, i64, %struct.iseq_inline_iv_cache_entry*) local_unnamed_addr #0
+declare void @sorbet_vm_setivar(i64, i64, i64, %struct.iseq_inline_iv_cache_entry*) local_unnamed_addr #3
 
-declare void @sorbet_vm_register_sig(i64, i64, i64, i64, i64 (i64, i64, i32, i64*, i64)*) local_unnamed_addr #0
+declare void @sorbet_vm_register_sig(i64, i64, i64, i64, i64 (i64, i64, i32, i64*, i64)*) local_unnamed_addr #3
 
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
 
-declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #3
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #3
 
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #3
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
 
-declare i64 @rb_int2big(i64) local_unnamed_addr #0
+declare i64 @rb_int2big(i64) local_unnamed_addr #3
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #3
+declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #4
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
-
-; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #4
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #3
 
 ; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xmalloc2(i64, i64) local_unnamed_addr #4
+declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #5
+
+; Function Attrs: allocsize(0,1)
+declare noalias nonnull i8* @ruby_xmalloc2(i64, i64) local_unnamed_addr #5
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #5
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #6
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #14
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #14
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_AttrReaderSigChecked.13<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !10 {
+define internal fastcc void @"func_AttrReaderSigChecked.13<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !10 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
@@ -247,7 +247,7 @@ functionEntryInitializers:
   %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
   store i64 %7, i64* %5, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #15
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #16
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !23, !tbaa !14
   %rubyId_initialize = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !24
@@ -266,7 +266,7 @@ functionEntryInitializers:
 17:                                               ; preds = %functionEntryInitializers
   %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
   %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !24, !tbaa !28
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !24
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !24
   br label %rb_vm_check_ints.exit3, !dbg !24
 
 rb_vm_check_ints.exit3:                           ; preds = %functionEntryInitializers, %17
@@ -287,7 +287,7 @@ rb_vm_check_ints.exit3:                           ; preds = %functionEntryInitia
 29:                                               ; preds = %rb_vm_check_ints.exit3
   %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !29
   %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !29, !tbaa !28
-  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #15, !dbg !29
+  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #16, !dbg !29
   br label %rb_vm_check_ints.exit2, !dbg !29
 
 rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.exit3, %29
@@ -316,10 +316,6 @@ rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.ex
   store i64* %43, i64** %40, align 8, !dbg !30
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !30
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !30, !tbaa !14
-  %rubyId_initialize71 = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !34
-  %rawSym72 = tail call i64 @rb_id2sym(i64 %rubyId_initialize71), !dbg !34
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !34
-  %rawSym73 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !34
   %44 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !34
   %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !34, !tbaa !31
   %needTakeSlowPath4 = icmp ne i64 %44, %45, !dbg !34
@@ -336,7 +332,7 @@ rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.ex
   %guardUpdated5 = icmp eq i64 %49, %50, !dbg !34
   tail call void @llvm.assume(i1 %guardUpdated5), !dbg !34
   %stackFrame77 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#10initialize", align 8, !dbg !34
-  %51 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !34
+  %51 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !34
   %52 = bitcast i8* %51 to i16*, !dbg !34
   %53 = load i16, i16* %52, align 8, !dbg !34
   %54 = and i16 %53, -384, !dbg !34
@@ -354,13 +350,13 @@ rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.ex
   %positional_table = alloca i64, align 8, !dbg !34
   %rubyId_foo78 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !34
   store i64 %rubyId_foo78, i64* %positional_table, align 8, !dbg !34
-  %62 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !34
+  %62 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !34
   %63 = bitcast i64* %positional_table to i8*, !dbg !34
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %63, i64 noundef 8, i1 noundef false) #15, !dbg !34
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %63, i64 noundef 8, i1 noundef false) #16, !dbg !34
   %64 = getelementptr inbounds i8, i8* %51, i64 32, !dbg !34
   %65 = bitcast i8* %64 to i8**, !dbg !34
   store i8* %62, i8** %65, align 8, !dbg !34, !tbaa !39
-  tail call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_AttrReaderSigChecked#10initialize", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame77, i1 noundef zeroext false) #15, !dbg !34
+  tail call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_AttrReaderSigChecked#10initialize", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame77, i1 noundef zeroext false) #16, !dbg !34
   %66 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !34, !tbaa !14
   %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 5, !dbg !34
   %68 = load i32, i32* %67, align 8, !dbg !34, !tbaa !25
@@ -374,17 +370,13 @@ rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.ex
 74:                                               ; preds = %47
   %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 8, !dbg !34
   %76 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %75, align 8, !dbg !34, !tbaa !28
-  %77 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %76, i32 noundef 0) #15, !dbg !34
+  %77 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %76, i32 noundef 0) #16, !dbg !34
   br label %rb_vm_check_ints.exit1, !dbg !34
 
 rb_vm_check_ints.exit1:                           ; preds = %47, %74
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !34, !tbaa !14
-  %rubyId_foo80 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
-  %rawSym81 = tail call i64 @rb_id2sym(i64 %rubyId_foo80), !dbg !40
-  %rubyId_normal82 = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !40
-  %rawSym83 = tail call i64 @rb_id2sym(i64 %rubyId_normal82), !dbg !40
   %stackFrame88 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#3foo", align 8, !dbg !40
-  %78 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !40
+  %78 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !40
   %79 = bitcast i8* %78 to i16*, !dbg !40
   %80 = load i16, i16* %79, align 8, !dbg !40
   %81 = and i16 %80, -384, !dbg !40
@@ -392,7 +384,7 @@ rb_vm_check_ints.exit1:                           ; preds = %47, %74
   %82 = getelementptr inbounds i8, i8* %78, i64 4, !dbg !40
   %83 = bitcast i8* %82 to i32*, !dbg !40
   tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %82, i8 0, i64 28, i1 false), !dbg !40
-  tail call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_AttrReaderSigChecked#3foo", i8* nonnull %78, %struct.rb_iseq_struct* %stackFrame88, i1 noundef zeroext false) #15, !dbg !40
+  tail call void @sorbet_vm_define_method(i64 %48, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_AttrReaderSigChecked#3foo", i8* nonnull %78, %struct.rb_iseq_struct* %stackFrame88, i1 noundef zeroext false) #16, !dbg !40
   %84 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !14
   %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 5, !dbg !40
   %86 = load i32, i32* %85, align 8, !dbg !40, !tbaa !25
@@ -406,7 +398,7 @@ rb_vm_check_ints.exit1:                           ; preds = %47, %74
 92:                                               ; preds = %rb_vm_check_ints.exit1
   %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 8, !dbg !40
   %94 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %93, align 8, !dbg !40, !tbaa !28
-  %95 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #15, !dbg !40
+  %95 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #16, !dbg !40
   br label %rb_vm_check_ints.exit, !dbg !40
 
 rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.exit1, %92
@@ -414,7 +406,7 @@ rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.ex
 }
 
 ; Function Attrs: sspreq
-define void @Init_sig_checked() local_unnamed_addr #8 {
+define void @Init_sig_checked() local_unnamed_addr #9 {
 entry:
   %locals.i22.i = alloca i64, align 8
   %locals.i20.i = alloca i64, i32 0, align 8
@@ -424,43 +416,42 @@ entry:
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
   store i64 %1, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #15
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #16
   store i64 %2, i64* @rubyIdPrecomputed_new, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_<", i64 0, i64 0), i64 noundef 1) #15
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_<", i64 0, i64 0), i64 noundef 1) #16
   store i64 %3, i64* @"rubyIdPrecomputed_<", align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #15
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #16
   store i64 %4, i64* @rubyIdPrecomputed_foo, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #15
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #16
   store i64 %5, i64* @"rubyIdPrecomputed_+", align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #15
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #16
   store i64 %6, i64* @rubyIdPrecomputed_puts, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #16
   store i64 %7, i64* @rubyIdPrecomputed_initialize, align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @"str_@foo", i64 0, i64 0), i64 noundef 4) #15
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @"str_@foo", i64 0, i64 0), i64 noundef 4) #16
   store i64 %8, i64* @"rubyIdPrecomputed_@foo", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([29 x i8], [29 x i8]* @"str_<class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 28) #15
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([29 x i8], [29 x i8]* @"str_<class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 28) #16
   store i64 %9, i64* @"rubyIdPrecomputed_<class:AttrReaderSigChecked>", align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #15
+  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #16
   store i64 %10, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_block in <class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 37) #15
+  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_block in <class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 37) #16
   store i64 %11, i64* @"rubyIdPrecomputed_block in <class:AttrReaderSigChecked>", align 8
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #15
+  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #16
   store i64 %12, i64* @rubyIdPrecomputed_params, align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_void, i64 0, i64 0), i64 noundef 4) #15
+  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_void, i64 0, i64 0), i64 noundef 4) #16
   store i64 %13, i64* @rubyIdPrecomputed_void, align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #15
+  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #16
   store i64 %14, i64* @rubyIdPrecomputed_returns, align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #15
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #16
   store i64 %15, i64* @rubyIdPrecomputed_extend, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %16, i64* @rubyIdPrecomputed_normal, align 8
-  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
-  tail call void @rb_gc_register_mark_object(i64 %17) #15
+  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
+  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  tail call void @rb_gc_register_mark_object(i64 %17) #16
   store i64 %17, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([63 x i8], [63 x i8]* @"str_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", i64 0, i64 0), i64 noundef 62) #15
-  tail call void @rb_gc_register_mark_object(i64 %18) #15
+  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([63 x i8], [63 x i8]* @"str_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", i64 0, i64 0), i64 noundef 62) #16
+  tail call void @rb_gc_register_mark_object(i64 %18) #16
   store i64 %18, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -482,22 +473,22 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !49
   %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !50
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
-  call void @rb_gc_register_mark_object(i64 %20) #15
+  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #16
+  call void @rb_gc_register_mark_object(i64 %20) #16
   %rubyId_initialize.i.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8
   %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
   %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %rubyId_initialize.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#10initialize", align 8
-  %22 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #15
+  %22 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #16
   store i64 %22, i64* @"<void-singleton>", align 8
-  %23 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #15
-  call void @rb_gc_register_mark_object(i64 %23) #15
+  %23 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #16
+  call void @rb_gc_register_mark_object(i64 %23) #16
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
   %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i19.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb", align 8
   %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %23, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i19.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i20.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked#3foo", align 8
-  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([29 x i8], [29 x i8]* @"str_<class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 28) #15
-  call void @rb_gc_register_mark_object(i64 %25) #15
+  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([29 x i8], [29 x i8]* @"str_<class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 28) #16
+  call void @rb_gc_register_mark_object(i64 %25) #16
   %26 = bitcast i64* %locals.i22.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %26)
   %"rubyId_<class:AttrReaderSigChecked>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:AttrReaderSigChecked>", align 8
@@ -507,8 +498,8 @@ entry:
   %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %25, i64 %"rubyId_<class:AttrReaderSigChecked>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/attr_reader/sig_checked.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i22.i, i32 noundef 1, i32 noundef 4)
   store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %26)
-  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_block in <class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 37) #15
-  call void @rb_gc_register_mark_object(i64 %28) #15
+  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_block in <class:AttrReaderSigChecked>", i64 0, i64 0), i64 noundef 37) #16
+  call void @rb_gc_register_mark_object(i64 %28) #16
   store i64 %28, i64* @"rubyStrFrozen_block in <class:AttrReaderSigChecked>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>", align 8
   %"rubyId_block in <class:AttrReaderSigChecked>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:AttrReaderSigChecked>", align 8
@@ -523,9 +514,9 @@ entry:
   store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_AttrReaderSigChecked.13<static-init>$block_2", align 8
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !41
   %rubyId_foo10.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !41
-  %31 = call i64 @rb_id2sym(i64 %rubyId_foo10.i) #15, !dbg !41
+  %31 = call i64 @rb_id2sym(i64 %rubyId_foo10.i) #18, !dbg !41
   store i64 %31, i64* %keywords.i, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !41
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 1, i32 noundef 1, i64* noundef nonnull align 8 %keywords.i), !dbg !41
   %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !41
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !41
   %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !51
@@ -547,14 +538,14 @@ entry:
   %41 = load i64, i64* %40, align 8, !tbaa !6
   %42 = and i64 %41, -33
   store i64 %42, i64* %40, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %35, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i) #15
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %35, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i) #16
   %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %43, align 8, !dbg !61, !tbaa !14
   %44 = load i64, i64* @rb_cObject, align 8, !dbg !62
-  %45 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @str_AttrReaderSigChecked, i64 0, i64 0), i64 %44) #15, !dbg !62
-  %46 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %45) #15, !dbg !62
-  call fastcc void @"func_AttrReaderSigChecked.13<static-init>L62"(i64 %45, %struct.rb_control_frame_struct* %46) #15, !dbg !62
-  call void @sorbet_popFrame() #15, !dbg !62
+  %45 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @str_AttrReaderSigChecked, i64 0, i64 0), i64 %44) #16, !dbg !62
+  %46 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %45) #16, !dbg !62
+  call fastcc void @"func_AttrReaderSigChecked.13<static-init>L62"(i64 %45, %struct.rb_control_frame_struct* %46) #16, !dbg !62
+  call void @sorbet_popFrame() #16, !dbg !62
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %43, align 8, !dbg !62, !tbaa !14
   %47 = load i64, i64* @guard_epoch_AttrReaderSigChecked, align 8, !dbg !43
   %48 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !31
@@ -636,7 +627,7 @@ afterSend37.i:                                    ; preds = %99, %sorbet_rb_int_
 
 "fastSymCallIntrinsic_Integer_<.i":               ; preds = %BB2.i, %sorbet_isa_Integer.exit
   %82 = phi i1 [ %70, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
-  call void @llvm.experimental.noalias.scope.decl(metadata !68) #15, !dbg !45
+  call void @llvm.experimental.noalias.scope.decl(metadata !68) #16, !dbg !45
   %83 = and i64 %i.sroa.0.0.i, 1, !dbg !45
   %84 = icmp eq i64 %83, 0, !dbg !45
   br i1 %84, label %89, label %85, !dbg !45, !prof !71
@@ -648,7 +639,7 @@ afterSend37.i:                                    ; preds = %99, %sorbet_rb_int_
   br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
 89:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %90 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !45, !noalias !68
+  %90 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #16, !dbg !45, !noalias !68
   br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
 sorbet_rb_int_lt.exit.i:                          ; preds = %89, %85
@@ -666,7 +657,7 @@ sorbet_rb_int_lt.exit.i:                          ; preds = %89, %85
 99:                                               ; preds = %sorbet_rb_int_lt.exit.i
   %100 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %91, i64 0, i32 8, !dbg !45
   %101 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %100, align 8, !dbg !45, !tbaa !28
-  %102 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %101, i32 noundef 0) #15, !dbg !45
+  %102 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %101, i32 noundef 0) #16, !dbg !45
   br label %afterSend37.i, !dbg !45
 
 "alternativeCallIntrinsic_Integer_+.i":           ; preds = %BB5.i
@@ -681,13 +672,13 @@ sorbet_rb_int_lt.exit.i:                          ; preds = %89, %85
   br label %BB2.i.backedge, !dbg !47
 
 "fastSymCallIntrinsic_Integer_+.i":               ; preds = %BB5.i
-  call void @llvm.experimental.noalias.scope.decl(metadata !72) #15, !dbg !47
+  call void @llvm.experimental.noalias.scope.decl(metadata !72) #16, !dbg !47
   %107 = and i64 %i.sroa.0.0.i, 1, !dbg !47
   %108 = icmp eq i64 %107, 0, !dbg !47
   br i1 %108, label %117, label %109, !dbg !47, !prof !71
 
 109:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %110 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !47
+  %110 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #19, !dbg !47
   %111 = extractvalue { i64, i1 } %110, 1, !dbg !47
   %112 = extractvalue { i64, i1 } %110, 0, !dbg !47
   br i1 %111, label %113, label %sorbet_rb_int_plus.exit.i, !dbg !47
@@ -695,11 +686,11 @@ sorbet_rb_int_lt.exit.i:                          ; preds = %89, %85
 113:                                              ; preds = %109
   %114 = ashr i64 %112, 1, !dbg !47
   %115 = xor i64 %114, -9223372036854775808, !dbg !47
-  %116 = call i64 @rb_int2big(i64 %115) #15, !dbg !47
+  %116 = call i64 @rb_int2big(i64 %115) #16, !dbg !47
   br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
 117:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %118 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !47, !noalias !72
+  %118 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #16, !dbg !47, !noalias !72
   br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
 sorbet_rb_int_plus.exit.i:                        ; preds = %117, %113, %109
@@ -717,7 +708,7 @@ sorbet_rb_int_plus.exit.i:                        ; preds = %117, %113, %109
 128:                                              ; preds = %sorbet_rb_int_plus.exit.i
   %129 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %120, i64 0, i32 8, !dbg !47
   %130 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %129, align 8, !dbg !47, !tbaa !28
-  %131 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %130, i32 noundef 0) #15, !dbg !47
+  %131 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %130, i32 noundef 0) #16, !dbg !47
   br label %BB2.i.backedge, !dbg !47
 
 BB2.i.backedge:                                   ; preds = %128, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
@@ -754,7 +745,7 @@ BB2.i.backedge:                                   ; preds = %128, %sorbet_rb_int
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_AttrReaderSigChecked#10initialize"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #7 !dbg !75 {
+define i64 @"func_AttrReaderSigChecked#10initialize"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #8 !dbg !75 {
 functionEntryInitializers:
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %1, align 8, !tbaa !14
@@ -764,7 +755,7 @@ functionEntryInitializers:
   br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !76, !prof !71
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #18, !dbg !76
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #20, !dbg !76
   unreachable, !dbg !76
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
@@ -792,19 +783,19 @@ sorbet_isa_Integer.exit:                          ; preds = %4
 typeTestSuccess:                                  ; preds = %fillRequiredArgs, %sorbet_isa_Integer.exit
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %1, align 8, !dbg !77, !tbaa !14
   %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !78
-  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %rawArg_foo, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #15, !dbg !78
+  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %rawArg_foo, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #16, !dbg !78
   %"rubyId_@foo13" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !79
-  %15 = tail call i64 @sorbet_vm_getivar(i64 %selfRaw, i64 %"rubyId_@foo13", %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo.3") #15, !dbg !79
+  %15 = tail call i64 @sorbet_vm_getivar(i64 %selfRaw, i64 %"rubyId_@foo13", %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo.3") #16, !dbg !79
   %"<void-singleton>" = load i64, i64* @"<void-singleton>", align 8
   ret i64 %"<void-singleton>"
 
 codeRepl:                                         ; preds = %4, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_AttrReaderSigChecked#10initialize.cold.1"(i64 %rawArg_foo) #19, !dbg !77
+  tail call fastcc void @"func_AttrReaderSigChecked#10initialize.cold.1"(i64 %rawArg_foo) #21, !dbg !77
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_AttrReaderSigChecked#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #7 !dbg !80 {
+define i64 @"func_AttrReaderSigChecked#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #8 !dbg !80 {
 functionEntryInitializers:
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %1, align 8, !tbaa !14
@@ -812,12 +803,12 @@ functionEntryInitializers:
   br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !81, !prof !64
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #18, !dbg !81
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #20, !dbg !81
   unreachable, !dbg !81
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
   %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !82
-  %2 = tail call i64 @sorbet_vm_getivar(i64 %selfRaw, i64 %"rubyId_@foo", %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo.4") #15, !dbg !82
+  %2 = tail call i64 @sorbet_vm_getivar(i64 %selfRaw, i64 %"rubyId_@foo", %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo.4") #16, !dbg !82
   %3 = and i64 %2, 1
   %4 = icmp eq i64 %3, 0
   br i1 %4, label %5, label %typeTestSuccess, !prof !64
@@ -842,12 +833,12 @@ typeTestSuccess:                                  ; preds = %fillRequiredArgs, %
   ret i64 %2
 
 codeRepl:                                         ; preds = %5, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_AttrReaderSigChecked#3foo.cold.1"(i64 %2) #19, !dbg !83
+  tail call fastcc void @"func_AttrReaderSigChecked#3foo.cold.1"(i64 %2) #21, !dbg !83
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_AttrReaderSigChecked.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #9 !dbg !42 {
+define internal i64 @"func_AttrReaderSigChecked.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #10 !dbg !42 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -864,8 +855,6 @@ functionEntryInitializers:
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !14
-  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !85
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !85
   %11 = load i64, i64* @rb_cInteger, align 8, !dbg !41
   %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !41
   %13 = load i64*, i64** %12, align 8, !dbg !41
@@ -881,11 +870,11 @@ functionEntryInitializers:
   %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !41
   store i64* %18, i64** %16, align 8, !dbg !41
   %send16 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_void, i64 0), !dbg !41
-  ret i64 %send16, !dbg !86
+  ret i64 %send16, !dbg !85
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_AttrReaderSigChecked.13<static-init>L62$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #9 !dbg !52 {
+define internal i64 @"func_AttrReaderSigChecked.13<static-init>L62$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #10 !dbg !52 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -911,40 +900,40 @@ functionEntryInitializers:
   %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !51
   store i64* %15, i64** %12, align 8, !dbg !51
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !51
-  ret i64 %send, !dbg !87
+  ret i64 %send, !dbg !86
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare void @llvm.experimental.noalias.scope.decl(metadata) #10
+declare void @llvm.experimental.noalias.scope.decl(metadata) #11
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #6
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #6
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #11
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #12
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_AttrReaderSigChecked#10initialize.cold.1"(i64 %rawArg_foo) unnamed_addr #12 !dbg !88 {
+define internal fastcc void @"func_AttrReaderSigChecked#10initialize.cold.1"(i64 %rawArg_foo) unnamed_addr #13 !dbg !87 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_foo, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !90
-  unreachable, !dbg !90
+  tail call void @sorbet_cast_failure(i64 %rawArg_foo, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !89
+  unreachable, !dbg !89
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_AttrReaderSigChecked#3foo.cold.1"(i64 %0) unnamed_addr #12 !dbg !91 {
+define internal fastcc void @"func_AttrReaderSigChecked#3foo.cold.1"(i64 %0) unnamed_addr #13 !dbg !90 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18
+  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20
   unreachable
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #13
+declare void @llvm.assume(i1 noundef) #14
 
 ; Function Attrs: ssp
-define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #9 {
+define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !31
@@ -953,7 +942,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #9 {
 }
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_AttrReaderSigChecked() local_unnamed_addr #9 {
+define linkonce void @const_recompute_AttrReaderSigChecked() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([21 x i8], [21 x i8]* @str_AttrReaderSigChecked, i64 0, i64 0), i64 20)
   store i64 %1, i64* @guarded_const_AttrReaderSigChecked, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !31
@@ -961,26 +950,28 @@ define linkonce void @const_recompute_AttrReaderSigChecked() local_unnamed_addr 
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nofree nosync nounwind readnone speculatable willreturn }
-attributes #4 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #5 = { argmemonly nofree nosync nounwind willreturn }
-attributes #6 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #7 = { nounwind sspreq uwtable }
-attributes #8 = { sspreq }
-attributes #9 = { ssp }
-attributes #10 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #11 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #12 = { cold minsize noreturn nounwind sspreq uwtable }
-attributes #13 = { nofree nosync nounwind willreturn }
-attributes #14 = { noreturn nounwind }
-attributes #15 = { nounwind }
-attributes #16 = { nounwind allocsize(0,1) }
-attributes #17 = { nounwind willreturn }
-attributes #18 = { noreturn }
-attributes #19 = { noinline }
+attributes #3 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { nofree nosync nounwind readnone speculatable willreturn }
+attributes #5 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #6 = { argmemonly nofree nosync nounwind willreturn }
+attributes #7 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #8 = { nounwind sspreq uwtable }
+attributes #9 = { sspreq }
+attributes #10 = { ssp }
+attributes #11 = { inaccessiblememonly nofree nosync nounwind willreturn }
+attributes #12 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #13 = { cold minsize noreturn nounwind sspreq uwtable }
+attributes #14 = { nofree nosync nounwind willreturn }
+attributes #15 = { noreturn nounwind }
+attributes #16 = { nounwind }
+attributes #17 = { nounwind allocsize(0,1) }
+attributes #18 = { nounwind readnone willreturn }
+attributes #19 = { nounwind willreturn }
+attributes #20 = { noreturn }
+attributes #21 = { noinline }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -1070,10 +1061,9 @@ attributes #19 = { noinline }
 !82 = !DILocation(line: 13, column: 16, scope: !80)
 !83 = !DILocation(line: 0, scope: !80)
 !84 = !{!21, !7, i64 24}
-!85 = !DILocation(line: 7, column: 15, scope: !42)
-!86 = !DILocation(line: 7, column: 3, scope: !42)
-!87 = !DILocation(line: 12, column: 3, scope: !52)
-!88 = distinct !DISubprogram(name: "func_AttrReaderSigChecked#10initialize.cold.1", linkageName: "func_AttrReaderSigChecked#10initialize.cold.1", scope: null, file: !4, type: !89, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!89 = !DISubroutineType(types: !5)
-!90 = !DILocation(line: 8, column: 18, scope: !88)
-!91 = distinct !DISubprogram(name: "func_AttrReaderSigChecked#3foo.cold.1", linkageName: "func_AttrReaderSigChecked#3foo.cold.1", scope: null, file: !4, type: !89, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!85 = !DILocation(line: 7, column: 3, scope: !42)
+!86 = !DILocation(line: 12, column: 3, scope: !52)
+!87 = distinct !DISubprogram(name: "func_AttrReaderSigChecked#10initialize.cold.1", linkageName: "func_AttrReaderSigChecked#10initialize.cold.1", scope: null, file: !4, type: !88, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!88 = !DISubroutineType(types: !5)
+!89 = !DILocation(line: 8, column: 18, scope: !87)
+!90 = distinct !DISubprogram(name: "func_AttrReaderSigChecked#3foo.cold.1", linkageName: "func_AttrReaderSigChecked#3foo.cold.1", scope: null, file: !4, type: !88, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)

--- a/test/testdata/ruby_benchmark/stripe/prop_const_getter.llo.exp
+++ b/test/testdata/ruby_benchmark/stripe/prop_const_getter.llo.exp
@@ -144,14 +144,12 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_returns = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_returns = internal unnamed_addr global i64 0, align 8
 @str_returns = private unnamed_addr constant [8 x i8] c"returns\00", align 1
-@rubyIdPrecomputed_normal = internal unnamed_addr global i64 0, align 8
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_without_accessors = internal unnamed_addr global i64 0, align 8
 @str_without_accessors = private unnamed_addr constant [18 x i8] c"without_accessors\00", align 1
 @ic_const = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_const = internal unnamed_addr global i64 0, align 8
 @str_const = private unnamed_addr constant [6 x i8] c"const\00", align 1
-@rubyIdPrecomputed_attr_reader = internal unnamed_addr global i64 0, align 8
 @str_attr_reader = private unnamed_addr constant [12 x i8] c"attr_reader\00", align 1
 @guard_epoch_MyStruct = linkonce local_unnamed_addr global i64 0
 @guarded_const_MyStruct = linkonce local_unnamed_addr global i64 0
@@ -159,6 +157,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"guard_epoch_T::Struct" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Struct" = linkonce local_unnamed_addr global i64 0
 
+; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 ; Function Attrs: cold noreturn
@@ -173,101 +172,101 @@ declare void @sorbet_raiseMissingKeywords(i64) local_unnamed_addr #2
 ; Function Attrs: noreturn
 declare void @sorbet_raiseExtraKeywords(i64) local_unnamed_addr #2
 
-declare i64 @sorbet_addMissingKWArg(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_addMissingKWArg(i64, i64) local_unnamed_addr #3
 
-declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
+declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #3
 
-declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #0
+declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32) local_unnamed_addr #3
 
-declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_readRealpath() local_unnamed_addr #0
+declare i64 @sorbet_readRealpath() local_unnamed_addr #3
 
-declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #0
+declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_unnamed_addr #3
 
-declare void @sorbet_popFrame() local_unnamed_addr #0
+declare void @sorbet_popFrame() local_unnamed_addr #3
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #3
 
-declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
+declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #3
 
-declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #3
 
-declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #3
 
-declare i64 @sorbet_rb_int_lt_slowpath(i64, i64) local_unnamed_addr #0
+declare i64 @sorbet_rb_int_lt_slowpath(i64, i64) local_unnamed_addr #3
 
-declare void @sorbet_vm_setivar(i64, i64, i64, %struct.iseq_inline_iv_cache_entry*) local_unnamed_addr #0
+declare void @sorbet_vm_setivar(i64, i64, i64, %struct.iseq_inline_iv_cache_entry*) local_unnamed_addr #3
 
-declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
+declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
 
-declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #3
 
-declare i64 @rb_intern(i8*) local_unnamed_addr #0
+declare i64 @rb_intern(i8*) local_unnamed_addr #3
 
-declare i64 @rb_id2str(i64) local_unnamed_addr #0
+declare i64 @rb_id2str(i64) local_unnamed_addr #3
 
-declare i64 @rb_sprintf(i8*, ...) local_unnamed_addr #0
+declare i64 @rb_sprintf(i8*, ...) local_unnamed_addr #3
 
-declare i64 @rb_intern_str(i64) local_unnamed_addr #0
+declare i64 @rb_intern_str(i64) local_unnamed_addr #3
 
-declare void @rb_add_method(i64, i64, i32, i8*, i32) local_unnamed_addr #0
+declare void @rb_add_method(i64, i64, i32, i8*, i32) local_unnamed_addr #3
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #3
 
-declare i64 @rb_hash_new_with_size(i64) local_unnamed_addr #0
+declare i64 @rb_hash_new_with_size(i64) local_unnamed_addr #3
 
-declare void @rb_hash_bulk_insert(i64, i64*, i64) local_unnamed_addr #0
+declare void @rb_hash_bulk_insert(i64, i64*, i64) local_unnamed_addr #3
 
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #3
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
 
-declare i64 @rb_int2big(i64) local_unnamed_addr #0
+declare i64 @rb_int2big(i64) local_unnamed_addr #3
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #3
+declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #4
 
-declare i64 @rb_hash_lookup2(i64, i64, i64) local_unnamed_addr #0
+declare i64 @rb_hash_lookup2(i64, i64, i64) local_unnamed_addr #3
 
-declare i64 @rb_hash_size_num(i64) local_unnamed_addr #0
+declare i64 @rb_hash_size_num(i64) local_unnamed_addr #3
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #0
+declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #3
 
-declare %struct.rb_callable_method_entry_struct* @rb_vm_frame_method_entry(%struct.rb_control_frame_struct*) local_unnamed_addr #0
+declare %struct.rb_callable_method_entry_struct* @rb_vm_frame_method_entry(%struct.rb_control_frame_struct*) local_unnamed_addr #3
 
-declare %struct.rb_callable_method_entry_struct* @rb_callable_method_entry(i64, i64) local_unnamed_addr #0
+declare %struct.rb_callable_method_entry_struct* @rb_callable_method_entry(i64, i64) local_unnamed_addr #3
 
-declare i64 @rb_vm_call_kw(%struct.rb_execution_context_struct*, i64, i64, i32, i64*, %struct.rb_callable_method_entry_struct*, i32) local_unnamed_addr #0
-
-; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #4
+declare i64 @rb_vm_call_kw(%struct.rb_execution_context_struct*, i64, i64, i32, i64*, %struct.rb_callable_method_entry_struct*, i32) local_unnamed_addr #3
 
 ; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xmalloc2(i64, i64) local_unnamed_addr #4
+declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #5
+
+; Function Attrs: allocsize(0,1)
+declare noalias nonnull i8* @ruby_xmalloc2(i64, i64) local_unnamed_addr #5
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #5
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #6
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #14
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #14
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_MyStruct.13<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !10 {
+define internal fastcc void @"func_MyStruct.13<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !10 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
@@ -280,7 +279,7 @@ functionEntryInitializers:
   %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
   store i64 %7, i64* %5, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #15
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #16
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !23, !tbaa !14
   %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !14
@@ -296,7 +295,7 @@ functionEntryInitializers:
 17:                                               ; preds = %functionEntryInitializers
   %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !24
   %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !24, !tbaa !28
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #15, !dbg !24
+  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !24
   br label %rb_vm_check_ints.exit3, !dbg !24
 
 rb_vm_check_ints.exit3:                           ; preds = %functionEntryInitializers, %17
@@ -314,15 +313,11 @@ rb_vm_check_ints.exit3:                           ; preds = %functionEntryInitia
 29:                                               ; preds = %rb_vm_check_ints.exit3
   %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !29
   %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !29, !tbaa !28
-  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #15, !dbg !29
+  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #16, !dbg !29
   br label %sorbet_setupParamKeywords.exit, !dbg !29
 
 sorbet_setupParamKeywords.exit:                   ; preds = %29, %rb_vm_check_ints.exit3
   store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !29, !tbaa !14
-  %rubyId_initialize = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !24
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_initialize), !dbg !24
-  %rubyId_normal = load i64, i64* @rubyIdPrecomputed_normal, align 8, !dbg !24
-  %rawSym56 = tail call i64 @rb_id2sym(i64 %rubyId_normal), !dbg !24
   %33 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !24
   %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !30
   %needTakeSlowPath = icmp ne i64 %33, %34, !dbg !24
@@ -339,7 +334,7 @@ sorbet_setupParamKeywords.exit:                   ; preds = %29, %rb_vm_check_in
   %guardUpdated = icmp eq i64 %38, %39, !dbg !24
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !24
   %stackFrame60 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct#10initialize", align 8, !dbg !24
-  %40 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !24
+  %40 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !24
   %41 = bitcast i8* %40 to i16*, !dbg !24
   %42 = load i16, i16* %41, align 8, !dbg !24
   %43 = and i16 %42, -384, !dbg !24
@@ -363,13 +358,13 @@ sorbet_setupParamKeywords.exit:                   ; preds = %29, %rb_vm_check_in
   %53 = getelementptr inbounds i8, i8* %40, i64 48, !dbg !24
   %54 = bitcast i8* %53 to i32*, !dbg !24
   store i32 1, i32* %54, align 8, !dbg !24, !tbaa !38
-  %55 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !24
+  %55 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !24
   %56 = bitcast i64* %keyword_table to i8*, !dbg !24
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %55, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %56, i64 noundef 8, i1 noundef false) #15, !dbg !24
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %55, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %56, i64 noundef 8, i1 noundef false) #16, !dbg !24
   %57 = getelementptr inbounds i8, i8* %40, i64 56, !dbg !24
   %58 = bitcast i8* %57 to i8**, !dbg !24
   store i8* %55, i8** %58, align 8, !dbg !24, !tbaa !39
-  tail call void @sorbet_vm_define_method(i64 %37, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_MyStruct#10initialize", i8* nonnull %40, %struct.rb_iseq_struct* %stackFrame60, i1 noundef zeroext false) #15, !dbg !24
+  tail call void @sorbet_vm_define_method(i64 %37, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*)* noundef @"func_MyStruct#10initialize", i8* nonnull %40, %struct.rb_iseq_struct* %stackFrame60, i1 noundef zeroext false) #16, !dbg !24
   %59 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !14
   %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 5, !dbg !24
   %61 = load i32, i32* %60, align 8, !dbg !24, !tbaa !25
@@ -383,15 +378,13 @@ sorbet_setupParamKeywords.exit:                   ; preds = %29, %rb_vm_check_in
 67:                                               ; preds = %36
   %68 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 8, !dbg !24
   %69 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %68, align 8, !dbg !24, !tbaa !28
-  %70 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %69, i32 noundef 0) #15, !dbg !24
+  %70 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %69, i32 noundef 0) #16, !dbg !24
   br label %rb_vm_check_ints.exit1, !dbg !24
 
 rb_vm_check_ints.exit1:                           ; preds = %36, %67
   store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !24, !tbaa !14
   %rubyId_foo62 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !40
   %rawSym63 = tail call i64 @rb_id2sym(i64 %rubyId_foo62), !dbg !40
-  %rubyId_without_accessors = load i64, i64* @rubyIdPrecomputed_without_accessors, align 8, !dbg !29
-  %rawSym64 = tail call i64 @rb_id2sym(i64 %rubyId_without_accessors), !dbg !29
   %71 = load i64, i64* @rb_cInteger, align 8, !dbg !29
   %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !29
   %73 = load i64*, i64** %72, align 8, !dbg !29
@@ -405,16 +398,12 @@ rb_vm_check_ints.exit1:                           ; preds = %36, %67
   %77 = getelementptr inbounds i64, i64* %76, i64 1, !dbg !29
   store i64* %77, i64** %72, align 8, !dbg !29
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_const, i64 0), !dbg !29
-  %rubyId_foo71 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !29
-  %rawSym72 = tail call i64 @rb_id2sym(i64 %rubyId_foo71), !dbg !29
-  %rubyId_attr_reader = load i64, i64* @rubyIdPrecomputed_attr_reader, align 8, !dbg !29
-  %rawSym73 = tail call i64 @rb_id2sym(i64 %rubyId_attr_reader), !dbg !29
-  %78 = tail call i64 @rb_intern(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0)) #15, !dbg !29
-  %79 = tail call i64 @rb_id2str(i64 %78) #15, !dbg !29
-  %80 = tail call i64 (i8*, ...) @rb_sprintf(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i64 %79) #15, !dbg !29
-  %81 = tail call i64 @rb_intern_str(i64 %80) #15, !dbg !29
+  %78 = tail call i64 @rb_intern(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0)) #16, !dbg !29
+  %79 = tail call i64 @rb_id2str(i64 %78) #16, !dbg !29
+  %80 = tail call i64 (i8*, ...) @rb_sprintf(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i64 %79) #16, !dbg !29
+  %81 = tail call i64 @rb_intern_str(i64 %80) #16, !dbg !29
   %82 = inttoptr i64 %81 to i8*, !dbg !29
-  tail call void @rb_add_method(i64 %37, i64 %78, i32 noundef 4, i8* %82, i32 noundef 1) #15, !dbg !29
+  tail call void @rb_add_method(i64 %37, i64 %78, i32 noundef 4, i8* %82, i32 noundef 1) #16, !dbg !29
   %83 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
   %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 5, !dbg !29
   %85 = load i32, i32* %84, align 8, !dbg !29, !tbaa !25
@@ -428,7 +417,7 @@ rb_vm_check_ints.exit1:                           ; preds = %36, %67
 91:                                               ; preds = %rb_vm_check_ints.exit1
   %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 8, !dbg !29
   %93 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %92, align 8, !dbg !29, !tbaa !28
-  %94 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %93, i32 noundef 0) #15, !dbg !29
+  %94 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %93, i32 noundef 0) #16, !dbg !29
   br label %rb_vm_check_ints.exit, !dbg !29
 
 rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.exit1, %91
@@ -436,7 +425,7 @@ rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.ex
 }
 
 ; Function Attrs: sspreq
-define void @Init_prop_const_getter() local_unnamed_addr #8 {
+define void @Init_prop_const_getter() local_unnamed_addr #9 {
 entry:
   %locals.i23.i = alloca i64, align 8
   %locals.i21.i = alloca i64, i32 0, align 8
@@ -451,47 +440,45 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %1)
   %2 = bitcast i64* %keywords16.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %2)
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
   store i64 %3, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #15
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #16
   store i64 %4, i64* @rubyIdPrecomputed_foo, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #15
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #16
   store i64 %5, i64* @rubyIdPrecomputed_new, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_<", i64 0, i64 0), i64 noundef 1) #15
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_<", i64 0, i64 0), i64 noundef 1) #16
   store i64 %6, i64* @"rubyIdPrecomputed_<", align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #15
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #16
   store i64 %7, i64* @"rubyIdPrecomputed_+", align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #15
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #16
   store i64 %8, i64* @rubyIdPrecomputed_puts, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #16
   store i64 %9, i64* @rubyIdPrecomputed_initialize, align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @"str_@foo", i64 0, i64 0), i64 noundef 4) #15
+  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @"str_@foo", i64 0, i64 0), i64 noundef 4) #16
   store i64 %10, i64* @"rubyIdPrecomputed_@foo", align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<class:MyStruct>", i64 0, i64 0), i64 noundef 16) #15
+  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<class:MyStruct>", i64 0, i64 0), i64 noundef 16) #16
   store i64 %11, i64* @"rubyIdPrecomputed_<class:MyStruct>", align 8
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #15
+  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #16
   store i64 %12, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <class:MyStruct>", i64 0, i64 0), i64 noundef 25) #15
+  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <class:MyStruct>", i64 0, i64 0), i64 noundef 25) #16
   store i64 %13, i64* @"rubyIdPrecomputed_block in <class:MyStruct>", align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #15
+  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #16
   store i64 %14, i64* @rubyIdPrecomputed_params, align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_void, i64 0, i64 0), i64 noundef 4) #15
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_void, i64 0, i64 0), i64 noundef 4) #16
   store i64 %15, i64* @rubyIdPrecomputed_void, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #15
+  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #16
   store i64 %16, i64* @rubyIdPrecomputed_returns, align 8
-  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
-  store i64 %17, i64* @rubyIdPrecomputed_normal, align 8
-  %18 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @str_without_accessors, i64 0, i64 0), i64 noundef 17) #15
+  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
+  %18 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @str_without_accessors, i64 0, i64 0), i64 noundef 17) #16
   store i64 %18, i64* @rubyIdPrecomputed_without_accessors, align 8
-  %19 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_const, i64 0, i64 0), i64 noundef 5) #15
+  %19 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_const, i64 0, i64 0), i64 noundef 5) #16
   store i64 %19, i64* @rubyIdPrecomputed_const, align 8
-  %20 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @str_attr_reader, i64 0, i64 0), i64 noundef 11) #15
-  store i64 %20, i64* @rubyIdPrecomputed_attr_reader, align 8
-  %21 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
-  tail call void @rb_gc_register_mark_object(i64 %21) #15
+  %20 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @str_attr_reader, i64 0, i64 0), i64 noundef 11) #16
+  %21 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  tail call void @rb_gc_register_mark_object(i64 %21) #16
   store i64 %21, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %22 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([57 x i8], [57 x i8]* @"str_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", i64 0, i64 0), i64 noundef 56) #15
-  tail call void @rb_gc_register_mark_object(i64 %22) #15
+  %22 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([57 x i8], [57 x i8]* @"str_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", i64 0, i64 0), i64 noundef 56) #16
+  tail call void @rb_gc_register_mark_object(i64 %22) #16
   store i64 %22, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 21)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -501,9 +488,9 @@ entry:
   store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !41
   %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !41
-  %24 = call i64 @rb_id2sym(i64 %rubyId_foo.i) #15, !dbg !41
+  %24 = call i64 @rb_id2sym(i64 %rubyId_foo.i) #18, !dbg !41
   store i64 %24, i64* %keywords.i, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 64, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords.i), !dbg !41
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 64, i32 noundef 1, i32 noundef 1, i64* noundef nonnull align 8 %keywords.i), !dbg !41
   %"rubyId_<.i" = load i64, i64* @"rubyIdPrecomputed_<", align 8, !dbg !45
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_<", i64 %"rubyId_<.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
   %rubyId_foo1.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !46
@@ -516,16 +503,16 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo5.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !49
   %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !50
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
-  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #15
-  call void @rb_gc_register_mark_object(i64 %25) #15
+  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #16
+  call void @rb_gc_register_mark_object(i64 %25) #16
   %rubyId_initialize.i.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8
   %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb", align 8
   %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %25, i64 %rubyId_initialize.i.i, i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i21.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct#10initialize", align 8
-  %27 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #15
+  %27 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([30 x i8], [30 x i8]* @sorbet_getVoidSingleton.name, i64 0, i64 0), i64 noundef 30) #16
   store i64 %27, i64* @"<void-singleton>", align 8
-  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<class:MyStruct>", i64 0, i64 0), i64 noundef 16) #15
-  call void @rb_gc_register_mark_object(i64 %28) #15
+  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<class:MyStruct>", i64 0, i64 0), i64 noundef 16) #16
+  call void @rb_gc_register_mark_object(i64 %28) #16
   %29 = bitcast i64* %locals.i23.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %29)
   %"rubyId_<class:MyStruct>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:MyStruct>", align 8
@@ -535,8 +522,8 @@ entry:
   %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %28, i64 %"rubyId_<class:MyStruct>.i.i", i64 %"rubyStr_test/testdata/ruby_benchmark/stripe/prop_const_getter.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i23.i, i32 noundef 1, i32 noundef 4)
   store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>", align 8
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %29)
-  %31 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <class:MyStruct>", i64 0, i64 0), i64 noundef 25) #15
-  call void @rb_gc_register_mark_object(i64 %31) #15
+  %31 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <class:MyStruct>", i64 0, i64 0), i64 noundef 25) #16
+  call void @rb_gc_register_mark_object(i64 %31) #16
   store i64 %31, i64* @"rubyStrFrozen_block in <class:MyStruct>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>", align 8
   %"rubyId_block in <class:MyStruct>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:MyStruct>", align 8
@@ -551,18 +538,18 @@ entry:
   store %struct.rb_iseq_struct* %33, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_MyStruct.13<static-init>$block_2", align 8
   %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !43
   %rubyId_foo11.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !43
-  %34 = call i64 @rb_id2sym(i64 %rubyId_foo11.i) #15, !dbg !43
+  %34 = call i64 @rb_id2sym(i64 %rubyId_foo11.i) #18, !dbg !43
   store i64 %34, i64* %keywords10.i, align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 64, i32 noundef 1, i32 noundef 1, i64* noundef nonnull %keywords10.i), !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 64, i32 noundef 1, i32 noundef 1, i64* noundef nonnull align 8 %keywords10.i), !dbg !43
   %rubyId_void.i = load i64, i64* @rubyIdPrecomputed_void, align 8, !dbg !43
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_void, i64 %rubyId_void.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !43
   %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !51
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !51
   %rubyId_const.i = load i64, i64* @rubyIdPrecomputed_const, align 8, !dbg !29
   %rubyId_without_accessors.i = load i64, i64* @rubyIdPrecomputed_without_accessors, align 8, !dbg !29
-  %35 = call i64 @rb_id2sym(i64 %rubyId_without_accessors.i) #15, !dbg !29
+  %35 = call i64 @rb_id2sym(i64 %rubyId_without_accessors.i) #18, !dbg !29
   store i64 %35, i64* %keywords16.i, align 8, !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_const, i64 %rubyId_const.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull %keywords16.i), !dbg !29
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_const, i64 %rubyId_const.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull align 8 %keywords16.i), !dbg !29
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %2)
@@ -580,7 +567,7 @@ entry:
   %45 = load i64, i64* %44, align 8, !tbaa !6
   %46 = and i64 %45, -33
   store i64 %46, i64* %44, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %39, %struct.rb_control_frame_struct* %41, %struct.rb_iseq_struct* %stackFrame.i) #15
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %39, %struct.rb_control_frame_struct* %41, %struct.rb_iseq_struct* %stackFrame.i) #16
   %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 0
   store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %47, align 8, !dbg !61, !tbaa !14
   %48 = load i64, i64* @"guard_epoch_T::Struct", align 8, !dbg !62
@@ -598,17 +585,15 @@ entry:
   %54 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !62, !tbaa !30
   %guardUpdated = icmp eq i64 %53, %54, !dbg !62
   call void @llvm.assume(i1 %guardUpdated), !dbg !62
-  %55 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_MyStruct, i64 0, i64 0), i64 %52) #15, !dbg !62
-  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #15, !dbg !62
-  call fastcc void @"func_MyStruct.13<static-init>L62"(i64 %55, %struct.rb_control_frame_struct* %56) #15, !dbg !62
-  call void @sorbet_popFrame() #15, !dbg !62
+  %55 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_MyStruct, i64 0, i64 0), i64 %52) #16, !dbg !62
+  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #16, !dbg !62
+  call fastcc void @"func_MyStruct.13<static-init>L62"(i64 %55, %struct.rb_control_frame_struct* %56) #16, !dbg !62
+  call void @sorbet_popFrame() #16, !dbg !62
   store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %47, align 8, !dbg !63, !tbaa !14
-  %rubyId_foo.i1 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !64
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_foo.i1) #15, !dbg !64
   %57 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !41
   %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !30
-  %needTakeSlowPath2 = icmp ne i64 %57, %58, !dbg !41
-  br i1 %needTakeSlowPath2, label %59, label %60, !dbg !41, !prof !32
+  %needTakeSlowPath1 = icmp ne i64 %57, %58, !dbg !41
+  br i1 %needTakeSlowPath1, label %59, label %60, !dbg !41, !prof !32
 
 59:                                               ; preds = %51
   call void @const_recompute_MyStruct(), !dbg !41
@@ -618,8 +603,8 @@ entry:
   %61 = load i64, i64* @guarded_const_MyStruct, align 8, !dbg !41
   %62 = load i64, i64* @guard_epoch_MyStruct, align 8, !dbg !41
   %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !30
-  %guardUpdated3 = icmp eq i64 %62, %63, !dbg !41
-  call void @llvm.assume(i1 %guardUpdated3), !dbg !41
+  %guardUpdated2 = icmp eq i64 %62, %63, !dbg !41
+  call void @llvm.assume(i1 %guardUpdated2), !dbg !41
   %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !41
   %65 = load i64*, i64** %64, align 8, !dbg !41
   store i64 %61, i64* %65, align 8, !dbg !41, !tbaa !6
@@ -628,14 +613,14 @@ entry:
   %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !41
   store i64* %67, i64** %64, align 8, !dbg !41
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_new, i64 0), !dbg !41
-  br label %BB2.i, !dbg !65
+  br label %BB2.i, !dbg !64
 
 BB2.i:                                            ; preds = %BB2.i.backedge, %60
   %i.sroa.0.0.i = phi i64 [ 1, %60 ], [ %i.sroa.0.0.i.be, %BB2.i.backedge ], !dbg !61
   store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %47, align 8, !tbaa !14
   %68 = and i64 %i.sroa.0.0.i, 1, !dbg !45
   %69 = icmp eq i64 %68, 0, !dbg !45
-  br i1 %69, label %70, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !45, !prof !66
+  br i1 %69, label %70, label %"fastSymCallIntrinsic_Integer_<.i", !dbg !45, !prof !65
 
 70:                                               ; preds = %BB2.i
   %71 = and i64 %i.sroa.0.0.i, 7, !dbg !45
@@ -643,12 +628,12 @@ BB2.i:                                            ; preds = %BB2.i.backedge, %60
   %73 = and i64 %i.sroa.0.0.i, -9, !dbg !45
   %74 = icmp eq i64 %73, 0, !dbg !45
   %75 = or i1 %72, %74, !dbg !45
-  br i1 %75, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !45, !prof !67
+  br i1 %75, label %"alternativeCallIntrinsic_Integer_<.i", label %sorbet_isa_Integer.exit, !dbg !45, !prof !66
 
 sorbet_isa_Integer.exit:                          ; preds = %70
   %76 = inttoptr i64 %i.sroa.0.0.i to %struct.iseq_inline_iv_cache_entry*, !dbg !45
   %77 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %76, i64 0, i32 0, !dbg !45
-  %78 = load i64, i64* %77, align 8, !dbg !45, !tbaa !68
+  %78 = load i64, i64* %77, align 8, !dbg !45, !tbaa !67
   %79 = and i64 %78, 31, !dbg !45
   %80 = icmp eq i64 %79, 10, !dbg !45
   br i1 %80, label %"fastSymCallIntrinsic_Integer_<.i", label %"alternativeCallIntrinsic_Integer_<.i", !dbg !45, !prof !27
@@ -660,13 +645,13 @@ BB5.i:                                            ; preds = %afterSend40.i
   store i64 %send, i64* %82, align 8, !dbg !46, !tbaa !6
   %83 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !46
   store i64* %83, i64** %81, align 8, !dbg !46
-  %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !46
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !46
   store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %47, align 8, !dbg !46, !tbaa !14
   br i1 %84, label %"fastSymCallIntrinsic_Integer_+.i", label %"alternativeCallIntrinsic_Integer_+.i", !dbg !47
 
 afterSend40.i:                                    ; preds = %109, %sorbet_rb_int_lt.exit.i, %"alternativeCallIntrinsic_Integer_<.i"
   %84 = phi i1 [ %87, %"alternativeCallIntrinsic_Integer_<.i" ], [ %92, %sorbet_rb_int_lt.exit.i ], [ %92, %109 ]
-  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send7, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult92.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult92.i, %109 ], !dbg !45
+  %"symIntrinsicRawPhi_<.i" = phi i64 [ %send6, %"alternativeCallIntrinsic_Integer_<.i" ], [ %rawSendResult92.i, %sorbet_rb_int_lt.exit.i ], [ %rawSendResult92.i, %109 ], !dbg !45
   %85 = and i64 %"symIntrinsicRawPhi_<.i", -9, !dbg !45
   %86 = icmp ne i64 %85, 0, !dbg !45
   br i1 %86, label %BB5.i, label %"func_<root>.17<static-init>$152.exit", !dbg !45
@@ -680,15 +665,15 @@ afterSend40.i:                                    ; preds = %109, %sorbet_rb_int
   store i64 20000001, i64* %90, align 8, !dbg !45, !tbaa !6
   %91 = getelementptr inbounds i64, i64* %90, i64 1, !dbg !45
   store i64* %91, i64** %88, align 8, !dbg !45
-  %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !45
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_<", i64 0), !dbg !45
   br label %afterSend40.i, !dbg !45
 
 "fastSymCallIntrinsic_Integer_<.i":               ; preds = %BB2.i, %sorbet_isa_Integer.exit
   %92 = phi i1 [ %80, %sorbet_isa_Integer.exit ], [ true, %BB2.i ]
-  call void @llvm.experimental.noalias.scope.decl(metadata !70) #15, !dbg !45
+  call void @llvm.experimental.noalias.scope.decl(metadata !69) #16, !dbg !45
   %93 = and i64 %i.sroa.0.0.i, 1, !dbg !45
   %94 = icmp eq i64 %93, 0, !dbg !45
-  br i1 %94, label %99, label %95, !dbg !45, !prof !73
+  br i1 %94, label %99, label %95, !dbg !45, !prof !72
 
 95:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
   %96 = ashr i64 %i.sroa.0.0.i, 1, !dbg !45
@@ -697,7 +682,7 @@ afterSend40.i:                                    ; preds = %109, %sorbet_rb_int
   br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
 99:                                               ; preds = %"fastSymCallIntrinsic_Integer_<.i"
-  %100 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #15, !dbg !45, !noalias !70
+  %100 = call i64 @sorbet_rb_int_lt_slowpath(i64 %i.sroa.0.0.i, i64 noundef 20000001) #16, !dbg !45, !noalias !69
   br label %sorbet_rb_int_lt.exit.i, !dbg !45
 
 sorbet_rb_int_lt.exit.i:                          ; preds = %99, %95
@@ -715,7 +700,7 @@ sorbet_rb_int_lt.exit.i:                          ; preds = %99, %95
 109:                                              ; preds = %sorbet_rb_int_lt.exit.i
   %110 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %101, i64 0, i32 8, !dbg !45
   %111 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %110, align 8, !dbg !45, !tbaa !28
-  %112 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %111, i32 noundef 0) #15, !dbg !45
+  %112 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %111, i32 noundef 0) #16, !dbg !45
   br label %afterSend40.i, !dbg !45
 
 "alternativeCallIntrinsic_Integer_+.i":           ; preds = %BB5.i
@@ -726,17 +711,17 @@ sorbet_rb_int_lt.exit.i:                          ; preds = %99, %95
   store i64 3, i64* %115, align 8, !dbg !47, !tbaa !6
   %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !47
   store i64* %116, i64** %113, align 8, !dbg !47
-  %send9 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !47
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @"ic_+", i64 0), !dbg !47
   br label %BB2.i.backedge, !dbg !47
 
 "fastSymCallIntrinsic_Integer_+.i":               ; preds = %BB5.i
-  call void @llvm.experimental.noalias.scope.decl(metadata !74) #15, !dbg !47
+  call void @llvm.experimental.noalias.scope.decl(metadata !73) #16, !dbg !47
   %117 = and i64 %i.sroa.0.0.i, 1, !dbg !47
   %118 = icmp eq i64 %117, 0, !dbg !47
-  br i1 %118, label %127, label %119, !dbg !47, !prof !73
+  br i1 %118, label %127, label %119, !dbg !47, !prof !72
 
 119:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %120 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #17, !dbg !47
+  %120 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %i.sroa.0.0.i, i64 noundef 2) #19, !dbg !47
   %121 = extractvalue { i64, i1 } %120, 1, !dbg !47
   %122 = extractvalue { i64, i1 } %120, 0, !dbg !47
   br i1 %121, label %123, label %sorbet_rb_int_plus.exit.i, !dbg !47
@@ -744,11 +729,11 @@ sorbet_rb_int_lt.exit.i:                          ; preds = %99, %95
 123:                                              ; preds = %119
   %124 = ashr i64 %122, 1, !dbg !47
   %125 = xor i64 %124, -9223372036854775808, !dbg !47
-  %126 = call i64 @rb_int2big(i64 %125) #15, !dbg !47
+  %126 = call i64 @rb_int2big(i64 %125) #16, !dbg !47
   br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
 127:                                              ; preds = %"fastSymCallIntrinsic_Integer_+.i"
-  %128 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #15, !dbg !47, !noalias !74
+  %128 = call i64 @sorbet_rb_int_plus_slowpath(i64 %i.sroa.0.0.i, i64 noundef 3) #16, !dbg !47, !noalias !73
   br label %sorbet_rb_int_plus.exit.i, !dbg !47
 
 sorbet_rb_int_plus.exit.i:                        ; preds = %127, %123, %119
@@ -766,11 +751,11 @@ sorbet_rb_int_plus.exit.i:                        ; preds = %127, %123, %119
 138:                                              ; preds = %sorbet_rb_int_plus.exit.i
   %139 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %130, i64 0, i32 8, !dbg !47
   %140 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %139, align 8, !dbg !47, !tbaa !28
-  %141 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %140, i32 noundef 0) #15, !dbg !47
+  %141 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %140, i32 noundef 0) #16, !dbg !47
   br label %BB2.i.backedge, !dbg !47
 
 BB2.i.backedge:                                   ; preds = %138, %sorbet_rb_int_plus.exit.i, %"alternativeCallIntrinsic_Integer_+.i"
-  %i.sroa.0.0.i.be = phi i64 [ %send9, %"alternativeCallIntrinsic_Integer_+.i" ], [ %129, %sorbet_rb_int_plus.exit.i ], [ %129, %138 ]
+  %i.sroa.0.0.i.be = phi i64 [ %send8, %"alternativeCallIntrinsic_Integer_+.i" ], [ %129, %sorbet_rb_int_plus.exit.i ], [ %129, %138 ]
   br label %BB2.i
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %afterSend40.i
@@ -783,214 +768,214 @@ BB2.i.backedge:                                   ; preds = %138, %sorbet_rb_int
   store i64 %i.sroa.0.0.i.lcssa, i64* %144, align 8, !dbg !48, !tbaa !6
   %145 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !48
   store i64* %145, i64** %142, align 8, !dbg !48
-  %send11 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !48
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !48
   store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %47, align 8, !dbg !48, !tbaa !14
   %146 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !49
   %147 = load i64*, i64** %146, align 8, !dbg !49
   store i64 %send, i64* %147, align 8, !dbg !49, !tbaa !6
   %148 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !49
   store i64* %148, i64** %146, align 8, !dbg !49
-  %send13 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !49
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo.1, i64 0), !dbg !49
   %149 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !50
   %150 = load i64*, i64** %149, align 8, !dbg !50
   store i64 %38, i64* %150, align 8, !dbg !50, !tbaa !6
   %151 = getelementptr inbounds i64, i64* %150, i64 1, !dbg !50
-  store i64 %send13, i64* %151, align 8, !dbg !50, !tbaa !6
+  store i64 %send12, i64* %151, align 8, !dbg !50, !tbaa !6
   %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !50
   store i64* %152, i64** %149, align 8, !dbg !50
-  %send15 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !50
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !50
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define i64 @"func_MyStruct#10initialize"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #7 !dbg !77 {
+define i64 @"func_MyStruct#10initialize"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %0) #8 !dbg !76 {
 functionEntryInitializers:
   %callArgs = alloca [2 x i64], align 8
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %1, align 8, !tbaa !14
-  %hashAttemptReadGuard = icmp ult i32 0, %argc, !dbg !78
-  br i1 %hashAttemptReadGuard, label %readKWHashArgCountSuccess, label %fillRequiredArgs.thread, !dbg !78
+  %hashAttemptReadGuard = icmp ult i32 0, %argc, !dbg !77
+  br i1 %hashAttemptReadGuard, label %readKWHashArgCountSuccess, label %fillRequiredArgs.thread, !dbg !77
 
 fillRequiredArgs.thread:                          ; preds = %functionEntryInitializers
-  %rubyId_foo39 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !78
-  %rawSym40 = tail call i64 @rb_id2sym(i64 %rubyId_foo39), !dbg !78
-  br label %kwArgContinue, !dbg !78
+  %rubyId_foo39 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !77
+  %rawSym40 = tail call i64 @rb_id2sym(i64 %rubyId_foo39), !dbg !77
+  br label %kwArgContinue, !dbg !77
 
 readKWHashArgCountSuccess:                        ; preds = %functionEntryInitializers
-  %argsWithoutHashCount = sub nuw i32 %argc, 1, !dbg !78
-  %2 = getelementptr i64, i64* %argArray, i32 %argsWithoutHashCount, !dbg !78
-  %KWArgHash = load i64, i64* %2, align 8, !dbg !78
-  %3 = and i64 %KWArgHash, 7, !dbg !78
-  %4 = icmp ne i64 %3, 0, !dbg !78
-  %5 = and i64 %KWArgHash, -9, !dbg !78
-  %6 = icmp eq i64 %5, 0, !dbg !78
-  %7 = or i1 %4, %6, !dbg !78
-  br i1 %7, label %argCountFailBlock, label %sorbet_isa_Hash.exit, !dbg !78
+  %argsWithoutHashCount = sub nuw i32 %argc, 1, !dbg !77
+  %2 = getelementptr i64, i64* %argArray, i32 %argsWithoutHashCount, !dbg !77
+  %KWArgHash = load i64, i64* %2, align 8, !dbg !77
+  %3 = and i64 %KWArgHash, 7, !dbg !77
+  %4 = icmp ne i64 %3, 0, !dbg !77
+  %5 = and i64 %KWArgHash, -9, !dbg !77
+  %6 = icmp eq i64 %5, 0, !dbg !77
+  %7 = or i1 %4, %6, !dbg !77
+  br i1 %7, label %argCountFailBlock, label %sorbet_isa_Hash.exit, !dbg !77
 
 sorbet_isa_Hash.exit:                             ; preds = %readKWHashArgCountSuccess
-  %8 = inttoptr i64 %KWArgHash to %struct.iseq_inline_iv_cache_entry*, !dbg !78
-  %9 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %8, i64 0, i32 0, !dbg !78
-  %10 = load i64, i64* %9, align 8, !dbg !78, !tbaa !68
-  %11 = and i64 %10, 31, !dbg !78
-  %12 = icmp eq i64 %11, 8, !dbg !78
+  %8 = inttoptr i64 %KWArgHash to %struct.iseq_inline_iv_cache_entry*, !dbg !77
+  %9 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %8, i64 0, i32 0, !dbg !77
+  %10 = load i64, i64* %9, align 8, !dbg !77, !tbaa !67
+  %11 = and i64 %10, 31, !dbg !77
+  %12 = icmp eq i64 %11, 8, !dbg !77
   br i1 %12, label %afterKWHash, label %argCountFailBlock
 
 afterKWHash:                                      ; preds = %sorbet_isa_Hash.exit
-  %tooManyArgs = icmp ugt i32 %argsWithoutHashCount, 0, !dbg !78
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !78, !prof !66
+  %tooManyArgs = icmp ugt i32 %argsWithoutHashCount, 0, !dbg !77
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !77, !prof !65
 
 argCountFailBlock:                                ; preds = %readKWHashArgCountSuccess, %sorbet_isa_Hash.exit, %afterKWHash
   %argcPhi32 = phi i32 [ %argsWithoutHashCount, %afterKWHash ], [ %argc, %sorbet_isa_Hash.exit ], [ %argc, %readKWHashArgCountSuccess ]
-  tail call void @sorbet_raiseArity(i32 %argcPhi32, i32 noundef 0, i32 noundef 0) #18, !dbg !78
-  unreachable, !dbg !78
+  tail call void @sorbet_raiseArity(i32 %argcPhi32, i32 noundef 0, i32 noundef 0) #20, !dbg !77
+  unreachable, !dbg !77
 
 fillRequiredArgs:                                 ; preds = %afterKWHash
-  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !78
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !78
-  %13 = icmp eq i64 %KWArgHash, 52, !dbg !78
-  br i1 %13, label %kwArgContinue, label %sorbet_getKWArg.exit, !dbg !78
+  %rubyId_foo = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !77
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_foo), !dbg !77
+  %13 = icmp eq i64 %KWArgHash, 52, !dbg !77
+  br i1 %13, label %kwArgContinue, label %sorbet_getKWArg.exit, !dbg !77
 
 sorbet_getKWArg.exit:                             ; preds = %fillRequiredArgs
-  %14 = tail call i64 @rb_hash_lookup2(i64 %KWArgHash, i64 %rawSym, i64 noundef 52) #15, !dbg !78
-  %15 = icmp eq i64 %14, 52, !dbg !78
-  br i1 %15, label %kwArgContinue.thread, label %sorbet_assertAllRequiredKWArgs.exit.thread, !dbg !78
+  %14 = tail call i64 @rb_hash_lookup2(i64 %KWArgHash, i64 %rawSym, i64 noundef 52) #16, !dbg !77
+  %15 = icmp eq i64 %14, 52, !dbg !77
+  br i1 %15, label %kwArgContinue.thread, label %sorbet_assertAllRequiredKWArgs.exit.thread, !dbg !77
 
 kwArgContinue:                                    ; preds = %fillRequiredArgs.thread, %fillRequiredArgs
   %rawSym4144 = phi i64 [ %rawSym40, %fillRequiredArgs.thread ], [ %rawSym, %fillRequiredArgs ]
-  %16 = tail call i64 @sorbet_addMissingKWArg(i64 noundef 52, i64 %rawSym4144), !dbg !78
-  %17 = icmp eq i64 %16, 52, !dbg !78
-  br i1 %17, label %sorbet_assertNoExtraKWArg.exit.thread, label %20, !dbg !78, !prof !27
+  %16 = tail call i64 @sorbet_addMissingKWArg(i64 noundef 52, i64 %rawSym4144), !dbg !77
+  %17 = icmp eq i64 %16, 52, !dbg !77
+  br i1 %17, label %sorbet_assertNoExtraKWArg.exit.thread, label %20, !dbg !77, !prof !27
 
 sorbet_assertNoExtraKWArg.exit.thread:            ; preds = %kwArgContinue
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %1, align 8, !dbg !79, !tbaa !14
-  br label %29, !dbg !80
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %1, align 8, !dbg !78, !tbaa !14
+  br label %29, !dbg !79
 
 kwArgContinue.thread:                             ; preds = %sorbet_getKWArg.exit
-  %18 = tail call i64 @sorbet_addMissingKWArg(i64 noundef 52, i64 %rawSym), !dbg !78
-  %19 = icmp eq i64 %18, 52, !dbg !78
-  br i1 %19, label %sorbet_assertAllRequiredKWArgs.exit.thread, label %20, !dbg !78, !prof !27
+  %18 = tail call i64 @sorbet_addMissingKWArg(i64 noundef 52, i64 %rawSym), !dbg !77
+  %19 = icmp eq i64 %18, 52, !dbg !77
+  br i1 %19, label %sorbet_assertAllRequiredKWArgs.exit.thread, label %20, !dbg !77, !prof !27
 
 20:                                               ; preds = %kwArgContinue.thread, %kwArgContinue
   %21 = phi i64 [ %18, %kwArgContinue.thread ], [ %16, %kwArgContinue ]
-  tail call void @sorbet_raiseMissingKeywords(i64 %21) #14, !dbg !78
-  unreachable, !dbg !78
+  tail call void @sorbet_raiseMissingKeywords(i64 %21) #15, !dbg !77
+  unreachable, !dbg !77
 
 sorbet_assertAllRequiredKWArgs.exit.thread:       ; preds = %kwArgContinue.thread, %sorbet_getKWArg.exit
   %foo.sroa.0.05154 = phi i64 [ %14, %sorbet_getKWArg.exit ], [ 8, %kwArgContinue.thread ]
-  %22 = tail call i64 @rb_hash_size_num(i64 %KWArgHash) #15, !dbg !78
-  %23 = trunc i64 %22 to i32, !dbg !78
-  %24 = sub nsw i32 %23, 1, !dbg !78
-  %25 = icmp eq i32 %24, 0, !dbg !78
-  br i1 %25, label %sorbet_assertNoExtraKWArg.exit, label %26, !dbg !78, !prof !27
+  %22 = tail call i64 @rb_hash_size_num(i64 %KWArgHash) #16, !dbg !77
+  %23 = trunc i64 %22 to i32, !dbg !77
+  %24 = sub nsw i32 %23, 1, !dbg !77
+  %25 = icmp eq i32 %24, 0, !dbg !77
+  br i1 %25, label %sorbet_assertNoExtraKWArg.exit, label %26, !dbg !77, !prof !27
 
 26:                                               ; preds = %sorbet_assertAllRequiredKWArgs.exit.thread
-  tail call void @sorbet_raiseExtraKeywords(i64 %KWArgHash) #14, !dbg !78
-  unreachable, !dbg !78
+  tail call void @sorbet_raiseExtraKeywords(i64 %KWArgHash) #15, !dbg !77
+  unreachable, !dbg !77
 
 sorbet_assertNoExtraKWArg.exit:                   ; preds = %sorbet_assertAllRequiredKWArgs.exit.thread
   %foo.sroa.0.05155 = phi i64 [ %foo.sroa.0.05154, %sorbet_assertAllRequiredKWArgs.exit.thread ]
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %1, align 8, !dbg !79, !tbaa !14
-  %27 = and i64 %foo.sroa.0.05155, 1, !dbg !80
-  %28 = icmp eq i64 %27, 0, !dbg !80
-  br i1 %28, label %29, label %typeTestSuccess11, !dbg !80, !prof !66
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %1, align 8, !dbg !78, !tbaa !14
+  %27 = and i64 %foo.sroa.0.05155, 1, !dbg !79
+  %28 = icmp eq i64 %27, 0, !dbg !79
+  br i1 %28, label %29, label %typeTestSuccess11, !dbg !79, !prof !65
 
 29:                                               ; preds = %sorbet_assertNoExtraKWArg.exit.thread, %sorbet_assertNoExtraKWArg.exit
   %foo.sroa.0.0515572 = phi i64 [ 8, %sorbet_assertNoExtraKWArg.exit.thread ], [ %foo.sroa.0.05155, %sorbet_assertNoExtraKWArg.exit ]
-  %30 = and i64 %foo.sroa.0.0515572, 7, !dbg !80
-  %31 = icmp ne i64 %30, 0, !dbg !80
-  %32 = and i64 %foo.sroa.0.0515572, -9, !dbg !80
-  %33 = icmp eq i64 %32, 0, !dbg !80
-  %34 = or i1 %31, %33, !dbg !80
-  br i1 %34, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !80
+  %30 = and i64 %foo.sroa.0.0515572, 7, !dbg !79
+  %31 = icmp ne i64 %30, 0, !dbg !79
+  %32 = and i64 %foo.sroa.0.0515572, -9, !dbg !79
+  %33 = icmp eq i64 %32, 0, !dbg !79
+  %34 = or i1 %31, %33, !dbg !79
+  br i1 %34, label %codeRepl, label %sorbet_isa_Integer.exit, !dbg !79
 
 sorbet_isa_Integer.exit:                          ; preds = %29
-  %35 = inttoptr i64 %foo.sroa.0.0515572 to %struct.iseq_inline_iv_cache_entry*, !dbg !80
-  %36 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %35, i64 0, i32 0, !dbg !80
-  %37 = load i64, i64* %36, align 8, !dbg !80, !tbaa !68
-  %38 = and i64 %37, 31, !dbg !80
-  %39 = icmp eq i64 %38, 10, !dbg !80
-  br i1 %39, label %typeTestSuccess11, label %codeRepl, !dbg !80, !prof !27
+  %35 = inttoptr i64 %foo.sroa.0.0515572 to %struct.iseq_inline_iv_cache_entry*, !dbg !79
+  %36 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %35, i64 0, i32 0, !dbg !79
+  %37 = load i64, i64* %36, align 8, !dbg !79, !tbaa !67
+  %38 = and i64 %37, 31, !dbg !79
+  %39 = icmp eq i64 %38, 10, !dbg !79
+  br i1 %39, label %typeTestSuccess11, label %codeRepl, !dbg !79, !prof !27
 
 codeRepl:                                         ; preds = %29, %sorbet_isa_Integer.exit
   %foo.sroa.0.0515573 = phi i64 [ %foo.sroa.0.0515572, %29 ], [ %foo.sroa.0.0515572, %sorbet_isa_Integer.exit ]
-  tail call fastcc void @"func_MyStruct#10initialize.cold.1"(i64 %foo.sroa.0.0515573) #19, !dbg !80
+  tail call fastcc void @"func_MyStruct#10initialize.cold.1"(i64 %foo.sroa.0.0515573) #21, !dbg !79
   unreachable
 
 typeTestSuccess11:                                ; preds = %sorbet_assertNoExtraKWArg.exit, %sorbet_isa_Integer.exit
   %foo.sroa.0.0515571 = phi i64 [ %foo.sroa.0.05155, %sorbet_assertNoExtraKWArg.exit ], [ %foo.sroa.0.0515572, %sorbet_isa_Integer.exit ]
-  %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !81
-  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %foo.sroa.0.0515571, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #15, !dbg !81
-  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %1, align 8, !dbg !81, !tbaa !14
-  %rubyId_foo14 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !78
-  %rawSym15 = tail call i64 @rb_id2sym(i64 %rubyId_foo14), !dbg !78
-  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !78
-  store i64 %rawSym15, i64* %callArgs0Addr, align 8, !dbg !78
-  %callArgs1Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 1, !dbg !78
-  store i64 %foo.sroa.0.0515571, i64* %callArgs1Addr, align 8, !dbg !78
-  %40 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !78
-  %41 = tail call i64 @rb_hash_new_with_size(i64 noundef 1) #15, !dbg !78
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %40, i64 %41) #15, !dbg !78
-  store i64 %41, i64* %callArgs0Addr, align 8, !dbg !78
-  call void @llvm.experimental.noalias.scope.decl(metadata !82), !dbg !78
-  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !14, !noalias !82
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !78
-  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !78, !tbaa !16, !noalias !82
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 3, !dbg !78
-  %46 = load i64, i64* %45, align 8, !dbg !78, !tbaa !85, !noalias !82
-  %47 = call %struct.rb_callable_method_entry_struct* @rb_vm_frame_method_entry(%struct.rb_control_frame_struct* %44) #15, !dbg !78, !noalias !82
-  %48 = getelementptr inbounds %struct.rb_callable_method_entry_struct, %struct.rb_callable_method_entry_struct* %47, i64 0, i32 1, !dbg !78
-  %49 = load i64, i64* %48, align 8, !dbg !78, !tbaa !86, !noalias !82
-  %50 = inttoptr i64 %49 to %struct.RClass*, !dbg !78
-  %51 = getelementptr inbounds %struct.RClass, %struct.RClass* %50, i64 0, i32 2, !dbg !78
-  %52 = load %struct.rb_classext_struct*, %struct.rb_classext_struct** %51, align 8, !dbg !78, !tbaa !88, !noalias !82
-  %53 = getelementptr inbounds %struct.rb_classext_struct, %struct.rb_classext_struct* %52, i64 0, i32 8, !dbg !78
-  %54 = load i64, i64* %53, align 8, !dbg !78, !tbaa !90, !noalias !82
-  %55 = inttoptr i64 %54 to %struct.RClass*, !dbg !78
-  %56 = getelementptr inbounds %struct.RClass, %struct.RClass* %55, i64 0, i32 1, !dbg !78
-  %57 = load i64, i64* %56, align 8, !dbg !78, !tbaa !92, !noalias !82
-  %58 = getelementptr inbounds %struct.rb_callable_method_entry_struct, %struct.rb_callable_method_entry_struct* %47, i64 0, i32 2, !dbg !78
-  %59 = load %struct.rb_method_definition_struct*, %struct.rb_method_definition_struct** %58, align 8, !dbg !78, !tbaa !93, !noalias !82
-  %60 = getelementptr inbounds %struct.rb_method_definition_struct, %struct.rb_method_definition_struct* %59, i64 0, i32 2, !dbg !78
-  %61 = load i64, i64* %60, align 8, !dbg !78, !tbaa !94, !noalias !82
-  %62 = call %struct.rb_callable_method_entry_struct* @rb_callable_method_entry(i64 %57, i64 %61) #15, !dbg !78, !noalias !82
-  %63 = icmp eq %struct.rb_callable_method_entry_struct* %62, null, !dbg !78
-  br i1 %63, label %64, label %sorbet_callSuper.exit, !dbg !78
+  %"rubyId_@foo" = load i64, i64* @"rubyIdPrecomputed_@foo", align 8, !dbg !80
+  tail call void @sorbet_vm_setivar(i64 %selfRaw, i64 %"rubyId_@foo", i64 %foo.sroa.0.0515571, %struct.iseq_inline_iv_cache_entry* noundef @"ivc_@foo") #16, !dbg !80
+  store i64* getelementptr inbounds ([21 x i64], [21 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %1, align 8, !dbg !80, !tbaa !14
+  %rubyId_foo14 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !77
+  %rawSym15 = tail call i64 @rb_id2sym(i64 %rubyId_foo14), !dbg !77
+  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 0, !dbg !77
+  store i64 %rawSym15, i64* %callArgs0Addr, align 8, !dbg !77
+  %callArgs1Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i32 0, i64 1, !dbg !77
+  store i64 %foo.sroa.0.0515571, i64* %callArgs1Addr, align 8, !dbg !77
+  %40 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !77
+  %41 = tail call i64 @rb_hash_new_with_size(i64 noundef 1) #16, !dbg !77
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %40, i64 %41) #16, !dbg !77
+  store i64 %41, i64* %callArgs0Addr, align 8, !dbg !77
+  call void @llvm.experimental.noalias.scope.decl(metadata !81), !dbg !77
+  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !77, !tbaa !14, !noalias !81
+  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2, !dbg !77
+  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !dbg !77, !tbaa !16, !noalias !81
+  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 3, !dbg !77
+  %46 = load i64, i64* %45, align 8, !dbg !77, !tbaa !84, !noalias !81
+  %47 = call %struct.rb_callable_method_entry_struct* @rb_vm_frame_method_entry(%struct.rb_control_frame_struct* %44) #16, !dbg !77, !noalias !81
+  %48 = getelementptr inbounds %struct.rb_callable_method_entry_struct, %struct.rb_callable_method_entry_struct* %47, i64 0, i32 1, !dbg !77
+  %49 = load i64, i64* %48, align 8, !dbg !77, !tbaa !85, !noalias !81
+  %50 = inttoptr i64 %49 to %struct.RClass*, !dbg !77
+  %51 = getelementptr inbounds %struct.RClass, %struct.RClass* %50, i64 0, i32 2, !dbg !77
+  %52 = load %struct.rb_classext_struct*, %struct.rb_classext_struct** %51, align 8, !dbg !77, !tbaa !87, !noalias !81
+  %53 = getelementptr inbounds %struct.rb_classext_struct, %struct.rb_classext_struct* %52, i64 0, i32 8, !dbg !77
+  %54 = load i64, i64* %53, align 8, !dbg !77, !tbaa !89, !noalias !81
+  %55 = inttoptr i64 %54 to %struct.RClass*, !dbg !77
+  %56 = getelementptr inbounds %struct.RClass, %struct.RClass* %55, i64 0, i32 1, !dbg !77
+  %57 = load i64, i64* %56, align 8, !dbg !77, !tbaa !91, !noalias !81
+  %58 = getelementptr inbounds %struct.rb_callable_method_entry_struct, %struct.rb_callable_method_entry_struct* %47, i64 0, i32 2, !dbg !77
+  %59 = load %struct.rb_method_definition_struct*, %struct.rb_method_definition_struct** %58, align 8, !dbg !77, !tbaa !92, !noalias !81
+  %60 = getelementptr inbounds %struct.rb_method_definition_struct, %struct.rb_method_definition_struct* %59, i64 0, i32 2, !dbg !77
+  %61 = load i64, i64* %60, align 8, !dbg !77, !tbaa !93, !noalias !81
+  %62 = call %struct.rb_callable_method_entry_struct* @rb_callable_method_entry(i64 %57, i64 %61) #16, !dbg !77, !noalias !81
+  %63 = icmp eq %struct.rb_callable_method_entry_struct* %62, null, !dbg !77
+  br i1 %63, label %64, label %sorbet_callSuper.exit, !dbg !77
 
 64:                                               ; preds = %typeTestSuccess11
-  %65 = load i64, i64* @rb_eRuntimeError, align 8, !dbg !78, !tbaa !6
-  call void (i64, i8*, ...) @rb_raise(i64 %65, i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @.str.7, i64 0, i64 0)) #14, !dbg !78
-  unreachable, !dbg !78
+  %65 = load i64, i64* @rb_eRuntimeError, align 8, !dbg !77, !tbaa !6
+  call void (i64, i8*, ...) @rb_raise(i64 %65, i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @.str.7, i64 0, i64 0)) #15, !dbg !77
+  unreachable, !dbg !77
 
 sorbet_callSuper.exit:                            ; preds = %typeTestSuccess11
-  %66 = call i64 @rb_vm_call_kw(%struct.rb_execution_context_struct* nonnull %42, i64 %46, i64 %61, i32 noundef 1, i64* noundef nonnull %40, %struct.rb_callable_method_entry_struct* nonnull %62, i32 noundef 1) #15, !dbg !78
+  %66 = call i64 @rb_vm_call_kw(%struct.rb_execution_context_struct* nonnull %42, i64 %46, i64 %61, i32 noundef 1, i64* noundef nonnull %40, %struct.rb_callable_method_entry_struct* nonnull %62, i32 noundef 1) #16, !dbg !77
   %"<void-singleton>" = load i64, i64* @"<void-singleton>", align 8
   ret i64 %"<void-singleton>"
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare void @llvm.experimental.noalias.scope.decl(metadata) #9
+declare void @llvm.experimental.noalias.scope.decl(metadata) #10
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #6
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #6
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #10
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #11
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_MyStruct#10initialize.cold.1"(i64 %foo.sroa.0.05155) unnamed_addr #11 !dbg !96 {
+define internal fastcc void @"func_MyStruct#10initialize.cold.1"(i64 %foo.sroa.0.05155) unnamed_addr #12 !dbg !95 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %foo.sroa.0.05155, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #18, !dbg !98
-  unreachable, !dbg !98
+  tail call void @sorbet_cast_failure(i64 %foo.sroa.0.05155, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sig, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !97
+  unreachable, !dbg !97
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #12
+declare void @llvm.assume(i1 noundef) #13
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_MyStruct() local_unnamed_addr #13 {
+define linkonce void @const_recompute_MyStruct() local_unnamed_addr #14 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @str_MyStruct, i64 0, i64 0), i64 8)
   store i64 %1, i64* @guarded_const_MyStruct, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !30
@@ -999,7 +984,7 @@ define linkonce void @const_recompute_MyStruct() local_unnamed_addr #13 {
 }
 
 ; Function Attrs: ssp
-define linkonce void @"const_recompute_T::Struct"() local_unnamed_addr #13 {
+define linkonce void @"const_recompute_T::Struct"() local_unnamed_addr #14 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([10 x i8], [10 x i8]* @"str_T::Struct", i64 0, i64 0), i64 9)
   store i64 %1, i64* @"guarded_const_T::Struct", align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !30
@@ -1007,26 +992,28 @@ define linkonce void @"const_recompute_T::Struct"() local_unnamed_addr #13 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nofree nosync nounwind readnone speculatable willreturn }
-attributes #4 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #5 = { argmemonly nofree nosync nounwind willreturn }
-attributes #6 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #7 = { nounwind sspreq uwtable }
-attributes #8 = { sspreq }
-attributes #9 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #10 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #11 = { cold minsize noreturn nounwind sspreq uwtable }
-attributes #12 = { nofree nosync nounwind willreturn }
-attributes #13 = { ssp }
-attributes #14 = { noreturn nounwind }
-attributes #15 = { nounwind }
-attributes #16 = { nounwind allocsize(0,1) }
-attributes #17 = { nounwind willreturn }
-attributes #18 = { noreturn }
-attributes #19 = { noinline }
+attributes #3 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { nofree nosync nounwind readnone speculatable willreturn }
+attributes #5 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #6 = { argmemonly nofree nosync nounwind willreturn }
+attributes #7 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #8 = { nounwind sspreq uwtable }
+attributes #9 = { sspreq }
+attributes #10 = { inaccessiblememonly nofree nosync nounwind willreturn }
+attributes #11 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #12 = { cold minsize noreturn nounwind sspreq uwtable }
+attributes #13 = { nofree nosync nounwind willreturn }
+attributes #14 = { ssp }
+attributes #15 = { noreturn nounwind }
+attributes #16 = { nounwind }
+attributes #17 = { nounwind allocsize(0,1) }
+attributes #18 = { nounwind readnone willreturn }
+attributes #19 = { nounwind willreturn }
+attributes #20 = { noreturn }
+attributes #21 = { noinline }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -1095,38 +1082,37 @@ attributes #19 = { noinline }
 !61 = !DILocation(line: 0, scope: !42)
 !62 = !DILocation(line: 5, column: 1, scope: !42)
 !63 = !DILocation(line: 5, column: 18, scope: !42)
-!64 = !DILocation(line: 9, column: 26, scope: !42)
-!65 = !DILocation(line: 11, column: 5, scope: !42)
-!66 = !{!"branch_weights", i32 1, i32 2000}
-!67 = !{!"branch_weights", i32 1073205, i32 2146410443}
-!68 = !{!69, !7, i64 0}
-!69 = !{!"RBasic", !7, i64 0, !7, i64 8}
-!70 = !{!71}
-!71 = distinct !{!71, !72, !"sorbet_rb_int_lt: argument 0"}
-!72 = distinct !{!72, !"sorbet_rb_int_lt"}
-!73 = !{!"branch_weights", i32 4001, i32 4000000}
-!74 = !{!75}
-!75 = distinct !{!75, !76, !"sorbet_rb_int_plus: argument 0"}
-!76 = distinct !{!76, !"sorbet_rb_int_plus"}
-!77 = distinct !DISubprogram(name: "MyStruct#initialize", linkageName: "func_MyStruct#10initialize", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!78 = !DILocation(line: 5, column: 1, scope: !77)
-!79 = !DILocation(line: 0, scope: !77)
-!80 = !DILocation(line: 6, column: 3, scope: !77)
-!81 = !DILocation(line: 6, column: 10, scope: !77)
-!82 = !{!83}
-!83 = distinct !{!83, !84, !"sorbet_callSuper: argument 0"}
-!84 = distinct !{!84, !"sorbet_callSuper"}
-!85 = !{!21, !7, i64 24}
-!86 = !{!87, !7, i64 8}
-!87 = !{!"rb_callable_method_entry_struct", !7, i64 0, !7, i64 8, !15, i64 16, !7, i64 24, !7, i64 32}
-!88 = !{!89, !15, i64 24}
-!89 = !{!"RClass", !69, i64 0, !7, i64 16, !15, i64 24, !31, i64 32}
-!90 = !{!91, !7, i64 64}
-!91 = !{!"rb_classext_struct", !15, i64 0, !15, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !15, i64 40, !15, i64 48, !15, i64 56, !7, i64 64, !7, i64 72, !15, i64 80, !7, i64 88}
-!92 = !{!89, !7, i64 16}
-!93 = !{!87, !15, i64 16}
-!94 = !{!95, !7, i64 32}
-!95 = !{!"rb_method_definition_struct", !8, i64 0, !18, i64 0, !18, i64 4, !8, i64 8, !7, i64 32, !7, i64 40}
-!96 = distinct !DISubprogram(name: "func_MyStruct#10initialize.cold.1", linkageName: "func_MyStruct#10initialize.cold.1", scope: null, file: !4, type: !97, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!97 = !DISubroutineType(types: !5)
-!98 = !DILocation(line: 6, column: 3, scope: !96)
+!64 = !DILocation(line: 11, column: 5, scope: !42)
+!65 = !{!"branch_weights", i32 1, i32 2000}
+!66 = !{!"branch_weights", i32 1073205, i32 2146410443}
+!67 = !{!68, !7, i64 0}
+!68 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!69 = !{!70}
+!70 = distinct !{!70, !71, !"sorbet_rb_int_lt: argument 0"}
+!71 = distinct !{!71, !"sorbet_rb_int_lt"}
+!72 = !{!"branch_weights", i32 4001, i32 4000000}
+!73 = !{!74}
+!74 = distinct !{!74, !75, !"sorbet_rb_int_plus: argument 0"}
+!75 = distinct !{!75, !"sorbet_rb_int_plus"}
+!76 = distinct !DISubprogram(name: "MyStruct#initialize", linkageName: "func_MyStruct#10initialize", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!77 = !DILocation(line: 5, column: 1, scope: !76)
+!78 = !DILocation(line: 0, scope: !76)
+!79 = !DILocation(line: 6, column: 3, scope: !76)
+!80 = !DILocation(line: 6, column: 10, scope: !76)
+!81 = !{!82}
+!82 = distinct !{!82, !83, !"sorbet_callSuper: argument 0"}
+!83 = distinct !{!83, !"sorbet_callSuper"}
+!84 = !{!21, !7, i64 24}
+!85 = !{!86, !7, i64 8}
+!86 = !{!"rb_callable_method_entry_struct", !7, i64 0, !7, i64 8, !15, i64 16, !7, i64 24, !7, i64 32}
+!87 = !{!88, !15, i64 24}
+!88 = !{!"RClass", !68, i64 0, !7, i64 16, !15, i64 24, !31, i64 32}
+!89 = !{!90, !7, i64 64}
+!90 = !{!"rb_classext_struct", !15, i64 0, !15, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !15, i64 40, !15, i64 48, !15, i64 56, !7, i64 64, !7, i64 72, !15, i64 80, !7, i64 88}
+!91 = !{!88, !7, i64 16}
+!92 = !{!86, !15, i64 16}
+!93 = !{!94, !7, i64 32}
+!94 = !{!"rb_method_definition_struct", !8, i64 0, !18, i64 0, !18, i64 4, !8, i64 8, !7, i64 32, !7, i64 40}
+!95 = distinct !DISubprogram(name: "func_MyStruct#10initialize.cold.1", linkageName: "func_MyStruct#10initialize.cold.1", scope: null, file: !4, type: !96, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!96 = !DISubroutineType(types: !5)
+!97 = !DILocation(line: 6, column: 3, scope: !95)


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This PR builds on #4645 to change things so that `Thread.current` doesn't implement a slow path and always directly calls `rb_thread_current`.  The current code would eventually do the same, but at the cost of having a slow path that would be optimized out by LLVM.  This change means that we can meaningfully assert that `Thread.current` returns a `Thread`, which in turns means that `Thread.current[:foo]` doesn't do type checks anymore.

But wait, there's more!  Our implementation of `Thread#[]` checks at runtime for ID-ness of its argument.  But if we have `Thread.current[:foo]`, then we know at compile time that our argument is guaranteed to be convertible to an ID.  So we can check for a constant symbol argument to `Thread#[]` (resp. `Thread#[]=`) and eliminate some runtime checking.  We also need to make `rb_id2sym` `const` so that the symbol for `:foo`, which is now unused, never actually gets materialized at runtime.

The benefits can be see in `test/testdata/ruby_benchmarks/stripe/lspace.rb`.  Before:

```
froydnj@pyro:~/src/sorbet$ ./tools/scripts/run_benchmarks.sh -b test/testdata/ruby_benchmark/stripe/while_10_000_000.rb -f test/testdata/ruby_benchmark/stripe/lspace.rb
...
source  interpreted     compiled
stripe/while_10_000_000.rb      .230    .101
stripe/lspace.rb        .897    .602
stripe/lspace.rb - baseline     .667    .501
```

After:

```
froydnj@pyro:~/src/sorbet$ ./tools/scripts/run_benchmarks.sh -b test/testdata/ruby_benchmark/stripe/while_10_000_000.rb -f test/testdata/ruby_benchmark/stripe/lspace.rb
...
source  interpreted     compiled
stripe/while_10_000_000.rb      .224    .099
stripe/lspace.rb        .880    .549
stripe/lspace.rb - baseline     .656    .450
```

Roughly 10% faster than before.

This could probably be improved further by combining interrupt checks in a single basic block; for `Thread.current[:foo]` we'll wind up with a basic block that looks like:

```
current = sorbet_Thread_current(...)
sorbet_afterIntrinsic()
val = sorbet_Thread_square_br_symarg(current, id_for_foo)
sorbet_afterIntrinsic()
```

and I think we could get away with combining the first `sorbet_afterIntrinsic` with the second, so long as we make sure to check for interrupts somewhere.  But that is a separate patch.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
