### PR TITLE
Add bundler installer RBI and change Psych.load_file

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/sorbet_ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/sorbet_ruby_2_6_hidden.rbi.exp
@@ -371,26 +371,6 @@ class Bundler::Injector
   def self.remove(gems, options=T.unsafe(nil)); end
 end
 
-class Bundler::Installer
-  def generate_bundler_executable_stubs(spec, options=T.unsafe(nil)); end
-
-  def generate_standalone_bundler_executable_stubs(spec); end
-
-  def initialize(root, definition); end
-
-  def post_install_messages(); end
-
-  def run(options); end
-end
-
-class Bundler::Installer
-  def self.ambiguous_gems(); end
-
-  def self.ambiguous_gems=(ambiguous_gems); end
-
-  def self.install(root, definition, options=T.unsafe(nil)); end
-end
-
 class Bundler::LockfileGenerator
   def definition(); end
 

--- a/gems/sorbet/test/hidden-method-finder/simple/sorbet_ruby_2_7_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/sorbet_ruby_2_7_hidden.rbi.exp
@@ -373,26 +373,6 @@ class Bundler::Injector
   def self.remove(gems, options=T.unsafe(nil)); end
 end
 
-class Bundler::Installer
-  def generate_bundler_executable_stubs(spec, options=T.unsafe(nil)); end
-
-  def generate_standalone_bundler_executable_stubs(spec); end
-
-  def initialize(root, definition); end
-
-  def post_install_messages(); end
-
-  def run(options); end
-end
-
-class Bundler::Installer
-  def self.ambiguous_gems(); end
-
-  def self.ambiguous_gems=(ambiguous_gems); end
-
-  def self.install(root, definition, options=T.unsafe(nil)); end
-end
-
 class Bundler::LockfileGenerator
   def definition(); end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/sorbet_ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/sorbet_ruby_2_6_hidden.rbi.exp
@@ -371,26 +371,6 @@ class Bundler::Injector
   def self.remove(gems, options=T.unsafe(nil)); end
 end
 
-class Bundler::Installer
-  def generate_bundler_executable_stubs(spec, options=T.unsafe(nil)); end
-
-  def generate_standalone_bundler_executable_stubs(spec); end
-
-  def initialize(root, definition); end
-
-  def post_install_messages(); end
-
-  def run(options); end
-end
-
-class Bundler::Installer
-  def self.ambiguous_gems(); end
-
-  def self.ambiguous_gems=(ambiguous_gems); end
-
-  def self.install(root, definition, options=T.unsafe(nil)); end
-end
-
 class Bundler::LockfileGenerator
   def definition(); end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/sorbet_ruby_2_7_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/sorbet_ruby_2_7_hidden.rbi.exp
@@ -373,26 +373,6 @@ class Bundler::Injector
   def self.remove(gems, options=T.unsafe(nil)); end
 end
 
-class Bundler::Installer
-  def generate_bundler_executable_stubs(spec, options=T.unsafe(nil)); end
-
-  def generate_standalone_bundler_executable_stubs(spec); end
-
-  def initialize(root, definition); end
-
-  def post_install_messages(); end
-
-  def run(options); end
-end
-
-class Bundler::Installer
-  def self.ambiguous_gems(); end
-
-  def self.ambiguous_gems=(ambiguous_gems); end
-
-  def self.install(root, definition, options=T.unsafe(nil)); end
-end
-
 class Bundler::LockfileGenerator
   def definition(); end
 

--- a/rbi/stdlib/bundler.rbi
+++ b/rbi/stdlib/bundler.rbi
@@ -10272,3 +10272,29 @@ class Bundler::YamlSyntaxError < Bundler::BundlerError
   sig {returns(T.untyped)}
   def status_code(); end
 end
+
+class Bundler::Installer
+  sig {params(ambiguous_gems: T.untyped).returns(T.untyped)}
+  def self.ambiguous_gems=(ambiguous_gems); end
+
+  sig {returns(T.untyped)}
+  def self.ambiguous_gems; end
+
+  sig {returns(T.untyped)}
+  def post_install_messages; end
+
+  sig {params(root: T.untyped, definition: T.untyped, options: T.untyped).returns(T.untyped)}
+  def self.install(root, definition, options = {}); end
+
+  sig {params(root: T.untyped, definition: T.untyped).void}
+  def initialize(root, definition); end
+
+  sig {params(options: T.untyped).void}
+  def run(options); end
+
+  sig {params(spec: T.untyped, options: T.untyped).void}
+  def generate_bundler_executable_stubs(spec, options = {}); end
+
+  sig {params(spec: T.untyped, options: T.untyped).void}
+  def generate_standalone_bundler_executable_stubs(spec, options = {}); end
+end

--- a/rbi/stdlib/psych.rbi
+++ b/rbi/stdlib/psych.rbi
@@ -625,8 +625,8 @@ module Psych
   # Load the document contained in `filename`. Returns the yaml contained in
   # `filename` as a Ruby object, or if the file is empty, it returns the
   # specified `fallback` return value, which defaults to `false`.
-  sig { params(filename: T.any(String, Pathname), fallback: T.untyped).returns(T.untyped) }
-  def self.load_file(filename, fallback: false); end
+  sig { params(filename: T.any(String, Pathname), kwargs: T.untyped).returns(T.untyped) }
+  def self.load_file(filename, **kwargs); end
 end
 
 class Psych::Exception < RuntimeError


### PR DESCRIPTION
Add missing definitions for `Bundler::Installer` in `bundler.rbi` and change the parameter for `Psych.load_file` to be `**kwargs`.

### Motivation

[Psych.load_file](https://github.com/ruby/psych/blob/a8922edb85abce2412588a0b2044cd343e1caa70/lib/psych.rb#L669) indeed takes `**kwargs` and accepts other options beyond `fallback`.

The [Bundler::Installer](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/installer.rb) class was missing from `bundler.rbi`. I put all signatures as `T.untyped` for now, but let me know if you know the right types for it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Current tests should cover it.