### PR TITLE
make checking during intrinsic generation stronger

### DIFF
--- a/compiler/IREmitter/Payload/PayloadIntrinsics.c
+++ b/compiler/IREmitter/Payload/PayloadIntrinsics.c
@@ -499,6 +499,17 @@ VALUE sorbet_int_rb_int_powm(VALUE recv, ID fun, int argc, VALUE *const restrict
     return rb_int_powm(argc, args, recv);
 }
 
+// Regexp#encoding
+// String#encoding
+// Calling convention: 0
+extern VALUE rb_obj_encoding(VALUE obj);
+
+VALUE sorbet_int_rb_obj_encoding(VALUE recv, ID fun, int argc, VALUE *const restrict args, BlockFFIType blk,
+                                 VALUE closure) {
+    rb_check_arity(argc, 0, 0);
+    return rb_obj_encoding(recv);
+}
+
 // String#*
 // Calling convention: 1
 extern VALUE rb_str_times(VALUE obj, VALUE arg_0);

--- a/compiler/IREmitter/WrappedIntrinsics.h
+++ b/compiler/IREmitter/WrappedIntrinsics.h
@@ -55,6 +55,8 @@
     {core::Symbols::Integer(), "lcm", CMethod{"sorbet_int_rb_lcm"}},
     {core::Symbols::Integer(), "odd?", CMethod{"sorbet_int_rb_int_odd_p"}},
     {core::Symbols::Integer(), "pow", CMethod{"sorbet_int_rb_int_powm"}},
+    {core::Symbols::Regexp(), "encoding", CMethod{"sorbet_int_rb_obj_encoding"}},
+    {core::Symbols::String(), "encoding", CMethod{"sorbet_int_rb_obj_encoding"}},
     {core::Symbols::String(), "*", CMethod{"sorbet_int_rb_str_times"}},
     {core::Symbols::String(), "+", CMethod{"sorbet_int_rb_str_plus"}},
     {core::Symbols::String(), "<<", CMethod{"sorbet_int_rb_str_concat"}},


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I ran into some debugging when trying to implement #4742, because the list of intrinsics attached to a C function isn't ordered in any way, but we only make decisions (for complicated reasons) based on the first element of that list.  Depending on the vagaries of Ruby hashing etc., you might run into a case where you specified a method should be patched/wrapped/intrinsified, but some similar method shares the underlying C implementation and winds up first in the list.  This latter method isn't specified in our `METHOD_WHITELIST`, and so we don't produce any additional output, leading to some head-scratching.

This PR attempts to address that and force you to explicitly list out all Ruby method names associated with a given C function.  Again, due to the vagaries of the Ruby implementation, this doesn't change much, but I hope it saves somebody else from running into the same problems I did.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
