### PR TITLE
Add a test case for T::Utils.run_all_sig_blocks and compiled code

### DIFF
--- a/test/testdata/compiler/disabled/kwsplat_compiled_sigs__1.rb
+++ b/test/testdata/compiler/disabled/kwsplat_compiled_sigs__1.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+require_relative './kwsplat_compiled_sigs__2'
+
+T::Utils.run_all_sig_blocks

--- a/test/testdata/compiler/disabled/kwsplat_compiled_sigs__2.rb
+++ b/test/testdata/compiler/disabled/kwsplat_compiled_sigs__2.rb
@@ -1,0 +1,14 @@
+# typed: strict
+# frozen_string_literal: true
+# compiled: true
+
+class A
+  extend T::Sig
+
+  sig {params(x: Integer, y: T.untyped).void}
+  def foo(x, **y)
+    puts x
+    puts y
+  end
+
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
There's a bad interaction between the `rb_sorbet_parameters` function in our runtime patches and sigs for functions that have a keyword splat. The following test crashes at runtime.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
More tests.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
