### PR TITLE
Packager: export_for_test

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -456,6 +456,8 @@ void GlobalState::initEmpty() {
 
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::export_()).arg(Names::arg0()).build();
     ENFORCE(method == Symbols::PackageSpec_export());
+    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::export_for_test()).arg(Names::arg0()).build();
+    ENFORCE(method == Symbols::PackageSpec_export_for_test());
 
     id = synthesizeClass(core::Names::Constants::Encoding());
     ENFORCE(id == Symbols::Encoding());

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -838,6 +838,10 @@ public:
         return MethodRef::fromRaw(8);
     }
 
+    static MethodRef PackageSpec_export_for_test() {
+        return MethodRef::fromRaw(9);
+    }
+
     static ClassOrModuleRef Encoding() {
         return ClassOrModuleRef::fromRaw(82);
     }
@@ -847,11 +851,11 @@ public:
     }
 
     static MethodRef Class_new() {
-        return MethodRef::fromRaw(9);
+        return MethodRef::fromRaw(10);
     }
 
     static MethodRef todoMethod() {
-        return MethodRef::fromRaw(10);
+        return MethodRef::fromRaw(11);
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
@@ -893,7 +897,7 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 202;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 42;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 43;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 3;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 99;

--- a/core/errors/packager.h
+++ b/core/errors/packager.h
@@ -19,5 +19,6 @@ constexpr ErrorClass PackageFileMustBeStrict{3711, StrictLevel::False};
 constexpr ErrorClass InvalidPackageName{3712, StrictLevel::False};
 constexpr ErrorClass DefinitionPackageMismatch{3713, StrictLevel::False};
 constexpr ErrorClass ImportConflict{3714, StrictLevel::False};
+constexpr ErrorClass InvalidExportForTest{3715, StrictLevel::False};
 } // namespace sorbet::core::errors::Packager
 #endif

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -412,6 +412,7 @@ NameDef names[] = {
     {"import"},
     {"test_import"},
     {"export_", "export"},
+    {"export_for_test"},
     {"PackageSpec", "PackageSpec", true},
     {"PackageRegistry", "<PackageRegistry>", true},
     {"PackageTests", "<PackageTests>", true},

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -804,8 +804,8 @@ public:
         for (const auto &exp : pkg.exports) {
             const auto &parts = exp.parts();
             ENFORCE(parts.size() > 0);
-            if (parts[0] != TEST_NAME) {          // Only add imports for non-test
-                auto loc = exp.fqn.loc.offsets(); // TODO XXX is this right?
+            if (parts[0] != TEST_NAME) { // Only add imports for non-test
+                auto loc = exp.fqn.loc.offsets();
                 addImport(pkg, loc, exp.fqn, ImportType::Test);
             }
         }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -292,27 +292,6 @@ ast::ExpressionPtr parts2literal(const vector<core::NameRef> &parts, core::LocOf
     return name;
 }
 
-// Prepend to a scope `Foo::Bar` some prefix -> `<toPrepend>::Foo::Bar`
-ast::ExpressionPtr prependScope(ast::ExpressionPtr scope, ast::ExpressionPtr toPrepend) {
-    // For `Bar::Baz::Bat`, `UnresolvedConstantLit` will contain `Bar`.
-    auto *lastConstLit = ast::cast_tree<ast::UnresolvedConstantLit>(scope);
-    if (lastConstLit != nullptr) {
-        while (auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(lastConstLit->scope)) {
-            lastConstLit = constLit;
-        }
-    }
-
-    // If `lastConstLit` is `nullptr`, then `scope` should be EmptyTree.
-    ENFORCE(lastConstLit != nullptr || ast::isa_tree<ast::EmptyTree>(scope));
-
-    if (lastConstLit == nullptr) {
-        return toPrepend;
-    } else {
-        lastConstLit->scope = move(toPrepend);
-        return scope;
-    }
-}
-
 // Prefix a constant reference with a name: `Foo::Bar` -> `<REGISTRY>::<name>::Foo::Bar`
 // Registry is either <PackageRegistry> or <PackageTests>. The latter if following the convention
 // that if scope starts with `Test::`.
@@ -962,14 +941,6 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
         }
 
         importedPackages = treeBuilder.makeModule(ctx, ImportType::Normal);
-        // Include an empty class definition <Mangled_Pkg_A>::Pkg::A::<Magic> in <PackageRegistry>.
-        // This ensures that the refernce to <PackageRegistry>::<Mangled_Pkg_A>::Pkg::A always
-        // exists.
-        auto stubName = prependScope(
-            name2Expr(core::Names::Constants::Magic(), package->name.fullName.toLiteral(core::LocOffsets::none())),
-            name2Expr(package->name.mangledName));
-        auto stubClass = ast::MK::Class(core::LocOffsets::none(), core::LocOffsets::none(), move(stubName), {}, {});
-        importedPackages.emplace_back(move(stubClass));
 
         treeBuilder.mergeSelfExportsForTest(*package);
         testImportedPackages = treeBuilder.makeModule(ctx, ImportType::Test);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -930,20 +930,6 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
         importedPackages.emplace_back(move(stubClass));
 
         testImportedPackages = treeBuilder.makeModule(ctx, ImportType::Test);
-
-        // In the test namespace for this package add an alias to give tests full access to the
-        // packaged code:
-        // module <PackageTests>
-        //   <Imports>
-        //   <Mangled_Pkg_A>::Pkg::A = <PackageRegistry>::<Mangled_Pkg_A>::Pkg::A
-        // end
-        auto assignRhs =
-            prependPackageScope(package->name.fullName.toLiteral(core::LocOffsets::none()), package->name.mangledName);
-        auto assign = ast::MK::Assign(core::LocOffsets::none(),
-                                      prependScope(package->name.fullName.toLiteral(core::LocOffsets::none()),
-                                                   name2Expr(package->name.mangledName)),
-                                      std::move(assignRhs));
-        testImportedPackages.emplace_back(std::move(assign));
     }
 
     auto packageNamespace =

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -960,7 +960,6 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
                 treeBuilder.mergeImports(*importedPackage, import);
             }
         }
-        treeBuilder.mergeSelfExportsForTest(*package);
 
         importedPackages = treeBuilder.makeModule(ctx, ImportType::Normal);
         // Include an empty class definition <Mangled_Pkg_A>::Pkg::A::<Magic> in <PackageRegistry>.
@@ -972,6 +971,7 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file, const Pa
         auto stubClass = ast::MK::Class(core::LocOffsets::none(), core::LocOffsets::none(), move(stubName), {}, {});
         importedPackages.emplace_back(move(stubClass));
 
+        treeBuilder.mergeSelfExportsForTest(*package);
         testImportedPackages = treeBuilder.makeModule(ctx, ImportType::Test);
     }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -860,7 +860,8 @@ private:
             if (parentSrc.exists()) {
                 // A conflicting import exist. Only report errors while constructing the test output
                 // to avoid duplicate errors because test imports are a superset of normal imports.
-                if (moduleType == ImportType::Test) {
+                bool isSelfImport = node->source.packageMangledName == pkgMangledName;
+                if (moduleType == ImportType::Test && !isSelfImport) {
                     if (auto e = ctx.beginError(node->source.importLoc, core::errors::Packager::ImportConflict)) {
                         // TODO Fix flaky ordering of errors. This is strange...not being done in parallel,
                         // and the file processing order is consistent.

--- a/test/cli/package-prefix-enforcement/package-prefix-enforcement.out
+++ b/test/cli/package-prefix-enforcement/package-prefix-enforcement.out
@@ -25,9 +25,4 @@ nested/nested.test.rb:9: Constants may not be defined outside of the enclosing p
 nested/nested.test.rb:16: Class or method definition must match enclosing package namespace `Test::Root::Nested` https://srb.help/3713
     16 |module Root::Nested::ShouldBeInTestPrefix
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-nested/nested.test.rb:16: Can't nest `ShouldBeInTestPrefix` under `Root::Nested` because `Root::Nested` is not a class or module https://srb.help/4015
-    16 |module Root::Nested::ShouldBeInTestPrefix
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    nested/__package.rb: `Root::Nested` defined here
-Errors: 8
+Errors: 7

--- a/test/cli/package-test-simple/main_lib/__package.rb
+++ b/test/cli/package-test-simple/main_lib/__package.rb
@@ -5,4 +5,5 @@
 class Project::MainLib < PackageSpec
   import Project::Util
   test_import Project::TestOnly
+  export_for_test Project::MainLib::Lib
 end

--- a/test/cli/package-test-simple/main_lib/lib.test.rb
+++ b/test/cli/package-test-simple/main_lib/lib.test.rb
@@ -2,7 +2,7 @@
 # typed: strict
 
 class Test::Project::MainLib::LibTest
-  # Tests can access their package's code
+  # Tests can access their package's code if exported for test
   Project::MainLib::Lib.new
   # Tests can access `import`
   Project::Util::MyUtil.new

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -87,17 +87,6 @@ UnorderedSet<string> knownExpectations = {"parse-tree",       "parse-tree-json",
                                           "document-symbols", "package-tree",     "document-formatting-rubyfmt",
                                           "autocorrects"};
 
-// This list will be progressively made empty, and we will not have any tests that
-// can swallow errors that don't have associated locations. See lines 479-483 below.
-// DO NOT add new tests here.
-// TODO(aadi-stripe) Fix these tests
-UnorderedSet<string> locationCheckExemptTests = {
-    "test/testdata/packager/nested_inner_namespaces",
-    "test/testdata/packager/import_subpackage",
-    "test/testdata/packager/nested_packages",
-    "test/testdata/packager/deeply_nested_packages",
-};
-
 ast::ParsedFile testSerialize(core::GlobalState &gs, ast::ParsedFile expr) {
     auto &savedFile = expr.file.data(gs);
     auto saved = core::serialize::Serializer::storeTree(savedFile, expr);
@@ -477,9 +466,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                 continue;
             }
             auto diag = errorToDiagnostic(*gs, *error);
-            if (diag == nullptr && locationCheckExemptTests.contains(singleTest)) {
-                continue;
-            }
             ENFORCE(diag != nullptr, "Error was given no valid location - '{}'", error->toString(*gs));
 
             auto path = error->loc.file().data(*gs).path();

--- a/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
@@ -11,9 +11,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Package_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
       <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
     end
-
-    class <emptyTree>::<C Package_Package$1>::<C Package>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -67,9 +64,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
       <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
-    end
-
-    class <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C <Magic>><<C <todo sym>>> < ()
     end
   end
 

--- a/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
@@ -17,11 +17,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Package$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C InnerClass>
+    end
+
+    module <emptyTree>::<C Package_Package$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
+    end
+
     module <emptyTree>::<C Package_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
       <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
     end
-
-    <emptyTree>::<C Package_Package$1>::<C Package> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -76,7 +82,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
     end
 
-    <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
+    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
+      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/export_for_test/__package.rb
+++ b/test/testdata/packager/export_for_test/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+# enable-packager: true
+
+class RootPkg < PackageSpec
+end

--- a/test/testdata/packager/export_for_test/foo/__package.rb
+++ b/test/testdata/packager/export_for_test/foo/__package.rb
@@ -7,4 +7,7 @@ class Opus::Foo < PackageSpec
 
   export Opus::Foo::FooClass
   export_for_test Opus::Foo::Private::ImplDetail
+
+  export_for_test Test::Opus::Foo::FooTest
+  #               ^^^^^^^^^^^^^^^^^^^^^^^^ error: Packages may not export_for_test names in the `Test::` namespace
 end

--- a/test/testdata/packager/export_for_test/foo/__package.rb
+++ b/test/testdata/packager/export_for_test/foo/__package.rb
@@ -1,0 +1,10 @@
+# typed: strict
+
+class Opus::Foo < PackageSpec
+  import Opus::Foo::Bar
+  import Opus::Util
+  test_import Opus::TestImported
+
+  export Opus::Foo::FooClass
+  export_for_test Opus::Foo::Private::ImplDetail
+end

--- a/test/testdata/packager/export_for_test/foo/bar/__package.rb
+++ b/test/testdata/packager/export_for_test/foo/bar/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class Opus::Foo::Bar < PackageSpec
+  export Opus::Foo::Bar::BarClass
+  export Test::Opus::Foo::Bar::BarClassTest
+end

--- a/test/testdata/packager/export_for_test/foo/bar/bar.rb
+++ b/test/testdata/packager/export_for_test/foo/bar/bar.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Opus::Foo::Bar::BarClass
+end

--- a/test/testdata/packager/export_for_test/foo/bar/bar.test.rb
+++ b/test/testdata/packager/export_for_test/foo/bar/bar.test.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+module Test::Opus::Foo::Bar
+  class BarClassTest
+  end
+end

--- a/test/testdata/packager/export_for_test/foo/foo.rb
+++ b/test/testdata/packager/export_for_test/foo/foo.rb
@@ -1,0 +1,11 @@
+# typed: strict
+
+module Opus::Foo
+  class FooClass; end
+
+  class Private::ImplDetail
+    extend T::Sig
+    sig {void}
+    def self.stub_stuff!; end
+  end
+end

--- a/test/testdata/packager/export_for_test/foo/foo.rb
+++ b/test/testdata/packager/export_for_test/foo/foo.rb
@@ -1,11 +1,39 @@
 # typed: strict
 
 module Opus::Foo
-  class FooClass; end
+  class FooClass # exported publicly
+    Inner = 1
+  end
+
+  class FooUnexported; end
 
   class Private::ImplDetail
     extend T::Sig
     sig {void}
     def self.stub_stuff!; end
   end
+
+
+  # Check Visiblity
+  # via import Opus::Foo::Bar
+  Opus::Foo::Bar::BarClass
+  Test::Opus::Foo::Bar::BarClassTest
+# ^^^^ error: Unable to resolve constant `Test`
+
+  # via import Opus::Util
+  Opus::Util::UtilClass
+  Test::Opus::Util::TestUtil
+# ^^^^ error: Unable to resolve constant `Test`
+
+  # via test_import Opus::TestImported
+  Opus::TestImported::TIClass
+# ^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `TestImported`
+  Test::Opus::TestImported::TITestClass
+# ^^^^ error: Unable to resolve constant `Test`
+
+  # via export_for_test Opus::Foo::Private::ImplDetail
+  Opus::Foo::Private::ImplDetail.stub_stuff!
+
+  # Visible because it's local to this package
+  Opus::Foo::FooUnexported
 end

--- a/test/testdata/packager/export_for_test/foo/foo.test.rb
+++ b/test/testdata/packager/export_for_test/foo/foo.test.rb
@@ -1,0 +1,2 @@
+# typed: strict
+

--- a/test/testdata/packager/export_for_test/foo/foo.test.rb
+++ b/test/testdata/packager/export_for_test/foo/foo.test.rb
@@ -1,2 +1,28 @@
 # typed: strict
 
+class Test::Opus::Foo::FooTest
+  # Check Visiblity
+  # via import Opus::Foo::Bar
+  Opus::Foo::Bar::BarClass
+  Test::Opus::Foo::Bar::BarClassTest
+
+  # via import Opus::Util
+  Opus::Util::UtilClass
+  Test::Opus::Util::TestUtil
+
+  # via test_import Opus::TestImported
+  Opus::TestImported::TIClass
+  Test::Opus::TestImported::TITestClass
+
+  # Test code gets all public exports from its corresponding package
+  # via export Opus::Foo::FooClass
+  Opus::Foo::FooClass
+  Opus::Foo::FooClass::Inner
+
+  # via export_for_test Opus::Foo::Private::ImplDetail
+  Opus::Foo::Private::ImplDetail.stub_stuff!
+
+  # Not exported at all from Foo
+  Opus::Foo::FooUnexported
+# ^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `FooUnexported`
+end

--- a/test/testdata/packager/export_for_test/pass.package-tree.exp
+++ b/test/testdata/packager/export_for_test/pass.package-tree.exp
@@ -19,6 +19,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C FooClass>)
 
     <self>.export_for_test(<emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail>)
+
+    <self>.export_for_test(<emptyTree>::<C <PackageTests>>::<C Opus_Foo_Package$1>::<C Test>::<C Opus>::<C Foo>::<C FooTest>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()

--- a/test/testdata/packager/export_for_test/pass.package-tree.exp
+++ b/test/testdata/packager/export_for_test/pass.package-tree.exp
@@ -1,0 +1,182 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C RootPkg><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    class <emptyTree>::<C RootPkg_Package$1>::<C RootPkg>::<C <Magic>><<C <todo sym>>> < ()
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Opus>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Opus>::<C Foo>::<C Bar>)
+
+    <self>.import(<emptyTree>::<C Opus>::<C Util>)
+
+    <self>.test_import(<emptyTree>::<C Opus>::<C TestImported>)
+
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C FooClass>)
+
+    <self>.export_for_test(<emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
+    end
+
+    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Util><<C <todo sym>>> < ()
+      <emptyTree>::<C UtilClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C UtilClass>
+    end
+
+    class <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C <Magic>><<C <todo sym>>> < ()
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
+    end
+
+    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
+      <emptyTree>::<C TIClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported>::<C TIClass>
+    end
+
+    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Util><<C <todo sym>>> < ()
+      <emptyTree>::<C UtilClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C UtilClass>
+    end
+
+    module <emptyTree>::<C Opus_Foo_Package$1>::<C Test>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C BarClassTest> = <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package$1>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>
+    end
+
+    module <emptyTree>::<C Opus_Foo_Package$1>::<C Test>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
+      <emptyTree>::<C TITestClass> = <emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package$1>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>
+    end
+
+    module <emptyTree>::<C Opus_Foo_Package$1>::<C Test>::<C Opus>::<C Util><<C <todo sym>>> < ()
+      <emptyTree>::<C TestUtil> = <emptyTree>::<C <PackageTests>>::<C Opus_Util_Package$1>::<C Test>::<C Opus>::<C Util>::<C TestUtil>
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>)
+
+    <self>.export(<emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package$1>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    class <emptyTree>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>::<C <Magic>><<C <todo sym>>> < ()
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1><<C <todo sym>>> < ()
+    class <emptyTree>::<C Opus>::<C Foo>::<C Bar>::<C BarClass><<C <todo sym>>> < (::<todo sym>)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package$1><<C <todo sym>>> < ()
+    module <emptyTree>::<C Test>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
+      class <emptyTree>::<C BarClassTest><<C <todo sym>>> < (::<todo sym>)
+      end
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus>::<C Foo><<C <todo sym>>> < ()
+      class <emptyTree>::<C FooClass><<C <todo sym>>> < (::<todo sym>)
+      end
+
+      class <emptyTree>::<C Private>::<C ImplDetail><<C <todo sym>>> < (::<todo sym>)
+        ::Sorbet::Private::Static.sig(<self>) do ||
+          <self>.void()
+        end
+
+        def self.stub_stuff!<<todo method>>(&<blk>)
+          <emptyTree>
+        end
+
+        <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+        ::Sorbet::Private::Static.keep_self_def(<self>, :stub_stuff!, :normal)
+      end
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Package$1><<C <todo sym>>> < ()
+    nil
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Opus>::<C TestImported><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported>::<C TIClass>)
+
+    <self>.export(<emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package$1>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    class <emptyTree>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported>::<C <Magic>><<C <todo sym>>> < ()
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package$1><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
+      class <emptyTree>::<C TIClass><<C <todo sym>>> < (::<todo sym>)
+      end
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package$1><<C <todo sym>>> < ()
+    module <emptyTree>::<C Test>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
+      class <emptyTree>::<C TITestClass><<C <todo sym>>> < (::<todo sym>)
+      end
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Opus>::<C Util><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C UtilClass>)
+
+    <self>.export(<emptyTree>::<C <PackageTests>>::<C Opus_Util_Package$1>::<C Test>::<C Opus>::<C Util>::<C TestUtil>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    class <emptyTree>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C <Magic>><<C <todo sym>>> < ()
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus>::<C Util><<C <todo sym>>> < ()
+      class <emptyTree>::<C UtilClass><<C <todo sym>>> < (::<todo sym>)
+      end
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C <PackageTests>>::<C Opus_Util_Package$1><<C <todo sym>>> < ()
+    module <emptyTree>::<C Test>::<C Opus>::<C Util><<C <todo sym>>> < ()
+      class <emptyTree>::<C TestUtil><<C <todo sym>>> < (::<todo sym>)
+      end
+    end
+  end
+end

--- a/test/testdata/packager/export_for_test/pass.package-tree.exp
+++ b/test/testdata/packager/export_for_test/pass.package-tree.exp
@@ -41,6 +41,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
     end
 
+    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C Private><<C <todo sym>>> < ()
+      <emptyTree>::<C ImplDetail> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail>
+    end
+
     module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
       <emptyTree>::<C TIClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported>::<C TIClass>
     end
@@ -95,6 +99,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1><<C <todo sym>>> < ()
     module <emptyTree>::<C Opus>::<C Foo><<C <todo sym>>> < ()
       class <emptyTree>::<C FooClass><<C <todo sym>>> < (::<todo sym>)
+        <emptyTree>::<C Inner> = 1
+      end
+
+      class <emptyTree>::<C FooUnexported><<C <todo sym>>> < (::<todo sym>)
       end
 
       class <emptyTree>::<C Private>::<C ImplDetail><<C <todo sym>>> < (::<todo sym>)
@@ -110,12 +118,48 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
         ::Sorbet::Private::Static.keep_self_def(<self>, :stub_stuff!, :normal)
       end
+
+      <emptyTree>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
+
+      <emptyTree>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>
+
+      <emptyTree>::<C Opus>::<C Util>::<C UtilClass>
+
+      <emptyTree>::<C Test>::<C Opus>::<C Util>::<C TestUtil>
+
+      <emptyTree>::<C Opus>::<C TestImported>::<C TIClass>
+
+      <emptyTree>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>
+
+      <emptyTree>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail>.stub_stuff!()
+
+      <emptyTree>::<C Opus>::<C Foo>::<C FooUnexported>
     end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Package$1><<C <todo sym>>> < ()
-    nil
+    class <emptyTree>::<C Test>::<C Opus>::<C Foo>::<C FooTest><<C <todo sym>>> < (::<todo sym>)
+      <emptyTree>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
+
+      <emptyTree>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>
+
+      <emptyTree>::<C Opus>::<C Util>::<C UtilClass>
+
+      <emptyTree>::<C Test>::<C Opus>::<C Util>::<C TestUtil>
+
+      <emptyTree>::<C Opus>::<C TestImported>::<C TIClass>
+
+      <emptyTree>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>
+
+      <emptyTree>::<C Opus>::<C Foo>::<C FooClass>
+
+      <emptyTree>::<C Opus>::<C Foo>::<C FooClass>::<C Inner>
+
+      <emptyTree>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail>.stub_stuff!()
+
+      <emptyTree>::<C Opus>::<C Foo>::<C FooUnexported>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/export_for_test/pass.package-tree.exp
+++ b/test/testdata/packager/export_for_test/pass.package-tree.exp
@@ -3,8 +3,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    class <emptyTree>::<C RootPkg_Package$1>::<C RootPkg>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -30,9 +28,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Util><<C <todo sym>>> < ()
       <emptyTree>::<C UtilClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C UtilClass>
-    end
-
-    class <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C <Magic>><<C <todo sym>>> < ()
     end
   end
 
@@ -78,8 +73,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    class <emptyTree>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -177,8 +170,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    class <emptyTree>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -211,8 +202,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    class <emptyTree>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/export_for_test/pass.package-tree.exp
+++ b/test/testdata/packager/export_for_test/pass.package-tree.exp
@@ -41,6 +41,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
     end
 
+    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C FooClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C FooClass>
+    end
+
     module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C Private><<C <todo sym>>> < ()
       <emptyTree>::<C ImplDetail> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail>
     end
@@ -79,6 +83,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -175,6 +182,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
+      <emptyTree>::<C TIClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported>::<C TIClass>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -206,6 +216,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus_Util_Package$1>::<C Opus>::<C Util><<C <todo sym>>> < ()
+      <emptyTree>::<C UtilClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C UtilClass>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/export_for_test/test_imported/__package.rb
+++ b/test/testdata/packager/export_for_test/test_imported/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class Opus::TestImported < PackageSpec
+  export Opus::TestImported::TIClass
+  export Test::Opus::TestImported::TITestClass
+end

--- a/test/testdata/packager/export_for_test/test_imported/test_imported.rb
+++ b/test/testdata/packager/export_for_test/test_imported/test_imported.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Opus::TestImported
+  class TIClass; end
+end

--- a/test/testdata/packager/export_for_test/test_imported/test_imported.test.rb
+++ b/test/testdata/packager/export_for_test/test_imported/test_imported.test.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Test::Opus::TestImported
+  class TITestClass; end
+end

--- a/test/testdata/packager/export_for_test/util/__package.rb
+++ b/test/testdata/packager/export_for_test/util/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class Opus::Util  < PackageSpec
+  export Opus::Util::UtilClass
+  export Test::Opus::Util::TestUtil
+end

--- a/test/testdata/packager/export_for_test/util/util.rb
+++ b/test/testdata/packager/export_for_test/util/util.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Opus::Util
+  class UtilClass; end
+end

--- a/test/testdata/packager/export_for_test/util/util.test.rb
+++ b/test/testdata/packager/export_for_test/util/util.test.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Test::Opus::Util
+  class TestUtil; end
+end

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -6,20 +6,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
-    end
-
     class <emptyTree>::<C A_Package$1>::<C A>::<C <Magic>><<C <todo sym>>> < ()
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
     module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
+      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C B>::<C BClass>
     end
-
-    <emptyTree>::<C A_Package$1>::<C A> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -33,7 +27,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    <emptyTree>::<C B_Package$1>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
+    module <emptyTree>::<C B_Package$1>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -6,6 +6,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
+    end
+
     class <emptyTree>::<C A_Package$1>::<C A>::<C <Magic>><<C <todo sym>>> < ()
     end
   end

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -9,9 +9,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
       <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
     end
-
-    class <emptyTree>::<C A_Package$1>::<C A>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -26,8 +23,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    class <emptyTree>::<C B_Package$1>::<C B>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -13,9 +13,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
       <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C B>
     end
-
-    class <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -61,8 +58,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    class <emptyTree>::<C Project_Baz_Package$1>::<C Project>::<C Baz>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -111,8 +106,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    class <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -26,8 +26,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
       <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C B>
     end
-
-    <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -68,7 +66,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    <emptyTree>::<C Project_Baz_Package$1>::<C Project>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1>::<C Project>::<C Baz>
+    module <emptyTree>::<C Project_Baz_Package$1>::<C Project>::<C Baz><<C <todo sym>>> < ()
+      <emptyTree>::<C C> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1>::<C Project>::<C Baz>::<C C>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -116,6 +116,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
+    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C B>
+    end
   end
 end

--- a/test/testdata/packager/import_subpackage/pass.package-tree.exp
+++ b/test/testdata/packager/import_subpackage/pass.package-tree.exp
@@ -16,8 +16,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Root_Package$1>::<C Root>::<C B><<C <todo sym>>> < ()
       <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>::<C Foo>
     end
-
-    <emptyTree>::<C Root_Package$1>::<C Root> = <emptyTree>::<C <PackageRegistry>>::<C Root_Package$1>::<C Root>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -31,7 +29,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    <emptyTree>::<C Root_B_Package$1>::<C Root>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>
+    module <emptyTree>::<C Root_B_Package$1>::<C Root>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>::<C Foo>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/import_subpackage/pass.package-tree.exp
+++ b/test/testdata/packager/import_subpackage/pass.package-tree.exp
@@ -7,9 +7,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Root_Package$1>::<C Root>::<C B><<C <todo sym>>> < ()
       <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>::<C Foo>
     end
-
-    class <emptyTree>::<C Root_Package$1>::<C Root>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -24,8 +21,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    class <emptyTree>::<C Root_B_Package$1>::<C Root>::<C B>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -39,6 +39,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C A_Package$1>::<C A><<C <todo sym>>> < ()
+      <emptyTree>::<C AClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C AClass>
+    end
+
+    module <emptyTree>::<C A_Package$1>::<C A><<C <todo sym>>> < ()
+      <emptyTree>::<C AModule> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C AModule>
+    end
+
+    module <emptyTree>::<C A_Package$1>::<C A><<C <todo sym>>> < ()
+      <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C REFERENCE>
+    end
+
     module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
       <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
     end
@@ -46,8 +58,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
       <emptyTree>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BModule>
     end
-
-    <emptyTree>::<C A_Package$1>::<C A> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -127,7 +137,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C REFERENCE>
     end
 
-    <emptyTree>::<C B_Package$1>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
+    module <emptyTree>::<C B_Package$1>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
+    end
+
+    module <emptyTree>::<C B_Package$1>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BModule>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -33,9 +33,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
       <emptyTree>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BModule>
     end
-
-    class <emptyTree>::<C A_Package$1>::<C A>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -118,9 +115,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     module <emptyTree>::<C B_Package$1>::<C A><<C <todo sym>>> < ()
       <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C REFERENCE>
-    end
-
-    class <emptyTree>::<C B_Package$1>::<C B>::<C <Magic>><<C <todo sym>>> < ()
     end
   end
 

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -46,8 +46,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    class <emptyTree>::<C MyPackage_Package$1>::<C MyPackage>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -51,7 +51,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    <emptyTree>::<C MyPackage_Package$1>::<C MyPackage> = <emptyTree>::<C <PackageRegistry>>::<C MyPackage_Package$1>::<C MyPackage>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/lsp_features/__package.rb
+++ b/test/testdata/packager/lsp_features/__package.rb
@@ -18,4 +18,8 @@ class Simpsons < PackageSpec
 
     export Simpsons::Family
     #                ^^^^^^ usage: family
+
+    export_for_test Simpsons::Private
+    #                         ^^^^^^^ usage: s-private
+    #               ^^^^^^^^^^^^^^^^^ symbol-search: "Simpsons", name = "Simpsons", container = "<PackageTests>::Simpsons_Package"
 end

--- a/test/testdata/packager/lsp_features/bart/__package.rb
+++ b/test/testdata/packager/lsp_features/bart/__package.rb
@@ -8,6 +8,7 @@ class Bart < PackageSpec
     export Bart::Character
     #            ^^^^^^^^^ usage: character
     #            ^^^^^^^^^ hover: Character class description
+    #      ^^^^^^^^^^^^^^^ symbol-search: "Bart", name = "Bart", container = "<PackageTests>::Bart_Package"
     export Bart::CatchPhrase
     #            ^^^^^^^^^^^ usage: catchphrase
 end

--- a/test/testdata/packager/lsp_features/family.rb
+++ b/test/testdata/packager/lsp_features/family.rb
@@ -33,4 +33,8 @@ module Simpsons
   end
 
   Test::Krabappel::Popquiz # error: Unable to resolve constant `Test`
+
+  class Private
+    #   ^^^^^^^ def: s-private
+  end
 end

--- a/test/testdata/packager/lsp_features/family.test.rb
+++ b/test/testdata/packager/lsp_features/family.test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# typed: true
+
+module Test::Simpsons
+  #    ^^^^^^^^^^^^^^ symbol-search: "Simpsons", name = "Test::Simpsons", container = "Test"
+
+
+  Simpsons::Private
+#           ^^^^^^^ usage: s-private
+end

--- a/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
@@ -15,9 +15,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C RootPackage_Package$1>::<C RootPackage>::<C Foo><<C <todo sym>>> < ()
       <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Constant>
     end
-
-    class <emptyTree>::<C RootPackage_Package$1>::<C RootPackage>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -69,8 +66,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    class <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
@@ -32,8 +32,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C RootPackage_Package$1>::<C RootPackage>::<C Foo><<C <todo sym>>> < ()
       <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Constant>
     end
-
-    <emptyTree>::<C RootPackage_Package$1>::<C RootPackage> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Package$1>::<C RootPackage>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -76,7 +74,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>
+    module <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>
+    end
+
+    module <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>
+    end
+
+    module <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Constant>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -9,9 +9,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Package_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
       <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
     end
-
-    class <emptyTree>::<C Package_Package$1>::<C Package>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -51,9 +48,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
     module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
       <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
-    end
-
-    class <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C <Magic>><<C <todo sym>>> < ()
     end
   end
 

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -15,11 +15,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Package$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
+    end
+
     module <emptyTree>::<C Package_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
       <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
     end
-
-    <emptyTree>::<C Package_Package$1>::<C Package> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -60,7 +62,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
     end
 
-    <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
+    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
+      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -15,9 +15,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
       <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C Foo>
     end
-
-    class <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -98,9 +95,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
       <emptyTree>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C CallsFoo>
-    end
-
-    class <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C <Magic>><<C <todo sym>>> < ()
     end
   end
 

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -21,6 +21,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C Bar>
+    end
+
+    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C CallsFoo>
+    end
+
     module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
       <emptyTree>::<C CallsBar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C CallsBar>
     end
@@ -28,8 +36,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
       <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C Foo>
     end
-
-    <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -107,7 +113,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C CallsFoo>
     end
 
-    <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
+    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C CallsBar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C CallsBar>
+    end
+
+    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C Foo>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/simple_test_import/main_lib/__package.rb
+++ b/test/testdata/packager/simple_test_import/main_lib/__package.rb
@@ -5,4 +5,6 @@
 class Project::MainLib < PackageSpec
   import Project::Util
   test_import Project::TestOnly
+
+  export_for_test Project::MainLib::Lib
 end

--- a/test/testdata/packager/simple_test_import/main_lib/lib.test.rb
+++ b/test/testdata/packager/simple_test_import/main_lib/lib.test.rb
@@ -2,7 +2,7 @@
 # typed: strict
 
 class Test::Project::MainLib::LibTest
-  # Tests can access their package's code
+  # Tests can access their package's code when exported
   Project::MainLib::Lib.new
   # Tests can access `import`
   Project::Util::MyUtil.new

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -26,8 +26,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Project_MainLib_Package$1>::<C Test>::<C Project>::<C Util><<C <todo sym>>> < ()
       <emptyTree>::<C UtilHelper> = <emptyTree>::<C <PackageTests>>::<C Project_Util_Package$1>::<C Test>::<C Project>::<C Util>::<C UtilHelper>
     end
-
-    <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C MainLib> = <emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package$1>::<C Project>::<C MainLib>
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -69,7 +67,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    <emptyTree>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>
+    module <emptyTree>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly><<C <todo sym>>> < ()
+      <emptyTree>::<C SomeHelper> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>::<C SomeHelper>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -91,7 +91,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    <emptyTree>::<C Project_Util_Package$1>::<C Project>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>
+    module <emptyTree>::<C Project_Util_Package$1>::<C Project>::<C Util><<C <todo sym>>> < ()
+      <emptyTree>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>::<C MyUtil>
+    end
   end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -3,6 +3,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.import(<emptyTree>::<C Project>::<C Util>)
 
     <self>.test_import(<emptyTree>::<C Project>::<C TestOnly>)
+
+    <self>.export_for_test(<emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package$1>::<C Project>::<C MainLib>::<C Lib>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
@@ -15,6 +17,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C MainLib><<C <todo sym>>> < ()
+      <emptyTree>::<C Lib> = <emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package$1>::<C Project>::<C MainLib>::<C Lib>
+    end
+
     module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C TestOnly><<C <todo sym>>> < ()
       <emptyTree>::<C SomeHelper> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>::<C SomeHelper>
     end

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -11,9 +11,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C Util><<C <todo sym>>> < ()
       <emptyTree>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>::<C MyUtil>
     end
-
-    class <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C MainLib>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -68,8 +65,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    class <emptyTree>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -92,8 +87,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    class <emptyTree>::<C Project_Util_Package$1>::<C Project>::<C Util>::<C <Magic>><<C <todo sym>>> < ()
-    end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()


### PR DESCRIPTION
For `--stripe-packages` mode only:
Changes how `Test` code accesses its corresponding normal package. It no longer automatically gets an alias set for all of the normal package's code because this caused name redefinition errors (this bug was tested for but masked by https://github.com/sorbet/sorbet/pull/4652).

We instead introduce an explicit `export_for_test` DSL method that adds an assignment into the `<PackageTest>::<Mangled Pkg Name>` module much like any other import.

* `export_for_test` is prohibited from exporting anything in `Test::*` itself
* Test code also automatically gets access to anything that is `exported` publicly by its package.
* Removes special `<PackageRegistry>::<Managled Pkg Name>::<Magic> placeholder since this is no longer need. (Exports are explicit instead of implicit)

### Motivation
Fix redifinition bug in `--stripe-packages`
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
