### PR TITLE
Clean up YARD cruft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ compiler/IREmitter/Intrinsics/WrappedIntrinsics.formatted.h
 
 # clangd caches data in this folder.
 /.clangd
+
+# for YARD documentation
+.yardoc/
+doc/

--- a/gems/sorbet-runtime/.gitignore
+++ b/gems/sorbet-runtime/.gitignore
@@ -1,0 +1,2 @@
+.yardoc/
+doc/

--- a/gems/sorbet-runtime/.gitignore
+++ b/gems/sorbet-runtime/.gitignore
@@ -1,2 +1,0 @@
-.yardoc/
-doc/

--- a/gems/sorbet-runtime/.yardopts
+++ b/gems/sorbet-runtime/.yardopts
@@ -1,0 +1,1 @@
+--markup=markdown

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -82,8 +82,9 @@ module T
 
   # Constructs a type alias. Used to create a short name for a larger type. In Ruby this returns a
   # wrapper that contains a proc that is evaluated to get the underlying type. This syntax however
-  # is needed for support by the static checker. Example usage:
+  # is needed for support by the static checker.
   #
+  # @example
   #  NilableString = T.type_alias {T.nilable(String)}
   #
   #  sig {params(arg: NilableString, default: String).returns(String)}
@@ -106,8 +107,9 @@ module T
   # References a type parameter which was previously defined with
   # `type_parameters`.
   #
-  # This is used for generic methods. Example usage:
+  # This is used for generic methods.
   #
+  # @example
   #  sig
   #  .type_parameters(:U)
   #  .params(
@@ -185,7 +187,7 @@ module T
   # cycle. However, we also don't actually need to do so; An untyped
   # identity method works just as well here.
   #
-  # sig {params(value: T.untyped).returns(T.untyped)}
+  # `sig {params(value: T.untyped).returns(T.untyped)}`
   def self.unsafe(value)
     value
   end
@@ -206,7 +208,7 @@ module T
   # Intended to be used to promise sorbet that a given nilable value happens
   # to contain a non-nil value at this point.
   #
-  # sig {params(arg: T.nilable(A)).returns(A)}
+  # `sig {params(arg: T.nilable(A)).returns(A)}`
   def self.must(arg)
     return arg if arg
     return arg if arg == false

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -130,12 +130,12 @@ module T::Configuration
   #
   # Parameters passed to value.call:
   #
-  # @param [TypeError] error TypeError that was raised
-  # @param [Hash] opts A hash containing contextual information on the error:
-  # @option opts [String] :kind One of:
-  #   ['T.cast', 'T.let', 'T.bind', 'T.assert_type!', 'T.must', 'T.absurd']
-  # @option opts [Object, nil] :type Expected param/return value type
-  # @option opts [Object] :value Actual param/return value
+  #  @param [TypeError] error TypeError that was raised
+  #  @param [Hash] opts A hash containing contextual information on the error:
+  #  @option opts [String] :kind One of:
+  #    ['T.cast', 'T.let', 'T.bind', 'T.assert_type!', 'T.must', 'T.absurd']
+  #  @option opts [Object, nil] :type Expected param/return value type
+  #  @option opts [Object] :value Actual param/return value
   #
   # @example
   #   T::Configuration.inline_type_error_handler = lambda do |error, opts|
@@ -179,8 +179,8 @@ module T::Configuration
   #
   # Parameters passed to value.call:
   #
-  # @param [StandardError] error The error that was raised
-  # @param [Thread::Backtrace::Location] location Location of the error
+  #  @param [StandardError] error The error that was raised
+  #  @param [Thread::Backtrace::Location] location Location of the error
   #
   # @example
   #   T::Configuration.sig_builder_error_handler = lambda do |error, location|
@@ -221,16 +221,16 @@ module T::Configuration
   #
   # Parameters passed to value.call:
   #
-  # @param [StandardError] error The error that was raised
-  # @param [Hash] opts A hash containing contextual information on the error:
-  # @option opts [Method, UnboundMethod] :method Method on which the signature build failed
-  # @option opts [T::Private::Methods::Declaration] :declaration Method
-  #   signature declaration struct
-  # @option opts [T::Private::Methods::Signature, nil] :signature Signature
-  #   that failed (nil if sig build failed before Signature initialization)
-  # @option opts [T::Private::Methods::Signature, nil] :super_signature Super
-  #   method's signature (nil if method is not an override or super method
-  #   does not have a method signature)
+  #  @param [StandardError] error The error that was raised
+  #  @param [Hash] opts A hash containing contextual information on the error:
+  #  @option opts [Method, UnboundMethod] :method Method on which the signature build failed
+  #  @option opts [T::Private::Methods::Declaration] :declaration Method
+  #    signature declaration struct
+  #  @option opts [T::Private::Methods::Signature, nil] :signature Signature
+  #    that failed (nil if sig build failed before Signature initialization)
+  #  @option opts [T::Private::Methods::Signature, nil] :super_signature Super
+  #    method's signature (nil if method is not an override or super method
+  #    does not have a method signature)
   #
   # @example
   #   T::Configuration.sig_validation_error_handler = lambda do |error, opts|
@@ -266,17 +266,17 @@ module T::Configuration
   #
   # Parameters passed to value.call:
   #
-  # @param [T::Private::Methods::Signature] signature Signature that failed
-  # @param [Hash] opts A hash containing contextual information on the error:
-  # @option opts [String] :message Error message
-  # @option opts [String] :kind One of:
-  #   ['Parameter', 'Block parameter', 'Return value']
-  # @option opts [Symbol] :name Param or block param name (nil for return
-  #   value)
-  # @option opts [Object] :type Expected param/return value type
-  # @option opts [Object] :value Actual param/return value
-  # @option opts [Thread::Backtrace::Location] :location Location of the
-  #   caller
+  #  @param [T::Private::Methods::Signature] signature Signature that failed
+  #  @param [Hash] opts A hash containing contextual information on the error:
+  #  @option opts [String] :message Error message
+  #  @option opts [String] :kind One of:
+  #    ['Parameter', 'Block parameter', 'Return value']
+  #  @option opts [Symbol] :name Param or block param name (nil for return
+  #    value)
+  #  @option opts [Object] :type Expected param/return value type
+  #  @option opts [Object] :value Actual param/return value
+  #  @option opts [Thread::Backtrace::Location] :location Location of the
+  #    caller
   #
   # @example
   #   T::Configuration.call_validation_error_handler = lambda do |signature, opts|
@@ -307,8 +307,8 @@ module T::Configuration
   #
   # Parameters passed to value.call:
   #
-  # @param [String] str Message to be logged
-  # @param [Hash] extra A hash containing additional parameters to be passed along to the logger.
+  #  @param [String] str Message to be logged
+  #  @param [Hash] extra A hash containing additional parameters to be passed along to the logger.
   #
   # @example
   #   T::Configuration.log_info_handler = lambda do |str, extra|
@@ -341,8 +341,8 @@ module T::Configuration
   #
   # Parameters passed to value.call:
   #
-  # @param [String] str Assertion message
-  # @param [Hash] extra A hash containing additional parameters to be passed along to the handler.
+  #  @param [String] str Assertion message
+  #  @param [Hash] extra A hash containing additional parameters to be passed along to the handler.
   #
   # @example
   #   T::Configuration.soft_assert_handler = lambda do |str, extra|
@@ -375,8 +375,8 @@ module T::Configuration
   #
   # Parameters passed to value.call:
   #
-  # @param [String] str Assertion message
-  # @param [Hash] extra A hash containing additional parameters to be passed along to the handler.
+  #  @param [String] str Assertion message
+  #  @param [Hash] extra A hash containing additional parameters to be passed along to the handler.
   #
   # @example
   #   T::Configuration.hard_assert_handler = lambda do |str, extra|
@@ -402,7 +402,7 @@ module T::Configuration
   # Set a list of class strings that are to be considered scalar.
   #   (pass nil to reset to default behavior)
   #
-  # @param [String] value Class name.
+  # @param [String] values Class name.
   #
   # @example
   #   T::Configuration.scalar_types = ["NilClass", "TrueClass", "FalseClass", ...]
@@ -455,7 +455,7 @@ module T::Configuration
   #   to names in generated code. Used by the runtime implementation
   #   associated with `--stripe-packages` mode.
   #
-  # @param [Lambda, Proc, nil] value Proc that converts a type (Class/Module)
+  # @param [Lambda, Proc, nil] handler Proc that converts a type (Class/Module)
   #   to a String (pass nil to reset to default behavior)
   def self.module_name_mangler=(handler)
     @module_name_mangler = handler
@@ -464,7 +464,7 @@ module T::Configuration
   # Set to a PII handler function. This will be called with the `sensitivity:`
   # annotations on things that use `T::Props` and can modify them ahead-of-time.
   #
-  # @param [Lambda, Proc, nil] value Proc that takes a hash mapping symbols to the
+  # @param [Lambda, Proc, nil] handler Proc that takes a hash mapping symbols to the
   # prop values. Pass nil to avoid changing `sensitivity:` annotations.
   def self.normalize_sensitivity_and_pii_handler=(handler)
     @sensitivity_and_pii_handler = handler
@@ -480,7 +480,7 @@ module T::Configuration
   # `nil` and will raise an exception when the redacted version of a prop is
   # accessed.
   #
-  # @param [Lambda, Proc, nil] value Proc that converts a value into its
+  # @param [Lambda, Proc, nil] handler Proc that converts a value into its
   # redacted version according to the spec passed as the second argument.
   def self.redaction_handler=(handler)
     @redaction_handler = handler
@@ -493,7 +493,7 @@ module T::Configuration
   # Set to a function which can get the 'owner' of a class. This is
   # used in reporting deserialization errors
   #
-  # @param [Lambda, Proc, nil] value Proc that takes a class and
+  # @param [Lambda, Proc, nil] handler Proc that takes a class and
   # produces its owner, or `nil` if it does not have one.
   def self.class_owner_finder=(handler)
     @class_owner_finder = handler

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -47,7 +47,7 @@ class T::Enum
   SerializedVal = T.type_alias {T.untyped}
   private_constant :SerializedVal
 
-  ## Enum class methods ##
+  ### Enum class methods ###
   sig {returns(T::Array[T.attached_class])}
   def self.values
     if @values.nil?
@@ -134,7 +134,7 @@ class T::Enum
     self.from_serialized(mongo_value)
   end
 
-  ## Enum instance methods ##
+  ### Enum instance methods ###
 
   sig {returns(T.self_type)}
   def dup
@@ -243,7 +243,7 @@ class T::Enum
     )
   end
 
-  ## Private implementation ##
+  ### Private implementation ###
 
   sig {params(serialized_val: SerializedVal).void}
   def initialize(serialized_val=nil)

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -156,7 +156,7 @@ class T::Private::Methods::Signature
     "#{@mode}_method"
   end
 
-  # @return [Hash] a mapping like {arg_name: [val, type], ...}, for only those args actually present.
+  # @return [Hash] a mapping like `{arg_name: [val, type], ...}`, for only those args actually present.
   def each_args_value_type(args)
     # Manually split out args and kwargs based on ruby's behavior. Do not try to implement this by
     # getting ruby to determine the kwargs for you (e.g., by defining this method to take *args and

--- a/gems/sorbet-runtime/lib/types/private/types/not_typed.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/not_typed.rb
@@ -6,17 +6,17 @@
 class T::Private::Types::NotTyped < T::Types::Base
   ERROR_MESSAGE = "Validation is being done on a `NotTyped`. Please report to #dev-productivity."
 
-  # @override Base
+  # overrides Base
   def name
     "<NOT-TYPED>"
   end
 
-  # @override Base
+  # overrides Base
   def valid?(obj)
     raise ERROR_MESSAGE
   end
 
-  # @override Base
+  # overrides Base
   private def subtype_of_single?(other)
     raise ERROR_MESSAGE
   end

--- a/gems/sorbet-runtime/lib/types/private/types/string_holder.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/string_holder.rb
@@ -9,17 +9,17 @@ class T::Private::Types::StringHolder < T::Types::Base
     @string = string
   end
 
-  # @override Base
+  # overrides Base
   def name
     string
   end
 
-  # @override Base
+  # overrides Base
   def valid?(obj)
     false
   end
 
-  # @override Base
+  # overrides Base
   private def subtype_of_single?(other)
     false
   end

--- a/gems/sorbet-runtime/lib/types/private/types/type_alias.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/type_alias.rb
@@ -13,17 +13,17 @@ module T::Private::Types
       @aliased_type ||= T::Utils.coerce(@callable.call)
     end
 
-    # @override Base
+    # overrides Base
     def name
       aliased_type.name
     end
 
-    # @override Base
+    # overrides Base
     def recursively_valid?(obj)
       aliased_type.recursively_valid?(obj)
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       aliased_type.valid?(obj)
     end

--- a/gems/sorbet-runtime/lib/types/private/types/void.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/void.rb
@@ -17,17 +17,17 @@ class T::Private::Types::Void < T::Types::Base
     freeze
   end
 
-  # @override Base
+  # overrides Base
   def name
     "<VOID>"
   end
 
-  # @override Base
+  # overrides Base
   def valid?(obj)
     raise ERROR_MESSAGE
   end
 
-  # @override Base
+  # overrides Base
   private def subtype_of_single?(other)
     raise ERROR_MESSAGE
   end

--- a/gems/sorbet-runtime/lib/types/props/_props.rb
+++ b/gems/sorbet-runtime/lib/types/props/_props.rb
@@ -38,8 +38,6 @@ module T::Props
       @decorator = decorator_class.new(self)
     end
 
-    # @!method self.prop(name, type, opts={})
-    #
     # Define a new property. See {file:README.md} for some concrete
     #  examples.
     #
@@ -50,7 +48,7 @@ module T::Props
     #
     # @param name [Symbol] The name of this property
     # @param cls [Class,T::Types::Base] The type of this
-    #   property. If the type is itself a {Document} subclass, this
+    #   property. If the type is itself a `Document` subclass, this
     #   property will be recursively serialized/deserialized.
     # @param rules [Hash] Options to control this property's behavior.
     # @option rules [T::Boolean,Symbol] :optional If `true`, this property
@@ -61,7 +59,7 @@ module T::Props
     #   If `false`, when the property is missing/nil after deserialization, it
     #   will be set to the default value (as defined by the `default` or
     #   `factory` option) or will raise if they are not present.
-    #   Deprecated: For {Model}s, if `:optional` is set to the special value
+    #   Deprecated: For `Model`s, if `:optional` is set to the special value
     #   `:existing`, the property can be saved as nil even if it was
     #   deserialized with a non-nil value. (Deprecated because there should
     #   never be a need for this behavior; the new behavior of non-optional
@@ -69,7 +67,8 @@ module T::Props
     # @option rules [Array] :enum An array of legal values; The
     #  property is required to take on one of those values.
     # @option rules [T::Boolean] :dont_store If true, this property will
-    #   not be saved on the hash resulting from {#serialize}
+    #   not be saved on the hash resulting from
+    #   {T::Props::Serializable#serialize}
     # @option rules [Object] :ifunset A value to be returned if this
     #   property is requested but has never been set (is set to
     #   `nil`). It is applied at property-access time, and never saved
@@ -93,10 +92,10 @@ module T::Props
     #  class directly.
     #
     # @option rules [Object] :default A default value that will be set
-    #   by {#initialize} if none is provided in the initialization
+    #   by `#initialize` if none is provided in the initialization
     #   hash. This will not affect objects loaded by {.from_hash}.
     # @option rules [Proc] :factory A `Proc` that will be called to
-    #   generate an initial value for this prop on {#initialize}, if
+    #   generate an initial value for this prop on `#initialize`, if
     #   none is provided.
     # @option rules [T::Boolean] :immutable If true, this prop cannot be
     #   modified after an instance is created or loaded from a hash.
@@ -116,8 +115,6 @@ module T::Props
       decorator.prop_defined(name, cls, rules)
     end
 
-    # @!method validate_prop_value(propname, value)
-    #
     # Validates the value of the specified prop. This method allows the caller to
     #  validate a value for a prop without having to set the data on the instance.
     #  Throws if invalid.

--- a/gems/sorbet-runtime/lib/types/props/custom_type.rb
+++ b/gems/sorbet-runtime/lib/types/props/custom_type.rb
@@ -37,7 +37,7 @@ module T::Props
     # Given an instance of this type, serialize that into a scalar type
     # supported by T::Props.
     #
-    # @param [Object] _instance
+    # @param [Object] instance
     # @return An instance of one of T::Configuration.scalar_types
     sig {abstract.params(instance: T.untyped).returns(T.untyped).checked(:never)}
     def serialize(instance); end

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -442,7 +442,7 @@ class T::Props::Decorator
     end
   end
 
-  # Create "#{prop_name}_redacted" method
+  # Create `#{prop_name}_redacted` method
   sig do
     params(
       prop_name: Symbol,

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -325,7 +325,7 @@ module T::Props::Serializable::DecoratorMethods
     instance.instance_variable_get(:@_extra_props) || EMPTY_EXTRA_PROPS
   end
 
-  # @override T::Props::PrettyPrintable
+  # overrides T::Props::PrettyPrintable
   private def inspect_instance_components(instance, multiline:, indent:)
     if (extra_props = extra_props(instance)) && !extra_props.empty?
       pretty_kvs = extra_props.map {|k, v| [k.to_sym, v.inspect]}
@@ -346,8 +346,6 @@ module T::Props::Serializable::ClassMethods
     @prop_by_serialized_forms ||= {}
   end
 
-  # @!method self.from_hash(hash, strict)
-  #
   # Allocate a new instance and call {#deserialize} to load a new
   # object from a hash.
   # @return [Serializable]

--- a/gems/sorbet-runtime/lib/types/types/attached_class.rb
+++ b/gems/sorbet-runtime/lib/types/types/attached_class.rb
@@ -10,17 +10,17 @@ module T::Types
 
     def initialize(); end
 
-    # @override Base
+    # overrides Base
     def name
       "T.attached_class"
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       true
     end
 
-    # @override Base
+    # overrides Base
     private def subtype_of_single?(other)
       case other
       when AttachedClassType

--- a/gems/sorbet-runtime/lib/types/types/class_of.rb
+++ b/gems/sorbet-runtime/lib/types/types/class_of.rb
@@ -10,17 +10,17 @@ module T::Types
       @type = type
     end
 
-    # @override Base
+    # overrides Base
     def name
       "T.class_of(#{@type})"
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       obj.is_a?(Module) && obj <= @type
     end
 
-    # @override Base
+    # overrides Base
     def subtype_of_single?(other)
       case other
       when ClassOf
@@ -30,7 +30,7 @@ module T::Types
       end
     end
 
-    # @override Base
+    # overrides Base
     def describe_obj(obj)
       obj.inspect
     end

--- a/gems/sorbet-runtime/lib/types/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/types/enum.rb
@@ -14,12 +14,12 @@ module T::Types
       @values = values
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       @values.member?(obj)
     end
 
-    # @override Base
+    # overrides Base
     private def subtype_of_single?(other)
       case other
       when Enum
@@ -29,12 +29,12 @@ module T::Types
       end
     end
 
-    # @override Base
+    # overrides Base
     def name
       "T.enum([#{@values.map(&:inspect).join(', ')}])"
     end
 
-    # @override Base
+    # overrides Base
     def describe_obj(obj)
       obj.inspect
     end

--- a/gems/sorbet-runtime/lib/types/types/fixed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_array.rb
@@ -12,12 +12,12 @@ module T::Types
       @types = types.map {|type| T::Utils.coerce(type)}
     end
 
-    # @override Base
+    # overrides Base
     def name
       "[#{@types.join(', ')}]"
     end
 
-    # @override Base
+    # overrides Base
     def recursively_valid?(obj)
       if obj.is_a?(Array) && obj.length == @types.length
         i = 0
@@ -33,7 +33,7 @@ module T::Types
       end
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       if obj.is_a?(Array) && obj.length == @types.length
         i = 0
@@ -49,7 +49,7 @@ module T::Types
       end
     end
 
-    # @override Base
+    # overrides Base
     private def subtype_of_single?(other)
       case other
       when FixedArray
@@ -69,7 +69,7 @@ module T::Types
     # instead of
     # "Expected [String, Symbol], got Array".
     #
-    # @override Base
+    # overrides Base
     def describe_obj(obj)
       if obj.is_a?(Array)
         if obj.length == @types.length

--- a/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
@@ -11,12 +11,12 @@ module T::Types
       @types = types.transform_values {|v| T::Utils.coerce(v)}
     end
 
-    # @override Base
+    # overrides Base
     def name
       serialize_hash(@types)
     end
 
-    # @override Base
+    # overrides Base
     def recursively_valid?(obj)
       return false unless obj.is_a?(Hash)
       return false if @types.any? {|key, type| !type.recursively_valid?(obj[key])}
@@ -24,7 +24,7 @@ module T::Types
       true
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       return false unless obj.is_a?(Hash)
       return false if @types.any? {|key, type| !type.valid?(obj[key])}
@@ -32,7 +32,7 @@ module T::Types
       true
     end
 
-    # @override Base
+    # overrides Base
     private def subtype_of_single?(other)
       case other
       when FixedHash
@@ -44,11 +44,11 @@ module T::Types
     end
 
     # This gives us better errors, e.g.:
-    # "Expected {a: String}, got {a: TrueClass}"
+    # `Expected {a: String}, got {a: TrueClass}`
     # instead of
-    # "Expected {a: String}, got Hash".
+    # `Expected {a: String}, got Hash`.
     #
-    # @override Base
+    # overrides Base
     def describe_obj(obj)
       if obj.is_a?(Hash)
         "type #{serialize_hash(obj.transform_values(&:class))}"

--- a/gems/sorbet-runtime/lib/types/types/intersection.rb
+++ b/gems/sorbet-runtime/lib/types/types/intersection.rb
@@ -18,22 +18,22 @@ module T::Types
       end.uniq
     end
 
-    # @override Base
+    # overrides Base
     def name
       "T.all(#{@types.map(&:name).sort.join(', ')})"
     end
 
-    # @override Base
+    # overrides Base
     def recursively_valid?(obj)
       @types.all? {|type| type.recursively_valid?(obj)}
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       @types.all? {|type| type.valid?(obj)}
     end
 
-    # @override Base
+    # overrides Base
     private def subtype_of_single?(other)
       raise "This should never be reached if you're going through `subtype_of?` (and you should be)"
     end

--- a/gems/sorbet-runtime/lib/types/types/noreturn.rb
+++ b/gems/sorbet-runtime/lib/types/types/noreturn.rb
@@ -7,17 +7,17 @@ module T::Types
 
     def initialize; end
 
-    # @override Base
+    # overrides Base
     def name
       "T.noreturn"
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       false
     end
 
-    # @override Base
+    # overrides Base
     private def subtype_of_single?(other)
       true
     end

--- a/gems/sorbet-runtime/lib/types/types/proc.rb
+++ b/gems/sorbet-runtime/lib/types/types/proc.rb
@@ -19,7 +19,7 @@ module T::Types
       @returns = T::Utils.coerce(returns)
     end
 
-    # @override Base
+    # overrides Base
     def name
       args = []
       @arg_types.each do |k, v|
@@ -28,12 +28,12 @@ module T::Types
       "T.proc.params(#{args.join(', ')}).returns(#{returns})"
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       obj.is_a?(::Proc)
     end
 
-    # @override Base
+    # overrides Base
     private def subtype_of_single?(other)
       case other
       when self.class

--- a/gems/sorbet-runtime/lib/types/types/self_type.rb
+++ b/gems/sorbet-runtime/lib/types/types/self_type.rb
@@ -8,17 +8,17 @@ module T::Types
 
     def initialize(); end
 
-    # @override Base
+    # overrides Base
     def name
       "T.self_type"
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       true
     end
 
-    # @override Base
+    # overrides Base
     private def subtype_of_single?(other)
       case other
       when SelfType

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -10,7 +10,7 @@ module T::Types
       @raw_type = raw_type
     end
 
-    # @override Base
+    # overrides Base
     def name
       # Memoize to mitigate pathological performance with anonymous modules (https://bugs.ruby-lang.org/issues/11119)
       #
@@ -19,12 +19,12 @@ module T::Types
       @name ||= @raw_type.name.freeze
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       obj.is_a?(@raw_type)
     end
 
-    # @override Base
+    # overrides Base
     private def subtype_of_single?(other)
       case other
       when Simple

--- a/gems/sorbet-runtime/lib/types/types/t_enum.rb
+++ b/gems/sorbet-runtime/lib/types/types/t_enum.rb
@@ -10,7 +10,7 @@ module T::Types
       @val = val
     end
 
-    # @override Base
+    # overrides Base
     def name
       # Strips the #<...> off, just leaving the ...
       # Reasoning: the user will have written something like
@@ -20,12 +20,12 @@ module T::Types
       @val.inspect[2..-2]
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       @val == obj
     end
 
-    # @override Base
+    # overrides Base
     private def subtype_of_single?(other)
       case other
       when TEnum

--- a/gems/sorbet-runtime/lib/types/types/typed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_array.rb
@@ -3,7 +3,7 @@
 
 module T::Types
   class TypedArray < TypedEnumerable
-    # @override Base
+    # overrides Base
     def name
       "T::Array[#{@type.name}]"
     end
@@ -12,12 +12,12 @@ module T::Types
       Array
     end
 
-    # @override Base
+    # overrides Base
     def recursively_valid?(obj)
       obj.is_a?(Array) && super
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       obj.is_a?(Array)
     end

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -16,17 +16,17 @@ module T::Types
       Enumerable
     end
 
-    # @override Base
+    # overrides Base
     def name
       "T::Enumerable[#{@type.name}]"
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       obj.is_a?(Enumerable)
     end
 
-    # @override Base
+    # overrides Base
     def recursively_valid?(obj)
       return false unless obj.is_a?(Enumerable)
       case obj
@@ -74,7 +74,7 @@ module T::Types
       end
     end
 
-    # @override Base
+    # overrides Base
     private def subtype_of_single?(other)
       if other.class <= TypedEnumerable &&
          underlying_class <= other.underlying_class
@@ -90,7 +90,7 @@ module T::Types
       end
     end
 
-    # @override Base
+    # overrides Base
     def describe_obj(obj)
       return super unless obj.is_a?(Enumerable)
       type_from_instance(obj).name

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerator.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerator.rb
@@ -9,17 +9,17 @@ module T::Types
       Enumerator
     end
 
-    # @override Base
+    # overrides Base
     def name
       "T::Enumerator[#{@type.name}]"
     end
 
-    # @override Base
+    # overrides Base
     def recursively_valid?(obj)
       obj.is_a?(Enumerator) && super
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       obj.is_a?(Enumerator)
     end

--- a/gems/sorbet-runtime/lib/types/types/typed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_hash.rb
@@ -16,17 +16,17 @@ module T::Types
       @type = T::Utils.coerce([keys, values])
     end
 
-    # @override Base
+    # overrides Base
     def name
       "T::Hash[#{@keys.name}, #{@values.name}]"
     end
 
-    # @override Base
+    # overrides Base
     def recursively_valid?(obj)
       obj.is_a?(Hash) && super
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       obj.is_a?(Hash)
     end

--- a/gems/sorbet-runtime/lib/types/types/typed_range.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_range.rb
@@ -9,17 +9,17 @@ module T::Types
       Hash
     end
 
-    # @override Base
+    # overrides Base
     def name
       "T::Range[#{@type.name}]"
     end
 
-    # @override Base
+    # overrides Base
     def recursively_valid?(obj)
       obj.is_a?(Range) && super
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       obj.is_a?(Range)
     end

--- a/gems/sorbet-runtime/lib/types/types/typed_set.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_set.rb
@@ -9,17 +9,17 @@ module T::Types
       Hash
     end
 
-    # @override Base
+    # overrides Base
     def name
       "T::Set[#{@type.name}]"
     end
 
-    # @override Base
+    # overrides Base
     def recursively_valid?(obj)
       obj.is_a?(Set) && super
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       obj.is_a?(Set)
     end

--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -18,7 +18,7 @@ module T::Types
       end.uniq
     end
 
-    # @override Base
+    # overrides Base
     def name
       type_shortcuts(@types)
     end
@@ -42,17 +42,17 @@ module T::Types
       end
     end
 
-    # @override Base
+    # overrides Base
     def recursively_valid?(obj)
       @types.any? {|type| type.recursively_valid?(obj)}
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       @types.any? {|type| type.valid?(obj)}
     end
 
-    # @override Base
+    # overrides Base
     private def subtype_of_single?(other)
       raise "This should never be reached if you're going through `subtype_of?` (and you should be)"
     end

--- a/gems/sorbet-runtime/lib/types/types/untyped.rb
+++ b/gems/sorbet-runtime/lib/types/types/untyped.rb
@@ -7,17 +7,17 @@ module T::Types
 
     def initialize; end
 
-    # @override Base
+    # overrides Base
     def name
       "T.untyped"
     end
 
-    # @override Base
+    # overrides Base
     def valid?(obj)
       true
     end
 
-    # @override Base
+    # overrides Base
     private def subtype_of_single?(other)
       true
     end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This cleans up the warnings when invoking `yard` on the `sorbet-runtime` gem. I don't think the gem uses `yard` in any official capacity, but it retains a lot of cruft. Some examples:

- `@override` is not a valid tag
- `@!method` is used needlessly/incorrectly
- A number of links (`{}`) aren't valid (and date to when `Struct` was contained in `Chalk::ODM`)
- `@param`/`@option` tags are used to document non-params, leading to warnings and incorrect documentation
- Some `param` names no longer match
- etc.

(I still find it useful to generate and browse the docs. For instance, a lot of class names are tricky to map back to file names.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I browsed the resulting documentation. There are still formatting issues but it's significantly better.

This PR only touches comments, it has no impact on live code.