### PR TITLE
add some more complex tests for splats with keyword args

### DIFF
--- a/test/testdata/compiler/disabled/splat_with_extra_kwargs.rb
+++ b/test/testdata/compiler/disabled/splat_with_extra_kwargs.rb
@@ -1,0 +1,13 @@
+# compiled: true
+# typed: true
+# frozen_string_literal: true
+
+def f(c: 3)
+  p (c)
+end
+
+begin
+  f(*[{c: 10, d: 8}])
+rescue ArgumentError => e
+  p e.message
+end

--- a/test/testdata/compiler/splat_args_with_kwargs.rb
+++ b/test/testdata/compiler/splat_args_with_kwargs.rb
@@ -24,6 +24,33 @@ end
 f(*[1,2,3],**{d:4}) { |x| p x }
 f(*[1,2,3],d: 4) { |x| p x }
 f(*[1,2,3]) { |x| p x }
+f(*[1,2,3,{}]) { |x| p x }
+f(*[1,2,3,{d: 10}]) { |x| p x }
+
+def expects_ArgumentError
+  begin
+    yield
+  rescue ArgumentError => e
+    p e.message
+  end
+end
+
+# Regular splat arguments are not re-processed as keyword args.
+expects_ArgumentError do
+  f(*[1,2,3,:d,10], d: 9) {|x| p x}
+end
+# Splat args with a kwargs-style hash are not re-processed if the call has kwargs.
+expects_ArgumentError do
+  f(*[1,2,3,{d: 10}], d: 9) {|x| p x}
+end
+# Splat args with a kwargs-style hash are not re-processed if the call has a kwsplat
+expects_ArgumentError do
+  f(*[1,2,3,{d: 10}], **{d: 9}) {|x| p x}
+end
+# Number of args checks are done before valid/invalid kwargs checks.
+expects_ArgumentError do
+  f(*[1,2,3,{d: 10}], e: 9) {|x| p x}
+end
 
 def g(*args,**kwargs)
   args.push "oops"

--- a/test/testdata/compiler/splat_args_with_kwargs.rb
+++ b/test/testdata/compiler/splat_args_with_kwargs.rb
@@ -32,10 +32,15 @@ def expects_ArgumentError
     yield
   rescue ArgumentError => e
     p e.message
+  else
+    raise "Didn't get expected ArgumentError"
   end
 end
 
 # Regular splat arguments are not re-processed as keyword args.
+expects_ArgumentError do
+  f(*[1,2,3,:d,10]) {|x| p x}
+end
 expects_ArgumentError do
   f(*[1,2,3,:d,10], d: 9) {|x| p x}
 end


### PR DESCRIPTION
### Motivation

I don't think we have tests for this anywhere: splat args with a hash in the last position treat the hash as keyword args where appropriate.  (This behavior does not trigger if the call already has keyword args or a keyword splat.)

Also added a disabled test for the case when the kwsplat-via-splat arg has an invalid kwarg (we currently report two wrong keyword arguments, rather than the single one the VM reports.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
