### PR TITLE
Refine error message when constant names are the same

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/base.rb
+++ b/gems/sorbet-runtime/lib/types/types/base.rb
@@ -133,7 +133,7 @@ module T::Types
       if valid?(obj)
         nil
       else
-        "Expected type #{self.name}, got #{describe_obj(obj)}"
+        error_message(obj)
       end
     end
 
@@ -141,8 +141,12 @@ module T::Types
       if recursively_valid?(obj)
         nil
       else
-        "Expected type #{self.name}, got #{describe_obj(obj)}"
+        error_message(obj)
       end
+    end
+
+    private def error_message(obj)
+      "Expected type #{self.name}, got #{describe_obj(obj)}"
     end
 
     def validate!(obj)

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -34,6 +34,23 @@ module T::Types
       end
     end
 
+    # overrides Base
+    private def error_message(obj)
+      error_message = super(obj)
+      actual_name = obj.class.name
+
+      return error_message unless name == actual_name
+
+      <<~MSG.strip
+        #{error_message}
+
+        The expected type and received object type have the same name but refer to different constants.
+        Expected type is #{name} with object id #{@raw_type.__id__}, but received type is #{actual_name} with object id #{obj.class.__id__}.
+
+        There might be a constant reloading problem in your application.
+      MSG
+    end
+
     def to_nilable
       @nilable ||= T::Types::Union.new([self, T::Utils::Nilable::NIL_TYPE])
     end


### PR DESCRIPTION
I pulled the error message construction into a private method in `T::Types::Base` so that `T::Types::Simple` can override it and refine the error message with an extra notice if the constant names are the same.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
If we have the name of the expected type and the name of the object class the same but referring to different constants, the default error message ends up being confusing. In those circumstances, it would be helpful to show that the constants refer to different objects even though they have the same name and that this is probably a code reloading issue.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
