### PR TITLE
Fix Pathname#cleanpath signature

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -526,7 +526,7 @@ class Pathname < Object
     params(
         consider_symlink: T::Boolean,
     )
-    .returns(T.untyped)
+    .returns(Pathname)
   end
   def cleanpath(consider_symlink=T.unsafe(nil)); end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`cleanpath` always returns a `Pathname`

https://github.com/ruby/ruby/blob/master/ext/pathname/lib/pathname.rb
