### PR TITLE
Fix array uniq! return type

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -2704,7 +2704,7 @@ class Array < Object
   # c = [["student","sam"], ["student","george"], ["teacher","matz"]]
   # c.uniq! {|s| s.first}   # => [["student", "sam"], ["teacher", "matz"]]
   # ```
-  sig {params(blk: T.nilable(T.proc.params(arg0: Elem).returns(BasicObject))).returns(T.nilable(T::Array[Elem])}
+  sig {params(blk: T.nilable(T.proc.params(arg0: Elem).returns(BasicObject))).returns(T.nilable(T::Array[Elem]))}
   def uniq!(&blk); end
 
   # Prepends objects to the front of `self`, moving other elements upwards. See


### PR DESCRIPTION
The uniq! array function can return nil as described by the method documentation on lines 2695-2702 on `rbi/core/array.rbi`, but the current signature for the uniq! function does not allow the return to be nil.  This pr adds `T.nilable()` to the signature of uniq! to fix this issue.