### PR TITLE
correctly indicate whether CMethod intrinsics handle blocks

### DIFF
--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -160,8 +160,10 @@ private:
 public:
     CallCMethod(core::ClassOrModuleRef rubyClass, string_view rubyMethod, CMethod cMethod,
                 optional<CMethod> cMethodWithBlock = nullopt, vector<string> expectedRubyCFuncs = {})
-        : SymbolBasedIntrinsicMethod(Intrinsics::HandleBlock::Handled), rubyClass(rubyClass), rubyMethod(rubyMethod),
-          cMethod(cMethod), cMethodWithBlock(cMethodWithBlock), expectedRubyCFuncs(expectedRubyCFuncs){};
+        : SymbolBasedIntrinsicMethod(cMethodWithBlock.has_value() ? Intrinsics::HandleBlock::Handled
+                                                                  : Intrinsics::HandleBlock::Unhandled),
+          rubyClass(rubyClass), rubyMethod(rubyMethod), cMethod(cMethod), cMethodWithBlock(cMethodWithBlock),
+          expectedRubyCFuncs(expectedRubyCFuncs){};
 
     virtual llvm::Value *makeCall(MethodCallContext &mcctx) const override {
         auto &cs = mcctx.cs;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`CallCMethod` for symbol-based intrinsics signals that it always handles blocks.  This is not necessarily true, especially for auto-generated wrapped intrinsics that never handle blocks.  Let's be more specific in indicating whether blocks can be handled.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
