### PR TITLE
Suppress errors::Resolver::RecursiveTypeAlias in autogen

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -572,6 +572,7 @@ int realmain(int argc, char *argv[]) {
             gs->suppressErrorClass(core::errors::Namer::InvalidClassOwner.code);
             gs->suppressErrorClass(core::errors::Namer::ModuleKindRedefinition.code);
             gs->suppressErrorClass(core::errors::Resolver::StubConstant.code);
+            gs->suppressErrorClass(core::errors::Resolver::RecursiveTypeAlias.code);
 
             indexed = pipeline::package(*gs, move(indexed), opts, *workers);
             indexed = move(pipeline::name(*gs, move(indexed), opts, *workers).result());


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Allow autogen to complete even if some `T.type_alias` RHS's don't resolve. Any true error here would be found during real typechecking.

### Motivation
Related to changes in https://github.com/sorbet/sorbet/pull/4721
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
Tested on Stripe's codebase.
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
