### PR TITLE
Allow passing arbitrary command line args in sorbet.run

### DIFF
--- a/emscripten/main.cc
+++ b/emscripten/main.cc
@@ -10,10 +10,50 @@
 
 using namespace std;
 
-extern "C" {
-void EMSCRIPTEN_KEEPALIVE typecheck(const char *rubySrc) {
+namespace {
+
+void typecheckString(const char *rubySrc) {
     const char *argv[] = {"sorbet", "--color=always", "--silence-dev-message", "-e", rubySrc};
-    sorbet::realmain::realmain(size(argv), const_cast<char **>(argv));
+    sorbet::realmain::realmain(size(argv), const_cast<char **>(&argv[0]));
+}
+
+} // namespace
+
+extern "C" {
+void EMSCRIPTEN_KEEPALIVE typecheck(const char *optionsJson) {
+    rapidjson::Document options;
+    options.Parse(optionsJson);
+    if (options.HasParseError()) {
+        fmt::print(stderr, "emscripten/main.cc: Failed to parse JSON from JavaScript: '{}'\n", optionsJson);
+        fmt::print(stderr, "emscripten/main.cc: Falling back to assuming input was Ruby source.\n", optionsJson);
+        return typecheckString(optionsJson);
+    }
+
+    if (!options.IsArray()) {
+        fmt::print(stderr, "JSON from JavaScript was not an array: '{}'\n", optionsJson);
+        fmt::print(stderr, "emscripten/main.cc: Falling back to assuming input was Ruby source.\n", optionsJson);
+        return typecheckString(optionsJson);
+    }
+
+    vector<string> argStrings;
+    for (rapidjson::SizeType i = 0; i < options.Size(); i++) {
+        const auto &argI = options[i];
+        if (!argI.IsString()) {
+            fmt::print(stderr, "JSON from JavaScript was not a String at element {} of array: '{}'\n", i, optionsJson);
+            fmt::print(stderr, "emscripten/main.cc: Falling back to assuming input was Ruby source.\n", optionsJson);
+            return typecheckString(optionsJson);
+        }
+
+        argStrings.push_back(argI.GetString());
+    }
+
+    vector<char *> argCharStars;
+    argCharStars.reserve(argStrings.size());
+    for (size_t i = 0; i < argStrings.size(); ++i) {
+        argCharStars.push_back(const_cast<char *>(argStrings[i].c_str()));
+    }
+
+    sorbet::realmain::realmain(argCharStars.size(), const_cast<char **>(&argCharStars[0]));
 }
 
 void EMSCRIPTEN_KEEPALIVE lsp(void (*respond)(const char *), const char *message) {


### PR DESCRIPTION
This does not attempt to pass any of those options to LSP at the moment.
That can cause surprises, for example, if you pass a flag that affects
type checking (like to enable requires ancestor) or that affects LSP,
those flags won't have an effect.

(This is because of an annoying implementation detail, which is that we
do not actually pretend to launch Sorbet with command line arguments in
service of LSP in the browser, preferring instead to use the LSP wrapper
that we've built for running our assorted test harnesses, all of which
assume that you're passing in a global state and parsed set of args.
That's not to say it would be impossible to invoke the arg parsing logic
and pass them in, it's just work I don't want to do right now.)

This change must be merged and deployed to sorbet.run before the
corresponding change upstream. This PR implements a pseudo-backwards
incompatible change: it changes the meaning of the `typecheck` function
from accepting a Ruby program as a string to accepting a stringified
JSON array of command line args.

In the interim period where the WASM payload has been updated on
sorbet.run but sorbet.run itself hasn't been updated, a warning will be
printed in the `#output` div on the page.

We will follow up quickly with a change to update the client to know
to send JSON instead of a Ruby program, so that warning should only show
for a few moments.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I want args in sorbet.run

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I've tested this against a local version of sorbet.run, to:

- test that the warning message is printed if the client is not yet updated
- test that the args are parsed and passed along if the client knows how to do
  that

You can see the sorbet.run PR here:

<https://github.com/sorbet/sorbet.run/pull/95>