### PR TITLE
Pull the container from sorbetruby

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -14,7 +14,7 @@ steps:
         queue: elastic
       plugins:
         - docker#0d9b114b0ca8ec7167787285274aa3842392374d:
-            image: "darkdimius/sorbet-build-image:latest"
+            image: "sorbetruby/sorbet-build-image:latest"
             workdir: /app
             always-pull: true
             init: true


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Move the build container to one that's managed by the `sorbetruby` dockerhub account.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Consolidate build infrastructure.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
