### PR TITLE
add an intrinsic for Kernel#class

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -162,6 +162,7 @@ SORBET_ALIVE(VALUE, sorbet_maybeAllocateObjectFastPath, (VALUE recv, struct Func
 SORBET_ALIVE(VALUE, sorbet_vm_instance_variable_get,
              (struct FunctionInlineCache * getCache, struct iseq_inline_iv_cache_entry *varCache,
               rb_control_frame_t *cfp, VALUE recv, ID var));
+SORBET_ALIVE(VALUE, sorbet_vm_class, (struct FunctionInlineCache * classCache, rb_control_frame_t *cfp, VALUE recv));
 
 SORBET_ALIVE(VALUE, sorbet_vm_fstring_new, (const char *ptr, long len));
 SORBET_ALIVE(VALUE, sorbet_vm_str_uplus, (VALUE str));

--- a/compiler/IREmitter/Payload/patches/vm_insnhelper.c
+++ b/compiler/IREmitter/Payload/patches/vm_insnhelper.c
@@ -977,3 +977,16 @@ VALUE sorbet_vm_instance_variable_get(struct FunctionInlineCache *getCache, IVC 
     reg_cfp->sp += 2;
     return sorbet_callFuncWithCache(getCache, VM_BLOCK_HANDLER_NONE);
 }
+
+VALUE sorbet_vm_class(struct FunctionInlineCache *classCache, rb_control_frame_t *reg_cfp, VALUE recv) {
+    sorbet_vmMethodSearch(classCache, recv);
+    rb_method_definition_t *classDef = classCache->cd.cc.me->def;
+    // We know that this function is the definition of Kernel#class.
+    if (classDef->type == VM_METHOD_TYPE_CFUNC && classDef->body.cfunc.func == rb_obj_class) {
+        return rb_obj_class(recv);
+    }
+    VALUE *sp = reg_cfp->sp;
+    *(sp + 0) = recv;
+    reg_cfp->sp += 1;
+    return sorbet_callFuncWithCache(classCache, VM_BLOCK_HANDLER_NONE);
+}

--- a/test/testdata/compiler/class_method.rb
+++ b/test/testdata/compiler/class_method.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+class NormalClass
+end
+
+p NormalClass.class
+p NormalClass.new.class
+
+class OverrideClass
+  def class
+    "SURPRISE"
+  end
+
+  def self.class
+    "UNEXPECTED"
+  end
+end
+
+p OverrideClass.class
+p OverrideClass.new.class


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was work done to speedup the slow path for prop getters.  It's somewhat effective; on the benchmark from #4806, before this change:

```
source  interpreted     compiled
stripe/while_10_000_000.rb      .225    .102
stripe/inexact_struct_getter.rb .292    1.171
stripe/inexact_struct_getter.rb - baseline      .067    1.069
```

After this change:

```
source  interpreted     compiled
stripe/while_10_000_000.rb      .219    .099
stripe/inexact_struct_getter.rb .294    1.046
stripe/inexact_struct_getter.rb - baseline      .075    .947
```

Good for ~10% or so, probably mostly due to eliminating pushing a Ruby stack frame for the method.  After #4806, we hit the slow path for prop getters less, but I think this is a reasonable optimization for the slow path, and things like `self.class.$FOO` are reasonably common in the code we've compiled so far at Stripe and the things we want to compile.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
