### PR TITLE
always-pull in pipeline.yaml

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -16,6 +16,7 @@ steps:
         - docker#0d9b114b0ca8ec7167787285274aa3842392374d:
             image: "darkdimius/sorbet-build-image:latest"
             workdir: /app
+            always-pull: true
             init: true
             propagate-environment: true
             environment:


### PR DESCRIPTION
### Motivation
Getting the build unstuck.

We need to make sure the new sorbet-build-image gets pulled in. I think this should do what we need. (See https://github.com/buildkite-plugins/docker-buildkite-plugin#always-pull-optional-boolean)


### Test plan
See included automated tests.
