### PR TITLE
Add note to requires_ancestor auto-correct

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -666,6 +666,8 @@ private:
         if (!send->args.empty()) {
             if (auto e = gs.beginError(loc, core::errors::Resolver::InvalidRequiredAncestor)) {
                 e.setHeader("`{}` only accepts a block", send->fun.show(gs));
+                e.addErrorNote("Use {} to auto-correct using the new syntax",
+                               "--isolate-error-code 5062 -a --typed true");
 
                 if (block != nullptr) {
                     return;

--- a/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.out
+++ b/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.out
@@ -1,6 +1,8 @@
 autocorrect-requires-ancestor-block.rb:12: `requires_ancestor` only accepts a block https://srb.help/5062
     12 |  requires_ancestor RA1
           ^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Use --isolate-error-code 5062 -a --typed true to auto-correct using the new syntax
   Autocorrect: Done
     autocorrect-requires-ancestor-block.rb:12: Replaced with `requires_ancestor { RA1 }`
     12 |  requires_ancestor RA1
@@ -9,6 +11,8 @@ autocorrect-requires-ancestor-block.rb:12: `requires_ancestor` only accepts a bl
 autocorrect-requires-ancestor-block.rb:13: `requires_ancestor` only accepts a block https://srb.help/5062
     13 |  requires_ancestor RA2, RA3
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Use --isolate-error-code 5062 -a --typed true to auto-correct using the new syntax
   Autocorrect: Done
     autocorrect-requires-ancestor-block.rb:13: Replaced with `requires_ancestor { RA2 }
   requires_ancestor { RA3 }`
@@ -18,6 +22,8 @@ autocorrect-requires-ancestor-block.rb:13: `requires_ancestor` only accepts a bl
 autocorrect-requires-ancestor-block.rb:14: `requires_ancestor` only accepts a block https://srb.help/5062
     14 |  requires_ancestor(RA4) { RA5 }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Use --isolate-error-code 5062 -a --typed true to auto-correct using the new syntax
 
 autocorrect-requires-ancestor-block.rb:12: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1` https://srb.help/7004
     12 |  requires_ancestor RA1


### PR DESCRIPTION
This PR adds an error note with the instructions to safely auto-correct the `requires_ancestor` usages.

### Motivation

More info on #4691

When trying to auto-correct for the new `requires_ancestor` syntax, we can't just use `bundle exec srb tc -a`, because other errors will be auto-corrected as well.

Because the syntax changed, Sorbet stops processing the old style occurrences of `requires_ancestor` and this results in numerous other errors, simply because the ancestor is missing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.