### PR TITLE
Add `T.untyped` detection during inference

### DIFF
--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -40,6 +40,7 @@ constexpr ErrorClass GenericArgumentKeywordArgs{7032, StrictLevel::True};
 constexpr ErrorClass KeywordArgHashWithoutSplat{7033, StrictLevel::True};
 constexpr ErrorClass UnnecessarySafeNavigation{7034, StrictLevel::True};
 constexpr ErrorClass TakesNoBlock{7035, StrictLevel::True};
+constexpr ErrorClass CallOnUntyped{7036, StrictLevel::Strict};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 } // namespace sorbet::core::errors::Infer
 #endif

--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -130,7 +130,11 @@ void ErrorReporter::pushDiagnostics(u4 epoch, core::FileRef file, const vector<u
             tags.push_back(DiagnosticTag::Unnecessary);
             diagnostic->tags = move(tags);
         }
-        diagnostic->severity = DiagnosticSeverity::Error;
+        if (error->what.code == sorbet::core::errors::Infer::CallOnUntyped.code) {
+            diagnostic->severity = DiagnosticSeverity::Warning;
+        } else {
+            diagnostic->severity = DiagnosticSeverity::Error;
+        }
 
         if (!error->autocorrects.empty()) {
             diagnostic->message += " (fix available)";

--- a/test/testdata/compiler/struct_from_hash.rb
+++ b/test/testdata/compiler/struct_from_hash.rb
@@ -12,7 +12,7 @@ class MyStruct < T::Struct
   sig {override.params(struct: T::Hash[String, T.untyped]).returns(MyStruct)}
   def self.from_hash(struct)
     if struct.key?('hash_by')
-      struct = struct.merge({'hash_by' => struct['hash_by'].to_sym})
+      struct = struct.merge({'hash_by' => T.unsafe(struct['hash_by']).to_sym})
     end
     super(struct)
   end


### PR DESCRIPTION
### Motivation
Experimental branch for `T.untyped` warnings


### Test plan
See included automated tests.
