### PR TITLE
Add missing RBI definition for `Bundler#default_gem?`

### DIFF
--- a/rbi/stdlib/bundler.rbi
+++ b/rbi/stdlib/bundler.rbi
@@ -9954,7 +9954,7 @@ class Bundler::StubSpecification < Bundler::RemoteSpecification
   sig {returns(T.untyped)}
   def default_gem(); end
 
-  sig { returns(T::Boolean) }
+  sig {returns(T::Boolean)}
   def default_gem?; end
 
   sig {returns(T.untyped)}


### PR DESCRIPTION
See https://github.com/ruby/ruby/blob/d92f09a5eea009fa28cd046e9d0eb698e3d94c5c/lib/bundler/stub_specification.rb#L62-L64

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
