### PR TITLE
Better error message for sealed with grandchild

### DIFF
--- a/gems/sorbet-runtime/test/types/fixtures/sealed_module/grandparent__1.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/sealed_module/grandparent__1.rb
@@ -1,0 +1,7 @@
+class GrandParent
+  extend T::Helpers
+  sealed!
+end
+
+class Parent < GrandParent
+end

--- a/gems/sorbet-runtime/test/types/fixtures/sealed_module/grandparent__2.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/sealed_module/grandparent__2.rb
@@ -1,0 +1,2 @@
+class Child < Parent
+end

--- a/gems/sorbet-runtime/test/types/sealed_module.rb
+++ b/gems/sorbet-runtime/test/types/sealed_module.rb
@@ -158,6 +158,15 @@ class Opus::Types::Test::SealedModuleTest < Critic::Unit::UnitTest
     assert_match(/was declared sealed and can only be inherited in/, err.message)
   end
 
+  it "errors when grandparent is sealed, and grand child is in another file" do
+    require_relative './fixtures/sealed_module/grandparent__1'
+
+    err = assert_raises(RuntimeError) do
+      require_relative './fixtures/sealed_module/grandparent__2'
+    end
+    assert_match(/does not seem to be a sealed module/, err.message)
+  end
+
   it "allows whitelisting certain sealed violations" do
     require_relative './fixtures/sealed_module/whitelist_violation__1'
     require_relative './fixtures/sealed_module/whitelist_violation__2'


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's not clear to me whether this should be allowed or not. This is
currently allowed statically. But at least for the moment, I figure I'd
add a better error message so people can track down the cause. We might
end up relaxing this but I haven't thought about it.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.