### PR TITLE
return string_views instead of strings from a couple methods

### DIFF
--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -252,12 +252,12 @@ string Loc::filePosToString(const GlobalState &gs, bool showFull) const {
     return buf.str();
 }
 
-optional<string> Loc::source(const GlobalState &gs) const {
+optional<string_view> Loc::source(const GlobalState &gs) const {
     if (!exists()) {
         return nullopt;
     } else {
         auto source = this->file().data(gs).source();
-        return string(source.substr(beginPos(), endPos() - beginPos()));
+        return source.substr(beginPos(), endPos() - beginPos());
     }
 }
 

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -119,7 +119,7 @@ public:
     }
     std::string showRaw(const GlobalState &gs) const;
     std::string filePosToString(const GlobalState &gs, bool showFull = false) const;
-    std::optional<std::string> source(const GlobalState &gs) const;
+    std::optional<std::string_view> source(const GlobalState &gs) const;
 
     bool operator==(const Loc &rhs) const;
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1377,15 +1377,15 @@ string ArgInfo::toString(const GlobalState &gs) const {
     return to_string(buf);
 }
 
-string ArgInfo::argumentName(const GlobalState &gs) const {
+string_view ArgInfo::argumentName(const GlobalState &gs) const {
     if (flags.isKeyword) {
-        return (string)name.shortName(gs);
+        return name.shortName(gs);
     } else {
         // positional arg
         if (auto source = loc.source(gs)) {
             return source.value();
         } else {
-            return (string)name.shortName(gs);
+            return name.shortName(gs);
         }
     }
 }

--- a/core/Types.h
+++ b/core/Types.h
@@ -55,7 +55,7 @@ public:
     bool isSyntheticBlockArgument() const;
     std::string toString(const GlobalState &gs) const;
     std::string show(const GlobalState &gs) const;
-    std::string argumentName(const GlobalState &gs) const;
+    std::string_view argumentName(const GlobalState &gs) const;
     ArgInfo(const ArgInfo &) = delete;
     ArgInfo() = default;
     ArgInfo(ArgInfo &&) noexcept = default;

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -210,9 +210,9 @@ public:
         }
         string newsrc;
         if (auto sendResp = response->isSend()) {
-            newsrc = replaceMethodNameInSend(source.value(), sendResp);
+            newsrc = replaceMethodNameInSend(string(source.value()), sendResp);
         } else if (auto defResp = response->isDefinition()) {
-            newsrc = replaceMethodNameInDef(source.value());
+            newsrc = replaceMethodNameInDef(string(source.value()));
         } else {
             ENFORCE(0, "Unexpected query response type while renaming method");
             return;

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -25,12 +25,13 @@ void addSignatureHelpItem(const core::GlobalState &gs, core::MethodRef method,
     for (const auto &arg : args) {
         // label field is populated with the name of the variable.
         // Not sure why VSCode does not display this for now.
-        auto parameter = make_unique<ParameterInformation>(arg.argumentName(gs));
+        auto argName = string(arg.argumentName(gs));
+        auto parameter = make_unique<ParameterInformation>(argName);
         if (i == activeParameter) {
             // this bolds the active parameter in markdown
-            methodDocumentation += "**_" + arg.argumentName(gs) + "_**";
+            methodDocumentation += "**_" + argName + "_**";
         } else {
-            methodDocumentation += arg.argumentName(gs);
+            methodDocumentation += argName;
         }
         if (i != args.size() - 1) {
             methodDocumentation += ", ";

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -79,7 +79,7 @@ void checkSigReturnType(core::MutableContext ctx, const ast::Send *send) {
             e.setHeader("The {} method should always return {}", "initialize", "void");
 
             auto loc = core::Loc(ctx.file, originalSend.loc());
-            string original = loc.source(ctx).value();
+            auto original = (string)loc.source(ctx).value();
             unsigned long returnsStart = original.find("returns");
             unsigned long returnsLength, afterReturnsPosition;
             string replacement;


### PR DESCRIPTION
### Motivation

Noticed this while working on other things.  Not allocating unless you really need to seems like a good thing, even if this probably only happens in error paths.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
