### PR TITLE
Fix some method redefined warnings

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
@@ -40,6 +40,11 @@ module T::Private::Abstract::Declare
         end
         super(*args, &blk)
       end
+
+      # Ruby doesn not emit "method redefined" warnings for aliased methods
+      # (more robust than undef_method that would create a small window in which the method doesn't exist)
+      mod.send(:alias_method, :initialize, :initialize)
+
       if mod.respond_to?(:ruby2_keywords, true)
         mod.send(:ruby2_keywords, :initialize)
       end

--- a/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
+++ b/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
@@ -83,6 +83,11 @@ module T::Props
         lazily_defined_methods[name] = blk
 
         cls = decorated_class
+        if cls.method_defined?(name)
+          # Ruby doesn not emit "method redefined" warnings for aliased methods
+          # (more robust than undef_method that would create a small window in which the method doesn't exist)
+          cls.send(:alias_method, name, name)
+        end
         cls.send(:define_method, name) do |*args|
           self.class.decorator.send(:eval_lazily_defined_method!, name)
           send(name, *args)


### PR DESCRIPTION
These are annoying when test a gem that includes sorbet, e.g.: https://github.com/Shopify/paquito/runs/3826638397#step:5:5

```
~/gems/sorbet-runtime-0.5.9209/lib/types/props/private/apply_default.rb:17: warning: method redefined; discarding old initialize
~/gems/sorbet-runtime-0.5.9209/lib/types/private/abstract/declare.rb:37: warning: previous definition of initialize was here
~/gems/sorbet-runtime-0.5.9209/lib/types/props/private/apply_default.rb:71: warning: method redefined; discarding old initialize
~/gems/sorbet-runtime-0.5.9209/lib/types/private/abstract/declare.rb:37: warning: previous definition of initialize was here
~/gems/sorbet-runtime-0.5.9209/lib/types/props/has_lazily_specialized_methods.rb:86: warning: method redefined; discarding old __t_props_generated_serialize
~/gems/sorbet-runtime-0.5.9209/lib/types/props/has_lazily_specialized_methods.rb:86: warning: previous definition of __t_props_generated_serialize was here
~/gems/sorbet-runtime-0.5.9209/lib/types/props/has_lazily_specialized_methods.rb:86: warning: method redefined; discarding old __t_props_generated_deserialize
~/gems/sorbet-runtime-0.5.9209/lib/types/props/has_lazily_specialized_methods.rb:86: warning: previous definition of __t_props_generated_deserialize was here

...

~/gems/sorbet-runtime-0.5.9209/lib/types/props/private/apply_default.rb:17: warning: method redefined; discarding old initialize
~/gems/sorbet-runtime-0.5.9209/lib/types/private/abstract/declare.rb:37: warning: previous definition of initialize was here
~/gems/sorbet-runtime-0.5.9209/lib/types/props/private/apply_default.rb:71: warning: method redefined; discarding old initialize
~/gems/sorbet-runtime-0.5.9209/lib/types/private/abstract/declare.rb:37: warning: previous definition of initialize was here

...

~/gems/sorbet-runtime-0.5.9209/lib/types/props/private/apply_default.rb:17: warning: method redefined; discarding old initialize
~/gems/sorbet-runtime-0.5.9209/lib/types/private/abstract/declare.rb:37: warning: previous definition of initialize was here
~/gems/sorbet-runtime-0.5.9209/lib/types/props/private/apply_default.rb:71: warning: method redefined; discarding old initialize
~/gems/sorbet-runtime-0.5.9209/lib/types/private/abstract/declare.rb:37: warning: previous definition of initialize was here
```

cc @paracycle 