### PR TITLE
Reimplement `flatMapHack` as `map.flatten(1)`

### DIFF
--- a/test/testdata/infer/flat_map.rb
+++ b/test/testdata/infer/flat_map.rb
@@ -1,23 +1,28 @@
 # typed: true
-T.assert_type!(
-  [1].flat_map {|x| x},
-  T::Array[Integer],
-)
 
-T.assert_type!(
-  [1].flat_map {|x| [x]},
-  T::Array[Integer],
-)
+class ContainerType
+  extend T::Sig
 
-T.assert_type!(
-  [1].flat_map {|x| [[x]]},
-  T::Array[T::Array[Integer]],
-)
+  sig { returns(T::Array[StringPair]) }
+  def to_ary
+    [StringPair.new, StringPair.new]
+  end
+end
 
-T.assert_type!(
-  [1].flat_map {|x| [[[x]]]},
-  T::Array[T::Array[T::Array[Integer]]],
-)
+class StringPair
+  extend T::Sig
+
+  sig { returns(T::Array[String]) }
+  def to_ary
+    ["1", "2"]
+  end
+end
+
+T.reveal_type([1].flat_map {|x| x}) # error: Revealed type: `T::Array[Integer]`
+T.reveal_type([1].flat_map {|x| [x]}) # error: Revealed type: `T::Array[Integer]`
+T.reveal_type([1].flat_map {|x| [[x]]}) # error: Revealed type: `T::Array[[Integer]]`
+T.reveal_type([1].flat_map {|x| [[[x]]]}) # error: Revealed type: `T::Array[[[Integer]]]`
+T.reveal_type([1].flat_map {|x| ContainerType.new }) # error: Revealed type: `T::Array[StringPair]`
 
 class A; end
 class B; end
@@ -27,7 +32,7 @@ class E; end
 class F; end
 class G; end
 
-T.assert_type!(
+T.reveal_type(
   [1].flat_map do |x|
     case rand
     when 0.1
@@ -45,6 +50,5 @@ T.assert_type!(
     else
       G.new
     end
-  end,
-  T::Array[T.any(A, B, C, D, E, F, G)],
-)
+  end
+) # error: Revealed type: `T::Array[T.any(A, B, C, D, E, F, G)]`


### PR DESCRIPTION
Finally `flat_map` respects `to_ary` return type as well.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The current implementation of `flat_map` was using code which was similar to the `flatten` code but it was incomplete since it was not respecting the return type of `to_ary` methods implemented by the types inside arrays.

A better implementation is to implement it as `map.flatten(1)`, that is dispatch `flatten(1)` on the return type of the `map`ping operation, which allows us to reuse the full `Array_flatten` implementation that uses `to_ary` return types for better typing. Moreover, any improvements to `Array_flatten` will be reflected automatically in `flat_map` implementation as well.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

I added a new test case for testing `to_ary` support in `flat_map` and also took the liberty of updating test to use `T.reveal_type` rather than `T.assert_type!` since the error output from the latter is not helpful at all.
