### PR TITLE
Stop conflating `super()` and `<super>()`

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -330,7 +330,7 @@ NameDef names[] = {
     {"blank_p", "blank?"},
     {"present_p", "present?"},
     {"nil"},
-    {"super"},
+    {"super", "<super>"},
     {"empty", ""},
 
     {"buildHash", "<build-hash>"},

--- a/test/testdata/desugar/blockpass.rb.desugar-tree.exp
+++ b/test/testdata/desugar/blockpass.rb.desugar-tree.exp
@@ -33,7 +33,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C CallsWithObjectChild><<C <todo sym>>> < (<emptyTree>::<C CallsWithObject>)
     def self.calls_with_object<<todo method>>(&blk)
-      ::<Magic>.<call-with-block>(<self>, :super, blk)
+      ::<Magic>.<call-with-block>(<self>, :<super>, blk)
     end
   end
 

--- a/test/testdata/desugar/magic_super.rb
+++ b/test/testdata/desugar/magic_super.rb
@@ -1,0 +1,20 @@
+# typed: true
+
+class Parent
+  def super(x)
+  end
+
+  def nullary; end
+
+  def unary(x); end
+end
+
+class Child < Parent
+  def nullary
+    super # error: Not enough arguments provided for method `Parent#super`. Expected: `1`, got: `0`
+  end
+
+  def unary(x)
+    super(1, 2) # error: Not enough arguments provided for method `Parent#super`. Expected: `1`, got: `2`
+  end
+end

--- a/test/testdata/desugar/magic_super.rb
+++ b/test/testdata/desugar/magic_super.rb
@@ -11,10 +11,15 @@ end
 
 class Child < Parent
   def nullary
-    super # error: Not enough arguments provided for method `Parent#super`. Expected: `1`, got: `0`
+    super
   end
 
   def unary(x)
-    super(1, 2) # error: Not enough arguments provided for method `Parent#super`. Expected: `1`, got: `2`
+    # Reporting no error here is actually incorrect, but consistently incorrect
+    #
+    # (it doesn't have to do with conflating `super()` and `<super>()` but
+    # rather that we don't type check `<super>` at all.
+    # See https://github.com/sorbet/sorbet/issues/1068)
+    super(1, 2)
   end
 end

--- a/test/testdata/desugar/splat.rb.desugar-tree.exp
+++ b/test/testdata/desugar/splat.rb.desugar-tree.exp
@@ -25,7 +25,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def foo<<todo method>>(&<blk>)
       begin
         a = [1, 2]
-        ::<Magic>.<call-with-splat>(<self>, :super, ::<Magic>.<splat>(a), nil)
+        ::<Magic>.<call-with-splat>(<self>, :<super>, ::<Magic>.<splat>(a), nil)
       end
     end
   end

--- a/test/testdata/infer/zsuper.rb.cfg.exp
+++ b/test/testdata/infer/zsuper.rb.cfg.exp
@@ -66,7 +66,7 @@ subgraph "cluster_::Bar#baz" {
     "bb::Bar#baz_0" [
         shape = invhouse;
         color = black;
-        label = "block[id=0, rubyBlockId=0]()\l<self>: Bar = cast(<self>: NilClass, Bar);\lb: T.untyped = load_arg(b)\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: Bar.super(b: T.untyped)\l<selfRestore>$6: Bar = <self>\l<unconditional>\l"
+        label = "block[id=0, rubyBlockId=0]()\l<self>: Bar = cast(<self>: NilClass, Bar);\lb: T.untyped = load_arg(b)\l<block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: Bar.<super>(b: T.untyped)\l<selfRestore>$6: Bar = <self>\l<unconditional>\l"
     ];
 
     "bb::Bar#baz_0" -> "bb::Bar#baz_2" [style="bold"];
@@ -89,14 +89,14 @@ subgraph "cluster_::Bar#baz" {
     "bb::Bar#baz_3" [
         shape = rectangle;
         color = black;
-        label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar)\l<returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$5, super>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
+        label = "block[id=3, rubyBlockId=0](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar)\l<returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$5, <super>>\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped\l<unconditional>\l"
     ];
 
     "bb::Bar#baz_3" -> "bb::Bar#baz_1" [style="bold"];
     "bb::Bar#baz_5" [
         shape = rectangle;
         color = black;
-        label = "block[id=5, rubyBlockId=1](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar)\louterLoops: 1\l<self>: Bar = loadSelf\l<blk>$7: T.untyped = load_yield_params(super)\la$1: T.untyped = yield_load_arg(0)\l<blockReturnTemp>$8: NilClass = <self>: Bar.puts(a$1: T.untyped)\l<blockReturnTemp>$11: T.noreturn = blockreturn<super> <blockReturnTemp>$8: NilClass\l<unconditional>\l"
+        label = "block[id=5, rubyBlockId=1](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar)\louterLoops: 1\l<self>: Bar = loadSelf\l<blk>$7: T.untyped = load_yield_params(<super>)\la$1: T.untyped = yield_load_arg(0)\l<blockReturnTemp>$8: NilClass = <self>: Bar.puts(a$1: T.untyped)\l<blockReturnTemp>$11: T.noreturn = blockreturn<<super>> <blockReturnTemp>$8: NilClass\l<unconditional>\l"
     ];
 
     "bb::Bar#baz_5" -> "bb::Bar#baz_2" [style="bold"];

--- a/test/testdata/local_vars/z_super_args.rb.index-tree.exp
+++ b/test/testdata/local_vars/z_super_args.rb.index-tree.exp
@@ -51,31 +51,31 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)
     def takes_positional<<todo method>>(arg0, &<blk>)
-      <self>.super(arg0)
+      <self>.<super>(arg0)
     end
 
     def takes_keyword<<todo method>>(arg0:, &<blk>)
-      <self>.super(:arg0, arg0)
+      <self>.<super>(:arg0, arg0)
     end
 
     def takes_two_keyword<<todo method>>(arg0:, arg1:, &<blk>)
-      <self>.super(:arg0, arg0, :arg1, arg1)
+      <self>.<super>(:arg0, arg0, :arg1, arg1)
     end
 
     def takes_positional_then_keyword<<todo method>>(arg0, arg1:, &<blk>)
-      <self>.super(arg0, :arg1, arg1)
+      <self>.<super>(arg0, :arg1, arg1)
     end
 
     def takes_rest<<todo method>>(*args, &<blk>)
-      <self>.super()
+      <self>.<super>()
     end
 
     def takes_keyword_rest<<todo method>>(*args:, &<blk>)
-      <self>.super()
+      <self>.<super>()
     end
 
     def takes_block<<todo method>>(&blk)
-      <self>.super()
+      <self>.<super>()
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :takes_positional, :normal)

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -100,7 +100,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   ::<Magic>.defined?("X")
 
-  <self>.super(ZSuperArgs)
+  <self>.<super>(ZSuperArgs)
 
   def kwfoo<<todo method>>(x:, y: = 1, *z:, &<blk>)
     <emptyTree>

--- a/test/testdata/rewriter/attr_reader_method_kind.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/attr_reader_method_kind.rb.rewrite-tree.exp
@@ -48,7 +48,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         @using_t_struct_prop = ::T.let(using_t_struct_prop, <emptyTree>::<C Integer>)
         @using_t_struct_const = ::T.let(using_t_struct_const, <emptyTree>::<C Integer>)
-        <self>.super(ZSuperArgs)
+        <self>.<super>(ZSuperArgs)
       end
     end
 

--- a/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def initialize<<todo method>>(foo: = 3, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
-        <self>.super(ZSuperArgs)
+        <self>.<super>(ZSuperArgs)
       end
     end
 
@@ -50,7 +50,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def initialize<<todo method>>(&<blk>)
-      <self>.super(ZSuperArgs)
+      <self>.<super>(ZSuperArgs)
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)

--- a/test/testdata/rewriter/t_struct/nilable.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/nilable.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def initialize<<todo method>>(foo: = nil, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
-        <self>.super(ZSuperArgs)
+        <self>.<super>(ZSuperArgs)
       end
     end
 

--- a/test/testdata/rewriter/t_struct/none.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/none.rb.rewrite-tree.exp
@@ -5,7 +5,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def initialize<<todo method>>(&<blk>)
-      <self>.super(ZSuperArgs)
+      <self>.<super>(ZSuperArgs)
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)

--- a/test/testdata/rewriter/t_struct/normal.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/normal.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def initialize<<todo method>>(foo:, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
-        <self>.super(ZSuperArgs)
+        <self>.<super>(ZSuperArgs)
       end
     end
 

--- a/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def initialize<<todo method>>(foo:, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C String>)
-        <self>.super(ZSuperArgs)
+        <self>.<super>(ZSuperArgs)
       end
     end
 

--- a/test/testdata/rewriter/t_struct/param_order.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/param_order.rb.rewrite-tree.exp
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
         @bar = ::T.let(bar, <emptyTree>::<C Integer>)
-        <self>.super(ZSuperArgs)
+        <self>.<super>(ZSuperArgs)
       end
     end
 

--- a/test/testdata/rewriter/t_struct/root.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/root.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def initialize<<todo method>>(foo:, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
-        <self>.super(ZSuperArgs)
+        <self>.<super>(ZSuperArgs)
       end
     end
 

--- a/test/testdata/rewriter/t_struct/some_default.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/some_default.rb.rewrite-tree.exp
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
         @bar = ::T.let(bar, <emptyTree>::<C T>::<C Boolean>)
-        <self>.super(ZSuperArgs)
+        <self>.<super>(ZSuperArgs)
       end
     end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Ruby actually lets you define a method with the name `super`, even though
`super` is normally a keyword.

Sorbet was previously modeling `super`-the-keyword by desugaring it to
`super`-a-method-call, which would be the wrong behavior if the program happened
to define a method with the name `super`.

(I happened to notice this while reviewing #4653)

This probably doesn't affect real code, but I figured I'd fix it while it was
fresh in mind.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.