### PR TITLE
add a very early global DCE pass to send less stuff through LLVM

### DIFF
--- a/compiler/ObjectFileEmitter/ObjectFileEmitter.cc
+++ b/compiler/ObjectFileEmitter/ObjectFileEmitter.cc
@@ -83,6 +83,7 @@ void addModulePasses(llvm::legacy::PassManager &pm) {
     // leave comments with added/removed passes
     // pmbuilder.populateModulePassManager(pm);
 
+    pm.add(llvm::createGlobalDCEPass());
     pm.add(llvm::createSROAPass()); // this is super useful for us so we want to run it early
     if (unnecessaryForUs) {
         pm.add(llvm::createForceFunctionAttrsLegacyPass());


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We actually have quite a bit of stuff in the codegen payload that might not actually be referenced by most of the files that we compile.  Deleting it *ought* to provide some kind of speedup.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
