### PR TITLE
Fix Set#initialize signature

### DIFF
--- a/rbi/stdlib/set.rbi
+++ b/rbi/stdlib/set.rbi
@@ -254,11 +254,11 @@ class Set < Object
 
   sig do
     type_parameters(:U).params(
-        enum: T::Enumerable[T.type_parameter(:U)],
+        enum: T.nilable(T::Enumerable[T.type_parameter(:U)]),
     )
     .void
   end
-  def initialize(enum=T.unsafe(nil)); end
+  def initialize(enum=nil); end
 
   # Returns true if the set and the given set have at least one element in
   # common.


### PR DESCRIPTION
`Set::new` accepts `nil` https://ruby-doc.org/stdlib-2.7.1/libdoc/set/rdoc/Set.html#method-c-new

```
irb(main):003:0> Set.new(nil)
=> #<Set: {}>
```

### Motivation

The current signature gave me an error while adding type signatures to Homebrew. Specifically:

```rb
sig { params(enum: T.nilable(T::Enumerable[Option])).void }
def initialize(enum = nil)
  @options = T.let(Set.new(enum), T::Set[Option])
end
```

```
options.rb:99: Expected T::Enumerable[T.type_parameter(:U)] but found T.nilable(T::Enumerable[Option]) for argument enum https://srb.help/7002
    99 |    @options = T.let(Set.new(enum), T::Set[Option])
                             ^^^^^^^^^^^^^
```

### Test plan

None
