### PR TITLE
Fix `non_forcing_is_a?` in package mode

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1929,7 +1929,6 @@ class ResolveTypeMembersAndFieldsWalk {
                     current = core::Symbols::root();
                     continue;
                 } else {
-
                     auto package = core::cast_type_nonnull<core::LiteralType>(packageType);
                     auto packageName = package.asName(ctx);
                     auto mangledName = packageName.lookupMangledPackageName(ctx.state);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1876,21 +1876,41 @@ class ResolveTypeMembersAndFieldsWalk {
         // we'll check to find out whether the first part is `""` or not, which means we're testing whether the string
         // did or did not begin with `::`.
         vector<string> parts = absl::StrSplit(shortName, "::");
-        // we want package mode to be theoretically compatible with non-package mode, so this special case exists for
-        // that: if we are given a package `A::B`, and a constant `C::D`, then we want to treat that like the user
-        // just wrote `::A::B::C::D`.
-        if (packageType && ctx.state.packageDB().empty()) {
+        if (packageType) {
+            // there's a little bit of a complexity here: we want
+            // `non_forcing_is_a?("C::D", package: "A::B")` to be
+            // looking for, more or less, `A::B::C::D`. We want this
+            // _regardless_ of whether we're in packaged mode or not,
+            // in fact: in non-packaged mode, we should treat this as
+            // looking for `::A::B::C::D`, and in packaged mode, we're
+            // looking for `A::B::C::D` nested inside the desugared
+            // `PkgRegistry::Pkg_A_B` namespace.
+            if (parts.front() == "") {
+                if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
+                    e.setHeader("The string given to `{}` should not be an absolute constant reference if a "
+                                "package name is also provided",
+                                method);
+                }
+                return;
+            }
             auto package = core::cast_type_nonnull<core::LiteralType>(packageType);
             auto name = package.asName(ctx).shortName(ctx);
             vector<string> pkgParts = absl::StrSplit(name, "::");
             // add the initial empty string to mimic the leading `::`
-            pkgParts.insert(pkgParts.begin(), "");
+            if (ctx.state.packageDB().empty()) {
+                pkgParts.insert(pkgParts.begin(), "");
+            }
             // and now add the rest of `parts` to it
             pkgParts.insert(pkgParts.end(), parts.begin(), parts.end());
             // and then treat this new vector as the parts to walk over
             parts = move(pkgParts);
-            // we want to make sure we don't take the package path if we've done this
-            packageType = nullptr;
+            // the path down below tries to find out if `packageType`
+            // is null to find out whether it should look up a package
+            // or not, so if we're not in package mode set
+            // `packageType` to null
+            if (ctx.state.packageDB().empty()) {
+                packageType = nullptr;
+            }
         }
 
         core::SymbolRef current;
@@ -1909,14 +1929,6 @@ class ResolveTypeMembersAndFieldsWalk {
                     current = core::Symbols::root();
                     continue;
                 } else {
-                    if (part == "") {
-                        if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
-                            e.setHeader("The string given to `{}` should not be an absolute constant reference if a "
-                                        "package name is also provided",
-                                        method);
-                        }
-                        return;
-                    }
 
                     auto package = core::cast_type_nonnull<core::LiteralType>(packageType);
                     auto packageName = package.asName(ctx);

--- a/test/testdata/packager/non_forcing_constants/foo/foo_no_forcing.rb
+++ b/test/testdata/packager/non_forcing_constants/foo/foo_no_forcing.rb
@@ -69,7 +69,7 @@ module Project::Foo::FooNonForcing
 
   sig {params(arg: T.untyped).returns(T::Boolean)}
   def self.good_check_is_bar(arg)
-    if T::NonForcingConstants.non_forcing_is_a?(arg, "Project::Bar::Bar", package: "Project::Bar")
+    if T::NonForcingConstants.non_forcing_is_a?(arg, "Bar", package: "Project::Bar")
       true
     else
       false


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Fix the behavior of `non_forcing_is_a?` in package mode.

The issue is specifically that we want `non_forcing_is_a?("C::D", package: "A::B")` to act like we're looking up `::A::B::C::D` in non-package mode. In packaged mode, this means we need to be looking up the constant `A::B::C::D` as defined by the `A::B` package. We were previously assuming an older semantics in which we'd look up `C::D` in the `A::B` package.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
