### PR TITLE
add test mixing optional and keyword args

### DIFF
--- a/test/testdata/compiler/keyword_arg.rb
+++ b/test/testdata/compiler/keyword_arg.rb
@@ -5,5 +5,12 @@ def my_name(name:, prefix: "Mr")
   prefix + " " + name
 end
 
+def f(a, b=3, name:, prefix: "Mr")
+  p a, b
+  prefix + " " + name
+end
+
 puts my_name(name: "Paul", prefix: "Master")
 puts my_name(name: "Paul")
+
+puts f(1, {x: 5}, name: "Nathan")


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I thought of this testcase after writing #4698, and sure enough, that PR doesn't (currently) handle it.  Let's add it so we make sure #4698 handles it correctly.

(The failure mode is that we were wrongly considering the optional argument to be the kwsplat argument.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
