### PR TITLE
add an intrinsic for unary plus on strings

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -159,6 +159,7 @@ SORBET_ALIVE(void, sorbet_vm_define_method,
              (VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp, rb_iseq_t *iseq, bool isSelf));
 
 SORBET_ALIVE(VALUE, sorbet_vm_fstring_new, (const char *ptr, long len));
+SORBET_ALIVE(VALUE, sorbet_vm_str_uplus, (VALUE str));
 
 extern void sorbet_throwReturn(rb_execution_context_t *ec, VALUE retval) __attribute__((noreturn));
 KEEP_ALIVE(sorbet_throwReturn);
@@ -1787,6 +1788,12 @@ VALUE sorbet_selfNew(VALUE recv, ID fun, int argc, VALUE *argv, BlockFFIType blk
     rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
     VALUE obj = argv[0];
     return rb_funcallv(obj, rb_intern("new"), argc - 1, argv + 1);
+}
+
+SORBET_INLINE
+VALUE sorbet_int_str_uplus(VALUE recv, ID fun, int argc, VALUE *argv, BlockFFIType blk, VALUE closure) {
+    rb_check_arity(argc, 0, 0);
+    return sorbet_vm_str_uplus(recv);
 }
 
 // ****

--- a/compiler/IREmitter/Payload/patches/string.c
+++ b/compiler/IREmitter/Payload/patches/string.c
@@ -4,3 +4,7 @@ VALUE sorbet_vm_fstring_new(const char *ptr, long len) {
     struct RString fake_str;
     return register_fstring(setup_fake_str(&fake_str, ptr, len, ENCINDEX_UTF_8));
 }
+
+VALUE sorbet_vm_str_uplus(VALUE str) {
+    return str_uplus(str);
+}

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -924,6 +924,7 @@ static const vector<CallCMethod> knownCMethodsInstance{
     {core::Symbols::Integer(), "!=", CMethod{"sorbet_rb_int_neq"}},
     {core::Symbols::Integer(), "times", CMethod{"sorbet_rb_int_dotimes", core::Symbols::Enumerator()},
      CMethod{"sorbet_rb_int_dotimes_withBlock", core::Symbols::Integer()}},
+    {core::Symbols::String(), "+@", CMethod{"sorbet_int_str_uplus", core::Symbols::String()}},
     {core::Symbols::Symbol(), "==", CMethod{"sorbet_rb_sym_equal"}},
     {core::Symbols::Symbol(), "===", CMethod{"sorbet_rb_sym_equal"}},
     {core::Symbols::Kernel(), "is_a?", CMethod{"sorbet_rb_obj_is_kind_of"}, nullopt, {"rb_obj_is_kind_of"}},

--- a/test/testdata/compiler/intrinsics/str_uplus.rb
+++ b/test/testdata/compiler/intrinsics/str_uplus.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL OPT
+
+extend T::Sig
+
+sig {returns(String)}
+def str_uplus
+  s = +''
+  s
+end
+
+# INITIAL-LABEL: @"func_Object#9str_uplus"
+# INITIAL: call i64 @sorbet_int_str_uplus
+# This is sort of a hack to see if we eliminate the exit type test, which we should.
+# INITIAL: typeTestSuccess:
+# INITIAL{LITERAL}: }
+
+# OPT-LABEL: @"func_Object#9str_uplus"
+# OPT: call i64 @sorbet_vm_str_uplus
+# OPT-NOT: typeTestSuccess:
+# OPT{LITERAL}: }
+
+p str_uplus()


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This comes up in (at least) logging code from time to time.  We can a) inline the call and b) not throw away type information about the duplicated string.  The latter is especially important for letting other, later calls on the string be optimized.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
