### PR TITLE
Add a comment about preallocation and jemalloc

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -753,6 +753,12 @@ void GlobalState::preallocateTables(u4 classAndModulesSize, u4 methodsSize, u4 f
     u4 constantNameSizeScaled = nextPowerOfTwo(constantNameSize);
     u4 uniqueNameSizeScaled = nextPowerOfTwo(uniqueNameSize);
 
+    // When preallocating in release builds, large initial reservations aren't necessarily a problem on hosts with lots
+    // of cores available as we use jemalloc as the allocator. An effect of this is that larger allocations will be
+    // mapped with MAP_NORESERVE, and will only be backed by real memory if they're used. As a result, the large number
+    // of threads spawned during indexing (where no symbol table entries are created) won't end up allocating memory to
+    // back the symbol tables when the global state is copied in each thread.
+
     // Note: reserve is a no-op if size is < current capacity.
     classAndModules.reserve(classAndModulesSizeScaled);
     methods.reserve(methodsSizeScaled);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Add a note explaining why duplicating the global state during indexing doesn't incur a large memory cost in the presence of large initial symbol table allocations and large numbers of cores.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Avoid reducing initial symbol table allocations in the future.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.