### PR TITLE
Add missing RBI definitions for Ripper::SexpBuilder and Ripper::SexpBuilderPP

### DIFF
--- a/rbi/stdlib/ripper.rbi
+++ b/rbi/stdlib/ripper.rbi
@@ -215,3 +215,11 @@ class Ripper::Filter
   # zero or more of the `Ripper::EXPR_*` constants.
   def state; end
 end
+
+class Ripper::SexpBuilder < ::Ripper
+  sig {returns(String)}
+  def error; end
+end
+
+class Ripper::SexpBuilderPP < Ripper::SexpBuilder
+end


### PR DESCRIPTION
These classes are in stdlib (and are used by solargraph)

### Motivation
Increasing stdlib coverage.

### Test plan
As far as I can tell, there are no automated tests for these? Please advise.