### PR TITLE
Remove redundant declare_file from build-ruby.bzl

### DIFF
--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -390,8 +390,6 @@ def _ruby_archive_impl(ctx):
         )),
     )
 
-    archive = ctx.actions.declare_file("ruby.tar.gz")
-
     return [DefaultInfo(files = depset([archive]))]
 
 _ruby_archive = rule(


### PR DESCRIPTION
Happened to spot that we have a redundant `declare_file("ruby.tar.gz")` in `build-ruby.bzl` as I was grepping around for other things.


### Motivation
Just tidiness. As far as we know this wasn't hurting anything.


### Test plan
This rule should be exercised in existing compiler CI.