### PR TITLE
make "generic" prop getters take the attr_reader fast path at runtime when possible

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -364,9 +364,10 @@ public:
         bool isRewriterSynthesized : 1;
         bool isAttrReader : 1;
         bool discardDef : 1;
+        bool genericPropGetter : 1;
 
         // In C++20 we can replace this with bit field initialzers
-        Flags() : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), discardDef(false) {}
+        Flags() : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), discardDef(false), genericPropGetter(false) {}
     };
     CheckSize(Flags, 1, 1);
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -367,7 +367,9 @@ public:
         bool genericPropGetter : 1;
 
         // In C++20 we can replace this with bit field initialzers
-        Flags() : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), discardDef(false), genericPropGetter(false) {}
+        Flags()
+            : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), discardDef(false),
+              genericPropGetter(false) {}
     };
     CheckSize(Flags, 1, 1);
 

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -158,6 +158,8 @@ SORBET_ALIVE(void, sorbet_vm_register_sig,
              (VALUE isSelf, VALUE method, VALUE self, VALUE arg, rb_block_call_func_t block));
 SORBET_ALIVE(void, sorbet_vm_define_method,
              (VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp, rb_iseq_t *iseq, bool isSelf));
+SORBET_ALIVE(void, sorbet_vm_define_prop_getter,
+             (VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp, rb_iseq_t *iseq));
 
 SORBET_ALIVE(VALUE, sorbet_maybeAllocateObjectFastPath, (VALUE recv, struct FunctionInlineCache *newCache));
 SORBET_ALIVE(VALUE, sorbet_vm_instance_variable_get,
@@ -469,6 +471,11 @@ VALUE sorbet_defineNestedClass(VALUE owner, const char *name, VALUE super) {
 SORBET_INLINE
 void sorbet_defineMethod(VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp, rb_iseq_t *iseq) {
     sorbet_vm_define_method(klass, name, methodPtr, paramp, iseq, false);
+}
+
+SORBET_INLINE
+void sorbet_definePropGetter(VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp, rb_iseq_t *iseq) {
+    sorbet_vm_define_prop_getter(klass, name, methodPtr, paramp, iseq);
 }
 
 // this DOES override existing methods

--- a/compiler/IREmitter/Payload/patches/proc.c
+++ b/compiler/IREmitter/Payload/patches/proc.c
@@ -1,0 +1,4 @@
+/* method_owner, the backing function for Method#owner, is not exported.  */
+VALUE sorbet_vm_method_owner(VALUE obj) {
+    return method_owner(obj);
+}

--- a/compiler/IREmitter/Payload/vm-payload.c
+++ b/compiler/IREmitter/Payload/vm-payload.c
@@ -527,24 +527,6 @@ void sorbet_vm_define_prop_getter(VALUE klass, const char *name, rb_sorbet_func_
         return;
     }
 
-    VALUE sig_table = sigs_for_methods();
-    VALUE mod_entry = rb_hash_lookup2(sig_table, klass, Qnil);
-    VALUE built_sig = Qnil;
-    ID id = rb_intern(name);
-    if (mod_entry != Qnil) {
-        built_sig = rb_hash_delete(mod_entry, ID2SYM(id));
-    }
-
-    struct method_block_params params;
-    params.klass = klass;
-    params.name = name;
-    params.id = id;
-    params.methodPtr = methodPtr;
-    params.paramp = paramp;
-    params.iseq = iseq;
-    params.isSelf = false;
-
-    VALUE methods = MOD_CONST_GET("T::Private::Methods");
-    VALUE args[] = {klass, built_sig};
-    rb_block_call(methods, rb_intern("_with_declared_signature"), 2, args, define_method_block, (VALUE)&params);
+    const bool isSelf = false;
+    return sorbet_vm_define_method(klass, name, method, params, iseq, isSelf);
 }

--- a/compiler/IREmitter/Payload/vm-payload.c
+++ b/compiler/IREmitter/Payload/vm-payload.c
@@ -499,3 +499,51 @@ void sorbet_vm_define_method(VALUE klass, const char *name, rb_sorbet_func_t met
     VALUE args[] = {klass, built_sig};
     rb_block_call(methods, rb_intern("_with_declared_signature"), 2, args, define_method_block, (VALUE)&params);
 }
+
+static VALUE sorbet_getTPropsDecorator() {
+    static const char decorator[] = "T::Props::Decorator";
+    return sorbet_getConstant(decorator, sizeof(decorator));
+}
+
+/* See the patched proc.c */
+extern VALUE sorbet_vm_rb_mod_instance_method(VALUE mod, VALUE vid);
+
+void sorbet_vm_define_prop_getter(VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp, rb_iseq_t *iseq) {
+    /* See T::Props::Decorator#define_getter_and_setter.  */
+    ID prop_get = rb_intern("prop_get");
+    VALUE decorator = rb_funcall(klass, rb_intern("decorator"), 0);
+    VALUE prop_get_method = rb_obj_method(decorator, rb_id2sym(prop_get));
+    VALUE method_owner = sorbet_vm_method_owner(prop_get_method);
+    /* The code that the compiler generated was fully general, accessing instance variables
+     * and going through any available prop_get_logic method.  In the case where prop_get
+     * is known to be defined from T::Props::Decorator, we can use the attr_reader fastpath,
+     * which is significantly faster.
+     */
+    if (method_owner == sorbet_getTPropsDecorator()) {
+        ID method_name = rb_intern(name);
+        ID attriv = rb_intern_str(rb_sprintf("@%" PRIsVALUE, rb_id2str(method_name)));
+        rb_add_method(klass, method_name, VM_METHOD_TYPE_IVAR, (void *)attriv, METHOD_VISI_PUBLIC);
+        return;
+    }
+
+    VALUE sig_table = sigs_for_methods();
+    VALUE mod_entry = rb_hash_lookup2(sig_table, klass, Qnil);
+    VALUE built_sig = Qnil;
+    ID id = rb_intern(name);
+    if (mod_entry != Qnil) {
+        built_sig = rb_hash_delete(mod_entry, ID2SYM(id));
+    }
+
+    struct method_block_params params;
+    params.klass = klass;
+    params.name = name;
+    params.id = id;
+    params.methodPtr = methodPtr;
+    params.paramp = paramp;
+    params.iseq = iseq;
+    params.isSelf = false;
+
+    VALUE methods = MOD_CONST_GET("T::Private::Methods");
+    VALUE args[] = {klass, built_sig};
+    rb_block_call(methods, rb_intern("_with_declared_signature"), 2, args, define_method_block, (VALUE)&params);
+}

--- a/compiler/IREmitter/Payload/vm-payload.c
+++ b/compiler/IREmitter/Payload/vm-payload.c
@@ -508,7 +508,8 @@ static VALUE sorbet_getTPropsDecorator() {
 /* See the patched proc.c */
 extern VALUE sorbet_vm_rb_mod_instance_method(VALUE mod, VALUE vid);
 
-void sorbet_vm_define_prop_getter(VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp, rb_iseq_t *iseq) {
+void sorbet_vm_define_prop_getter(VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp,
+                                  rb_iseq_t *iseq) {
     /* See T::Props::Decorator#define_getter_and_setter.  */
     ID prop_get = rb_intern("prop_get");
     VALUE decorator = rb_funcall(klass, rb_intern("decorator"), 0);

--- a/compiler/IREmitter/Payload/vm-payload.c
+++ b/compiler/IREmitter/Payload/vm-payload.c
@@ -506,7 +506,7 @@ static VALUE sorbet_getTPropsDecorator() {
 }
 
 /* See the patched proc.c */
-extern VALUE sorbet_vm_rb_mod_instance_method(VALUE mod, VALUE vid);
+extern VALUE sorbet_vm_method_owner(VALUE obj);
 
 void sorbet_vm_define_prop_getter(VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp,
                                   rb_iseq_t *iseq) {
@@ -528,5 +528,5 @@ void sorbet_vm_define_prop_getter(VALUE klass, const char *name, rb_sorbet_func_
     }
 
     const bool isSelf = false;
-    return sorbet_vm_define_method(klass, name, method, params, iseq, isSelf);
+    sorbet_vm_define_method(klass, name, methodPtr, paramp, iseq, isSelf);
 }

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -473,8 +473,7 @@ public:
         } else {
             const bool isPropGetter = methodKind == core::Names::genericPropGetter();
 
-            ENFORCE(methodKind == core::Names::normal() ||
-                    isPropGetter ||
+            ENFORCE(methodKind == core::Names::normal() || isPropGetter ||
                         (methodKind == core::Names::attrReader() && funcSym.data(cs)->isFinalMethod()),
                     "Unknown method kind: {}", methodKind.show(cs));
 
@@ -485,7 +484,9 @@ public:
             auto *stackFrameVar = Payload::rubyStackFrameVar(cs, builder, mcctx.irctx, funcSym);
             auto *stackFrame = builder.CreateLoad(stackFrameVar, "stackFrame");
 
-            const char *payloadFuncName = isSelf ? "sorbet_defineMethodSingleton" : isPropGetter ? "sorbet_definePropGetter" : "sorbet_defineMethod";
+            const char *payloadFuncName = isSelf         ? "sorbet_defineMethodSingleton"
+                                          : isPropGetter ? "sorbet_definePropGetter"
+                                                         : "sorbet_defineMethod";
             auto rubyFunc = cs.getFunction(payloadFuncName);
             auto *paramInfo = buildParamInfo(cs, builder, mcctx.irctx, funcSym, mcctx.rubyBlockId);
             builder.CreateCall(rubyFunc, {klass, name, funcHandle, paramInfo, stackFrame});

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -278,6 +278,7 @@ NameDef names[] = {
 
     {"instance"},
     {"normal"},
+    {"genericPropGetter"},
 
     {"raise"},
     {"rewriterRaiseUnimplemented", "Sorbet rewriter pass partially unimplemented"},

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -368,7 +368,9 @@ public:
         auto name = methodDef.name;
         auto keepName = methodDef.flags.isSelfMethod ? core::Names::keepSelfDef() : core::Names::keepDef();
 
-        auto kind = methodDef.flags.genericPropGetter ? core::Names::genericPropGetter() : methodDef.flags.isAttrReader ? core::Names::attrReader() : core::Names::normal();
+        auto kind = methodDef.flags.genericPropGetter ? core::Names::genericPropGetter()
+                    : methodDef.flags.isAttrReader    ? core::Names::attrReader()
+                                                      : core::Names::normal();
         auto discardable = methodDef.flags.discardDef;
         methods.addExpr(*md, move(tree));
 

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -368,7 +368,7 @@ public:
         auto name = methodDef.name;
         auto keepName = methodDef.flags.isSelfMethod ? core::Names::keepSelfDef() : core::Names::keepDef();
 
-        auto kind = methodDef.flags.isAttrReader ? core::Names::attrReader() : core::Names::normal();
+        auto kind = methodDef.flags.genericPropGetter ? core::Names::genericPropGetter() : methodDef.flags.isAttrReader ? core::Names::attrReader() : core::Names::normal();
         auto discardable = methodDef.flags.discardDef;
         methods.addExpr(*md, move(tree));
 

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -334,14 +334,15 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, 
         nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, ast::MK::RaiseUnimplemented(loc)));
     } else if (ret.ifunset == nullptr) {
         if (knownNonModel(propContext.syntacticSuperClass)) {
-            auto isAttrReader = true;
+            ast::MethodDef::Flags flags;
+            flags.isAttrReader = true;
             if (wantTypedInitialize(propContext.syntacticSuperClass)) {
-                nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, ast::MK::Instance(nameLoc, ivarName), isAttrReader));
+                nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, ast::MK::Instance(nameLoc, ivarName), flags));
             } else {
                 // Need to hide the instance variable access, because there wasn't a typed constructor to declare it
                 auto ivarGet = ast::MK::Send1(loc, ast::MK::Self(loc), core::Names::instanceVariableGet(),
                                               ast::MK::Symbol(nameLoc, ivarName));
-                nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, std::move(ivarGet), isAttrReader));
+                nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, std::move(ivarGet), flags));
             }
         } else {
             // Models have a custom decorator, which means we have to forward the prop get to it.

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -345,6 +345,9 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, 
                 nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, std::move(ivarGet), flags));
             }
         } else {
+            ast::MethodDef::Flags flags;
+            flags.genericPropGetter = true;
+
             // Models have a custom decorator, which means we have to forward the prop get to it.
             // If this is actually a T::InexactStruct or Chalk::ODM::Document sub-sub-class, this implementation is
             // correct but does extra work.
@@ -361,7 +364,7 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, 
                                                ast::MK::Self(loc), ast::MK::Symbol(nameLoc, name), std::move(arg2));
 
             auto insSeq = ast::MK::InsSeq1(loc, std::move(assign), std::move(propGetLogic));
-            nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, std::move(insSeq)));
+            nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, std::move(insSeq), flags));
         }
     } else {
         nodes.emplace_back(ASTUtil::mkGet(ctx, loc, name, ast::MK::RaiseUnimplemented(loc)));

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -246,15 +246,14 @@ ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
 }
 
 ast::ExpressionPtr ASTUtil::mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::ExpressionPtr rhs,
-                                  bool isAttrReader) {
-    auto ret = ast::MK::SyntheticMethod0(loc, loc, name, move(rhs));
-    ast::cast_tree_nonnull<ast::MethodDef>(ret).flags.isAttrReader = isAttrReader;
+                                  ast::MethodDef::Flags flags) {
+    auto ret = ast::MK::SyntheticMethod0(loc, loc, name, move(rhs), flags);
     return ret;
 }
 
 ast::ExpressionPtr ASTUtil::mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name, core::LocOffsets argLoc,
-                                  ast::ExpressionPtr rhs) {
-    return ast::MK::SyntheticMethod1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs));
+                                  ast::ExpressionPtr rhs, ast::MethodDef::Flags flags) {
+    return ast::MK::SyntheticMethod1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs), flags);
 }
 
 ast::ExpressionPtr ASTUtil::mkNilable(core::LocOffsets loc, ast::ExpressionPtr type) {

--- a/rewriter/Util.h
+++ b/rewriter/Util.h
@@ -22,10 +22,11 @@ public:
     static ast::ExpressionPtr mkKwArgsHash(const ast::Send *send);
 
     static ast::ExpressionPtr mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::ExpressionPtr rhs,
-                                    bool isAttrReader = false);
+                                    ast::MethodDef::Flags flags = ast::MethodDef::Flags());
 
     static ast::ExpressionPtr mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name,
-                                    core::LocOffsets argLoc, ast::ExpressionPtr rhs);
+                                    core::LocOffsets argLoc, ast::ExpressionPtr rhs,
+                                    ast::MethodDef::Flags flags = ast::MethodDef::Flags());
 
     static ast::ExpressionPtr mkNilable(core::LocOffsets loc, ast::ExpressionPtr type);
 

--- a/test/testdata/rewriter/chalk_odm_document.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/chalk_odm_document.rb.rewrite-tree.exp
@@ -63,7 +63,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.prop(:my_child_method, <emptyTree>::<C Integer>, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :my_child_method, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :my_child_method, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :my_child_method=, :normal)
   end

--- a/test/testdata/rewriter/not_prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/not_prop.rb.rewrite-tree.exp
@@ -30,7 +30,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.prop(:array_of_explicit, <emptyTree>::<C Array>, :array, <emptyTree>::<C String>, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :array_of_explicit, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :array_of_explicit, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :array_of_explicit=, :normal)
 

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -1666,7 +1666,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :foo }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -5500,7 +5500,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :default }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -5563,7 +5563,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :t_nilable }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -5615,7 +5615,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :array }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -5681,7 +5681,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :t_array }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -5751,7 +5751,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :hash_of }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -5805,7 +5805,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :const_explicit }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -5840,7 +5840,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :const }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -5882,7 +5882,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :enum_prop }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -5939,7 +5939,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :foreign }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -6010,7 +6010,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :foreign_lazy }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -6080,7 +6080,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :foreign_proc }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -6147,7 +6147,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :foreign_invalid }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -6324,7 +6324,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :empty_hash_rules }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -6391,7 +6391,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :hash_rules }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -6927,7 +6927,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :token }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -6974,7 +6974,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :created }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -7412,7 +7412,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :token }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
 
@@ -7461,7 +7461,7 @@ ClassDef{
               localVariable = <U <self>>
             }
             Literal{ value = :created }
-            Literal{ value = :normal }
+            Literal{ value = :genericPropGetter }
           ]
         }
       ]

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -115,7 +115,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.prop(:foo, <emptyTree>::<C String>, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :foo, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :foo, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :foo=, :normal)
 
@@ -514,51 +514,51 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.prop(:default, <emptyTree>::<C String>, :default, "", :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :default, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :default, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :default=, :normal)
 
     <self>.prop(:t_nilable, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>), :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :t_nilable, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :t_nilable, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :t_nilable=, :normal)
 
     <self>.prop(:array, <emptyTree>::<C Array>, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :array, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :array, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :array=, :normal)
 
     <self>.prop(:t_array, <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>), :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :t_array, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :t_array, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :t_array=, :normal)
 
     <self>.prop(:hash_of, <emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C String>), :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :hash_of, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :hash_of, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :hash_of=, :normal)
 
     <self>.prop(:const_explicit, <emptyTree>::<C String>, :immutable, true, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :const_explicit, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :const_explicit, :genericPropGetter)
 
     <self>.const(:const, <emptyTree>::<C String>, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :const, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :const, :genericPropGetter)
 
     <self>.prop(:enum_prop, <emptyTree>::<C String>, :enum, ["hello", "goodbye"], :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :enum_prop, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :enum_prop, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :enum_prop=, :normal)
 
     <self>.prop(:foreign, <emptyTree>::<C String>, :foreign, <emptyTree>::<C ForeignClass>, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :foreign, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :foreign, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :foreign=, :normal)
 
@@ -566,7 +566,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>::<C ForeignClass>
       end, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :foreign_lazy, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :foreign_lazy, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :foreign_lazy=, :normal)
 
@@ -574,7 +574,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>::<C ForeignClass>
       end, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :foreign_proc, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :foreign_proc, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :foreign_proc=, :normal)
 
@@ -582,7 +582,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         :not_a_type
       end, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :foreign_invalid, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :foreign_invalid, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :foreign_invalid=, :normal)
 
@@ -600,13 +600,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.prop(:empty_hash_rules, <emptyTree>::<C String>, {:without_accessors => true})
 
-    ::Sorbet::Private::Static.keep_def(<self>, :empty_hash_rules, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :empty_hash_rules, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :empty_hash_rules=, :normal)
 
     <self>.prop(:hash_rules, <emptyTree>::<C String>, {:enum => ["hello", "goodbye"], :without_accessors => true})
 
-    ::Sorbet::Private::Static.keep_def(<self>, :hash_rules, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :hash_rules, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :hash_rules=, :normal)
   end
@@ -672,13 +672,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.token_prop(:without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :token, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :token, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :token=, :normal)
 
     <self>.created_prop(:without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :created, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :created, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :created=, :normal)
   end
@@ -733,13 +733,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.timestamped_token_prop(:without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :token, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :token, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :token=, :normal)
 
     <self>.created_prop(:immutable, true, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :created, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :created, :genericPropGetter)
   end
 
   class <emptyTree>::<C Chalk>::<C ODM>::<C Document><<C <todo sym>>> < (::<todo sym>)

--- a/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
@@ -133,13 +133,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.const(:not_a_symbol, <emptyTree>::<C String>, :computed_by, "not_a_symbol", :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :not_a_symbol, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :not_a_symbol, :genericPropGetter)
 
     symbol_in_variable = :symbol_in_variable
 
     <self>.const(:symbol_in_variable, <emptyTree>::<C String>, :computed_by, symbol_in_variable, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :symbol_in_variable, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :symbol_in_variable, :genericPropGetter)
 
     <self>.const(:num_unknown_type, <emptyTree>::<C Integer>, :computed_by, :compute_num_unknown_type, :without_accessors, true)
 

--- a/test/testdata/rewriter/prop_foreign.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_foreign.rb.rewrite-tree.exp
@@ -123,7 +123,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>::<C ForeignClass>
       end, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :foreign_lazy, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :foreign_lazy, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :foreign_lazy=, :normal)
 
@@ -131,7 +131,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>::<C ForeignClass>
       end, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :foreign_proc, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :foreign_proc, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :foreign_proc=, :normal)
 
@@ -139,7 +139,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         :not_a_type
       end, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :foreign_invalid, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :foreign_invalid, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :foreign_invalid=, :normal)
   end

--- a/test/testdata/rewriter/prop_missing.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_missing.rb.rewrite-tree.exp
@@ -35,12 +35,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.prop(:foo, <emptyTree>::<C Integer>, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :foo, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :foo, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :foo=, :normal)
 
     <self>.const(:bar, <emptyTree>::<C Integer>, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :bar, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :bar, :genericPropGetter)
   end
 end

--- a/test/testdata/rewriter/shard_by_merchant_prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/shard_by_merchant_prop.rb.rewrite-tree.exp
@@ -38,7 +38,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.merchant_prop(:without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :merchant, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :merchant, :genericPropGetter)
   end
 
   class <emptyTree>::<C MerchantTokenPropModel><<C <todo sym>>> < (::<todo sym>)
@@ -59,7 +59,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.merchant_token_prop(:without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :merchant, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :merchant, :genericPropGetter)
   end
 
   <emptyTree>::<C T>.reveal_type(<emptyTree>::<C MerchantPropModel>.new().merchant())

--- a/test/testdata/rewriter/t_struct/inexact.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/inexact.rb.rewrite-tree.exp
@@ -76,7 +76,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.prop(:qux, <emptyTree>::<C Symbol>, :without_accessors, true)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :qux, :normal)
+    ::Sorbet::Private::Static.keep_def(<self>, :qux, :genericPropGetter)
 
     ::Sorbet::Private::Static.keep_def(<self>, :qux=, :normal)
   end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Props in the interpreter have a fast path defined for them, assuming their `prop_get` method was defined by `T::Props::Decorator`.  (We're not considering `prop_set` for the purposes of this PR.)

https://github.com/sorbet/sorbet/blob/b4bd63aa4f3646900dca12e9eb93e7f04238dbe2/gems/sorbet-runtime/lib/types/props/decorator.rb#L367-L389

The prop rewriter in Sorbet attempts to emulate this, but it only chooses the `attr_reader` fastpath when the syntactically enclosing class is known to be a non-model:

https://github.com/sorbet/sorbet/blob/b4bd63aa4f3646900dca12e9eb93e7f04238dbe2/rewriter/Prop.cc#L336-L364

Everything else that *could* be a subclass of `Chalk::ODM::Document` takes the much slower path, which goes through `instance_variable_get` and `prop_get_logic`.

#4801 sped up the `instance_variable_get` path, but it's still significantly slower than the interpreter.

This PR proposes that we propagate information from the rewriter to the compiler about prop getters that we think need to go through the fully generic path.  The compiler then generates special code to define the prop getter via a new payload function.  This function uses the same logic as sorbet-runtime to determine whether we can take the same `attr_reader` fast path.  If we can't, the compiled version of the slowpath is likely faster due to the `instance_variable_get` optimizations, so we use that.

This change does hurt type safety, as such props will no longer have their types checked, since accesses go through `attr_reader`.  I think, however, that we already have the same sorts of issues with props that would take the rewriter fastpath, so I don't think this technically makes anything worse.

Benchmarks on a toy benchmark:

```ruby
# frozen_string_literal: true
# typed: true
# compiled: true

class MySuperclass < T::InexactStruct
end

# Hide that we're actually a T::InexactStruct subclass to force the slowpath
class MyStruct < MySuperclass
  const :foo, Integer
end

my_struct = MyStruct.new(foo: 430)

i = 0
while i < 10_000_000

  my_struct.foo

  i += 1
end

puts i
puts my_struct.foo
```

Before this change:

```
source  interpreted     compiled
stripe/while_10_000_000.rb      .225    .102
stripe/inexact_struct_getter.rb .292    1.171
stripe/inexact_struct_getter.rb - baseline      .067    1.069
```

After this change:

```
source  interpreted     compiled
stripe/while_10_000_000.rb      .223    .097
stripe/inexact_struct_getter.rb .296    .189
stripe/inexact_struct_getter.rb - baseline      .073    .092
```

Not quite as fast as the interpreter (though some of that might be noise), but at least we're not an order of magnitude+ slower any more.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
