### PR TITLE
fix C-style string casts around the codebase

### DIFF
--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -943,7 +943,7 @@ void IREmitter::buildInitFor(CompilerState &cs, const core::SymbolRef &sym, stri
         auto linkageType = llvm::Function::ExternalLinkage;
         std::vector<llvm::Type *> NoArgs(0, llvm::Type::getVoidTy(cs));
         auto ft = llvm::FunctionType::get(llvm::Type::getVoidTy(cs), NoArgs, false);
-        entryFunc = llvm::Function::Create(ft, linkageType, "Init_" + (string)baseName, *cs.module);
+        entryFunc = llvm::Function::Create(ft, linkageType, "Init_" + string(baseName), *cs.module);
     } else {
         entryFunc = IREmitterHelpers::getInitFunction(cs, sym);
     }

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -66,7 +66,7 @@ AliasesAndKeywords setupAliasesAndKeywords(CompilerState &cs, const cfg::CFG &cf
                     } else if (name.size() > 1 && name[0] == '$') {
                         res.aliases[bind.bind.variable] = Alias::forGlobalField(i->name);
                     } else {
-                        ENFORCE(stoi((string)name) > 0, "'" + ((string)name) + "' is not a valid global name");
+                        ENFORCE(stoi(string(name)) > 0, "'" + string(name) + "' is not a valid global name");
                         res.aliases[bind.bind.variable] = Alias::forGlobalField(i->name);
                     }
                 } else {

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -30,7 +30,7 @@ string getFunctionNamePrefix(CompilerState &cs, core::SymbolRef sym) {
     string suffix;
     auto name = sym.data(cs)->name;
     if (name.kind() == core::NameKind::CONSTANT && name.dataCnst(cs)->original.kind() == core::NameKind::UTF8) {
-        suffix = (string)name.shortName(cs);
+        suffix = string(name.shortName(cs));
     } else {
         suffix = name.toString(cs);
     }
@@ -54,7 +54,7 @@ string IREmitterHelpers::getFunctionName(CompilerState &cs, core::SymbolRef sym)
     auto name = sym.data(cs)->name;
     string suffix;
     if (name.kind() == core::NameKind::UTF8) {
-        suffix = (string)name.shortName(cs);
+        suffix = string(name.shortName(cs));
     } else {
         suffix = name.toString(cs);
     }

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -71,7 +71,7 @@ llvm::Value *Payload::doubleToRubyValue(CompilerState &cs, llvm::IRBuilderBase &
 llvm::Value *Payload::cPtrToRubyRegexp(CompilerState &cs, llvm::IRBuilderBase &builder, std::string_view str,
                                        int options) {
     // all regexp are frozen. We'll allocate it at load time and share it.
-    string rawName = "rubyRegexpFrozen_" + (string)str;
+    string rawName = "rubyRegexpFrozen_" + string(str);
     auto tp = llvm::Type::getInt64Ty(cs);
     auto zero = llvm::ConstantInt::get(cs, llvm::APInt(64, 0));
     llvm::Constant *indices[] = {zero};
@@ -128,7 +128,7 @@ llvm::Value *Payload::cPtrToRubyString(CompilerState &cs, llvm::IRBuilderBase &b
                                   "rawRubyStr");
     }
     // this is a frozen string. We'll allocate it at load time and share it.
-    string rawName = "rubyStrFrozen_" + (string)str;
+    string rawName = "rubyStrFrozen_" + string(str);
     auto tp = llvm::Type::getInt64Ty(cs);
     auto zero = llvm::ConstantInt::get(cs, llvm::APInt(64, 0));
     llvm::Constant *indices[] = {zero};
@@ -180,7 +180,7 @@ llvm::Value *Payload::idIntern(CompilerState &cs, llvm::IRBuilderBase &builder, 
     auto zero = llvm::ConstantInt::get(cs, llvm::APInt(64, 0));
     auto name = llvm::StringRef(idName.data(), idName.length());
     llvm::Constant *indices[] = {zero};
-    string rawName = "rubyIdPrecomputed_" + (string)idName;
+    string rawName = "rubyIdPrecomputed_" + string(idName);
     auto tp = llvm::Type::getInt64Ty(cs);
     auto globalDeclaration = static_cast<llvm::GlobalVariable *>(cs.module->getOrInsertGlobal(rawName, tp, [&] {
         llvm::IRBuilder<> globalInitBuilder(cs);
@@ -239,7 +239,7 @@ llvm::Value *Payload::getRubyConstant(CompilerState &cs, core::SymbolRef sym, ll
 
 llvm::Value *Payload::toCString(CompilerState &cs, string_view str, llvm::IRBuilderBase &builder) {
     llvm::StringRef valueRef(str.data(), str.length());
-    auto globalName = "addr_str_" + (string)str;
+    auto globalName = "addr_str_" + string(str);
     auto globalDeclaration =
         static_cast<llvm::GlobalVariable *>(cs.module->getOrInsertGlobal(globalName, builder.getInt8PtrTy(), [&] {
             auto valueGlobal = builder.CreateGlobalString(valueRef, llvm::Twine("str_") + valueRef);
@@ -948,7 +948,7 @@ llvm::Value *buildInstanceVariableCache(CompilerState &cs, std::string_view name
     auto *zero = llvm::ConstantAggregateZero::get(cacheTy);
     // No special initialization necessary, unlike function inline caches.
     return new llvm::GlobalVariable(*cs.module, cacheTy, false, llvm::GlobalVariable::InternalLinkage, zero,
-                                    llvm::Twine("ivc_") + (string)name);
+                                    llvm::Twine("ivc_") + string(name));
 }
 
 } // namespace

--- a/compiler/Passes/Lowerings.cc
+++ b/compiler/Passes/Lowerings.cc
@@ -115,7 +115,7 @@ public:
                 return builder.CreateLoad(globalDeclaration);
             }
         }
-        auto str = (string)symName;
+        string str(symName);
         ENFORCE(str.length() < 2 || (str[0] != ':'), "implementation assumes that strings dont start with ::");
         auto loaderName = "const_load" + str;
         auto guardEpochName = "guard_epoch_" + str;

--- a/core/Error.cc
+++ b/core/Error.cc
@@ -177,7 +177,7 @@ unique_ptr<Error> ErrorBuilder::build() {
     return err;
 }
 
-string ErrorColors::coloredPatternReplace = (string)coloredPatternSigil;
+string ErrorColors::coloredPatternReplace = string(coloredPatternSigil);
 
 void ErrorColors::enableColors() {
     rang::setControlMode(rang::control::Force);

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -12,7 +12,7 @@ using namespace std;
 namespace sorbet::infer {
 
 unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg) {
-    Timer timeit(ctx.state.tracer(), "Inference::run", {{"func", (string)cfg->symbol.toStringFullName(ctx)}});
+    Timer timeit(ctx.state.tracer(), "Inference::run", {{"func", string(cfg->symbol.toStringFullName(ctx))}});
     ENFORCE(cfg->symbol == ctx.owner.asMethodRef());
     auto methodLoc = cfg->symbol.data(ctx)->loc();
     prodCounterInc("types.input.methods.typechecked");

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -108,7 +108,7 @@ ast::ExpressionPtr fetchTreeFromCache(core::GlobalState &gs, core::FileRef fref,
 }
 
 unique_ptr<parser::Node> runParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print) {
-    Timer timeit(gs.tracer(), "runParser", {{"file", (string)file.data(gs).path()}});
+    Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
     unique_ptr<parser::Node> nodes;
     {
         core::UnfreezeNameTable nameTableAccess(gs); // enters strings from source code as names
@@ -131,7 +131,7 @@ unique_ptr<parser::Node> runParser(core::GlobalState &gs, core::FileRef file, co
 
 ast::ExpressionPtr runDesugar(core::GlobalState &gs, core::FileRef file, unique_ptr<parser::Node> parseTree,
                               const options::Printers &print) {
-    Timer timeit(gs.tracer(), "runDesugar", {{"file", (string)file.data(gs).path()}});
+    Timer timeit(gs.tracer(), "runDesugar", {{"file", string(file.data(gs).path())}});
     ast::ExpressionPtr ast;
     core::MutableContext ctx(gs, core::Symbols::root(), file);
     {
@@ -149,13 +149,13 @@ ast::ExpressionPtr runDesugar(core::GlobalState &gs, core::FileRef file, unique_
 
 ast::ExpressionPtr runRewriter(core::GlobalState &gs, core::FileRef file, ast::ExpressionPtr ast) {
     core::MutableContext ctx(gs, core::Symbols::root(), file);
-    Timer timeit(gs.tracer(), "runRewriter", {{"file", (string)file.data(gs).path()}});
+    Timer timeit(gs.tracer(), "runRewriter", {{"file", string(file.data(gs).path())}});
     core::UnfreezeNameTable nameTableAccess(gs); // creates temporaries during desugaring
     return rewriter::Rewriter::run(ctx, move(ast));
 }
 
 ast::ParsedFile runLocalVars(core::GlobalState &gs, ast::ParsedFile tree) {
-    Timer timeit(gs.tracer(), "runLocalVars", {{"file", (string)tree.file.data(gs).path()}});
+    Timer timeit(gs.tracer(), "runLocalVars", {{"file", string(tree.file.data(gs).path())}});
     core::MutableContext ctx(gs, core::Symbols::root(), tree.file);
     return sorbet::local_vars::LocalVars::run(ctx, move(tree));
 }
@@ -373,7 +373,7 @@ ast::ExpressionPtr readFileWithStrictnessOverrides(unique_ptr<core::GlobalState>
         return ast;
     }
     auto fileName = file.dataAllowingUnsafe(*gs).path();
-    Timer timeit(gs->tracer(), "readFileWithStrictnessOverrides", {{"file", (string)fileName}});
+    Timer timeit(gs->tracer(), "readFileWithStrictnessOverrides", {{"file", string(fileName)}});
     string src;
     bool fileFound = true;
     try {
@@ -559,7 +559,7 @@ ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const 
         return result;
     }
 
-    Timer timeit(ctx.state.tracer(), "typecheckOne", {{"file", (string)f.data(ctx).path()}});
+    Timer timeit(ctx.state.tracer(), "typecheckOne", {{"file", string(f.data(ctx).path())}});
     try {
         if (opts.print.CFG.enabled) {
             opts.print.CFG.fmt("digraph \"{}\" {{\n", FileOps::getFileName(f.data(ctx).path()));
@@ -740,7 +740,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
                 // appear before file's old EOF.
                 const int prohibitedLines = f.file.data(*gs).source().size();
                 auto newSource = fmt::format("{}\n{}", string(prohibitedLines, '\n'), f.file.data(*gs).source());
-                auto newFile = make_shared<core::File>((string)f.file.data(*gs).path(), move(newSource),
+                auto newFile = make_shared<core::File>(string(f.file.data(*gs).path()), move(newSource),
                                                        f.file.data(*gs).sourceType);
                 gs = core::GlobalState::replaceFile(move(gs), f.file, move(newFile));
                 f.file.data(*gs).strictLevel = decideStrictLevel(*gs, f.file, opts);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1856,7 +1856,7 @@ vector<SymbolFinderResult> findSymbols(const core::GlobalState &gs, vector<ast::
         ast::ParsedFile job;
         for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
             if (result.gotItem()) {
-                Timer timeit(gs.tracer(), "naming.findSymbolsOne", {{"file", (string)job.file.data(gs).path()}});
+                Timer timeit(gs.tracer(), "naming.findSymbolsOne", {{"file", string(job.file.data(gs).path())}});
                 core::Context ctx(gs, core::Symbols::root(), job.file);
                 job.tree = ast::ShallowMap::apply(ctx, finder, std::move(job.tree));
                 SymbolFinderResult jobOutput{move(job), finder.getAndClearFoundDefinitions()};
@@ -1922,7 +1922,7 @@ vector<ast::ParsedFile> symbolizeTrees(const core::GlobalState &gs, vector<ast::
         ast::ParsedFile job;
         for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
             if (result.gotItem()) {
-                Timer timeit(gs.tracer(), "naming.symbolizeTreesOne", {{"file", (string)job.file.data(gs).path()}});
+                Timer timeit(gs.tracer(), "naming.symbolizeTreesOne", {{"file", string(job.file.data(gs).path())}});
                 core::Context ctx(gs, core::Symbols::root(), job.file);
                 job.tree = ast::ShallowMap::apply(ctx, inserter, std::move(job.tree));
                 output.emplace_back(move(job));

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -79,7 +79,7 @@ void checkSigReturnType(core::MutableContext ctx, const ast::Send *send) {
             e.setHeader("The {} method should always return {}", "initialize", "void");
 
             auto loc = core::Loc(ctx.file, originalSend.loc());
-            auto original = (string)loc.source(ctx).value();
+            auto original = string(loc.source(ctx).value());
             unsigned long returnsStart = original.find("returns");
             unsigned long returnsLength, afterReturnsPosition;
             string replacement;

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -550,7 +550,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         const int prohibitedLines = f.file.data(*gs).source().size();
         auto newSource = absl::StrCat(string(prohibitedLines + 1, '\n'), f.file.data(*gs).source());
         auto newFile =
-            make_shared<core::File>((string)f.file.data(*gs).path(), move(newSource), f.file.data(*gs).sourceType);
+            make_shared<core::File>(string(f.file.data(*gs).path()), move(newSource), f.file.data(*gs).sourceType);
         gs = core::GlobalState::replaceFile(move(gs), f.file, move(newFile));
 
         // this replicates the logic of pipeline::indexOne


### PR DESCRIPTION
### Motivation

This PR started life as a followup PR for review comments in #4669.  But then I figured, why not go the extra mile and delete `(string)` casts elsewhere in the codebase too?

I tried adding a `const std::string &pathAsString() const` method to `core::File`, but it resulted in some overload issues, so it was easier to keep the casting of `string(...path())` everywhere. :(

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
