### PR TITLE
Remove unused `foreign_hint_only` from prop modifiers

### DIFF
--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -267,18 +267,10 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
     it 'disallows non-proc arguments' do
       T::Configuration.expects(:soft_assert_handler).with do |msg, _|
         msg.include?('Please use a Proc that returns a model class instead')
-      end.times(3)
+      end.times(1)
 
       Class.new(TestForeignProps) do
         prop :foreign3, String, foreign: MyTestModel
-      end
-
-      Class.new(TestForeignProps) do
-        prop :foreign3, String, foreign_hint_only: MyTestModel
-      end
-
-      Class.new(TestForeignProps) do
-        prop :foreign3, String, foreign_hint_only: [MyTestModel]
       end
     end
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This PR removes all references to `foreign_hint_only` since no models use it anymore.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Deprecation of foreign loaders

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
- Existing automated tests
- Tested in pay-server. See https://go/builds/bui_KTXk6Ax9ZDH8uQ
