### PR TITLE
Add a super-splat test

### DIFF
--- a/test/testdata/compiler/disabled/super_splat.rb
+++ b/test/testdata/compiler/disabled/super_splat.rb
@@ -1,0 +1,24 @@
+# compiled: true
+# typed: true
+# frozen_string_literal: true
+
+class Parent
+  extend T::Sig
+
+  def foo(*args)
+    puts args
+  end
+
+end
+
+class Child < Parent
+  extend T::Sig
+
+  def foo(*args)
+    super(*T.unsafe(args))
+  end
+
+end
+
+args = [1,2,3]
+Child.new.foo(*[1,2,3])


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
`super` and the `call-with-splat` intrinsic aren't interacting well, and the
result is that compiler-generated code will end up trying to call a method with
the name `super` instead of invoking super when splat args are given.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
More tests.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.