### PR TITLE
Disable always-pull in buildkite config

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -16,7 +16,7 @@ steps:
         - docker#0d9b114b0ca8ec7167787285274aa3842392374d:
             image: "sorbetruby/sorbet-build-image:latest"
             workdir: /app
-            always-pull: true
+            always-pull: false
             init: true
             propagate-environment: true
             environment:


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Docker will limit manifest pulls to [100 request in a 6 hour period](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/). Given that we run two containers for each build, there's a very real chance that we could hit this with `always-pull: true` enabled in pipeline.yaml. The [behavior of `always-pull: true`](https://github.com/buildkite-plugins/docker-buildkite-plugin/blob/9f90d8ef742d9fa1eb3556720e16f2b842ff1cb2/hooks/command#L283-L290) is to unconditionally use `docker pull` when starting the agent, which does seem to correspond to a pull of the manifest.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Keeping our builds running.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
