### PR TITLE
Update casting methods (`T.let`, `T.cast`, etc) to take the type as a block

### DIFF
--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -127,10 +127,10 @@ module T
   # exception at runtime if the value doesn't match the type.
   #
   # Compared to `T.let`, `T.cast` is _trusted_ by static system.
-  def self.cast(value, type, checked: true)
+  def self.cast(value, type=nil, checked: true, &blk)
     return value unless checked
 
-    Private::Casts.cast(value, type, cast_method: "T.cast")
+    Private::Casts.cast(value, type || blk.call, cast_method: "T.cast", &blk)
   end
 
   # Tells the typechecker to declare a variable of type `type`. Use
@@ -142,10 +142,10 @@ module T
   #
   # If `checked` is true, raises an exception at runtime if the value
   # doesn't match the type.
-  def self.let(value, type, checked: true)
+  def self.let(value, type=nil, checked: true, &blk)
     return value unless checked
 
-    Private::Casts.cast(value, type, cast_method: "T.let")
+    Private::Casts.cast(value, type || blk.call, cast_method: "T.let", &blk)
   end
 
   # Tells the type checker to treat `self` in the current block as `type`.
@@ -161,20 +161,20 @@ module T
   #
   # If `checked` is true, raises an exception at runtime if the value
   # doesn't match the type (this is the default).
-  def self.bind(value, type, checked: true)
+  def self.bind(value, type=nil, checked: true, &blk)
     return value unless checked
 
-    Private::Casts.cast(value, type, cast_method: "T.bind")
+    Private::Casts.cast(value, type || blk.call, cast_method: "T.bind", &blk)
   end
 
   # Tells the typechecker to ensure that `value` is of type `type` (if not, the typechecker will
   # fail). Use this for debugging typechecking errors, or to ensure that type information is
   # statically known and being checked appropriately. If `checked` is true, raises an exception at
   # runtime if the value doesn't match the type.
-  def self.assert_type!(value, type, checked: true)
+  def self.assert_type!(value, type=nil, checked: true, &blk)
     return value unless checked
 
-    Private::Casts.cast(value, type, cast_method: "T.assert_type!")
+    Private::Casts.cast(value, type || blk.call, cast_method: "T.assert_type!", &blk)
   end
 
   # For the static type checker, strips all type information from a value

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -31,8 +31,8 @@ module T::Utils
   # type `type`, including recursively through collections. Note that
   # in some cases this runtime check can be very expensive, especially
   # with large collections of objects.
-  def self.check_type_recursive!(value, type)
-    T::Private::Casts.cast_recursive(value, type, cast_method: "T.check_type_recursive!")
+  def self.check_type_recursive!(value, type=nil, &blk)
+    T::Private::Casts.cast_recursive(value, type || blk.call, cast_method: "T.check_type_recursive!")
   end
 
   # Returns the set of all methods (public, protected, private) defined on a module or its

--- a/gems/sorbet-runtime/test/types/casts.rb
+++ b/gems/sorbet-runtime/test/types/casts.rb
@@ -66,5 +66,71 @@ module Opus::Types::Test
         end
       end
     end
+
+    describe "with blocks" do
+      %i[cast assert_type!].each do |cast_name|
+        method = T.method(cast_name)
+
+        describe "T.#{cast_name}" do
+          it 'allows correct casts' do
+            assert_equal(:foo, method.call(:foo) { Symbol })
+            assert_equal(:foo, method.call(:foo) { T.any(Symbol, Integer) })
+            assert_equal(:foo, method.call(:foo) { T.untyped })
+          end
+
+          it 'rejects invalid casts' do
+            assert_raises(TypeError) do
+              method.call(:foo) { Integer }
+            end
+
+            assert_raises(TypeError) do
+              method.call(:foo) { T.any(String, Integer) }
+            end
+
+            assert_raises(TypeError) do
+              method.call(:foo) { T.noreturn }
+            end
+          end
+
+          it 'allows invalid casts with checked: false' do
+            assert_equal(:foo, method.call(:foo, checked: false) { Integer })
+            assert_equal(:foo, method.call(:foo, checked: false) { T.any(String, Integer) })
+            assert_equal(:foo, method.call(:foo, checked: false) { T.noreturn })
+          end
+
+          it 'has a good error message' do
+            lno = nil
+            ex = assert_raises(TypeError) do
+              lno = __LINE__; method.call(:foo) { T.any(String, Integer) }
+            end
+            assert_match(/T.#{cast_name}: /, ex.message)
+            assert_match(/type T.any\(Integer, String\)/, ex.message)
+            assert_match(/\nCaller: #{__FILE__}:#{lno}/, ex.message)
+          end
+        end
+      end
+
+      describe "T.assert_type with collections" do
+        it "does not do recursive type-checking of arrays with `assert_type!`" do
+          assert_equal([1], T.assert_type!([1]) { T::Array[String] })
+        end
+
+        it "does do recursive type-checking of arrays with `check_type_recursive!`" do
+          assert_raises(TypeError) do
+            T::Utils.check_type_recursive!([1]) { T::Array[String] }
+          end
+        end
+
+        it "does not do recursive type-checking of hashes with `assert_type!`" do
+          assert_equal({x: "y"}, T.assert_type!({x: "y"}) { T::Hash[Symbol, Integer] })
+        end
+
+        it "does do recursive type-checking of arrays with `check_type_recursive!`" do
+          assert_raises(TypeError) do
+            T::Utils.check_type_recursive!({x: "y"}) { T::Hash[Symbol, Integer] }
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
NOTE: I know this would take some updates to the static type checking also but wanted to get a temperature check on this approach first.

### Motivation

When debugging a performance issue we found that sometimes simply initializing types is slow. This is especially true to `T.any` (and thus `T.nilable` since it's an alias for `T.any(NilClass, ...)`). This means if you have a `T.let` on a hot path, there's no way to not pay a performance penalty even if you make an attempt with `checked: false`.

Here are some benchmarks

```ruby
Benchmark.bm do |x|
  x.report('any                 ') { 10000.times { T.let(1, T.any(Integer, String), checked: false) } }
  x.report('nilable any         ') { 10000.times { T.let(1, T.nilable(T.any(Integer, String)), checked: false) } }
  x.report('complex type        ') { 10000.times { T.let(1..1, T::Range[Integer], checked: false) } }
  x.report('nilable complex type') { 10000.times { T.let(1..1, T.nilable(T::Range[Integer]), checked: false) } }
  x.report('simple type         ') { 10000.times { T.let(1, Integer, checked: false) } }
  x.report('nilable simple type ') { 10000.times { T.let(1, T.nilable(Integer), checked: false) } }
end

       user     system      total        real
any                   0.044301   0.000395   0.044696 (  0.050076)
nilable any           0.064349   0.000205   0.064554 (  0.064723)
complex type          0.005004   0.000049   0.005053 (  0.005101)
nilable complex type  0.035156   0.000288   0.035444 (  0.035752)
simple type           0.001076   0.000019   0.001095 (  0.001120)
nilable simple type   0.007957   0.000043   0.008000 (  0.008037)
```

I've explicitly disabled type checking in these benchmarks sure that simply initializing the types is the bottleneck

This PR updates `T.let` to take a block (similar to `T.type_alias`) and only evaluates the block if we actually want to type check. Here are the benchmarks after that PR when passing the types via block:
```
Benchmark.bm do |x|
  x.report('any                 ') { 10000.times { T.let(1, checked: false) { T.any(Integer, String) } } }
  x.report('nilable any         ') { 10000.times { T.let(1, checked: false) { T.nilable(T.any(Integer, String)) } } }
  x.report('complex type        ') { 10000.times { T.let(1..1, checked: false) { T::Range[Integer] } } }
  x.report('nilable complex type') { 10000.times { T.let(1..1, checked: false) { T.nilable(T::Range[Integer]) } } }
  x.report('simple type         ') { 10000.times { T.let(1, checked: false) { Integer } } }
  x.report('nilable simple type ') { 10000.times { T.let(1, checked: false) { T.nilable(Integer) } } }
end

       user     system      total        real
any                   0.001261   0.000065   0.001326 (  0.001369)
nilable any           0.001186   0.000002   0.001188 (  0.001190)
complex type          0.001253   0.000041   0.001294 (  0.001339)
nilable complex type  0.001200   0.000002   0.001202 (  0.001202)
simple type           0.001176   0.000002   0.001178 (  0.001179)
nilable simple type   0.001234   0.000007   0.001241 (  0.001272)
```

### Test plan

See included automated tests.
