### PR TITLE
delete unneeded CompilerState variable in finishTypecheckFile

### DIFF
--- a/plugin_injector/plugin_injector.cc
+++ b/plugin_injector/plugin_injector.cc
@@ -305,7 +305,6 @@ public:
 
         unique_ptr<llvm::Module> module = move(threadState->combinedModule);
         unique_ptr<llvm::DIBuilder> debug = move(threadState->debugInfo);
-        llvm::DICompileUnit *compileUnit = threadState->compileUnit;
         threadState->compileUnit = nullptr;
 
         // It is possible, though unusual, to never have typecheck() called.
@@ -339,7 +338,6 @@ public:
 
         debug->finalize();
 
-        compiler::CompilerState cs(gs, lctx, module.get(), debug.get(), compileUnit, f, nullptr, nullptr);
         string fileName = objectFileName(gs, f);
         ensureOutputDir(compiledOutputDir.value(), fileName);
         if (irOutputDir.has_value()) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This `CompilerState` variable was unused, and deleting this would enable strengthening some invariants on `CompilerState`'s constructor (e.g. the passed-in basic blocks must always be non-`nullptr`).

`compileUnit` is deleted because it is now unused.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
