### PR TITLE
fixup comment for SymbolBasedIntrinsicMethod::skipFastPathTest

### DIFF
--- a/compiler/IREmitter/SymbolBasedIntrinsicMethod.h
+++ b/compiler/IREmitter/SymbolBasedIntrinsicMethod.h
@@ -31,7 +31,7 @@ public:
     virtual llvm::Value *receiverFastPathTest(MethodCallContext &mcctx, core::ClassOrModuleRef potentialClass) const;
 
     // The above is a runtime test, since it returns an llvm::Value (which might be `true`).
-    // This method is a compile test for instances where we statically know the compile-time
+    // This method is a compile test for instances where we statically know the runtime
     // test would succeed.  This might be done for intrinsics which we know don't have
     // a slow path through the VM (e.g. calls on Sorbet::Private::Static) or where having
     // a slow path through the VM would hinder optimizations like having an assumption


### PR DESCRIPTION
### Motivation

Realized I wrote this comment a little too fast yesterday.  I think it makes more sense now.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
