### PR TITLE
Make `requires_ancestor` take a block

### DIFF
--- a/gems/sorbet-runtime/lib/types/helpers.rb
+++ b/gems/sorbet-runtime/lib/types/helpers.rb
@@ -4,6 +4,8 @@
 # Use as a mixin with extend (`extend T::Helpers`).
 # Docs at https://confluence.corp.stripe.com/display/PRODINFRA/Ruby+Types
 module T::Helpers
+  extend T::Sig
+
   Private = T::Private
 
   ### Class/Module Helpers ###
@@ -44,7 +46,7 @@ module T::Helpers
   #   module MyHelper
   #     extend T::Helpers
   #
-  #     requires_ancestor Kernel
+  #     requires_ancestor { Kernel }
   #   end
   #
   #   class MyClass < BasicObject # error: `MyClass` must include `Kernel` (required by `MyHelper`)
@@ -52,5 +54,5 @@ module T::Helpers
   #   end
   #
   # TODO: implement the checks in sorbet-runtime.
-  def requires_ancestor(mod, *mods); end
+  def requires_ancestor(&block); end
 end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -91,23 +91,25 @@ module T::Helpers
   sig {void}
   def sealed!; end
 
-  # We do not use signatures on the following methods as to not duplicate errors
+  # We do not use signatures on `mixes_in_class_methods` as to not duplicate errors
   # between the `namer` phase and typechecking for calls.
   #
   # With the following example:
   #
   # ```
   # class A
-  #   requires_ancestor "A"
+  #   mixes_in_class_methods A
   # end
   # ```
   #
   # Using a signature would mean we would generate two errors:
-  # 1. error: `requires_ancestor` must only contain constant literals (from namer)
+  # 1. error: `mixes_in_class_methods` must only contain constant literals (from namer)
   # 2. error: Expected `Module` but found `NilClass` for argument `mod` (from calls)
 
   def mixes_in_class_methods(mod, *mods); end
-  def requires_ancestor(mod, *mods); end
+
+  sig { params(block: T.proc.returns(Module)).void }
+  def requires_ancestor(&block); end
 end
 
 module T::Array

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -667,6 +667,10 @@ private:
             if (auto e = gs.beginError(loc, core::errors::Resolver::InvalidRequiredAncestor)) {
                 e.setHeader("`{}` only accepts a block", send->fun.show(gs));
 
+                if (block != nullptr) {
+                    return;
+                }
+
                 string replacement = "";
                 int indent = core::Loc::offset2Pos(todo.file.data(gs), send->loc.beginPos()).column - 1;
                 int index = 1;

--- a/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.out
+++ b/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.out
@@ -1,48 +1,59 @@
-autocorrect-requires-ancestor-block.rb:10: `requires_ancestor` only accepts a block https://srb.help/5062
-    10 |  requires_ancestor RA1
+autocorrect-requires-ancestor-block.rb:12: `requires_ancestor` only accepts a block https://srb.help/5062
+    12 |  requires_ancestor RA1
           ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    autocorrect-requires-ancestor-block.rb:10: Replaced with `requires_ancestor { RA1 }`
-    10 |  requires_ancestor RA1
+    autocorrect-requires-ancestor-block.rb:12: Replaced with `requires_ancestor { RA1 }`
+    12 |  requires_ancestor RA1
           ^^^^^^^^^^^^^^^^^^^^^
 
-autocorrect-requires-ancestor-block.rb:11: `requires_ancestor` only accepts a block https://srb.help/5062
-    11 |  requires_ancestor RA2, RA3
+autocorrect-requires-ancestor-block.rb:13: `requires_ancestor` only accepts a block https://srb.help/5062
+    13 |  requires_ancestor RA2, RA3
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    autocorrect-requires-ancestor-block.rb:11: Replaced with `requires_ancestor { RA2 }
+    autocorrect-requires-ancestor-block.rb:13: Replaced with `requires_ancestor { RA2 }
   requires_ancestor { RA3 }`
-    11 |  requires_ancestor RA2, RA3
+    13 |  requires_ancestor RA2, RA3
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-autocorrect-requires-ancestor-block.rb:10: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1` https://srb.help/7004
-    10 |  requires_ancestor RA1
+autocorrect-requires-ancestor-block.rb:14: `requires_ancestor` only accepts a block https://srb.help/5062
+    14 |  requires_ancestor(RA4) { RA5 }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-requires-ancestor-block.rb:12: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1` https://srb.help/7004
+    12 |  requires_ancestor RA1
           ^^^^^^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: `requires_ancestor` defined here
      112 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-autocorrect-requires-ancestor-block.rb:10: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
-    10 |  requires_ancestor RA1
+autocorrect-requires-ancestor-block.rb:12: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
+    12 |  requires_ancestor RA1
           ^^^^^^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: defined here
      112 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-autocorrect-requires-ancestor-block.rb:11: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `2` https://srb.help/7004
-    11 |  requires_ancestor RA2, RA3
+autocorrect-requires-ancestor-block.rb:13: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `2` https://srb.help/7004
+    13 |  requires_ancestor RA2, RA3
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: `requires_ancestor` defined here
      112 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-autocorrect-requires-ancestor-block.rb:11: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
-    11 |  requires_ancestor RA2, RA3
+autocorrect-requires-ancestor-block.rb:13: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
+    13 |  requires_ancestor RA2, RA3
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: defined here
      112 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 6
+
+autocorrect-requires-ancestor-block.rb:14: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1` https://srb.help/7004
+    14 |  requires_ancestor(RA4) { RA5 }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: `requires_ancestor` defined here
+     112 |  def requires_ancestor(&block); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 8
 
 --------------------------------------------------------------------------
 
@@ -51,6 +62,8 @@ Errors: 6
 class RA1; end
 module RA2; end
 module RA3; end
+module RA4; end
+module RA5; end
 
 module M
   extend T::Helpers
@@ -58,4 +71,5 @@ module M
   requires_ancestor { RA1 }
   requires_ancestor { RA2 }
   requires_ancestor { RA3 }
+  requires_ancestor(RA4) { RA5 }
 end

--- a/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.out
+++ b/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.out
@@ -1,0 +1,61 @@
+autocorrect-requires-ancestor-block.rb:10: `requires_ancestor` only accepts a block https://srb.help/5062
+    10 |  requires_ancestor RA1
+          ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-requires-ancestor-block.rb:10: Replaced with `requires_ancestor { RA1 }`
+    10 |  requires_ancestor RA1
+          ^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-requires-ancestor-block.rb:11: `requires_ancestor` only accepts a block https://srb.help/5062
+    11 |  requires_ancestor RA2, RA3
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-requires-ancestor-block.rb:11: Replaced with `requires_ancestor { RA2 }
+  requires_ancestor { RA3 }`
+    11 |  requires_ancestor RA2, RA3
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-requires-ancestor-block.rb:10: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1` https://srb.help/7004
+    10 |  requires_ancestor RA1
+          ^^^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: `requires_ancestor` defined here
+     112 |  def requires_ancestor(&block); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-requires-ancestor-block.rb:10: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
+    10 |  requires_ancestor RA1
+          ^^^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: defined here
+     112 |  def requires_ancestor(&block); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-requires-ancestor-block.rb:11: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `2` https://srb.help/7004
+    11 |  requires_ancestor RA2, RA3
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: `requires_ancestor` defined here
+     112 |  def requires_ancestor(&block); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-requires-ancestor-block.rb:11: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
+    11 |  requires_ancestor RA2, RA3
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: defined here
+     112 |  def requires_ancestor(&block); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 6
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+class RA1; end
+module RA2; end
+module RA3; end
+
+module M
+  extend T::Helpers
+
+  requires_ancestor { RA1 }
+  requires_ancestor { RA2 }
+  requires_ancestor { RA3 }
+end

--- a/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.rb
+++ b/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+class RA1; end
+module RA2; end
+module RA3; end
+
+module M
+  extend T::Helpers
+
+  requires_ancestor RA1
+  requires_ancestor RA2, RA3
+end

--- a/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.rb
+++ b/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.rb
@@ -3,10 +3,13 @@
 class RA1; end
 module RA2; end
 module RA3; end
+module RA4; end
+module RA5; end
 
 module M
   extend T::Helpers
 
   requires_ancestor RA1
   requires_ancestor RA2, RA3
+  requires_ancestor(RA4) { RA5 }
 end

--- a/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.sh
+++ b/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+tmp="$(mktemp -d)"
+cp "test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.rb" "$tmp"
+
+old_pwd="$(pwd)"
+cd "$tmp" || exit 1
+
+"$old_pwd/main/sorbet" --silence-dev-message --enable-experimental-requires-ancestor -a autocorrect-requires-ancestor-block.rb 2>&1
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+cat autocorrect-requires-ancestor-block.rb
+rm -rf "$tmp"

--- a/test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.out
+++ b/test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.out
@@ -4,6 +4,6 @@ test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ance
      9 |class Bar < BasicObject
         ^^^^^^^^^^^^^^^^^^^^^^^
     test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.rb:6: required by `Foo` here
-     6 |  requires_ancestor Kernel
-                            ^^^^^^
+     6 |  requires_ancestor { Kernel }
+                              ^^^^^^
 Errors: 1

--- a/test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.rb
+++ b/test/cli/enable-experimental-requires-ancestor/enable-experimental-requires-ancestor.rb
@@ -3,7 +3,7 @@
 module Foo
   extend T::Helpers
 
-  requires_ancestor Kernel
+  requires_ancestor { Kernel }
 end
 
 class Bar < BasicObject

--- a/test/testdata/lsp/requires_ancestor.1.rbupdate
+++ b/test/testdata/lsp/requires_ancestor.1.rbupdate
@@ -8,7 +8,7 @@ end
 module B
   extend T::Helpers
 
-  requires_ancestor A
+  requires_ancestor { A }
 
   def foo_b
     foo_a

--- a/test/testdata/lsp/requires_ancestor.2.rbupdate
+++ b/test/testdata/lsp/requires_ancestor.2.rbupdate
@@ -8,7 +8,7 @@ end
 module B
   extend T::Helpers
 
-  # requires_ancestor A
+  # requires_ancestor { A }
 
   def foo_b
     foo_a # error: Method `foo_a` does not exist on `B`
@@ -21,7 +21,7 @@ end
 
 module D
   extend T::Helpers
-  requires_ancestor E
+  requires_ancestor { E }
 end
 
 module E

--- a/test/testdata/lsp/requires_ancestor.3.rbupdate
+++ b/test/testdata/lsp/requires_ancestor.3.rbupdate
@@ -8,7 +8,7 @@ end
 module B
   extend T::Helpers
 
-  # requires_ancestor A
+  # requires_ancestor { A }
 
   def foo_b
     foo_a # error: Method `foo_a` does not exist on `B`
@@ -22,7 +22,7 @@ end
 
 module D
   extend T::Helpers
-  requires_ancestor E
+  requires_ancestor { E }
 end
 
 module E

--- a/test/testdata/resolver/requires_ancestor_calls_ancestors.rb
+++ b/test/testdata/resolver/requires_ancestor_calls_ancestors.rb
@@ -6,7 +6,7 @@
 module Test1
   module M1
     extend T::Helpers
-    requires_ancestor M2
+    requires_ancestor { M2 }
 
     def m1
       m2
@@ -23,7 +23,7 @@ end
 module Test2
   module M1
     extend T::Helpers
-    requires_ancestor M3
+    requires_ancestor { M3 }
 
     def m1
       m2
@@ -46,7 +46,7 @@ end
 module Test3
   module M1
     extend T::Helpers
-    requires_ancestor M4
+    requires_ancestor { M4 }
 
     def m1
       m2
@@ -79,7 +79,7 @@ module Test4
 
   module M2
     extend T::Helpers
-    requires_ancestor M1
+    requires_ancestor { M1 }
 
     def m2
       m1
@@ -88,7 +88,7 @@ module Test4
 
   module M3
     extend T::Helpers
-    requires_ancestor M2
+    requires_ancestor { M2 }
 
     def m3
       m1
@@ -98,7 +98,7 @@ module Test4
 
   module M4
     extend T::Helpers
-    requires_ancestor M3
+    requires_ancestor { M3 }
 
     def m4
       m1
@@ -127,7 +127,7 @@ end
 module Test5
   module M1
     extend T::Helpers
-    requires_ancestor C1
+    requires_ancestor { C1 }
 
     def m1
       c1
@@ -146,7 +146,7 @@ end
 module Test6
   module M1
     extend T::Helpers
-    requires_ancestor C2
+    requires_ancestor { C2 }
 
     def m1
       c1
@@ -169,7 +169,7 @@ module Test7
   module M1
     extend T::Helpers
 
-    requires_ancestor C3
+    requires_ancestor { C3 }
 
     def m1
       c3

--- a/test/testdata/resolver/requires_ancestor_calls_types.rb
+++ b/test/testdata/resolver/requires_ancestor_calls_types.rb
@@ -14,7 +14,7 @@ end
 module Test1
   module M1
     extend T::Helpers
-    requires_ancestor RA1
+    requires_ancestor { RA1 }
 
     def m1
       foo
@@ -27,7 +27,7 @@ end
 module Test2
   module M1
     extend T::Helpers
-    requires_ancestor RA1
+    requires_ancestor { RA1 }
 
     def m1
       self.foo
@@ -41,7 +41,7 @@ module Test3
   module M1
     extend T::Helpers
     extend T::Sig
-    requires_ancestor RA1
+    requires_ancestor { RA1 }
 
     def m1
       get_me.foo
@@ -66,7 +66,8 @@ module Test4
   module M1
     extend T::Helpers
     extend T::Sig
-    requires_ancestor Kernel, RA1
+    requires_ancestor { Kernel }
+    requires_ancestor { RA1 }
 
     def m1
       any_m1_ra1.foo
@@ -97,7 +98,7 @@ module Test5
   module M1
     extend T::Helpers
     extend T::Sig
-    requires_ancestor RA2
+    requires_ancestor { RA2 }
     include RA1
 
     def m1
@@ -117,7 +118,7 @@ module Test6
   module M1
     extend T::Helpers
     extend T::Sig
-    requires_ancestor RA1
+    requires_ancestor { RA1 }
 
     def m1
       m = m1?
@@ -138,7 +139,8 @@ module Test7
   module M1
     extend T::Helpers
     extend T::Sig
-    requires_ancestor RA1, RA2
+    requires_ancestor { RA1 }
+    requires_ancestor { RA2 }
 
     def m1
       m = tuple
@@ -159,7 +161,8 @@ module Test8
   module M1
     extend T::Helpers
     extend T::Sig
-    requires_ancestor RA1, RA2
+    requires_ancestor { RA1 }
+    requires_ancestor { RA2 }
 
     def m1
       m = shape
@@ -179,7 +182,7 @@ end
 module Test9
   module M1
     extend T::Helpers
-    requires_ancestor RA1
+    requires_ancestor { RA1 }
   end
 
   class C1
@@ -209,7 +212,7 @@ end
 module Test10
   module M1
     extend T::Helpers
-    requires_ancestor RA1
+    requires_ancestor { RA1 }
   end
 
   module M2
@@ -235,7 +238,7 @@ end
 module Test11
   module M1
     extend T::Helpers
-    requires_ancestor RA1
+    requires_ancestor { RA1 }
   end
 
   class C1

--- a/test/testdata/resolver/requires_ancestor_disabled.rb
+++ b/test/testdata/resolver/requires_ancestor_disabled.rb
@@ -5,7 +5,7 @@
 
 module Test1
   module M1
-    requires_ancestor M2 # error: Method `requires_ancestor` does not exist on `T.class_of(Test1::M1)`
+    requires_ancestor { M2 } # error: Method `requires_ancestor` does not exist on `T.class_of(Test1::M1)`
   end
 
   module M2; end
@@ -16,7 +16,7 @@ end
 module Test2
   module M1
     extend T::Helpers
-    requires_ancestor M2
+    requires_ancestor { M2 }
 
     def m1
       m2 # error: Method `m2` does not exist on `Test2::M1`
@@ -33,7 +33,7 @@ end
 module Test3
   module M1
     extend T::Helpers
-    requires_ancestor M2
+    requires_ancestor { M2 }
   end
 
   module M2; end

--- a/test/testdata/resolver/requires_ancestor_errors.rb
+++ b/test/testdata/resolver/requires_ancestor_errors.rb
@@ -72,3 +72,27 @@ class Helper9 < String
   requires_ancestor { String }
   #                   ^^^^^^ error: `String` is already inherited by `Helper9`
 end
+
+module Helper10
+  extend T::Helpers
+
+  requires_ancestor
+# ^^^^^^^^^^^^^^^^^ error: `requires_ancestor` requires a block parameter, but no block was passed
+end
+
+module Helper11
+  extend T::Helpers
+
+  requires_ancestor (Kernel)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1`
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `requires_ancestor` only accepts a block
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `requires_ancestor` requires a block parameter, but no block was passed
+end
+
+module Helper12
+  extend T::Helpers
+
+  requires_ancestor (Kernel) { Kernel }
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1`
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `requires_ancestor` only accepts a block
+end

--- a/test/testdata/resolver/requires_ancestor_errors.rb
+++ b/test/testdata/resolver/requires_ancestor_errors.rb
@@ -2,57 +2,57 @@
 # enable-experimental-requires-ancestor: true
 
 module Helper1
-  requires_ancestor Object # error: Method `requires_ancestor` does not exist on `T.class_of(Helper1)`
+  requires_ancestor { Object } # error: Method `requires_ancestor` does not exist on `T.class_of(Helper1)`
 end
 
 module Helper2
   extend T::Helpers
 
-  requires_ancestor # error: Not enough arguments provided for method `T::Helpers#requires_ancestor`. Expected: `1+`, got: `0`
+  requires_ancestor # error: `requires_ancestor` requires a block parameter, but no block was passed
 end
 
 module Helper3
   extend T::Helpers
 
-  requires_ancestor NotFound
-  #                 ^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
-  #                 ^^^^^^^^ error: Unable to resolve constant `NotFound`
+  requires_ancestor { NotFound }
+  #                   ^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
+  #                   ^^^^^^^^ error: Unable to resolve constant `NotFound`
 end
 
 class Helper4
   extend T::Helpers
 
-  requires_ancestor Object # error: `requires_ancestor` can only be declared inside a module or an abstract class
+  requires_ancestor { Object } # error: `requires_ancestor` can only be declared inside a module or an abstract class
 
   class << self
     extend T::Helpers
-    requires_ancestor String # error: `requires_ancestor` can only be declared inside a module or an abstract class
+    requires_ancestor { String } # error: `requires_ancestor` can only be declared inside a module or an abstract class
   end
 end
 
 module Helper5
   extend T::Helpers
 
-  requires_ancestor Object, "Object"
-  #                         ^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
+  requires_ancestor { "Object" } # error: Expected `Module` but found `String("Object")` for block result type
+  #                   ^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
 
-  requires_ancestor T.class_of(Object)
-  #                 ^^^^^^^^^^^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
+  requires_ancestor { T.class_of(Object) } # error: Expected `Module` but found `<Type: T.class_of(Object)>` for block result type
+  #                   ^^^^^^^^^^^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
 end
 
 module Helper6
   extend T::Helpers
 
-  requires_ancestor Helper6
-  #                 ^^^^^^^ error: Must not pass yourself to `requires_ancestor`
+  requires_ancestor { Helper6 }
+  #                   ^^^^^^^ error: Must not pass yourself to `requires_ancestor`
 end
 
 module Helper7
   extend T::Helpers
   include Kernel
 
-  requires_ancestor Kernel
-  #                 ^^^^^^ error: `Kernel` is already included by `Helper7`
+  requires_ancestor { Kernel }
+  #                   ^^^^^^ error: `Kernel` is already included by `Helper7`
 end
 
 class Helper8
@@ -60,8 +60,8 @@ class Helper8
 
   abstract!
 
-  requires_ancestor Object
-  #                 ^^^^^^ error: `Object` is already inherited by `Helper8`
+  requires_ancestor { Object }
+  #                   ^^^^^^ error: `Object` is already inherited by `Helper8`
 end
 
 class Helper9 < String
@@ -69,6 +69,6 @@ class Helper9 < String
 
   abstract!
 
-  requires_ancestor String
-  #                 ^^^^^^ error: `String` is already inherited by `Helper9`
+  requires_ancestor { String }
+  #                   ^^^^^^ error: `String` is already inherited by `Helper9`
 end

--- a/test/testdata/resolver/requires_ancestor_kernel.rb
+++ b/test/testdata/resolver/requires_ancestor_kernel.rb
@@ -4,7 +4,7 @@
 module MyHelper
   extend T::Helpers
 
-  requires_ancestor Kernel
+  requires_ancestor { Kernel }
 
   def error(message)
     puts "An error occurred: #{message}"

--- a/test/testdata/resolver/requires_ancestor_lin.rb
+++ b/test/testdata/resolver/requires_ancestor_lin.rb
@@ -9,7 +9,7 @@ module R2; end
 module Test1
   module M1
     extend T::Helpers
-    requires_ancestor R1
+    requires_ancestor { R1 }
   end
 
   class C1 # error: `Test1::C1` must include `R1` (required by `Test1::M1`)
@@ -27,13 +27,13 @@ end
 module Test2
   module M1
     extend T::Helpers
-    requires_ancestor R1
+    requires_ancestor { R1 }
   end
 
   module M2
     extend T::Helpers
     interface!
-    requires_ancestor R2
+    requires_ancestor { R2 }
   end
 
   class C1
@@ -59,7 +59,7 @@ end
 module Test3
   module M1
     extend T::Helpers
-    requires_ancestor R1
+    requires_ancestor { R1 }
   end
 
   module M2
@@ -88,7 +88,7 @@ end
 module Test4
   module M1
     extend T::Helpers
-    requires_ancestor C1
+    requires_ancestor { C1 }
   end
 
   class C1
@@ -108,7 +108,7 @@ end
 module Test5
   module M1
     extend T::Helpers
-    requires_ancestor C2
+    requires_ancestor { C2 }
   end
 
   class C1
@@ -141,12 +141,12 @@ end
 module Test6
   module M1
     extend T::Helpers
-    requires_ancestor M2
+    requires_ancestor { M2 }
   end
 
   module M2
     extend T::Helpers
-    requires_ancestor M1
+    requires_ancestor { M1 }
   end
 
   class C1 # error: `Test6::C1` must include `Test6::M2` (required by `Test6::M1`)
@@ -167,18 +167,18 @@ end
 module Test7
   module M1
     extend T::Helpers
-    requires_ancestor M2
+    requires_ancestor { M2 }
   end
 
   module M2
     extend T::Helpers
-    requires_ancestor C2
+    requires_ancestor { C2 }
   end
 
   class C1
     extend T::Helpers
     abstract!
-    requires_ancestor M1
+    requires_ancestor { M1 }
   end
 
   class C2 < C1
@@ -207,7 +207,7 @@ end
 module Test8
   module M1
     extend T::Helpers
-    requires_ancestor R1
+    requires_ancestor { R1 }
   end
 
   module M2
@@ -231,7 +231,7 @@ end
 module Test9
   module M1
     extend T::Helpers
-    requires_ancestor R1
+    requires_ancestor { R1 }
   end
 
   module M2 # error: `T.class_of(Test9::M2)` must include `R1` (required by `Test9::M1`)

--- a/test/testdata/resolver/requires_ancestor_no_subtyping.rb
+++ b/test/testdata/resolver/requires_ancestor_no_subtyping.rb
@@ -12,7 +12,7 @@ module Test1
 
   module M1
     extend T::Helpers
-    requires_ancestor RA
+    requires_ancestor { RA }
   end
 
   class C1

--- a/test/testdata/resolver/requires_ancestor_object.rb
+++ b/test/testdata/resolver/requires_ancestor_object.rb
@@ -4,7 +4,7 @@
 module Helper
   extend T::Helpers
 
-  requires_ancestor Object
+  requires_ancestor { Object }
 
   def get_my_class_name
     self.class.name

--- a/test/testdata/resolver/requires_ancestor_unrelated_classes.rb
+++ b/test/testdata/resolver/requires_ancestor_unrelated_classes.rb
@@ -10,12 +10,14 @@ class R3; end
 module Test1
   module M1
     extend T::Helpers
-    requires_ancestor R1, R2
+    requires_ancestor { R1 }
+    requires_ancestor { R2 }
   end
 
   module M2 # error: `Test1::M2` requires unrelated classes `R1` and `R3` making it impossible to include
     extend T::Helpers
-    requires_ancestor R1, R3
+    requires_ancestor { R1 }
+    requires_ancestor { R3 }
   end
 end
 
@@ -24,12 +26,12 @@ end
 module Test2
   module M1
     extend T::Helpers
-    requires_ancestor R1
+    requires_ancestor { R1 }
   end
 
   module M2
     extend T::Helpers
-    requires_ancestor R3
+    requires_ancestor { R3 }
   end
 
   module M3 # error: `Test2::M3` requires unrelated classes `R3` and `R1` making it impossible to include
@@ -43,12 +45,12 @@ end
 module Test3
   module M1
     extend T::Helpers
-    requires_ancestor R1
+    requires_ancestor { R1 }
   end
 
   module M2
     extend T::Helpers
-    requires_ancestor R3
+    requires_ancestor { R3 }
   end
 
   module M3
@@ -68,7 +70,8 @@ module Test4
 # ^^^^^^^^ error: `Test4::C1` requires unrelated classes `R2` and `R3` making it impossible to inherit
     extend T::Helpers
     abstract!
-    requires_ancestor R2, R3
+    requires_ancestor { R2 }
+    requires_ancestor { R3 }
   end
 
   class C2 < C1
@@ -85,13 +88,13 @@ end
 module Test5
   module M1
     extend T::Helpers
-    requires_ancestor R2
+    requires_ancestor { R2 }
   end
 
   module M2 # error: `Test5::M2` requires unrelated classes `R3` and `R2` making it impossible to include
     extend T::Helpers
     include M1
-    requires_ancestor R3
+    requires_ancestor { R3 }
   end
 
   class C1 < R2
@@ -109,14 +112,15 @@ module Test6
   module M1
     extend T::Helpers
     abstract!
-    requires_ancestor R2
+    requires_ancestor { R2 }
   end
 
   module M2
 # ^^^^^^^^^ error: `Test6::M2` requires unrelated classes `R2` and `R3` making it impossible to include
     extend T::Helpers
     abstract!
-    requires_ancestor R2, R3
+    requires_ancestor { R2 }
+    requires_ancestor { R3 }
   end
 
   module M3
@@ -133,14 +137,15 @@ module Test7
   module M1
     extend T::Helpers
     interface!
-    requires_ancestor R2
+    requires_ancestor { R2 }
   end
 
   module M2
 # ^^^^^^^^^ error: `Test7::M2` requires unrelated classes `R2` and `R3` making it impossible to include
     extend T::Helpers
     interface!
-    requires_ancestor R2, R3
+    requires_ancestor { R2 }
+    requires_ancestor { R3 }
   end
 
   module M3

--- a/test/testdata/resolver/requires_ancestor_unsupported_generics.rb
+++ b/test/testdata/resolver/requires_ancestor_unsupported_generics.rb
@@ -11,7 +11,7 @@ module Test1
 
   module M # error: `Test1::M` can't require generic ancestor `Test1::RA` (unsupported)
     extend T::Helpers
-    requires_ancestor RA
+    requires_ancestor { RA }
   end
 end
 
@@ -23,6 +23,6 @@ module Test2
 
   module M # error: `Test2::M` can't require generic ancestor `Test2::RA` (unsupported)
     extend T::Helpers
-    requires_ancestor RA
+    requires_ancestor { RA }
   end
 end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -787,7 +787,7 @@ end
 module Bar
   extend T::Helpers
 
-  requires_ancestor Foo
+  requires_ancestor { Foo }
 
   def bar
     foo
@@ -819,7 +819,7 @@ end
 module Bar
   extend T::Helpers
 
-  requires_ancestor Foo
+  requires_ancestor { Foo }
 
   def bar
     foo

--- a/website/docs/requires-ancestor.md
+++ b/website/docs/requires-ancestor.md
@@ -64,7 +64,7 @@ Let's change our base example to use `requires_ancestor`:
 module MyHelper
   extend T::Helpers
 
-  requires_ancestor Kernel
+  requires_ancestor { Kernel }
 
   def say_error(message)
     raise "InternalError: #{message}"
@@ -88,7 +88,7 @@ inherited:
 module MyHelper
   extend T::Helpers
 
-  requires_ancestor Object
+  requires_ancestor { Object }
 
   def class_name
     self.class.name
@@ -134,7 +134,8 @@ end
 module MyTestHelper
   extend T::Helpers
 
-  requires_ancestor Test::TestAssertions, MyLogger
+  requires_ancestor { Test::TestAssertions }
+  requires_ancestor { MyLogger }
 
   def assert_not_equal(x, y)
     if assert_equal(x, y)


### PR DESCRIPTION
### Motivation

Change `requires_ancestor` syntax from:

```rb
module M
  extend T::Helpers

  requires_ancestor RA
end
```

to:

```rb
module M
  extend T::Helpers

  requires_ancestor { RA }
end
```

As to avoid eager loading constants.

Also add an autocorrect:

```
autocorrect-requires-ancestor-block.rb:12: `requires_ancestor` only accepts a block https://srb.help/5062
    12 |  requires_ancestor C
          ^^^^^^^^^^^^^^^^^^^
  Autocorrect: Done
    autocorrect-requires-ancestor-block.rb:12: Replaced with `requires_ancestor { C }`
    12 |  requires_ancestor C
          ^^^^^^^^^^^^^^^^^^^
```

### Test plan

See included automated tests.

cc @vinistock.