### PR TITLE
Describe error code 5046

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -686,9 +686,26 @@ class ChildTwo < T::Struct
 end
 ```
 
-## 5046 
+## 5046
 
-In `typed: strict` the `Array` and `Hash` aliases needs to be the expanded `T::Array[T.untyped]` or `T::Hash[T.untyped, T.untyped]` types respectively.
+Generic classes must be passed all their generic type arguments when being used
+as types. For example:
+
+```ruby
+T.let([], Array)              # error
+T.let([], T::Array[Integer])  # ok
+```
+
+Many classes in the standard library are generic classes ([see
+here](stdlib.md)), and must be passed type arguments, including `Array` and
+`Hash`. Any user-defined generic classes must similarly be provided type
+arguments when used.
+
+For legacy reasons relating to the intial rollout of Sorbet, this error is only
+reported at `# typed: strict` for standard library generic classes and `# typed:
+true` for all user-defined generic classes. (In an ideal world, it would have
+always been reported at `# typed: true`, and we might change this in the
+future.)
 
 ## 5047
 

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -686,6 +686,10 @@ class ChildTwo < T::Struct
 end
 ```
 
+## 5046 
+
+In `typed: strict` the `Array` and `Hash` aliases needs to be the expanded `T::Array[T.untyped]` or `T::Hash[T.untyped, T.untyped]` types respectively.
+
 ## 5047
 
 A class or module tried to inherit, include, or extend a final class or module.

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -696,16 +696,16 @@ T.let([], Array)              # error
 T.let([], T::Array[Integer])  # ok
 ```
 
-Many classes in the standard library are generic classes ([see
-here](stdlib.md)), and must be passed type arguments, including `Array` and
-`Hash`. Any user-defined generic classes must similarly be provided type
+Many classes in the standard library are generic classes
+([see here](stdlib.md)), and must be passed type arguments, including `Array`
+and `Hash`. Any user-defined generic classes must similarly be provided type
 arguments when used.
 
 For legacy reasons relating to the intial rollout of Sorbet, this error is only
-reported at `# typed: strict` for standard library generic classes and `# typed:
-true` for all user-defined generic classes. (In an ideal world, it would have
-always been reported at `# typed: true`, and we might change this in the
-future.)
+reported at `# typed: strict` for standard library generic classes and
+`# typed: true` for all user-defined generic classes. (In an ideal world, it
+would have always been reported at `# typed: true`, and we might change this in
+the future.)
 
 ## 5047
 


### PR DESCRIPTION
Adds an error description for 5046.

Example: https://sorbet.run/#%23%20typed%3A%20strict%0A%23%20%20%20%20%20%20%20%20%5E%5E%5E%5E%20try%20changing%20this%20to%20strict%0A%0AT.let%28%7B%7D%2C%20Hash%29

### Motivation

The error "Malformed type declaration. Generic class without type arguments Hash" is confusing if you don't realise that `Hash`/`Array` aliases aren't available in `type: strict`. "Malformed" primes you to think you've typed something wrong.
