### PR TITLE
`success?` can also return `nil`

### DIFF
--- a/rbi/core/process.rbi
+++ b/rbi/core/process.rbi
@@ -1751,7 +1751,7 @@ class Process::Status < Object
   # Returns `true` if *stat* is successful, `false` if not. Returns `nil` if
   # [`exited?`](https://docs.ruby-lang.org/en/2.7.0/Process/Status.html#method-i-exited-3F)
   # is not `true`.
-  sig {returns(T::Boolean)}
+  sig {returns(T.nilable(T::Boolean))}
   def success?(); end
 
   # Returns the number of the signal that caused *stat* to terminate (or `nil`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
`Process::Status#success?` can also return `nil`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fix a bad stdlib rbi

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.