### PR TITLE
Do not load gems marked as require: false

### DIFF
--- a/gems/sorbet/lib/gem_loader.rb
+++ b/gems/sorbet/lib/gem_loader.rb
@@ -1215,10 +1215,12 @@ class Sorbet::Private::GemLoader
     require 'bundler/lockfile_parser'
 
     specs = []
-    lockfile_parser = Bundler::LockfileParser.new(File.read(Bundler.default_lockfile))
     # Do not load gems in Gemfile where require is false
-    dependencies = lockfile_parser.dependencies.reject { |name, dep| dep.autorequire && dep.autorequire.empty? }
-    required_dependency_names = dependencies.values.map(&:name)
+    gemfile_dependencies = Bundler.load.dependencies.
+      reject { |dep| dep.autorequire && dep.autorequire.empty? }
+    required_dependency_names = gemfile_dependencies.map(&:name)
+
+    lockfile_parser = Bundler::LockfileParser.new(File.read(Bundler.default_lockfile))
     lockfile_parser.specs.each do |spec|
       # Only include the spec for a gem and it's dependencies if it's autorequired.
       if required_dependency_names.include?(spec.name)


### PR DESCRIPTION
Fixes https://github.com/sorbet/sorbet/issues/4814 . Note that sigs will still be generated for gems' dependencies, just not for ones marked `require: false`.

### Test plan
There should probably be an automated test for this, I just haven't been able to get the test suite running locally on my M1 mac :(