### PR TITLE
add an intrinsic for Array#length

### DIFF
--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -895,6 +895,7 @@ static const vector<CallCMethod> knownCMethodsInstance{
     {core::Symbols::Array(), "compact!", CMethod{"sorbet_rb_array_compact_bang"}},
     {core::Symbols::Array(), "to_h", CMethod{"sorbet_rb_array_to_h", core::Symbols::Hash()}},
     {core::Symbols::Array(), "size", CMethod{"sorbet_rb_array_len", core::Symbols::Integer()}},
+    {core::Symbols::Array(), "length", CMethod{"sorbet_rb_array_len", core::Symbols::Integer()}},
     {core::Symbols::Hash(), "[]", CMethod{"sorbet_rb_hash_square_br"}},
     {core::Symbols::Hash(), "[]=", CMethod{"sorbet_rb_hash_square_br_eq"}},
     {core::Symbols::Hash(), "each_pair", CMethod{"sorbet_rb_hash_each_pair", core::Symbols::Enumerator()},

--- a/test/testdata/compiler/intrinsics/array_size.rb
+++ b/test/testdata/compiler/intrinsics/array_size.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+extend T::Sig
+
+sig {params(ary: T::Array[Integer]).returns(Integer)}
+def ary_length(ary)
+  ary.length
+end
+
+# INITIAL-LABEL: "func_Object#10ary_length"
+# INITIAL: call i64 @sorbet_rb_array_len
+# INITIAL{LITERAL}: }
+
+sig {params(ary: T::Array[Integer]).returns(Integer)}
+def ary_size(ary)
+  ary.size
+end
+
+# INITIAL-LABEL: "func_Object#8ary_size"
+# INITIAL: call i64 @sorbet_rb_array_len
+# INITIAL{LITERAL}: }
+
+p ary_length([1, 2, 3])
+p ary_size([1, 2, 3])
+p ary_length([])
+p ary_size([])


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We handled `Array#size`, but not `Array#length`.  Let's fix that, and add a test so we don't regress.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
