### PR TITLE
use inspect to print values for type errors rather than to_s

### DIFF
--- a/compiler/IREmitter/Payload/vm-payload.c
+++ b/compiler/IREmitter/Payload/vm-payload.c
@@ -124,7 +124,7 @@ __attribute__((__cold__, __noreturn__)) void sorbet_cast_failure(VALUE value, ch
     // https://github.com/sorbet/sorbet/blob/b045fb1ba12756c3760fe516dc315580d93f3621/gems/sorbet-runtime/lib/types/types/base.rb#L105
     //
     // e.g. we need to teach the `got` part to do `T.class_of`
-    rb_raise(rb_eTypeError, "%s: Expected type %s, got type %s with value %" PRIsVALUE, castMethod, type,
+    rb_raise(rb_eTypeError, "%s: Expected type %s, got type %s with value %+" PRIsVALUE, castMethod, type,
              rb_obj_classname(value), value);
 }
 

--- a/test/testdata/compiler/symbol_type_error.rb
+++ b/test/testdata/compiler/symbol_type_error.rb
@@ -6,5 +6,7 @@ begin
   foo = T.let(T.unsafe(:foo), Integer)
 rescue TypeError => e
   # Ensure that the message about symbols matches the runtime
-  puts e.message
+  # The runtime adds a `Caller:` line; this test just cares about whether we
+  # print the value in the message identically to the runtime.
+  puts e.message.split("\n")[0]
 end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

More identical behavior between the runtime and the compiler.  The `inspect` call is magically introduced with the `+` format modifier in `sorbet_cast_failure`.

I had to modify the behavior of the test slightly, since I didn't want to deal with calling `caller_locations` from inside the VM.  I think it's OK to not match the `Caller: ` line here, but I am open to other opinions.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
