### PR TITLE
Limit flatten search depth

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3035,6 +3035,7 @@ public:
         ENFORCE(!ap->targs.empty());
         element = ap->targs.front();
 
+        int64_t MAX_DEPTH = 100;
         int64_t depth;
         if (args.args.size() == 1) {
             auto argTyp = args.args[0]->type;
@@ -3057,10 +3058,10 @@ public:
                 depth = lt.asInteger();
             } else {
                 // Negative values behave like no depth was given
-                depth = INT64_MAX;
+                depth = MAX_DEPTH;
             }
         } else if (args.args.size() == 0) {
-            depth = INT64_MAX;
+            depth = MAX_DEPTH;
         } else {
             // If our arity is off, then calls.cc will report an error due to mismatch with the RBI elsewhere, so we
             // don't need to do anything special here

--- a/test/testdata/infer/flatten.rb
+++ b/test/testdata/infer/flatten.rb
@@ -78,6 +78,33 @@ class FlatTypeCollection
   end
 end
 
+class CircularTypeOne
+  extend T::Sig
+
+  sig { returns(T::Array[CircularTypeTwo])}
+  def to_ary
+    []
+  end
+end
+
+class CircularTypeTwo
+  extend T::Sig
+
+  sig { returns(T::Array[CircularTypeOne])}
+  def to_ary
+    []
+  end
+end
+
+class SelfReferentialType
+  extend T::Sig
+
+  sig { returns(T::Array[SelfReferentialType])}
+  def to_ary
+    []
+  end
+end
+
 integer_pairs = T.let([IntegerPair.new(1, 2), IntegerPair.new(3, 4)], T::Array[IntegerPair])
 super_pairs = T.let([SuperPair.new(1, 2)], T::Array[SuperPair])
 
@@ -96,6 +123,9 @@ flat_type_collections = T.let(
   [FlatTypeCollection.new, FlatTypeCollection.new, FlatTypeCollection.new],
   T::Array[FlatTypeCollection]
 )
+
+circular_one_collection = T.let([], T::Array[CircularTypeOne])
+self_referential_collection =  T.let([], T::Array[SelfReferentialType])
 
 T.reveal_type(flat_tuple.flatten) # error: Revealed type: `T::Array[Integer]`
 T.reveal_type(nested_tuple.flatten) # error: Revealed type: `T::Array[Integer]`
@@ -121,6 +151,9 @@ T.reveal_type(nested_generic_pairs.flatten(2)) # error: Revealed type: `T::Array
 
 T.reveal_type(nested_flat_type_list.flatten) # error: Revealed type: `T::Array[FlatType]`
 T.reveal_type(flat_type_collections.flatten) # error: Revealed type: `T::Array[FlatType]`
+
+T.reveal_type(circular_one_collection.flatten) # error: Revealed type: `T::Array[CircularTypeOne]`
+T.reveal_type(self_referential_collection.flatten) # error: Revealed type: `T::Array[SelfReferentialType]`
 
 xs.flatten(1 + 1) # error: You must pass an Integer literal to specify a depth
 


### PR DESCRIPTION
Currently, if Sorbet encounters a recursive loop between types during its lookup of `to_ary` return types, it enters an infinite loop (well, not quite infinite but `INT64_MAX` sized) and segfaults due to a stack overflow.

However, most `flatten` calls in the wild will not be doing flattening that deep and we find it perfectly reasonable to limit the max flatten search depth to a number like `100`.

This allows Sorbet to resolve `flatten` calls to some type, which would always be correct for self-referencing types and might be false for circular references (for example, two-cycles of types would alternate between the two types at every depth level, so stopping at a random depth could give the wrong result). In either case, since we don't expect any real world code to be doing more than 100 levels of flattening, the behaviour should be correct against such programs.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #4707 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
