### PR TITLE
Add a test case for a compiled/runtime type error mismatch

### DIFF
--- a/test/testdata/compiler/disabled/symbol_type_error.rb
+++ b/test/testdata/compiler/disabled/symbol_type_error.rb
@@ -1,0 +1,10 @@
+# typed: strict
+# frozen_string_literal: true
+# compiled: true
+
+begin
+  foo = T.let(T.unsafe(:foo), Integer)
+rescue TypeError => e
+  # Ensure that the message about symbols matches the runtime
+  puts e.message
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Compiled code prints out values using `to_s` instead of `inspect`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
More tests

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.