### PR TITLE
Use `default_checked_level` in inline type checking (`T.let`, `T.cast`, etc)

### DIFF
--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -26,16 +26,16 @@ module T
   # here still applies, but additional checking and/or analysis is
   # performed in C++ for that method.
 
-  sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean).returns(BasicObject)}
+  sig {params(value: T.untyped, type: T.untyped, checked: T.nilable(T.any(T::Boolean, Symbol))).returns(BasicObject)}
   def self.let(value, type, checked: true); end
 
-  sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean).returns(BasicObject)}
+  sig {params(value: T.untyped, type: T.untyped, checked: T.nilable(T.any(T::Boolean, Symbol))).returns(BasicObject)}
   def self.bind(value, type, checked: true); end
 
-  sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean).returns(BasicObject)}
+  sig {params(value: T.untyped, type: T.untyped, checked: T.nilable(T.any(T::Boolean, Symbol))).returns(BasicObject)}
   def self.assert_type!(value, type, checked: true); end
 
-  sig {params(value: T.untyped, type: T.untyped, checked: T::Boolean).returns(BasicObject)}
+  sig {params(value: T.untyped, type: T.untyped, checked: T.nilable(T.any(T::Boolean, Symbol))).returns(BasicObject)}
   def self.cast(value, type, checked: true); end
 
   sig {params(type: T.untyped).returns(BasicObject)}


### PR DESCRIPTION
Alternative approach to #4236, using the `default_checked_level` to determine whether to do inline type checking, not just for sig type checking.

I read through that PR and tried to address some of the performance concerns by using `replace_method` to swap to a faster implementation. This poses a challenge that I'll comment on inline.

### Motivation

We want to be able to easily disable sorbet-runtime in production while keeping it during development and tests. Currently there's `T::Configuration.default_checked_level` which enables globally opting out of type checking but this only works for sigs currently, not inline type checking like `T.let` and friends. This PR enables using the same mechanism to turn off more of the runtime type checking.

### Test plan

No tests yet, wanted to validate the approach.
