### PR TITLE
Revert "Don't prepend ./ to file paths' when using --dir=. (#4673)"

### DIFF
--- a/common/common.cc
+++ b/common/common.cc
@@ -223,7 +223,7 @@ bool sorbet::FileOps::isFolder(string_view path, string_view ignorePattern, cons
 bool sorbet::FileOps::isFileIgnored(string_view basePath, string_view filePath,
                                     const vector<string> &absoluteIgnorePatterns,
                                     const vector<string> &relativeIgnorePatterns) {
-    ENFORCE(filePath.substr(0, basePath.length()) == basePath, "filePath='{}', basePath='{}'", filePath, basePath);
+    ENFORCE(filePath.substr(0, basePath.length()) == basePath);
     // Note: relative_path always includes a leading /
     string_view relative_path = filePath.substr(basePath.length());
     for (auto &p : absoluteIgnorePatterns) {
@@ -248,8 +248,6 @@ bool sorbet::FileOps::isFileIgnored(string_view basePath, string_view filePath,
     return false;
 }
 
-namespace {
-
 void appendFilesInDir(string_view basePath, const string &path, const sorbet::UnorderedSet<string> &extensions,
                       bool recursive, vector<string> &result, const std::vector<std::string> &absoluteIgnorePatterns,
                       const std::vector<std::string> &relativeIgnorePatterns) {
@@ -267,7 +265,6 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
     }
 
     while ((entry = readdir(dir)) != nullptr) {
-        // Will always add a ./ prefix (convenient for matching ignore patterns)
         auto fullPath = fmt::format("{}/{}", path, entry->d_name);
         if (sorbet::FileOps::isFileIgnored(basePath, fullPath, absoluteIgnorePatterns, relativeIgnorePatterns)) {
             continue;
@@ -282,13 +279,7 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
             if (dotLocation != string::npos) {
                 string_view ext(fullPath.c_str() + dotLocation, fullPath.size() - dotLocation);
                 if (extensions.contains(ext)) {
-                    // Remove the ./ prefix in the final path (but it's convenient to have it
-                    // above for the sake of matching ignore patterns). Also don't allocate unless we have to.
-                    if (basePath == ".") {
-                        result.push_back(fullPath.erase(0, 2));
-                    } else {
-                        result.push_back(move(fullPath));
-                    }
+                    result.push_back(move(fullPath));
                 }
             }
         }
@@ -296,16 +287,14 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
     closedir(dir);
 }
 
-} // namespace
-
-vector<string> sorbet::FileOps::listFilesInDir(string_view basePath, const UnorderedSet<string> &extensions,
-                                               bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
+vector<string> sorbet::FileOps::listFilesInDir(string_view path, const UnorderedSet<string> &extensions, bool recursive,
+                                               const std::vector<std::string> &absoluteIgnorePatterns,
                                                const std::vector<std::string> &relativeIgnorePatterns) {
     vector<string> result;
     // Mini-optimization: appendFilesInDir needs to grab a c_str from path, so we pass in a string reference to avoid
     // copying.
-    string path(basePath);
-    appendFilesInDir(basePath, path, extensions, recursive, result, absoluteIgnorePatterns, relativeIgnorePatterns);
+    string pathStr(path);
+    appendFilesInDir(path, pathStr, extensions, recursive, result, absoluteIgnorePatterns, relativeIgnorePatterns);
     fast_sort(result);
     return result;
 }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -182,11 +182,6 @@ public:
             curPrefixPos = path.find_last_of('/', curPrefixPos - 1);
         }
 
-        const auto root = packageInfoByPathPrefix.find("");
-        if (root != packageInfoByPathPrefix.end()) {
-            return root->second.get();
-        }
-
         return nullptr;
     }
 };
@@ -706,12 +701,7 @@ unique_ptr<PackageInfo> getPackageInfo(core::MutableContext ctx, ast::ParsedFile
     package.tree = ast::TreeMap::apply(ctx, finder, move(package.tree));
     finder.finalize(ctx);
     if (finder.info) {
-        if (packageFilePath.find('.') == string::npos) {
-            finder.info->packagePathPrefixes.emplace_back("");
-        } else {
-            finder.info->packagePathPrefixes.emplace_back(
-                packageFilePath.substr(0, packageFilePath.find_last_of('/') + 1));
-        }
+        finder.info->packagePathPrefixes.emplace_back(packageFilePath.substr(0, packageFilePath.find_last_of('/') + 1));
         const string_view shortName = finder.info->name.mangledName.shortName(ctx.state);
         const string_view dirNameFromShortName = shortName.substr(0, shortName.find("_Package"));
 

--- a/test/cli/file-sigils-json/file-sigils-json.out
+++ b/test/cli/file-sigils-json/file-sigils-json.out
@@ -27,18 +27,18 @@ No errors! Great job.
 {
  "files": [
   {
-   "path": "compiled-false.rb",
+   "path": "./compiled-false.rb",
    "strict": "False",
    "min_error_level": "Max",
    "compiled": "CompiledFalse"
   },
   {
-   "path": "compiled-none.rb",
+   "path": "./compiled-none.rb",
    "strict": "False",
    "min_error_level": "Max"
   },
   {
-   "path": "compiled-true.rb",
+   "path": "./compiled-true.rb",
    "sigil": "True",
    "strict": "True",
    "min_error_level": "Max",

--- a/test/cli/files-dirs/files-dirs.out
+++ b/test/cli/files-dirs/files-dirs.out
@@ -28,7 +28,7 @@ Usage:
 {
  "files": [
   {
-   "path": "foo.rb",
+   "path": "./foo.rb",
    "strict": "False",
    "min_error_level": "Max"
   }
@@ -39,7 +39,7 @@ Note: --dir and -e are meant to be additive
 {
  "files": [
   {
-   "path": "foo.rb",
+   "path": "./foo.rb",
    "strict": "False",
    "min_error_level": "Max"
   }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


This broke something, we're not sure why yet.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.