### PR TITLE
Enforce that errors from pipeline tests must have locations

### DIFF
--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -86,8 +86,10 @@ UnorderedSet<string> knownExpectations = {"parse-tree",       "parse-tree-json",
                                           "document-symbols", "package-tree",     "document-formatting-rubyfmt",
                                           "autocorrects"};
 
-// TODO: This list will be progressively made empty, and we will not have any tests that
-// can swallow errors that don't have association locations. See lines 481-484 below.
+// This list will be progressively made empty, and we will not have any tests that
+// can swallow errors that don't have associated locations. See lines 479-483 below.
+// DO NOT add new tests here.
+// TODO (jez) Fix these tests
 UnorderedSet<string> locationCheckExemptTests = {"test/testdata/packager/nested_inner_namespaces",
                                                  "test/testdata/packager/import_subpackage",
                                                  "test/testdata/packager/nested_packages",

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -92,9 +92,9 @@ UnorderedSet<string> locationCheckExemptTests = {"test/testdata/packager/nested_
                                                  "test/testdata/packager/import_subpackage",
                                                  "test/testdata/packager/nested_packages",
                                                  "test/testdata/packager/deeply_nested_packages",
-                                                 "test/testdata/desugar/assign_empty_stats",
-                                                 "test/testdata/desugar/assign_keyword",
-                                                 "test/testdata/lsp/struct_fuzz"};
+                                                 "test/testdata/desugar/assign_empty_stmts.rb",
+                                                 "test/testdata/desugar/assign_keyword.rb",
+                                                 "test/testdata/lsp/struct_fuzz.rb"};
 
 ast::ParsedFile testSerialize(core::GlobalState &gs, ast::ParsedFile expr) {
     auto &savedFile = expr.file.data(gs);

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -88,16 +88,13 @@ UnorderedSet<string> knownExpectations = {"parse-tree",       "parse-tree-json",
 
 // TODO: This list will be progressively made empty, and we will not have any tests that
 // can swallow errors that don't have association locations. See lines 481-484 below.
-UnorderedSet<string> locationCheckExemptTests = {
-    "test/testdata/packager/nested_inner_namespaces",
-    "test/testdata/packager/import_subpackage",
-    "test/testdata/packager/nested_packages",
-    "test/testdata/packager/deeply_nested_packages",
-    "test/testdata/desugar/assign_empty_stats",
-    "test/testdata/desugar/assign_keyword",
-    "test/testdata/lsp/struct_fuzz"
-};
-
+UnorderedSet<string> locationCheckExemptTests = {"test/testdata/packager/nested_inner_namespaces",
+                                                 "test/testdata/packager/import_subpackage",
+                                                 "test/testdata/packager/nested_packages",
+                                                 "test/testdata/packager/deeply_nested_packages",
+                                                 "test/testdata/desugar/assign_empty_stats",
+                                                 "test/testdata/desugar/assign_keyword",
+                                                 "test/testdata/lsp/struct_fuzz"};
 
 ast::ParsedFile testSerialize(core::GlobalState &gs, ast::ParsedFile expr) {
     auto &savedFile = expr.file.data(gs);

--- a/test/testdata/packager/import_subpackage/a/__package.rb
+++ b/test/testdata/packager/import_subpackage/a/__package.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# typed: strict
+# enable-packager: true
+
+class Root < PackageSpec
+  import Root::B
+end

--- a/test/testdata/packager/import_subpackage/a/b/__package.rb
+++ b/test/testdata/packager/import_subpackage/a/b/__package.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# typed: strict
+# enable-packager: true
+
+class Root::B < PackageSpec
+  export Root::B::Foo
+end

--- a/test/testdata/packager/import_subpackage/a/b/foo.rb
+++ b/test/testdata/packager/import_subpackage/a/b/foo.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+module Root::B::Foo; end

--- a/test/testdata/packager/import_subpackage/pass.package-tree.exp
+++ b/test/testdata/packager/import_subpackage/pass.package-tree.exp
@@ -1,0 +1,42 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Root><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Root>::<C B>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Root_Package$1>::<C Root>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>::<C Foo>
+    end
+
+    class <emptyTree>::<C Root_Package$1>::<C Root>::<C <Magic>><<C <todo sym>>> < ()
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Root_Package$1>::<C Root>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>::<C Foo>
+    end
+
+    <emptyTree>::<C Root_Package$1>::<C Root> = <emptyTree>::<C <PackageRegistry>>::<C Root_Package$1>::<C Root>
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Root>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>::<C Foo>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    class <emptyTree>::<C Root_B_Package$1>::<C Root>::<C B>::<C <Magic>><<C <todo sym>>> < ()
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    <emptyTree>::<C Root_B_Package$1>::<C Root>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1><<C <todo sym>>> < ()
+    module <emptyTree>::<C Root>::<C B>::<C Foo><<C <todo sym>>> < ()
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Currently the pipeline tests do nothing if they encounter errors without valid locations, resulting in tests missing issues sometimes.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This limitation/bug unfortunately missed a fundamental issue with Rigorous Packaging design, in the packager.cc pass.

Adding an allow-list/exemption list for tests that currently fail due to location-less errors. These will be fixed incrementally

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

cc @jez @ngroman @elliottt 