### PR TITLE
add extra information to the objectFileEmission timer

### DIFF
--- a/compiler/ObjectFileEmitter/ObjectFileEmitter.cc
+++ b/compiler/ObjectFileEmitter/ObjectFileEmitter.cc
@@ -51,9 +51,9 @@ namespace {
 constexpr int sizeLevel = 0;
 constexpr int optLevel = 2;
 
-bool outputObjectFile(spdlog::logger &logger, llvm::legacy::PassManager &pm, const string &fileName,
-                      unique_ptr<llvm::Module> module, llvm::TargetMachine *targetMachine) {
-    Timer timer(logger, "objectFileEmission");
+bool outputObjectFile(spdlog::logger &logger, llvm::legacy::PassManager &pm, const string &rubyFileName,
+                      const string &fileName, unique_ptr<llvm::Module> module, llvm::TargetMachine *targetMachine) {
+    Timer timer(logger, "objectFileEmission", {{"file", rubyFileName}});
     std::error_code ec;
     llvm::raw_fd_ostream dest(fileName, ec, llvm::sys::fs::OF_None);
 
@@ -447,7 +447,7 @@ void ObjectFileEmitter::init() {
     }
     auto objectFileName = fmt::format("{}/{}.o", soDir, objectName);
     auto soNamePrefix = fmt::format("{}/{}", soDir, objectName);
-    if (!outputObjectFile(logger, pm, objectFileName, move(module), targetMachine)) {
+    if (!outputObjectFile(logger, pm, string(objectName), objectFileName, move(module), targetMachine)) {
         return false;
     }
     if (!Linker::run(logger, {objectFileName}, soNamePrefix)) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Printing timing statistics for Stripe's codebase indicates that objectFileEmission is taking entirely too long.  Let's add some more information to assist in figuring out what's going on.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
