### PR TITLE
Only sync back files that were compiled with run_sorbet.sh

### DIFF
--- a/test/run_sorbet.sh
+++ b/test/run_sorbet.sh
@@ -127,7 +127,10 @@ if "${command[@]}"; then
 
   if [[ -n "${EMIT_SYNCBACK:-}" && -n "$explicit_llvmir" ]]; then
     echo '### BEGIN SYNCBACK ###'
-    find "$orig_llvmir" -name '*.ll'
+    for source in "${rb_files[@]}"; do
+      # compgen returns non-zero when the glob doesn't match
+      compgen -G "${orig_llvmir}/${source}.*ll" || true
+    done
     echo '### END SYNCBACK ###'
   fi
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Currently all llvm outputs are sync'd back when using `tools/scripts/remote-script`. This PR only syncs the ones produced by the files given to `run_sorbet.sh`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.