### PR TITLE
Remove unnecessary type parameter from Set#initialize

### DIFF
--- a/rbi/stdlib/set.rbi
+++ b/rbi/stdlib/set.rbi
@@ -253,8 +253,8 @@ class Set < Object
   def flatten!(); end
 
   sig do
-    type_parameters(:U).params(
-        enum: T.nilable(T::Enumerable[T.type_parameter(:U)]),
+    params(
+        enum: T.nilable(T::Enumerable[BasicObject]),
     )
     .void
   end


### PR DESCRIPTION
Currently `Set#initialize` has a type parameter in `set.rbi`, which doesn't actually seem to be necessary. (Opening this first as a draft so I can test it against Stripe's codebase.)


### Motivation
This type variable happens to conflict in weird ways with the goal of compiling stdlib `set.rb`, so if we can get rid of it that would be nice.


### Test plan
I think existing CI should exercise this pretty well.
