### PR TITLE
Fix errors in `T.bind` example

### DIFF
--- a/website/docs/procs.md
+++ b/website/docs/procs.md
@@ -221,7 +221,7 @@ Like with `T.cast`, the full range of Sorbet types can be used in the `T.bind`
 annotation. For example, here is a more complicated example that uses `T.any`
 with `T.bind`:
 
-<a href="https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20Concern%0A%20%20def%20included%28%26block%29%0A%20%20end%0Aend%0A%0Amodule%20Taggable%0A%20%20extend%20Concern%0A%0A%20%20included%20do%0A%20%20%20%20T.bind%28self%2C%20T.any%28Post%2C%20Article%29%29%0A%0A%20%20%20%20create_tag!%0A%20%20end%0Aend%0A%0Aclass%20Post%0A%20%20include%20Taggable%0A%0A%20%20def%20create_tag!%0A%20%20end%0Aend%0A%0Aclass%20Article%0A%20%20include%20Taggable%0Aend">
+<a href="https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20Callbacks%0A%20%20def%20included%28%26block%29%0A%20%20end%0Aend%0A%0Amodule%20Taggable%0A%20%20extend%20Callbacks%0A%0A%20%20included%20do%0A%20%20%20%20T.bind%28self%2C%20T.any%28Post%2C%20Article%29%29%0A%0A%20%20%20%20create_tag!%0A%20%20end%0Aend%0A%0Aclass%20Post%0A%20%20include%20Taggable%0A%0A%20%20def%20create_tag!%0A%20%20end%0Aend%0A%0Aclass%20Article%0A%20%20include%20Taggable%0Aend">
   → View on sorbet.run
 </a>
 


### PR DESCRIPTION
Fixes some errors in the complex `T.bind` example added in https://github.com/sorbet/sorbet/pull/4170. cc @vinistock 

[Before](https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20Concern%0A%20%20def%20included%28%26block%29%0A%20%20end%0Aend%0A%0Amodule%20Taggeable%0A%20%20extend%20Concern%0A%0A%20%20included%20do%0A%20%20%20%20T.bind%28self%2C%20T.any%28Post%2C%20Article%29%29%0A%0A%20%20%20%20create_tag!%0A%20%20end%0Aend%0A%0Aclass%20Post%0A%20%20include%20Taggeable%0A%0A%20%20def%20self.create_tag!%0A%20%20end%0Aend%0A%0Aclass%20Article%0A%20%20include%20Taggeable%0Aend) vs [After](https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20Callbacks%0A%20%20def%20included%28%26block%29%0A%20%20end%0Aend%0A%0Amodule%20Taggable%0A%20%20extend%20Callbacks%0A%0A%20%20included%20do%0A%20%20%20%20T.bind%28self%2C%20T.any%28Post%2C%20Article%29%29%0A%0A%20%20%20%20create_tag!%0A%20%20end%0Aend%0A%0Aclass%20Post%0A%20%20include%20Taggable%0A%0A%20%20def%20create_tag!%0A%20%20end%0Aend%0A%0Aclass%20Article%0A%20%20include%20Taggable%0Aend)

- Changed `included` example to `before_create` so it's more similar to the previous example
- Made `create_tag` an instance method, otherwise both classes error so it's unclear what the example is showing
- Fixed typo, `Taggeable` should be `Taggable`