### PR TITLE
Stop `to_ary` recursion when we hit `NilClass`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2972,7 +2972,16 @@ class Array_flatten : public IntrinsicMethod {
 
         auto dispatched = type.dispatchCall(gs, innerArgs);
         if (dispatched.main.errors.empty()) {
-            return recursivelyFlattenArrays(gs, args, move(dispatched.returnType), newDepth);
+            if (dispatched.returnType.isNilClass()) {
+                // According to the Ruby spec, it is valid for `to_ary` to return `nil`
+                // which will stop `flatten` descending further.
+                //
+                // So, when we find a `NilClass` return type from `to_ary`, the type
+                // we have is the one we are looking for.
+                return type;
+            } else {
+                return recursivelyFlattenArrays(gs, args, move(dispatched.returnType), newDepth);
+            }
         }
 
         return type;

--- a/test/testdata/infer/flatten.rb
+++ b/test/testdata/infer/flatten.rb
@@ -58,6 +58,26 @@ class GenericPair
   end
 end
 
+# This type cannot be flattened anymore
+# since it returns `nil` from `to_ary`.
+class FlatType
+  extend T::Sig
+
+  sig { returns(NilClass) }
+  def to_ary
+    nil
+  end
+end
+
+class FlatTypeCollection
+  extend T::Sig
+
+  sig { returns(T::Array[FlatType]) }
+  def to_ary
+    [FlatType.new, FlatType.new, FlatType.new]
+  end
+end
+
 integer_pairs = T.let([IntegerPair.new(1, 2), IntegerPair.new(3, 4)], T::Array[IntegerPair])
 super_pairs = T.let([SuperPair.new(1, 2)], T::Array[SuperPair])
 
@@ -65,6 +85,16 @@ generic_pairs = T.let([GenericPair.new(1, 2), GenericPair.new(3, 4)], T::Array[G
 nested_generic_pairs = T.let(
   [GenericPair.new(GenericPair.new(1, 2), GenericPair.new(3, 4))],
   T::Array[GenericPair[GenericPair[Integer]]]
+)
+
+nested_flat_type_list = T.let(
+  [FlatType.new, FlatType.new, [FlatType.new, [FlatType.new]]],
+  T::Array[T.any(FlatType, T::Array[T.any(FlatType, T::Array[FlatType])])]
+)
+
+flat_type_collections = T.let(
+  [FlatTypeCollection.new, FlatTypeCollection.new, FlatTypeCollection.new],
+  T::Array[FlatTypeCollection]
 )
 
 T.reveal_type(flat_tuple.flatten) # error: Revealed type: `T::Array[Integer]`
@@ -87,6 +117,9 @@ T.reveal_type(super_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
 T.reveal_type(generic_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
 T.reveal_type(nested_generic_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
 T.reveal_type(nested_generic_pairs.flatten(1)) # error: Revealed type: `T::Array[T::Array[GenericPair[Integer]]]`
+
+T.reveal_type(nested_flat_type_list.flatten) # error: Revealed type: `T::Array[FlatType]`
+T.reveal_type(flat_type_collections.flatten) # error: Revealed type: `T::Array[FlatType]`
 
 xs.flatten(1 + 1) # error: You must pass an Integer literal to specify a depth
 


### PR DESCRIPTION
`to_ary` recursion for `flatten` should stop when we hit a `NilClass` return type, since this is [how Ruby behaves](https://github.com/ruby/spec/blob/136a6ab8189cd409801a3bc2721e7589b43faf10/core/array/flatten_spec.rb#L114-L117).

### Motivation

According to the [Ruby spec](https://github.com/ruby/spec/blob/136a6ab8189cd409801a3bc2721e7589b43faf10/core/array/flatten_spec.rb#L114-L117), it is valid for `to_ary` to return `nil` which will stop `flatten` descending further into resolving the array type.

Active Record actually uses this, so `ActiveRecord::Core` has a [private implementation of `to_ary` which returns `nil`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/core.rb#L750-L760)
for Active Record model types.

The reason why Active Record does this is explained in more detail [here](https://tenderlovemaking.com/2011/06/28/til-its-ok-to-return-nil-from-to_ary.html).

Since Active Record defines `to_ary` like this, the only way to get proper flatten happening on collections of model instances is to be able to define `to_ary` on model classes to return `NilClass`, which we should use to stop recursing. Otherwise, we either get `T::Array[T.untyped]` since Sorbet does not know the signature of `to_ary` in Active Record, or if we define it as `NilClass`, we get `T::Array[NilClass]`, which is not correct either.

Basically, the moment we find a `NilClass` return type from any `to_ary` call, we should be returning the type we already have.


### Test plan

See included automated tests.

Co-authored-by: "Ryan Wilson-Perkin" <ryan.wilsonperkin@shopify.com>

/cc @kddnewton @ryanwilsonperkin 