### PR TITLE
Revert "Allow requires_ancestor to accept positional arguments"

### DIFF
--- a/gems/sorbet-runtime/lib/types/helpers.rb
+++ b/gems/sorbet-runtime/lib/types/helpers.rb
@@ -54,5 +54,5 @@ module T::Helpers
   #   end
   #
   # TODO: implement the checks in sorbet-runtime.
-  def requires_ancestor(*mods, &block); end
+  def requires_ancestor(&block); end
 end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -108,8 +108,8 @@ module T::Helpers
 
   def mixes_in_class_methods(mod, *mods); end
 
-  sig { params(mods: Module, block: T.nilable(T.proc.returns(Module))).void }
-  def requires_ancestor(*mods, &block); end
+  sig { params(block: T.proc.returns(Module)).void }
+  def requires_ancestor(&block); end
 end
 
 module T::Array

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -663,7 +663,7 @@ private:
 
         auto *block = ast::cast_tree<ast::Block>(send->block);
 
-        if (!send->args.empty() || block == nullptr) {
+        if (!send->args.empty()) {
             if (auto e = gs.beginError(loc, core::errors::Resolver::InvalidRequiredAncestor)) {
                 e.setHeader("`{}` only accepts a block", send->fun.show(gs));
                 e.addErrorNote("Use {} to auto-correct using the new syntax",

--- a/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.out
+++ b/test/cli/autocorrect-requires-ancestor-block/autocorrect-requires-ancestor-block.out
@@ -24,7 +24,42 @@ autocorrect-requires-ancestor-block.rb:14: `requires_ancestor` only accepts a bl
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     Use --isolate-error-code 5062 -a --typed true to auto-correct using the new syntax
-Errors: 3
+
+autocorrect-requires-ancestor-block.rb:12: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1` https://srb.help/7004
+    12 |  requires_ancestor RA1
+          ^^^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: `requires_ancestor` defined here
+     112 |  def requires_ancestor(&block); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-requires-ancestor-block.rb:12: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
+    12 |  requires_ancestor RA1
+          ^^^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: defined here
+     112 |  def requires_ancestor(&block); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-requires-ancestor-block.rb:13: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `2` https://srb.help/7004
+    13 |  requires_ancestor RA2, RA3
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: `requires_ancestor` defined here
+     112 |  def requires_ancestor(&block); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-requires-ancestor-block.rb:13: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
+    13 |  requires_ancestor RA2, RA3
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: defined here
+     112 |  def requires_ancestor(&block); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-requires-ancestor-block.rb:14: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1` https://srb.help/7004
+    14 |  requires_ancestor(RA4) { RA5 }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L112: `requires_ancestor` defined here
+     112 |  def requires_ancestor(&block); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 8
 
 --------------------------------------------------------------------------
 

--- a/test/testdata/resolver/requires_ancestor_calls_ancestors.rb
+++ b/test/testdata/resolver/requires_ancestor_calls_ancestors.rb
@@ -213,9 +213,3 @@ module Test7
     def c3; end
   end
 end
-
-module NoBlock
-  extend T::Helpers
-  requires_ancestor Kernel
-# ^^^^^^^^^^^^^^^^^^^^^^^^ error: `requires_ancestor` only accepts a block
-end

--- a/test/testdata/resolver/requires_ancestor_errors.rb
+++ b/test/testdata/resolver/requires_ancestor_errors.rb
@@ -8,8 +8,7 @@ end
 module Helper2
   extend T::Helpers
 
-  requires_ancestor
-# ^^^^^^^^^^^^^^^^^ error: `requires_ancestor` only accepts a block
+  requires_ancestor # error: `requires_ancestor` requires a block parameter, but no block was passed
 end
 
 module Helper3
@@ -78,19 +77,22 @@ module Helper10
   extend T::Helpers
 
   requires_ancestor
-# ^^^^^^^^^^^^^^^^^ error: `requires_ancestor` only accepts a block
+# ^^^^^^^^^^^^^^^^^ error: `requires_ancestor` requires a block parameter, but no block was passed
 end
 
 module Helper11
   extend T::Helpers
 
   requires_ancestor (Kernel)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1`
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `requires_ancestor` only accepts a block
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `requires_ancestor` requires a block parameter, but no block was passed
 end
 
 module Helper12
   extend T::Helpers
 
   requires_ancestor (Kernel) { Kernel }
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1`
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `requires_ancestor` only accepts a block
 end


### PR DESCRIPTION
This reverts commit 5d376f814209c35e72cbb66c3c77156e7f052332.

Today we complete (roughly) the one month we determined to keep backwards compatibility for the `requires_ancestor` old syntax. As agreed on #4691, I'm reverting the commit to only accept the new syntax.

### Test plan

See included automated tests.