### PR TITLE
Decrement depth in `flatten` only if flattening arrays

### DIFF
--- a/test/testdata/infer/flatten.rb
+++ b/test/testdata/infer/flatten.rb
@@ -116,7 +116,8 @@ T.reveal_type(integer_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
 T.reveal_type(super_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
 T.reveal_type(generic_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
 T.reveal_type(nested_generic_pairs.flatten) # error: Revealed type: `T::Array[Integer]`
-T.reveal_type(nested_generic_pairs.flatten(1)) # error: Revealed type: `T::Array[T::Array[GenericPair[Integer]]]`
+T.reveal_type(nested_generic_pairs.flatten(1)) # error: Revealed type: `T::Array[GenericPair[Integer]]`
+T.reveal_type(nested_generic_pairs.flatten(2)) # error: Revealed type: `T::Array[Integer]`
 
 T.reveal_type(nested_flat_type_list.flatten) # error: Revealed type: `T::Array[FlatType]`
 T.reveal_type(flat_type_collections.flatten) # error: Revealed type: `T::Array[FlatType]`
@@ -129,3 +130,17 @@ xs.flatten(true)
 
   xs.flatten(1, 1)
 # ^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `Array#flatten`. Expected: `0..1`, got: `2`
+
+or_type_collection = [
+  case rand
+  when (0..0.5)
+    1
+  else
+    ["2"]
+  end
+]
+
+T.reveal_type(or_type_collection) # error: Revealed type: `[T.any(T::Array[String], Integer)] (1-tuple)`
+T.reveal_type(or_type_collection.flatten(1)) # error: Revealed type: `T::Array[T.any(String, Integer)]`
+T.reveal_type(or_type_collection.flatten(2)) # error: Revealed type: `T::Array[T.any(String, Integer)]`
+T.reveal_type(or_type_collection.flatten) # error: Revealed type: `T::Array[T.any(String, Integer)]`


### PR DESCRIPTION
The `recursivelyFlattenArrays` method was unconditionally decrementing the `depth` counter before performing any operations, but that leads to wrong results.

We should only be decrementing the `depth` counter if we are descending into the member type of an array or tuple type.

**Note:** Additionally, there was another problem with the type of the `newDepth` variable and `depth` argument for `typeToAry` method being `int`, which was causing negative wraparounds for large flatten `depth` values, in particular for when the depth parameter was not supplied. I've updated all `depth` variables to use the `int64_t` type.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For example, the fact that we were acting like we were flattening one level when trying to resolve the flatten result for left and right of an `Or` type was producing the wrong result for this:

[→ View on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Ax%20%3D%20%5B%0A%20%20case%20rand%0A%20%20when%20%280..0.5%29%0A%20%20%20%201%0A%20%20else%0A%20%20%20%20%5B%222%22%5D%0A%20%20end%0A%5D.flatten%281%29%0A%0AT.reveal_type%28x%29)
```ruby
[
  case rand
  when (0..0.5)
    1
  else
    ["2"]
  end
].flatten(1)
```

The code is clearly equivalent to `[1].flatten(1) #=> [1]` or `[["2"]].flatten(1) #=> ["2"]`, and, thus should have the type: `T::Array[T.any(Integer, String)]`.

However, since we were doing the decrement eagerly, we were getting `T::Array[T.any(T::Array[String], Integer)]`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
