### PR TITLE
add a fastpath for instance_variable_set with a constant symbol argument

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -163,6 +163,9 @@ SORBET_ALIVE(VALUE, sorbet_maybeAllocateObjectFastPath, (VALUE recv, struct Func
 SORBET_ALIVE(VALUE, sorbet_vm_instance_variable_get,
              (struct FunctionInlineCache * getCache, struct iseq_inline_iv_cache_entry *varCache,
               rb_control_frame_t *cfp, VALUE recv, ID var));
+SORBET_ALIVE(VALUE, sorbet_vm_instance_variable_set,
+             (struct FunctionInlineCache * getCache, struct iseq_inline_iv_cache_entry *varCache,
+              rb_control_frame_t *cfp, VALUE recv, ID var, VALUE value));
 SORBET_ALIVE(VALUE, sorbet_vm_class, (struct FunctionInlineCache * classCache, rb_control_frame_t *cfp, VALUE recv));
 
 SORBET_ALIVE(VALUE, sorbet_vm_fstring_new, (const char *ptr, long len));

--- a/compiler/IREmitter/Payload/patches/object.c
+++ b/compiler/IREmitter/Payload/patches/object.c
@@ -122,3 +122,7 @@ VALUE (*sorbet_vm_Class_new_func(void))() {
 VALUE (*sorbet_vm_Kernel_instance_variable_get_func(void))(VALUE obj, VALUE iv) {
     return rb_obj_ivar_get;
 }
+
+VALUE (*sorbet_vm_Kernel_instance_variable_set_func(void))(VALUE obj, VALUE iv, VALUE value) {
+    return rb_obj_ivar_set;
+}

--- a/test/testdata/compiler/instance_variable_fastpaths.rb
+++ b/test/testdata/compiler/instance_variable_fastpaths.rb
@@ -59,3 +59,49 @@ a.non_constant_arg_set(:@y, 371)
 p a.fast_get
 p a.non_constant_arg_get(:@x)
 p a.non_constant_arg_get(:@y)
+
+class FewArgs
+  def instance_variable_get
+    "nothing"
+  end
+
+# INITIAL-LABEL: define internal i64 @"func_FewArgs#21instance_variable_get"
+# INITIAL-NOT: call i64 @sorbet_vm_instance_variable_get
+# INITIAL{LITERAL}: }
+
+  def instance_variable_set
+    "nada"
+  end
+
+# INITIAL-LABEL: define internal i64 @"func_FewArgs#21instance_variable_set"
+# INITIAL-NOT: call i64 @sorbet_vm_instance_variable_set
+# INITIAL{LITERAL}: }
+
+end
+
+f = FewArgs.new
+p f.instance_variable_get
+p f.instance_variable_set
+
+class ManyArgs
+  def instance_variable_get(x, y)
+    x + y
+  end
+
+# INITIAL-LABEL: define internal i64 @"func_ManyArgs#21instance_variable_get"
+# INITIAL-NOT: call i64 @sorbet_vm_instance_variable_get
+# INITIAL{LITERAL}: }
+
+  def instance_variable_set(x, y, z)
+    x + y + z
+  end
+
+# INITIAL-LABEL: define internal i64 @"func_ManyArgs#21instance_variable_set"
+# INITIAL-NOT: call i64 @sorbet_vm_instance_variable_set
+# INITIAL{LITERAL}: }
+
+end
+
+m = ManyArgs.new
+p m.instance_variable_get(3, 9)
+p m.instance_variable_set(1, 8, 5)

--- a/test/testdata/compiler/instance_variable_fastpaths.rb
+++ b/test/testdata/compiler/instance_variable_fastpaths.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+class A
+  def initialize(x)
+    @x = x
+  end
+
+  def fast_get
+    instance_variable_get(:@x)
+  end
+
+# INITIAL-LABEL: define internal i64 @"func_A#8fast_get"
+# INITIAL: call i64 @sorbet_vm_instance_variable_get
+# INITIAL{LITERAL}: }
+
+# Can't really test too many or too few args because those won't get past Sorbet.
+
+  def non_constant_arg_get(sym)
+    instance_variable_get(sym)
+  end
+
+# INITIAL-LABEL: define internal i64 @"func_A#20non_constant_arg_get"
+# INITIAL-NOT: call i64 @sorbet_vm_instance_variable_get
+# INITIAL{LITERAL}: }
+
+  def fast_set(x)
+    instance_variable_set(:@x, x)
+  end
+
+# INITIAL-LABEL: define internal i64 @"func_A#8fast_set"
+# INITIAL: call i64 @sorbet_vm_instance_variable_set
+# INITIAL{LITERAL}: }
+
+  def non_constant_arg_set(sym, value)
+    instance_variable_set(sym, value)
+  end
+
+# INITIAL-LABEL: define internal i64 @"func_A#20non_constant_arg_set"
+# INITIAL-NOT: call i64 @sorbet_vm_instance_variable_set
+# INITIAL{LITERAL}: }
+
+end
+
+a = A.new(897)
+p a.fast_get
+p a.non_constant_arg_get(:@x)
+p a.non_constant_arg_get(:@y)
+
+a.fast_set(76)
+p a.fast_get
+p a.non_constant_arg_get(:@x)
+p a.non_constant_arg_get(:@y)
+
+a.non_constant_arg_set(:@x, 492)
+a.non_constant_arg_set(:@y, 371)
+p a.fast_get
+p a.non_constant_arg_get(:@x)
+p a.non_constant_arg_get(:@y)


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

#4801 was pretty effective; let's do the same change for `instance_variable_set` so we can reap speedups there too.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
