### PR TITLE
Exempt fewer tests from loc.exists() checking

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -376,8 +376,7 @@ public:
         return Send1(loc, T(loc), core::Names::nilable(), std::move(arg));
     }
 
-    static ExpressionPtr KeepForIDE(ExpressionPtr arg) {
-        auto loc = core::LocOffsets::none();
+    static ExpressionPtr KeepForIDE(core::LocOffsets loc, ExpressionPtr arg) {
         return Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::keepForIde(),
                      std::move(arg));
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2376,10 +2376,17 @@ public:
         ENFORCE(args.args.size() == 1);
         auto ty = core::Types::widen(gs, args.args.front()->type);
         auto loc = args.argLoc(0);
+        if (!loc.exists()) {
+            // This might be because our argument was an EmptyTree (`begin; end`). Fall back to
+            // using the loc of the whole send.
+            loc = args.callLoc();
+        }
         if (auto e = gs.beginError(loc, core::errors::Infer::UntypedConstantSuggestion)) {
             e.setHeader("Constants must have type annotations with `{}` when specifying `{}`", "T.let",
                         "# typed: strict");
-            if (!ty.isUntyped() && loc.exists()) {
+            if (!ty.isUntyped() && loc.exists() && loc != args.callLoc()) {
+                // (skip the autocorrect if we had to fall back to using callLoc, because using that
+                // will suggest something syntactically invalid like `T.let(U = begin; end, NilClass))`
                 e.replaceWith(fmt::format("Initialize as `{}`", ty.show(gs)), loc, "T.let({}, {})",
                               loc.source(gs).value(), ty.show(gs));
             }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2376,15 +2376,17 @@ public:
         ENFORCE(args.args.size() == 1);
         auto ty = core::Types::widen(gs, args.args.front()->type);
         auto loc = args.argLoc(0);
+        auto argLocExists = true;
         if (!loc.exists()) {
             // This might be because our argument was an EmptyTree (`begin; end`). Fall back to
             // using the loc of the whole send.
+            argLocExists = false;
             loc = args.callLoc();
         }
         if (auto e = gs.beginError(loc, core::errors::Infer::UntypedConstantSuggestion)) {
             e.setHeader("Constants must have type annotations with `{}` when specifying `{}`", "T.let",
                         "# typed: strict");
-            if (!ty.isUntyped() && loc.exists() && loc != args.callLoc()) {
+            if (!ty.isUntyped() && loc.exists() && argLocExists) {
                 // (skip the autocorrect if we had to fall back to using callLoc, because using that
                 // will suggest something syntactically invalid like `T.let(U = begin; end, NilClass))`
                 e.replaceWith(fmt::format("Initialize as `{}`", ty.show(gs)), loc, "T.let({}, {})",

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1618,13 +1618,14 @@ public:
                 }
             }
         }
+        auto loc = klass.declLoc;
         ast::InsSeq::STATS_store ideSeqs;
         if (ast::isa_tree<ast::ConstantLit>(klass.name)) {
-            ideSeqs.emplace_back(ast::MK::KeepForIDE(klass.name.deepCopy()));
+            ideSeqs.emplace_back(ast::MK::KeepForIDE(loc, klass.name.deepCopy()));
         }
         if (klass.kind == ast::ClassDef::Kind::Class && !klass.ancestors.empty() &&
             shouldLeaveAncestorForIDE(klass.ancestors.front())) {
-            ideSeqs.emplace_back(ast::MK::KeepForIDE(klass.ancestors.front().deepCopy()));
+            ideSeqs.emplace_back(ast::MK::KeepForIDE(loc, klass.ancestors.front().deepCopy()));
         }
 
         if (klass.symbol != core::Symbols::root() && !ctx.file.data(ctx).isRBI() &&
@@ -1646,7 +1647,6 @@ public:
         }
 
         ast::InsSeq::STATS_store retSeqs;
-        auto loc = klass.declLoc;
         retSeqs.emplace_back(std::move(tree));
         for (auto &stat : ideSeqs) {
             retSeqs.emplace_back(std::move(stat));

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1621,11 +1621,11 @@ public:
         auto loc = klass.declLoc;
         ast::InsSeq::STATS_store ideSeqs;
         if (ast::isa_tree<ast::ConstantLit>(klass.name)) {
-            ideSeqs.emplace_back(ast::MK::KeepForIDE(loc, klass.name.deepCopy()));
+            ideSeqs.emplace_back(ast::MK::KeepForIDE(loc.copyWithZeroLength(), klass.name.deepCopy()));
         }
         if (klass.kind == ast::ClassDef::Kind::Class && !klass.ancestors.empty() &&
             shouldLeaveAncestorForIDE(klass.ancestors.front())) {
-            ideSeqs.emplace_back(ast::MK::KeepForIDE(loc, klass.ancestors.front().deepCopy()));
+            ideSeqs.emplace_back(ast::MK::KeepForIDE(loc.copyWithZeroLength(), klass.ancestors.front().deepCopy()));
         }
 
         if (klass.symbol != core::Symbols::root() && !ctx.file.data(ctx).isRBI() &&

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1457,6 +1457,11 @@ class ResolveTypeMembersAndFieldsWalk {
                 // Instead of emitting an error now, emit an error in infer that has a proper type suggestion
                 auto rhs = move(job.asgn->rhs);
                 auto loc = rhs.loc();
+                if (!loc.exists()) {
+                    // If the rhs happens to be an EmptyTree (e.g., `begin; end`) there will be no loc.
+                    // In that case, use the assign's loc instead.
+                    loc = job.asgn->loc;
+                }
                 job.asgn->rhs = ast::MK::Send1(loc, ast::MK::Constant(loc, core::Symbols::Magic()),
                                                core::Names::suggestType(), move(rhs));
             }

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -89,14 +89,13 @@ UnorderedSet<string> knownExpectations = {"parse-tree",       "parse-tree-json",
 // This list will be progressively made empty, and we will not have any tests that
 // can swallow errors that don't have associated locations. See lines 479-483 below.
 // DO NOT add new tests here.
-// TODO (jez) Fix these tests
-UnorderedSet<string> locationCheckExemptTests = {"test/testdata/packager/nested_inner_namespaces",
-                                                 "test/testdata/packager/import_subpackage",
-                                                 "test/testdata/packager/nested_packages",
-                                                 "test/testdata/packager/deeply_nested_packages",
-                                                 "test/testdata/desugar/assign_empty_stmts.rb",
-                                                 "test/testdata/desugar/assign_keyword.rb",
-                                                 "test/testdata/lsp/struct_fuzz.rb"};
+// TODO(aadi-stripe) Fix these tests
+UnorderedSet<string> locationCheckExemptTests = {
+    "test/testdata/packager/nested_inner_namespaces",
+    "test/testdata/packager/import_subpackage",
+    "test/testdata/packager/nested_packages",
+    "test/testdata/packager/deeply_nested_packages",
+};
 
 ast::ParsedFile testSerialize(core::GlobalState &gs, ast::ParsedFile expr) {
     auto &savedFile = expr.file.data(gs);

--- a/test/testdata/desugar/assign_empty_stmts.rb
+++ b/test/testdata/desugar/assign_empty_stmts.rb
@@ -1,3 +1,3 @@
 # typed: strict
-U = begin
+U = begin # error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
 end

--- a/test/testdata/desugar/assign_keyword.rb
+++ b/test/testdata/desugar/assign_keyword.rb
@@ -1,2 +1,4 @@
 # typed: strict
-U = redo # error: Unsupported node type `Redo`
+  U = redo
+# ^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+#     ^^^^ error: Unsupported node type `Redo`

--- a/test/testdata/lsp/struct_fuzz.rb
+++ b/test/testdata/lsp/struct_fuzz.rb
@@ -1,6 +1,8 @@
 # typed: true
 # no-stdlib: true
   ::B=Struct.new:x
+# ^^^^^^^^^^^^^^^^ error: Method `keep_for_ide` does not exist on `T.class_of(Sorbet::Private::Static)`
+# ^^^^^^^^^^^^^^^^ error: Method `keep_for_ide` does not exist on `T.class_of(Sorbet::Private::Static)`
 # ^^^^^^^^^^^^^^^^ error: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)`
 # ^^^^^^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(B)`
 # ^^^^^^^^^^^^^^^^ error: Method `params` does not exist on `T.class_of(B)`

--- a/test/testdata/lsp/struct_fuzz.rb
+++ b/test/testdata/lsp/struct_fuzz.rb
@@ -1,8 +1,6 @@
 # typed: true
 # no-stdlib: true
-  ::B=Struct.new:x
-# ^^^^^^^^^^^^^^^^ error: Method `keep_for_ide` does not exist on `T.class_of(Sorbet::Private::Static)`
-# ^^^^^^^^^^^^^^^^ error: Method `keep_for_ide` does not exist on `T.class_of(Sorbet::Private::Static)`
+  ::B=Struct.new:x # error-with-dupes: Method `keep_for_ide` does not exist on `T.class_of(Sorbet::Private::Static)`
 # ^^^^^^^^^^^^^^^^ error: Method `keep_def` does not exist on `T.class_of(Sorbet::Private::Static)`
 # ^^^^^^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(B)`
 # ^^^^^^^^^^^^^^^^ error: Method `params` does not exist on `T.class_of(B)`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Follow up to #4652. Fixes all the non-packager related tests, and thus moves the
TODO to blame to @aadi-stripe.

### Commit summary

Review by commit.

- **Remove some exempted tests** (bfd70ce19)


- **Fix locs for keep_for_ide** (20dfd1d91)


- **Fix keep_for_ide-related test** (0c893588e)


- **Use better loc in certain EmptyTree cases** (d16138992)

  (EmptyTree does not have a loc)

- **Fix EmptyTree-related loc tests** (c96107ee6)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.