### PR TITLE
Fix Pathname#readlink signature

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -1046,7 +1046,7 @@ class Pathname < Object
   #
   # See
   # [`File.readlink`](https://docs.ruby-lang.org/en/2.7.0/File.html#method-c-readlink).
-  sig {returns(String)}
+  sig {returns(T.self_type)}
   def readlink(); end
 
   # Returns the real (absolute) pathname of `self` in the actual filesystem.


### PR DESCRIPTION
`Pathname#readlink` returns a `Pathname` https://github.com/ruby/ruby/blob/b9f34062/ext/pathname/pathname.c#L687-L698

```
irb(main):001:0> require 'pathname'
=> true
irb(main):002:0> Pathname('/usr/local/bin/brew').readlink
=> #<Pathname:../Homebrew/bin/brew>
irb(main):003:0> Pathname('/usr/local/bin/brew').readlink.class
=> Pathname
```

### Motivation

Adding type signatures to Homebrew

```rb
def fix_dynamic_linkage
  symlink_files.each do |file|
    link = file.readlink
    # Don't fix relative symlinks
    next unless link.absolute?

    link_starts_cellar = link.to_s.start_with?(HOMEBREW_CELLAR.to_s)
    link_starts_prefix = link.to_s.start_with?(HOMEBREW_PREFIX.to_s)
    next if !link_starts_cellar && !link_starts_prefix

    new_src = link.relative_path_from(file.parent)
    file.unlink
    FileUtils.ln_s(new_src, file)
  end
end

def symlink_files
  symlink_files = []
  path.find do |pn|
    symlink_files << pn if pn.symlink?
  end
  symlink_files
end
```

```
Method absolute? does not exist on String https://srb.help/7003
    73 |      next unless link.absolute?
                          ^^^^^^^^^^^^^^
Method relative_path_from does not exist on String https://srb.help/7003
    79 |      new_src = link.relative_path_from(file.parent)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

### Test plan

None