### PR TITLE
enable symbol-based intrinsics to avoid after-intrinsic processing

### DIFF
--- a/compiler/IREmitter/SymbolBasedIntrinsicMethod.h
+++ b/compiler/IREmitter/SymbolBasedIntrinsicMethod.h
@@ -40,6 +40,13 @@ public:
     // You should not typically be returning true from this.
     virtual bool skipFastPathTest(MethodCallContext &mcctx, core::ClassOrModuleRef potentialClass) const;
 
+    // Returns whether we should be calling Payload::afterIntrinsic to handle any
+    // post-intrinsic processing (e.g. checking whether VM-level interrupts have arrived).
+    // The default is to call.
+    //
+    // You should not typically be returning false from this.
+    virtual bool needsAfterIntrinsicProcessing() const;
+
     SymbolBasedIntrinsicMethod(Intrinsics::HandleBlock blockHandled) : blockHandled(blockHandled){};
     virtual ~SymbolBasedIntrinsicMethod() = default;
     static std::vector<const SymbolBasedIntrinsicMethod *> &definedIntrinsics(const core::GlobalState &gs);

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -509,6 +509,9 @@ public:
     virtual bool skipFastPathTest(MethodCallContext &mcctx, core::ClassOrModuleRef potentialClass) const override {
         return true;
     }
+    virtual bool needsAfterIntrinsicProcessing() const override {
+        return false;
+    }
     virtual InlinedVector<core::ClassOrModuleRef, 2> applicableClasses(const core::GlobalState &gs) const override {
         return {core::Symbols::Sorbet_Private_Static().data(gs)->lookupSingletonClass(gs)};
     };
@@ -558,6 +561,9 @@ public:
     virtual bool skipFastPathTest(MethodCallContext &mcctx, core::ClassOrModuleRef potentialClass) const override {
         return true;
     }
+    virtual bool needsAfterIntrinsicProcessing() const override {
+        return false;
+    }
     virtual InlinedVector<core::ClassOrModuleRef, 2> applicableClasses(const core::GlobalState &gs) const override {
         return {core::Symbols::Sorbet_Private_Static_ResolvedSig().data(gs)->lookupSingletonClass(gs)};
     };
@@ -576,6 +582,9 @@ public:
 
     virtual bool skipFastPathTest(MethodCallContext &mcctx, core::ClassOrModuleRef potentialClass) const override {
         return true;
+    }
+    virtual bool needsAfterIntrinsicProcessing() const override {
+        return false;
     }
     virtual InlinedVector<core::ClassOrModuleRef, 2> applicableClasses(const core::GlobalState &gs) const override {
         return {core::Symbols::Sorbet_Private_Static().data(gs)->lookupSingletonClass(gs)};

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -994,6 +994,10 @@ bool SymbolBasedIntrinsicMethod::skipFastPathTest(MethodCallContext &mcctx,
     return false;
 }
 
+bool SymbolBasedIntrinsicMethod::needsAfterIntrinsicProcessing() const {
+    return true;
+}
+
 void SymbolBasedIntrinsicMethod::sanityCheck(const core::GlobalState &gs) const {}
 
 vector<const SymbolBasedIntrinsicMethod *> &SymbolBasedIntrinsicMethod::definedIntrinsics(const core::GlobalState &gs) {

--- a/compiler/IREmitter/sends.cc
+++ b/compiler/IREmitter/sends.cc
@@ -166,7 +166,9 @@ llvm::Value *trySymbolBasedIntrinsic(MethodCallContext &mcctx) {
 
         if (intrinsics.size() == 1 && intrinsics[0].method->skipFastPathTest(mcctx, intrinsics[0].klass)) {
             auto fastPathRes = intrinsics[0].method->makeCall(mcctx);
-            Payload::afterIntrinsic(cs, builder);
+            if (intrinsics[0].method->needsAfterIntrinsicProcessing()) {
+                Payload::afterIntrinsic(cs, builder);
+            }
             auto fastPathEnd = builder.GetInsertBlock();
             builder.CreateBr(afterSend);
             builder.SetInsertPoint(afterSend);
@@ -189,7 +191,9 @@ llvm::Value *trySymbolBasedIntrinsic(MethodCallContext &mcctx) {
             builder.CreateCondBr(Payload::setExpectedBool(cs, builder, typeTest, true), fastPath, alternative);
             builder.SetInsertPoint(fastPath);
             auto fastPathRes = intrinsic.method->makeCall(mcctx);
-            Payload::afterIntrinsic(cs, builder);
+            if (intrinsic.method->needsAfterIntrinsicProcessing()) {
+                Payload::afterIntrinsic(cs, builder);
+            }
             auto fastPathEnd = builder.GetInsertBlock();
             builder.CreateBr(afterSend);
             phi->addIncoming(fastPathRes, fastPathEnd);

--- a/test/testdata/compiler/all_arguments.opt.ll.exp
+++ b/test/testdata/compiler/all_arguments.opt.ll.exp
@@ -187,8 +187,6 @@ declare i64 @rb_ary_new() local_unnamed_addr #2
 
 declare i64 @rb_hash_delete_entry(i64, i64) local_unnamed_addr #2
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #2
-
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #3
 
@@ -807,401 +805,384 @@ entry:
   %155 = load i16, i16* %119, align 8, !dbg !29
   %156 = and i16 %155, 32, !dbg !29
   %157 = icmp eq i16 %156, 0, !dbg !29
-  br i1 %157, label %sorbet_setupParamKeywords.exit.i, label %158, !dbg !29
+  br i1 %157, label %"func_<root>.17<static-init>$152.exit", label %158, !dbg !29
 
 158:                                              ; preds = %entry
   %159 = add nsw i32 %152, 1, !dbg !29
   %160 = getelementptr inbounds i8, i8* %118, i64 52, !dbg !29
   %161 = bitcast i8* %160 to i32*, !dbg !29
   store i32 %159, i32* %161, align 4, !dbg !29, !tbaa !81
-  br label %sorbet_setupParamKeywords.exit.i, !dbg !29
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !29
 
-sorbet_setupParamKeywords.exit.i:                 ; preds = %158, %entry
+"func_<root>.17<static-init>$152.exit":           ; preds = %entry, %158
   %162 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #14, !dbg !29
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %162, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %110, i64 noundef 24, i1 noundef false) #11, !dbg !29
   %163 = getelementptr inbounds i8, i8* %118, i64 56, !dbg !29
   %164 = bitcast i8* %163 to i8**, !dbg !29
   store i8* %162, i8** %164, align 8, !dbg !29, !tbaa !82
   call void @sorbet_vm_define_method(i64 %117, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#14take_arguments", i8* nonnull %118, %struct.rb_iseq_struct* %stackFrame387.i, i1 noundef zeroext false) #11, !dbg !29
-  %165 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !14
-  %166 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %165, i64 0, i32 5, !dbg !29
-  %167 = load i32, i32* %166, align 8, !dbg !29, !tbaa !83
-  %168 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %165, i64 0, i32 6, !dbg !29
-  %169 = load i32, i32* %168, align 4, !dbg !29, !tbaa !84
-  %170 = xor i32 %169, -1, !dbg !29
-  %171 = and i32 %170, %167, !dbg !29
-  %172 = icmp eq i32 %171, 0, !dbg !29
-  br i1 %172, label %"func_<root>.17<static-init>$152.exit", label %173, !dbg !29, !prof !20
-
-173:                                              ; preds = %sorbet_setupParamKeywords.exit.i
-  %174 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %165, i64 0, i32 8, !dbg !29
-  %175 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %174, align 8, !dbg !29, !tbaa !85
-  %176 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %175, i32 noundef 0) #11, !dbg !29
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !29
-
-"func_<root>.17<static-init>$152.exit":           ; preds = %sorbet_setupParamKeywords.exit.i, %173
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %116, align 8, !dbg !29, !tbaa !14
-  %177 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !31
-  %178 = load i64*, i64** %177, align 8, !dbg !31
-  store i64 %105, i64* %178, align 8, !dbg !31, !tbaa !6
-  %179 = getelementptr inbounds i64, i64* %178, i64 1, !dbg !31
-  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !31
-  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !31
-  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !31
-  %183 = bitcast i64* %179 to <4 x i64>*, !dbg !31
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %183, align 8, !dbg !31, !tbaa !6
-  %184 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !31
-  %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !31
-  %186 = bitcast i64* %184 to <2 x i64>*, !dbg !31
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %186, align 8, !dbg !31, !tbaa !6
-  %187 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !31
-  store i64 -13, i64* %187, align 8, !dbg !31, !tbaa !6
-  %188 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !31
-  store i64 -15, i64* %188, align 8, !dbg !31, !tbaa !6
-  %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !31
-  store i64* %189, i64** %177, align 8, !dbg !31
+  %165 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !31
+  %166 = load i64*, i64** %165, align 8, !dbg !31
+  store i64 %105, i64* %166, align 8, !dbg !31, !tbaa !6
+  %167 = getelementptr inbounds i64, i64* %166, i64 1, !dbg !31
+  %168 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !31
+  %169 = getelementptr inbounds i64, i64* %168, i64 1, !dbg !31
+  %170 = getelementptr inbounds i64, i64* %169, i64 1, !dbg !31
+  %171 = bitcast i64* %167 to <4 x i64>*, !dbg !31
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %171, align 8, !dbg !31, !tbaa !6
+  %172 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !31
+  %173 = getelementptr inbounds i64, i64* %172, i64 1, !dbg !31
+  %174 = bitcast i64* %172 to <2 x i64>*, !dbg !31
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %174, align 8, !dbg !31, !tbaa !6
+  %175 = getelementptr inbounds i64, i64* %173, i64 1, !dbg !31
+  store i64 -13, i64* %175, align 8, !dbg !31, !tbaa !6
+  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !31
+  store i64 -15, i64* %176, align 8, !dbg !31, !tbaa !6
+  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !31
+  store i64* %177, i64** %165, align 8, !dbg !31
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments, i64 0), !dbg !31
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %116, align 8, !dbg !31, !tbaa !14
-  %190 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !32
-  %191 = load i64*, i64** %190, align 8, !dbg !32
-  store i64 %105, i64* %191, align 8, !dbg !32, !tbaa !6
-  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !32
-  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !32
-  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !32
-  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !32
-  %196 = bitcast i64* %192 to <4 x i64>*, !dbg !32
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %196, align 8, !dbg !32, !tbaa !6
-  %197 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !32
-  %198 = getelementptr inbounds i64, i64* %197, i64 1, !dbg !32
-  %199 = bitcast i64* %197 to <2 x i64>*, !dbg !32
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %199, align 8, !dbg !32, !tbaa !6
-  %200 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !32
-  store i64 -15, i64* %200, align 8, !dbg !32, !tbaa !6
-  %201 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !32
-  store i64* %201, i64** %190, align 8, !dbg !32
+  %178 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !32
+  %179 = load i64*, i64** %178, align 8, !dbg !32
+  store i64 %105, i64* %179, align 8, !dbg !32, !tbaa !6
+  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !32
+  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !32
+  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !32
+  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !32
+  %184 = bitcast i64* %180 to <4 x i64>*, !dbg !32
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %184, align 8, !dbg !32, !tbaa !6
+  %185 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !32
+  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !32
+  %187 = bitcast i64* %185 to <2 x i64>*, !dbg !32
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %187, align 8, !dbg !32, !tbaa !6
+  %188 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !32
+  store i64 -15, i64* %188, align 8, !dbg !32, !tbaa !6
+  %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !32
+  store i64* %189, i64** %178, align 8, !dbg !32
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !32
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %116, align 8, !dbg !32, !tbaa !14
-  %202 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !33
-  %203 = load i64*, i64** %202, align 8, !dbg !33
-  store i64 %105, i64* %203, align 8, !dbg !33, !tbaa !6
-  %204 = getelementptr inbounds i64, i64* %203, i64 1, !dbg !33
-  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !33
-  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !33
-  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !33
-  %208 = bitcast i64* %204 to <4 x i64>*, !dbg !33
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %208, align 8, !dbg !33, !tbaa !6
-  %209 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !33
-  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !33
-  %211 = bitcast i64* %209 to <2 x i64>*, !dbg !33
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %211, align 8, !dbg !33, !tbaa !6
-  %212 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !33
-  store i64* %212, i64** %202, align 8, !dbg !33
+  %190 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !33
+  %191 = load i64*, i64** %190, align 8, !dbg !33
+  store i64 %105, i64* %191, align 8, !dbg !33, !tbaa !6
+  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !33
+  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !33
+  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !33
+  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !33
+  %196 = bitcast i64* %192 to <4 x i64>*, !dbg !33
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %196, align 8, !dbg !33, !tbaa !6
+  %197 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !33
+  %198 = getelementptr inbounds i64, i64* %197, i64 1, !dbg !33
+  %199 = bitcast i64* %197 to <2 x i64>*, !dbg !33
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %199, align 8, !dbg !33, !tbaa !6
+  %200 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !33
+  store i64* %200, i64** %190, align 8, !dbg !33
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !33
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %116, align 8, !dbg !33, !tbaa !14
-  %213 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !34
-  %214 = load i64*, i64** %213, align 8, !dbg !34
-  store i64 %105, i64* %214, align 8, !dbg !34, !tbaa !6
-  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !34
-  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !34
-  %217 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !34
-  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !34
-  %219 = bitcast i64* %215 to <4 x i64>*, !dbg !34
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %219, align 8, !dbg !34, !tbaa !6
-  %220 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !34
-  store i64 -15, i64* %220, align 8, !dbg !34, !tbaa !6
-  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !34
-  store i64* %221, i64** %213, align 8, !dbg !34
+  %201 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !34
+  %202 = load i64*, i64** %201, align 8, !dbg !34
+  store i64 %105, i64* %202, align 8, !dbg !34, !tbaa !6
+  %203 = getelementptr inbounds i64, i64* %202, i64 1, !dbg !34
+  %204 = getelementptr inbounds i64, i64* %203, i64 1, !dbg !34
+  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !34
+  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !34
+  %207 = bitcast i64* %203 to <4 x i64>*, !dbg !34
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %207, align 8, !dbg !34, !tbaa !6
+  %208 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !34
+  store i64 -15, i64* %208, align 8, !dbg !34, !tbaa !6
+  %209 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !34
+  store i64* %209, i64** %201, align 8, !dbg !34
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !34
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %116, align 8, !dbg !34, !tbaa !14
-  %222 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !35
-  %223 = load i64*, i64** %222, align 8, !dbg !35
-  store i64 %105, i64* %223, align 8, !dbg !35, !tbaa !6
-  %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !35
-  %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !35
-  %226 = getelementptr inbounds i64, i64* %225, i64 1, !dbg !35
-  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !35
-  %228 = bitcast i64* %224 to <4 x i64>*, !dbg !35
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %228, align 8, !dbg !35, !tbaa !6
-  %229 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !35
-  store i64* %229, i64** %222, align 8, !dbg !35
+  %210 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !35
+  %211 = load i64*, i64** %210, align 8, !dbg !35
+  store i64 %105, i64* %211, align 8, !dbg !35, !tbaa !6
+  %212 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !35
+  %213 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !35
+  %214 = getelementptr inbounds i64, i64* %213, i64 1, !dbg !35
+  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !35
+  %216 = bitcast i64* %212 to <4 x i64>*, !dbg !35
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %216, align 8, !dbg !35, !tbaa !6
+  %217 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !35
+  store i64* %217, i64** %210, align 8, !dbg !35
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !35
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %116, align 8, !dbg !35, !tbaa !14
-  %230 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !36
-  %231 = load i64*, i64** %230, align 8, !dbg !36
-  store i64 %105, i64* %231, align 8, !dbg !36, !tbaa !6
-  %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !36
-  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !36
-  %234 = bitcast i64* %232 to <2 x i64>*, !dbg !36
-  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %234, align 8, !dbg !36, !tbaa !6
-  %235 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !36
-  store i64 -15, i64* %235, align 8, !dbg !36, !tbaa !6
-  %236 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !36
-  store i64* %236, i64** %230, align 8, !dbg !36
+  %218 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !36
+  %219 = load i64*, i64** %218, align 8, !dbg !36
+  store i64 %105, i64* %219, align 8, !dbg !36, !tbaa !6
+  %220 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !36
+  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !36
+  %222 = bitcast i64* %220 to <2 x i64>*, !dbg !36
+  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %222, align 8, !dbg !36, !tbaa !6
+  %223 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !36
+  store i64 -15, i64* %223, align 8, !dbg !36, !tbaa !6
+  %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !36
+  store i64* %224, i64** %218, align 8, !dbg !36
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !36
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %116, align 8, !dbg !36, !tbaa !14
-  %237 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !37
-  %238 = load i64*, i64** %237, align 8, !dbg !37
-  store i64 %105, i64* %238, align 8, !dbg !37, !tbaa !6
-  %239 = getelementptr inbounds i64, i64* %238, i64 1, !dbg !37
-  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !37
-  %241 = bitcast i64* %239 to <2 x i64>*, !dbg !37
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %241, align 8, !dbg !37, !tbaa !6
-  %242 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !37
-  store i64* %242, i64** %237, align 8, !dbg !37
+  %225 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !37
+  %226 = load i64*, i64** %225, align 8, !dbg !37
+  store i64 %105, i64* %226, align 8, !dbg !37, !tbaa !6
+  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !37
+  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !37
+  %229 = bitcast i64* %227 to <2 x i64>*, !dbg !37
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %229, align 8, !dbg !37, !tbaa !6
+  %230 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !37
+  store i64* %230, i64** %225, align 8, !dbg !37
   %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !37
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %116, align 8, !dbg !37, !tbaa !14
-  %243 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !38
-  %244 = load i64*, i64** %243, align 8, !dbg !38
-  store i64 %105, i64* %244, align 8, !dbg !38, !tbaa !6
-  %245 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !38
-  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !38
-  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !38
-  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !38
-  %249 = bitcast i64* %245 to <4 x i64>*, !dbg !38
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %249, align 8, !dbg !38, !tbaa !6
-  %250 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !38
-  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !38
-  %252 = bitcast i64* %250 to <2 x i64>*, !dbg !38
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %252, align 8, !dbg !38, !tbaa !6
-  %253 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !38
-  store i64 -13, i64* %253, align 8, !dbg !38, !tbaa !6
-  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !38
-  store i64 -15, i64* %254, align 8, !dbg !38, !tbaa !6
-  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !38
-  store i64 -17, i64* %255, align 8, !dbg !38, !tbaa !6
-  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !38
-  store i64* %256, i64** %243, align 8, !dbg !38
+  %231 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !38
+  %232 = load i64*, i64** %231, align 8, !dbg !38
+  store i64 %105, i64* %232, align 8, !dbg !38, !tbaa !6
+  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !38
+  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !38
+  %235 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !38
+  %236 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !38
+  %237 = bitcast i64* %233 to <4 x i64>*, !dbg !38
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %237, align 8, !dbg !38, !tbaa !6
+  %238 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !38
+  %239 = getelementptr inbounds i64, i64* %238, i64 1, !dbg !38
+  %240 = bitcast i64* %238 to <2 x i64>*, !dbg !38
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %240, align 8, !dbg !38, !tbaa !6
+  %241 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !38
+  store i64 -13, i64* %241, align 8, !dbg !38, !tbaa !6
+  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !38
+  store i64 -15, i64* %242, align 8, !dbg !38, !tbaa !6
+  %243 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !38
+  store i64 -17, i64* %243, align 8, !dbg !38, !tbaa !6
+  %244 = getelementptr inbounds i64, i64* %243, i64 1, !dbg !38
+  store i64* %244, i64** %231, align 8, !dbg !38
   %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !38
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %116, align 8, !dbg !38, !tbaa !14
-  %257 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !39
-  %258 = load i64*, i64** %257, align 8, !dbg !39
-  store i64 %105, i64* %258, align 8, !dbg !39, !tbaa !6
-  %259 = getelementptr inbounds i64, i64* %258, i64 1, !dbg !39
-  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !39
-  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !39
-  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !39
-  %263 = bitcast i64* %259 to <4 x i64>*, !dbg !39
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %263, align 8, !dbg !39, !tbaa !6
-  %264 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !39
-  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !39
-  %266 = bitcast i64* %264 to <2 x i64>*, !dbg !39
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %266, align 8, !dbg !39, !tbaa !6
-  %267 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !39
-  store i64 -15, i64* %267, align 8, !dbg !39, !tbaa !6
-  %268 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !39
-  store i64 -17, i64* %268, align 8, !dbg !39, !tbaa !6
-  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !39
-  store i64* %269, i64** %257, align 8, !dbg !39
+  %245 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !39
+  %246 = load i64*, i64** %245, align 8, !dbg !39
+  store i64 %105, i64* %246, align 8, !dbg !39, !tbaa !6
+  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !39
+  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !39
+  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !39
+  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !39
+  %251 = bitcast i64* %247 to <4 x i64>*, !dbg !39
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %251, align 8, !dbg !39, !tbaa !6
+  %252 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !39
+  %253 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !39
+  %254 = bitcast i64* %252 to <2 x i64>*, !dbg !39
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %254, align 8, !dbg !39, !tbaa !6
+  %255 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !39
+  store i64 -15, i64* %255, align 8, !dbg !39, !tbaa !6
+  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !39
+  store i64 -17, i64* %256, align 8, !dbg !39, !tbaa !6
+  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !39
+  store i64* %257, i64** %245, align 8, !dbg !39
   %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !39
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %116, align 8, !dbg !39, !tbaa !14
-  %270 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !40
-  %271 = load i64*, i64** %270, align 8, !dbg !40
-  store i64 %105, i64* %271, align 8, !dbg !40, !tbaa !6
-  %272 = getelementptr inbounds i64, i64* %271, i64 1, !dbg !40
-  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !40
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !40
-  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !40
-  %276 = bitcast i64* %272 to <4 x i64>*, !dbg !40
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %276, align 8, !dbg !40, !tbaa !6
-  %277 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !40
-  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !40
-  %279 = bitcast i64* %277 to <2 x i64>*, !dbg !40
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %279, align 8, !dbg !40, !tbaa !6
-  %280 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !40
-  store i64 -17, i64* %280, align 8, !dbg !40, !tbaa !6
-  %281 = getelementptr inbounds i64, i64* %280, i64 1, !dbg !40
-  store i64* %281, i64** %270, align 8, !dbg !40
+  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !40
+  %259 = load i64*, i64** %258, align 8, !dbg !40
+  store i64 %105, i64* %259, align 8, !dbg !40, !tbaa !6
+  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !40
+  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !40
+  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !40
+  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !40
+  %264 = bitcast i64* %260 to <4 x i64>*, !dbg !40
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %264, align 8, !dbg !40, !tbaa !6
+  %265 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !40
+  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !40
+  %267 = bitcast i64* %265 to <2 x i64>*, !dbg !40
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %267, align 8, !dbg !40, !tbaa !6
+  %268 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !40
+  store i64 -17, i64* %268, align 8, !dbg !40, !tbaa !6
+  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !40
+  store i64* %269, i64** %258, align 8, !dbg !40
   %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !40
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %116, align 8, !dbg !40, !tbaa !14
-  %282 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !41
-  %283 = load i64*, i64** %282, align 8, !dbg !41
-  store i64 %105, i64* %283, align 8, !dbg !41, !tbaa !6
-  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !41
-  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !41
-  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !41
-  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !41
-  %288 = bitcast i64* %284 to <4 x i64>*, !dbg !41
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %288, align 8, !dbg !41, !tbaa !6
-  %289 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !41
-  %290 = getelementptr inbounds i64, i64* %289, i64 1, !dbg !41
-  %291 = bitcast i64* %289 to <2 x i64>*, !dbg !41
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %291, align 8, !dbg !41, !tbaa !6
-  %292 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !41
-  store i64* %292, i64** %282, align 8, !dbg !41
+  %270 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !41
+  %271 = load i64*, i64** %270, align 8, !dbg !41
+  store i64 %105, i64* %271, align 8, !dbg !41, !tbaa !6
+  %272 = getelementptr inbounds i64, i64* %271, i64 1, !dbg !41
+  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !41
+  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !41
+  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !41
+  %276 = bitcast i64* %272 to <4 x i64>*, !dbg !41
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %276, align 8, !dbg !41, !tbaa !6
+  %277 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !41
+  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !41
+  %279 = bitcast i64* %277 to <2 x i64>*, !dbg !41
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %279, align 8, !dbg !41, !tbaa !6
+  %280 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !41
+  store i64* %280, i64** %270, align 8, !dbg !41
   %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !41
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %116, align 8, !dbg !41, !tbaa !14
-  %293 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !42
-  %294 = load i64*, i64** %293, align 8, !dbg !42
-  store i64 %105, i64* %294, align 8, !dbg !42, !tbaa !6
-  %295 = getelementptr inbounds i64, i64* %294, i64 1, !dbg !42
-  %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !42
-  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !42
-  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !42
-  %299 = bitcast i64* %295 to <4 x i64>*, !dbg !42
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %299, align 8, !dbg !42, !tbaa !6
-  %300 = getelementptr inbounds i64, i64* %298, i64 1, !dbg !42
-  store i64 -17, i64* %300, align 8, !dbg !42, !tbaa !6
-  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !42
-  store i64* %301, i64** %293, align 8, !dbg !42
+  %281 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !42
+  %282 = load i64*, i64** %281, align 8, !dbg !42
+  store i64 %105, i64* %282, align 8, !dbg !42, !tbaa !6
+  %283 = getelementptr inbounds i64, i64* %282, i64 1, !dbg !42
+  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !42
+  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !42
+  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !42
+  %287 = bitcast i64* %283 to <4 x i64>*, !dbg !42
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %287, align 8, !dbg !42, !tbaa !6
+  %288 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !42
+  store i64 -17, i64* %288, align 8, !dbg !42, !tbaa !6
+  %289 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !42
+  store i64* %289, i64** %281, align 8, !dbg !42
   %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !42
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %116, align 8, !dbg !42, !tbaa !14
-  %302 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !43
-  %303 = load i64*, i64** %302, align 8, !dbg !43
-  store i64 %105, i64* %303, align 8, !dbg !43, !tbaa !6
-  %304 = getelementptr inbounds i64, i64* %303, i64 1, !dbg !43
-  %305 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !43
-  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !43
-  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !43
-  %308 = bitcast i64* %304 to <4 x i64>*, !dbg !43
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %308, align 8, !dbg !43, !tbaa !6
-  %309 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !43
-  store i64* %309, i64** %302, align 8, !dbg !43
+  %290 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !43
+  %291 = load i64*, i64** %290, align 8, !dbg !43
+  store i64 %105, i64* %291, align 8, !dbg !43, !tbaa !6
+  %292 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !43
+  %293 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !43
+  %294 = getelementptr inbounds i64, i64* %293, i64 1, !dbg !43
+  %295 = getelementptr inbounds i64, i64* %294, i64 1, !dbg !43
+  %296 = bitcast i64* %292 to <4 x i64>*, !dbg !43
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %296, align 8, !dbg !43, !tbaa !6
+  %297 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !43
+  store i64* %297, i64** %290, align 8, !dbg !43
   %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !43
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %116, align 8, !dbg !43, !tbaa !14
-  %310 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !44
-  %311 = load i64*, i64** %310, align 8, !dbg !44
-  store i64 %105, i64* %311, align 8, !dbg !44, !tbaa !6
-  %312 = getelementptr inbounds i64, i64* %311, i64 1, !dbg !44
-  %313 = getelementptr inbounds i64, i64* %312, i64 1, !dbg !44
-  %314 = bitcast i64* %312 to <2 x i64>*, !dbg !44
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %314, align 8, !dbg !44, !tbaa !6
-  %315 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !44
-  store i64 -17, i64* %315, align 8, !dbg !44, !tbaa !6
-  %316 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !44
-  store i64* %316, i64** %310, align 8, !dbg !44
+  %298 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !44
+  %299 = load i64*, i64** %298, align 8, !dbg !44
+  store i64 %105, i64* %299, align 8, !dbg !44, !tbaa !6
+  %300 = getelementptr inbounds i64, i64* %299, i64 1, !dbg !44
+  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !44
+  %302 = bitcast i64* %300 to <2 x i64>*, !dbg !44
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %302, align 8, !dbg !44, !tbaa !6
+  %303 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !44
+  store i64 -17, i64* %303, align 8, !dbg !44, !tbaa !6
+  %304 = getelementptr inbounds i64, i64* %303, i64 1, !dbg !44
+  store i64* %304, i64** %298, align 8, !dbg !44
   %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !44
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %116, align 8, !dbg !44, !tbaa !14
-  %317 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !45
-  %318 = load i64*, i64** %317, align 8, !dbg !45
-  store i64 %105, i64* %318, align 8, !dbg !45, !tbaa !6
+  %305 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !45
+  %306 = load i64*, i64** %305, align 8, !dbg !45
+  store i64 %105, i64* %306, align 8, !dbg !45, !tbaa !6
+  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !45
+  %308 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !45
+  %309 = getelementptr inbounds i64, i64* %308, i64 1, !dbg !45
+  %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !45
+  %311 = bitcast i64* %307 to <4 x i64>*, !dbg !45
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %311, align 8, !dbg !45, !tbaa !6
+  %312 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !45
+  %313 = getelementptr inbounds i64, i64* %312, i64 1, !dbg !45
+  %314 = bitcast i64* %312 to <2 x i64>*, !dbg !45
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %314, align 8, !dbg !45, !tbaa !6
+  %315 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !45
+  store i64 -13, i64* %315, align 8, !dbg !45, !tbaa !6
+  %316 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !45
+  store i64 -15, i64* %316, align 8, !dbg !45, !tbaa !6
+  %317 = getelementptr inbounds i64, i64* %316, i64 1, !dbg !45
+  store i64 -17, i64* %317, align 8, !dbg !45, !tbaa !6
+  %318 = getelementptr inbounds i64, i64* %317, i64 1, !dbg !45
+  store i64 -19, i64* %318, align 8, !dbg !45, !tbaa !6
   %319 = getelementptr inbounds i64, i64* %318, i64 1, !dbg !45
-  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !45
-  %321 = getelementptr inbounds i64, i64* %320, i64 1, !dbg !45
-  %322 = getelementptr inbounds i64, i64* %321, i64 1, !dbg !45
-  %323 = bitcast i64* %319 to <4 x i64>*, !dbg !45
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %323, align 8, !dbg !45, !tbaa !6
-  %324 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !45
-  %325 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !45
-  %326 = bitcast i64* %324 to <2 x i64>*, !dbg !45
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %326, align 8, !dbg !45, !tbaa !6
-  %327 = getelementptr inbounds i64, i64* %325, i64 1, !dbg !45
-  store i64 -13, i64* %327, align 8, !dbg !45, !tbaa !6
-  %328 = getelementptr inbounds i64, i64* %327, i64 1, !dbg !45
-  store i64 -15, i64* %328, align 8, !dbg !45, !tbaa !6
-  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !45
-  store i64 -17, i64* %329, align 8, !dbg !45, !tbaa !6
-  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !45
-  store i64 -19, i64* %330, align 8, !dbg !45, !tbaa !6
-  %331 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !45
-  store i64* %331, i64** %317, align 8, !dbg !45
+  store i64* %319, i64** %305, align 8, !dbg !45
   %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !45
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %116, align 8, !dbg !45, !tbaa !14
-  %332 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !46
-  %333 = load i64*, i64** %332, align 8, !dbg !46
-  store i64 %105, i64* %333, align 8, !dbg !46, !tbaa !6
-  %334 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !46
-  %335 = getelementptr inbounds i64, i64* %334, i64 1, !dbg !46
-  %336 = getelementptr inbounds i64, i64* %335, i64 1, !dbg !46
-  %337 = getelementptr inbounds i64, i64* %336, i64 1, !dbg !46
-  %338 = bitcast i64* %334 to <4 x i64>*, !dbg !46
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %338, align 8, !dbg !46, !tbaa !6
-  %339 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !46
-  %340 = getelementptr inbounds i64, i64* %339, i64 1, !dbg !46
-  %341 = bitcast i64* %339 to <2 x i64>*, !dbg !46
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %341, align 8, !dbg !46, !tbaa !6
-  %342 = getelementptr inbounds i64, i64* %340, i64 1, !dbg !46
-  store i64 -15, i64* %342, align 8, !dbg !46, !tbaa !6
-  %343 = getelementptr inbounds i64, i64* %342, i64 1, !dbg !46
-  store i64 -17, i64* %343, align 8, !dbg !46, !tbaa !6
-  %344 = getelementptr inbounds i64, i64* %343, i64 1, !dbg !46
-  store i64 -19, i64* %344, align 8, !dbg !46, !tbaa !6
-  %345 = getelementptr inbounds i64, i64* %344, i64 1, !dbg !46
-  store i64* %345, i64** %332, align 8, !dbg !46
+  %320 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !46
+  %321 = load i64*, i64** %320, align 8, !dbg !46
+  store i64 %105, i64* %321, align 8, !dbg !46, !tbaa !6
+  %322 = getelementptr inbounds i64, i64* %321, i64 1, !dbg !46
+  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !46
+  %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !46
+  %325 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !46
+  %326 = bitcast i64* %322 to <4 x i64>*, !dbg !46
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %326, align 8, !dbg !46, !tbaa !6
+  %327 = getelementptr inbounds i64, i64* %325, i64 1, !dbg !46
+  %328 = getelementptr inbounds i64, i64* %327, i64 1, !dbg !46
+  %329 = bitcast i64* %327 to <2 x i64>*, !dbg !46
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %329, align 8, !dbg !46, !tbaa !6
+  %330 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !46
+  store i64 -15, i64* %330, align 8, !dbg !46, !tbaa !6
+  %331 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !46
+  store i64 -17, i64* %331, align 8, !dbg !46, !tbaa !6
+  %332 = getelementptr inbounds i64, i64* %331, i64 1, !dbg !46
+  store i64 -19, i64* %332, align 8, !dbg !46, !tbaa !6
+  %333 = getelementptr inbounds i64, i64* %332, i64 1, !dbg !46
+  store i64* %333, i64** %320, align 8, !dbg !46
   %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !46
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %116, align 8, !dbg !46, !tbaa !14
-  %346 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !47
-  %347 = load i64*, i64** %346, align 8, !dbg !47
-  store i64 %105, i64* %347, align 8, !dbg !47, !tbaa !6
-  %348 = getelementptr inbounds i64, i64* %347, i64 1, !dbg !47
-  %349 = getelementptr inbounds i64, i64* %348, i64 1, !dbg !47
-  %350 = getelementptr inbounds i64, i64* %349, i64 1, !dbg !47
-  %351 = getelementptr inbounds i64, i64* %350, i64 1, !dbg !47
-  %352 = bitcast i64* %348 to <4 x i64>*, !dbg !47
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %352, align 8, !dbg !47, !tbaa !6
-  %353 = getelementptr inbounds i64, i64* %351, i64 1, !dbg !47
-  %354 = getelementptr inbounds i64, i64* %353, i64 1, !dbg !47
-  %355 = bitcast i64* %353 to <2 x i64>*, !dbg !47
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %355, align 8, !dbg !47, !tbaa !6
-  %356 = getelementptr inbounds i64, i64* %354, i64 1, !dbg !47
-  store i64 -17, i64* %356, align 8, !dbg !47, !tbaa !6
-  %357 = getelementptr inbounds i64, i64* %356, i64 1, !dbg !47
-  store i64 -19, i64* %357, align 8, !dbg !47, !tbaa !6
-  %358 = getelementptr inbounds i64, i64* %357, i64 1, !dbg !47
-  store i64* %358, i64** %346, align 8, !dbg !47
+  %334 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !47
+  %335 = load i64*, i64** %334, align 8, !dbg !47
+  store i64 %105, i64* %335, align 8, !dbg !47, !tbaa !6
+  %336 = getelementptr inbounds i64, i64* %335, i64 1, !dbg !47
+  %337 = getelementptr inbounds i64, i64* %336, i64 1, !dbg !47
+  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !47
+  %339 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !47
+  %340 = bitcast i64* %336 to <4 x i64>*, !dbg !47
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %340, align 8, !dbg !47, !tbaa !6
+  %341 = getelementptr inbounds i64, i64* %339, i64 1, !dbg !47
+  %342 = getelementptr inbounds i64, i64* %341, i64 1, !dbg !47
+  %343 = bitcast i64* %341 to <2 x i64>*, !dbg !47
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %343, align 8, !dbg !47, !tbaa !6
+  %344 = getelementptr inbounds i64, i64* %342, i64 1, !dbg !47
+  store i64 -17, i64* %344, align 8, !dbg !47, !tbaa !6
+  %345 = getelementptr inbounds i64, i64* %344, i64 1, !dbg !47
+  store i64 -19, i64* %345, align 8, !dbg !47, !tbaa !6
+  %346 = getelementptr inbounds i64, i64* %345, i64 1, !dbg !47
+  store i64* %346, i64** %334, align 8, !dbg !47
   %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !47
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %116, align 8, !dbg !47, !tbaa !14
-  %359 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !48
-  %360 = load i64*, i64** %359, align 8, !dbg !48
-  store i64 %105, i64* %360, align 8, !dbg !48, !tbaa !6
-  %361 = getelementptr inbounds i64, i64* %360, i64 1, !dbg !48
-  %362 = getelementptr inbounds i64, i64* %361, i64 1, !dbg !48
-  %363 = getelementptr inbounds i64, i64* %362, i64 1, !dbg !48
-  %364 = getelementptr inbounds i64, i64* %363, i64 1, !dbg !48
-  %365 = bitcast i64* %361 to <4 x i64>*, !dbg !48
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %365, align 8, !dbg !48, !tbaa !6
-  %366 = getelementptr inbounds i64, i64* %364, i64 1, !dbg !48
-  %367 = getelementptr inbounds i64, i64* %366, i64 1, !dbg !48
-  %368 = bitcast i64* %366 to <2 x i64>*, !dbg !48
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %368, align 8, !dbg !48, !tbaa !6
-  %369 = getelementptr inbounds i64, i64* %367, i64 1, !dbg !48
-  store i64 -19, i64* %369, align 8, !dbg !48, !tbaa !6
-  %370 = getelementptr inbounds i64, i64* %369, i64 1, !dbg !48
-  store i64* %370, i64** %359, align 8, !dbg !48
+  %347 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !48
+  %348 = load i64*, i64** %347, align 8, !dbg !48
+  store i64 %105, i64* %348, align 8, !dbg !48, !tbaa !6
+  %349 = getelementptr inbounds i64, i64* %348, i64 1, !dbg !48
+  %350 = getelementptr inbounds i64, i64* %349, i64 1, !dbg !48
+  %351 = getelementptr inbounds i64, i64* %350, i64 1, !dbg !48
+  %352 = getelementptr inbounds i64, i64* %351, i64 1, !dbg !48
+  %353 = bitcast i64* %349 to <4 x i64>*, !dbg !48
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %353, align 8, !dbg !48, !tbaa !6
+  %354 = getelementptr inbounds i64, i64* %352, i64 1, !dbg !48
+  %355 = getelementptr inbounds i64, i64* %354, i64 1, !dbg !48
+  %356 = bitcast i64* %354 to <2 x i64>*, !dbg !48
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %356, align 8, !dbg !48, !tbaa !6
+  %357 = getelementptr inbounds i64, i64* %355, i64 1, !dbg !48
+  store i64 -19, i64* %357, align 8, !dbg !48, !tbaa !6
+  %358 = getelementptr inbounds i64, i64* %357, i64 1, !dbg !48
+  store i64* %358, i64** %347, align 8, !dbg !48
   %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !48
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %116, align 8, !dbg !48, !tbaa !14
-  %371 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !49
-  %372 = load i64*, i64** %371, align 8, !dbg !49
-  store i64 %105, i64* %372, align 8, !dbg !49, !tbaa !6
-  %373 = getelementptr inbounds i64, i64* %372, i64 1, !dbg !49
-  %374 = getelementptr inbounds i64, i64* %373, i64 1, !dbg !49
-  %375 = getelementptr inbounds i64, i64* %374, i64 1, !dbg !49
-  %376 = getelementptr inbounds i64, i64* %375, i64 1, !dbg !49
-  %377 = bitcast i64* %373 to <4 x i64>*, !dbg !49
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %377, align 8, !dbg !49, !tbaa !6
-  %378 = getelementptr inbounds i64, i64* %376, i64 1, !dbg !49
-  %379 = getelementptr inbounds i64, i64* %378, i64 1, !dbg !49
-  %380 = bitcast i64* %378 to <2 x i64>*, !dbg !49
-  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %380, align 8, !dbg !49, !tbaa !6
-  %381 = getelementptr inbounds i64, i64* %379, i64 1, !dbg !49
-  store i64* %381, i64** %371, align 8, !dbg !49
+  %359 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !49
+  %360 = load i64*, i64** %359, align 8, !dbg !49
+  store i64 %105, i64* %360, align 8, !dbg !49, !tbaa !6
+  %361 = getelementptr inbounds i64, i64* %360, i64 1, !dbg !49
+  %362 = getelementptr inbounds i64, i64* %361, i64 1, !dbg !49
+  %363 = getelementptr inbounds i64, i64* %362, i64 1, !dbg !49
+  %364 = getelementptr inbounds i64, i64* %363, i64 1, !dbg !49
+  %365 = bitcast i64* %361 to <4 x i64>*, !dbg !49
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %365, align 8, !dbg !49, !tbaa !6
+  %366 = getelementptr inbounds i64, i64* %364, i64 1, !dbg !49
+  %367 = getelementptr inbounds i64, i64* %366, i64 1, !dbg !49
+  %368 = bitcast i64* %366 to <2 x i64>*, !dbg !49
+  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %368, align 8, !dbg !49, !tbaa !6
+  %369 = getelementptr inbounds i64, i64* %367, i64 1, !dbg !49
+  store i64* %369, i64** %359, align 8, !dbg !49
   %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !49
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %116, align 8, !dbg !49, !tbaa !14
-  %382 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !50
-  %383 = load i64*, i64** %382, align 8, !dbg !50
-  store i64 %105, i64* %383, align 8, !dbg !50, !tbaa !6
-  %384 = getelementptr inbounds i64, i64* %383, i64 1, !dbg !50
-  %385 = getelementptr inbounds i64, i64* %384, i64 1, !dbg !50
-  %386 = getelementptr inbounds i64, i64* %385, i64 1, !dbg !50
-  %387 = getelementptr inbounds i64, i64* %386, i64 1, !dbg !50
-  %388 = bitcast i64* %384 to <4 x i64>*, !dbg !50
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %388, align 8, !dbg !50, !tbaa !6
-  %389 = getelementptr inbounds i64, i64* %387, i64 1, !dbg !50
-  store i64 -19, i64* %389, align 8, !dbg !50, !tbaa !6
-  %390 = getelementptr inbounds i64, i64* %389, i64 1, !dbg !50
-  store i64* %390, i64** %382, align 8, !dbg !50
+  %370 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !50
+  %371 = load i64*, i64** %370, align 8, !dbg !50
+  store i64 %105, i64* %371, align 8, !dbg !50, !tbaa !6
+  %372 = getelementptr inbounds i64, i64* %371, i64 1, !dbg !50
+  %373 = getelementptr inbounds i64, i64* %372, i64 1, !dbg !50
+  %374 = getelementptr inbounds i64, i64* %373, i64 1, !dbg !50
+  %375 = getelementptr inbounds i64, i64* %374, i64 1, !dbg !50
+  %376 = bitcast i64* %372 to <4 x i64>*, !dbg !50
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %376, align 8, !dbg !50, !tbaa !6
+  %377 = getelementptr inbounds i64, i64* %375, i64 1, !dbg !50
+  store i64 -19, i64* %377, align 8, !dbg !50, !tbaa !6
+  %378 = getelementptr inbounds i64, i64* %377, i64 1, !dbg !50
+  store i64* %378, i64** %370, align 8, !dbg !50
   %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !50
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %116, align 8, !dbg !50, !tbaa !14
-  %391 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !51
-  %392 = load i64*, i64** %391, align 8, !dbg !51
-  store i64 %105, i64* %392, align 8, !dbg !51, !tbaa !6
-  %393 = getelementptr inbounds i64, i64* %392, i64 1, !dbg !51
-  %394 = getelementptr inbounds i64, i64* %393, i64 1, !dbg !51
-  %395 = getelementptr inbounds i64, i64* %394, i64 1, !dbg !51
-  %396 = getelementptr inbounds i64, i64* %395, i64 1, !dbg !51
-  %397 = bitcast i64* %393 to <4 x i64>*, !dbg !51
-  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %397, align 8, !dbg !51, !tbaa !6
-  %398 = getelementptr inbounds i64, i64* %396, i64 1, !dbg !51
-  store i64* %398, i64** %391, align 8, !dbg !51
+  %379 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %108, i64 0, i32 1, !dbg !51
+  %380 = load i64*, i64** %379, align 8, !dbg !51
+  store i64 %105, i64* %380, align 8, !dbg !51, !tbaa !6
+  %381 = getelementptr inbounds i64, i64* %380, i64 1, !dbg !51
+  %382 = getelementptr inbounds i64, i64* %381, i64 1, !dbg !51
+  %383 = getelementptr inbounds i64, i64* %382, i64 1, !dbg !51
+  %384 = getelementptr inbounds i64, i64* %383, i64 1, !dbg !51
+  %385 = bitcast i64* %381 to <4 x i64>*, !dbg !51
+  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %385, align 8, !dbg !51, !tbaa !6
+  %386 = getelementptr inbounds i64, i64* %384, i64 1, !dbg !51
+  store i64* %386, i64** %379, align 8, !dbg !51
   %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !51
   call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %109)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %110)
@@ -1319,6 +1300,3 @@ attributes #14 = { nounwind allocsize(0,1) }
 !80 = !{!70, !57, i64 48}
 !81 = !{!70, !57, i64 52}
 !82 = !{!70, !15, i64 56}
-!83 = !{!63, !57, i64 40}
-!84 = !{!63, !57, i64 44}
-!85 = !{!63, !15, i64 56}

--- a/test/testdata/compiler/block_no_args_captures_constant.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args_captures_constant.opt.ll.exp
@@ -405,29 +405,12 @@ entry:
   %32 = getelementptr inbounds i8, i8* %28, i64 4, !dbg !62
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %32, i8 0, i64 28, i1 false) #12, !dbg !62
   call void @sorbet_vm_define_method(i64 %26, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %28, %struct.rb_iseq_struct* %stackFrame13.i, i1 noundef zeroext false) #12, !dbg !62
-  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !62, !tbaa !14
-  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 5, !dbg !62
-  %35 = load i32, i32* %34, align 8, !dbg !62, !tbaa !44
-  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 6, !dbg !62
-  %37 = load i32, i32* %36, align 4, !dbg !62, !tbaa !45
-  %38 = xor i32 %37, -1, !dbg !62
-  %39 = and i32 %38, %35, !dbg !62
-  %40 = icmp eq i32 %39, 0, !dbg !62
-  br i1 %40, label %"func_<root>.17<static-init>$152.exit", label %41, !dbg !62, !prof !46
-
-41:                                               ; preds = %entry
-  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 8, !dbg !62
-  %43 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %42, align 8, !dbg !62, !tbaa !47
-  %44 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %43, i32 noundef 0) #12, !dbg !62
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !62
-
-"func_<root>.17<static-init>$152.exit":           ; preds = %entry, %41
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %25, align 8, !dbg !62, !tbaa !14
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %19, i64 0, i32 1, !dbg !50
-  %46 = load i64*, i64** %45, align 8, !dbg !50
-  store i64 %16, i64* %46, align 8, !dbg !50, !tbaa !6
-  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !50
-  store i64* %47, i64** %45, align 8, !dbg !50
+  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %19, i64 0, i32 1, !dbg !50
+  %34 = load i64*, i64** %33, align 8, !dbg !50
+  store i64 %16, i64* %34, align 8, !dbg !50, !tbaa !6
+  %35 = getelementptr inbounds i64, i64* %34, i64 1, !dbg !50
+  store i64* %35, i64** %33, align 8, !dbg !50
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !50
   ret void
 }

--- a/test/testdata/compiler/block_type_checking.opt.ll.exp
+++ b/test/testdata/compiler/block_type_checking.opt.ll.exp
@@ -142,11 +142,11 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @rubyIdPrecomputed_extend = internal unnamed_addr global i64 0, align 8
 @str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
+@rb_cObject = external local_unnamed_addr constant i64
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
 @guard_epoch_Foo = linkonce local_unnamed_addr global i64 0
 @guarded_const_Foo = linkonce local_unnamed_addr global i64 0
-@rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_T = linkonce local_unnamed_addr global i64 0
 @guarded_const_T = linkonce local_unnamed_addr global i64 0
 @rb_cInteger = external local_unnamed_addr constant i64
@@ -260,142 +260,14 @@ functionEntryInitializers:
   ret i64 13, !dbg !25
 }
 
-; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_Foo.13<static-init>L62"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #9 !dbg !26 {
-functionEntryInitializers:
-  %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
-  %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !21
-  %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !23
-  %6 = load i64, i64* %5, align 8, !tbaa !6
-  %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #17
-  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !27, !tbaa !15
-  %rubyId_bar = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !28
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_bar), !dbg !28
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_Foo.13<static-init>L62$block_1"), !dbg !28
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !28
-  %11 = load i32, i32* %10, align 8, !dbg !28, !tbaa !29
-  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !28
-  %13 = load i32, i32* %12, align 4, !dbg !28, !tbaa !30
-  %14 = xor i32 %13, -1, !dbg !28
-  %15 = and i32 %14, %11, !dbg !28
-  %16 = icmp eq i32 %15, 0, !dbg !28
-  br i1 %16, label %rb_vm_check_ints.exit1, label %17, !dbg !28, !prof !31
-
-17:                                               ; preds = %functionEntryInitializers
-  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !28
-  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !28, !tbaa !32
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #17, !dbg !28
-  br label %rb_vm_check_ints.exit1, !dbg !28
-
-rb_vm_check_ints.exit1:                           ; preds = %functionEntryInitializers, %17
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !28, !tbaa !15
-  %21 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !33
-  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !34
-  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !33
-  br i1 %needTakeSlowPath, label %23, label %24, !dbg !33, !prof !36
-
-23:                                               ; preds = %rb_vm_check_ints.exit1
-  tail call void @"const_recompute_T::Sig"(), !dbg !33
-  br label %24, !dbg !33
-
-24:                                               ; preds = %rb_vm_check_ints.exit1, %23
-  %25 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !33
-  %26 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !33
-  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !34
-  %guardUpdated = icmp eq i64 %26, %27, !dbg !33
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !33
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !33
-  %29 = load i64*, i64** %28, align 8, !dbg !33
-  store i64 %selfRaw, i64* %29, align 8, !dbg !33, !tbaa !6
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !33
-  store i64 %25, i64* %30, align 8, !dbg !33, !tbaa !6
-  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !33
-  store i64* %31, i64** %28, align 8, !dbg !33
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !33
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !33, !tbaa !15
-  %32 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !37
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !37, !tbaa !34
-  %needTakeSlowPath2 = icmp ne i64 %32, %33, !dbg !37
-  br i1 %needTakeSlowPath2, label %34, label %35, !dbg !37, !prof !36
-
-34:                                               ; preds = %24
-  tail call void @const_recompute_Foo(), !dbg !37
-  br label %35, !dbg !37
-
-35:                                               ; preds = %24, %34
-  %36 = load i64, i64* @guarded_const_Foo, align 8, !dbg !37
-  %37 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !37
-  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !37, !tbaa !34
-  %guardUpdated3 = icmp eq i64 %37, %38, !dbg !37
-  tail call void @llvm.assume(i1 %guardUpdated3), !dbg !37
-  %stackFrame43 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8, !dbg !37
-  %39 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !37
-  %40 = bitcast i8* %39 to i16*, !dbg !37
-  %41 = load i16, i16* %40, align 8, !dbg !37
-  %42 = and i16 %41, -384, !dbg !37
-  %43 = or i16 %42, 65, !dbg !37
-  store i16 %43, i16* %40, align 8, !dbg !37
-  %44 = getelementptr inbounds i8, i8* %39, i64 8, !dbg !37
-  %45 = bitcast i8* %44 to i32*, !dbg !37
-  store i32 1, i32* %45, align 8, !dbg !37, !tbaa !38
-  %46 = getelementptr inbounds i8, i8* %39, i64 12, !dbg !37
-  %47 = bitcast i8* %46 to i32*, !dbg !37
-  %48 = getelementptr inbounds i8, i8* %39, i64 28, !dbg !37
-  %49 = bitcast i8* %48 to i32*, !dbg !37
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 16, i1 false), !dbg !37
-  store i32 1, i32* %49, align 4, !dbg !37, !tbaa !41
-  %50 = getelementptr inbounds i8, i8* %39, i64 4, !dbg !37
-  %51 = bitcast i8* %50 to i32*, !dbg !37
-  store i32 2, i32* %51, align 4, !dbg !37, !tbaa !42
-  %positional_table = alloca i64, i32 2, align 8, !dbg !37
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !37
-  store i64 %rubyId_x, i64* %positional_table, align 8, !dbg !37
-  %rubyId_blk = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !37
-  %52 = getelementptr i64, i64* %positional_table, i32 1, !dbg !37
-  store i64 %rubyId_blk, i64* %52, align 8, !dbg !37
-  %53 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #18, !dbg !37
-  %54 = bitcast i64* %positional_table to i8*, !dbg !37
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %53, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %54, i64 noundef 16, i1 noundef false) #17, !dbg !37
-  %55 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !37
-  %56 = bitcast i8* %55 to i8**, !dbg !37
-  store i8* %53, i8** %56, align 8, !dbg !37, !tbaa !43
-  tail call void @sorbet_vm_define_method(i64 %36, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Foo#3bar", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame43, i1 noundef zeroext false) #17, !dbg !37
-  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !15
-  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 5, !dbg !37
-  %59 = load i32, i32* %58, align 8, !dbg !37, !tbaa !29
-  %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 6, !dbg !37
-  %61 = load i32, i32* %60, align 4, !dbg !37, !tbaa !30
-  %62 = xor i32 %61, -1, !dbg !37
-  %63 = and i32 %62, %59, !dbg !37
-  %64 = icmp eq i32 %63, 0, !dbg !37
-  br i1 %64, label %rb_vm_check_ints.exit, label %65, !dbg !37, !prof !31
-
-65:                                               ; preds = %35
-  %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 8, !dbg !37
-  %67 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %66, align 8, !dbg !37, !tbaa !32
-  %68 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %67, i32 noundef 0) #17, !dbg !37
-  br label %rb_vm_check_ints.exit, !dbg !37
-
-rb_vm_check_ints.exit:                            ; preds = %35, %65
-  ret void
-}
-
 ; Function Attrs: sspreq
-define void @Init_block_type_checking() local_unnamed_addr #10 {
+define void @Init_block_type_checking() local_unnamed_addr #9 {
 entry:
+  %positional_table.i.i = alloca i64, i32 2, align 8, !dbg !26
   %locals.i18.i = alloca i64, i32 0, align 8
   %locals.i16.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, i32 2, align 8, !dbg !44
+  %keywords.i = alloca i64, i32 2, align 8, !dbg !29
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %0)
@@ -448,14 +320,14 @@ entry:
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !46
-  %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !46
-  %rubyId_bar.i = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
-  %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !31
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !31
+  %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !31
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !31
+  %rubyId_bar.i = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !31
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !31
+  %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !32
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !32
   %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #17
   call void @rb_gc_register_mark_object(i64 %22) #17
   %rubyId_bar.i.i = load i64, i64* @rubyIdPrecomputed_bar, align 8
@@ -475,27 +347,27 @@ entry:
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %26, i64 %"rubyId_block in <class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i19.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>$block_1", align 8
-  %rubyId_proc.i = load i64, i64* @rubyIdPrecomputed_proc, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_proc, i64 %rubyId_proc.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !48
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !48
-  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !44
-  %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !44
-  %28 = call i64 @rb_id2sym(i64 %rubyId_x.i) #19, !dbg !44
-  store i64 %28, i64* %keywords.i, align 8, !dbg !44
-  %rubyId_blk.i = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !44
-  %29 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #19, !dbg !44
-  %30 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !44
-  store i64 %29, i64* %30, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords.i), !dbg !44
-  %rubyId_returns10.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.1, i64 %rubyId_returns10.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !44
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !33
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !33
+  %rubyId_proc.i = load i64, i64* @rubyIdPrecomputed_proc, align 8, !dbg !33
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_proc, i64 %rubyId_proc.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !33
+  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !33
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !33
+  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !29
+  %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !29
+  %28 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !29
+  store i64 %28, i64* %keywords.i, align 8, !dbg !29
+  %rubyId_blk.i = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !29
+  %29 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #18, !dbg !29
+  %30 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !29
+  store i64 %29, i64* %30, align 8, !dbg !29
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords.i), !dbg !29
+  %rubyId_returns10.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !29
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.1, i64 %rubyId_returns10.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
+  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !34
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !34
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %0)
   %31 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
   %32 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %31, i64 0, i32 18
-  %33 = load i64, i64* %32, align 8, !tbaa !49
+  %33 = load i64, i64* %32, align 8, !tbaa !35
   %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
   %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !17
@@ -509,191 +381,264 @@ entry:
   store i64 %41, i64* %39, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i) #17
   %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %42, align 8, !dbg !57, !tbaa !15
-  %43 = load i64, i64* @rb_cObject, align 8, !dbg !58
-  %44 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 %43) #17, !dbg !58
-  %45 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %44) #17, !dbg !58
-  call fastcc void @"func_Foo.13<static-init>L62"(i64 %44, %struct.rb_control_frame_struct* %45) #17, !dbg !58
-  call void @sorbet_popFrame() #17, !dbg !58
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %42, align 8, !dbg !58, !tbaa !15
-  %46 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !46
-  %47 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !34
-  %needTakeSlowPath = icmp ne i64 %46, %47, !dbg !46
-  br i1 %needTakeSlowPath, label %48, label %49, !dbg !46, !prof !36
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %42, align 8, !dbg !44, !tbaa !15
+  %43 = load i64, i64* @rb_cObject, align 8, !dbg !45
+  %44 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 %43) #17, !dbg !45
+  %45 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %44) #17, !dbg !45
+  %46 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %46) #17
+  %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
+  %47 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 2
+  %49 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %48, align 8, !tbaa !17
+  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %50, align 8, !tbaa !21
+  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 4
+  %52 = load i64*, i64** %51, align 8, !tbaa !23
+  %53 = load i64, i64* %52, align 8, !tbaa !6
+  %54 = and i64 %53, -33
+  store i64 %54, i64* %52, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %47, %struct.rb_control_frame_struct* %49, %struct.rb_iseq_struct* %stackFrame.i.i1) #17
+  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %45, i64 0, i32 0
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %55, align 8, !dbg !46, !tbaa !15
+  %rubyId_bar.i.i2 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !47
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_bar.i.i2) #17, !dbg !47
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %44, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_Foo.13<static-init>L62$block_1") #17, !dbg !47
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %55, align 8, !dbg !47, !tbaa !15
+  %56 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
+  %57 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
+  %needTakeSlowPath = icmp ne i64 %56, %57, !dbg !48
+  br i1 %needTakeSlowPath, label %58, label %59, !dbg !48, !prof !50
 
-48:                                               ; preds = %entry
-  call void @const_recompute_Foo(), !dbg !46
-  br label %49, !dbg !46
+58:                                               ; preds = %entry
+  call void @"const_recompute_T::Sig"(), !dbg !48
+  br label %59, !dbg !48
 
-49:                                               ; preds = %entry, %48
-  %50 = load i64, i64* @guarded_const_Foo, align 8, !dbg !46
-  %51 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !46
-  %52 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !34
-  %guardUpdated = icmp eq i64 %51, %52, !dbg !46
-  call void @llvm.assume(i1 %guardUpdated), !dbg !46
-  %53 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %50, %struct.FunctionInlineCache* noundef @ic_new) #17, !dbg !46
-  %54 = icmp eq i64 %53, 52, !dbg !46
-  br i1 %54, label %slowNew.i, label %fastNew.i, !dbg !46
+59:                                               ; preds = %entry, %58
+  %60 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !48
+  %61 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
+  %62 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
+  %guardUpdated = icmp eq i64 %61, %62, !dbg !48
+  call void @llvm.assume(i1 %guardUpdated), !dbg !48
+  %63 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %45, i64 0, i32 1, !dbg !48
+  %64 = load i64*, i64** %63, align 8, !dbg !48
+  store i64 %44, i64* %64, align 8, !dbg !48, !tbaa !6
+  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !48
+  store i64 %60, i64* %65, align 8, !dbg !48, !tbaa !6
+  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !48
+  store i64* %66, i64** %63, align 8, !dbg !48
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !48
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %55, align 8, !dbg !48, !tbaa !15
+  %67 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
+  %68 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
+  %needTakeSlowPath3 = icmp ne i64 %67, %68, !dbg !26
+  br i1 %needTakeSlowPath3, label %69, label %70, !dbg !26, !prof !50
 
-slowNew.i:                                        ; preds = %49
-  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !46
-  %56 = load i64*, i64** %55, align 8, !dbg !46
-  store i64 %50, i64* %56, align 8, !dbg !46, !tbaa !6
-  %57 = getelementptr inbounds i64, i64* %56, i64 1, !dbg !46
-  store i64* %57, i64** %55, align 8, !dbg !46
-  %58 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #17, !dbg !46
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !46
+69:                                               ; preds = %59
+  call void @const_recompute_Foo(), !dbg !26
+  br label %70, !dbg !26
 
-fastNew.i:                                        ; preds = %49
-  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !46
-  %60 = load i64*, i64** %59, align 8, !dbg !46
-  store i64 %53, i64* %60, align 8, !dbg !46, !tbaa !6
-  %61 = getelementptr inbounds i64, i64* %60, i64 1, !dbg !46
-  store i64* %61, i64** %59, align 8, !dbg !46
-  %62 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #17, !dbg !46
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !46
+70:                                               ; preds = %59, %69
+  %71 = load i64, i64* @guarded_const_Foo, align 8, !dbg !26
+  %72 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
+  %73 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
+  %guardUpdated4 = icmp eq i64 %72, %73, !dbg !26
+  call void @llvm.assume(i1 %guardUpdated4), !dbg !26
+  %stackFrame43.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8, !dbg !26
+  %74 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !26
+  %75 = bitcast i8* %74 to i16*, !dbg !26
+  %76 = load i16, i16* %75, align 8, !dbg !26
+  %77 = and i16 %76, -384, !dbg !26
+  %78 = or i16 %77, 65, !dbg !26
+  store i16 %78, i16* %75, align 8, !dbg !26
+  %79 = getelementptr inbounds i8, i8* %74, i64 8, !dbg !26
+  %80 = bitcast i8* %79 to i32*, !dbg !26
+  store i32 1, i32* %80, align 8, !dbg !26, !tbaa !51
+  %81 = getelementptr inbounds i8, i8* %74, i64 12, !dbg !26
+  %82 = getelementptr inbounds i8, i8* %74, i64 28, !dbg !26
+  %83 = bitcast i8* %82 to i32*, !dbg !26
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %81, i8 0, i64 16, i1 false) #17, !dbg !26
+  store i32 1, i32* %83, align 4, !dbg !26, !tbaa !54
+  %84 = getelementptr inbounds i8, i8* %74, i64 4, !dbg !26
+  %85 = bitcast i8* %84 to i32*, !dbg !26
+  store i32 2, i32* %85, align 4, !dbg !26, !tbaa !55
+  %rubyId_x.i.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !26
+  store i64 %rubyId_x.i.i, i64* %positional_table.i.i, align 8, !dbg !26
+  %rubyId_blk.i.i = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !26
+  %86 = getelementptr i64, i64* %positional_table.i.i, i32 1, !dbg !26
+  store i64 %rubyId_blk.i.i, i64* %86, align 8, !dbg !26
+  %87 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !26
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %87, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %46, i64 noundef 16, i1 noundef false) #17, !dbg !26
+  %88 = getelementptr inbounds i8, i8* %74, i64 32, !dbg !26
+  %89 = bitcast i8* %88 to i8**, !dbg !26
+  store i8* %87, i8** %89, align 8, !dbg !26, !tbaa !56
+  call void @sorbet_vm_define_method(i64 %71, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Foo#3bar", i8* nonnull %74, %struct.rb_iseq_struct* %stackFrame43.i.i, i1 noundef zeroext false) #17, !dbg !26
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %46) #17
+  call void @sorbet_popFrame() #17, !dbg !45
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %42, align 8, !dbg !45, !tbaa !15
+  %90 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %71, %struct.FunctionInlineCache* noundef @ic_new) #17, !dbg !31
+  %91 = icmp eq i64 %90, 52, !dbg !31
+  br i1 %91, label %slowNew.i, label %fastNew.i, !dbg !31
+
+slowNew.i:                                        ; preds = %70
+  %92 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !31
+  %93 = load i64*, i64** %92, align 8, !dbg !31
+  store i64 %71, i64* %93, align 8, !dbg !31, !tbaa !6
+  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !31
+  store i64* %94, i64** %92, align 8, !dbg !31
+  %95 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #17, !dbg !31
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !31
+
+fastNew.i:                                        ; preds = %70
+  %96 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !31
+  %97 = load i64*, i64** %96, align 8, !dbg !31
+  store i64 %90, i64* %97, align 8, !dbg !31, !tbaa !6
+  %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !31
+  store i64* %98, i64** %96, align 8, !dbg !31
+  %99 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #17, !dbg !31
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !31
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %slowNew.i, %fastNew.i
-  %initializedObject.i = phi i64 [ %58, %slowNew.i ], [ %53, %fastNew.i ], !dbg !46
-  %63 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !46
-  %64 = load i64*, i64** %63, align 8, !dbg !46
-  store i64 %initializedObject.i, i64* %64, align 8, !dbg !46, !tbaa !6
-  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !46
-  store i64 11, i64* %65, align 8, !dbg !46, !tbaa !6
-  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !46
-  store i64* %66, i64** %63, align 8, !dbg !46
-  %67 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !15
-  %68 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %67, i64 0, i32 2, !dbg !46
-  %69 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %68, align 8, !dbg !46, !tbaa !17
-  %70 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.17<static-init>$152$block_1", i8* null, i32 0, i32 0) #17, !dbg !46
-  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %69, i64 0, i32 3, !dbg !46
-  %72 = bitcast i64* %71 to %struct.rb_captured_block*, !dbg !46
-  %73 = getelementptr inbounds i64, i64* %71, i64 2, !dbg !46
-  %74 = bitcast i64* %73 to %struct.vm_ifunc**, !dbg !46
-  store %struct.vm_ifunc* %70, %struct.vm_ifunc** %74, align 8, !dbg !46, !tbaa !59
-  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %67, i64 0, i32 17, !dbg !46
-  store i64 0, i64* %75, align 8, !dbg !46, !tbaa !60
-  call void @llvm.experimental.noalias.scope.decl(metadata !61) #17, !dbg !46
-  %76 = ptrtoint %struct.rb_captured_block* %72 to i64, !dbg !46
-  %77 = or i64 %76, 3, !dbg !46
-  %78 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %77) #17, !dbg !46
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %42, align 8, !dbg !46, !tbaa !15
-  %79 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !47
-  %80 = load i64*, i64** %79, align 8, !dbg !47
-  store i64 %33, i64* %80, align 8, !dbg !47, !tbaa !6
-  %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !47
-  store i64 %78, i64* %81, align 8, !dbg !47, !tbaa !6
-  %82 = getelementptr inbounds i64, i64* %81, i64 1, !dbg !47
-  store i64* %82, i64** %79, align 8, !dbg !47
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !47
+  %initializedObject.i = phi i64 [ %95, %slowNew.i ], [ %90, %fastNew.i ], !dbg !31
+  %100 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !31
+  %101 = load i64*, i64** %100, align 8, !dbg !31
+  store i64 %initializedObject.i, i64* %101, align 8, !dbg !31, !tbaa !6
+  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !31
+  store i64 11, i64* %102, align 8, !dbg !31, !tbaa !6
+  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !31
+  store i64* %103, i64** %100, align 8, !dbg !31
+  %104 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !31, !tbaa !15
+  %105 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %104, i64 0, i32 2, !dbg !31
+  %106 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %105, align 8, !dbg !31, !tbaa !17
+  %107 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* @"func_<root>.17<static-init>$152$block_1", i8* null, i32 0, i32 0) #17, !dbg !31
+  %108 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %106, i64 0, i32 3, !dbg !31
+  %109 = bitcast i64* %108 to %struct.rb_captured_block*, !dbg !31
+  %110 = getelementptr inbounds i64, i64* %108, i64 2, !dbg !31
+  %111 = bitcast i64* %110 to %struct.vm_ifunc**, !dbg !31
+  store %struct.vm_ifunc* %107, %struct.vm_ifunc** %111, align 8, !dbg !31, !tbaa !57
+  %112 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %104, i64 0, i32 17, !dbg !31
+  store i64 0, i64* %112, align 8, !dbg !31, !tbaa !58
+  call void @llvm.experimental.noalias.scope.decl(metadata !59) #17, !dbg !31
+  %113 = ptrtoint %struct.rb_captured_block* %109 to i64, !dbg !31
+  %114 = or i64 %113, 3, !dbg !31
+  %115 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %114) #17, !dbg !31
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %42, align 8, !dbg !31, !tbaa !15
+  %116 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 1, !dbg !32
+  %117 = load i64*, i64** %116, align 8, !dbg !32
+  store i64 %33, i64* %117, align 8, !dbg !32, !tbaa !6
+  %118 = getelementptr inbounds i64, i64* %117, i64 1, !dbg !32
+  store i64 %115, i64* %118, align 8, !dbg !32, !tbaa !6
+  %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !32
+  store i64* %119, i64** %116, align 8, !dbg !32
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !32
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @"func_Foo#3bar"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #9 !dbg !64 {
+define internal i64 @"func_Foo#3bar"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #10 !dbg !62 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !tbaa !15
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !65
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !65
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !65
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !65, !prof !66
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !63
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !63
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !63
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !63, !prof !64
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #20, !dbg !65
-  unreachable, !dbg !65
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #20, !dbg !63
+  unreachable, !dbg !63
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !65
-  %1 = tail call i32 @rb_block_given_p() #17, !dbg !65
-  %2 = icmp eq i32 %1, 0, !dbg !65
-  br i1 %2, label %sorbet_getMethodBlockAsProc.exit, label %3, !dbg !65
+  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !63
+  %1 = tail call i32 @rb_block_given_p() #17, !dbg !63
+  %2 = icmp eq i32 %1, 0, !dbg !63
+  br i1 %2, label %sorbet_getMethodBlockAsProc.exit, label %3, !dbg !63
 
 3:                                                ; preds = %fillRequiredArgs
-  %4 = tail call i64 @rb_block_proc() #17, !dbg !65
-  br label %sorbet_getMethodBlockAsProc.exit, !dbg !65
+  %4 = tail call i64 @rb_block_proc() #17, !dbg !63
+  br label %sorbet_getMethodBlockAsProc.exit, !dbg !63
 
 sorbet_getMethodBlockAsProc.exit:                 ; preds = %fillRequiredArgs, %3
-  %5 = phi i64 [ %4, %3 ], [ 8, %fillRequiredArgs ], !dbg !65
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !67, !tbaa !15
-  %6 = and i64 %rawArg_x, 1, !dbg !68
-  %7 = icmp eq i64 %6, 0, !dbg !68
-  br i1 %7, label %8, label %typeTestSuccess, !dbg !68, !prof !69
+  %5 = phi i64 [ %4, %3 ], [ 8, %fillRequiredArgs ], !dbg !63
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !65, !tbaa !15
+  %6 = and i64 %rawArg_x, 1, !dbg !66
+  %7 = icmp eq i64 %6, 0, !dbg !66
+  br i1 %7, label %8, label %typeTestSuccess, !dbg !66, !prof !67
 
 8:                                                ; preds = %sorbet_getMethodBlockAsProc.exit
-  %9 = and i64 %rawArg_x, 7, !dbg !68
-  %10 = icmp ne i64 %9, 0, !dbg !68
-  %11 = and i64 %rawArg_x, -9, !dbg !68
-  %12 = icmp eq i64 %11, 0, !dbg !68
-  %13 = or i1 %10, %12, !dbg !68
-  br i1 %13, label %codeRepl25, label %sorbet_isa_Integer.exit, !dbg !68
+  %9 = and i64 %rawArg_x, 7, !dbg !66
+  %10 = icmp ne i64 %9, 0, !dbg !66
+  %11 = and i64 %rawArg_x, -9, !dbg !66
+  %12 = icmp eq i64 %11, 0, !dbg !66
+  %13 = or i1 %10, %12, !dbg !66
+  br i1 %13, label %codeRepl25, label %sorbet_isa_Integer.exit, !dbg !66
 
 sorbet_isa_Integer.exit:                          ; preds = %8
-  %14 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !68
-  %15 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %14, i64 0, i32 0, !dbg !68
-  %16 = load i64, i64* %15, align 8, !dbg !68, !tbaa !70
-  %17 = and i64 %16, 31, !dbg !68
-  %18 = icmp eq i64 %17, 10, !dbg !68
-  br i1 %18, label %typeTestSuccess, label %codeRepl25, !dbg !68, !prof !31
+  %14 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !66
+  %15 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %14, i64 0, i32 0, !dbg !66
+  %16 = load i64, i64* %15, align 8, !dbg !66, !tbaa !68
+  %17 = and i64 %16, 31, !dbg !66
+  %18 = icmp eq i64 %17, 10, !dbg !66
+  br i1 %18, label %typeTestSuccess, label %codeRepl25, !dbg !66, !prof !70
 
 typeTestSuccess:                                  ; preds = %sorbet_getMethodBlockAsProc.exit, %sorbet_isa_Integer.exit
-  %19 = tail call i32 @rb_block_given_p() #17, !dbg !72
-  %20 = icmp ne i32 %19, 0, !dbg !72
-  br i1 %20, label %typeTestSuccess7, label %codeRepl24, !dbg !72, !prof !31
+  %19 = tail call i32 @rb_block_given_p() #17, !dbg !71
+  %20 = icmp ne i32 %19, 0, !dbg !71
+  br i1 %20, label %typeTestSuccess7, label %codeRepl24, !dbg !71, !prof !70
 
 codeRepl25:                                       ; preds = %8, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_Foo#3bar.cold.3"(i64 %rawArg_x) #21, !dbg !68
+  tail call fastcc void @"func_Foo#3bar.cold.3"(i64 %rawArg_x) #21, !dbg !66
   unreachable
 
 typeTestSuccess7:                                 ; preds = %typeTestSuccess
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !72, !tbaa !15
-  %rawBlockSendResult = tail call i64 @sorbet_vm_callBlock(%struct.rb_control_frame_struct* nonnull %cfp, i32 noundef 0, i64* noundef null, i32 noundef 0), !dbg !73
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %0, align 8, !dbg !73, !tbaa !15
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !74), !dbg !77
-  %21 = and i64 %rawArg_x, 1, !dbg !77
-  %22 = and i64 %21, %rawBlockSendResult, !dbg !77
-  %23 = icmp eq i64 %22, 0, !dbg !77
-  br i1 %23, label %33, label %24, !dbg !77, !prof !66
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !71, !tbaa !15
+  %rawBlockSendResult = tail call i64 @sorbet_vm_callBlock(%struct.rb_control_frame_struct* nonnull %cfp, i32 noundef 0, i64* noundef null, i32 noundef 0), !dbg !72
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %0, align 8, !dbg !72, !tbaa !15
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !73), !dbg !76
+  %21 = and i64 %rawArg_x, 1, !dbg !76
+  %22 = and i64 %21, %rawBlockSendResult, !dbg !76
+  %23 = icmp eq i64 %22, 0, !dbg !76
+  br i1 %23, label %33, label %24, !dbg !76, !prof !64
 
 24:                                               ; preds = %typeTestSuccess7
-  %25 = add nsw i64 %rawBlockSendResult, -1, !dbg !77
-  %26 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_x, i64 %25) #22, !dbg !77
-  %27 = extractvalue { i64, i1 } %26, 1, !dbg !77
-  %28 = extractvalue { i64, i1 } %26, 0, !dbg !77
-  br i1 %27, label %29, label %sorbet_rb_int_plus.exit, !dbg !77
+  %25 = add nsw i64 %rawBlockSendResult, -1, !dbg !76
+  %26 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_x, i64 %25) #22, !dbg !76
+  %27 = extractvalue { i64, i1 } %26, 1, !dbg !76
+  %28 = extractvalue { i64, i1 } %26, 0, !dbg !76
+  br i1 %27, label %29, label %sorbet_rb_int_plus.exit, !dbg !76
 
 29:                                               ; preds = %24
-  %30 = ashr i64 %28, 1, !dbg !77
-  %31 = xor i64 %30, -9223372036854775808, !dbg !77
-  %32 = tail call i64 @rb_int2big(i64 %31) #17, !dbg !77, !noalias !74
-  br label %sorbet_rb_int_plus.exit, !dbg !77
+  %30 = ashr i64 %28, 1, !dbg !76
+  %31 = xor i64 %30, -9223372036854775808, !dbg !76
+  %32 = tail call i64 @rb_int2big(i64 %31) #17, !dbg !76, !noalias !73
+  br label %sorbet_rb_int_plus.exit, !dbg !76
 
 33:                                               ; preds = %typeTestSuccess7
-  %34 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_x, i64 %rawBlockSendResult) #17, !dbg !77, !noalias !74
-  br label %sorbet_rb_int_plus.exit, !dbg !77
+  %34 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_x, i64 %rawBlockSendResult) #17, !dbg !76, !noalias !73
+  br label %sorbet_rb_int_plus.exit, !dbg !76
 
 sorbet_rb_int_plus.exit:                          ; preds = %29, %24, %33
-  %35 = phi i64 [ %34, %33 ], [ %32, %29 ], [ %28, %24 ], !dbg !77
-  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !77, !tbaa !15
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 5, !dbg !77
-  %38 = load i32, i32* %37, align 8, !dbg !77, !tbaa !29
-  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 6, !dbg !77
-  %40 = load i32, i32* %39, align 4, !dbg !77, !tbaa !30
-  %41 = xor i32 %40, -1, !dbg !77
-  %42 = and i32 %41, %38, !dbg !77
-  %43 = icmp eq i32 %42, 0, !dbg !77
-  br i1 %43, label %rb_vm_check_ints.exit, label %44, !dbg !77, !prof !31
+  %35 = phi i64 [ %34, %33 ], [ %32, %29 ], [ %28, %24 ], !dbg !76
+  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !76, !tbaa !15
+  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 5, !dbg !76
+  %38 = load i32, i32* %37, align 8, !dbg !76, !tbaa !77
+  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 6, !dbg !76
+  %40 = load i32, i32* %39, align 4, !dbg !76, !tbaa !78
+  %41 = xor i32 %40, -1, !dbg !76
+  %42 = and i32 %41, %38, !dbg !76
+  %43 = icmp eq i32 %42, 0, !dbg !76
+  br i1 %43, label %rb_vm_check_ints.exit, label %44, !dbg !76, !prof !70
 
 44:                                               ; preds = %sorbet_rb_int_plus.exit
-  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 8, !dbg !77
-  %46 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %45, align 8, !dbg !77, !tbaa !32
-  %47 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %46, i32 noundef 0) #17, !dbg !77
-  br label %rb_vm_check_ints.exit, !dbg !77
+  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 8, !dbg !76
+  %46 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %45, align 8, !dbg !76, !tbaa !79
+  %47 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %46, i32 noundef 0) #17, !dbg !76
+  br label %rb_vm_check_ints.exit, !dbg !76
 
 rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.exit, %44
   %48 = and i64 %35, 1
   %49 = icmp eq i64 %48, 0
-  br i1 %49, label %50, label %typeTestSuccess17, !prof !69
+  br i1 %49, label %50, label %typeTestSuccess17, !prof !67
 
 50:                                               ; preds = %rb_vm_check_ints.exit
   %51 = and i64 %35, 7
@@ -706,31 +651,31 @@ rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.
 sorbet_isa_Integer.exit26:                        ; preds = %50
   %56 = inttoptr i64 %35 to %struct.iseq_inline_iv_cache_entry*
   %57 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %56, i64 0, i32 0
-  %58 = load i64, i64* %57, align 8, !tbaa !70
+  %58 = load i64, i64* %57, align 8, !tbaa !68
   %59 = and i64 %58, 31
   %60 = icmp eq i64 %59, 10
-  br i1 %60, label %typeTestSuccess17, label %codeRepl, !prof !31
+  br i1 %60, label %typeTestSuccess17, label %codeRepl, !prof !70
 
 codeRepl24:                                       ; preds = %typeTestSuccess
-  tail call fastcc void @"func_Foo#3bar.cold.2"(i64 %5) #21, !dbg !72
+  tail call fastcc void @"func_Foo#3bar.cold.2"(i64 %5) #21, !dbg !71
   unreachable
 
 typeTestSuccess17:                                ; preds = %rb_vm_check_ints.exit, %sorbet_isa_Integer.exit26
   ret i64 %35
 
 codeRepl:                                         ; preds = %50, %sorbet_isa_Integer.exit26
-  tail call fastcc void @"func_Foo#3bar.cold.1"(i64 %35) #21, !dbg !67
+  tail call fastcc void @"func_Foo#3bar.cold.1"(i64 %35) #21, !dbg !65
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_Foo.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #11 !dbg !45 {
+define internal i64 @"func_Foo.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #11 !dbg !30 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !78
+  %4 = load i64, i64* %3, align 8, !tbaa !80
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>$block_1", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
   store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !21
@@ -741,55 +686,55 @@ functionEntryInitializers:
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %10, align 8, !tbaa !15
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !48
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !34
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !48
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !48, !prof !36
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !33
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !49
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !33
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !33, !prof !50
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !48
-  br label %14, !dbg !48
+  tail call void @const_recompute_T(), !dbg !33
+  br label %14, !dbg !33
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !48
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !48
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !34
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !48
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !48
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !48
-  %19 = load i64*, i64** %18, align 8, !dbg !48
-  store i64 %15, i64* %19, align 8, !dbg !48, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !48
-  store i64* %20, i64** %18, align 8, !dbg !48
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_proc, i64 0), !dbg !48
-  %21 = load i64, i64* @rb_cInteger, align 8, !dbg !48
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !48
-  %23 = load i64*, i64** %22, align 8, !dbg !48
-  store i64 %send, i64* %23, align 8, !dbg !48, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !48
-  store i64 %21, i64* %24, align 8, !dbg !48, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !48
-  store i64* %25, i64** %22, align 8, !dbg !48
-  %send41 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !48
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !44
-  %27 = load i64*, i64** %26, align 8, !dbg !44
-  store i64 %4, i64* %27, align 8, !dbg !44, !tbaa !6
-  %28 = getelementptr inbounds i64, i64* %27, i64 1, !dbg !44
-  store i64 %21, i64* %28, align 8, !dbg !44, !tbaa !6
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !44
-  store i64 %send41, i64* %29, align 8, !dbg !44, !tbaa !6
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !44
-  store i64* %30, i64** %26, align 8, !dbg !44
-  %send43 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !44
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !44
-  %32 = load i64*, i64** %31, align 8, !dbg !44
-  store i64 %send43, i64* %32, align 8, !dbg !44, !tbaa !6
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !44
-  store i64 %21, i64* %33, align 8, !dbg !44, !tbaa !6
-  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !44
-  store i64* %34, i64** %31, align 8, !dbg !44
-  %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.1, i64 0), !dbg !44
-  ret i64 %send45, !dbg !79
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !33
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !33
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !49
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !33
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !33
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !33
+  %19 = load i64*, i64** %18, align 8, !dbg !33
+  store i64 %15, i64* %19, align 8, !dbg !33, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !33
+  store i64* %20, i64** %18, align 8, !dbg !33
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_proc, i64 0), !dbg !33
+  %21 = load i64, i64* @rb_cInteger, align 8, !dbg !33
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !33
+  %23 = load i64*, i64** %22, align 8, !dbg !33
+  store i64 %send, i64* %23, align 8, !dbg !33, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !33
+  store i64 %21, i64* %24, align 8, !dbg !33, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !33
+  store i64* %25, i64** %22, align 8, !dbg !33
+  %send41 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !33
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !29
+  %27 = load i64*, i64** %26, align 8, !dbg !29
+  store i64 %4, i64* %27, align 8, !dbg !29, !tbaa !6
+  %28 = getelementptr inbounds i64, i64* %27, i64 1, !dbg !29
+  store i64 %21, i64* %28, align 8, !dbg !29, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !29
+  store i64 %send41, i64* %29, align 8, !dbg !29, !tbaa !6
+  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !29
+  store i64* %30, i64** %26, align 8, !dbg !29
+  %send43 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !29
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !29
+  %32 = load i64*, i64** %31, align 8, !dbg !29
+  store i64 %send43, i64* %32, align 8, !dbg !29, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !29
+  store i64 %21, i64* %33, align 8, !dbg !29, !tbaa !6
+  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !29
+  store i64* %34, i64** %31, align 8, !dbg !29
+  %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.1, i64 0), !dbg !29
+  ret i64 %send45, !dbg !81
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
@@ -799,24 +744,24 @@ declare void @llvm.experimental.noalias.scope.decl(metadata) #12
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #13
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Foo#3bar.cold.1"(i64 %0) unnamed_addr #14 !dbg !80 {
+define internal fastcc void @"func_Foo#3bar.cold.1"(i64 %0) unnamed_addr #14 !dbg !82 {
 newFuncRoot:
   tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20
   unreachable
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Foo#3bar.cold.2"(i64 %0) unnamed_addr #14 !dbg !82 {
+define internal fastcc void @"func_Foo#3bar.cold.2"(i64 %0) unnamed_addr #14 !dbg !84 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([16 x i8], [16 x i8]* @"str_Parameter 'blk'", i64 0, i64 0), i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_T.proc.returns(Integer)", i64 0, i64 0)) #20, !dbg !83
-  unreachable, !dbg !83
+  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([16 x i8], [16 x i8]* @"str_Parameter 'blk'", i64 0, i64 0), i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_T.proc.returns(Integer)", i64 0, i64 0)) #20, !dbg !85
+  unreachable, !dbg !85
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Foo#3bar.cold.3"(i64 %rawArg_x) unnamed_addr #14 !dbg !84 {
+define internal fastcc void @"func_Foo#3bar.cold.3"(i64 %rawArg_x) unnamed_addr #14 !dbg !86 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_Parameter 'x'", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !85
-  unreachable, !dbg !85
+  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_Parameter 'x'", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !87
+  unreachable, !dbg !87
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
@@ -826,7 +771,7 @@ declare void @llvm.assume(i1 noundef) #15
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #11 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !49
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
@@ -835,7 +780,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #11 {
 define linkonce void @const_recompute_Foo() local_unnamed_addr #11 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 3)
   store i64 %1, i64* @guarded_const_Foo, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !49
   store i64 %2, i64* @guard_epoch_Foo, align 8
   ret void
 }
@@ -844,7 +789,7 @@ define linkonce void @const_recompute_Foo() local_unnamed_addr #11 {
 define linkonce void @const_recompute_T() local_unnamed_addr #11 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_T, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_T, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !34
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !49
   store i64 %2, i64* @guard_epoch_T, align 8
   ret void
 }
@@ -858,8 +803,8 @@ attributes #5 = { nofree nosync nounwind readnone speculatable willreturn }
 attributes #6 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #7 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #8 = { nofree nosync nounwind ssp willreturn }
-attributes #9 = { nounwind sspreq uwtable }
-attributes #10 = { sspreq }
+attributes #9 = { sspreq }
+attributes #10 = { nounwind sspreq uwtable }
 attributes #11 = { ssp }
 attributes #12 = { inaccessiblememonly nofree nosync nounwind willreturn }
 attributes #13 = { argmemonly nofree nosync nounwind willreturn writeonly }
@@ -867,8 +812,8 @@ attributes #14 = { cold minsize noreturn nounwind sspreq uwtable }
 attributes #15 = { nofree nosync nounwind willreturn }
 attributes #16 = { noreturn nounwind }
 attributes #17 = { nounwind }
-attributes #18 = { nounwind allocsize(0,1) }
-attributes #19 = { nounwind readnone willreturn }
+attributes #18 = { nounwind readnone willreturn }
+attributes #19 = { nounwind allocsize(0,1) }
 attributes #20 = { noreturn }
 attributes #21 = { noinline }
 attributes #22 = { nounwind willreturn }
@@ -902,63 +847,65 @@ attributes #22 = { nounwind willreturn }
 !23 = !{!22, !16, i64 32}
 !24 = !DILocation(line: 16, column: 3, scope: !10)
 !25 = !DILocation(line: 15, column: 10, scope: !10)
-!26 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.13<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!27 = !DILocation(line: 0, scope: !26)
-!28 = !DILocation(line: 8, column: 3, scope: !26)
-!29 = !{!18, !19, i64 40}
-!30 = !{!18, !19, i64 44}
-!31 = !{!"branch_weights", i32 2000, i32 1}
-!32 = !{!18, !16, i64 56}
-!33 = !DILocation(line: 6, column: 3, scope: !26)
-!34 = !{!35, !35, i64 0}
-!35 = !{!"long long", !8, i64 0}
-!36 = !{!"branch_weights", i32 1, i32 10000}
-!37 = !DILocation(line: 9, column: 3, scope: !26)
-!38 = !{!39, !19, i64 8}
-!39 = !{!"rb_sorbet_param_struct", !40, i64 0, !19, i64 4, !19, i64 8, !19, i64 12, !19, i64 16, !19, i64 20, !19, i64 24, !19, i64 28, !16, i64 32, !19, i64 40, !19, i64 44, !19, i64 48, !19, i64 52, !16, i64 56}
-!40 = !{!"", !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 1, !19, i64 1}
-!41 = !{!39, !19, i64 28}
-!42 = !{!39, !19, i64 4}
-!43 = !{!39, !16, i64 32}
-!44 = !DILocation(line: 8, column: 8, scope: !45)
-!45 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.13<static-init>L62$block_1", scope: !26, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!46 = !DILocation(line: 15, column: 10, scope: !11)
-!47 = !DILocation(line: 18, column: 1, scope: !11)
-!48 = !DILocation(line: 8, column: 32, scope: !45)
-!49 = !{!50, !7, i64 400}
-!50 = !{!"rb_vm_struct", !7, i64 0, !51, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !35, i64 216, !8, i64 224, !52, i64 264, !52, i64 280, !52, i64 296, !52, i64 312, !7, i64 328, !19, i64 336, !19, i64 340, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !54, i64 472, !55, i64 992, !16, i64 1016, !16, i64 1024, !19, i64 1032, !19, i64 1036, !52, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !19, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !19, i64 1192, !56, i64 1200, !8, i64 1232}
-!51 = !{!"rb_global_vm_lock_struct", !16, i64 0, !8, i64 8, !52, i64 48, !16, i64 64, !19, i64 72, !8, i64 80, !8, i64 128, !19, i64 176, !19, i64 180}
-!52 = !{!"list_head", !53, i64 0}
-!53 = !{!"list_node", !16, i64 0, !16, i64 8}
-!54 = !{!"", !8, i64 0}
-!55 = !{!"rb_hook_list_struct", !16, i64 0, !19, i64 8, !19, i64 12, !19, i64 16}
-!56 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!57 = !DILocation(line: 0, scope: !11)
-!58 = !DILocation(line: 5, column: 1, scope: !11)
-!59 = !{!8, !8, i64 0}
-!60 = !{!18, !7, i64 128}
-!61 = !{!62}
-!62 = distinct !{!62, !63, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!63 = distinct !{!63, !"VM_BH_FROM_IFUNC_BLOCK"}
-!64 = distinct !DISubprogram(name: "Foo#bar", linkageName: "func_Foo#3bar", scope: null, file: !4, line: 9, type: !12, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!65 = !DILocation(line: 9, column: 3, scope: !64)
-!66 = !{!"branch_weights", i32 4001, i32 4000000}
-!67 = !DILocation(line: 0, scope: !64)
-!68 = !DILocation(line: 9, column: 11, scope: !64)
-!69 = !{!"branch_weights", i32 1, i32 2000}
-!70 = !{!71, !7, i64 0}
-!71 = !{!"RBasic", !7, i64 0, !7, i64 8}
-!72 = !DILocation(line: 9, column: 15, scope: !64)
-!73 = !DILocation(line: 10, column: 9, scope: !64)
-!74 = !{!75}
-!75 = distinct !{!75, !76, !"sorbet_rb_int_plus: argument 0"}
-!76 = distinct !{!76, !"sorbet_rb_int_plus"}
-!77 = !DILocation(line: 11, column: 5, scope: !64)
-!78 = !{!22, !7, i64 24}
-!79 = !DILocation(line: 8, column: 3, scope: !45)
-!80 = distinct !DISubprogram(name: "func_Foo#3bar.cold.1", linkageName: "func_Foo#3bar.cold.1", scope: null, file: !4, type: !81, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!81 = !DISubroutineType(types: !5)
-!82 = distinct !DISubprogram(name: "func_Foo#3bar.cold.2", linkageName: "func_Foo#3bar.cold.2", scope: null, file: !4, type: !81, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!83 = !DILocation(line: 9, column: 15, scope: !82)
-!84 = distinct !DISubprogram(name: "func_Foo#3bar.cold.3", linkageName: "func_Foo#3bar.cold.3", scope: null, file: !4, type: !81, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!85 = !DILocation(line: 9, column: 11, scope: !84)
+!26 = !DILocation(line: 9, column: 3, scope: !27, inlinedAt: !28)
+!27 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.13<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!28 = distinct !DILocation(line: 5, column: 1, scope: !11)
+!29 = !DILocation(line: 8, column: 8, scope: !30)
+!30 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.13<static-init>L62$block_1", scope: !27, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!31 = !DILocation(line: 15, column: 10, scope: !11)
+!32 = !DILocation(line: 18, column: 1, scope: !11)
+!33 = !DILocation(line: 8, column: 32, scope: !30)
+!34 = !DILocation(line: 6, column: 3, scope: !27)
+!35 = !{!36, !7, i64 400}
+!36 = !{!"rb_vm_struct", !7, i64 0, !37, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !40, i64 216, !8, i64 224, !38, i64 264, !38, i64 280, !38, i64 296, !38, i64 312, !7, i64 328, !19, i64 336, !19, i64 340, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !41, i64 472, !42, i64 992, !16, i64 1016, !16, i64 1024, !19, i64 1032, !19, i64 1036, !38, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !19, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !19, i64 1192, !43, i64 1200, !8, i64 1232}
+!37 = !{!"rb_global_vm_lock_struct", !16, i64 0, !8, i64 8, !38, i64 48, !16, i64 64, !19, i64 72, !8, i64 80, !8, i64 128, !19, i64 176, !19, i64 180}
+!38 = !{!"list_head", !39, i64 0}
+!39 = !{!"list_node", !16, i64 0, !16, i64 8}
+!40 = !{!"long long", !8, i64 0}
+!41 = !{!"", !8, i64 0}
+!42 = !{!"rb_hook_list_struct", !16, i64 0, !19, i64 8, !19, i64 12, !19, i64 16}
+!43 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!44 = !DILocation(line: 0, scope: !11)
+!45 = !DILocation(line: 5, column: 1, scope: !11)
+!46 = !DILocation(line: 0, scope: !27, inlinedAt: !28)
+!47 = !DILocation(line: 8, column: 3, scope: !27, inlinedAt: !28)
+!48 = !DILocation(line: 6, column: 3, scope: !27, inlinedAt: !28)
+!49 = !{!40, !40, i64 0}
+!50 = !{!"branch_weights", i32 1, i32 10000}
+!51 = !{!52, !19, i64 8}
+!52 = !{!"rb_sorbet_param_struct", !53, i64 0, !19, i64 4, !19, i64 8, !19, i64 12, !19, i64 16, !19, i64 20, !19, i64 24, !19, i64 28, !16, i64 32, !19, i64 40, !19, i64 44, !19, i64 48, !19, i64 52, !16, i64 56}
+!53 = !{!"", !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 0, !19, i64 1, !19, i64 1}
+!54 = !{!52, !19, i64 28}
+!55 = !{!52, !19, i64 4}
+!56 = !{!52, !16, i64 32}
+!57 = !{!8, !8, i64 0}
+!58 = !{!18, !7, i64 128}
+!59 = !{!60}
+!60 = distinct !{!60, !61, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
+!61 = distinct !{!61, !"VM_BH_FROM_IFUNC_BLOCK"}
+!62 = distinct !DISubprogram(name: "Foo#bar", linkageName: "func_Foo#3bar", scope: null, file: !4, line: 9, type: !12, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!63 = !DILocation(line: 9, column: 3, scope: !62)
+!64 = !{!"branch_weights", i32 4001, i32 4000000}
+!65 = !DILocation(line: 0, scope: !62)
+!66 = !DILocation(line: 9, column: 11, scope: !62)
+!67 = !{!"branch_weights", i32 1, i32 2000}
+!68 = !{!69, !7, i64 0}
+!69 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!70 = !{!"branch_weights", i32 2000, i32 1}
+!71 = !DILocation(line: 9, column: 15, scope: !62)
+!72 = !DILocation(line: 10, column: 9, scope: !62)
+!73 = !{!74}
+!74 = distinct !{!74, !75, !"sorbet_rb_int_plus: argument 0"}
+!75 = distinct !{!75, !"sorbet_rb_int_plus"}
+!76 = !DILocation(line: 11, column: 5, scope: !62)
+!77 = !{!18, !19, i64 40}
+!78 = !{!18, !19, i64 44}
+!79 = !{!18, !16, i64 56}
+!80 = !{!22, !7, i64 24}
+!81 = !DILocation(line: 8, column: 3, scope: !30)
+!82 = distinct !DISubprogram(name: "func_Foo#3bar.cold.1", linkageName: "func_Foo#3bar.cold.1", scope: null, file: !4, type: !83, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!83 = !DISubroutineType(types: !5)
+!84 = distinct !DISubprogram(name: "func_Foo#3bar.cold.2", linkageName: "func_Foo#3bar.cold.2", scope: null, file: !4, type: !83, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!85 = !DILocation(line: 9, column: 15, scope: !84)
+!86 = distinct !DISubprogram(name: "func_Foo#3bar.cold.3", linkageName: "func_Foo#3bar.cold.3", scope: null, file: !4, type: !83, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!87 = !DILocation(line: 9, column: 11, scope: !86)

--- a/test/testdata/compiler/casts.opt.ll.exp
+++ b/test/testdata/compiler/casts.opt.ll.exp
@@ -484,340 +484,15 @@ codeRepl:                                         ; preds = %fillRequiredArgs, %
   unreachable
 }
 
-; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_<root>.17<static-init>$152"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #8 !dbg !49 {
-functionEntryInitializers:
-  %callArgs = alloca [4 x i64], align 8
-  %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !50
-  %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !51
-  %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !53
-  %6 = load i64, i64* %5, align 8, !tbaa !6
-  %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #17
-  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !54, !tbaa !14
-  %9 = load i64, i64* @rb_cObject, align 8, !dbg !55
-  %stackFrame74 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8, !dbg !55
-  %10 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !55
-  %11 = bitcast i8* %10 to i16*, !dbg !55
-  %12 = load i16, i16* %11, align 8, !dbg !55
-  %13 = and i16 %12, -384, !dbg !55
-  %14 = or i16 %13, 1, !dbg !55
-  store i16 %14, i16* %11, align 8, !dbg !55
-  %15 = getelementptr inbounds i8, i8* %10, i64 8, !dbg !55
-  %16 = bitcast i8* %15 to i32*, !dbg !55
-  store i32 1, i32* %16, align 8, !dbg !55, !tbaa !56
-  %17 = getelementptr inbounds i8, i8* %10, i64 12, !dbg !55
-  %18 = bitcast i8* %17 to i32*, !dbg !55
-  %19 = getelementptr inbounds i8, i8* %10, i64 4, !dbg !55
-  %20 = bitcast i8* %19 to i32*, !dbg !55
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %17, i8 0, i64 20, i1 false), !dbg !55
-  store i32 1, i32* %20, align 4, !dbg !55, !tbaa !59
-  %positional_table = alloca i64, align 8, !dbg !55
-  %rubyId_arg = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !55
-  store i64 %rubyId_arg, i64* %positional_table, align 8, !dbg !55
-  %21 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !55
-  %22 = bitcast i64* %positional_table to i8*, !dbg !55
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %21, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %22, i64 noundef 8, i1 noundef false) #17, !dbg !55
-  %23 = getelementptr inbounds i8, i8* %10, i64 32, !dbg !55
-  %24 = bitcast i8* %23 to i8**, !dbg !55
-  store i8* %21, i8** %24, align 8, !dbg !55, !tbaa !60
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooAll", i8* nonnull %10, %struct.rb_iseq_struct* %stackFrame74, i1 noundef zeroext false) #17, !dbg !55
-  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !55, !tbaa !14
-  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 5, !dbg !55
-  %27 = load i32, i32* %26, align 8, !dbg !55, !tbaa !39
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 6, !dbg !55
-  %29 = load i32, i32* %28, align 4, !dbg !55, !tbaa !43
-  %30 = xor i32 %29, -1, !dbg !55
-  %31 = and i32 %30, %27, !dbg !55
-  %32 = icmp eq i32 %31, 0, !dbg !55
-  br i1 %32, label %rb_vm_check_ints.exit4, label %33, !dbg !55, !prof !20
-
-33:                                               ; preds = %functionEntryInitializers
-  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 8, !dbg !55
-  %35 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %34, align 8, !dbg !55, !tbaa !44
-  %36 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %35, i32 noundef 0) #17, !dbg !55
-  br label %rb_vm_check_ints.exit4, !dbg !55
-
-rb_vm_check_ints.exit4:                           ; preds = %functionEntryInitializers, %33
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !dbg !55, !tbaa !14
-  %stackFrame83 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8, !dbg !61
-  %37 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !61
-  %38 = bitcast i8* %37 to i16*, !dbg !61
-  %39 = load i16, i16* %38, align 8, !dbg !61
-  %40 = and i16 %39, -384, !dbg !61
-  %41 = or i16 %40, 1, !dbg !61
-  store i16 %41, i16* %38, align 8, !dbg !61
-  %42 = getelementptr inbounds i8, i8* %37, i64 8, !dbg !61
-  %43 = bitcast i8* %42 to i32*, !dbg !61
-  store i32 1, i32* %43, align 8, !dbg !61, !tbaa !56
-  %44 = getelementptr inbounds i8, i8* %37, i64 12, !dbg !61
-  %45 = bitcast i8* %44 to i32*, !dbg !61
-  %46 = getelementptr inbounds i8, i8* %37, i64 4, !dbg !61
-  %47 = bitcast i8* %46 to i32*, !dbg !61
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %44, i8 0, i64 20, i1 false), !dbg !61
-  store i32 1, i32* %47, align 4, !dbg !61, !tbaa !59
-  %positional_table85 = alloca i64, align 8, !dbg !61
-  %rubyId_arg86 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !61
-  store i64 %rubyId_arg86, i64* %positional_table85, align 8, !dbg !61
-  %48 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !61
-  %49 = bitcast i64* %positional_table85 to i8*, !dbg !61
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %48, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %49, i64 noundef 8, i1 noundef false) #17, !dbg !61
-  %50 = getelementptr inbounds i8, i8* %37, i64 32, !dbg !61
-  %51 = bitcast i8* %50 to i8**, !dbg !61
-  store i8* %48, i8** %51, align 8, !dbg !61, !tbaa !60
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny1", i8* nonnull %37, %struct.rb_iseq_struct* %stackFrame83, i1 noundef zeroext false) #17, !dbg !61
-  %52 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !61, !tbaa !14
-  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 5, !dbg !61
-  %54 = load i32, i32* %53, align 8, !dbg !61, !tbaa !39
-  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 6, !dbg !61
-  %56 = load i32, i32* %55, align 4, !dbg !61, !tbaa !43
-  %57 = xor i32 %56, -1, !dbg !61
-  %58 = and i32 %57, %54, !dbg !61
-  %59 = icmp eq i32 %58, 0, !dbg !61
-  br i1 %59, label %rb_vm_check_ints.exit3, label %60, !dbg !61, !prof !20
-
-60:                                               ; preds = %rb_vm_check_ints.exit4
-  %61 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 8, !dbg !61
-  %62 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %61, align 8, !dbg !61, !tbaa !44
-  %63 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %62, i32 noundef 0) #17, !dbg !61
-  br label %rb_vm_check_ints.exit3, !dbg !61
-
-rb_vm_check_ints.exit3:                           ; preds = %rb_vm_check_ints.exit4, %60
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !61, !tbaa !14
-  %stackFrame95 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8, !dbg !62
-  %64 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !62
-  %65 = bitcast i8* %64 to i16*, !dbg !62
-  %66 = load i16, i16* %65, align 8, !dbg !62
-  %67 = and i16 %66, -384, !dbg !62
-  %68 = or i16 %67, 1, !dbg !62
-  store i16 %68, i16* %65, align 8, !dbg !62
-  %69 = getelementptr inbounds i8, i8* %64, i64 8, !dbg !62
-  %70 = bitcast i8* %69 to i32*, !dbg !62
-  store i32 1, i32* %70, align 8, !dbg !62, !tbaa !56
-  %71 = getelementptr inbounds i8, i8* %64, i64 12, !dbg !62
-  %72 = bitcast i8* %71 to i32*, !dbg !62
-  %73 = getelementptr inbounds i8, i8* %64, i64 4, !dbg !62
-  %74 = bitcast i8* %73 to i32*, !dbg !62
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %71, i8 0, i64 20, i1 false), !dbg !62
-  store i32 1, i32* %74, align 4, !dbg !62, !tbaa !59
-  %positional_table97 = alloca i64, align 8, !dbg !62
-  %rubyId_arg98 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !62
-  store i64 %rubyId_arg98, i64* %positional_table97, align 8, !dbg !62
-  %75 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !62
-  %76 = bitcast i64* %positional_table97 to i8*, !dbg !62
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %75, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %76, i64 noundef 8, i1 noundef false) #17, !dbg !62
-  %77 = getelementptr inbounds i8, i8* %64, i64 32, !dbg !62
-  %78 = bitcast i8* %77 to i8**, !dbg !62
-  store i8* %75, i8** %78, align 8, !dbg !62, !tbaa !60
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny2", i8* nonnull %64, %struct.rb_iseq_struct* %stackFrame95, i1 noundef zeroext false) #17, !dbg !62
-  %79 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !62, !tbaa !14
-  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 5, !dbg !62
-  %81 = load i32, i32* %80, align 8, !dbg !62, !tbaa !39
-  %82 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 6, !dbg !62
-  %83 = load i32, i32* %82, align 4, !dbg !62, !tbaa !43
-  %84 = xor i32 %83, -1, !dbg !62
-  %85 = and i32 %84, %81, !dbg !62
-  %86 = icmp eq i32 %85, 0, !dbg !62
-  br i1 %86, label %rb_vm_check_ints.exit2, label %87, !dbg !62, !prof !20
-
-87:                                               ; preds = %rb_vm_check_ints.exit3
-  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %79, i64 0, i32 8, !dbg !62
-  %89 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %88, align 8, !dbg !62, !tbaa !44
-  %90 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %89, i32 noundef 0) #17, !dbg !62
-  br label %rb_vm_check_ints.exit2, !dbg !62
-
-rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.exit3, %87
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %8, align 8, !dbg !62, !tbaa !14
-  %stackFrame107 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8, !dbg !63
-  %91 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !63
-  %92 = bitcast i8* %91 to i16*, !dbg !63
-  %93 = load i16, i16* %92, align 8, !dbg !63
-  %94 = and i16 %93, -384, !dbg !63
-  %95 = or i16 %94, 1, !dbg !63
-  store i16 %95, i16* %92, align 8, !dbg !63
-  %96 = getelementptr inbounds i8, i8* %91, i64 8, !dbg !63
-  %97 = bitcast i8* %96 to i32*, !dbg !63
-  store i32 1, i32* %97, align 8, !dbg !63, !tbaa !56
-  %98 = getelementptr inbounds i8, i8* %91, i64 12, !dbg !63
-  %99 = bitcast i8* %98 to i32*, !dbg !63
-  %100 = getelementptr inbounds i8, i8* %91, i64 4, !dbg !63
-  %101 = bitcast i8* %100 to i32*, !dbg !63
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %98, i8 0, i64 20, i1 false), !dbg !63
-  store i32 1, i32* %101, align 4, !dbg !63, !tbaa !59
-  %positional_table109 = alloca i64, align 8, !dbg !63
-  %rubyId_arg110 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !63
-  store i64 %rubyId_arg110, i64* %positional_table109, align 8, !dbg !63
-  %102 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !63
-  %103 = bitcast i64* %positional_table109 to i8*, !dbg !63
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %102, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %103, i64 noundef 8, i1 noundef false) #17, !dbg !63
-  %104 = getelementptr inbounds i8, i8* %91, i64 32, !dbg !63
-  %105 = bitcast i8* %104 to i8**, !dbg !63
-  store i8* %102, i8** %105, align 8, !dbg !63, !tbaa !60
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooInt", i8* nonnull %91, %struct.rb_iseq_struct* %stackFrame107, i1 noundef zeroext false) #17, !dbg !63
-  %106 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !63, !tbaa !14
-  %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 5, !dbg !63
-  %108 = load i32, i32* %107, align 8, !dbg !63, !tbaa !39
-  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 6, !dbg !63
-  %110 = load i32, i32* %109, align 4, !dbg !63, !tbaa !43
-  %111 = xor i32 %110, -1, !dbg !63
-  %112 = and i32 %111, %108, !dbg !63
-  %113 = icmp eq i32 %112, 0, !dbg !63
-  br i1 %113, label %rb_vm_check_ints.exit1, label %114, !dbg !63, !prof !20
-
-114:                                              ; preds = %rb_vm_check_ints.exit2
-  %115 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 8, !dbg !63
-  %116 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %115, align 8, !dbg !63, !tbaa !44
-  %117 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %116, i32 noundef 0) #17, !dbg !63
-  br label %rb_vm_check_ints.exit1, !dbg !63
-
-rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.exit2, %114
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %8, align 8, !dbg !63, !tbaa !14
-  %stackFrame119 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8, !dbg !64
-  %118 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !64
-  %119 = bitcast i8* %118 to i16*, !dbg !64
-  %120 = load i16, i16* %119, align 8, !dbg !64
-  %121 = and i16 %120, -384, !dbg !64
-  %122 = or i16 %121, 1, !dbg !64
-  store i16 %122, i16* %119, align 8, !dbg !64
-  %123 = getelementptr inbounds i8, i8* %118, i64 8, !dbg !64
-  %124 = bitcast i8* %123 to i32*, !dbg !64
-  store i32 1, i32* %124, align 8, !dbg !64, !tbaa !56
-  %125 = getelementptr inbounds i8, i8* %118, i64 12, !dbg !64
-  %126 = bitcast i8* %125 to i32*, !dbg !64
-  %127 = getelementptr inbounds i8, i8* %118, i64 4, !dbg !64
-  %128 = bitcast i8* %127 to i32*, !dbg !64
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %125, i8 0, i64 20, i1 false), !dbg !64
-  store i32 1, i32* %128, align 4, !dbg !64, !tbaa !59
-  %positional_table121 = alloca i64, align 8, !dbg !64
-  %rubyId_arg122 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !64
-  store i64 %rubyId_arg122, i64* %positional_table121, align 8, !dbg !64
-  %129 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !64
-  %130 = bitcast i64* %positional_table121 to i8*, !dbg !64
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %129, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %130, i64 noundef 8, i1 noundef false) #17, !dbg !64
-  %131 = getelementptr inbounds i8, i8* %118, i64 32, !dbg !64
-  %132 = bitcast i8* %131 to i8**, !dbg !64
-  store i8* %129, i8** %132, align 8, !dbg !64, !tbaa !60
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8fooArray", i8* nonnull %118, %struct.rb_iseq_struct* %stackFrame119, i1 noundef zeroext false) #17, !dbg !64
-  %133 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !64, !tbaa !14
-  %134 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 5, !dbg !64
-  %135 = load i32, i32* %134, align 8, !dbg !64, !tbaa !39
-  %136 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 6, !dbg !64
-  %137 = load i32, i32* %136, align 4, !dbg !64, !tbaa !43
-  %138 = xor i32 %137, -1, !dbg !64
-  %139 = and i32 %138, %135, !dbg !64
-  %140 = icmp eq i32 %139, 0, !dbg !64
-  br i1 %140, label %rb_vm_check_ints.exit, label %141, !dbg !64, !prof !20
-
-141:                                              ; preds = %rb_vm_check_ints.exit1
-  %142 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 8, !dbg !64
-  %143 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %142, align 8, !dbg !64, !tbaa !44
-  %144 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %143, i32 noundef 0) #17, !dbg !64
-  br label %rb_vm_check_ints.exit, !dbg !64
-
-rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.exit1, %141
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %8, align 8, !dbg !64, !tbaa !14
-  %145 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !65
-  %146 = load i64*, i64** %145, align 8, !dbg !65
-  store i64 %selfRaw, i64* %146, align 8, !dbg !65, !tbaa !6
-  %147 = getelementptr inbounds i64, i64* %146, i64 1, !dbg !65
-  store i64 5, i64* %147, align 8, !dbg !65, !tbaa !6
-  %148 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !65
-  store i64* %148, i64** %145, align 8, !dbg !65
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooInt, i64 0), !dbg !65
-  %149 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !66
-  %150 = load i64*, i64** %149, align 8, !dbg !66
-  store i64 %selfRaw, i64* %150, align 8, !dbg !66, !tbaa !6
-  %151 = getelementptr inbounds i64, i64* %150, i64 1, !dbg !66
-  store i64 %send, i64* %151, align 8, !dbg !66, !tbaa !6
-  %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !66
-  store i64* %152, i64** %149, align 8, !dbg !66
-  %send6 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !66
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %8, align 8, !dbg !66, !tbaa !14
-  %153 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !67
-  %154 = load i64*, i64** %153, align 8, !dbg !67
-  store i64 %selfRaw, i64* %154, align 8, !dbg !67, !tbaa !6
-  %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !67
-  store i64 5, i64* %155, align 8, !dbg !67, !tbaa !6
-  %156 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !67
-  store i64* %156, i64** %153, align 8, !dbg !67
-  %send8 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny1, i64 0), !dbg !67
-  %157 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !68
-  %158 = load i64*, i64** %157, align 8, !dbg !68
-  store i64 %selfRaw, i64* %158, align 8, !dbg !68, !tbaa !6
-  %159 = getelementptr inbounds i64, i64* %158, i64 1, !dbg !68
-  store i64 %send8, i64* %159, align 8, !dbg !68, !tbaa !6
-  %160 = getelementptr inbounds i64, i64* %159, i64 1, !dbg !68
-  store i64* %160, i64** %157, align 8, !dbg !68
-  %send10 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !68
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %8, align 8, !dbg !68, !tbaa !14
-  %161 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !69
-  %162 = load i64*, i64** %161, align 8, !dbg !69
-  store i64 %selfRaw, i64* %162, align 8, !dbg !69, !tbaa !6
-  %163 = getelementptr inbounds i64, i64* %162, i64 1, !dbg !69
-  store i64 5, i64* %163, align 8, !dbg !69, !tbaa !6
-  %164 = getelementptr inbounds i64, i64* %163, i64 1, !dbg !69
-  store i64* %164, i64** %161, align 8, !dbg !69
-  %send12 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny2, i64 0), !dbg !69
-  %165 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !70
-  %166 = load i64*, i64** %165, align 8, !dbg !70
-  store i64 %selfRaw, i64* %166, align 8, !dbg !70, !tbaa !6
-  %167 = getelementptr inbounds i64, i64* %166, i64 1, !dbg !70
-  store i64 %send12, i64* %167, align 8, !dbg !70, !tbaa !6
-  %168 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !70
-  store i64* %168, i64** %165, align 8, !dbg !70
-  %send14 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !70
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %8, align 8, !dbg !70, !tbaa !14
-  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !71
-  %170 = load i64*, i64** %169, align 8, !dbg !71
-  store i64 %selfRaw, i64* %170, align 8, !dbg !71, !tbaa !6
-  %171 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !71
-  store i64 5, i64* %171, align 8, !dbg !71, !tbaa !6
-  %172 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !71
-  store i64* %172, i64** %169, align 8, !dbg !71
-  %send16 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAll, i64 0), !dbg !71
-  %173 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !72
-  %174 = load i64*, i64** %173, align 8, !dbg !72
-  store i64 %selfRaw, i64* %174, align 8, !dbg !72, !tbaa !6
-  %175 = getelementptr inbounds i64, i64* %174, i64 1, !dbg !72
-  store i64 %send16, i64* %175, align 8, !dbg !72, !tbaa !6
-  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !72
-  store i64* %176, i64** %173, align 8, !dbg !72
-  %send18 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !72
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %8, align 8, !dbg !72, !tbaa !14
-  %callArgs0Addr = getelementptr [4 x i64], [4 x i64]* %callArgs, i32 0, i64 0, !dbg !73
-  store i64 5, i64* %callArgs0Addr, align 8, !dbg !73
-  %177 = getelementptr [4 x i64], [4 x i64]* %callArgs, i64 0, i64 0, !dbg !73
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !74), !dbg !73
-  %178 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %177) #17, !dbg !73
-  %179 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !77
-  %180 = load i64*, i64** %179, align 8, !dbg !77
-  store i64 %selfRaw, i64* %180, align 8, !dbg !77, !tbaa !6
-  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !77
-  store i64 %178, i64* %181, align 8, !dbg !77, !tbaa !6
-  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !77
-  store i64* %182, i64** %179, align 8, !dbg !77
-  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooArray, i64 0), !dbg !77
-  %183 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !78
-  %184 = load i64*, i64** %183, align 8, !dbg !78
-  store i64 %selfRaw, i64* %184, align 8, !dbg !78, !tbaa !6
-  %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !78
-  store i64 %send20, i64* %185, align 8, !dbg !78, !tbaa !6
-  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !78
-  store i64* %186, i64** %183, align 8, !dbg !78
-  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !78
-  ret void
-}
-
-; Function Attrs: ssp
+; Function Attrs: sspreq
 define void @Init_casts() local_unnamed_addr #9 {
 entry:
+  %callArgs.i = alloca [4 x i64], align 8
+  %positional_table.i = alloca i64, align 8, !dbg !49
+  %positional_table85.i = alloca i64, align 8, !dbg !51
+  %positional_table97.i = alloca i64, align 8, !dbg !52
+  %positional_table109.i = alloca i64, align 8, !dbg !53
+  %positional_table121.i = alloca i64, align 8, !dbg !54
   %locals.i33.i = alloca i64, i32 0, align 8
   %locals.i31.i = alloca i64, i32 0, align 8
   %locals.i29.i = alloca i64, i32 0, align 8
@@ -886,33 +561,272 @@ entry:
   %"rubyStr_test/testdata/compiler/casts.rb.i32.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/casts.rb.i32.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i33.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %rubyId_fooInt.i = load i64, i64* @rubyIdPrecomputed_fooInt, align 8, !dbg !65
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooInt, i64 %rubyId_fooInt.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !65
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !66
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !66
-  %rubyId_fooAny1.i = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8, !dbg !67
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny1, i64 %rubyId_fooAny1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !67
-  %rubyId_puts6.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !68
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts6.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !68
-  %rubyId_fooAny2.i = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8, !dbg !69
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny2, i64 %rubyId_fooAny2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !69
-  %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !70
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !70
-  %rubyId_fooAll.i = load i64, i64* @rubyIdPrecomputed_fooAll, align 8, !dbg !71
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAll, i64 %rubyId_fooAll.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !71
-  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !72
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !72
-  %rubyId_fooArray.i = load i64, i64* @rubyIdPrecomputed_fooArray, align 8, !dbg !77
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooArray, i64 %rubyId_fooArray.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !77
-  %rubyId_puts21.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !78
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts21.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !78
+  %rubyId_fooInt.i = load i64, i64* @rubyIdPrecomputed_fooInt, align 8, !dbg !55
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooInt, i64 %rubyId_fooInt.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !55
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !56
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !56
+  %rubyId_fooAny1.i = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8, !dbg !57
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny1, i64 %rubyId_fooAny1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !57
+  %rubyId_puts6.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !58
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts6.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !58
+  %rubyId_fooAny2.i = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8, !dbg !59
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny2, i64 %rubyId_fooAny2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !59
+  %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !60
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !60
+  %rubyId_fooAll.i = load i64, i64* @rubyIdPrecomputed_fooAll, align 8, !dbg !61
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAll, i64 %rubyId_fooAll.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !61
+  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !62
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !62
+  %rubyId_fooArray.i = load i64, i64* @rubyIdPrecomputed_fooArray, align 8, !dbg !63
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooArray, i64 %rubyId_fooArray.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !63
+  %rubyId_puts21.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !64
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts21.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !64
   %24 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %25 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %24, i64 0, i32 18
-  %26 = load i64, i64* %25, align 8, !tbaa !79
+  %26 = load i64, i64* %25, align 8, !tbaa !65
   %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2
-  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !tbaa !50
-  call fastcc void @"func_<root>.17<static-init>$152"(i64 %26, %struct.rb_control_frame_struct* %29) #17
+  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !tbaa !74
+  %30 = bitcast [4 x i64]* %callArgs.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %30)
+  %31 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %31)
+  %32 = bitcast i64* %positional_table85.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %32)
+  %33 = bitcast i64* %positional_table97.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %33)
+  %34 = bitcast i64* %positional_table109.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %34)
+  %35 = bitcast i64* %positional_table121.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35)
+  %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !tbaa !74
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !75
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
+  %39 = load i64*, i64** %38, align 8, !tbaa !77
+  %40 = load i64, i64* %39, align 8, !tbaa !6
+  %41 = and i64 %40, -33
+  store i64 %41, i64* %39, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %27, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i) #17
+  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 0
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %42, align 8, !dbg !78, !tbaa !14
+  %43 = load i64, i64* @rb_cObject, align 8, !dbg !49
+  %stackFrame74.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8, !dbg !49
+  %44 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !49
+  %45 = bitcast i8* %44 to i16*, !dbg !49
+  %46 = load i16, i16* %45, align 8, !dbg !49
+  %47 = and i16 %46, -384, !dbg !49
+  %48 = or i16 %47, 1, !dbg !49
+  store i16 %48, i16* %45, align 8, !dbg !49
+  %49 = getelementptr inbounds i8, i8* %44, i64 8, !dbg !49
+  %50 = bitcast i8* %49 to i32*, !dbg !49
+  store i32 1, i32* %50, align 8, !dbg !49, !tbaa !79
+  %51 = getelementptr inbounds i8, i8* %44, i64 12, !dbg !49
+  %52 = getelementptr inbounds i8, i8* %44, i64 4, !dbg !49
+  %53 = bitcast i8* %52 to i32*, !dbg !49
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %51, i8 0, i64 20, i1 false) #17, !dbg !49
+  store i32 1, i32* %53, align 4, !dbg !49, !tbaa !82
+  %rubyId_arg.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !49
+  store i64 %rubyId_arg.i, i64* %positional_table.i, align 8, !dbg !49
+  %54 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !49
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %54, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %31, i64 noundef 8, i1 noundef false) #17, !dbg !49
+  %55 = getelementptr inbounds i8, i8* %44, i64 32, !dbg !49
+  %56 = bitcast i8* %55 to i8**, !dbg !49
+  store i8* %54, i8** %56, align 8, !dbg !49, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooAll", i8* nonnull %44, %struct.rb_iseq_struct* %stackFrame74.i, i1 noundef zeroext false) #17, !dbg !49
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %42, align 8, !dbg !49, !tbaa !14
+  %stackFrame83.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8, !dbg !51
+  %57 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !51
+  %58 = bitcast i8* %57 to i16*, !dbg !51
+  %59 = load i16, i16* %58, align 8, !dbg !51
+  %60 = and i16 %59, -384, !dbg !51
+  %61 = or i16 %60, 1, !dbg !51
+  store i16 %61, i16* %58, align 8, !dbg !51
+  %62 = getelementptr inbounds i8, i8* %57, i64 8, !dbg !51
+  %63 = bitcast i8* %62 to i32*, !dbg !51
+  store i32 1, i32* %63, align 8, !dbg !51, !tbaa !79
+  %64 = getelementptr inbounds i8, i8* %57, i64 12, !dbg !51
+  %65 = getelementptr inbounds i8, i8* %57, i64 4, !dbg !51
+  %66 = bitcast i8* %65 to i32*, !dbg !51
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %64, i8 0, i64 20, i1 false) #17, !dbg !51
+  store i32 1, i32* %66, align 4, !dbg !51, !tbaa !82
+  %rubyId_arg86.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !51
+  store i64 %rubyId_arg86.i, i64* %positional_table85.i, align 8, !dbg !51
+  %67 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !51
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %67, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %32, i64 noundef 8, i1 noundef false) #17, !dbg !51
+  %68 = getelementptr inbounds i8, i8* %57, i64 32, !dbg !51
+  %69 = bitcast i8* %68 to i8**, !dbg !51
+  store i8* %67, i8** %69, align 8, !dbg !51, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny1", i8* nonnull %57, %struct.rb_iseq_struct* %stackFrame83.i, i1 noundef zeroext false) #17, !dbg !51
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %42, align 8, !dbg !51, !tbaa !14
+  %stackFrame95.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8, !dbg !52
+  %70 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !52
+  %71 = bitcast i8* %70 to i16*, !dbg !52
+  %72 = load i16, i16* %71, align 8, !dbg !52
+  %73 = and i16 %72, -384, !dbg !52
+  %74 = or i16 %73, 1, !dbg !52
+  store i16 %74, i16* %71, align 8, !dbg !52
+  %75 = getelementptr inbounds i8, i8* %70, i64 8, !dbg !52
+  %76 = bitcast i8* %75 to i32*, !dbg !52
+  store i32 1, i32* %76, align 8, !dbg !52, !tbaa !79
+  %77 = getelementptr inbounds i8, i8* %70, i64 12, !dbg !52
+  %78 = getelementptr inbounds i8, i8* %70, i64 4, !dbg !52
+  %79 = bitcast i8* %78 to i32*, !dbg !52
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %77, i8 0, i64 20, i1 false) #17, !dbg !52
+  store i32 1, i32* %79, align 4, !dbg !52, !tbaa !82
+  %rubyId_arg98.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !52
+  store i64 %rubyId_arg98.i, i64* %positional_table97.i, align 8, !dbg !52
+  %80 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !52
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %80, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %33, i64 noundef 8, i1 noundef false) #17, !dbg !52
+  %81 = getelementptr inbounds i8, i8* %70, i64 32, !dbg !52
+  %82 = bitcast i8* %81 to i8**, !dbg !52
+  store i8* %80, i8** %82, align 8, !dbg !52, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny2", i8* nonnull %70, %struct.rb_iseq_struct* %stackFrame95.i, i1 noundef zeroext false) #17, !dbg !52
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %42, align 8, !dbg !52, !tbaa !14
+  %stackFrame107.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8, !dbg !53
+  %83 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !53
+  %84 = bitcast i8* %83 to i16*, !dbg !53
+  %85 = load i16, i16* %84, align 8, !dbg !53
+  %86 = and i16 %85, -384, !dbg !53
+  %87 = or i16 %86, 1, !dbg !53
+  store i16 %87, i16* %84, align 8, !dbg !53
+  %88 = getelementptr inbounds i8, i8* %83, i64 8, !dbg !53
+  %89 = bitcast i8* %88 to i32*, !dbg !53
+  store i32 1, i32* %89, align 8, !dbg !53, !tbaa !79
+  %90 = getelementptr inbounds i8, i8* %83, i64 12, !dbg !53
+  %91 = getelementptr inbounds i8, i8* %83, i64 4, !dbg !53
+  %92 = bitcast i8* %91 to i32*, !dbg !53
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %90, i8 0, i64 20, i1 false) #17, !dbg !53
+  store i32 1, i32* %92, align 4, !dbg !53, !tbaa !82
+  %rubyId_arg110.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !53
+  store i64 %rubyId_arg110.i, i64* %positional_table109.i, align 8, !dbg !53
+  %93 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !53
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %93, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %34, i64 noundef 8, i1 noundef false) #17, !dbg !53
+  %94 = getelementptr inbounds i8, i8* %83, i64 32, !dbg !53
+  %95 = bitcast i8* %94 to i8**, !dbg !53
+  store i8* %93, i8** %95, align 8, !dbg !53, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooInt", i8* nonnull %83, %struct.rb_iseq_struct* %stackFrame107.i, i1 noundef zeroext false) #17, !dbg !53
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %42, align 8, !dbg !53, !tbaa !14
+  %stackFrame119.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8, !dbg !54
+  %96 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !54
+  %97 = bitcast i8* %96 to i16*, !dbg !54
+  %98 = load i16, i16* %97, align 8, !dbg !54
+  %99 = and i16 %98, -384, !dbg !54
+  %100 = or i16 %99, 1, !dbg !54
+  store i16 %100, i16* %97, align 8, !dbg !54
+  %101 = getelementptr inbounds i8, i8* %96, i64 8, !dbg !54
+  %102 = bitcast i8* %101 to i32*, !dbg !54
+  store i32 1, i32* %102, align 8, !dbg !54, !tbaa !79
+  %103 = getelementptr inbounds i8, i8* %96, i64 12, !dbg !54
+  %104 = getelementptr inbounds i8, i8* %96, i64 4, !dbg !54
+  %105 = bitcast i8* %104 to i32*, !dbg !54
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %103, i8 0, i64 20, i1 false) #17, !dbg !54
+  store i32 1, i32* %105, align 4, !dbg !54, !tbaa !82
+  %rubyId_arg122.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !54
+  store i64 %rubyId_arg122.i, i64* %positional_table121.i, align 8, !dbg !54
+  %106 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !54
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %106, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %35, i64 noundef 8, i1 noundef false) #17, !dbg !54
+  %107 = getelementptr inbounds i8, i8* %96, i64 32, !dbg !54
+  %108 = bitcast i8* %107 to i8**, !dbg !54
+  store i8* %106, i8** %108, align 8, !dbg !54, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8fooArray", i8* nonnull %96, %struct.rb_iseq_struct* %stackFrame119.i, i1 noundef zeroext false) #17, !dbg !54
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %42, align 8, !dbg !54, !tbaa !14
+  %109 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !55
+  %110 = load i64*, i64** %109, align 8, !dbg !55
+  store i64 %26, i64* %110, align 8, !dbg !55, !tbaa !6
+  %111 = getelementptr inbounds i64, i64* %110, i64 1, !dbg !55
+  store i64 5, i64* %111, align 8, !dbg !55, !tbaa !6
+  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !55
+  store i64* %112, i64** %109, align 8, !dbg !55
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooInt, i64 0), !dbg !55
+  %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !56
+  %114 = load i64*, i64** %113, align 8, !dbg !56
+  store i64 %26, i64* %114, align 8, !dbg !56, !tbaa !6
+  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !56
+  store i64 %send, i64* %115, align 8, !dbg !56, !tbaa !6
+  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !56
+  store i64* %116, i64** %113, align 8, !dbg !56
+  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !56
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %42, align 8, !dbg !56, !tbaa !14
+  %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !57
+  %118 = load i64*, i64** %117, align 8, !dbg !57
+  store i64 %26, i64* %118, align 8, !dbg !57, !tbaa !6
+  %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !57
+  store i64 5, i64* %119, align 8, !dbg !57, !tbaa !6
+  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !57
+  store i64* %120, i64** %117, align 8, !dbg !57
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny1, i64 0), !dbg !57
+  %121 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !58
+  %122 = load i64*, i64** %121, align 8, !dbg !58
+  store i64 %26, i64* %122, align 8, !dbg !58, !tbaa !6
+  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !58
+  store i64 %send4, i64* %123, align 8, !dbg !58, !tbaa !6
+  %124 = getelementptr inbounds i64, i64* %123, i64 1, !dbg !58
+  store i64* %124, i64** %121, align 8, !dbg !58
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !58
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %42, align 8, !dbg !58, !tbaa !14
+  %125 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !59
+  %126 = load i64*, i64** %125, align 8, !dbg !59
+  store i64 %26, i64* %126, align 8, !dbg !59, !tbaa !6
+  %127 = getelementptr inbounds i64, i64* %126, i64 1, !dbg !59
+  store i64 5, i64* %127, align 8, !dbg !59, !tbaa !6
+  %128 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !59
+  store i64* %128, i64** %125, align 8, !dbg !59
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny2, i64 0), !dbg !59
+  %129 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !60
+  %130 = load i64*, i64** %129, align 8, !dbg !60
+  store i64 %26, i64* %130, align 8, !dbg !60, !tbaa !6
+  %131 = getelementptr inbounds i64, i64* %130, i64 1, !dbg !60
+  store i64 %send8, i64* %131, align 8, !dbg !60, !tbaa !6
+  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !60
+  store i64* %132, i64** %129, align 8, !dbg !60
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !60
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %42, align 8, !dbg !60, !tbaa !14
+  %133 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !61
+  %134 = load i64*, i64** %133, align 8, !dbg !61
+  store i64 %26, i64* %134, align 8, !dbg !61, !tbaa !6
+  %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !61
+  store i64 5, i64* %135, align 8, !dbg !61, !tbaa !6
+  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !61
+  store i64* %136, i64** %133, align 8, !dbg !61
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAll, i64 0), !dbg !61
+  %137 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !62
+  %138 = load i64*, i64** %137, align 8, !dbg !62
+  store i64 %26, i64* %138, align 8, !dbg !62, !tbaa !6
+  %139 = getelementptr inbounds i64, i64* %138, i64 1, !dbg !62
+  store i64 %send12, i64* %139, align 8, !dbg !62, !tbaa !6
+  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !62
+  store i64* %140, i64** %137, align 8, !dbg !62
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !62
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %42, align 8, !dbg !62, !tbaa !14
+  %callArgs0Addr.i = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i32 0, i64 0, !dbg !84
+  store i64 5, i64* %callArgs0Addr.i, align 8, !dbg !84
+  %141 = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i64 0, i64 0, !dbg !84
+  call void @llvm.experimental.noalias.scope.decl(metadata !85) #17, !dbg !84
+  %142 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %141) #17, !dbg !84
+  %143 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !63
+  %144 = load i64*, i64** %143, align 8, !dbg !63
+  store i64 %26, i64* %144, align 8, !dbg !63, !tbaa !6
+  %145 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !63
+  store i64 %142, i64* %145, align 8, !dbg !63, !tbaa !6
+  %146 = getelementptr inbounds i64, i64* %145, i64 1, !dbg !63
+  store i64* %146, i64** %143, align 8, !dbg !63
+  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooArray, i64 0), !dbg !63
+  %147 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !64
+  %148 = load i64*, i64** %147, align 8, !dbg !64
+  store i64 %26, i64* %148, align 8, !dbg !64, !tbaa !6
+  %149 = getelementptr inbounds i64, i64* %148, i64 1, !dbg !64
+  store i64 %send16, i64* %149, align 8, !dbg !64, !tbaa !6
+  %150 = getelementptr inbounds i64, i64* %149, i64 1, !dbg !64
+  store i64* %150, i64** %147, align 8, !dbg !64
+  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !64
+  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %30)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %31)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %32)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %33)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %34)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35)
   ret void
 }
 
@@ -921,6 +835,12 @@ declare void @llvm.experimental.noalias.scope.decl(metadata) #10
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #11
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #6
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #6
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Object#6fooAll.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !88 {
@@ -966,7 +886,7 @@ attributes #5 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="a
 attributes #6 = { argmemonly nofree nosync nounwind willreturn }
 attributes #7 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #8 = { nounwind sspreq uwtable }
-attributes #9 = { ssp }
+attributes #9 = { sspreq }
 attributes #10 = { inaccessiblememonly nofree nosync nounwind willreturn }
 attributes #11 = { argmemonly nofree nosync nounwind willreturn writeonly }
 attributes #12 = { cold minsize noreturn nounwind sspreq uwtable }
@@ -1029,45 +949,45 @@ attributes #18 = { nounwind allocsize(0,1) }
 !46 = !DILocation(line: 21, column: 1, scope: !45)
 !47 = !DILocation(line: 21, column: 14, scope: !45)
 !48 = !DILocation(line: 22, column: 3, scope: !45)
-!49 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!50 = !{!40, !15, i64 16}
-!51 = !{!52, !15, i64 16}
-!52 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
-!53 = !{!52, !15, i64 32}
-!54 = !DILocation(line: 0, scope: !49)
-!55 = !DILocation(line: 5, column: 1, scope: !49)
-!56 = !{!57, !41, i64 8}
-!57 = !{!"rb_sorbet_param_struct", !58, i64 0, !41, i64 4, !41, i64 8, !41, i64 12, !41, i64 16, !41, i64 20, !41, i64 24, !41, i64 28, !15, i64 32, !41, i64 40, !41, i64 44, !41, i64 48, !41, i64 52, !15, i64 56}
-!58 = !{!"", !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 1, !41, i64 1}
-!59 = !{!57, !41, i64 4}
-!60 = !{!57, !15, i64 32}
-!61 = !DILocation(line: 9, column: 1, scope: !49)
-!62 = !DILocation(line: 13, column: 1, scope: !49)
-!63 = !DILocation(line: 17, column: 1, scope: !49)
-!64 = !DILocation(line: 21, column: 1, scope: !49)
-!65 = !DILocation(line: 25, column: 6, scope: !49)
-!66 = !DILocation(line: 25, column: 1, scope: !49)
-!67 = !DILocation(line: 26, column: 6, scope: !49)
-!68 = !DILocation(line: 26, column: 1, scope: !49)
-!69 = !DILocation(line: 27, column: 6, scope: !49)
-!70 = !DILocation(line: 27, column: 1, scope: !49)
-!71 = !DILocation(line: 28, column: 6, scope: !49)
-!72 = !DILocation(line: 28, column: 1, scope: !49)
-!73 = !DILocation(line: 29, column: 15, scope: !49)
-!74 = !{!75}
-!75 = distinct !{!75, !76, !"sorbet_buildArrayIntrinsic: argument 0"}
-!76 = distinct !{!76, !"sorbet_buildArrayIntrinsic"}
-!77 = !DILocation(line: 29, column: 6, scope: !49)
-!78 = !DILocation(line: 29, column: 1, scope: !49)
-!79 = !{!80, !7, i64 400}
-!80 = !{!"rb_vm_struct", !7, i64 0, !81, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !84, i64 216, !8, i64 224, !82, i64 264, !82, i64 280, !82, i64 296, !82, i64 312, !7, i64 328, !41, i64 336, !41, i64 340, !41, i64 344, !41, i64 344, !41, i64 344, !41, i64 344, !41, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !85, i64 472, !86, i64 992, !15, i64 1016, !15, i64 1024, !41, i64 1032, !41, i64 1036, !82, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !41, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !41, i64 1192, !87, i64 1200, !8, i64 1232}
-!81 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !82, i64 48, !15, i64 64, !41, i64 72, !8, i64 80, !8, i64 128, !41, i64 176, !41, i64 180}
-!82 = !{!"list_head", !83, i64 0}
-!83 = !{!"list_node", !15, i64 0, !15, i64 8}
-!84 = !{!"long long", !8, i64 0}
-!85 = !{!"", !8, i64 0}
-!86 = !{!"rb_hook_list_struct", !15, i64 0, !41, i64 8, !41, i64 12, !41, i64 16}
-!87 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!49 = !DILocation(line: 5, column: 1, scope: !50)
+!50 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!51 = !DILocation(line: 9, column: 1, scope: !50)
+!52 = !DILocation(line: 13, column: 1, scope: !50)
+!53 = !DILocation(line: 17, column: 1, scope: !50)
+!54 = !DILocation(line: 21, column: 1, scope: !50)
+!55 = !DILocation(line: 25, column: 6, scope: !50)
+!56 = !DILocation(line: 25, column: 1, scope: !50)
+!57 = !DILocation(line: 26, column: 6, scope: !50)
+!58 = !DILocation(line: 26, column: 1, scope: !50)
+!59 = !DILocation(line: 27, column: 6, scope: !50)
+!60 = !DILocation(line: 27, column: 1, scope: !50)
+!61 = !DILocation(line: 28, column: 6, scope: !50)
+!62 = !DILocation(line: 28, column: 1, scope: !50)
+!63 = !DILocation(line: 29, column: 6, scope: !50)
+!64 = !DILocation(line: 29, column: 1, scope: !50)
+!65 = !{!66, !7, i64 400}
+!66 = !{!"rb_vm_struct", !7, i64 0, !67, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !70, i64 216, !8, i64 224, !68, i64 264, !68, i64 280, !68, i64 296, !68, i64 312, !7, i64 328, !41, i64 336, !41, i64 340, !41, i64 344, !41, i64 344, !41, i64 344, !41, i64 344, !41, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !71, i64 472, !72, i64 992, !15, i64 1016, !15, i64 1024, !41, i64 1032, !41, i64 1036, !68, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !41, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !41, i64 1192, !73, i64 1200, !8, i64 1232}
+!67 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !68, i64 48, !15, i64 64, !41, i64 72, !8, i64 80, !8, i64 128, !41, i64 176, !41, i64 180}
+!68 = !{!"list_head", !69, i64 0}
+!69 = !{!"list_node", !15, i64 0, !15, i64 8}
+!70 = !{!"long long", !8, i64 0}
+!71 = !{!"", !8, i64 0}
+!72 = !{!"rb_hook_list_struct", !15, i64 0, !41, i64 8, !41, i64 12, !41, i64 16}
+!73 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!74 = !{!40, !15, i64 16}
+!75 = !{!76, !15, i64 16}
+!76 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!77 = !{!76, !15, i64 32}
+!78 = !DILocation(line: 0, scope: !50)
+!79 = !{!80, !41, i64 8}
+!80 = !{!"rb_sorbet_param_struct", !81, i64 0, !41, i64 4, !41, i64 8, !41, i64 12, !41, i64 16, !41, i64 20, !41, i64 24, !41, i64 28, !15, i64 32, !41, i64 40, !41, i64 44, !41, i64 48, !41, i64 52, !15, i64 56}
+!81 = !{!"", !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 0, !41, i64 1, !41, i64 1}
+!82 = !{!80, !41, i64 4}
+!83 = !{!80, !15, i64 32}
+!84 = !DILocation(line: 29, column: 15, scope: !50)
+!85 = !{!86}
+!86 = distinct !{!86, !87, !"sorbet_buildArrayIntrinsic: argument 0"}
+!87 = distinct !{!87, !"sorbet_buildArrayIntrinsic"}
 !88 = distinct !DISubprogram(name: "func_Object#6fooAll.cold.1", linkageName: "func_Object#6fooAll.cold.1", scope: null, file: !4, type: !89, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
 !89 = !DISubroutineType(types: !5)
 !90 = !DILocation(line: 6, column: 3, scope: !88)

--- a/test/testdata/compiler/classfields.opt.ll.exp
+++ b/test/testdata/compiler/classfields.opt.ll.exp
@@ -171,8 +171,6 @@ declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
-
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #3
 
@@ -200,44 +198,43 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
 define void @Init_classfields() local_unnamed_addr #5 {
 entry:
   %positional_table.i.i = alloca i64, align 8, !dbg !10
-  %0 = alloca %struct.rb_calling_info, align 8
   %locals.i25.i = alloca i64, i32 0, align 8
   %locals.i23.i = alloca i64, i32 0, align 8
   %locals.i19.i = alloca i64, i32 0, align 8
   %locals.i17.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
-  store i64 %1, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
-  store i64 %2, i64* @rubyIdPrecomputed_new, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #11
-  store i64 %3, i64* @rubyIdPrecomputed_initialize, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
-  store i64 %4, i64* @rubyIdPrecomputed_write, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
-  store i64 %5, i64* @rubyIdPrecomputed_read, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
-  store i64 %6, i64* @rubyIdPrecomputed_puts, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @"str_@@f", i64 0, i64 0), i64 noundef 3) #11
-  store i64 %7, i64* @"rubyIdPrecomputed_@@f", align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:B>", i64 0, i64 0), i64 noundef 9) #11
-  store i64 %8, i64* @"rubyIdPrecomputed_<class:B>", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #11
-  store i64 %10, i64* @rubyIdPrecomputed_a, align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
+  store i64 %1, i64* @rubyIdPrecomputed_new, align 8
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #11
+  store i64 %2, i64* @rubyIdPrecomputed_initialize, align 8
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
+  store i64 %3, i64* @rubyIdPrecomputed_write, align 8
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
+  store i64 %4, i64* @rubyIdPrecomputed_read, align 8
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  store i64 %5, i64* @rubyIdPrecomputed_puts, align 8
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @"str_@@f", i64 0, i64 0), i64 noundef 3) #11
+  store i64 %6, i64* @"rubyIdPrecomputed_@@f", align 8
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:B>", i64 0, i64 0), i64 noundef 9) #11
+  store i64 %7, i64* @"rubyIdPrecomputed_<class:B>", align 8
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #11
+  store i64 %9, i64* @rubyIdPrecomputed_a, align 8
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %10) #11
+  store i64 %10, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_test/testdata/compiler/classfields.rb", i64 0, i64 0), i64 noundef 37) #11
   tail call void @rb_gc_register_mark_object(i64 %11) #11
-  store i64 %11, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %12 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_test/testdata/compiler/classfields.rb", i64 0, i64 0), i64 noundef 37) #11
-  tail call void @rb_gc_register_mark_object(i64 %12) #11
-  store i64 %12, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
+  store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 29)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/classfields.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !17
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
   %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !17
@@ -256,382 +253,320 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.3, i64 %rubyId_read11.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
   %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %14) #11
+  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %13) #11
   %rubyId_write.i.i = load i64, i64* @rubyIdPrecomputed_write, align 8
   %"rubyStr_test/testdata/compiler/classfields.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_write.i.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#5write", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %16) #11
-  store i64 %16, i64* @rubyStrFrozen_read, align 8
+  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %rubyId_write.i.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#5write", align 8
+  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %15) #11
+  store i64 %15, i64* @rubyStrFrozen_read, align 8
   %rubyId_read.i.i = load i64, i64* @rubyIdPrecomputed_read, align 8
   %"rubyStr_test/testdata/compiler/classfields.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %rubyId_read.i.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 16, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8
+  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %rubyId_read.i.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 16, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8
   %rubyId_read.i20.i = load i64, i64* @rubyIdPrecomputed_read, align 8
   %rubyStr_read.i21.i = load i64, i64* @rubyStrFrozen_read, align 8
   %"rubyStr_test/testdata/compiler/classfields.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_read.i21.i, i64 %rubyId_read.i20.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 19, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:B>", i64 0, i64 0), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %19) #11
+  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_read.i21.i, i64 %rubyId_read.i20.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 19, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8
+  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:B>", i64 0, i64 0), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %18) #11
   %"rubyId_<class:B>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:B>", align 8
   %"rubyStr_test/testdata/compiler/classfields.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %"rubyId_<class:B>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.13<static-init>", align 8
-  %21 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !22
-  %22 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %21, i64 0, i32 18
-  %23 = load i64, i64* %22, align 8, !tbaa !24
-  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2
-  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !tbaa !34
+  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %"rubyId_<class:B>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.13<static-init>", align 8
+  %20 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !22
+  %21 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %20, i64 0, i32 18
+  %22 = load i64, i64* %21, align 8, !tbaa !24
+  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
+  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !34
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %27, align 8, !tbaa !37
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4
-  %29 = load i64*, i64** %28, align 8, !tbaa !39
-  %30 = load i64, i64* %29, align 8, !tbaa !6
-  %31 = and i64 %30, -33
-  store i64 %31, i64* %29, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %24, %struct.rb_control_frame_struct* %26, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %32, align 8, !dbg !40, !tbaa !22
-  %33 = load i64, i64* @rb_cObject, align 8, !dbg !41
-  %34 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_B, i64 0, i64 0), i64 %33) #11, !dbg !41
-  %35 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %34) #11, !dbg !41
-  %36 = bitcast %struct.rb_calling_info* %0 to i8*, !dbg !41
-  call void @llvm.lifetime.start.p0i8(i64 noundef 24, i8* noundef nonnull align 8 dereferenceable(24) %36) #11, !dbg !41
-  %37 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 0, !dbg !41
-  store i64 0, i64* %37, align 8, !dbg !41, !tbaa !42
-  %38 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 3, !dbg !41
-  store i32 0, i32* %38, align 4, !dbg !41, !tbaa !44
-  %39 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 1, !dbg !41
-  store i64 %34, i64* %39, align 8, !dbg !41, !tbaa !45
-  %40 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 2, !dbg !41
-  store i32 0, i32* %40, align 8, !dbg !41, !tbaa !46
-  %41 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %41) #11
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %26, align 8, !tbaa !37
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
+  %28 = load i64*, i64** %27, align 8, !tbaa !39
+  %29 = load i64, i64* %28, align 8, !tbaa !6
+  %30 = and i64 %29, -33
+  store i64 %30, i64* %28, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %23, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %31, align 8, !dbg !40, !tbaa !22
+  %32 = load i64, i64* @rb_cObject, align 8, !dbg !41
+  %33 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_B, i64 0, i64 0), i64 %32) #11, !dbg !41
+  %34 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %33) #11, !dbg !41
+  %35 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.13<static-init>", align 8
-  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2
-  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !tbaa !34
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %45, align 8, !tbaa !37
-  %46 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 4
-  %47 = load i64*, i64** %46, align 8, !tbaa !39
-  %48 = load i64, i64* %47, align 8, !tbaa !6
-  %49 = and i64 %48, -33
-  store i64 %49, i64* %47, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %42, %struct.rb_control_frame_struct* %44, %struct.rb_iseq_struct* %stackFrame.i.i) #11
-  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %50, align 8, !dbg !47, !tbaa !22
-  %51 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
-  %52 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !48
-  %needTakeSlowPath = icmp ne i64 %51, %52, !dbg !10
-  br i1 %needTakeSlowPath, label %53, label %54, !dbg !10, !prof !49
+  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
+  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2
+  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !tbaa !34
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %39, align 8, !tbaa !37
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 4
+  %41 = load i64*, i64** %40, align 8, !tbaa !39
+  %42 = load i64, i64* %41, align 8, !tbaa !6
+  %43 = and i64 %42, -33
+  store i64 %43, i64* %41, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %36, %struct.rb_control_frame_struct* %38, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 0
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %44, align 8, !dbg !42, !tbaa !22
+  %45 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
+  %46 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !43
+  %needTakeSlowPath = icmp ne i64 %45, %46, !dbg !10
+  br i1 %needTakeSlowPath, label %47, label %48, !dbg !10, !prof !44
 
-53:                                               ; preds = %entry
+47:                                               ; preds = %entry
   call void @const_recompute_B(), !dbg !10
-  br label %54, !dbg !10
+  br label %48, !dbg !10
 
-54:                                               ; preds = %entry, %53
-  %55 = load i64, i64* @guarded_const_B, align 8, !dbg !10
-  %56 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
-  %57 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !48
-  %guardUpdated = icmp eq i64 %56, %57, !dbg !10
+48:                                               ; preds = %entry, %47
+  %49 = load i64, i64* @guarded_const_B, align 8, !dbg !10
+  %50 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
+  %51 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !43
+  %guardUpdated = icmp eq i64 %50, %51, !dbg !10
   call void @llvm.assume(i1 %guardUpdated), !dbg !10
   %stackFrame26.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#5write", align 8, !dbg !10
-  %58 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
-  %59 = bitcast i8* %58 to i16*, !dbg !10
-  %60 = load i16, i16* %59, align 8, !dbg !10
-  %61 = and i16 %60, -384, !dbg !10
-  %62 = or i16 %61, 1, !dbg !10
-  store i16 %62, i16* %59, align 8, !dbg !10
-  %63 = getelementptr inbounds i8, i8* %58, i64 8, !dbg !10
-  %64 = bitcast i8* %63 to i32*, !dbg !10
-  store i32 1, i32* %64, align 8, !dbg !10, !tbaa !50
-  %65 = getelementptr inbounds i8, i8* %58, i64 12, !dbg !10
-  %66 = getelementptr inbounds i8, i8* %58, i64 4, !dbg !10
-  %67 = bitcast i8* %66 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %65, i8 0, i64 20, i1 false) #11, !dbg !10
-  store i32 1, i32* %67, align 4, !dbg !10, !tbaa !53
+  %52 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %53 = bitcast i8* %52 to i16*, !dbg !10
+  %54 = load i16, i16* %53, align 8, !dbg !10
+  %55 = and i16 %54, -384, !dbg !10
+  %56 = or i16 %55, 1, !dbg !10
+  store i16 %56, i16* %53, align 8, !dbg !10
+  %57 = getelementptr inbounds i8, i8* %52, i64 8, !dbg !10
+  %58 = bitcast i8* %57 to i32*, !dbg !10
+  store i32 1, i32* %58, align 8, !dbg !10, !tbaa !45
+  %59 = getelementptr inbounds i8, i8* %52, i64 12, !dbg !10
+  %60 = getelementptr inbounds i8, i8* %52, i64 4, !dbg !10
+  %61 = bitcast i8* %60 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %59, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %61, align 4, !dbg !10, !tbaa !48
   %rubyId_a.i.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !10
   store i64 %rubyId_a.i.i, i64* %positional_table.i.i, align 8, !dbg !10
-  %68 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %68, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %41, i64 noundef 8, i1 noundef false) #11, !dbg !10
-  %69 = getelementptr inbounds i8, i8* %58, i64 32, !dbg !10
-  %70 = bitcast i8* %69 to i8**, !dbg !10
-  store i8* %68, i8** %70, align 8, !dbg !10, !tbaa !54
-  call void @sorbet_vm_define_method(i64 %55, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#5write", i8* nonnull %58, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext false) #11, !dbg !10
-  %71 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !22
-  %72 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 5, !dbg !10
-  %73 = load i32, i32* %72, align 8, !dbg !10, !tbaa !55
-  %74 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 6, !dbg !10
-  %75 = load i32, i32* %74, align 4, !dbg !10, !tbaa !56
-  %76 = xor i32 %75, -1, !dbg !10
-  %77 = and i32 %76, %73, !dbg !10
-  %78 = icmp eq i32 %77, 0, !dbg !10
-  br i1 %78, label %rb_vm_check_ints.exit2.i.i, label %79, !dbg !10, !prof !57
-
-79:                                               ; preds = %54
-  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 8, !dbg !10
-  %81 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %80, align 8, !dbg !10, !tbaa !58
-  %82 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %81, i32 noundef 0) #11, !dbg !10
-  br label %rb_vm_check_ints.exit2.i.i, !dbg !10
-
-rb_vm_check_ints.exit2.i.i:                       ; preds = %79, %54
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %50, align 8, !dbg !10, !tbaa !22
-  %stackFrame35.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8, !dbg !59
-  %83 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !59
-  %84 = bitcast i8* %83 to i16*, !dbg !59
-  %85 = load i16, i16* %84, align 8, !dbg !59
-  %86 = and i16 %85, -384, !dbg !59
-  store i16 %86, i16* %84, align 8, !dbg !59
-  %87 = getelementptr inbounds i8, i8* %83, i64 4, !dbg !59
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %87, i8 0, i64 28, i1 false) #11, !dbg !59
-  call void @sorbet_vm_define_method(i64 %55, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#4read", i8* nonnull %83, %struct.rb_iseq_struct* %stackFrame35.i.i, i1 noundef zeroext false) #11, !dbg !59
-  %88 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !59, !tbaa !22
-  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %88, i64 0, i32 5, !dbg !59
-  %90 = load i32, i32* %89, align 8, !dbg !59, !tbaa !55
-  %91 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %88, i64 0, i32 6, !dbg !59
-  %92 = load i32, i32* %91, align 4, !dbg !59, !tbaa !56
-  %93 = xor i32 %92, -1, !dbg !59
-  %94 = and i32 %93, %90, !dbg !59
-  %95 = icmp eq i32 %94, 0, !dbg !59
-  br i1 %95, label %rb_vm_check_ints.exit1.i.i, label %96, !dbg !59, !prof !57
-
-96:                                               ; preds = %rb_vm_check_ints.exit2.i.i
-  %97 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %88, i64 0, i32 8, !dbg !59
-  %98 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %97, align 8, !dbg !59, !tbaa !58
-  %99 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %98, i32 noundef 0) #11, !dbg !59
-  br label %rb_vm_check_ints.exit1.i.i, !dbg !59
-
-rb_vm_check_ints.exit1.i.i:                       ; preds = %96, %rb_vm_check_ints.exit2.i.i
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %50, align 8, !dbg !59, !tbaa !22
-  %stackFrame45.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8, !dbg !60
-  %100 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !60
-  %101 = bitcast i8* %100 to i16*, !dbg !60
-  %102 = load i16, i16* %101, align 8, !dbg !60
-  %103 = and i16 %102, -384, !dbg !60
-  store i16 %103, i16* %101, align 8, !dbg !60
-  %104 = getelementptr inbounds i8, i8* %100, i64 4, !dbg !60
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %104, i8 0, i64 28, i1 false) #11, !dbg !60
-  call void @sorbet_vm_define_method(i64 %55, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_B.4read, i8* nonnull %100, %struct.rb_iseq_struct* %stackFrame45.i.i, i1 noundef zeroext true) #11, !dbg !60
-  %105 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !60, !tbaa !22
-  %106 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %105, i64 0, i32 5, !dbg !60
-  %107 = load i32, i32* %106, align 8, !dbg !60, !tbaa !55
-  %108 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %105, i64 0, i32 6, !dbg !60
-  %109 = load i32, i32* %108, align 4, !dbg !60, !tbaa !56
-  %110 = xor i32 %109, -1, !dbg !60
-  %111 = and i32 %110, %107, !dbg !60
-  %112 = icmp eq i32 %111, 0, !dbg !60
-  br i1 %112, label %"func_B.13<static-init>L62.exit.i", label %113, !dbg !60, !prof !57
-
-113:                                              ; preds = %rb_vm_check_ints.exit1.i.i
-  %114 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %105, i64 0, i32 8, !dbg !60
-  %115 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %114, align 8, !dbg !60, !tbaa !58
-  %116 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %115, i32 noundef 0) #11, !dbg !60
-  br label %"func_B.13<static-init>L62.exit.i", !dbg !60
-
-"func_B.13<static-init>L62.exit.i":               ; preds = %113, %rb_vm_check_ints.exit1.i.i
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %41) #11
+  %62 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %35, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %63 = getelementptr inbounds i8, i8* %52, i64 32, !dbg !10
+  %64 = bitcast i8* %63 to i8**, !dbg !10
+  store i8* %62, i8** %64, align 8, !dbg !10, !tbaa !49
+  call void @sorbet_vm_define_method(i64 %49, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#5write", i8* nonnull %52, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext false) #11, !dbg !10
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %44, align 8, !dbg !10, !tbaa !22
+  %stackFrame35.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8, !dbg !50
+  %65 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !50
+  %66 = bitcast i8* %65 to i16*, !dbg !50
+  %67 = load i16, i16* %66, align 8, !dbg !50
+  %68 = and i16 %67, -384, !dbg !50
+  store i16 %68, i16* %66, align 8, !dbg !50
+  %69 = getelementptr inbounds i8, i8* %65, i64 4, !dbg !50
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %69, i8 0, i64 28, i1 false) #11, !dbg !50
+  call void @sorbet_vm_define_method(i64 %49, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#4read", i8* nonnull %65, %struct.rb_iseq_struct* %stackFrame35.i.i, i1 noundef zeroext false) #11, !dbg !50
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %44, align 8, !dbg !50, !tbaa !22
+  %stackFrame45.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8, !dbg !51
+  %70 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !51
+  %71 = bitcast i8* %70 to i16*, !dbg !51
+  %72 = load i16, i16* %71, align 8, !dbg !51
+  %73 = and i16 %72, -384, !dbg !51
+  store i16 %73, i16* %71, align 8, !dbg !51
+  %74 = getelementptr inbounds i8, i8* %70, i64 4, !dbg !51
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %74, i8 0, i64 28, i1 false) #11, !dbg !51
+  call void @sorbet_vm_define_method(i64 %49, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_B.4read, i8* nonnull %70, %struct.rb_iseq_struct* %stackFrame45.i.i, i1 noundef zeroext true) #11, !dbg !51
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35) #11
   call void @sorbet_popFrame() #11, !dbg !41
-  call void @llvm.lifetime.end.p0i8(i64 noundef 24, i8* noundef nonnull %36) #11, !dbg !41
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %32, align 8, !dbg !41, !tbaa !22
-  %117 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %55, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !17
-  %118 = icmp eq i64 %117, 52, !dbg !17
-  br i1 %118, label %slowNew.i, label %fastNew.i, !dbg !17
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %31, align 8, !dbg !41, !tbaa !22
+  %75 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %49, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !17
+  %76 = icmp eq i64 %75, 52, !dbg !17
+  br i1 %76, label %slowNew.i, label %fastNew.i, !dbg !17
 
-slowNew.i:                                        ; preds = %"func_B.13<static-init>L62.exit.i"
-  %119 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !17
-  %120 = load i64*, i64** %119, align 8, !dbg !17
-  store i64 %55, i64* %120, align 8, !dbg !17, !tbaa !6
-  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !17
-  store i64* %121, i64** %119, align 8, !dbg !17
-  %122 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !17
+slowNew.i:                                        ; preds = %48
+  %77 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !17
+  %78 = load i64*, i64** %77, align 8, !dbg !17
+  store i64 %49, i64* %78, align 8, !dbg !17, !tbaa !6
+  %79 = getelementptr inbounds i64, i64* %78, i64 1, !dbg !17
+  store i64* %79, i64** %77, align 8, !dbg !17
+  %80 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !17
   br label %afterNew.i, !dbg !17
 
-fastNew.i:                                        ; preds = %"func_B.13<static-init>L62.exit.i"
-  %123 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !17
-  %124 = load i64*, i64** %123, align 8, !dbg !17
-  store i64 %117, i64* %124, align 8, !dbg !17, !tbaa !6
-  %125 = getelementptr inbounds i64, i64* %124, i64 1, !dbg !17
-  store i64* %125, i64** %123, align 8, !dbg !17
-  %126 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !17
+fastNew.i:                                        ; preds = %48
+  %81 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !17
+  %82 = load i64*, i64** %81, align 8, !dbg !17
+  store i64 %75, i64* %82, align 8, !dbg !17, !tbaa !6
+  %83 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !17
+  store i64* %83, i64** %81, align 8, !dbg !17
+  %84 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !17
   br label %afterNew.i, !dbg !17
 
 afterNew.i:                                       ; preds = %fastNew.i, %slowNew.i
-  %initializedObject.i = phi i64 [ %122, %slowNew.i ], [ %117, %fastNew.i ], !dbg !17
-  %127 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !17
-  %128 = load i64*, i64** %127, align 8, !dbg !17
-  store i64 %initializedObject.i, i64* %128, align 8, !dbg !17, !tbaa !6
-  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !17
-  store i64 3, i64* %129, align 8, !dbg !17, !tbaa !6
-  %130 = getelementptr inbounds i64, i64* %129, i64 1, !dbg !17
-  store i64* %130, i64** %127, align 8, !dbg !17
+  %initializedObject.i = phi i64 [ %80, %slowNew.i ], [ %75, %fastNew.i ], !dbg !17
+  %85 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !17
+  %86 = load i64*, i64** %85, align 8, !dbg !17
+  store i64 %initializedObject.i, i64* %86, align 8, !dbg !17, !tbaa !6
+  %87 = getelementptr inbounds i64, i64* %86, i64 1, !dbg !17
+  store i64 3, i64* %87, align 8, !dbg !17, !tbaa !6
+  %88 = getelementptr inbounds i64, i64* %87, i64 1, !dbg !17
+  store i64* %88, i64** %85, align 8, !dbg !17
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %32, align 8, !dbg !17, !tbaa !22
-  %131 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !18
-  %132 = load i64*, i64** %131, align 8, !dbg !18
-  store i64 %55, i64* %132, align 8, !dbg !18, !tbaa !6
-  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !18
-  store i64* %133, i64** %131, align 8, !dbg !18
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %31, align 8, !dbg !17, !tbaa !22
+  %89 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !18
+  %90 = load i64*, i64** %89, align 8, !dbg !18
+  store i64 %49, i64* %90, align 8, !dbg !18, !tbaa !6
+  %91 = getelementptr inbounds i64, i64* %90, i64 1, !dbg !18
+  store i64* %91, i64** %89, align 8, !dbg !18
   %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
-  %134 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !19
-  %135 = load i64*, i64** %134, align 8, !dbg !19
-  store i64 %23, i64* %135, align 8, !dbg !19, !tbaa !6
-  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !19
-  store i64 %send5, i64* %136, align 8, !dbg !19, !tbaa !6
-  %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !19
-  store i64* %137, i64** %134, align 8, !dbg !19
+  %92 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !19
+  %93 = load i64*, i64** %92, align 8, !dbg !19
+  store i64 %22, i64* %93, align 8, !dbg !19, !tbaa !6
+  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !19
+  store i64 %send5, i64* %94, align 8, !dbg !19, !tbaa !6
+  %95 = getelementptr inbounds i64, i64* %94, i64 1, !dbg !19
+  store i64* %95, i64** %92, align 8, !dbg !19
   %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %32, align 8, !dbg !19, !tbaa !22
-  %138 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %55, %struct.FunctionInlineCache* noundef @ic_new.1) #11, !dbg !20
-  %139 = icmp eq i64 %138, 52, !dbg !20
-  br i1 %139, label %slowNew51.i, label %fastNew52.i, !dbg !20
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %31, align 8, !dbg !19, !tbaa !22
+  %96 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %49, %struct.FunctionInlineCache* noundef @ic_new.1) #11, !dbg !20
+  %97 = icmp eq i64 %96, 52, !dbg !20
+  br i1 %97, label %slowNew51.i, label %fastNew52.i, !dbg !20
 
 slowNew51.i:                                      ; preds = %afterNew.i
-  %140 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !20
-  %141 = load i64*, i64** %140, align 8, !dbg !20
-  store i64 %55, i64* %141, align 8, !dbg !20, !tbaa !6
-  %142 = getelementptr inbounds i64, i64* %141, i64 1, !dbg !20
-  store i64* %142, i64** %140, align 8, !dbg !20
-  %143 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new.1, i64 noundef 0) #11, !dbg !20
+  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !20
+  %99 = load i64*, i64** %98, align 8, !dbg !20
+  store i64 %49, i64* %99, align 8, !dbg !20, !tbaa !6
+  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !20
+  store i64* %100, i64** %98, align 8, !dbg !20
+  %101 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new.1, i64 noundef 0) #11, !dbg !20
   br label %"func_<root>.17<static-init>$152.exit", !dbg !20
 
 fastNew52.i:                                      ; preds = %afterNew.i
-  %144 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !20
-  %145 = load i64*, i64** %144, align 8, !dbg !20
-  store i64 %138, i64* %145, align 8, !dbg !20, !tbaa !6
-  %146 = getelementptr inbounds i64, i64* %145, i64 1, !dbg !20
-  store i64* %146, i64** %144, align 8, !dbg !20
-  %147 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize.2, i64 noundef 0) #11, !dbg !20
+  %102 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !20
+  %103 = load i64*, i64** %102, align 8, !dbg !20
+  store i64 %96, i64* %103, align 8, !dbg !20, !tbaa !6
+  %104 = getelementptr inbounds i64, i64* %103, i64 1, !dbg !20
+  store i64* %104, i64** %102, align 8, !dbg !20
+  %105 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize.2, i64 noundef 0) #11, !dbg !20
   br label %"func_<root>.17<static-init>$152.exit", !dbg !20
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %slowNew51.i, %fastNew52.i
-  %initializedObject57.i = phi i64 [ %143, %slowNew51.i ], [ %138, %fastNew52.i ], !dbg !20
-  %148 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !20
-  %149 = load i64*, i64** %148, align 8, !dbg !20
-  store i64 %initializedObject57.i, i64* %149, align 8, !dbg !20, !tbaa !6
-  %150 = getelementptr inbounds i64, i64* %149, i64 1, !dbg !20
-  store i64* %150, i64** %148, align 8, !dbg !20
+  %initializedObject57.i = phi i64 [ %101, %slowNew51.i ], [ %96, %fastNew52.i ], !dbg !20
+  %106 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !20
+  %107 = load i64*, i64** %106, align 8, !dbg !20
+  store i64 %initializedObject57.i, i64* %107, align 8, !dbg !20, !tbaa !6
+  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !20
+  store i64* %108, i64** %106, align 8, !dbg !20
   %send9 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.3, i64 0), !dbg !20
-  %151 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !21
-  %152 = load i64*, i64** %151, align 8, !dbg !21
-  store i64 %23, i64* %152, align 8, !dbg !21, !tbaa !6
-  %153 = getelementptr inbounds i64, i64* %152, i64 1, !dbg !21
-  store i64 %send9, i64* %153, align 8, !dbg !21, !tbaa !6
-  %154 = getelementptr inbounds i64, i64* %153, i64 1, !dbg !21
-  store i64* %154, i64** %151, align 8, !dbg !21
+  %109 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !21
+  %110 = load i64*, i64** %109, align 8, !dbg !21
+  store i64 %22, i64* %110, align 8, !dbg !21, !tbaa !6
+  %111 = getelementptr inbounds i64, i64* %110, i64 1, !dbg !21
+  store i64 %send9, i64* %111, align 8, !dbg !21, !tbaa !6
+  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !21
+  store i64* %112, i64** %109, align 8, !dbg !21
   %send11 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !21
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @"func_B#5write"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !61 {
+define internal i64 @"func_B#5write"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !52 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !22
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !62
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !62
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !62
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !62, !prof !63
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !53
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !53
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !53
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !53, !prof !54
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !62
-  unreachable, !dbg !62
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !53
+  unreachable, !dbg !53
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !62
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !64, !tbaa !22
-  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !65
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !65, !tbaa !48
-  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !65
-  br i1 %needTakeSlowPath, label %3, label %4, !dbg !65, !prof !49
+  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !53
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !55, !tbaa !22
+  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !56
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !56, !tbaa !43
+  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !56
+  br i1 %needTakeSlowPath, label %3, label %4, !dbg !56, !prof !44
 
 3:                                                ; preds = %fillRequiredArgs
-  tail call void @const_recompute_B(), !dbg !65
-  br label %4, !dbg !65
+  tail call void @const_recompute_B(), !dbg !56
+  br label %4, !dbg !56
 
 4:                                                ; preds = %fillRequiredArgs, %3
-  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !65
-  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !65
-  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !65, !tbaa !48
-  %guardUpdated = icmp eq i64 %6, %7, !dbg !65
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !65
-  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !65
-  tail call void @rb_cvar_set(i64 %5, i64 %"rubyId_@@f", i64 %rawArg_a) #11, !dbg !65
-  %"rubyId_@@f7" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !66
-  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f7") #11, !dbg !66
+  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !56
+  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !56
+  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !56, !tbaa !43
+  %guardUpdated = icmp eq i64 %6, %7, !dbg !56
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !56
+  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !56
+  tail call void @rb_cvar_set(i64 %5, i64 %"rubyId_@@f", i64 %rawArg_a) #11, !dbg !56
+  %"rubyId_@@f7" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !57
+  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f7") #11, !dbg !57
   ret i64 %8
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @"func_B#4read"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !67 {
+define internal i64 @"func_B#4read"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !58 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !tbaa !22
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !68
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !68, !prof !69
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !59
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !59, !prof !60
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !68
-  unreachable, !dbg !68
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !59
+  unreachable, !dbg !59
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !70, !tbaa !22
-  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !71
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !71, !tbaa !48
-  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !71
-  br i1 %needTakeSlowPath, label %3, label %4, !dbg !71, !prof !49
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !61, !tbaa !22
+  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !62
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !62, !tbaa !43
+  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !62
+  br i1 %needTakeSlowPath, label %3, label %4, !dbg !62, !prof !44
 
 3:                                                ; preds = %fillRequiredArgs
-  tail call void @const_recompute_B(), !dbg !71
-  br label %4, !dbg !71
+  tail call void @const_recompute_B(), !dbg !62
+  br label %4, !dbg !62
 
 4:                                                ; preds = %fillRequiredArgs, %3
-  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !71
-  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !71
-  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !71, !tbaa !48
-  %guardUpdated = icmp eq i64 %6, %7, !dbg !71
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !71
-  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !71
-  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !71
+  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !62
+  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !62
+  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !62, !tbaa !43
+  %guardUpdated = icmp eq i64 %6, %7, !dbg !62
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !62
+  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !62
+  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !62
   ret i64 %8
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @func_B.4read(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !72 {
+define internal i64 @func_B.4read(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !63 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %0, align 8, !tbaa !22
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !73
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !73, !prof !69
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !64
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !64, !prof !60
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !73
-  unreachable, !dbg !73
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !64
+  unreachable, !dbg !64
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %0, align 8, !dbg !74, !tbaa !22
-  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !75
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !75, !tbaa !48
-  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !75
-  br i1 %needTakeSlowPath, label %3, label %4, !dbg !75, !prof !49
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %0, align 8, !dbg !65, !tbaa !22
+  %1 = load i64, i64* @guard_epoch_B, align 8, !dbg !66
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !66, !tbaa !43
+  %needTakeSlowPath = icmp ne i64 %1, %2, !dbg !66
+  br i1 %needTakeSlowPath, label %3, label %4, !dbg !66, !prof !44
 
 3:                                                ; preds = %fillRequiredArgs
-  tail call void @const_recompute_B(), !dbg !75
-  br label %4, !dbg !75
+  tail call void @const_recompute_B(), !dbg !66
+  br label %4, !dbg !66
 
 4:                                                ; preds = %fillRequiredArgs, %3
-  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !75
-  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !75
-  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !75, !tbaa !48
-  %guardUpdated = icmp eq i64 %6, %7, !dbg !75
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !75
-  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !75
-  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !75
+  %5 = load i64, i64* @guarded_const_B, align 8, !dbg !66
+  %6 = load i64, i64* @guard_epoch_B, align 8, !dbg !66
+  %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !66, !tbaa !43
+  %guardUpdated = icmp eq i64 %6, %7, !dbg !66
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !66
+  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !66
+  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !66
   ret i64 %8
 }
 
@@ -645,7 +580,7 @@ declare void @llvm.assume(i1 noundef) #8
 define linkonce void @const_recompute_B() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_B, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_B, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !48
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !43
   store i64 %2, i64* @guard_epoch_B, align 8
   ret void
 }
@@ -710,37 +645,28 @@ attributes #13 = { noreturn }
 !39 = !{!38, !23, i64 32}
 !40 = !DILocation(line: 0, scope: !16)
 !41 = !DILocation(line: 5, column: 1, scope: !16)
-!42 = !{!43, !7, i64 0}
-!43 = !{!"rb_calling_info", !7, i64 0, !7, i64 8, !29, i64 16, !29, i64 20}
-!44 = !{!43, !29, i64 20}
-!45 = !{!43, !7, i64 8}
-!46 = !{!43, !29, i64 16}
-!47 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
-!48 = !{!30, !30, i64 0}
-!49 = !{!"branch_weights", i32 1, i32 10000}
-!50 = !{!51, !29, i64 8}
-!51 = !{!"rb_sorbet_param_struct", !52, i64 0, !29, i64 4, !29, i64 8, !29, i64 12, !29, i64 16, !29, i64 20, !29, i64 24, !29, i64 28, !23, i64 32, !29, i64 40, !29, i64 44, !29, i64 48, !29, i64 52, !23, i64 56}
-!52 = !{!"", !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 1, !29, i64 1}
-!53 = !{!51, !29, i64 4}
-!54 = !{!51, !23, i64 32}
-!55 = !{!35, !29, i64 40}
-!56 = !{!35, !29, i64 44}
-!57 = !{!"branch_weights", i32 2000, i32 1}
-!58 = !{!35, !23, i64 56}
-!59 = !DILocation(line: 16, column: 3, scope: !11, inlinedAt: !15)
-!60 = !DILocation(line: 19, column: 3, scope: !11, inlinedAt: !15)
-!61 = distinct !DISubprogram(name: "B#write", linkageName: "func_B#5write", scope: null, file: !4, line: 7, type: !12, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!62 = !DILocation(line: 7, column: 3, scope: !61)
-!63 = !{!"branch_weights", i32 4001, i32 4000000}
-!64 = !DILocation(line: 7, column: 13, scope: !61)
-!65 = !DILocation(line: 8, column: 11, scope: !61)
-!66 = !DILocation(line: 8, column: 5, scope: !61)
-!67 = distinct !DISubprogram(name: "B#read", linkageName: "func_B#4read", scope: null, file: !4, line: 16, type: !12, scopeLine: 16, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!68 = !DILocation(line: 16, column: 3, scope: !67)
-!69 = !{!"branch_weights", i32 1, i32 2000}
-!70 = !DILocation(line: 0, scope: !67)
-!71 = !DILocation(line: 17, column: 5, scope: !67)
-!72 = distinct !DISubprogram(name: "B.read", linkageName: "func_B.4read", scope: null, file: !4, line: 19, type: !12, scopeLine: 19, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!73 = !DILocation(line: 19, column: 3, scope: !72)
-!74 = !DILocation(line: 0, scope: !72)
-!75 = !DILocation(line: 20, column: 5, scope: !72)
+!42 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
+!43 = !{!30, !30, i64 0}
+!44 = !{!"branch_weights", i32 1, i32 10000}
+!45 = !{!46, !29, i64 8}
+!46 = !{!"rb_sorbet_param_struct", !47, i64 0, !29, i64 4, !29, i64 8, !29, i64 12, !29, i64 16, !29, i64 20, !29, i64 24, !29, i64 28, !23, i64 32, !29, i64 40, !29, i64 44, !29, i64 48, !29, i64 52, !23, i64 56}
+!47 = !{!"", !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 1, !29, i64 1}
+!48 = !{!46, !29, i64 4}
+!49 = !{!46, !23, i64 32}
+!50 = !DILocation(line: 16, column: 3, scope: !11, inlinedAt: !15)
+!51 = !DILocation(line: 19, column: 3, scope: !11, inlinedAt: !15)
+!52 = distinct !DISubprogram(name: "B#write", linkageName: "func_B#5write", scope: null, file: !4, line: 7, type: !12, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!53 = !DILocation(line: 7, column: 3, scope: !52)
+!54 = !{!"branch_weights", i32 4001, i32 4000000}
+!55 = !DILocation(line: 7, column: 13, scope: !52)
+!56 = !DILocation(line: 8, column: 11, scope: !52)
+!57 = !DILocation(line: 8, column: 5, scope: !52)
+!58 = distinct !DISubprogram(name: "B#read", linkageName: "func_B#4read", scope: null, file: !4, line: 16, type: !12, scopeLine: 16, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!59 = !DILocation(line: 16, column: 3, scope: !58)
+!60 = !{!"branch_weights", i32 1, i32 2000}
+!61 = !DILocation(line: 0, scope: !58)
+!62 = !DILocation(line: 17, column: 5, scope: !58)
+!63 = distinct !DISubprogram(name: "B.read", linkageName: "func_B.4read", scope: null, file: !4, line: 19, type: !12, scopeLine: 19, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!64 = !DILocation(line: 19, column: 3, scope: !63)
+!65 = !DILocation(line: 0, scope: !63)
+!66 = !DILocation(line: 20, column: 5, scope: !63)

--- a/test/testdata/compiler/constant_cache.opt.ll.exp
+++ b/test/testdata/compiler/constant_cache.opt.ll.exp
@@ -142,8 +142,6 @@ declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
-
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 
@@ -323,29 +321,12 @@ entry:
   %40 = getelementptr inbounds i8, i8* %36, i64 4, !dbg !48
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %40, i8 0, i64 28, i1 false) #11, !dbg !48
   call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %36, %struct.rb_iseq_struct* %stackFrame22.i, i1 noundef zeroext false) #11, !dbg !48
-  %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !48, !tbaa !14
-  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 5, !dbg !48
-  %43 = load i32, i32* %42, align 8, !dbg !48, !tbaa !49
-  %44 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 6, !dbg !48
-  %45 = load i32, i32* %44, align 4, !dbg !48, !tbaa !50
-  %46 = xor i32 %45, -1, !dbg !48
-  %47 = and i32 %46, %43, !dbg !48
-  %48 = icmp eq i32 %47, 0, !dbg !48
-  br i1 %48, label %"func_<root>.17<static-init>$152.exit", label %49, !dbg !48, !prof !51
-
-49:                                               ; preds = %entry
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 8, !dbg !48
-  %51 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %50, align 8, !dbg !48, !tbaa !52
-  %52 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %51, i32 noundef 0) #11, !dbg !48
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !48
-
-"func_<root>.17<static-init>$152.exit":           ; preds = %entry, %49
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %23, align 8, !dbg !48, !tbaa !14
-  %53 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !26
-  %54 = load i64*, i64** %53, align 8, !dbg !26
-  store i64 %14, i64* %54, align 8, !dbg !26, !tbaa !6
-  %55 = getelementptr inbounds i64, i64* %54, i64 1, !dbg !26
-  store i64* %55, i64** %53, align 8, !dbg !26
+  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !26
+  %42 = load i64*, i64** %41, align 8, !dbg !26
+  store i64 %14, i64* %42, align 8, !dbg !26, !tbaa !6
+  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !26
+  store i64* %43, i64** %41, align 8, !dbg !26
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !26
   ret void
 }
@@ -431,7 +412,3 @@ attributes #12 = { nounwind allocsize(0,1) }
 !46 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.13<static-init>L61", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !47 = distinct !DILocation(line: 4, column: 1, scope: !27)
 !48 = !DILocation(line: 5, column: 1, scope: !27)
-!49 = !{!38, !33, i64 40}
-!50 = !{!38, !33, i64 44}
-!51 = !{!"branch_weights", i32 2000, i32 1}
-!52 = !{!38, !15, i64 56}

--- a/test/testdata/compiler/custom_plus.opt.ll.exp
+++ b/test/testdata/compiler/custom_plus.opt.ll.exp
@@ -173,8 +173,6 @@ declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
-
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #3
 
@@ -240,186 +238,140 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
 define internal fastcc void @"func_<root>.17<static-init>$152"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #5 !dbg !21 {
 functionEntryInitializers:
   %positional_table.i = alloca i64, align 8, !dbg !22
-  %0 = alloca %struct.rb_calling_info, align 8
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %1 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %2 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %1, i64 0, i32 2
-  %3 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %2, align 8, !tbaa !25
-  %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %3, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %4, align 8, !tbaa !29
-  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %3, i64 0, i32 4
-  %6 = load i64*, i64** %5, align 8, !tbaa !31
-  %7 = load i64, i64* %6, align 8, !tbaa !6
-  %8 = and i64 %7, -33
-  store i64 %8, i64* %6, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %1, %struct.rb_control_frame_struct* %3, %struct.rb_iseq_struct* %stackFrame) #11
-  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %9, align 8, !dbg !32, !tbaa !14
-  %10 = load i64, i64* @rb_cObject, align 8, !dbg !33
-  %11 = tail call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %10) #11, !dbg !33
-  %12 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %11) #11, !dbg !33
-  %13 = bitcast %struct.rb_calling_info* %0 to i8*, !dbg !33
-  call void @llvm.lifetime.start.p0i8(i64 noundef 24, i8* noundef nonnull align 8 dereferenceable(24) %13) #11, !dbg !33
-  %14 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 0, !dbg !33
-  store i64 0, i64* %14, align 8, !dbg !33, !tbaa !34
-  %15 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 3, !dbg !33
-  store i32 0, i32* %15, align 4, !dbg !33, !tbaa !36
-  %16 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 1, !dbg !33
-  store i64 %11, i64* %16, align 8, !dbg !33, !tbaa !37
-  %17 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 2, !dbg !33
-  store i32 0, i32* %17, align 8, !dbg !33, !tbaa !38
-  %18 = bitcast i64* %positional_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %18)
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !25
+  %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !29
+  %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
+  %5 = load i64*, i64** %4, align 8, !tbaa !31
+  %6 = load i64, i64* %5, align 8, !tbaa !6
+  %7 = and i64 %6, -33
+  store i64 %7, i64* %5, align 8, !tbaa !6
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #11
+  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !32, !tbaa !14
+  %9 = load i64, i64* @rb_cObject, align 8, !dbg !33
+  %10 = tail call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %9) #11, !dbg !33
+  %11 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %10) #11, !dbg !33
+  %12 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %12)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 2
-  %21 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %20, align 8, !tbaa !25
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %22, align 8, !tbaa !29
-  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 4
-  %24 = load i64*, i64** %23, align 8, !tbaa !31
-  %25 = load i64, i64* %24, align 8, !tbaa !6
-  %26 = and i64 %25, -33
-  store i64 %26, i64* %24, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %19, %struct.rb_control_frame_struct* %21, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %27, align 8, !dbg !39, !tbaa !14
-  %28 = load i64, i64* @guard_epoch_A, align 8, !dbg !22
-  %29 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !40
-  %needTakeSlowPath = icmp ne i64 %28, %29, !dbg !22
-  br i1 %needTakeSlowPath, label %30, label %31, !dbg !22, !prof !42
+  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 2
+  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !25
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !29
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 4
+  %18 = load i64*, i64** %17, align 8, !tbaa !31
+  %19 = load i64, i64* %18, align 8, !tbaa !6
+  %20 = and i64 %19, -33
+  store i64 %20, i64* %18, align 8, !tbaa !6
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %21, align 8, !dbg !34, !tbaa !14
+  %22 = load i64, i64* @guard_epoch_A, align 8, !dbg !22
+  %23 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !35
+  %needTakeSlowPath = icmp ne i64 %22, %23, !dbg !22
+  br i1 %needTakeSlowPath, label %24, label %25, !dbg !22, !prof !37
 
-30:                                               ; preds = %functionEntryInitializers
+24:                                               ; preds = %functionEntryInitializers
   tail call void @const_recompute_A(), !dbg !22
-  br label %31, !dbg !22
+  br label %25, !dbg !22
 
-31:                                               ; preds = %functionEntryInitializers, %30
-  %32 = load i64, i64* @guarded_const_A, align 8, !dbg !22
-  %33 = load i64, i64* @guard_epoch_A, align 8, !dbg !22
-  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !40
-  %guardUpdated = icmp eq i64 %33, %34, !dbg !22
+25:                                               ; preds = %functionEntryInitializers, %24
+  %26 = load i64, i64* @guarded_const_A, align 8, !dbg !22
+  %27 = load i64, i64* @guard_epoch_A, align 8, !dbg !22
+  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !35
+  %guardUpdated = icmp eq i64 %27, %28, !dbg !22
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !22
   %stackFrame8.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#1+", align 8, !dbg !22
-  %35 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !22
-  %36 = bitcast i8* %35 to i16*, !dbg !22
-  %37 = load i16, i16* %36, align 8, !dbg !22
-  %38 = and i16 %37, -384, !dbg !22
-  %39 = or i16 %38, 1, !dbg !22
-  store i16 %39, i16* %36, align 8, !dbg !22
-  %40 = getelementptr inbounds i8, i8* %35, i64 8, !dbg !22
-  %41 = bitcast i8* %40 to i32*, !dbg !22
-  store i32 1, i32* %41, align 8, !dbg !22, !tbaa !43
-  %42 = getelementptr inbounds i8, i8* %35, i64 12, !dbg !22
-  %43 = getelementptr inbounds i8, i8* %35, i64 4, !dbg !22
-  %44 = bitcast i8* %43 to i32*, !dbg !22
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %42, i8 0, i64 20, i1 false) #11, !dbg !22
-  store i32 1, i32* %44, align 4, !dbg !22, !tbaa !46
+  %29 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !22
+  %30 = bitcast i8* %29 to i16*, !dbg !22
+  %31 = load i16, i16* %30, align 8, !dbg !22
+  %32 = and i16 %31, -384, !dbg !22
+  %33 = or i16 %32, 1, !dbg !22
+  store i16 %33, i16* %30, align 8, !dbg !22
+  %34 = getelementptr inbounds i8, i8* %29, i64 8, !dbg !22
+  %35 = bitcast i8* %34 to i32*, !dbg !22
+  store i32 1, i32* %35, align 8, !dbg !22, !tbaa !38
+  %36 = getelementptr inbounds i8, i8* %29, i64 12, !dbg !22
+  %37 = getelementptr inbounds i8, i8* %29, i64 4, !dbg !22
+  %38 = bitcast i8* %37 to i32*, !dbg !22
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %36, i8 0, i64 20, i1 false) #11, !dbg !22
+  store i32 1, i32* %38, align 4, !dbg !22, !tbaa !41
   %rubyId_b.i = load i64, i64* @rubyIdPrecomputed_b, align 8, !dbg !22
   store i64 %rubyId_b.i, i64* %positional_table.i, align 8, !dbg !22
-  %45 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !22
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %45, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %18, i64 noundef 8, i1 noundef false) #11, !dbg !22
-  %46 = getelementptr inbounds i8, i8* %35, i64 32, !dbg !22
-  %47 = bitcast i8* %46 to i8**, !dbg !22
-  store i8* %45, i8** %47, align 8, !dbg !22, !tbaa !47
-  tail call void @sorbet_vm_define_method(i64 %32, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#1+", i8* nonnull %35, %struct.rb_iseq_struct* %stackFrame8.i, i1 noundef zeroext false) #11, !dbg !22
-  %48 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !22, !tbaa !14
-  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 5, !dbg !22
-  %50 = load i32, i32* %49, align 8, !dbg !22, !tbaa !48
-  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 6, !dbg !22
-  %52 = load i32, i32* %51, align 4, !dbg !22, !tbaa !49
-  %53 = xor i32 %52, -1, !dbg !22
-  %54 = and i32 %53, %50, !dbg !22
-  %55 = icmp eq i32 %54, 0, !dbg !22
-  br i1 %55, label %"func_A.13<static-init>L79.exit", label %56, !dbg !22, !prof !50
-
-56:                                               ; preds = %31
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 8, !dbg !22
-  %58 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %57, align 8, !dbg !22, !tbaa !51
-  %59 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %58, i32 noundef 0) #11, !dbg !22
-  br label %"func_A.13<static-init>L79.exit", !dbg !22
-
-"func_A.13<static-init>L79.exit":                 ; preds = %31, %56
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %18)
+  %39 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !22
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %39, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %12, i64 noundef 8, i1 noundef false) #11, !dbg !22
+  %40 = getelementptr inbounds i8, i8* %29, i64 32, !dbg !22
+  %41 = bitcast i8* %40 to i8**, !dbg !22
+  store i8* %39, i8** %41, align 8, !dbg !22, !tbaa !42
+  tail call void @sorbet_vm_define_method(i64 %26, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#1+", i8* nonnull %29, %struct.rb_iseq_struct* %stackFrame8.i, i1 noundef zeroext false) #11, !dbg !22
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %12)
   tail call void @sorbet_popFrame() #11, !dbg !33
-  call void @llvm.lifetime.end.p0i8(i64 noundef 24, i8* noundef nonnull %13) #11, !dbg !33
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %9, align 8, !dbg !33, !tbaa !14
-  %60 = tail call i64 @sorbet_maybeAllocateObjectFastPath(i64 %32, %struct.FunctionInlineCache* noundef @ic_new), !dbg !52
-  %61 = icmp eq i64 %60, 52, !dbg !52
-  br i1 %61, label %slowNew, label %fastNew, !dbg !52
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !33, !tbaa !14
+  %42 = tail call i64 @sorbet_maybeAllocateObjectFastPath(i64 %26, %struct.FunctionInlineCache* noundef @ic_new), !dbg !43
+  %43 = icmp eq i64 %42, 52, !dbg !43
+  br i1 %43, label %slowNew, label %fastNew, !dbg !43
 
-slowNew:                                          ; preds = %"func_A.13<static-init>L79.exit"
-  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !52
-  %63 = load i64*, i64** %62, align 8, !dbg !52
-  store i64 %32, i64* %63, align 8, !dbg !52, !tbaa !6
-  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !52
-  store i64* %64, i64** %62, align 8, !dbg !52
-  %65 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0), !dbg !52
-  br label %afterNew, !dbg !52
+slowNew:                                          ; preds = %25
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !43
+  %45 = load i64*, i64** %44, align 8, !dbg !43
+  store i64 %26, i64* %45, align 8, !dbg !43, !tbaa !6
+  %46 = getelementptr inbounds i64, i64* %45, i64 1, !dbg !43
+  store i64* %46, i64** %44, align 8, !dbg !43
+  %47 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0), !dbg !43
+  br label %afterNew, !dbg !43
 
-fastNew:                                          ; preds = %"func_A.13<static-init>L79.exit"
-  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !52
-  %67 = load i64*, i64** %66, align 8, !dbg !52
-  store i64 %60, i64* %67, align 8, !dbg !52, !tbaa !6
-  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !52
-  store i64* %68, i64** %66, align 8, !dbg !52
-  %69 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0), !dbg !52
-  br label %afterNew, !dbg !52
+fastNew:                                          ; preds = %25
+  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !43
+  %49 = load i64*, i64** %48, align 8, !dbg !43
+  store i64 %42, i64* %49, align 8, !dbg !43, !tbaa !6
+  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !43
+  store i64* %50, i64** %48, align 8, !dbg !43
+  %51 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0), !dbg !43
+  br label %afterNew, !dbg !43
 
 afterNew:                                         ; preds = %fastNew, %slowNew
-  %initializedObject = phi i64 [ %65, %slowNew ], [ %60, %fastNew ], !dbg !52
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %9, align 8, !dbg !52, !tbaa !14
-  %stackFrame29 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8delegate", align 8, !dbg !53
-  %70 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !53
-  %71 = bitcast i8* %70 to i16*, !dbg !53
-  %72 = load i16, i16* %71, align 8, !dbg !53
-  %73 = and i16 %72, -384, !dbg !53
-  %74 = or i16 %73, 1, !dbg !53
-  store i16 %74, i16* %71, align 8, !dbg !53
-  %75 = getelementptr inbounds i8, i8* %70, i64 8, !dbg !53
-  %76 = bitcast i8* %75 to i32*, !dbg !53
-  store i32 1, i32* %76, align 8, !dbg !53, !tbaa !43
-  %77 = getelementptr inbounds i8, i8* %70, i64 12, !dbg !53
-  %78 = bitcast i8* %77 to i32*, !dbg !53
-  %79 = getelementptr inbounds i8, i8* %70, i64 4, !dbg !53
-  %80 = bitcast i8* %79 to i32*, !dbg !53
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %77, i8 0, i64 20, i1 false), !dbg !53
-  store i32 1, i32* %80, align 4, !dbg !53, !tbaa !46
-  %positional_table = alloca i64, align 8, !dbg !53
-  %rubyId_a = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !53
-  store i64 %rubyId_a, i64* %positional_table, align 8, !dbg !53
-  %81 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !53
-  %82 = bitcast i64* %positional_table to i8*, !dbg !53
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %81, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %82, i64 noundef 8, i1 noundef false) #11, !dbg !53
-  %83 = getelementptr inbounds i8, i8* %70, i64 32, !dbg !53
-  %84 = bitcast i8* %83 to i8**, !dbg !53
-  store i8* %81, i8** %84, align 8, !dbg !53, !tbaa !47
-  tail call void @sorbet_vm_define_method(i64 %10, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_delegate, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8delegate", i8* nonnull %70, %struct.rb_iseq_struct* %stackFrame29, i1 noundef zeroext false) #11, !dbg !53
-  %85 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !53, !tbaa !14
-  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 5, !dbg !53
-  %87 = load i32, i32* %86, align 8, !dbg !53, !tbaa !48
-  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 6, !dbg !53
-  %89 = load i32, i32* %88, align 4, !dbg !53, !tbaa !49
-  %90 = xor i32 %89, -1, !dbg !53
-  %91 = and i32 %90, %87, !dbg !53
-  %92 = icmp eq i32 %91, 0, !dbg !53
-  br i1 %92, label %rb_vm_check_ints.exit, label %93, !dbg !53, !prof !50
-
-93:                                               ; preds = %afterNew
-  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 8, !dbg !53
-  %95 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %94, align 8, !dbg !53, !tbaa !51
-  %96 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %95, i32 noundef 0) #11, !dbg !53
-  br label %rb_vm_check_ints.exit, !dbg !53
-
-rb_vm_check_ints.exit:                            ; preds = %afterNew, %93
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %9, align 8, !dbg !53, !tbaa !14
-  %97 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !54
-  %98 = load i64*, i64** %97, align 8, !dbg !54
-  store i64 %selfRaw, i64* %98, align 8, !dbg !54, !tbaa !6
-  %99 = getelementptr inbounds i64, i64* %98, i64 1, !dbg !54
-  store i64 %initializedObject, i64* %99, align 8, !dbg !54, !tbaa !6
-  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !54
-  store i64* %100, i64** %97, align 8, !dbg !54
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_delegate, i64 0), !dbg !54
+  %initializedObject = phi i64 [ %47, %slowNew ], [ %42, %fastNew ], !dbg !43
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !43, !tbaa !14
+  %stackFrame29 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8delegate", align 8, !dbg !44
+  %52 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !44
+  %53 = bitcast i8* %52 to i16*, !dbg !44
+  %54 = load i16, i16* %53, align 8, !dbg !44
+  %55 = and i16 %54, -384, !dbg !44
+  %56 = or i16 %55, 1, !dbg !44
+  store i16 %56, i16* %53, align 8, !dbg !44
+  %57 = getelementptr inbounds i8, i8* %52, i64 8, !dbg !44
+  %58 = bitcast i8* %57 to i32*, !dbg !44
+  store i32 1, i32* %58, align 8, !dbg !44, !tbaa !38
+  %59 = getelementptr inbounds i8, i8* %52, i64 12, !dbg !44
+  %60 = bitcast i8* %59 to i32*, !dbg !44
+  %61 = getelementptr inbounds i8, i8* %52, i64 4, !dbg !44
+  %62 = bitcast i8* %61 to i32*, !dbg !44
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %59, i8 0, i64 20, i1 false), !dbg !44
+  store i32 1, i32* %62, align 4, !dbg !44, !tbaa !41
+  %positional_table = alloca i64, align 8, !dbg !44
+  %rubyId_a = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !44
+  store i64 %rubyId_a, i64* %positional_table, align 8, !dbg !44
+  %63 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !44
+  %64 = bitcast i64* %positional_table to i8*, !dbg !44
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %63, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %64, i64 noundef 8, i1 noundef false) #11, !dbg !44
+  %65 = getelementptr inbounds i8, i8* %52, i64 32, !dbg !44
+  %66 = bitcast i8* %65 to i8**, !dbg !44
+  store i8* %63, i8** %66, align 8, !dbg !44, !tbaa !42
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_delegate, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8delegate", i8* nonnull %52, %struct.rb_iseq_struct* %stackFrame29, i1 noundef zeroext false) #11, !dbg !44
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %8, align 8, !dbg !44, !tbaa !14
+  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !45
+  %68 = load i64*, i64** %67, align 8, !dbg !45
+  store i64 %selfRaw, i64* %68, align 8, !dbg !45, !tbaa !6
+  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !45
+  store i64 %initializedObject, i64* %69, align 8, !dbg !45, !tbaa !6
+  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !45
+  store i64* %70, i64** %67, align 8, !dbg !45
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_delegate, i64 0), !dbg !45
   ret void
 }
 
@@ -471,25 +423,25 @@ entry:
   %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_ok, i64 0, i64 0), i64 noundef 2) #11
   call void @rb_gc_register_mark_object(i64 %14) #11
   store i64 %14, i64* @rubyStrFrozen_ok, align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !55
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !55
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
   %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_fail, i64 0, i64 0), i64 noundef 4) #11
   call void @rb_gc_register_mark_object(i64 %15) #11
   store i64 %15, i64* @rubyStrFrozen_fail, align 8
-  %rubyId_puts3.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !56
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts3.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !56
+  %rubyId_puts3.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts3.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
   %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
   call void @rb_gc_register_mark_object(i64 %16) #11
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/custom_plus.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
   %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !52
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !52
-  %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !52
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !52
-  %rubyId_delegate.i = load i64, i64* @rubyIdPrecomputed_delegate, align 8, !dbg !54
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_delegate, i64 %rubyId_delegate.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !54
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !43
+  %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !43
+  %rubyId_delegate.i = load i64, i64* @rubyIdPrecomputed_delegate, align 8, !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_delegate, i64 %rubyId_delegate.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
   %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #11
   call void @rb_gc_register_mark_object(i64 %18) #11
   %"rubyId_+.i.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8
@@ -504,7 +456,7 @@ entry:
   store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
   %22 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %23 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %22, i64 0, i32 18
-  %24 = load i64, i64* %23, align 8, !tbaa !57
+  %24 = load i64, i64* %23, align 8, !tbaa !48
   %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 2
   %27 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !25
@@ -513,21 +465,21 @@ entry:
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @"func_A#1+"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 returned %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #5 !dbg !65 {
+define internal i64 @"func_A#1+"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 returned %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #5 !dbg !56 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !14
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !66
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !66
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !66
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !66, !prof !17
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !57
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !57
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !57
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !57, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #10, !dbg !66
-  unreachable, !dbg !66
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #10, !dbg !57
+  unreachable, !dbg !57
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !67, !tbaa !14
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !58, !tbaa !14
   ret i64 %selfRaw
 }
 
@@ -541,7 +493,7 @@ declare void @llvm.assume(i1 noundef) #8
 define linkonce void @const_recompute_A() local_unnamed_addr #6 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !40
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !35
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -597,37 +549,28 @@ attributes #12 = { nounwind allocsize(0,1) }
 !31 = !{!30, !15, i64 32}
 !32 = !DILocation(line: 0, scope: !21)
 !33 = !DILocation(line: 6, column: 1, scope: !21)
-!34 = !{!35, !7, i64 0}
-!35 = !{!"rb_calling_info", !7, i64 0, !7, i64 8, !27, i64 16, !27, i64 20}
-!36 = !{!35, !27, i64 20}
-!37 = !{!35, !7, i64 8}
-!38 = !{!35, !27, i64 16}
-!39 = !DILocation(line: 0, scope: !23, inlinedAt: !24)
-!40 = !{!41, !41, i64 0}
-!41 = !{!"long long", !8, i64 0}
-!42 = !{!"branch_weights", i32 1, i32 10000}
-!43 = !{!44, !27, i64 8}
-!44 = !{!"rb_sorbet_param_struct", !45, i64 0, !27, i64 4, !27, i64 8, !27, i64 12, !27, i64 16, !27, i64 20, !27, i64 24, !27, i64 28, !15, i64 32, !27, i64 40, !27, i64 44, !27, i64 48, !27, i64 52, !15, i64 56}
-!45 = !{!"", !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 1, !27, i64 1}
-!46 = !{!44, !27, i64 4}
-!47 = !{!44, !15, i64 32}
-!48 = !{!26, !27, i64 40}
-!49 = !{!26, !27, i64 44}
-!50 = !{!"branch_weights", i32 2000, i32 1}
-!51 = !{!26, !15, i64 56}
-!52 = !DILocation(line: 12, column: 5, scope: !21)
-!53 = !DILocation(line: 14, column: 1, scope: !21)
-!54 = !DILocation(line: 22, column: 1, scope: !21)
-!55 = !DILocation(line: 16, column: 5, scope: !10)
-!56 = !DILocation(line: 18, column: 5, scope: !10)
-!57 = !{!58, !7, i64 400}
-!58 = !{!"rb_vm_struct", !7, i64 0, !59, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !41, i64 216, !8, i64 224, !60, i64 264, !60, i64 280, !60, i64 296, !60, i64 312, !7, i64 328, !27, i64 336, !27, i64 340, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !62, i64 472, !63, i64 992, !15, i64 1016, !15, i64 1024, !27, i64 1032, !27, i64 1036, !60, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !27, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !27, i64 1192, !64, i64 1200, !8, i64 1232}
-!59 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !60, i64 48, !15, i64 64, !27, i64 72, !8, i64 80, !8, i64 128, !27, i64 176, !27, i64 180}
-!60 = !{!"list_head", !61, i64 0}
-!61 = !{!"list_node", !15, i64 0, !15, i64 8}
-!62 = !{!"", !8, i64 0}
-!63 = !{!"rb_hook_list_struct", !15, i64 0, !27, i64 8, !27, i64 12, !27, i64 16}
-!64 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!65 = distinct !DISubprogram(name: "A#+", linkageName: "func_A#1+", scope: null, file: !4, line: 7, type: !11, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!66 = !DILocation(line: 7, column: 3, scope: !65)
-!67 = !DILocation(line: 0, scope: !65)
+!34 = !DILocation(line: 0, scope: !23, inlinedAt: !24)
+!35 = !{!36, !36, i64 0}
+!36 = !{!"long long", !8, i64 0}
+!37 = !{!"branch_weights", i32 1, i32 10000}
+!38 = !{!39, !27, i64 8}
+!39 = !{!"rb_sorbet_param_struct", !40, i64 0, !27, i64 4, !27, i64 8, !27, i64 12, !27, i64 16, !27, i64 20, !27, i64 24, !27, i64 28, !15, i64 32, !27, i64 40, !27, i64 44, !27, i64 48, !27, i64 52, !15, i64 56}
+!40 = !{!"", !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 0, !27, i64 1, !27, i64 1}
+!41 = !{!39, !27, i64 4}
+!42 = !{!39, !15, i64 32}
+!43 = !DILocation(line: 12, column: 5, scope: !21)
+!44 = !DILocation(line: 14, column: 1, scope: !21)
+!45 = !DILocation(line: 22, column: 1, scope: !21)
+!46 = !DILocation(line: 16, column: 5, scope: !10)
+!47 = !DILocation(line: 18, column: 5, scope: !10)
+!48 = !{!49, !7, i64 400}
+!49 = !{!"rb_vm_struct", !7, i64 0, !50, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !36, i64 216, !8, i64 224, !51, i64 264, !51, i64 280, !51, i64 296, !51, i64 312, !7, i64 328, !27, i64 336, !27, i64 340, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 344, !27, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !53, i64 472, !54, i64 992, !15, i64 1016, !15, i64 1024, !27, i64 1032, !27, i64 1036, !51, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !27, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !27, i64 1192, !55, i64 1200, !8, i64 1232}
+!50 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !51, i64 48, !15, i64 64, !27, i64 72, !8, i64 80, !8, i64 128, !27, i64 176, !27, i64 180}
+!51 = !{!"list_head", !52, i64 0}
+!52 = !{!"list_node", !15, i64 0, !15, i64 8}
+!53 = !{!"", !8, i64 0}
+!54 = !{!"rb_hook_list_struct", !15, i64 0, !27, i64 8, !27, i64 12, !27, i64 16}
+!55 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!56 = distinct !DISubprogram(name: "A#+", linkageName: "func_A#1+", scope: null, file: !4, line: 7, type: !11, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!57 = !DILocation(line: 7, column: 3, scope: !56)
+!58 = !DILocation(line: 0, scope: !56)

--- a/test/testdata/compiler/direct_call.opt.ll.exp
+++ b/test/testdata/compiler/direct_call.opt.ll.exp
@@ -128,8 +128,6 @@ declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
-
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 
@@ -260,64 +258,30 @@ entry:
   %29 = getelementptr inbounds i8, i8* %25, i64 4, !dbg !43
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %29, i8 0, i64 28, i1 false) #9, !dbg !43
   call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %25, %struct.rb_iseq_struct* %stackFrame22.i, i1 noundef zeroext false) #9, !dbg !43
-  %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !43, !tbaa !14
-  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 5, !dbg !43
-  %32 = load i32, i32* %31, align 8, !dbg !43, !tbaa !44
-  %33 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 6, !dbg !43
-  %34 = load i32, i32* %33, align 4, !dbg !43, !tbaa !45
-  %35 = xor i32 %34, -1, !dbg !43
-  %36 = and i32 %35, %32, !dbg !43
-  %37 = icmp eq i32 %36, 0, !dbg !43
-  br i1 %37, label %rb_vm_check_ints.exit1.i, label %38, !dbg !43, !prof !46
-
-38:                                               ; preds = %entry
-  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 8, !dbg !43
-  %40 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %39, align 8, !dbg !43, !tbaa !47
-  %41 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %40, i32 noundef 0) #9, !dbg !43
-  br label %rb_vm_check_ints.exit1.i, !dbg !43
-
-rb_vm_check_ints.exit1.i:                         ; preds = %38, %entry
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %23, align 8, !dbg !43, !tbaa !14
-  %stackFrame31.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8, !dbg !48
-  %42 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !48
-  %43 = bitcast i8* %42 to i16*, !dbg !48
-  %44 = load i16, i16* %43, align 8, !dbg !48
-  %45 = and i16 %44, -384, !dbg !48
-  store i16 %45, i16* %43, align 8, !dbg !48
-  %46 = getelementptr inbounds i8, i8* %42, i64 4, !dbg !48
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 28, i1 false) #9, !dbg !48
-  call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3bar", i8* nonnull %42, %struct.rb_iseq_struct* %stackFrame31.i, i1 noundef zeroext false) #9, !dbg !48
-  %47 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !48, !tbaa !14
-  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 5, !dbg !48
-  %49 = load i32, i32* %48, align 8, !dbg !48, !tbaa !44
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 6, !dbg !48
-  %51 = load i32, i32* %50, align 4, !dbg !48, !tbaa !45
-  %52 = xor i32 %51, -1, !dbg !48
-  %53 = and i32 %52, %49, !dbg !48
-  %54 = icmp eq i32 %53, 0, !dbg !48
-  br i1 %54, label %"func_<root>.17<static-init>$152.exit", label %55, !dbg !48, !prof !46
-
-55:                                               ; preds = %rb_vm_check_ints.exit1.i
-  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 8, !dbg !48
-  %57 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %56, align 8, !dbg !48, !tbaa !47
-  %58 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %57, i32 noundef 0) #9, !dbg !48
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !48
-
-"func_<root>.17<static-init>$152.exit":           ; preds = %rb_vm_check_ints.exit1.i, %55
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %23, align 8, !dbg !48, !tbaa !14
-  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !23
-  %60 = load i64*, i64** %59, align 8, !dbg !23
-  store i64 %14, i64* %60, align 8, !dbg !23, !tbaa !6
-  %61 = getelementptr inbounds i64, i64* %60, i64 1, !dbg !23
-  store i64* %61, i64** %59, align 8, !dbg !23
+  %stackFrame31.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8, !dbg !44
+  %30 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !44
+  %31 = bitcast i8* %30 to i16*, !dbg !44
+  %32 = load i16, i16* %31, align 8, !dbg !44
+  %33 = and i16 %32, -384, !dbg !44
+  store i16 %33, i16* %31, align 8, !dbg !44
+  %34 = getelementptr inbounds i8, i8* %30, i64 4, !dbg !44
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %34, i8 0, i64 28, i1 false) #9, !dbg !44
+  call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3bar", i8* nonnull %30, %struct.rb_iseq_struct* %stackFrame31.i, i1 noundef zeroext false) #9, !dbg !44
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %23, align 8, !dbg !44, !tbaa !14
+  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !23
+  %36 = load i64*, i64** %35, align 8, !dbg !23
+  store i64 %14, i64* %36, align 8, !dbg !23, !tbaa !6
+  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !23
+  store i64* %37, i64** %35, align 8, !dbg !23
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 0), !dbg !23
-  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !25
-  %63 = load i64*, i64** %62, align 8, !dbg !25
-  store i64 %14, i64* %63, align 8, !dbg !25, !tbaa !6
-  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !25
-  store i64 %send, i64* %64, align 8, !dbg !25, !tbaa !6
-  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !25
-  store i64* %65, i64** %62, align 8, !dbg !25
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !25
+  %39 = load i64*, i64** %38, align 8, !dbg !25
+  store i64 %14, i64* %39, align 8, !dbg !25, !tbaa !6
+  %40 = getelementptr inbounds i64, i64* %39, i64 1, !dbg !25
+  store i64 %send, i64* %40, align 8, !dbg !25, !tbaa !6
+  %41 = getelementptr inbounds i64, i64* %40, i64 1, !dbg !25
+  store i64* %41, i64** %38, align 8, !dbg !25
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !25
   ret void
 }
@@ -384,8 +348,4 @@ attributes #10 = { nounwind allocsize(0,1) }
 !41 = !{!40, !15, i64 32}
 !42 = !DILocation(line: 0, scope: !24)
 !43 = !DILocation(line: 4, column: 1, scope: !24)
-!44 = !{!37, !31, i64 40}
-!45 = !{!37, !31, i64 44}
-!46 = !{!"branch_weights", i32 2000, i32 1}
-!47 = !{!37, !15, i64 56}
-!48 = !DILocation(line: 8, column: 1, scope: !24)
+!44 = !DILocation(line: 8, column: 1, scope: !24)

--- a/test/testdata/compiler/exceptions/basic.opt.ll.exp
+++ b/test/testdata/compiler/exceptions/basic.opt.ll.exp
@@ -197,8 +197,6 @@ declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
-
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #3
 
@@ -226,276 +224,247 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
 define void @Init_basic() local_unnamed_addr #5 {
 entry:
   %positional_table.i.i = alloca i64, align 8, !dbg !10
-  %0 = alloca %struct.rb_calling_info, align 8
   %locals.i31.i = alloca i64, i32 0, align 8
   %locals.i26.i = alloca i64, i32 5, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
-  store i64 %1, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
-  store i64 %2, i64* @rubyIdPrecomputed_puts, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
-  store i64 %3, i64* @rubyIdPrecomputed_test, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<exceptionValue>", i64 0, i64 0), i64 noundef 16) #11
-  store i64 %4, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #11
-  store i64 %5, i64* @rubyIdPrecomputed_x, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_<returnMethodTemp>", i64 0, i64 0), i64 noundef 18) #11
-  store i64 %6, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @"str_<magic>", i64 0, i64 0), i64 noundef 7) #11
-  store i64 %7, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_<gotoDeadTemp>", i64 0, i64 0), i64 noundef 14) #11
-  store i64 %8, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_rescue in test", i64 0, i64 0), i64 noundef 14) #11
-  store i64 %9, i64* @"rubyIdPrecomputed_rescue in test", align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_ensure in test", i64 0, i64 0), i64 noundef 14) #11
-  store i64 %10, i64* @"rubyIdPrecomputed_ensure in test", align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_raise, i64 0, i64 0), i64 noundef 5) #11
-  store i64 %11, i64* @rubyIdPrecomputed_raise, align 8
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @"str_is_a?", i64 0, i64 0), i64 noundef 5) #11
-  store i64 %12, i64* @"rubyIdPrecomputed_is_a?", align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
-  store i64 %13, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  %15 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  store i64 %1, i64* @rubyIdPrecomputed_puts, align 8
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
+  store i64 %2, i64* @rubyIdPrecomputed_test, align 8
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<exceptionValue>", i64 0, i64 0), i64 noundef 16) #11
+  store i64 %3, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #11
+  store i64 %4, i64* @rubyIdPrecomputed_x, align 8
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_<returnMethodTemp>", i64 0, i64 0), i64 noundef 18) #11
+  store i64 %5, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @"str_<magic>", i64 0, i64 0), i64 noundef 7) #11
+  store i64 %6, i64* @"rubyIdPrecomputed_<magic>", align 8
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_<gotoDeadTemp>", i64 0, i64 0), i64 noundef 14) #11
+  store i64 %7, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_rescue in test", i64 0, i64 0), i64 noundef 14) #11
+  store i64 %8, i64* @"rubyIdPrecomputed_rescue in test", align 8
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_ensure in test", i64 0, i64 0), i64 noundef 14) #11
+  store i64 %9, i64* @"rubyIdPrecomputed_ensure in test", align 8
+  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_raise, i64 0, i64 0), i64 noundef 5) #11
+  store i64 %10, i64* @rubyIdPrecomputed_raise, align 8
+  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @"str_is_a?", i64 0, i64 0), i64 noundef 5) #11
+  store i64 %11, i64* @"rubyIdPrecomputed_is_a?", align 8
+  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  store i64 %12, i64* @"rubyIdPrecomputed_<class:A>", align 8
+  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
+  %14 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %14) #11
+  store i64 %14, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %15 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/exceptions/basic.rb", i64 0, i64 0), i64 noundef 42) #11
   tail call void @rb_gc_register_mark_object(i64 %15) #11
-  store i64 %15, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %16 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/exceptions/basic.rb", i64 0, i64 0), i64 noundef 42) #11
-  tail call void @rb_gc_register_mark_object(i64 %16) #11
-  store i64 %16, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
+  store i64 %15, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_=== no-raise ===", i64 0, i64 0), i64 noundef 16) #11
-  call void @rb_gc_register_mark_object(i64 %18) #11
-  store i64 %18, i64* @"rubyStrFrozen_=== no-raise ===", align 8
+  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_=== no-raise ===", i64 0, i64 0), i64 noundef 16) #11
+  call void @rb_gc_register_mark_object(i64 %17) #11
+  store i64 %17, i64* @"rubyStrFrozen_=== no-raise ===", align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
   %rubyId_test.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !18
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_=== raise ===", i64 0, i64 0), i64 noundef 13) #11
-  call void @rb_gc_register_mark_object(i64 %19) #11
-  store i64 %19, i64* @"rubyStrFrozen_=== raise ===", align 8
+  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_=== raise ===", i64 0, i64 0), i64 noundef 13) #11
+  call void @rb_gc_register_mark_object(i64 %18) #11
+  store i64 %18, i64* @"rubyStrFrozen_=== raise ===", align 8
   %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   %rubyId_test5.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !20
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test.2, i64 %rubyId_test5.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %20) #11
-  %21 = bitcast i64* %locals.i26.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %21)
+  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %19) #11
+  %20 = bitcast i64* %locals.i26.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %20)
   %rubyId_test.i.i = load i64, i64* @rubyIdPrecomputed_test, align 8
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i25.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
   %"rubyId_<exceptionValue>.i.i" = load i64, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
   store i64 %"rubyId_<exceptionValue>.i.i", i64* %locals.i26.i, align 8
   %rubyId_x.i.i = load i64, i64* @rubyIdPrecomputed_x, align 8
-  %22 = getelementptr i64, i64* %locals.i26.i, i32 1
-  store i64 %rubyId_x.i.i, i64* %22, align 8
+  %21 = getelementptr i64, i64* %locals.i26.i, i32 1
+  store i64 %rubyId_x.i.i, i64* %21, align 8
   %"rubyId_<returnMethodTemp>.i.i" = load i64, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %23 = getelementptr i64, i64* %locals.i26.i, i32 2
-  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %23, align 8
+  %22 = getelementptr i64, i64* %locals.i26.i, i32 2
+  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %22, align 8
   %"rubyId_<magic>.i.i" = load i64, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %24 = getelementptr i64, i64* %locals.i26.i, i32 3
-  store i64 %"rubyId_<magic>.i.i", i64* %24, align 8
+  %23 = getelementptr i64, i64* %locals.i26.i, i32 3
+  store i64 %"rubyId_<magic>.i.i", i64* %23, align 8
   %"rubyId_<gotoDeadTemp>.i.i" = load i64, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %25 = getelementptr i64, i64* %locals.i26.i, i32 4
-  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %25, align 8
-  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i25.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i26.i, i32 noundef 5, i32 noundef 2)
-  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
-  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %21)
-  %27 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_rescue in test", i64 0, i64 0), i64 noundef 14) #11
-  call void @rb_gc_register_mark_object(i64 %27) #11
+  %24 = getelementptr i64, i64* %locals.i26.i, i32 4
+  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %24, align 8
+  %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i25.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i26.i, i32 noundef 5, i32 noundef 2)
+  store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %20)
+  %26 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_rescue in test", i64 0, i64 0), i64 noundef 14) #11
+  call void @rb_gc_register_mark_object(i64 %26) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
   %"rubyId_rescue in test.i.i" = load i64, i64* @"rubyIdPrecomputed_rescue in test", align 8
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i27.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %27, i64 %"rubyId_rescue in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i27.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_2", align 8
-  %29 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_ensure in test", i64 0, i64 0), i64 noundef 14) #11
-  call void @rb_gc_register_mark_object(i64 %29) #11
+  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %26, i64 %"rubyId_rescue in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i27.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_2", align 8
+  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_ensure in test", i64 0, i64 0), i64 noundef 14) #11
+  call void @rb_gc_register_mark_object(i64 %28) #11
   %stackFrame.i28.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
   %"rubyId_ensure in test.i.i" = load i64, i64* @"rubyIdPrecomputed_ensure in test", align 8
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i29.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %29, i64 %"rubyId_ensure in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i29.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i28.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_3", align 8
-  %31 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #11
-  store i64 %31, i64* @"<retry-singleton>", align 8
-  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_begin, i64 0, i64 0), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %32) #11
-  store i64 %32, i64* @rubyStrFrozen_begin, align 8
+  %29 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %28, i64 %"rubyId_ensure in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i29.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i28.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %29, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_3", align 8
+  %30 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #11
+  store i64 %30, i64* @"<retry-singleton>", align 8
+  %31 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_begin, i64 0, i64 0), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %31) #11
+  store i64 %31, i64* @rubyStrFrozen_begin, align 8
   %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
   %rubyId_puts10.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts10.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %33 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
-  call void @rb_gc_register_mark_object(i64 %33) #11
-  store i64 %33, i64* @rubyStrFrozen_foo, align 8
+  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
+  call void @rb_gc_register_mark_object(i64 %32) #11
+  store i64 %32, i64* @rubyStrFrozen_foo, align 8
   %rubyId_raise.i = load i64, i64* @rubyIdPrecomputed_raise, align 8, !dbg !25
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_raise, i64 %rubyId_raise.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
   %"rubyId_is_a?.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !26
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
   %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !28
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  %34 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_else, i64 0, i64 0), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %34) #11
-  store i64 %34, i64* @rubyStrFrozen_else, align 8
+  %33 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_else, i64 0, i64 0), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %33) #11
+  store i64 %33, i64* @rubyStrFrozen_else, align 8
   %rubyId_puts19.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !29
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts19.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
-  %35 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_ensure, i64 0, i64 0), i64 noundef 6) #11
-  call void @rb_gc_register_mark_object(i64 %35) #11
-  store i64 %35, i64* @rubyStrFrozen_ensure, align 8
+  %34 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_ensure, i64 0, i64 0), i64 noundef 6) #11
+  call void @rb_gc_register_mark_object(i64 %34) #11
+  store i64 %34, i64* @rubyStrFrozen_ensure, align 8
   %rubyId_puts22.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !31
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts22.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !31
-  %36 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %36) #11
+  %35 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %35) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %37 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %36, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %37, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %38 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !33
-  %39 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %38, i64 0, i32 18
-  %40 = load i64, i64* %39, align 8, !tbaa !35
-  %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
-  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 2
-  %43 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %42, align 8, !tbaa !45
+  %36 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %35, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %36, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %37 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !33
+  %38 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %37, i64 0, i32 18
+  %39 = load i64, i64* %38, align 8, !tbaa !35
+  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
+  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 2
+  %42 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %41, align 8, !tbaa !45
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %44, align 8, !tbaa !48
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 4
-  %46 = load i64*, i64** %45, align 8, !tbaa !50
-  %47 = load i64, i64* %46, align 8, !tbaa !6
-  %48 = and i64 %47, -33
-  store i64 %48, i64* %46, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %41, %struct.rb_control_frame_struct* %43, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %49, align 8, !dbg !51, !tbaa !33
-  %50 = load i64, i64* @rb_cObject, align 8, !dbg !52
-  %51 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %50) #11, !dbg !52
-  %52 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %51) #11, !dbg !52
-  %53 = bitcast %struct.rb_calling_info* %0 to i8*, !dbg !52
-  call void @llvm.lifetime.start.p0i8(i64 noundef 24, i8* noundef nonnull align 8 dereferenceable(24) %53) #11, !dbg !52
-  %54 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 0, !dbg !52
-  store i64 0, i64* %54, align 8, !dbg !52, !tbaa !53
-  %55 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 3, !dbg !52
-  store i32 0, i32* %55, align 4, !dbg !52, !tbaa !55
-  %56 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 1, !dbg !52
-  store i64 %51, i64* %56, align 8, !dbg !52, !tbaa !56
-  %57 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 2, !dbg !52
-  store i32 0, i32* %57, align 8, !dbg !52, !tbaa !57
-  %58 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %58) #11
+  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %43, align 8, !tbaa !48
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 4
+  %45 = load i64*, i64** %44, align 8, !tbaa !50
+  %46 = load i64, i64* %45, align 8, !tbaa !6
+  %47 = and i64 %46, -33
+  store i64 %47, i64* %45, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %40, %struct.rb_control_frame_struct* %42, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %48, align 8, !dbg !51, !tbaa !33
+  %49 = load i64, i64* @rb_cObject, align 8, !dbg !52
+  %50 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %49) #11, !dbg !52
+  %51 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %50) #11, !dbg !52
+  %52 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %52) #11
   %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %59 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
-  %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 2
-  %61 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %60, align 8, !tbaa !45
-  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %61, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %62, align 8, !tbaa !48
-  %63 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %61, i64 0, i32 4
-  %64 = load i64*, i64** %63, align 8, !tbaa !50
-  %65 = load i64, i64* %64, align 8, !tbaa !6
-  %66 = and i64 %65, -33
-  store i64 %66, i64* %64, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %59, %struct.rb_control_frame_struct* %61, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
-  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %52, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %67, align 8, !dbg !58, !tbaa !33
-  %68 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %69 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !59
-  %needTakeSlowPath = icmp ne i64 %68, %69, !dbg !10
-  br i1 %needTakeSlowPath, label %70, label %71, !dbg !10, !prof !60
+  %53 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
+  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 2
+  %55 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %54, align 8, !tbaa !45
+  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %55, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %56, align 8, !tbaa !48
+  %57 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %55, i64 0, i32 4
+  %58 = load i64*, i64** %57, align 8, !tbaa !50
+  %59 = load i64, i64* %58, align 8, !tbaa !6
+  %60 = and i64 %59, -33
+  store i64 %60, i64* %58, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %53, %struct.rb_control_frame_struct* %55, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
+  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %61, align 8, !dbg !53, !tbaa !33
+  %62 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !54
+  %needTakeSlowPath = icmp ne i64 %62, %63, !dbg !10
+  br i1 %needTakeSlowPath, label %64, label %65, !dbg !10, !prof !55
 
-70:                                               ; preds = %entry
+64:                                               ; preds = %entry
   call void @const_recompute_A(), !dbg !10
-  br label %71, !dbg !10
+  br label %65, !dbg !10
 
-71:                                               ; preds = %entry, %70
-  %72 = load i64, i64* @guarded_const_A, align 8, !dbg !10
-  %73 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %74 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !59
-  %guardUpdated = icmp eq i64 %73, %74, !dbg !10
+65:                                               ; preds = %entry, %64
+  %66 = load i64, i64* @guarded_const_A, align 8, !dbg !10
+  %67 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %68 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !54
+  %guardUpdated = icmp eq i64 %67, %68, !dbg !10
   call void @llvm.assume(i1 %guardUpdated), !dbg !10
   %stackFrame8.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8, !dbg !10
-  %75 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
-  %76 = bitcast i8* %75 to i16*, !dbg !10
-  %77 = load i16, i16* %76, align 8, !dbg !10
-  %78 = and i16 %77, -384, !dbg !10
-  %79 = or i16 %78, 1, !dbg !10
-  store i16 %79, i16* %76, align 8, !dbg !10
-  %80 = getelementptr inbounds i8, i8* %75, i64 8, !dbg !10
-  %81 = bitcast i8* %80 to i32*, !dbg !10
-  store i32 1, i32* %81, align 8, !dbg !10, !tbaa !61
-  %82 = getelementptr inbounds i8, i8* %75, i64 12, !dbg !10
-  %83 = getelementptr inbounds i8, i8* %75, i64 4, !dbg !10
-  %84 = bitcast i8* %83 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %82, i8 0, i64 20, i1 false) #11, !dbg !10
-  store i32 1, i32* %84, align 4, !dbg !10, !tbaa !64
+  %69 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %70 = bitcast i8* %69 to i16*, !dbg !10
+  %71 = load i16, i16* %70, align 8, !dbg !10
+  %72 = and i16 %71, -384, !dbg !10
+  %73 = or i16 %72, 1, !dbg !10
+  store i16 %73, i16* %70, align 8, !dbg !10
+  %74 = getelementptr inbounds i8, i8* %69, i64 8, !dbg !10
+  %75 = bitcast i8* %74 to i32*, !dbg !10
+  store i32 1, i32* %75, align 8, !dbg !10, !tbaa !56
+  %76 = getelementptr inbounds i8, i8* %69, i64 12, !dbg !10
+  %77 = getelementptr inbounds i8, i8* %69, i64 4, !dbg !10
+  %78 = bitcast i8* %77 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %78, align 4, !dbg !10, !tbaa !59
   %rubyId_x.i.i2 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !10
   store i64 %rubyId_x.i.i2, i64* %positional_table.i.i, align 8, !dbg !10
-  %85 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %85, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %58, i64 noundef 8, i1 noundef false) #11, !dbg !10
-  %86 = getelementptr inbounds i8, i8* %75, i64 32, !dbg !10
-  %87 = bitcast i8* %86 to i8**, !dbg !10
-  store i8* %85, i8** %87, align 8, !dbg !10, !tbaa !65
-  call void @sorbet_vm_define_method(i64 %72, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_A.4test, i8* nonnull %75, %struct.rb_iseq_struct* %stackFrame8.i.i, i1 noundef zeroext true) #11, !dbg !10
-  %88 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !33
-  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %88, i64 0, i32 5, !dbg !10
-  %90 = load i32, i32* %89, align 8, !dbg !10, !tbaa !66
-  %91 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %88, i64 0, i32 6, !dbg !10
-  %92 = load i32, i32* %91, align 4, !dbg !10, !tbaa !67
-  %93 = xor i32 %92, -1, !dbg !10
-  %94 = and i32 %93, %90, !dbg !10
-  %95 = icmp eq i32 %94, 0, !dbg !10
-  br i1 %95, label %"func_<root>.17<static-init>$152.exit", label %96, !dbg !10, !prof !68
-
-96:                                               ; preds = %71
-  %97 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %88, i64 0, i32 8, !dbg !10
-  %98 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %97, align 8, !dbg !10, !tbaa !69
-  %99 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %98, i32 noundef 0) #11, !dbg !10
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !10
-
-"func_<root>.17<static-init>$152.exit":           ; preds = %71, %96
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %58) #11
+  %79 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %79, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %52, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %80 = getelementptr inbounds i8, i8* %69, i64 32, !dbg !10
+  %81 = bitcast i8* %80 to i8**, !dbg !10
+  store i8* %79, i8** %81, align 8, !dbg !10, !tbaa !60
+  call void @sorbet_vm_define_method(i64 %66, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_A.4test, i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame8.i.i, i1 noundef zeroext true) #11, !dbg !10
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %52) #11
   call void @sorbet_popFrame() #11, !dbg !52
-  call void @llvm.lifetime.end.p0i8(i64 noundef 24, i8* noundef nonnull %53) #11, !dbg !52
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %49, align 8, !dbg !52, !tbaa !33
-  %"rubyStr_=== no-raise ===.i" = load i64, i64* @"rubyStrFrozen_=== no-raise ===", align 8, !dbg !70
-  %100 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !17
-  %101 = load i64*, i64** %100, align 8, !dbg !17
-  store i64 %40, i64* %101, align 8, !dbg !17, !tbaa !6
-  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !17
-  store i64 %"rubyStr_=== no-raise ===.i", i64* %102, align 8, !dbg !17, !tbaa !6
-  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !17
-  store i64* %103, i64** %100, align 8, !dbg !17
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %48, align 8, !dbg !52, !tbaa !33
+  %"rubyStr_=== no-raise ===.i" = load i64, i64* @"rubyStrFrozen_=== no-raise ===", align 8, !dbg !61
+  %82 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !17
+  %83 = load i64*, i64** %82, align 8, !dbg !17
+  store i64 %39, i64* %83, align 8, !dbg !17, !tbaa !6
+  %84 = getelementptr inbounds i64, i64* %83, i64 1, !dbg !17
+  store i64 %"rubyStr_=== no-raise ===.i", i64* %84, align 8, !dbg !17, !tbaa !6
+  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !17
+  store i64* %85, i64** %82, align 8, !dbg !17
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %49, align 8, !dbg !17, !tbaa !33
-  %104 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !18
-  %105 = load i64*, i64** %104, align 8, !dbg !18
-  store i64 %72, i64* %105, align 8, !dbg !18, !tbaa !6
-  %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !18
-  store i64 0, i64* %106, align 8, !dbg !18, !tbaa !6
-  %107 = getelementptr inbounds i64, i64* %106, i64 1, !dbg !18
-  store i64* %107, i64** %104, align 8, !dbg !18
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %48, align 8, !dbg !17, !tbaa !33
+  %86 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !18
+  %87 = load i64*, i64** %86, align 8, !dbg !18
+  store i64 %66, i64* %87, align 8, !dbg !18, !tbaa !6
+  %88 = getelementptr inbounds i64, i64* %87, i64 1, !dbg !18
+  store i64 0, i64* %88, align 8, !dbg !18, !tbaa !6
+  %89 = getelementptr inbounds i64, i64* %88, i64 1, !dbg !18
+  store i64* %89, i64** %86, align 8, !dbg !18
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !18
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %49, align 8, !dbg !18, !tbaa !33
-  %"rubyStr_=== raise ===.i" = load i64, i64* @"rubyStrFrozen_=== raise ===", align 8, !dbg !71
-  %108 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !19
-  %109 = load i64*, i64** %108, align 8, !dbg !19
-  store i64 %40, i64* %109, align 8, !dbg !19, !tbaa !6
-  %110 = getelementptr inbounds i64, i64* %109, i64 1, !dbg !19
-  store i64 %"rubyStr_=== raise ===.i", i64* %110, align 8, !dbg !19, !tbaa !6
-  %111 = getelementptr inbounds i64, i64* %110, i64 1, !dbg !19
-  store i64* %111, i64** %108, align 8, !dbg !19
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %48, align 8, !dbg !18, !tbaa !33
+  %"rubyStr_=== raise ===.i" = load i64, i64* @"rubyStrFrozen_=== raise ===", align 8, !dbg !62
+  %90 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !19
+  %91 = load i64*, i64** %90, align 8, !dbg !19
+  store i64 %39, i64* %91, align 8, !dbg !19, !tbaa !6
+  %92 = getelementptr inbounds i64, i64* %91, i64 1, !dbg !19
+  store i64 %"rubyStr_=== raise ===.i", i64* %92, align 8, !dbg !19, !tbaa !6
+  %93 = getelementptr inbounds i64, i64* %92, i64 1, !dbg !19
+  store i64* %93, i64** %90, align 8, !dbg !19
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %49, align 8, !dbg !19, !tbaa !33
-  %112 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 1, !dbg !20
-  %113 = load i64*, i64** %112, align 8, !dbg !20
-  store i64 %72, i64* %113, align 8, !dbg !20, !tbaa !6
-  %114 = getelementptr inbounds i64, i64* %113, i64 1, !dbg !20
-  store i64 20, i64* %114, align 8, !dbg !20, !tbaa !6
-  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !20
-  store i64* %115, i64** %112, align 8, !dbg !20
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %48, align 8, !dbg !19, !tbaa !33
+  %94 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !20
+  %95 = load i64*, i64** %94, align 8, !dbg !20
+  store i64 %66, i64* %95, align 8, !dbg !20, !tbaa !6
+  %96 = getelementptr inbounds i64, i64* %95, i64 1, !dbg !20
+  store i64 20, i64* %96, align 8, !dbg !20, !tbaa !6
+  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !20
+  store i64* %97, i64** %94, align 8, !dbg !20
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test.2, i64 0), !dbg !20
   ret void
 }
@@ -505,51 +474,51 @@ define internal i64 @func_A.4test(i32 %argc, i64* nocapture readonly %argArray, 
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !33
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !72
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !72
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !72
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !72, !prof !73
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !63
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !63
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !63
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !63, !prof !64
 
 postProcess:                                      ; preds = %sorbet_writeLocal.exit, %exception-continue
-  %"<returnValue>.sroa.0.0" = phi i64 [ %13, %exception-continue ], [ %10, %sorbet_writeLocal.exit ], !dbg !74
+  %"<returnValue>.sroa.0.0" = phi i64 [ %13, %exception-continue ], [ %10, %sorbet_writeLocal.exit ], !dbg !65
   ret i64 %"<returnValue>.sroa.0.0"
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !72
-  unreachable, !dbg !72
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !63
+  unreachable, !dbg !63
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !72
-  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !72
-  %2 = load i64*, i64** %1, align 8, !dbg !72, !tbaa !50
-  %3 = load i64, i64* %2, align 8, !dbg !72, !tbaa !6
-  %4 = and i64 %3, 8, !dbg !72
-  %5 = icmp eq i64 %4, 0, !dbg !72
-  br i1 %5, label %6, label %8, !dbg !72, !prof !68
+  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !63
+  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !63
+  %2 = load i64*, i64** %1, align 8, !dbg !63, !tbaa !50
+  %3 = load i64, i64* %2, align 8, !dbg !63, !tbaa !6
+  %4 = and i64 %3, 8, !dbg !63
+  %5 = icmp eq i64 %4, 0, !dbg !63
+  br i1 %5, label %6, label %8, !dbg !63, !prof !66
 
 6:                                                ; preds = %fillRequiredArgs
-  %7 = getelementptr inbounds i64, i64* %2, i64 -4, !dbg !72
-  store i64 %rawArg_x, i64* %7, align 8, !dbg !72, !tbaa !6
-  br label %sorbet_writeLocal.exit, !dbg !72
+  %7 = getelementptr inbounds i64, i64* %2, i64 -4, !dbg !63
+  store i64 %rawArg_x, i64* %7, align 8, !dbg !63, !tbaa !6
+  br label %sorbet_writeLocal.exit, !dbg !63
 
 8:                                                ; preds = %fillRequiredArgs
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %2, i32 noundef -4, i64 %rawArg_x) #11, !dbg !72
-  br label %sorbet_writeLocal.exit, !dbg !72
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %2, i32 noundef -4, i64 %rawArg_x) #11, !dbg !63
+  br label %sorbet_writeLocal.exit, !dbg !63
 
 sorbet_writeLocal.exit:                           ; preds = %6, %8
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !74, !tbaa !33
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !75, !tbaa !33
-  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !75
-  %10 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %9, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_1", i64** nonnull %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !75
-  %ensureReturnValue = icmp ne i64 %10, 52, !dbg !75
-  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !75
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !65, !tbaa !33
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !67, !tbaa !33
+  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !67
+  %10 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %9, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_1", i64** nonnull %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_A.4test$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !67
+  %ensureReturnValue = icmp ne i64 %10, 52, !dbg !67
+  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !67
 
 exception-continue:                               ; preds = %sorbet_writeLocal.exit
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %0, align 8, !tbaa !33
-  %11 = load i64*, i64** %1, align 8, !dbg !76, !tbaa !50
-  %12 = getelementptr inbounds i64, i64* %11, i64 -5, !dbg !76
-  %13 = load i64, i64* %12, align 8, !dbg !76, !tbaa !6
-  br label %postProcess, !dbg !76
+  %11 = load i64*, i64** %1, align 8, !dbg !68, !tbaa !50
+  %12 = getelementptr inbounds i64, i64* %11, i64 -5, !dbg !68
+  %13 = load i64, i64* %12, align 8, !dbg !68, !tbaa !6
+  br label %postProcess, !dbg !68
 }
 
 ; Function Attrs: ssp
@@ -559,9 +528,9 @@ functionEntryInitializers:
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !45
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !77
+  %4 = load i64, i64* %3, align 8, !tbaa !69
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !33
-  %rubyStr_begin = load i64, i64* @rubyStrFrozen_begin, align 8, !dbg !78
+  %rubyStr_begin = load i64, i64* @rubyStrFrozen_begin, align 8, !dbg !70
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !21
   %6 = load i64*, i64** %5, align 8, !dbg !21
   store i64 %4, i64* %6, align 8, !dbg !21, !tbaa !6
@@ -592,7 +561,7 @@ BB5:                                              ; preds = %functionEntryInitia
   store i64* %21, i64** %18, align 8, !dbg !24
   %send25 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !24
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %pc, align 8, !dbg !24, !tbaa !33
-  %rubyStr_foo = load i64, i64* @rubyStrFrozen_foo, align 8, !dbg !79
+  %rubyStr_foo = load i64, i64* @rubyStrFrozen_foo, align 8, !dbg !71
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !25
   %23 = load i64*, i64** %22, align 8, !dbg !25
   store i64 %4, i64* %23, align 8, !dbg !25, !tbaa !6
@@ -605,7 +574,7 @@ BB5:                                              ; preds = %functionEntryInitia
   %27 = load i64, i64* %26, align 8, !dbg !25, !tbaa !6
   %28 = and i64 %27, 8, !dbg !25
   %29 = icmp eq i64 %28, 0, !dbg !25
-  br i1 %29, label %30, label %32, !dbg !25, !prof !68
+  br i1 %29, label %30, label %32, !dbg !25, !prof !66
 
 30:                                               ; preds = %BB5
   %31 = getelementptr inbounds i64, i64* %26, i64 -5, !dbg !25
@@ -628,7 +597,7 @@ vm_get_ep.exit34:
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !45
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !77
+  %4 = load i64, i64* %3, align 8, !tbaa !69
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_2", align 8
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #11
   %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
@@ -658,31 +627,31 @@ blockExit:                                        ; preds = %75, %73, %60, %58
   ret i64 52
 
 vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
-  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !33
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2, !dbg !80
-  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !dbg !80, !tbaa !45
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4, !dbg !80
-  %28 = load i64*, i64** %27, align 8, !dbg !80
-  %29 = getelementptr inbounds i64, i64* %28, i64 -1, !dbg !80
-  %30 = load i64, i64* %29, align 8, !dbg !80, !tbaa !6
-  %31 = and i64 %30, -4, !dbg !80
-  %32 = inttoptr i64 %31 to i64*, !dbg !80
-  %33 = load i64, i64* %32, align 8, !dbg !80, !tbaa !6
-  %34 = and i64 %33, 8, !dbg !80
-  %35 = icmp eq i64 %34, 0, !dbg !80
-  br i1 %35, label %36, label %38, !dbg !80, !prof !68
+  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !72, !tbaa !33
+  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2, !dbg !72
+  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !dbg !72, !tbaa !45
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4, !dbg !72
+  %28 = load i64*, i64** %27, align 8, !dbg !72
+  %29 = getelementptr inbounds i64, i64* %28, i64 -1, !dbg !72
+  %30 = load i64, i64* %29, align 8, !dbg !72, !tbaa !6
+  %31 = and i64 %30, -4, !dbg !72
+  %32 = inttoptr i64 %31 to i64*, !dbg !72
+  %33 = load i64, i64* %32, align 8, !dbg !72, !tbaa !6
+  %34 = and i64 %33, 8, !dbg !72
+  %35 = icmp eq i64 %34, 0, !dbg !72
+  br i1 %35, label %36, label %38, !dbg !72, !prof !66
 
 36:                                               ; preds = %vm_get_ep.exit32
-  %37 = getelementptr inbounds i64, i64* %32, i64 -3, !dbg !80
-  store i64 8, i64* %37, align 8, !dbg !80, !tbaa !6
-  br label %vm_get_ep.exit30, !dbg !80
+  %37 = getelementptr inbounds i64, i64* %32, i64 -3, !dbg !72
+  store i64 8, i64* %37, align 8, !dbg !72, !tbaa !6
+  br label %vm_get_ep.exit30, !dbg !72
 
 38:                                               ; preds = %vm_get_ep.exit32
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %32, i32 noundef -3, i64 noundef 8) #11, !dbg !80
-  br label %vm_get_ep.exit30, !dbg !80
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %32, i32 noundef -3, i64 noundef 8) #11, !dbg !72
+  br label %vm_get_ep.exit30, !dbg !72
 
 vm_get_ep.exit30:                                 ; preds = %36, %38
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !81, !tbaa !33
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !73, !tbaa !33
   %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !33
   %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %39, i64 0, i32 2, !dbg !28
   %41 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %40, align 8, !dbg !28, !tbaa !45
@@ -706,7 +675,7 @@ vm_get_ep.exit30:                                 ; preds = %36, %38
   %55 = load i64, i64* %54, align 8, !dbg !28, !tbaa !6
   %56 = and i64 %55, 8, !dbg !28
   %57 = icmp eq i64 %56, 0, !dbg !28
-  br i1 %57, label %58, label %60, !dbg !28, !prof !68
+  br i1 %57, label %58, label %60, !dbg !28, !prof !66
 
 58:                                               ; preds = %vm_get_ep.exit30
   %59 = getelementptr inbounds i64, i64* %54, i64 -5, !dbg !28
@@ -719,28 +688,28 @@ vm_get_ep.exit30:                                 ; preds = %36, %38
 
 vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !tbaa !33
-  %61 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !82, !tbaa !33
-  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 2, !dbg !82
-  %63 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %62, align 8, !dbg !82, !tbaa !45
-  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %63, i64 0, i32 4, !dbg !82
-  %65 = load i64*, i64** %64, align 8, !dbg !82
-  %66 = getelementptr inbounds i64, i64* %65, i64 -1, !dbg !82
-  %67 = load i64, i64* %66, align 8, !dbg !82, !tbaa !6
-  %68 = and i64 %67, -4, !dbg !82
-  %69 = inttoptr i64 %68 to i64*, !dbg !82
-  %70 = load i64, i64* %69, align 8, !dbg !82, !tbaa !6
-  %71 = and i64 %70, 8, !dbg !82
-  %72 = icmp eq i64 %71, 0, !dbg !82
-  br i1 %72, label %73, label %75, !dbg !82, !prof !68
+  %61 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !74, !tbaa !33
+  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 2, !dbg !74
+  %63 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %62, align 8, !dbg !74, !tbaa !45
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %63, i64 0, i32 4, !dbg !74
+  %65 = load i64*, i64** %64, align 8, !dbg !74
+  %66 = getelementptr inbounds i64, i64* %65, i64 -1, !dbg !74
+  %67 = load i64, i64* %66, align 8, !dbg !74, !tbaa !6
+  %68 = and i64 %67, -4, !dbg !74
+  %69 = inttoptr i64 %68 to i64*, !dbg !74
+  %70 = load i64, i64* %69, align 8, !dbg !74, !tbaa !6
+  %71 = and i64 %70, 8, !dbg !74
+  %72 = icmp eq i64 %71, 0, !dbg !74
+  br i1 %72, label %73, label %75, !dbg !74, !prof !66
 
 73:                                               ; preds = %vm_get_ep.exit
-  %74 = getelementptr inbounds i64, i64* %69, i64 -7, !dbg !82
-  store i64 20, i64* %74, align 8, !dbg !82, !tbaa !6
-  br label %blockExit, !dbg !82
+  %74 = getelementptr inbounds i64, i64* %69, i64 -7, !dbg !74
+  store i64 20, i64* %74, align 8, !dbg !74, !tbaa !6
+  br label %blockExit, !dbg !74
 
 75:                                               ; preds = %vm_get_ep.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %69, i32 noundef -7, i64 noundef 20) #11, !dbg !82
-  br label %blockExit, !dbg !82
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %69, i32 noundef -7, i64 noundef 20) #11, !dbg !74
+  br label %blockExit, !dbg !74
 }
 
 ; Function Attrs: ssp
@@ -750,7 +719,7 @@ functionEntryInitializers:
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !45
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !77
+  %4 = load i64, i64* %3, align 8, !tbaa !69
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_3", align 8
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #11
   %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
@@ -758,7 +727,7 @@ functionEntryInitializers:
   %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !45
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !tbaa !33
-  %rubyStr_ensure = load i64, i64* @rubyStrFrozen_ensure, align 8, !dbg !83
+  %rubyStr_ensure = load i64, i64* @rubyStrFrozen_ensure, align 8, !dbg !75
   %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !31, !tbaa !33
   %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !31
   %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !31, !tbaa !45
@@ -781,9 +750,9 @@ functionEntryInitializers:
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !45
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !77
+  %4 = load i64, i64* %3, align 8, !tbaa !69
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !tbaa !33
-  %rubyStr_else = load i64, i64* @rubyStrFrozen_else, align 8, !dbg !84
+  %rubyStr_else = load i64, i64* @rubyStrFrozen_else, align 8, !dbg !76
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !29
   %6 = load i64*, i64** %5, align 8, !dbg !29
   store i64 %4, i64* %6, align 8, !dbg !29, !tbaa !6
@@ -797,7 +766,7 @@ functionEntryInitializers:
   %11 = load i64, i64* %10, align 8, !dbg !29, !tbaa !6
   %12 = and i64 %11, 8, !dbg !29
   %13 = icmp eq i64 %12, 0, !dbg !29
-  br i1 %13, label %14, label %16, !dbg !29, !prof !68
+  br i1 %13, label %14, label %16, !dbg !29, !prof !66
 
 14:                                               ; preds = %functionEntryInitializers
   %15 = getelementptr inbounds i64, i64* %10, i64 -5, !dbg !29
@@ -822,7 +791,7 @@ declare void @llvm.assume(i1 noundef) #9
 define linkonce void @const_recompute_A() local_unnamed_addr #7 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !59
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !54
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -898,35 +867,27 @@ attributes #13 = { noreturn }
 !50 = !{!49, !34, i64 32}
 !51 = !DILocation(line: 0, scope: !16)
 !52 = !DILocation(line: 5, column: 1, scope: !16)
-!53 = !{!54, !7, i64 0}
-!54 = !{!"rb_calling_info", !7, i64 0, !7, i64 8, !40, i64 16, !40, i64 20}
-!55 = !{!54, !40, i64 20}
-!56 = !{!54, !7, i64 8}
-!57 = !{!54, !40, i64 16}
-!58 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
-!59 = !{!41, !41, i64 0}
-!60 = !{!"branch_weights", i32 1, i32 10000}
-!61 = !{!62, !40, i64 8}
-!62 = !{!"rb_sorbet_param_struct", !63, i64 0, !40, i64 4, !40, i64 8, !40, i64 12, !40, i64 16, !40, i64 20, !40, i64 24, !40, i64 28, !34, i64 32, !40, i64 40, !40, i64 44, !40, i64 48, !40, i64 52, !34, i64 56}
-!63 = !{!"", !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 1, !40, i64 1}
-!64 = !{!62, !40, i64 4}
-!65 = !{!62, !34, i64 32}
-!66 = !{!46, !40, i64 40}
-!67 = !{!46, !40, i64 44}
-!68 = !{!"branch_weights", i32 2000, i32 1}
-!69 = !{!46, !34, i64 56}
-!70 = !DILocation(line: 23, column: 6, scope: !16)
-!71 = !DILocation(line: 26, column: 6, scope: !16)
-!72 = !DILocation(line: 6, column: 3, scope: !23)
-!73 = !{!"branch_weights", i32 4001, i32 4000000}
-!74 = !DILocation(line: 0, scope: !23)
-!75 = !DILocation(line: 8, column: 7, scope: !23)
-!76 = !DILocation(line: 20, column: 3, scope: !23)
-!77 = !{!49, !7, i64 24}
-!78 = !DILocation(line: 8, column: 12, scope: !22)
-!79 = !DILocation(line: 11, column: 15, scope: !22)
-!80 = !DILocation(line: 0, scope: !27)
-!81 = !DILocation(line: 13, column: 5, scope: !27)
-!82 = !DILocation(line: 8, column: 7, scope: !27)
-!83 = !DILocation(line: 18, column: 12, scope: !32)
-!84 = !DILocation(line: 16, column: 12, scope: !30)
+!53 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
+!54 = !{!41, !41, i64 0}
+!55 = !{!"branch_weights", i32 1, i32 10000}
+!56 = !{!57, !40, i64 8}
+!57 = !{!"rb_sorbet_param_struct", !58, i64 0, !40, i64 4, !40, i64 8, !40, i64 12, !40, i64 16, !40, i64 20, !40, i64 24, !40, i64 28, !34, i64 32, !40, i64 40, !40, i64 44, !40, i64 48, !40, i64 52, !34, i64 56}
+!58 = !{!"", !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 0, !40, i64 1, !40, i64 1}
+!59 = !{!57, !40, i64 4}
+!60 = !{!57, !34, i64 32}
+!61 = !DILocation(line: 23, column: 6, scope: !16)
+!62 = !DILocation(line: 26, column: 6, scope: !16)
+!63 = !DILocation(line: 6, column: 3, scope: !23)
+!64 = !{!"branch_weights", i32 4001, i32 4000000}
+!65 = !DILocation(line: 0, scope: !23)
+!66 = !{!"branch_weights", i32 2000, i32 1}
+!67 = !DILocation(line: 8, column: 7, scope: !23)
+!68 = !DILocation(line: 20, column: 3, scope: !23)
+!69 = !{!49, !7, i64 24}
+!70 = !DILocation(line: 8, column: 12, scope: !22)
+!71 = !DILocation(line: 11, column: 15, scope: !22)
+!72 = !DILocation(line: 0, scope: !27)
+!73 = !DILocation(line: 13, column: 5, scope: !27)
+!74 = !DILocation(line: 8, column: 7, scope: !27)
+!75 = !DILocation(line: 18, column: 12, scope: !32)
+!76 = !DILocation(line: 16, column: 12, scope: !30)

--- a/test/testdata/compiler/float-intrinsics.opt.ll.exp
+++ b/test/testdata/compiler/float-intrinsics.opt.ll.exp
@@ -209,15 +209,15 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_Rational.42 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lte.43 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.44 = internal global %struct.FunctionInlineCache zeroinitializer
-@"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
-@"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
-@rb_cObject = external local_unnamed_addr constant i64
-@rb_mKernel = external local_unnamed_addr constant i64
 @guard_epoch_T = linkonce local_unnamed_addr global i64 0
 @guarded_const_T = linkonce local_unnamed_addr global i64 0
 @rb_cFloat = external local_unnamed_addr constant i64
 @"guard_epoch_T::Boolean" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Boolean" = linkonce local_unnamed_addr global i64 0
+@"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
+@"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
+@rb_cObject = external local_unnamed_addr constant i64
+@rb_mKernel = external local_unnamed_addr constant i64
 
 declare i64 @rb_float_plus(i64, i64) local_unnamed_addr #0
 
@@ -275,14 +275,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #13
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #14
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #13
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #14
   unreachable
 }
 
@@ -298,7 +298,7 @@ functionEntryInitializers:
   br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !16, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #14, !dbg !16
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #15, !dbg !16
   unreachable, !dbg !16
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
@@ -326,7 +326,7 @@ sorbet_isa_Float.exit:                            ; preds = %4
   br i1 %14, label %typeTestSuccess7, label %codeRepl22, !dbg !18, !prof !21
 
 codeRepl22:                                       ; preds = %4, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #15, !dbg !18
+  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #16, !dbg !18
   unreachable
 
 typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
@@ -336,7 +336,7 @@ typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %
   %15 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !23
   tail call void @llvm.experimental.noalias.scope.decl(metadata !24), !dbg !23
   %16 = load i64, i64* %15, align 8, !dbg !23, !tbaa !6, !alias.scope !24
-  %17 = tail call i64 @rb_float_plus(i64 %rawArg_x, i64 %16) #16, !dbg !23, !noalias !24
+  %17 = tail call i64 @rb_float_plus(i64 %rawArg_x, i64 %16) #17, !dbg !23, !noalias !24
   %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !14
   %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 5, !dbg !23
   %20 = load i32, i32* %19, align 8, !dbg !23, !tbaa !27
@@ -350,7 +350,7 @@ typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %
 26:                                               ; preds = %typeTestSuccess7
   %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !23
   %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !23, !tbaa !32
-  %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #16, !dbg !23
+  %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #17, !dbg !23
   br label %typeTestSuccess14, !dbg !23
 
 typeTestSuccess14:                                ; preds = %26, %typeTestSuccess7
@@ -368,7 +368,7 @@ functionEntryInitializers:
   br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !34, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #14, !dbg !34
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #15, !dbg !34
   unreachable, !dbg !34
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
@@ -397,7 +397,7 @@ sorbet_isa_Float.exit:                            ; preds = %7
   br i1 %17, label %typeTestSuccess7, label %codeRepl20, !dbg !35, !prof !21
 
 codeRepl20:                                       ; preds = %7, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %4) #15, !dbg !35
+  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %4) #16, !dbg !35
   unreachable
 
 typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
@@ -425,7 +425,7 @@ functionEntryInitializers:
   br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !39, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #14, !dbg !39
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #15, !dbg !39
   unreachable, !dbg !39
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
@@ -453,7 +453,7 @@ sorbet_isa_Float.exit:                            ; preds = %4
   br i1 %14, label %typeTestSuccess7, label %codeRepl22, !dbg !40, !prof !21
 
 codeRepl22:                                       ; preds = %4, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #15, !dbg !40
+  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #16, !dbg !40
   unreachable
 
 typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
@@ -463,7 +463,7 @@ typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %
   %15 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !42
   tail call void @llvm.experimental.noalias.scope.decl(metadata !43), !dbg !42
   %16 = load i64, i64* %15, align 8, !dbg !42, !tbaa !6, !alias.scope !43
-  %17 = tail call i64 @sorbet_flo_lt(i64 %rawArg_x, i64 %16) #16, !dbg !42, !noalias !43
+  %17 = tail call i64 @sorbet_flo_lt(i64 %rawArg_x, i64 %16) #17, !dbg !42, !noalias !43
   %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !42, !tbaa !14
   %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 5, !dbg !42
   %20 = load i32, i32* %19, align 8, !dbg !42, !tbaa !27
@@ -477,7 +477,7 @@ typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %
 26:                                               ; preds = %typeTestSuccess7
   %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !42
   %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !42, !tbaa !32
-  %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #16, !dbg !42
+  %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #17, !dbg !42
   br label %rb_vm_check_ints.exit, !dbg !42
 
 rb_vm_check_ints.exit:                            ; preds = %typeTestSuccess7, %26
@@ -490,7 +490,7 @@ typeTestSuccess14:                                ; preds = %rb_vm_check_ints.ex
   ret i64 %17
 
 codeRepl:                                         ; preds = %rb_vm_check_ints.exit
-  tail call fastcc void @"func_Object#2lt.cold.1"(i64 %17) #15, !dbg !47
+  tail call fastcc void @"func_Object#2lt.cold.1"(i64 %17) #16, !dbg !47
   unreachable
 }
 
@@ -506,7 +506,7 @@ functionEntryInitializers:
   br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !49, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #14, !dbg !49
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #15, !dbg !49
   unreachable, !dbg !49
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
@@ -534,7 +534,7 @@ sorbet_isa_Float.exit:                            ; preds = %4
   br i1 %14, label %typeTestSuccess7, label %codeRepl22, !dbg !50, !prof !21
 
 codeRepl22:                                       ; preds = %4, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #15, !dbg !50
+  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #16, !dbg !50
   unreachable
 
 typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
@@ -544,7 +544,7 @@ typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %
   %15 = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !52
   tail call void @llvm.experimental.noalias.scope.decl(metadata !53), !dbg !52
   %16 = load i64, i64* %15, align 8, !dbg !52, !tbaa !6, !alias.scope !53
-  %17 = tail call i64 @sorbet_flo_le(i64 %rawArg_x, i64 %16) #16, !dbg !52, !noalias !53
+  %17 = tail call i64 @sorbet_flo_le(i64 %rawArg_x, i64 %16) #17, !dbg !52, !noalias !53
   %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !14
   %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 5, !dbg !52
   %20 = load i32, i32* %19, align 8, !dbg !52, !tbaa !27
@@ -558,7 +558,7 @@ typeTestSuccess7:                                 ; preds = %fillRequiredArgs, %
 26:                                               ; preds = %typeTestSuccess7
   %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !52
   %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !52, !tbaa !32
-  %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #16, !dbg !52
+  %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #17, !dbg !52
   br label %rb_vm_check_ints.exit, !dbg !52
 
 rb_vm_check_ints.exit:                            ; preds = %typeTestSuccess7, %26
@@ -571,1006 +571,312 @@ typeTestSuccess14:                                ; preds = %rb_vm_check_ints.ex
   ret i64 %17
 
 codeRepl:                                         ; preds = %rb_vm_check_ints.exit
-  tail call fastcc void @"func_Object#2lt.cold.1"(i64 %17) #15, !dbg !56
+  tail call fastcc void @"func_Object#2lt.cold.1"(i64 %17) #16, !dbg !56
   unreachable
 }
 
-; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_<root>.17<static-init>$152"(i64 %selfRaw, %struct.rb_control_frame_struct* %cfp) unnamed_addr #7 !dbg !57 {
-functionEntryInitializers:
-  %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !58
-  %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !59
-  %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !61
-  %6 = load i64, i64* %5, align 8, !tbaa !6
-  %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #16
-  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !62, !tbaa !14
-  %rubyId_plus = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !63
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_plus), !dbg !63
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_1"), !dbg !63
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !63, !tbaa !14
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 5, !dbg !63
-  %11 = load i32, i32* %10, align 8, !dbg !63, !tbaa !27
-  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 6, !dbg !63
-  %13 = load i32, i32* %12, align 4, !dbg !63, !tbaa !31
-  %14 = xor i32 %13, -1, !dbg !63
-  %15 = and i32 %14, %11, !dbg !63
-  %16 = icmp eq i32 %15, 0, !dbg !63
-  br i1 %16, label %rb_vm_check_ints.exit3, label %17, !dbg !63, !prof !21
-
-17:                                               ; preds = %functionEntryInitializers
-  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 8, !dbg !63
-  %19 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %18, align 8, !dbg !63, !tbaa !32
-  %20 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %19, i32 noundef 0) #16, !dbg !63
-  br label %rb_vm_check_ints.exit3, !dbg !63
-
-rb_vm_check_ints.exit3:                           ; preds = %functionEntryInitializers, %17
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !63, !tbaa !14
-  %rubyId_minus = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !64
-  %rawSym258 = tail call i64 @rb_id2sym(i64 %rubyId_minus), !dbg !64
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym258, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_2"), !dbg !64
-  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !64, !tbaa !14
-  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !64
-  %23 = load i32, i32* %22, align 8, !dbg !64, !tbaa !27
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 6, !dbg !64
-  %25 = load i32, i32* %24, align 4, !dbg !64, !tbaa !31
-  %26 = xor i32 %25, -1, !dbg !64
-  %27 = and i32 %26, %23, !dbg !64
-  %28 = icmp eq i32 %27, 0, !dbg !64
-  br i1 %28, label %rb_vm_check_ints.exit5, label %29, !dbg !64, !prof !21
-
-29:                                               ; preds = %rb_vm_check_ints.exit3
-  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !64
-  %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !64, !tbaa !32
-  %32 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #16, !dbg !64
-  br label %rb_vm_check_ints.exit5, !dbg !64
-
-rb_vm_check_ints.exit5:                           ; preds = %rb_vm_check_ints.exit3, %29
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %8, align 8, !dbg !64, !tbaa !14
-  %rubyId_lt = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !65
-  %rawSym272 = tail call i64 @rb_id2sym(i64 %rubyId_lt), !dbg !65
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym272, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_3"), !dbg !65
-  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !14
-  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 5, !dbg !65
-  %35 = load i32, i32* %34, align 8, !dbg !65, !tbaa !27
-  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 6, !dbg !65
-  %37 = load i32, i32* %36, align 4, !dbg !65, !tbaa !31
-  %38 = xor i32 %37, -1, !dbg !65
-  %39 = and i32 %38, %35, !dbg !65
-  %40 = icmp eq i32 %39, 0, !dbg !65
-  br i1 %40, label %rb_vm_check_ints.exit7, label %41, !dbg !65, !prof !21
-
-41:                                               ; preds = %rb_vm_check_ints.exit5
-  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 8, !dbg !65
-  %43 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %42, align 8, !dbg !65, !tbaa !32
-  %44 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %43, i32 noundef 0) #16, !dbg !65
-  br label %rb_vm_check_ints.exit7, !dbg !65
-
-rb_vm_check_ints.exit7:                           ; preds = %rb_vm_check_ints.exit5, %41
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %8, align 8, !dbg !65, !tbaa !14
-  %rubyId_lte = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !66
-  %rawSym286 = tail call i64 @rb_id2sym(i64 %rubyId_lte), !dbg !66
-  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym286, i64 %selfRaw, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_4"), !dbg !66
-  %45 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !14
-  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 5, !dbg !66
-  %47 = load i32, i32* %46, align 8, !dbg !66, !tbaa !27
-  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 6, !dbg !66
-  %49 = load i32, i32* %48, align 4, !dbg !66, !tbaa !31
-  %50 = xor i32 %49, -1, !dbg !66
-  %51 = and i32 %50, %47, !dbg !66
-  %52 = icmp eq i32 %51, 0, !dbg !66
-  br i1 %52, label %rb_vm_check_ints.exit6, label %53, !dbg !66, !prof !21
-
-53:                                               ; preds = %rb_vm_check_ints.exit7
-  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 8, !dbg !66
-  %55 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %54, align 8, !dbg !66, !tbaa !32
-  %56 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %55, i32 noundef 0) #16, !dbg !66
-  br label %rb_vm_check_ints.exit6, !dbg !66
-
-rb_vm_check_ints.exit6:                           ; preds = %rb_vm_check_ints.exit7, %53
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !66, !tbaa !14
-  %57 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !67
-  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !68
-  %needTakeSlowPath = icmp ne i64 %57, %58, !dbg !67
-  br i1 %needTakeSlowPath, label %59, label %60, !dbg !67, !prof !70
-
-59:                                               ; preds = %rb_vm_check_ints.exit6
-  tail call void @"const_recompute_T::Sig"(), !dbg !67
-  br label %60, !dbg !67
-
-60:                                               ; preds = %rb_vm_check_ints.exit6, %59
-  %61 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !67
-  %62 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !67
-  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !67, !tbaa !68
-  %guardUpdated = icmp eq i64 %62, %63, !dbg !67
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !67
-  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !67
-  %65 = load i64*, i64** %64, align 8, !dbg !67
-  store i64 %selfRaw, i64* %65, align 8, !dbg !67, !tbaa !6
-  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !67
-  store i64 %61, i64* %66, align 8, !dbg !67, !tbaa !6
-  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !67
-  store i64* %67, i64** %64, align 8, !dbg !67
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !67
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !67, !tbaa !14
-  %68 = load i64, i64* @rb_cObject, align 8, !dbg !71
-  %stackFrame309 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8, !dbg !71
-  %69 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !71
-  %70 = bitcast i8* %69 to i16*, !dbg !71
-  %71 = load i16, i16* %70, align 8, !dbg !71
-  %72 = and i16 %71, -384, !dbg !71
-  %73 = or i16 %72, 1, !dbg !71
-  store i16 %73, i16* %70, align 8, !dbg !71
-  %74 = getelementptr inbounds i8, i8* %69, i64 8, !dbg !71
-  %75 = bitcast i8* %74 to i32*, !dbg !71
-  store i32 2, i32* %75, align 8, !dbg !71, !tbaa !72
-  %76 = getelementptr inbounds i8, i8* %69, i64 12, !dbg !71
-  %77 = bitcast i8* %76 to i32*, !dbg !71
-  %78 = getelementptr inbounds i8, i8* %69, i64 4, !dbg !71
-  %79 = bitcast i8* %78 to i32*, !dbg !71
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 20, i1 false), !dbg !71
-  store i32 2, i32* %79, align 4, !dbg !71, !tbaa !75
-  %positional_table = alloca i64, i32 2, align 8, !dbg !71
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !71
-  store i64 %rubyId_x, i64* %positional_table, align 8, !dbg !71
-  %rubyId_y = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !71
-  %80 = getelementptr i64, i64* %positional_table, i32 1, !dbg !71
-  store i64 %rubyId_y, i64* %80, align 8, !dbg !71
-  %81 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !71
-  %82 = bitcast i64* %positional_table to i8*, !dbg !71
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %81, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %82, i64 noundef 16, i1 noundef false) #16, !dbg !71
-  %83 = getelementptr inbounds i8, i8* %69, i64 32, !dbg !71
-  %84 = bitcast i8* %83 to i8**, !dbg !71
-  store i8* %81, i8** %84, align 8, !dbg !71, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#4plus", i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame309, i1 noundef zeroext false) #16, !dbg !71
-  %85 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !71, !tbaa !14
-  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 5, !dbg !71
-  %87 = load i32, i32* %86, align 8, !dbg !71, !tbaa !27
-  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 6, !dbg !71
-  %89 = load i32, i32* %88, align 4, !dbg !71, !tbaa !31
-  %90 = xor i32 %89, -1, !dbg !71
-  %91 = and i32 %90, %87, !dbg !71
-  %92 = icmp eq i32 %91, 0, !dbg !71
-  br i1 %92, label %rb_vm_check_ints.exit4, label %93, !dbg !71, !prof !21
-
-93:                                               ; preds = %60
-  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 8, !dbg !71
-  %95 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %94, align 8, !dbg !71, !tbaa !32
-  %96 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %95, i32 noundef 0) #16, !dbg !71
-  br label %rb_vm_check_ints.exit4, !dbg !71
-
-rb_vm_check_ints.exit4:                           ; preds = %60, %93
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %8, align 8, !dbg !71, !tbaa !14
-  %stackFrame319 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8, !dbg !77
-  %97 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !77
-  %98 = bitcast i8* %97 to i16*, !dbg !77
-  %99 = load i16, i16* %98, align 8, !dbg !77
-  %100 = and i16 %99, -384, !dbg !77
-  %101 = or i16 %100, 1, !dbg !77
-  store i16 %101, i16* %98, align 8, !dbg !77
-  %102 = getelementptr inbounds i8, i8* %97, i64 8, !dbg !77
-  %103 = bitcast i8* %102 to i32*, !dbg !77
-  store i32 2, i32* %103, align 8, !dbg !77, !tbaa !72
-  %104 = getelementptr inbounds i8, i8* %97, i64 12, !dbg !77
-  %105 = bitcast i8* %104 to i32*, !dbg !77
-  %106 = getelementptr inbounds i8, i8* %97, i64 4, !dbg !77
-  %107 = bitcast i8* %106 to i32*, !dbg !77
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %104, i8 0, i64 20, i1 false), !dbg !77
-  store i32 2, i32* %107, align 4, !dbg !77, !tbaa !75
-  %positional_table321 = alloca i64, i32 2, align 8, !dbg !77
-  %rubyId_x322 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !77
-  store i64 %rubyId_x322, i64* %positional_table321, align 8, !dbg !77
-  %rubyId_y323 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !77
-  %108 = getelementptr i64, i64* %positional_table321, i32 1, !dbg !77
-  store i64 %rubyId_y323, i64* %108, align 8, !dbg !77
-  %109 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !77
-  %110 = bitcast i64* %positional_table321 to i8*, !dbg !77
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %109, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %110, i64 noundef 16, i1 noundef false) #16, !dbg !77
-  %111 = getelementptr inbounds i8, i8* %97, i64 32, !dbg !77
-  %112 = bitcast i8* %111 to i8**, !dbg !77
-  store i8* %109, i8** %112, align 8, !dbg !77, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#5minus", i8* nonnull %97, %struct.rb_iseq_struct* %stackFrame319, i1 noundef zeroext false) #16, !dbg !77
-  %113 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !77, !tbaa !14
-  %114 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 5, !dbg !77
-  %115 = load i32, i32* %114, align 8, !dbg !77, !tbaa !27
-  %116 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 6, !dbg !77
-  %117 = load i32, i32* %116, align 4, !dbg !77, !tbaa !31
-  %118 = xor i32 %117, -1, !dbg !77
-  %119 = and i32 %118, %115, !dbg !77
-  %120 = icmp eq i32 %119, 0, !dbg !77
-  br i1 %120, label %rb_vm_check_ints.exit2, label %121, !dbg !77, !prof !21
-
-121:                                              ; preds = %rb_vm_check_ints.exit4
-  %122 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %113, i64 0, i32 8, !dbg !77
-  %123 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %122, align 8, !dbg !77, !tbaa !32
-  %124 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %123, i32 noundef 0) #16, !dbg !77
-  br label %rb_vm_check_ints.exit2, !dbg !77
-
-rb_vm_check_ints.exit2:                           ; preds = %rb_vm_check_ints.exit4, %121
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !dbg !77, !tbaa !14
-  %stackFrame333 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8, !dbg !78
-  %125 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !78
-  %126 = bitcast i8* %125 to i16*, !dbg !78
-  %127 = load i16, i16* %126, align 8, !dbg !78
-  %128 = and i16 %127, -384, !dbg !78
-  %129 = or i16 %128, 1, !dbg !78
-  store i16 %129, i16* %126, align 8, !dbg !78
-  %130 = getelementptr inbounds i8, i8* %125, i64 8, !dbg !78
-  %131 = bitcast i8* %130 to i32*, !dbg !78
-  store i32 2, i32* %131, align 8, !dbg !78, !tbaa !72
-  %132 = getelementptr inbounds i8, i8* %125, i64 12, !dbg !78
-  %133 = bitcast i8* %132 to i32*, !dbg !78
-  %134 = getelementptr inbounds i8, i8* %125, i64 4, !dbg !78
-  %135 = bitcast i8* %134 to i32*, !dbg !78
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %132, i8 0, i64 20, i1 false), !dbg !78
-  store i32 2, i32* %135, align 4, !dbg !78, !tbaa !75
-  %positional_table335 = alloca i64, i32 2, align 8, !dbg !78
-  %rubyId_x336 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !78
-  store i64 %rubyId_x336, i64* %positional_table335, align 8, !dbg !78
-  %rubyId_y337 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !78
-  %136 = getelementptr i64, i64* %positional_table335, i32 1, !dbg !78
-  store i64 %rubyId_y337, i64* %136, align 8, !dbg !78
-  %137 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !78
-  %138 = bitcast i64* %positional_table335 to i8*, !dbg !78
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %137, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %138, i64 noundef 16, i1 noundef false) #16, !dbg !78
-  %139 = getelementptr inbounds i8, i8* %125, i64 32, !dbg !78
-  %140 = bitcast i8* %139 to i8**, !dbg !78
-  store i8* %137, i8** %140, align 8, !dbg !78, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#2lt", i8* nonnull %125, %struct.rb_iseq_struct* %stackFrame333, i1 noundef zeroext false) #16, !dbg !78
-  %141 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !78, !tbaa !14
-  %142 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 5, !dbg !78
-  %143 = load i32, i32* %142, align 8, !dbg !78, !tbaa !27
-  %144 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 6, !dbg !78
-  %145 = load i32, i32* %144, align 4, !dbg !78, !tbaa !31
-  %146 = xor i32 %145, -1, !dbg !78
-  %147 = and i32 %146, %143, !dbg !78
-  %148 = icmp eq i32 %147, 0, !dbg !78
-  br i1 %148, label %rb_vm_check_ints.exit1, label %149, !dbg !78, !prof !21
-
-149:                                              ; preds = %rb_vm_check_ints.exit2
-  %150 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %141, i64 0, i32 8, !dbg !78
-  %151 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %150, align 8, !dbg !78, !tbaa !32
-  %152 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %151, i32 noundef 0) #16, !dbg !78
-  br label %rb_vm_check_ints.exit1, !dbg !78
-
-rb_vm_check_ints.exit1:                           ; preds = %rb_vm_check_ints.exit2, %149
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %8, align 8, !dbg !78, !tbaa !14
-  %stackFrame347 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8, !dbg !79
-  %153 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !79
-  %154 = bitcast i8* %153 to i16*, !dbg !79
-  %155 = load i16, i16* %154, align 8, !dbg !79
-  %156 = and i16 %155, -384, !dbg !79
-  %157 = or i16 %156, 1, !dbg !79
-  store i16 %157, i16* %154, align 8, !dbg !79
-  %158 = getelementptr inbounds i8, i8* %153, i64 8, !dbg !79
-  %159 = bitcast i8* %158 to i32*, !dbg !79
-  store i32 2, i32* %159, align 8, !dbg !79, !tbaa !72
-  %160 = getelementptr inbounds i8, i8* %153, i64 12, !dbg !79
-  %161 = bitcast i8* %160 to i32*, !dbg !79
-  %162 = getelementptr inbounds i8, i8* %153, i64 4, !dbg !79
-  %163 = bitcast i8* %162 to i32*, !dbg !79
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %160, i8 0, i64 20, i1 false), !dbg !79
-  store i32 2, i32* %163, align 4, !dbg !79, !tbaa !75
-  %positional_table349 = alloca i64, i32 2, align 8, !dbg !79
-  %rubyId_x350 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !79
-  store i64 %rubyId_x350, i64* %positional_table349, align 8, !dbg !79
-  %rubyId_y351 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !79
-  %164 = getelementptr i64, i64* %positional_table349, i32 1, !dbg !79
-  store i64 %rubyId_y351, i64* %164, align 8, !dbg !79
-  %165 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #17, !dbg !79
-  %166 = bitcast i64* %positional_table349 to i8*, !dbg !79
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %165, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %166, i64 noundef 16, i1 noundef false) #16, !dbg !79
-  %167 = getelementptr inbounds i8, i8* %153, i64 32, !dbg !79
-  %168 = bitcast i8* %167 to i8**, !dbg !79
-  store i8* %165, i8** %168, align 8, !dbg !79, !tbaa !76
-  tail call void @sorbet_vm_define_method(i64 %68, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3lte", i8* nonnull %153, %struct.rb_iseq_struct* %stackFrame347, i1 noundef zeroext false) #16, !dbg !79
-  %169 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !79, !tbaa !14
-  %170 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %169, i64 0, i32 5, !dbg !79
-  %171 = load i32, i32* %170, align 8, !dbg !79, !tbaa !27
-  %172 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %169, i64 0, i32 6, !dbg !79
-  %173 = load i32, i32* %172, align 4, !dbg !79, !tbaa !31
-  %174 = xor i32 %173, -1, !dbg !79
-  %175 = and i32 %174, %171, !dbg !79
-  %176 = icmp eq i32 %175, 0, !dbg !79
-  br i1 %176, label %rb_vm_check_ints.exit, label %177, !dbg !79, !prof !21
-
-177:                                              ; preds = %rb_vm_check_ints.exit1
-  %178 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %169, i64 0, i32 8, !dbg !79
-  %179 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %178, align 8, !dbg !79, !tbaa !32
-  %180 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %179, i32 noundef 0) #16, !dbg !79
-  br label %rb_vm_check_ints.exit, !dbg !79
-
-rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.exit1, %177
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %8, align 8, !dbg !79, !tbaa !14
-  %181 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !80
-  %182 = load i64*, i64** %181, align 8, !dbg !80
-  store i64 %selfRaw, i64* %182, align 8, !dbg !80, !tbaa !6
-  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !80
-  %184 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !80
-  %185 = bitcast i64* %183 to <2 x i64>*, !dbg !80
-  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %185, align 8, !dbg !80, !tbaa !6
-  %186 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !80
-  store i64* %186, i64** %181, align 8, !dbg !80
-  %send9 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus, i64 0), !dbg !80
-  %187 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !81
-  %188 = load i64*, i64** %187, align 8, !dbg !81
-  store i64 %selfRaw, i64* %188, align 8, !dbg !81, !tbaa !6
-  %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !81
-  store i64 %send9, i64* %189, align 8, !dbg !81, !tbaa !6
-  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !81
-  store i64* %190, i64** %187, align 8, !dbg !81
-  %send11 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !81
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %8, align 8, !dbg !81, !tbaa !14
-  %191 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !82
-  %192 = load i64*, i64** %191, align 8, !dbg !82
-  store i64 %selfRaw, i64* %192, align 8, !dbg !82, !tbaa !6
-  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !82
-  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !82
-  %195 = bitcast i64* %193 to <2 x i64>*, !dbg !82
-  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %195, align 8, !dbg !82, !tbaa !6
-  %196 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !82
-  store i64* %196, i64** %191, align 8, !dbg !82
-  %send13 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus, i64 0), !dbg !82
-  %197 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !83
-  %198 = load i64*, i64** %197, align 8, !dbg !83
-  store i64 %selfRaw, i64* %198, align 8, !dbg !83, !tbaa !6
-  %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !83
-  store i64 %send13, i64* %199, align 8, !dbg !83, !tbaa !6
-  %200 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !83
-  store i64* %200, i64** %197, align 8, !dbg !83
-  %send15 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.12, i64 0), !dbg !83
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %8, align 8, !dbg !83, !tbaa !14
-  %201 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !84
-  %202 = load i64*, i64** %201, align 8, !dbg !84
-  store i64 %selfRaw, i64* %202, align 8, !dbg !84, !tbaa !6
-  %203 = getelementptr inbounds i64, i64* %202, i64 1, !dbg !84
-  %204 = getelementptr inbounds i64, i64* %203, i64 1, !dbg !84
-  %205 = bitcast i64* %203 to <2 x i64>*, !dbg !84
-  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %205, align 8, !dbg !84, !tbaa !6
-  %206 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !84
-  store i64* %206, i64** %201, align 8, !dbg !84
-  %send17 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt, i64 0), !dbg !84
-  %207 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !85
-  %208 = load i64*, i64** %207, align 8, !dbg !85
-  store i64 %selfRaw, i64* %208, align 8, !dbg !85, !tbaa !6
-  %209 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !85
-  store i64 %send17, i64* %209, align 8, !dbg !85, !tbaa !6
-  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !85
-  store i64* %210, i64** %207, align 8, !dbg !85
-  %send19 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.13, i64 0), !dbg !85
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %8, align 8, !dbg !85, !tbaa !14
-  %211 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !86
-  %212 = load i64*, i64** %211, align 8, !dbg !86
-  store i64 %selfRaw, i64* %212, align 8, !dbg !86, !tbaa !6
-  %213 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !86
-  %214 = getelementptr inbounds i64, i64* %213, i64 1, !dbg !86
-  %215 = bitcast i64* %213 to <2 x i64>*, !dbg !86
-  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %215, align 8, !dbg !86, !tbaa !6
-  %216 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !86
-  store i64* %216, i64** %211, align 8, !dbg !86
-  %send21 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.14, i64 0), !dbg !86
-  %217 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !87
-  %218 = load i64*, i64** %217, align 8, !dbg !87
-  store i64 %selfRaw, i64* %218, align 8, !dbg !87, !tbaa !6
-  %219 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !87
-  store i64 %send21, i64* %219, align 8, !dbg !87, !tbaa !6
-  %220 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !87
-  store i64* %220, i64** %217, align 8, !dbg !87
-  %send23 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.15, i64 0), !dbg !87
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 31), i64** %8, align 8, !dbg !87, !tbaa !14
-  %221 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !88
-  %222 = load i64*, i64** %221, align 8, !dbg !88
-  store i64 %selfRaw, i64* %222, align 8, !dbg !88, !tbaa !6
-  %223 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !88
-  %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !88
-  %225 = bitcast i64* %223 to <2 x i64>*, !dbg !88
-  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %225, align 8, !dbg !88, !tbaa !6
-  %226 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !88
-  store i64* %226, i64** %221, align 8, !dbg !88
-  %send25 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte, i64 0), !dbg !88
-  %227 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !89
-  %228 = load i64*, i64** %227, align 8, !dbg !89
-  store i64 %selfRaw, i64* %228, align 8, !dbg !89, !tbaa !6
-  %229 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !89
-  store i64 %send25, i64* %229, align 8, !dbg !89, !tbaa !6
-  %230 = getelementptr inbounds i64, i64* %229, i64 1, !dbg !89
-  store i64* %230, i64** %227, align 8, !dbg !89
-  %send27 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.16, i64 0), !dbg !89
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 32), i64** %8, align 8, !dbg !89, !tbaa !14
-  %231 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !90
-  %232 = load i64*, i64** %231, align 8, !dbg !90
-  store i64 %selfRaw, i64* %232, align 8, !dbg !90, !tbaa !6
-  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !90
-  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !90
-  %235 = bitcast i64* %233 to <2 x i64>*, !dbg !90
-  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %235, align 8, !dbg !90, !tbaa !6
-  %236 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !90
-  store i64* %236, i64** %231, align 8, !dbg !90
-  %send29 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.17, i64 0), !dbg !90
-  %237 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !91
-  %238 = load i64*, i64** %237, align 8, !dbg !91
-  store i64 %selfRaw, i64* %238, align 8, !dbg !91, !tbaa !6
-  %239 = getelementptr inbounds i64, i64* %238, i64 1, !dbg !91
-  store i64 %send29, i64* %239, align 8, !dbg !91, !tbaa !6
-  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !91
-  store i64* %240, i64** %237, align 8, !dbg !91
-  %send31 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.18, i64 0), !dbg !91
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 33), i64** %8, align 8, !dbg !91, !tbaa !14
-  %241 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !92
-  %242 = load i64*, i64** %241, align 8, !dbg !92
-  store i64 %selfRaw, i64* %242, align 8, !dbg !92, !tbaa !6
-  %243 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !92
-  %244 = getelementptr inbounds i64, i64* %243, i64 1, !dbg !92
-  %245 = bitcast i64* %243 to <2 x i64>*, !dbg !92
-  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %245, align 8, !dbg !92, !tbaa !6
-  %246 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !92
-  store i64* %246, i64** %241, align 8, !dbg !92
-  %send33 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.19, i64 0), !dbg !92
-  %247 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !93
-  %248 = load i64*, i64** %247, align 8, !dbg !93
-  store i64 %selfRaw, i64* %248, align 8, !dbg !93, !tbaa !6
-  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !93
-  store i64 %send33, i64* %249, align 8, !dbg !93, !tbaa !6
-  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !93
-  store i64* %250, i64** %247, align 8, !dbg !93
-  %send35 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.20, i64 0), !dbg !93
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 36), i64** %8, align 8, !dbg !93, !tbaa !14
-  %251 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !94
-  %252 = load i64*, i64** %251, align 8, !dbg !94
-  store i64 %selfRaw, i64* %252, align 8, !dbg !94, !tbaa !6
-  %253 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !94
-  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !94
-  %255 = bitcast i64* %253 to <2 x i64>*, !dbg !94
-  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %255, align 8, !dbg !94, !tbaa !6
-  %256 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !94
-  store i64* %256, i64** %251, align 8, !dbg !94
-  %send37 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.21, i64 0), !dbg !94
-  %257 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !95
-  %258 = load i64*, i64** %257, align 8, !dbg !95
-  store i64 %selfRaw, i64* %258, align 8, !dbg !95, !tbaa !6
-  %259 = getelementptr inbounds i64, i64* %258, i64 1, !dbg !95
-  store i64 %send37, i64* %259, align 8, !dbg !95, !tbaa !6
-  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !95
-  store i64* %260, i64** %257, align 8, !dbg !95
-  %send39 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.22, i64 0), !dbg !95
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 37), i64** %8, align 8, !dbg !95, !tbaa !14
-  %rubyStr_8.9 = load i64, i64* @rubyStrFrozen_8.9, align 8, !dbg !96
-  %261 = load i64, i64* @rb_mKernel, align 8, !dbg !96
-  %262 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !96
-  %263 = load i64*, i64** %262, align 8, !dbg !96
-  store i64 %261, i64* %263, align 8, !dbg !96, !tbaa !6
-  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !96
-  store i64 %rubyStr_8.9, i64* %264, align 8, !dbg !96, !tbaa !6
-  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !96
-  store i64* %265, i64** %262, align 8, !dbg !96
-  %send41 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational, i64 0), !dbg !96
-  %266 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !97
-  %267 = load i64*, i64** %266, align 8, !dbg !97
-  store i64 %selfRaw, i64* %267, align 8, !dbg !97, !tbaa !6
-  %268 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !97
-  store i64 36028797018963970, i64* %268, align 8, !dbg !97, !tbaa !6
-  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !97
-  store i64 %send41, i64* %269, align 8, !dbg !97, !tbaa !6
-  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !97
-  store i64* %270, i64** %266, align 8, !dbg !97
-  %send43 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.23, i64 0), !dbg !97
-  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !98
-  %272 = load i64*, i64** %271, align 8, !dbg !98
-  store i64 %selfRaw, i64* %272, align 8, !dbg !98, !tbaa !6
-  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !98
-  store i64 %send43, i64* %273, align 8, !dbg !98, !tbaa !6
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !98
-  store i64* %274, i64** %271, align 8, !dbg !98
-  %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.24, i64 0), !dbg !98
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 38), i64** %8, align 8, !dbg !98, !tbaa !14
-  %rubyStr_5 = load i64, i64* @rubyStrFrozen_5, align 8, !dbg !99
-  %275 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !99
-  %276 = load i64*, i64** %275, align 8, !dbg !99
-  store i64 %261, i64* %276, align 8, !dbg !99, !tbaa !6
-  %277 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !99
-  store i64 1, i64* %277, align 8, !dbg !99, !tbaa !6
-  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !99
-  store i64 %rubyStr_5, i64* %278, align 8, !dbg !99, !tbaa !6
-  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !99
-  store i64* %279, i64** %275, align 8, !dbg !99
-  %send47 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex, i64 0), !dbg !99
-  %280 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !100
-  %281 = load i64*, i64** %280, align 8, !dbg !100
-  store i64 %selfRaw, i64* %281, align 8, !dbg !100, !tbaa !6
-  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !100
-  store i64 36028797018963970, i64* %282, align 8, !dbg !100, !tbaa !6
-  %283 = getelementptr inbounds i64, i64* %282, i64 1, !dbg !100
-  store i64 %send47, i64* %283, align 8, !dbg !100, !tbaa !6
-  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !100
-  store i64* %284, i64** %280, align 8, !dbg !100
-  %send49 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.25, i64 0), !dbg !100
-  %285 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !101
-  %286 = load i64*, i64** %285, align 8, !dbg !101
-  store i64 %selfRaw, i64* %286, align 8, !dbg !101, !tbaa !6
-  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !101
-  store i64 %send49, i64* %287, align 8, !dbg !101, !tbaa !6
-  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !101
-  store i64* %288, i64** %285, align 8, !dbg !101
-  %send51 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.26, i64 0), !dbg !101
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 40), i64** %8, align 8, !dbg !101, !tbaa !14
-  %289 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !102
-  %290 = load i64*, i64** %289, align 8, !dbg !102
-  store i64 %selfRaw, i64* %290, align 8, !dbg !102, !tbaa !6
-  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !102
-  %292 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !102
-  %293 = bitcast i64* %291 to <2 x i64>*, !dbg !102
-  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %293, align 8, !dbg !102, !tbaa !6
-  %294 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !102
-  store i64* %294, i64** %289, align 8, !dbg !102
-  %send53 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.27, i64 0), !dbg !102
-  %295 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !103
-  %296 = load i64*, i64** %295, align 8, !dbg !103
-  store i64 %selfRaw, i64* %296, align 8, !dbg !103, !tbaa !6
-  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !103
-  store i64 %send53, i64* %297, align 8, !dbg !103, !tbaa !6
-  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !103
-  store i64* %298, i64** %295, align 8, !dbg !103
-  %send55 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.28, i64 0), !dbg !103
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 41), i64** %8, align 8, !dbg !103, !tbaa !14
-  %rubyStr_15.4 = load i64, i64* @rubyStrFrozen_15.4, align 8, !dbg !104
-  %299 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !104
-  %300 = load i64*, i64** %299, align 8, !dbg !104
-  store i64 %261, i64* %300, align 8, !dbg !104, !tbaa !6
-  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !104
-  store i64 %rubyStr_15.4, i64* %301, align 8, !dbg !104, !tbaa !6
-  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !104
-  store i64* %302, i64** %299, align 8, !dbg !104
-  %send57 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.29, i64 0), !dbg !104
-  %303 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !105
-  %304 = load i64*, i64** %303, align 8, !dbg !105
-  store i64 %selfRaw, i64* %304, align 8, !dbg !105, !tbaa !6
-  %305 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !105
-  store i64 199622053483197234, i64* %305, align 8, !dbg !105, !tbaa !6
-  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !105
-  store i64 %send57, i64* %306, align 8, !dbg !105, !tbaa !6
-  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !105
-  store i64* %307, i64** %303, align 8, !dbg !105
-  %send59 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.30, i64 0), !dbg !105
-  %308 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !106
-  %309 = load i64*, i64** %308, align 8, !dbg !106
-  store i64 %selfRaw, i64* %309, align 8, !dbg !106, !tbaa !6
-  %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !106
-  store i64 %send59, i64* %310, align 8, !dbg !106, !tbaa !6
-  %311 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !106
-  store i64* %311, i64** %308, align 8, !dbg !106
-  %send61 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.31, i64 0), !dbg !106
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 42), i64** %8, align 8, !dbg !106, !tbaa !14
-  %rubyStr_18 = load i64, i64* @rubyStrFrozen_18, align 8, !dbg !107
-  %312 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !107
-  %313 = load i64*, i64** %312, align 8, !dbg !107
-  store i64 %261, i64* %313, align 8, !dbg !107, !tbaa !6
-  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !107
-  store i64 1, i64* %314, align 8, !dbg !107, !tbaa !6
-  %315 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !107
-  store i64 %rubyStr_18, i64* %315, align 8, !dbg !107, !tbaa !6
-  %316 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !107
-  store i64* %316, i64** %312, align 8, !dbg !107
-  %send63 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex.32, i64 0), !dbg !107
-  %317 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !108
-  %318 = load i64*, i64** %317, align 8, !dbg !108
-  store i64 %selfRaw, i64* %318, align 8, !dbg !108, !tbaa !6
-  %319 = getelementptr inbounds i64, i64* %318, i64 1, !dbg !108
-  store i64 199565758487855106, i64* %319, align 8, !dbg !108, !tbaa !6
-  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !108
-  store i64 %send63, i64* %320, align 8, !dbg !108, !tbaa !6
-  %321 = getelementptr inbounds i64, i64* %320, i64 1, !dbg !108
-  store i64* %321, i64** %317, align 8, !dbg !108
-  %send65 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.33, i64 0), !dbg !108
-  %322 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !109
-  %323 = load i64*, i64** %322, align 8, !dbg !109
-  store i64 %selfRaw, i64* %323, align 8, !dbg !109, !tbaa !6
-  %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !109
-  store i64 %send65, i64* %324, align 8, !dbg !109, !tbaa !6
-  %325 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !109
-  store i64* %325, i64** %322, align 8, !dbg !109
-  %send67 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.34, i64 0), !dbg !109
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 44), i64** %8, align 8, !dbg !109, !tbaa !14
-  %326 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !110
-  %327 = load i64*, i64** %326, align 8, !dbg !110
-  store i64 %selfRaw, i64* %327, align 8, !dbg !110, !tbaa !6
-  %328 = getelementptr inbounds i64, i64* %327, i64 1, !dbg !110
-  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !110
-  %330 = bitcast i64* %328 to <2 x i64>*, !dbg !110
-  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %330, align 8, !dbg !110, !tbaa !6
-  %331 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !110
-  store i64* %331, i64** %326, align 8, !dbg !110
-  %send69 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.35, i64 0), !dbg !110
-  %332 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !111
-  %333 = load i64*, i64** %332, align 8, !dbg !111
-  store i64 %selfRaw, i64* %333, align 8, !dbg !111, !tbaa !6
-  %334 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !111
-  store i64 %send69, i64* %334, align 8, !dbg !111, !tbaa !6
-  %335 = getelementptr inbounds i64, i64* %334, i64 1, !dbg !111
-  store i64* %335, i64** %332, align 8, !dbg !111
-  %send71 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.36, i64 0), !dbg !111
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 45), i64** %8, align 8, !dbg !111, !tbaa !14
-  %rubyStr_25.4 = load i64, i64* @rubyStrFrozen_25.4, align 8, !dbg !112
-  %336 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !112
-  %337 = load i64*, i64** %336, align 8, !dbg !112
-  store i64 %261, i64* %337, align 8, !dbg !112, !tbaa !6
-  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !112
-  store i64 %rubyStr_25.4, i64* %338, align 8, !dbg !112, !tbaa !6
-  %339 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !112
-  store i64* %339, i64** %336, align 8, !dbg !112
-  %send73 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.37, i64 0), !dbg !112
-  %340 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !113
-  %341 = load i64*, i64** %340, align 8, !dbg !113
-  store i64 %selfRaw, i64* %341, align 8, !dbg !113, !tbaa !6
-  %342 = getelementptr inbounds i64, i64* %341, i64 1, !dbg !113
-  store i64 113040350646999450, i64* %342, align 8, !dbg !113, !tbaa !6
-  %343 = getelementptr inbounds i64, i64* %342, i64 1, !dbg !113
-  store i64 %send73, i64* %343, align 8, !dbg !113, !tbaa !6
-  %344 = getelementptr inbounds i64, i64* %343, i64 1, !dbg !113
-  store i64* %344, i64** %340, align 8, !dbg !113
-  %send75 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.38, i64 0), !dbg !113
-  %345 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !114
-  %346 = load i64*, i64** %345, align 8, !dbg !114
-  store i64 %selfRaw, i64* %346, align 8, !dbg !114, !tbaa !6
-  %347 = getelementptr inbounds i64, i64* %346, i64 1, !dbg !114
-  store i64 %send75, i64* %347, align 8, !dbg !114, !tbaa !6
-  %348 = getelementptr inbounds i64, i64* %347, i64 1, !dbg !114
-  store i64* %348, i64** %345, align 8, !dbg !114
-  %send77 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.39, i64 0), !dbg !114
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 47), i64** %8, align 8, !dbg !114, !tbaa !14
-  %349 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !115
-  %350 = load i64*, i64** %349, align 8, !dbg !115
-  store i64 %selfRaw, i64* %350, align 8, !dbg !115, !tbaa !6
-  %351 = getelementptr inbounds i64, i64* %350, i64 1, !dbg !115
-  %352 = getelementptr inbounds i64, i64* %351, i64 1, !dbg !115
-  %353 = bitcast i64* %351 to <2 x i64>*, !dbg !115
-  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %353, align 8, !dbg !115, !tbaa !6
-  %354 = getelementptr inbounds i64, i64* %352, i64 1, !dbg !115
-  store i64* %354, i64** %349, align 8, !dbg !115
-  %send79 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.40, i64 0), !dbg !115
-  %355 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !116
-  %356 = load i64*, i64** %355, align 8, !dbg !116
-  store i64 %selfRaw, i64* %356, align 8, !dbg !116, !tbaa !6
-  %357 = getelementptr inbounds i64, i64* %356, i64 1, !dbg !116
-  store i64 %send79, i64* %357, align 8, !dbg !116, !tbaa !6
-  %358 = getelementptr inbounds i64, i64* %357, i64 1, !dbg !116
-  store i64* %358, i64** %355, align 8, !dbg !116
-  %send81 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.41, i64 0), !dbg !116
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 48), i64** %8, align 8, !dbg !116, !tbaa !14
-  %rubyStr_5.923 = load i64, i64* @rubyStrFrozen_5.923, align 8, !dbg !117
-  %359 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !117
-  %360 = load i64*, i64** %359, align 8, !dbg !117
-  store i64 %261, i64* %360, align 8, !dbg !117, !tbaa !6
-  %361 = getelementptr inbounds i64, i64* %360, i64 1, !dbg !117
-  store i64 %rubyStr_5.923, i64* %361, align 8, !dbg !117, !tbaa !6
-  %362 = getelementptr inbounds i64, i64* %361, i64 1, !dbg !117
-  store i64* %362, i64** %359, align 8, !dbg !117
-  %send83 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.42, i64 0), !dbg !117
-  %363 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !118
-  %364 = load i64*, i64** %363, align 8, !dbg !118
-  store i64 %selfRaw, i64* %364, align 8, !dbg !118, !tbaa !6
-  %365 = getelementptr inbounds i64, i64* %364, i64 1, !dbg !118
-  store i64 113040350646999450, i64* %365, align 8, !dbg !118, !tbaa !6
-  %366 = getelementptr inbounds i64, i64* %365, i64 1, !dbg !118
-  store i64 %send83, i64* %366, align 8, !dbg !118, !tbaa !6
-  %367 = getelementptr inbounds i64, i64* %366, i64 1, !dbg !118
-  store i64* %367, i64** %363, align 8, !dbg !118
-  %send85 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.43, i64 0), !dbg !118
-  %368 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !119
-  %369 = load i64*, i64** %368, align 8, !dbg !119
-  store i64 %selfRaw, i64* %369, align 8, !dbg !119, !tbaa !6
-  %370 = getelementptr inbounds i64, i64* %369, i64 1, !dbg !119
-  store i64 %send85, i64* %370, align 8, !dbg !119, !tbaa !6
-  %371 = getelementptr inbounds i64, i64* %370, i64 1, !dbg !119
-  store i64* %371, i64** %368, align 8, !dbg !119
-  %send87 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.44, i64 0), !dbg !119
-  ret void
-}
-
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$152$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !120 {
+define internal i64 @"func_<root>.17<static-init>$152$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !57 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !58
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !59
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !121
+  %4 = load i64, i64* %3, align 8, !tbaa !60
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !59
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !62
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !61
+  %7 = load i64*, i64** %6, align 8, !tbaa !63
   %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !14
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !122
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !122, !tbaa !68
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !122
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !122, !prof !70
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !64
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !64, !tbaa !65
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !64
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !64, !prof !67
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !122
-  br label %14, !dbg !122
+  tail call void @const_recompute_T(), !dbg !64
+  br label %14, !dbg !64
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !122
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !122
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !122, !tbaa !68
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !122
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !122
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !122
-  %19 = load i64*, i64** %18, align 8, !dbg !122
-  store i64 %15, i64* %19, align 8, !dbg !122, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !122
-  store i64* %20, i64** %18, align 8, !dbg !122
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped, i64 0), !dbg !122
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !123
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !123
-  %23 = load i64*, i64** %22, align 8, !dbg !123
-  store i64 %4, i64* %23, align 8, !dbg !123, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !123
-  store i64 %21, i64* %24, align 8, !dbg !123, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !123
-  store i64 %send, i64* %25, align 8, !dbg !123, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !123
-  store i64* %26, i64** %22, align 8, !dbg !123
-  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !123
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !124
-  %28 = load i64*, i64** %27, align 8, !dbg !124
-  store i64 %15, i64* %28, align 8, !dbg !124, !tbaa !6
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !124
-  store i64* %29, i64** %27, align 8, !dbg !124
-  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.1, i64 0), !dbg !124
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !123
-  %31 = load i64*, i64** %30, align 8, !dbg !123
-  store i64 %send38, i64* %31, align 8, !dbg !123, !tbaa !6
-  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !123
-  store i64 %send40, i64* %32, align 8, !dbg !123, !tbaa !6
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !123
-  store i64* %33, i64** %30, align 8, !dbg !123
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !123
-  ret i64 %send42, !dbg !125
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !64
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !64
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !64, !tbaa !65
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !64
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !64
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !64
+  %19 = load i64*, i64** %18, align 8, !dbg !64
+  store i64 %15, i64* %19, align 8, !dbg !64, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !64
+  store i64* %20, i64** %18, align 8, !dbg !64
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped, i64 0), !dbg !64
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !68
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !68
+  %23 = load i64*, i64** %22, align 8, !dbg !68
+  store i64 %4, i64* %23, align 8, !dbg !68, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !68
+  store i64 %21, i64* %24, align 8, !dbg !68, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !68
+  store i64 %send, i64* %25, align 8, !dbg !68, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !68
+  store i64* %26, i64** %22, align 8, !dbg !68
+  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !68
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !69
+  %28 = load i64*, i64** %27, align 8, !dbg !69
+  store i64 %15, i64* %28, align 8, !dbg !69, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !69
+  store i64* %29, i64** %27, align 8, !dbg !69
+  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.1, i64 0), !dbg !69
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !68
+  %31 = load i64*, i64** %30, align 8, !dbg !68
+  store i64 %send38, i64* %31, align 8, !dbg !68, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !68
+  store i64 %send40, i64* %32, align 8, !dbg !68, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !68
+  store i64* %33, i64** %30, align 8, !dbg !68
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !68
+  ret i64 %send42, !dbg !70
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$152$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !126 {
+define internal i64 @"func_<root>.17<static-init>$152$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !71 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !58
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !59
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !121
+  %4 = load i64, i64* %3, align 8, !tbaa !60
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_2", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !59
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !62
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !61
+  %7 = load i64*, i64** %6, align 8, !tbaa !63
   %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %10, align 8, !tbaa !14
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !127
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !127, !tbaa !68
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !127
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !127, !prof !70
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !72
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !72, !tbaa !65
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !72
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !72, !prof !67
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !127
-  br label %14, !dbg !127
+  tail call void @const_recompute_T(), !dbg !72
+  br label %14, !dbg !72
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !127
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !127
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !127, !tbaa !68
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !127
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !127
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !127
-  %19 = load i64*, i64** %18, align 8, !dbg !127
-  store i64 %15, i64* %19, align 8, !dbg !127, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !127
-  store i64* %20, i64** %18, align 8, !dbg !127
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.2, i64 0), !dbg !127
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !128
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !128
-  %23 = load i64*, i64** %22, align 8, !dbg !128
-  store i64 %4, i64* %23, align 8, !dbg !128, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !128
-  store i64 %21, i64* %24, align 8, !dbg !128, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !128
-  store i64 %send, i64* %25, align 8, !dbg !128, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !128
-  store i64* %26, i64** %22, align 8, !dbg !128
-  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.3, i64 0), !dbg !128
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !129
-  %28 = load i64*, i64** %27, align 8, !dbg !129
-  store i64 %15, i64* %28, align 8, !dbg !129, !tbaa !6
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !129
-  store i64* %29, i64** %27, align 8, !dbg !129
-  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.4, i64 0), !dbg !129
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !128
-  %31 = load i64*, i64** %30, align 8, !dbg !128
-  store i64 %send38, i64* %31, align 8, !dbg !128, !tbaa !6
-  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !128
-  store i64 %send40, i64* %32, align 8, !dbg !128, !tbaa !6
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !128
-  store i64* %33, i64** %30, align 8, !dbg !128
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.5, i64 0), !dbg !128
-  ret i64 %send42, !dbg !130
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !72
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !72
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !72, !tbaa !65
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !72
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !72
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !72
+  %19 = load i64*, i64** %18, align 8, !dbg !72
+  store i64 %15, i64* %19, align 8, !dbg !72, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !72
+  store i64* %20, i64** %18, align 8, !dbg !72
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.2, i64 0), !dbg !72
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !73
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !73
+  %23 = load i64*, i64** %22, align 8, !dbg !73
+  store i64 %4, i64* %23, align 8, !dbg !73, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !73
+  store i64 %21, i64* %24, align 8, !dbg !73, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !73
+  store i64 %send, i64* %25, align 8, !dbg !73, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !73
+  store i64* %26, i64** %22, align 8, !dbg !73
+  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.3, i64 0), !dbg !73
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !74
+  %28 = load i64*, i64** %27, align 8, !dbg !74
+  store i64 %15, i64* %28, align 8, !dbg !74, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !74
+  store i64* %29, i64** %27, align 8, !dbg !74
+  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.4, i64 0), !dbg !74
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !73
+  %31 = load i64*, i64** %30, align 8, !dbg !73
+  store i64 %send38, i64* %31, align 8, !dbg !73, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !73
+  store i64 %send40, i64* %32, align 8, !dbg !73, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !73
+  store i64* %33, i64** %30, align 8, !dbg !73
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.5, i64 0), !dbg !73
+  ret i64 %send42, !dbg !75
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$152$block_3"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !131 {
+define internal i64 @"func_<root>.17<static-init>$152$block_3"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !76 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !58
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !59
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !121
+  %4 = load i64, i64* %3, align 8, !tbaa !60
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_3", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !59
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !62
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !61
+  %7 = load i64*, i64** %6, align 8, !tbaa !63
   %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %10, align 8, !tbaa !14
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !132
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !132, !tbaa !68
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !132
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !132, !prof !70
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !77
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !77, !tbaa !65
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !77
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !77, !prof !67
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !132
-  br label %14, !dbg !132
+  tail call void @const_recompute_T(), !dbg !77
+  br label %14, !dbg !77
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !132
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !132
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !132, !tbaa !68
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !132
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !132
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !132
-  %19 = load i64*, i64** %18, align 8, !dbg !132
-  store i64 %15, i64* %19, align 8, !dbg !132, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !132
-  store i64* %20, i64** %18, align 8, !dbg !132
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.6, i64 0), !dbg !132
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !133
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !133
-  %23 = load i64*, i64** %22, align 8, !dbg !133
-  store i64 %4, i64* %23, align 8, !dbg !133, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !133
-  store i64 %21, i64* %24, align 8, !dbg !133, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !133
-  store i64 %send, i64* %25, align 8, !dbg !133, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !133
-  store i64* %26, i64** %22, align 8, !dbg !133
-  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.7, i64 0), !dbg !133
-  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !133
-  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !133, !tbaa !68
-  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !133
-  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !133, !prof !70
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !77
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !77
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !77, !tbaa !65
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !77
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !77
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !77
+  %19 = load i64*, i64** %18, align 8, !dbg !77
+  store i64 %15, i64* %19, align 8, !dbg !77, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !77
+  store i64* %20, i64** %18, align 8, !dbg !77
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.6, i64 0), !dbg !77
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !78
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !78
+  %23 = load i64*, i64** %22, align 8, !dbg !78
+  store i64 %4, i64* %23, align 8, !dbg !78, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !78
+  store i64 %21, i64* %24, align 8, !dbg !78, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !78
+  store i64 %send, i64* %25, align 8, !dbg !78, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !78
+  store i64* %26, i64** %22, align 8, !dbg !78
+  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.7, i64 0), !dbg !78
+  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !78
+  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !78, !tbaa !65
+  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !78
+  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !78, !prof !67
 
 29:                                               ; preds = %14
-  tail call void @"const_recompute_T::Boolean"(), !dbg !133
-  br label %30, !dbg !133
+  tail call void @"const_recompute_T::Boolean"(), !dbg !78
+  br label %30, !dbg !78
 
 30:                                               ; preds = %14, %29
-  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !133
-  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !133
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !133, !tbaa !68
-  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !133
-  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !133
-  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !133
-  %35 = load i64*, i64** %34, align 8, !dbg !133
-  store i64 %send34, i64* %35, align 8, !dbg !133, !tbaa !6
-  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !133
-  store i64 %31, i64* %36, align 8, !dbg !133, !tbaa !6
-  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !133
-  store i64* %37, i64** %34, align 8, !dbg !133
-  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.8, i64 0), !dbg !133
-  ret i64 %send36, !dbg !134
+  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !78
+  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !78
+  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !78, !tbaa !65
+  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !78
+  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !78
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !78
+  %35 = load i64*, i64** %34, align 8, !dbg !78
+  store i64 %send34, i64* %35, align 8, !dbg !78, !tbaa !6
+  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !78
+  store i64 %31, i64* %36, align 8, !dbg !78, !tbaa !6
+  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !78
+  store i64* %37, i64** %34, align 8, !dbg !78
+  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.8, i64 0), !dbg !78
+  ret i64 %send36, !dbg !79
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$152$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !135 {
+define internal i64 @"func_<root>.17<static-init>$152$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !80 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !58
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !59
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !121
+  %4 = load i64, i64* %3, align 8, !tbaa !60
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_4", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !59
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !62
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !61
+  %7 = load i64*, i64** %6, align 8, !tbaa !63
   %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %10, align 8, !tbaa !14
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !136
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !136, !tbaa !68
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !136
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !136, !prof !70
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !81
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !81, !tbaa !65
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !81
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !81, !prof !67
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !136
-  br label %14, !dbg !136
+  tail call void @const_recompute_T(), !dbg !81
+  br label %14, !dbg !81
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !136
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !136
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !136, !tbaa !68
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !136
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !136
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !136
-  %19 = load i64*, i64** %18, align 8, !dbg !136
-  store i64 %15, i64* %19, align 8, !dbg !136, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !136
-  store i64* %20, i64** %18, align 8, !dbg !136
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.9, i64 0), !dbg !136
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !137
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !137
-  %23 = load i64*, i64** %22, align 8, !dbg !137
-  store i64 %4, i64* %23, align 8, !dbg !137, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !137
-  store i64 %21, i64* %24, align 8, !dbg !137, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !137
-  store i64 %send, i64* %25, align 8, !dbg !137, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !137
-  store i64* %26, i64** %22, align 8, !dbg !137
-  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.10, i64 0), !dbg !137
-  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !137
-  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !137, !tbaa !68
-  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !137
-  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !137, !prof !70
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !81
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !81
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !81, !tbaa !65
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !81
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !81
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !81
+  %19 = load i64*, i64** %18, align 8, !dbg !81
+  store i64 %15, i64* %19, align 8, !dbg !81, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !81
+  store i64* %20, i64** %18, align 8, !dbg !81
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.9, i64 0), !dbg !81
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !82
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !82
+  %23 = load i64*, i64** %22, align 8, !dbg !82
+  store i64 %4, i64* %23, align 8, !dbg !82, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !82
+  store i64 %21, i64* %24, align 8, !dbg !82, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !82
+  store i64 %send, i64* %25, align 8, !dbg !82, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !82
+  store i64* %26, i64** %22, align 8, !dbg !82
+  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.10, i64 0), !dbg !82
+  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !82
+  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !82, !tbaa !65
+  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !82
+  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !82, !prof !67
 
 29:                                               ; preds = %14
-  tail call void @"const_recompute_T::Boolean"(), !dbg !137
-  br label %30, !dbg !137
+  tail call void @"const_recompute_T::Boolean"(), !dbg !82
+  br label %30, !dbg !82
 
 30:                                               ; preds = %14, %29
-  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !137
-  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !137
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !137, !tbaa !68
-  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !137
-  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !137
-  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !137
-  %35 = load i64*, i64** %34, align 8, !dbg !137
-  store i64 %send34, i64* %35, align 8, !dbg !137, !tbaa !6
-  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !137
-  store i64 %31, i64* %36, align 8, !dbg !137, !tbaa !6
-  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !137
-  store i64* %37, i64** %34, align 8, !dbg !137
-  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.11, i64 0), !dbg !137
-  ret i64 %send36, !dbg !138
+  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !82
+  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !82
+  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !82, !tbaa !65
+  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !82
+  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !82
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !82
+  %35 = load i64*, i64** %34, align 8, !dbg !82
+  store i64 %send34, i64* %35, align 8, !dbg !82, !tbaa !6
+  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !82
+  store i64 %31, i64* %36, align 8, !dbg !82, !tbaa !6
+  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !82
+  store i64* %37, i64** %34, align 8, !dbg !82
+  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.11, i64 0), !dbg !82
+  ret i64 %send36, !dbg !83
 }
 
-; Function Attrs: ssp
-define void @Init_float-intrinsics() local_unnamed_addr #8 {
+; Function Attrs: sspreq
+define void @Init_float-intrinsics() local_unnamed_addr #9 {
 entry:
+  %positional_table.i = alloca i64, i32 2, align 8, !dbg !84
+  %positional_table321.i = alloca i64, i32 2, align 8, !dbg !85
+  %positional_table335.i = alloca i64, i32 2, align 8, !dbg !86
+  %positional_table349.i = alloca i64, i32 2, align 8, !dbg !87
   %locals.i163.i = alloca i64, align 8
   %locals.i161.i = alloca i64, i32 0, align 8
   %locals.i159.i = alloca i64, i32 0, align 8
   %locals.i157.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, i32 2, align 8, !dbg !123
-  %keywords12.i = alloca i64, i32 2, align 8, !dbg !128
-  %keywords26.i = alloca i64, i32 2, align 8, !dbg !133
-  %keywords38.i = alloca i64, i32 2, align 8, !dbg !137
+  %keywords.i = alloca i64, i32 2, align 8, !dbg !68
+  %keywords12.i = alloca i64, i32 2, align 8, !dbg !73
+  %keywords26.i = alloca i64, i32 2, align 8, !dbg !78
+  %keywords38.i = alloca i64, i32 2, align 8, !dbg !82
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %0)
@@ -1580,49 +886,49 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %2)
   %3 = bitcast i64* %keywords38.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %3)
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #16
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #17
   store i64 %4, i64* @rubyIdPrecomputed_plus, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #16
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #16
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #17
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #17
   store i64 %6, i64* @rubyIdPrecomputed_minus, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_-, i64 0, i64 0), i64 noundef 1) #16
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_-, i64 0, i64 0), i64 noundef 1) #17
   store i64 %7, i64* @rubyIdPrecomputed_-, align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #16
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #17
   store i64 %8, i64* @rubyIdPrecomputed_lt, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_<", i64 0, i64 0), i64 noundef 1) #16
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #16
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_<", i64 0, i64 0), i64 noundef 1) #17
+  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #17
   store i64 %10, i64* @rubyIdPrecomputed_lte, align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @"str_<=", i64 0, i64 0), i64 noundef 2) #16
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @"str_<=", i64 0, i64 0), i64 noundef 2) #17
+  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
   store i64 %12, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #16
+  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #17
   store i64 %13, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #16
+  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #17
   store i64 %14, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #16
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #17
   store i64 %15, i64* @rubyIdPrecomputed_x, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_y, i64 0, i64 0), i64 noundef 1) #16
+  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_y, i64 0, i64 0), i64 noundef 1) #17
   store i64 %16, i64* @rubyIdPrecomputed_y, align 8
-  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_untyped, i64 0, i64 0), i64 noundef 7) #16
+  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_untyped, i64 0, i64 0), i64 noundef 7) #17
   store i64 %17, i64* @rubyIdPrecomputed_untyped, align 8
-  %18 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #16
+  %18 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #17
   store i64 %18, i64* @rubyIdPrecomputed_params, align 8
-  %19 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #16
+  %19 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #17
   store i64 %19, i64* @rubyIdPrecomputed_returns, align 8
-  %20 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #16
+  %20 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #17
   store i64 %20, i64* @rubyIdPrecomputed_extend, align 8
-  %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
-  %22 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #16
+  %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #17
+  %22 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #17
   store i64 %22, i64* @rubyIdPrecomputed_p, align 8
-  %23 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_Rational, i64 0, i64 0), i64 noundef 8) #16
+  %23 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_Rational, i64 0, i64 0), i64 noundef 8) #17
   store i64 %23, i64* @rubyIdPrecomputed_Rational, align 8
-  %24 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Complex, i64 0, i64 0), i64 noundef 7) #16
+  %24 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Complex, i64 0, i64 0), i64 noundef 7) #17
   store i64 %24, i64* @rubyIdPrecomputed_Complex, align 8
-  %25 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #16
-  tail call void @rb_gc_register_mark_object(i64 %25) #16
+  %25 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #17
+  tail call void @rb_gc_register_mark_object(i64 %25) #17
   store i64 %25, i64* @rubyStrFrozen_plus, align 8
-  %26 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/float-intrinsics.rb", i64 0, i64 0), i64 noundef 42) #16
-  tail call void @rb_gc_register_mark_object(i64 %26) #16
+  %26 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/float-intrinsics.rb", i64 0, i64 0), i64 noundef 42) #17
+  tail call void @rb_gc_register_mark_object(i64 %26) #17
   store i64 %26, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 49)
   %rubyId_plus.i.i = load i64, i64* @rubyIdPrecomputed_plus, align 8
@@ -1630,28 +936,28 @@ entry:
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_plus.i.i, i64 %rubyId_plus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8
-  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #16
-  call void @rb_gc_register_mark_object(i64 %28) #16
+  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #17
+  call void @rb_gc_register_mark_object(i64 %28) #17
   %rubyId_minus.i.i = load i64, i64* @rubyIdPrecomputed_minus, align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i156.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %29 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %28, i64 %rubyId_minus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i156.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i157.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %29, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8
   %rubyId_-.i = load i64, i64* @rubyIdPrecomputed_-, align 8, !dbg !37
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_-, i64 %rubyId_-.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !37
-  %30 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #16
-  call void @rb_gc_register_mark_object(i64 %30) #16
+  %30 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #17
+  call void @rb_gc_register_mark_object(i64 %30) #17
   %rubyId_lt.i.i = load i64, i64* @rubyIdPrecomputed_lt, align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i158.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %31 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %30, i64 %rubyId_lt.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i158.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 18, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i159.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %31, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8
-  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #16
-  call void @rb_gc_register_mark_object(i64 %32) #16
+  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #17
+  call void @rb_gc_register_mark_object(i64 %32) #17
   %rubyId_lte.i.i = load i64, i64* @rubyIdPrecomputed_lte, align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i160.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %33 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %32, i64 %rubyId_lte.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i160.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 23, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i161.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %33, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8
-  %34 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
-  call void @rb_gc_register_mark_object(i64 %34) #16
+  %34 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
+  call void @rb_gc_register_mark_object(i64 %34) #17
   %35 = bitcast i64* %locals.i163.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -1661,8 +967,8 @@ entry:
   %36 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %34, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i162.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i163.i, i32 noundef 1, i32 noundef 4)
   store %struct.rb_iseq_struct* %36, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35)
-  %37 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #16
-  call void @rb_gc_register_mark_object(i64 %37) #16
+  %37 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #17
+  call void @rb_gc_register_mark_object(i64 %37) #17
   store i64 %37, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
@@ -1687,178 +993,730 @@ entry:
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i176.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %41 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i175.i", i64 %"rubyId_block in <top (required)>.i174.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i176.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i173.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %41, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_4", align 8
-  %rubyId_untyped.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !122
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !122
-  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !123
-  %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !123
-  %42 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !123
-  store i64 %42, i64* %keywords.i, align 8, !dbg !123
-  %rubyId_y.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !123
-  %43 = call i64 @rb_id2sym(i64 %rubyId_y.i) #18, !dbg !123
-  %44 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !123
-  store i64 %43, i64* %44, align 8, !dbg !123
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords.i), !dbg !123
-  %rubyId_untyped6.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !124
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped6.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !124
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !123
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !123
-  %rubyId_untyped9.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !127
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.2, i64 %rubyId_untyped9.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !127
-  %rubyId_params11.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !128
-  %rubyId_x13.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !128
-  %45 = call i64 @rb_id2sym(i64 %rubyId_x13.i) #18, !dbg !128
-  store i64 %45, i64* %keywords12.i, align 8, !dbg !128
-  %rubyId_y15.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !128
-  %46 = call i64 @rb_id2sym(i64 %rubyId_y15.i) #18, !dbg !128
-  %47 = getelementptr i64, i64* %keywords12.i, i32 1, !dbg !128
-  store i64 %46, i64* %47, align 8, !dbg !128
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.3, i64 %rubyId_params11.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords12.i), !dbg !128
-  %rubyId_untyped19.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !129
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.4, i64 %rubyId_untyped19.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !129
-  %rubyId_returns21.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !128
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.5, i64 %rubyId_returns21.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !128
-  %rubyId_untyped23.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !132
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.6, i64 %rubyId_untyped23.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !132
-  %rubyId_params25.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !133
-  %rubyId_x27.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !133
-  %48 = call i64 @rb_id2sym(i64 %rubyId_x27.i) #18, !dbg !133
-  store i64 %48, i64* %keywords26.i, align 8, !dbg !133
-  %rubyId_y29.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !133
-  %49 = call i64 @rb_id2sym(i64 %rubyId_y29.i) #18, !dbg !133
-  %50 = getelementptr i64, i64* %keywords26.i, i32 1, !dbg !133
-  store i64 %49, i64* %50, align 8, !dbg !133
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.7, i64 %rubyId_params25.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords26.i), !dbg !133
-  %rubyId_returns33.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !133
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.8, i64 %rubyId_returns33.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !133
-  %rubyId_untyped35.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !136
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.9, i64 %rubyId_untyped35.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !136
-  %rubyId_params37.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !137
-  %rubyId_x39.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !137
-  %51 = call i64 @rb_id2sym(i64 %rubyId_x39.i) #18, !dbg !137
-  store i64 %51, i64* %keywords38.i, align 8, !dbg !137
-  %rubyId_y41.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !137
-  %52 = call i64 @rb_id2sym(i64 %rubyId_y41.i) #18, !dbg !137
-  %53 = getelementptr i64, i64* %keywords38.i, i32 1, !dbg !137
-  store i64 %52, i64* %53, align 8, !dbg !137
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.10, i64 %rubyId_params37.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords38.i), !dbg !137
-  %rubyId_returns45.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !137
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.11, i64 %rubyId_returns45.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !137
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !67
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !67
-  %rubyId_plus.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !80
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus, i64 %rubyId_plus.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !80
-  %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !81
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !81
-  %rubyId_minus.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !82
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus, i64 %rubyId_minus.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !82
-  %rubyId_p55.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !83
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p55.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !83
-  %rubyId_lt.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !84
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt, i64 %rubyId_lt.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !84
-  %rubyId_p60.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !85
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p60.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !85
-  %rubyId_lt63.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !86
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.14, i64 %rubyId_lt63.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !86
-  %rubyId_p66.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !87
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.15, i64 %rubyId_p66.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !87
-  %rubyId_lte.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !88
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte, i64 %rubyId_lte.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !88
-  %rubyId_p71.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !89
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.16, i64 %rubyId_p71.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !89
-  %rubyId_lte74.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !90
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.17, i64 %rubyId_lte74.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !90
-  %rubyId_p77.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !91
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.18, i64 %rubyId_p77.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !91
-  %rubyId_lte80.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !92
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.19, i64 %rubyId_lte80.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !92
-  %rubyId_p83.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !93
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.20, i64 %rubyId_p83.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !93
-  %rubyId_plus86.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !94
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.21, i64 %rubyId_plus86.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !94
-  %rubyId_p89.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !95
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.22, i64 %rubyId_p89.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !95
-  %54 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_8.9, i64 0, i64 0), i64 noundef 3) #16
-  call void @rb_gc_register_mark_object(i64 %54) #16
+  %rubyId_untyped.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !64
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !64
+  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !68
+  %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !68
+  %42 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !68
+  store i64 %42, i64* %keywords.i, align 8, !dbg !68
+  %rubyId_y.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !68
+  %43 = call i64 @rb_id2sym(i64 %rubyId_y.i) #18, !dbg !68
+  %44 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !68
+  store i64 %43, i64* %44, align 8, !dbg !68
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords.i), !dbg !68
+  %rubyId_untyped6.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !69
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped6.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !69
+  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !68
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !68
+  %rubyId_untyped9.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !72
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.2, i64 %rubyId_untyped9.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !72
+  %rubyId_params11.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !73
+  %rubyId_x13.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !73
+  %45 = call i64 @rb_id2sym(i64 %rubyId_x13.i) #18, !dbg !73
+  store i64 %45, i64* %keywords12.i, align 8, !dbg !73
+  %rubyId_y15.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !73
+  %46 = call i64 @rb_id2sym(i64 %rubyId_y15.i) #18, !dbg !73
+  %47 = getelementptr i64, i64* %keywords12.i, i32 1, !dbg !73
+  store i64 %46, i64* %47, align 8, !dbg !73
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.3, i64 %rubyId_params11.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords12.i), !dbg !73
+  %rubyId_untyped19.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !74
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.4, i64 %rubyId_untyped19.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !74
+  %rubyId_returns21.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !73
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.5, i64 %rubyId_returns21.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !73
+  %rubyId_untyped23.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !77
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.6, i64 %rubyId_untyped23.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !77
+  %rubyId_params25.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !78
+  %rubyId_x27.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !78
+  %48 = call i64 @rb_id2sym(i64 %rubyId_x27.i) #18, !dbg !78
+  store i64 %48, i64* %keywords26.i, align 8, !dbg !78
+  %rubyId_y29.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !78
+  %49 = call i64 @rb_id2sym(i64 %rubyId_y29.i) #18, !dbg !78
+  %50 = getelementptr i64, i64* %keywords26.i, i32 1, !dbg !78
+  store i64 %49, i64* %50, align 8, !dbg !78
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.7, i64 %rubyId_params25.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords26.i), !dbg !78
+  %rubyId_returns33.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !78
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.8, i64 %rubyId_returns33.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !78
+  %rubyId_untyped35.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !81
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.9, i64 %rubyId_untyped35.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !81
+  %rubyId_params37.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !82
+  %rubyId_x39.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !82
+  %51 = call i64 @rb_id2sym(i64 %rubyId_x39.i) #18, !dbg !82
+  store i64 %51, i64* %keywords38.i, align 8, !dbg !82
+  %rubyId_y41.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !82
+  %52 = call i64 @rb_id2sym(i64 %rubyId_y41.i) #18, !dbg !82
+  %53 = getelementptr i64, i64* %keywords38.i, i32 1, !dbg !82
+  store i64 %52, i64* %53, align 8, !dbg !82
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.10, i64 %rubyId_params37.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords38.i), !dbg !82
+  %rubyId_returns45.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !82
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.11, i64 %rubyId_returns45.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !82
+  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !88
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !88
+  %rubyId_plus.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !89
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus, i64 %rubyId_plus.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !89
+  %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !90
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !90
+  %rubyId_minus.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !91
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus, i64 %rubyId_minus.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !91
+  %rubyId_p55.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !92
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p55.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !92
+  %rubyId_lt.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !93
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt, i64 %rubyId_lt.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !93
+  %rubyId_p60.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !94
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p60.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !94
+  %rubyId_lt63.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !95
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.14, i64 %rubyId_lt63.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !95
+  %rubyId_p66.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !96
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.15, i64 %rubyId_p66.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !96
+  %rubyId_lte.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !97
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte, i64 %rubyId_lte.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !97
+  %rubyId_p71.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !98
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.16, i64 %rubyId_p71.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !98
+  %rubyId_lte74.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !99
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.17, i64 %rubyId_lte74.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !99
+  %rubyId_p77.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !100
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.18, i64 %rubyId_p77.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !100
+  %rubyId_lte80.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !101
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.19, i64 %rubyId_lte80.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !101
+  %rubyId_p83.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !102
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.20, i64 %rubyId_p83.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !102
+  %rubyId_plus86.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !103
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.21, i64 %rubyId_plus86.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !103
+  %rubyId_p89.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !104
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.22, i64 %rubyId_p89.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
+  %54 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_8.9, i64 0, i64 0), i64 noundef 3) #17
+  call void @rb_gc_register_mark_object(i64 %54) #17
   store i64 %54, i64* @rubyStrFrozen_8.9, align 8
-  %rubyId_Rational.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !96
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !96
-  %rubyId_plus93.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !97
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.23, i64 %rubyId_plus93.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !97
-  %rubyId_p96.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !98
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.24, i64 %rubyId_p96.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !98
-  %55 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_5, i64 0, i64 0), i64 noundef 1) #16
-  call void @rb_gc_register_mark_object(i64 %55) #16
+  %rubyId_Rational.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !105
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !105
+  %rubyId_plus93.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !106
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.23, i64 %rubyId_plus93.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !106
+  %rubyId_p96.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !107
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.24, i64 %rubyId_p96.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !107
+  %55 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_5, i64 0, i64 0), i64 noundef 1) #17
+  call void @rb_gc_register_mark_object(i64 %55) #17
   store i64 %55, i64* @rubyStrFrozen_5, align 8
-  %rubyId_Complex.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !99
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex, i64 %rubyId_Complex.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !99
-  %rubyId_plus100.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !100
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.25, i64 %rubyId_plus100.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !100
-  %rubyId_p103.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !101
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.26, i64 %rubyId_p103.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !101
-  %rubyId_minus106.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !102
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.27, i64 %rubyId_minus106.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !102
-  %rubyId_p109.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !103
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.28, i64 %rubyId_p109.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !103
-  %56 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_15.4, i64 0, i64 0), i64 noundef 4) #16
-  call void @rb_gc_register_mark_object(i64 %56) #16
+  %rubyId_Complex.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !108
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex, i64 %rubyId_Complex.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !108
+  %rubyId_plus100.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !109
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.25, i64 %rubyId_plus100.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !109
+  %rubyId_p103.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !110
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.26, i64 %rubyId_p103.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !110
+  %rubyId_minus106.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !111
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.27, i64 %rubyId_minus106.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !111
+  %rubyId_p109.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !112
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.28, i64 %rubyId_p109.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
+  %56 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_15.4, i64 0, i64 0), i64 noundef 4) #17
+  call void @rb_gc_register_mark_object(i64 %56) #17
   store i64 %56, i64* @rubyStrFrozen_15.4, align 8
-  %rubyId_Rational112.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !104
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.29, i64 %rubyId_Rational112.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
-  %rubyId_minus114.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !105
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.30, i64 %rubyId_minus114.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !105
-  %rubyId_p117.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !106
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.31, i64 %rubyId_p117.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !106
-  %57 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_18, i64 0, i64 0), i64 noundef 2) #16
-  call void @rb_gc_register_mark_object(i64 %57) #16
+  %rubyId_Rational112.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !113
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.29, i64 %rubyId_Rational112.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !113
+  %rubyId_minus114.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !114
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.30, i64 %rubyId_minus114.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !114
+  %rubyId_p117.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !115
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.31, i64 %rubyId_p117.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !115
+  %57 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_18, i64 0, i64 0), i64 noundef 2) #17
+  call void @rb_gc_register_mark_object(i64 %57) #17
   store i64 %57, i64* @rubyStrFrozen_18, align 8
-  %rubyId_Complex120.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !107
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.32, i64 %rubyId_Complex120.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !107
-  %rubyId_minus122.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !108
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.33, i64 %rubyId_minus122.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !108
-  %rubyId_p125.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !109
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.34, i64 %rubyId_p125.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !109
-  %rubyId_lt128.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !110
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.35, i64 %rubyId_lt128.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !110
-  %rubyId_p131.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !111
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.36, i64 %rubyId_p131.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !111
-  %58 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_25.4, i64 0, i64 0), i64 noundef 4) #16
-  call void @rb_gc_register_mark_object(i64 %58) #16
+  %rubyId_Complex120.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !116
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.32, i64 %rubyId_Complex120.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !116
+  %rubyId_minus122.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !117
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.33, i64 %rubyId_minus122.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !117
+  %rubyId_p125.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !118
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.34, i64 %rubyId_p125.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !118
+  %rubyId_lt128.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !119
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.35, i64 %rubyId_lt128.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !119
+  %rubyId_p131.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !120
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.36, i64 %rubyId_p131.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !120
+  %58 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_25.4, i64 0, i64 0), i64 noundef 4) #17
+  call void @rb_gc_register_mark_object(i64 %58) #17
   store i64 %58, i64* @rubyStrFrozen_25.4, align 8
-  %rubyId_Rational134.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !112
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.37, i64 %rubyId_Rational134.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
-  %rubyId_lt136.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !113
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.38, i64 %rubyId_lt136.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !113
-  %rubyId_p139.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !114
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.39, i64 %rubyId_p139.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !114
-  %rubyId_lte142.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !115
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.40, i64 %rubyId_lte142.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !115
-  %rubyId_p145.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !116
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.41, i64 %rubyId_p145.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !116
-  %59 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_5.923, i64 0, i64 0), i64 noundef 5) #16
-  call void @rb_gc_register_mark_object(i64 %59) #16
+  %rubyId_Rational134.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !121
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.37, i64 %rubyId_Rational134.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !121
+  %rubyId_lt136.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !122
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.38, i64 %rubyId_lt136.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !122
+  %rubyId_p139.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !123
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.39, i64 %rubyId_p139.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !123
+  %rubyId_lte142.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !124
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.40, i64 %rubyId_lte142.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !124
+  %rubyId_p145.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !125
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.41, i64 %rubyId_p145.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !125
+  %59 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_5.923, i64 0, i64 0), i64 noundef 5) #17
+  call void @rb_gc_register_mark_object(i64 %59) #17
   store i64 %59, i64* @rubyStrFrozen_5.923, align 8
-  %rubyId_Rational148.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !117
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.42, i64 %rubyId_Rational148.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !117
-  %rubyId_lte150.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !118
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.43, i64 %rubyId_lte150.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !118
-  %rubyId_p153.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !119
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.44, i64 %rubyId_p153.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !119
+  %rubyId_Rational148.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !126
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.42, i64 %rubyId_Rational148.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !126
+  %rubyId_lte150.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !127
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.43, i64 %rubyId_lte150.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !127
+  %rubyId_p153.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !128
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.44, i64 %rubyId_p153.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !128
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %3)
   %60 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %61 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %60, i64 0, i32 18
-  %62 = load i64, i64* %61, align 8, !tbaa !139
+  %62 = load i64, i64* %61, align 8, !tbaa !129
   %63 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %64 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %63, i64 0, i32 2
-  %65 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %64, align 8, !tbaa !58
-  call fastcc void @"func_<root>.17<static-init>$152"(i64 %62, %struct.rb_control_frame_struct* %65) #16
+  %65 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %64, align 8, !tbaa !59
+  %66 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %66)
+  %67 = bitcast i64* %positional_table321.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %67)
+  %68 = bitcast i64* %positional_table335.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %68)
+  %69 = bitcast i64* %positional_table349.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %69)
+  %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %70 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %70, align 8, !tbaa !62
+  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 4
+  %72 = load i64*, i64** %71, align 8, !tbaa !63
+  %73 = load i64, i64* %72, align 8, !tbaa !6
+  %74 = and i64 %73, -33
+  store i64 %74, i64* %72, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %63, %struct.rb_control_frame_struct* %65, %struct.rb_iseq_struct* %stackFrame.i) #17
+  %75 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 0
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %75, align 8, !dbg !137, !tbaa !14
+  %rubyId_plus.i1 = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !138
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_plus.i1) #17, !dbg !138
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i, i64 %62, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_1") #17, !dbg !138
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %75, align 8, !dbg !138, !tbaa !14
+  %rubyId_minus.i2 = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !139
+  %rawSym258.i = call i64 @rb_id2sym(i64 %rubyId_minus.i2) #17, !dbg !139
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym258.i, i64 %62, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_2") #17, !dbg !139
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %75, align 8, !dbg !139, !tbaa !14
+  %rubyId_lt.i3 = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !140
+  %rawSym272.i = call i64 @rb_id2sym(i64 %rubyId_lt.i3) #17, !dbg !140
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym272.i, i64 %62, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_3") #17, !dbg !140
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %75, align 8, !dbg !140, !tbaa !14
+  %rubyId_lte.i4 = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !141
+  %rawSym286.i = call i64 @rb_id2sym(i64 %rubyId_lte.i4) #17, !dbg !141
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym286.i, i64 %62, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_4") #17, !dbg !141
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %75, align 8, !dbg !141, !tbaa !14
+  %76 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !88
+  %77 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !88, !tbaa !65
+  %needTakeSlowPath = icmp ne i64 %76, %77, !dbg !88
+  br i1 %needTakeSlowPath, label %78, label %79, !dbg !88, !prof !67
+
+78:                                               ; preds = %entry
+  call void @"const_recompute_T::Sig"(), !dbg !88
+  br label %79, !dbg !88
+
+79:                                               ; preds = %entry, %78
+  %80 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !88
+  %81 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !88
+  %82 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !88, !tbaa !65
+  %guardUpdated = icmp eq i64 %81, %82, !dbg !88
+  call void @llvm.assume(i1 %guardUpdated), !dbg !88
+  %83 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !88
+  %84 = load i64*, i64** %83, align 8, !dbg !88
+  store i64 %62, i64* %84, align 8, !dbg !88, !tbaa !6
+  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !88
+  store i64 %80, i64* %85, align 8, !dbg !88, !tbaa !6
+  %86 = getelementptr inbounds i64, i64* %85, i64 1, !dbg !88
+  store i64* %86, i64** %83, align 8, !dbg !88
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !88
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %75, align 8, !dbg !88, !tbaa !14
+  %87 = load i64, i64* @rb_cObject, align 8, !dbg !84
+  %stackFrame309.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8, !dbg !84
+  %88 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !84
+  %89 = bitcast i8* %88 to i16*, !dbg !84
+  %90 = load i16, i16* %89, align 8, !dbg !84
+  %91 = and i16 %90, -384, !dbg !84
+  %92 = or i16 %91, 1, !dbg !84
+  store i16 %92, i16* %89, align 8, !dbg !84
+  %93 = getelementptr inbounds i8, i8* %88, i64 8, !dbg !84
+  %94 = bitcast i8* %93 to i32*, !dbg !84
+  store i32 2, i32* %94, align 8, !dbg !84, !tbaa !142
+  %95 = getelementptr inbounds i8, i8* %88, i64 12, !dbg !84
+  %96 = getelementptr inbounds i8, i8* %88, i64 4, !dbg !84
+  %97 = bitcast i8* %96 to i32*, !dbg !84
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %95, i8 0, i64 20, i1 false) #17, !dbg !84
+  store i32 2, i32* %97, align 4, !dbg !84, !tbaa !145
+  %rubyId_x.i5 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !84
+  store i64 %rubyId_x.i5, i64* %positional_table.i, align 8, !dbg !84
+  %rubyId_y.i6 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !84
+  %98 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !84
+  store i64 %rubyId_y.i6, i64* %98, align 8, !dbg !84
+  %99 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !84
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %99, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %66, i64 noundef 16, i1 noundef false) #17, !dbg !84
+  %100 = getelementptr inbounds i8, i8* %88, i64 32, !dbg !84
+  %101 = bitcast i8* %100 to i8**, !dbg !84
+  store i8* %99, i8** %101, align 8, !dbg !84, !tbaa !146
+  call void @sorbet_vm_define_method(i64 %87, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#4plus", i8* nonnull %88, %struct.rb_iseq_struct* %stackFrame309.i, i1 noundef zeroext false) #17, !dbg !84
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %75, align 8, !dbg !84, !tbaa !14
+  %stackFrame319.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8, !dbg !85
+  %102 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !85
+  %103 = bitcast i8* %102 to i16*, !dbg !85
+  %104 = load i16, i16* %103, align 8, !dbg !85
+  %105 = and i16 %104, -384, !dbg !85
+  %106 = or i16 %105, 1, !dbg !85
+  store i16 %106, i16* %103, align 8, !dbg !85
+  %107 = getelementptr inbounds i8, i8* %102, i64 8, !dbg !85
+  %108 = bitcast i8* %107 to i32*, !dbg !85
+  store i32 2, i32* %108, align 8, !dbg !85, !tbaa !142
+  %109 = getelementptr inbounds i8, i8* %102, i64 12, !dbg !85
+  %110 = getelementptr inbounds i8, i8* %102, i64 4, !dbg !85
+  %111 = bitcast i8* %110 to i32*, !dbg !85
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %109, i8 0, i64 20, i1 false) #17, !dbg !85
+  store i32 2, i32* %111, align 4, !dbg !85, !tbaa !145
+  %rubyId_x322.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !85
+  store i64 %rubyId_x322.i, i64* %positional_table321.i, align 8, !dbg !85
+  %rubyId_y323.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !85
+  %112 = getelementptr i64, i64* %positional_table321.i, i32 1, !dbg !85
+  store i64 %rubyId_y323.i, i64* %112, align 8, !dbg !85
+  %113 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !85
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %113, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %67, i64 noundef 16, i1 noundef false) #17, !dbg !85
+  %114 = getelementptr inbounds i8, i8* %102, i64 32, !dbg !85
+  %115 = bitcast i8* %114 to i8**, !dbg !85
+  store i8* %113, i8** %115, align 8, !dbg !85, !tbaa !146
+  call void @sorbet_vm_define_method(i64 %87, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#5minus", i8* nonnull %102, %struct.rb_iseq_struct* %stackFrame319.i, i1 noundef zeroext false) #17, !dbg !85
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %75, align 8, !dbg !85, !tbaa !14
+  %stackFrame333.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8, !dbg !86
+  %116 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !86
+  %117 = bitcast i8* %116 to i16*, !dbg !86
+  %118 = load i16, i16* %117, align 8, !dbg !86
+  %119 = and i16 %118, -384, !dbg !86
+  %120 = or i16 %119, 1, !dbg !86
+  store i16 %120, i16* %117, align 8, !dbg !86
+  %121 = getelementptr inbounds i8, i8* %116, i64 8, !dbg !86
+  %122 = bitcast i8* %121 to i32*, !dbg !86
+  store i32 2, i32* %122, align 8, !dbg !86, !tbaa !142
+  %123 = getelementptr inbounds i8, i8* %116, i64 12, !dbg !86
+  %124 = getelementptr inbounds i8, i8* %116, i64 4, !dbg !86
+  %125 = bitcast i8* %124 to i32*, !dbg !86
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %123, i8 0, i64 20, i1 false) #17, !dbg !86
+  store i32 2, i32* %125, align 4, !dbg !86, !tbaa !145
+  %rubyId_x336.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !86
+  store i64 %rubyId_x336.i, i64* %positional_table335.i, align 8, !dbg !86
+  %rubyId_y337.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !86
+  %126 = getelementptr i64, i64* %positional_table335.i, i32 1, !dbg !86
+  store i64 %rubyId_y337.i, i64* %126, align 8, !dbg !86
+  %127 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !86
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %127, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %68, i64 noundef 16, i1 noundef false) #17, !dbg !86
+  %128 = getelementptr inbounds i8, i8* %116, i64 32, !dbg !86
+  %129 = bitcast i8* %128 to i8**, !dbg !86
+  store i8* %127, i8** %129, align 8, !dbg !86, !tbaa !146
+  call void @sorbet_vm_define_method(i64 %87, i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#2lt", i8* nonnull %116, %struct.rb_iseq_struct* %stackFrame333.i, i1 noundef zeroext false) #17, !dbg !86
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %75, align 8, !dbg !86, !tbaa !14
+  %stackFrame347.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8, !dbg !87
+  %130 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !87
+  %131 = bitcast i8* %130 to i16*, !dbg !87
+  %132 = load i16, i16* %131, align 8, !dbg !87
+  %133 = and i16 %132, -384, !dbg !87
+  %134 = or i16 %133, 1, !dbg !87
+  store i16 %134, i16* %131, align 8, !dbg !87
+  %135 = getelementptr inbounds i8, i8* %130, i64 8, !dbg !87
+  %136 = bitcast i8* %135 to i32*, !dbg !87
+  store i32 2, i32* %136, align 8, !dbg !87, !tbaa !142
+  %137 = getelementptr inbounds i8, i8* %130, i64 12, !dbg !87
+  %138 = getelementptr inbounds i8, i8* %130, i64 4, !dbg !87
+  %139 = bitcast i8* %138 to i32*, !dbg !87
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %137, i8 0, i64 20, i1 false) #17, !dbg !87
+  store i32 2, i32* %139, align 4, !dbg !87, !tbaa !145
+  %rubyId_x350.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !87
+  store i64 %rubyId_x350.i, i64* %positional_table349.i, align 8, !dbg !87
+  %rubyId_y351.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !87
+  %140 = getelementptr i64, i64* %positional_table349.i, i32 1, !dbg !87
+  store i64 %rubyId_y351.i, i64* %140, align 8, !dbg !87
+  %141 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !87
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %141, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %69, i64 noundef 16, i1 noundef false) #17, !dbg !87
+  %142 = getelementptr inbounds i8, i8* %130, i64 32, !dbg !87
+  %143 = bitcast i8* %142 to i8**, !dbg !87
+  store i8* %141, i8** %143, align 8, !dbg !87, !tbaa !146
+  call void @sorbet_vm_define_method(i64 %87, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3lte", i8* nonnull %130, %struct.rb_iseq_struct* %stackFrame347.i, i1 noundef zeroext false) #17, !dbg !87
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %75, align 8, !dbg !87, !tbaa !14
+  %144 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !89
+  %145 = load i64*, i64** %144, align 8, !dbg !89
+  store i64 %62, i64* %145, align 8, !dbg !89, !tbaa !6
+  %146 = getelementptr inbounds i64, i64* %145, i64 1, !dbg !89
+  %147 = getelementptr inbounds i64, i64* %146, i64 1, !dbg !89
+  %148 = bitcast i64* %146 to <2 x i64>*, !dbg !89
+  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %148, align 8, !dbg !89, !tbaa !6
+  %149 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !89
+  store i64* %149, i64** %144, align 8, !dbg !89
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus, i64 0), !dbg !89
+  %150 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !90
+  %151 = load i64*, i64** %150, align 8, !dbg !90
+  store i64 %62, i64* %151, align 8, !dbg !90, !tbaa !6
+  %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !90
+  store i64 %send8, i64* %152, align 8, !dbg !90, !tbaa !6
+  %153 = getelementptr inbounds i64, i64* %152, i64 1, !dbg !90
+  store i64* %153, i64** %150, align 8, !dbg !90
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !90
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %75, align 8, !dbg !90, !tbaa !14
+  %154 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !91
+  %155 = load i64*, i64** %154, align 8, !dbg !91
+  store i64 %62, i64* %155, align 8, !dbg !91, !tbaa !6
+  %156 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !91
+  %157 = getelementptr inbounds i64, i64* %156, i64 1, !dbg !91
+  %158 = bitcast i64* %156 to <2 x i64>*, !dbg !91
+  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %158, align 8, !dbg !91, !tbaa !6
+  %159 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !91
+  store i64* %159, i64** %154, align 8, !dbg !91
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus, i64 0), !dbg !91
+  %160 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !92
+  %161 = load i64*, i64** %160, align 8, !dbg !92
+  store i64 %62, i64* %161, align 8, !dbg !92, !tbaa !6
+  %162 = getelementptr inbounds i64, i64* %161, i64 1, !dbg !92
+  store i64 %send12, i64* %162, align 8, !dbg !92, !tbaa !6
+  %163 = getelementptr inbounds i64, i64* %162, i64 1, !dbg !92
+  store i64* %163, i64** %160, align 8, !dbg !92
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.12, i64 0), !dbg !92
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %75, align 8, !dbg !92, !tbaa !14
+  %164 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !93
+  %165 = load i64*, i64** %164, align 8, !dbg !93
+  store i64 %62, i64* %165, align 8, !dbg !93, !tbaa !6
+  %166 = getelementptr inbounds i64, i64* %165, i64 1, !dbg !93
+  %167 = getelementptr inbounds i64, i64* %166, i64 1, !dbg !93
+  %168 = bitcast i64* %166 to <2 x i64>*, !dbg !93
+  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %168, align 8, !dbg !93, !tbaa !6
+  %169 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !93
+  store i64* %169, i64** %164, align 8, !dbg !93
+  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt, i64 0), !dbg !93
+  %170 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !94
+  %171 = load i64*, i64** %170, align 8, !dbg !94
+  store i64 %62, i64* %171, align 8, !dbg !94, !tbaa !6
+  %172 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !94
+  store i64 %send16, i64* %172, align 8, !dbg !94, !tbaa !6
+  %173 = getelementptr inbounds i64, i64* %172, i64 1, !dbg !94
+  store i64* %173, i64** %170, align 8, !dbg !94
+  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.13, i64 0), !dbg !94
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %75, align 8, !dbg !94, !tbaa !14
+  %174 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !95
+  %175 = load i64*, i64** %174, align 8, !dbg !95
+  store i64 %62, i64* %175, align 8, !dbg !95, !tbaa !6
+  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !95
+  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !95
+  %178 = bitcast i64* %176 to <2 x i64>*, !dbg !95
+  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %178, align 8, !dbg !95, !tbaa !6
+  %179 = getelementptr inbounds i64, i64* %177, i64 1, !dbg !95
+  store i64* %179, i64** %174, align 8, !dbg !95
+  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.14, i64 0), !dbg !95
+  %180 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !96
+  %181 = load i64*, i64** %180, align 8, !dbg !96
+  store i64 %62, i64* %181, align 8, !dbg !96, !tbaa !6
+  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !96
+  store i64 %send20, i64* %182, align 8, !dbg !96, !tbaa !6
+  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !96
+  store i64* %183, i64** %180, align 8, !dbg !96
+  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.15, i64 0), !dbg !96
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 31), i64** %75, align 8, !dbg !96, !tbaa !14
+  %184 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !97
+  %185 = load i64*, i64** %184, align 8, !dbg !97
+  store i64 %62, i64* %185, align 8, !dbg !97, !tbaa !6
+  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !97
+  %187 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !97
+  %188 = bitcast i64* %186 to <2 x i64>*, !dbg !97
+  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %188, align 8, !dbg !97, !tbaa !6
+  %189 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !97
+  store i64* %189, i64** %184, align 8, !dbg !97
+  %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte, i64 0), !dbg !97
+  %190 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !98
+  %191 = load i64*, i64** %190, align 8, !dbg !98
+  store i64 %62, i64* %191, align 8, !dbg !98, !tbaa !6
+  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !98
+  store i64 %send24, i64* %192, align 8, !dbg !98, !tbaa !6
+  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !98
+  store i64* %193, i64** %190, align 8, !dbg !98
+  %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.16, i64 0), !dbg !98
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 32), i64** %75, align 8, !dbg !98, !tbaa !14
+  %194 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !99
+  %195 = load i64*, i64** %194, align 8, !dbg !99
+  store i64 %62, i64* %195, align 8, !dbg !99, !tbaa !6
+  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !99
+  %197 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !99
+  %198 = bitcast i64* %196 to <2 x i64>*, !dbg !99
+  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %198, align 8, !dbg !99, !tbaa !6
+  %199 = getelementptr inbounds i64, i64* %197, i64 1, !dbg !99
+  store i64* %199, i64** %194, align 8, !dbg !99
+  %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.17, i64 0), !dbg !99
+  %200 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !100
+  %201 = load i64*, i64** %200, align 8, !dbg !100
+  store i64 %62, i64* %201, align 8, !dbg !100, !tbaa !6
+  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !100
+  store i64 %send28, i64* %202, align 8, !dbg !100, !tbaa !6
+  %203 = getelementptr inbounds i64, i64* %202, i64 1, !dbg !100
+  store i64* %203, i64** %200, align 8, !dbg !100
+  %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.18, i64 0), !dbg !100
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 33), i64** %75, align 8, !dbg !100, !tbaa !14
+  %204 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !101
+  %205 = load i64*, i64** %204, align 8, !dbg !101
+  store i64 %62, i64* %205, align 8, !dbg !101, !tbaa !6
+  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !101
+  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !101
+  %208 = bitcast i64* %206 to <2 x i64>*, !dbg !101
+  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %208, align 8, !dbg !101, !tbaa !6
+  %209 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !101
+  store i64* %209, i64** %204, align 8, !dbg !101
+  %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.19, i64 0), !dbg !101
+  %210 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !102
+  %211 = load i64*, i64** %210, align 8, !dbg !102
+  store i64 %62, i64* %211, align 8, !dbg !102, !tbaa !6
+  %212 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !102
+  store i64 %send32, i64* %212, align 8, !dbg !102, !tbaa !6
+  %213 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !102
+  store i64* %213, i64** %210, align 8, !dbg !102
+  %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.20, i64 0), !dbg !102
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 36), i64** %75, align 8, !dbg !102, !tbaa !14
+  %214 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !103
+  %215 = load i64*, i64** %214, align 8, !dbg !103
+  store i64 %62, i64* %215, align 8, !dbg !103, !tbaa !6
+  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !103
+  %217 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !103
+  %218 = bitcast i64* %216 to <2 x i64>*, !dbg !103
+  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %218, align 8, !dbg !103, !tbaa !6
+  %219 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !103
+  store i64* %219, i64** %214, align 8, !dbg !103
+  %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.21, i64 0), !dbg !103
+  %220 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !104
+  %221 = load i64*, i64** %220, align 8, !dbg !104
+  store i64 %62, i64* %221, align 8, !dbg !104, !tbaa !6
+  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !104
+  store i64 %send36, i64* %222, align 8, !dbg !104, !tbaa !6
+  %223 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !104
+  store i64* %223, i64** %220, align 8, !dbg !104
+  %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.22, i64 0), !dbg !104
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 37), i64** %75, align 8, !dbg !104, !tbaa !14
+  %rubyStr_8.9.i = load i64, i64* @rubyStrFrozen_8.9, align 8, !dbg !105
+  %224 = load i64, i64* @rb_mKernel, align 8, !dbg !105
+  %225 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !105
+  %226 = load i64*, i64** %225, align 8, !dbg !105
+  store i64 %224, i64* %226, align 8, !dbg !105, !tbaa !6
+  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !105
+  store i64 %rubyStr_8.9.i, i64* %227, align 8, !dbg !105, !tbaa !6
+  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !105
+  store i64* %228, i64** %225, align 8, !dbg !105
+  %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational, i64 0), !dbg !105
+  %229 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !106
+  %230 = load i64*, i64** %229, align 8, !dbg !106
+  store i64 %62, i64* %230, align 8, !dbg !106, !tbaa !6
+  %231 = getelementptr inbounds i64, i64* %230, i64 1, !dbg !106
+  store i64 36028797018963970, i64* %231, align 8, !dbg !106, !tbaa !6
+  %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !106
+  store i64 %send40, i64* %232, align 8, !dbg !106, !tbaa !6
+  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !106
+  store i64* %233, i64** %229, align 8, !dbg !106
+  %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.23, i64 0), !dbg !106
+  %234 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !107
+  %235 = load i64*, i64** %234, align 8, !dbg !107
+  store i64 %62, i64* %235, align 8, !dbg !107, !tbaa !6
+  %236 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !107
+  store i64 %send42, i64* %236, align 8, !dbg !107, !tbaa !6
+  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !107
+  store i64* %237, i64** %234, align 8, !dbg !107
+  %send44 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.24, i64 0), !dbg !107
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 38), i64** %75, align 8, !dbg !107, !tbaa !14
+  %rubyStr_5.i = load i64, i64* @rubyStrFrozen_5, align 8, !dbg !108
+  %238 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !108
+  %239 = load i64*, i64** %238, align 8, !dbg !108
+  store i64 %224, i64* %239, align 8, !dbg !108, !tbaa !6
+  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !108
+  store i64 1, i64* %240, align 8, !dbg !108, !tbaa !6
+  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !108
+  store i64 %rubyStr_5.i, i64* %241, align 8, !dbg !108, !tbaa !6
+  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !108
+  store i64* %242, i64** %238, align 8, !dbg !108
+  %send46 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex, i64 0), !dbg !108
+  %243 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !109
+  %244 = load i64*, i64** %243, align 8, !dbg !109
+  store i64 %62, i64* %244, align 8, !dbg !109, !tbaa !6
+  %245 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !109
+  store i64 36028797018963970, i64* %245, align 8, !dbg !109, !tbaa !6
+  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !109
+  store i64 %send46, i64* %246, align 8, !dbg !109, !tbaa !6
+  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !109
+  store i64* %247, i64** %243, align 8, !dbg !109
+  %send48 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.25, i64 0), !dbg !109
+  %248 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !110
+  %249 = load i64*, i64** %248, align 8, !dbg !110
+  store i64 %62, i64* %249, align 8, !dbg !110, !tbaa !6
+  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !110
+  store i64 %send48, i64* %250, align 8, !dbg !110, !tbaa !6
+  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !110
+  store i64* %251, i64** %248, align 8, !dbg !110
+  %send50 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.26, i64 0), !dbg !110
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 40), i64** %75, align 8, !dbg !110, !tbaa !14
+  %252 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !111
+  %253 = load i64*, i64** %252, align 8, !dbg !111
+  store i64 %62, i64* %253, align 8, !dbg !111, !tbaa !6
+  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !111
+  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !111
+  %256 = bitcast i64* %254 to <2 x i64>*, !dbg !111
+  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %256, align 8, !dbg !111, !tbaa !6
+  %257 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !111
+  store i64* %257, i64** %252, align 8, !dbg !111
+  %send52 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.27, i64 0), !dbg !111
+  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !112
+  %259 = load i64*, i64** %258, align 8, !dbg !112
+  store i64 %62, i64* %259, align 8, !dbg !112, !tbaa !6
+  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !112
+  store i64 %send52, i64* %260, align 8, !dbg !112, !tbaa !6
+  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !112
+  store i64* %261, i64** %258, align 8, !dbg !112
+  %send54 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.28, i64 0), !dbg !112
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 41), i64** %75, align 8, !dbg !112, !tbaa !14
+  %rubyStr_15.4.i = load i64, i64* @rubyStrFrozen_15.4, align 8, !dbg !113
+  %262 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !113
+  %263 = load i64*, i64** %262, align 8, !dbg !113
+  store i64 %224, i64* %263, align 8, !dbg !113, !tbaa !6
+  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !113
+  store i64 %rubyStr_15.4.i, i64* %264, align 8, !dbg !113, !tbaa !6
+  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !113
+  store i64* %265, i64** %262, align 8, !dbg !113
+  %send56 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.29, i64 0), !dbg !113
+  %266 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !114
+  %267 = load i64*, i64** %266, align 8, !dbg !114
+  store i64 %62, i64* %267, align 8, !dbg !114, !tbaa !6
+  %268 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !114
+  store i64 199622053483197234, i64* %268, align 8, !dbg !114, !tbaa !6
+  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !114
+  store i64 %send56, i64* %269, align 8, !dbg !114, !tbaa !6
+  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !114
+  store i64* %270, i64** %266, align 8, !dbg !114
+  %send58 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.30, i64 0), !dbg !114
+  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !115
+  %272 = load i64*, i64** %271, align 8, !dbg !115
+  store i64 %62, i64* %272, align 8, !dbg !115, !tbaa !6
+  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !115
+  store i64 %send58, i64* %273, align 8, !dbg !115, !tbaa !6
+  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !115
+  store i64* %274, i64** %271, align 8, !dbg !115
+  %send60 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.31, i64 0), !dbg !115
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 42), i64** %75, align 8, !dbg !115, !tbaa !14
+  %rubyStr_18.i = load i64, i64* @rubyStrFrozen_18, align 8, !dbg !116
+  %275 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !116
+  %276 = load i64*, i64** %275, align 8, !dbg !116
+  store i64 %224, i64* %276, align 8, !dbg !116, !tbaa !6
+  %277 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !116
+  store i64 1, i64* %277, align 8, !dbg !116, !tbaa !6
+  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !116
+  store i64 %rubyStr_18.i, i64* %278, align 8, !dbg !116, !tbaa !6
+  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !116
+  store i64* %279, i64** %275, align 8, !dbg !116
+  %send62 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex.32, i64 0), !dbg !116
+  %280 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !117
+  %281 = load i64*, i64** %280, align 8, !dbg !117
+  store i64 %62, i64* %281, align 8, !dbg !117, !tbaa !6
+  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !117
+  store i64 199565758487855106, i64* %282, align 8, !dbg !117, !tbaa !6
+  %283 = getelementptr inbounds i64, i64* %282, i64 1, !dbg !117
+  store i64 %send62, i64* %283, align 8, !dbg !117, !tbaa !6
+  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !117
+  store i64* %284, i64** %280, align 8, !dbg !117
+  %send64 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.33, i64 0), !dbg !117
+  %285 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !118
+  %286 = load i64*, i64** %285, align 8, !dbg !118
+  store i64 %62, i64* %286, align 8, !dbg !118, !tbaa !6
+  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !118
+  store i64 %send64, i64* %287, align 8, !dbg !118, !tbaa !6
+  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !118
+  store i64* %288, i64** %285, align 8, !dbg !118
+  %send66 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.34, i64 0), !dbg !118
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 44), i64** %75, align 8, !dbg !118, !tbaa !14
+  %289 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !119
+  %290 = load i64*, i64** %289, align 8, !dbg !119
+  store i64 %62, i64* %290, align 8, !dbg !119, !tbaa !6
+  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !119
+  %292 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !119
+  %293 = bitcast i64* %291 to <2 x i64>*, !dbg !119
+  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %293, align 8, !dbg !119, !tbaa !6
+  %294 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !119
+  store i64* %294, i64** %289, align 8, !dbg !119
+  %send68 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.35, i64 0), !dbg !119
+  %295 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !120
+  %296 = load i64*, i64** %295, align 8, !dbg !120
+  store i64 %62, i64* %296, align 8, !dbg !120, !tbaa !6
+  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !120
+  store i64 %send68, i64* %297, align 8, !dbg !120, !tbaa !6
+  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !120
+  store i64* %298, i64** %295, align 8, !dbg !120
+  %send70 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.36, i64 0), !dbg !120
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 45), i64** %75, align 8, !dbg !120, !tbaa !14
+  %rubyStr_25.4.i = load i64, i64* @rubyStrFrozen_25.4, align 8, !dbg !121
+  %299 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !121
+  %300 = load i64*, i64** %299, align 8, !dbg !121
+  store i64 %224, i64* %300, align 8, !dbg !121, !tbaa !6
+  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !121
+  store i64 %rubyStr_25.4.i, i64* %301, align 8, !dbg !121, !tbaa !6
+  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !121
+  store i64* %302, i64** %299, align 8, !dbg !121
+  %send72 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.37, i64 0), !dbg !121
+  %303 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !122
+  %304 = load i64*, i64** %303, align 8, !dbg !122
+  store i64 %62, i64* %304, align 8, !dbg !122, !tbaa !6
+  %305 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !122
+  store i64 113040350646999450, i64* %305, align 8, !dbg !122, !tbaa !6
+  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !122
+  store i64 %send72, i64* %306, align 8, !dbg !122, !tbaa !6
+  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !122
+  store i64* %307, i64** %303, align 8, !dbg !122
+  %send74 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.38, i64 0), !dbg !122
+  %308 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !123
+  %309 = load i64*, i64** %308, align 8, !dbg !123
+  store i64 %62, i64* %309, align 8, !dbg !123, !tbaa !6
+  %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !123
+  store i64 %send74, i64* %310, align 8, !dbg !123, !tbaa !6
+  %311 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !123
+  store i64* %311, i64** %308, align 8, !dbg !123
+  %send76 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.39, i64 0), !dbg !123
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 47), i64** %75, align 8, !dbg !123, !tbaa !14
+  %312 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !124
+  %313 = load i64*, i64** %312, align 8, !dbg !124
+  store i64 %62, i64* %313, align 8, !dbg !124, !tbaa !6
+  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !124
+  %315 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !124
+  %316 = bitcast i64* %314 to <2 x i64>*, !dbg !124
+  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %316, align 8, !dbg !124, !tbaa !6
+  %317 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !124
+  store i64* %317, i64** %312, align 8, !dbg !124
+  %send78 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.40, i64 0), !dbg !124
+  %318 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !125
+  %319 = load i64*, i64** %318, align 8, !dbg !125
+  store i64 %62, i64* %319, align 8, !dbg !125, !tbaa !6
+  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !125
+  store i64 %send78, i64* %320, align 8, !dbg !125, !tbaa !6
+  %321 = getelementptr inbounds i64, i64* %320, i64 1, !dbg !125
+  store i64* %321, i64** %318, align 8, !dbg !125
+  %send80 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.41, i64 0), !dbg !125
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 48), i64** %75, align 8, !dbg !125, !tbaa !14
+  %rubyStr_5.923.i = load i64, i64* @rubyStrFrozen_5.923, align 8, !dbg !126
+  %322 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !126
+  %323 = load i64*, i64** %322, align 8, !dbg !126
+  store i64 %224, i64* %323, align 8, !dbg !126, !tbaa !6
+  %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !126
+  store i64 %rubyStr_5.923.i, i64* %324, align 8, !dbg !126, !tbaa !6
+  %325 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !126
+  store i64* %325, i64** %322, align 8, !dbg !126
+  %send82 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.42, i64 0), !dbg !126
+  %326 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !127
+  %327 = load i64*, i64** %326, align 8, !dbg !127
+  store i64 %62, i64* %327, align 8, !dbg !127, !tbaa !6
+  %328 = getelementptr inbounds i64, i64* %327, i64 1, !dbg !127
+  store i64 113040350646999450, i64* %328, align 8, !dbg !127, !tbaa !6
+  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !127
+  store i64 %send82, i64* %329, align 8, !dbg !127, !tbaa !6
+  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !127
+  store i64* %330, i64** %326, align 8, !dbg !127
+  %send84 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.43, i64 0), !dbg !127
+  %331 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !128
+  %332 = load i64*, i64** %331, align 8, !dbg !128
+  store i64 %62, i64* %332, align 8, !dbg !128, !tbaa !6
+  %333 = getelementptr inbounds i64, i64* %332, i64 1, !dbg !128
+  store i64 %send84, i64* %333, align 8, !dbg !128, !tbaa !6
+  %334 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !128
+  store i64* %334, i64** %331, align 8, !dbg !128
+  %send86 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.44, i64 0), !dbg !128
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %66)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %67)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %68)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %69)
   ret void
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare void @llvm.experimental.noalias.scope.decl(metadata) #9
+declare void @llvm.experimental.noalias.scope.decl(metadata) #10
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
@@ -1867,39 +1725,30 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #10
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #11
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#2lt.cold.1"(i64 %0) unnamed_addr #11 !dbg !147 {
+define internal fastcc void @"func_Object#2lt.cold.1"(i64 %0) unnamed_addr #12 !dbg !147 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @"str_T::Boolean", i64 0, i64 0)) #14
+  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @"str_T::Boolean", i64 0, i64 0)) #15
   unreachable
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) unnamed_addr #11 !dbg !149 {
+define internal fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) unnamed_addr #12 !dbg !149 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_Parameter 'x'", i64 0, i64 0), i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_Float, i64 0, i64 0)) #14, !dbg !150
+  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_Parameter 'x'", i64 0, i64 0), i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_Float, i64 0, i64 0)) #15, !dbg !150
   unreachable, !dbg !150
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #12
-
-; Function Attrs: ssp
-define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #8 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
-  store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !68
-  store i64 %2, i64* @"guard_epoch_T::Sig", align 8
-  ret void
-}
+declare void @llvm.assume(i1 noundef) #13
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_T() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_T, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_T, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !68
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !65
   store i64 %2, i64* @guard_epoch_T, align 8
   ret void
 }
@@ -1908,8 +1757,17 @@ define linkonce void @const_recompute_T() local_unnamed_addr #8 {
 define linkonce void @"const_recompute_T::Boolean"() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"str_T::Boolean", i64 0, i64 0), i64 10)
   store i64 %1, i64* @"guarded_const_T::Boolean", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !68
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !65
   store i64 %2, i64* @"guard_epoch_T::Boolean", align 8
+  ret void
+}
+
+; Function Attrs: ssp
+define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #8 {
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
+  store i64 %1, i64* @"guarded_const_T::Sig", align 8
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !65
+  store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
 
@@ -1922,16 +1780,17 @@ attributes #5 = { argmemonly nofree nosync nounwind willreturn }
 attributes #6 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #7 = { nounwind sspreq uwtable }
 attributes #8 = { ssp }
-attributes #9 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #10 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #11 = { cold minsize noreturn nounwind sspreq uwtable }
-attributes #12 = { nofree nosync nounwind willreturn }
-attributes #13 = { noreturn nounwind }
-attributes #14 = { noreturn }
-attributes #15 = { noinline }
-attributes #16 = { nounwind }
-attributes #17 = { nounwind allocsize(0,1) }
+attributes #9 = { sspreq }
+attributes #10 = { inaccessiblememonly nofree nosync nounwind willreturn }
+attributes #11 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #12 = { cold minsize noreturn nounwind sspreq uwtable }
+attributes #13 = { nofree nosync nounwind willreturn }
+attributes #14 = { noreturn nounwind }
+attributes #15 = { noreturn }
+attributes #16 = { noinline }
+attributes #17 = { nounwind }
 attributes #18 = { nounwind readnone willreturn }
+attributes #19 = { nounwind allocsize(0,1) }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -1993,96 +1852,96 @@ attributes #18 = { nounwind readnone willreturn }
 !54 = distinct !{!54, !55, !"sorbet_int_flo_le: argument 0"}
 !55 = distinct !{!55, !"sorbet_int_flo_le"}
 !56 = !DILocation(line: 0, scope: !48)
-!57 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!58 = !{!28, !15, i64 16}
-!59 = !{!60, !15, i64 16}
-!60 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
-!61 = !{!60, !15, i64 32}
-!62 = !DILocation(line: 0, scope: !57)
-!63 = !DILocation(line: 7, column: 1, scope: !57)
-!64 = !DILocation(line: 12, column: 1, scope: !57)
-!65 = !DILocation(line: 17, column: 1, scope: !57)
-!66 = !DILocation(line: 22, column: 1, scope: !57)
-!67 = !DILocation(line: 5, column: 1, scope: !57)
-!68 = !{!69, !69, i64 0}
-!69 = !{!"long long", !8, i64 0}
-!70 = !{!"branch_weights", i32 1, i32 10000}
-!71 = !DILocation(line: 8, column: 1, scope: !57)
-!72 = !{!73, !29, i64 8}
-!73 = !{!"rb_sorbet_param_struct", !74, i64 0, !29, i64 4, !29, i64 8, !29, i64 12, !29, i64 16, !29, i64 20, !29, i64 24, !29, i64 28, !15, i64 32, !29, i64 40, !29, i64 44, !29, i64 48, !29, i64 52, !15, i64 56}
-!74 = !{!"", !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 1, !29, i64 1}
-!75 = !{!73, !29, i64 4}
-!76 = !{!73, !15, i64 32}
-!77 = !DILocation(line: 13, column: 1, scope: !57)
-!78 = !DILocation(line: 18, column: 1, scope: !57)
-!79 = !DILocation(line: 23, column: 1, scope: !57)
-!80 = !DILocation(line: 27, column: 3, scope: !57)
-!81 = !DILocation(line: 27, column: 1, scope: !57)
-!82 = !DILocation(line: 28, column: 3, scope: !57)
-!83 = !DILocation(line: 28, column: 1, scope: !57)
-!84 = !DILocation(line: 29, column: 3, scope: !57)
-!85 = !DILocation(line: 29, column: 1, scope: !57)
-!86 = !DILocation(line: 30, column: 3, scope: !57)
-!87 = !DILocation(line: 30, column: 1, scope: !57)
-!88 = !DILocation(line: 31, column: 3, scope: !57)
-!89 = !DILocation(line: 31, column: 1, scope: !57)
-!90 = !DILocation(line: 32, column: 3, scope: !57)
-!91 = !DILocation(line: 32, column: 1, scope: !57)
-!92 = !DILocation(line: 33, column: 3, scope: !57)
-!93 = !DILocation(line: 33, column: 1, scope: !57)
-!94 = !DILocation(line: 36, column: 3, scope: !57)
-!95 = !DILocation(line: 36, column: 1, scope: !57)
-!96 = !DILocation(line: 37, column: 13, scope: !57)
-!97 = !DILocation(line: 37, column: 3, scope: !57)
-!98 = !DILocation(line: 37, column: 1, scope: !57)
-!99 = !DILocation(line: 38, column: 13, scope: !57)
-!100 = !DILocation(line: 38, column: 3, scope: !57)
-!101 = !DILocation(line: 38, column: 1, scope: !57)
-!102 = !DILocation(line: 40, column: 3, scope: !57)
-!103 = !DILocation(line: 40, column: 1, scope: !57)
-!104 = !DILocation(line: 41, column: 15, scope: !57)
-!105 = !DILocation(line: 41, column: 3, scope: !57)
-!106 = !DILocation(line: 41, column: 1, scope: !57)
-!107 = !DILocation(line: 42, column: 15, scope: !57)
-!108 = !DILocation(line: 42, column: 3, scope: !57)
-!109 = !DILocation(line: 42, column: 1, scope: !57)
-!110 = !DILocation(line: 44, column: 3, scope: !57)
-!111 = !DILocation(line: 44, column: 1, scope: !57)
-!112 = !DILocation(line: 45, column: 12, scope: !57)
-!113 = !DILocation(line: 45, column: 3, scope: !57)
-!114 = !DILocation(line: 45, column: 1, scope: !57)
-!115 = !DILocation(line: 47, column: 3, scope: !57)
-!116 = !DILocation(line: 47, column: 1, scope: !57)
-!117 = !DILocation(line: 48, column: 13, scope: !57)
-!118 = !DILocation(line: 48, column: 3, scope: !57)
-!119 = !DILocation(line: 48, column: 1, scope: !57)
-!120 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_1", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!121 = !{!60, !7, i64 24}
-!122 = !DILocation(line: 7, column: 26, scope: !120)
-!123 = !DILocation(line: 7, column: 6, scope: !120)
-!124 = !DILocation(line: 7, column: 45, scope: !120)
-!125 = !DILocation(line: 7, column: 1, scope: !120)
-!126 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_2", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!127 = !DILocation(line: 12, column: 26, scope: !126)
-!128 = !DILocation(line: 12, column: 6, scope: !126)
-!129 = !DILocation(line: 12, column: 45, scope: !126)
-!130 = !DILocation(line: 12, column: 1, scope: !126)
-!131 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_3", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!132 = !DILocation(line: 17, column: 26, scope: !131)
-!133 = !DILocation(line: 17, column: 6, scope: !131)
-!134 = !DILocation(line: 17, column: 1, scope: !131)
-!135 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_4", scope: !57, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!136 = !DILocation(line: 22, column: 26, scope: !135)
-!137 = !DILocation(line: 22, column: 6, scope: !135)
-!138 = !DILocation(line: 22, column: 1, scope: !135)
-!139 = !{!140, !7, i64 400}
-!140 = !{!"rb_vm_struct", !7, i64 0, !141, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !69, i64 216, !8, i64 224, !142, i64 264, !142, i64 280, !142, i64 296, !142, i64 312, !7, i64 328, !29, i64 336, !29, i64 340, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !144, i64 472, !145, i64 992, !15, i64 1016, !15, i64 1024, !29, i64 1032, !29, i64 1036, !142, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !29, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !29, i64 1192, !146, i64 1200, !8, i64 1232}
-!141 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !142, i64 48, !15, i64 64, !29, i64 72, !8, i64 80, !8, i64 128, !29, i64 176, !29, i64 180}
-!142 = !{!"list_head", !143, i64 0}
-!143 = !{!"list_node", !15, i64 0, !15, i64 8}
-!144 = !{!"", !8, i64 0}
-!145 = !{!"rb_hook_list_struct", !15, i64 0, !29, i64 8, !29, i64 12, !29, i64 16}
-!146 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!57 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_1", scope: !58, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!58 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!59 = !{!28, !15, i64 16}
+!60 = !{!61, !7, i64 24}
+!61 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!62 = !{!61, !15, i64 16}
+!63 = !{!61, !15, i64 32}
+!64 = !DILocation(line: 7, column: 26, scope: !57)
+!65 = !{!66, !66, i64 0}
+!66 = !{!"long long", !8, i64 0}
+!67 = !{!"branch_weights", i32 1, i32 10000}
+!68 = !DILocation(line: 7, column: 6, scope: !57)
+!69 = !DILocation(line: 7, column: 45, scope: !57)
+!70 = !DILocation(line: 7, column: 1, scope: !57)
+!71 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_2", scope: !58, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!72 = !DILocation(line: 12, column: 26, scope: !71)
+!73 = !DILocation(line: 12, column: 6, scope: !71)
+!74 = !DILocation(line: 12, column: 45, scope: !71)
+!75 = !DILocation(line: 12, column: 1, scope: !71)
+!76 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_3", scope: !58, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!77 = !DILocation(line: 17, column: 26, scope: !76)
+!78 = !DILocation(line: 17, column: 6, scope: !76)
+!79 = !DILocation(line: 17, column: 1, scope: !76)
+!80 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152$block_4", scope: !58, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!81 = !DILocation(line: 22, column: 26, scope: !80)
+!82 = !DILocation(line: 22, column: 6, scope: !80)
+!83 = !DILocation(line: 22, column: 1, scope: !80)
+!84 = !DILocation(line: 8, column: 1, scope: !58)
+!85 = !DILocation(line: 13, column: 1, scope: !58)
+!86 = !DILocation(line: 18, column: 1, scope: !58)
+!87 = !DILocation(line: 23, column: 1, scope: !58)
+!88 = !DILocation(line: 5, column: 1, scope: !58)
+!89 = !DILocation(line: 27, column: 3, scope: !58)
+!90 = !DILocation(line: 27, column: 1, scope: !58)
+!91 = !DILocation(line: 28, column: 3, scope: !58)
+!92 = !DILocation(line: 28, column: 1, scope: !58)
+!93 = !DILocation(line: 29, column: 3, scope: !58)
+!94 = !DILocation(line: 29, column: 1, scope: !58)
+!95 = !DILocation(line: 30, column: 3, scope: !58)
+!96 = !DILocation(line: 30, column: 1, scope: !58)
+!97 = !DILocation(line: 31, column: 3, scope: !58)
+!98 = !DILocation(line: 31, column: 1, scope: !58)
+!99 = !DILocation(line: 32, column: 3, scope: !58)
+!100 = !DILocation(line: 32, column: 1, scope: !58)
+!101 = !DILocation(line: 33, column: 3, scope: !58)
+!102 = !DILocation(line: 33, column: 1, scope: !58)
+!103 = !DILocation(line: 36, column: 3, scope: !58)
+!104 = !DILocation(line: 36, column: 1, scope: !58)
+!105 = !DILocation(line: 37, column: 13, scope: !58)
+!106 = !DILocation(line: 37, column: 3, scope: !58)
+!107 = !DILocation(line: 37, column: 1, scope: !58)
+!108 = !DILocation(line: 38, column: 13, scope: !58)
+!109 = !DILocation(line: 38, column: 3, scope: !58)
+!110 = !DILocation(line: 38, column: 1, scope: !58)
+!111 = !DILocation(line: 40, column: 3, scope: !58)
+!112 = !DILocation(line: 40, column: 1, scope: !58)
+!113 = !DILocation(line: 41, column: 15, scope: !58)
+!114 = !DILocation(line: 41, column: 3, scope: !58)
+!115 = !DILocation(line: 41, column: 1, scope: !58)
+!116 = !DILocation(line: 42, column: 15, scope: !58)
+!117 = !DILocation(line: 42, column: 3, scope: !58)
+!118 = !DILocation(line: 42, column: 1, scope: !58)
+!119 = !DILocation(line: 44, column: 3, scope: !58)
+!120 = !DILocation(line: 44, column: 1, scope: !58)
+!121 = !DILocation(line: 45, column: 12, scope: !58)
+!122 = !DILocation(line: 45, column: 3, scope: !58)
+!123 = !DILocation(line: 45, column: 1, scope: !58)
+!124 = !DILocation(line: 47, column: 3, scope: !58)
+!125 = !DILocation(line: 47, column: 1, scope: !58)
+!126 = !DILocation(line: 48, column: 13, scope: !58)
+!127 = !DILocation(line: 48, column: 3, scope: !58)
+!128 = !DILocation(line: 48, column: 1, scope: !58)
+!129 = !{!130, !7, i64 400}
+!130 = !{!"rb_vm_struct", !7, i64 0, !131, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !66, i64 216, !8, i64 224, !132, i64 264, !132, i64 280, !132, i64 296, !132, i64 312, !7, i64 328, !29, i64 336, !29, i64 340, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !134, i64 472, !135, i64 992, !15, i64 1016, !15, i64 1024, !29, i64 1032, !29, i64 1036, !132, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !29, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !29, i64 1192, !136, i64 1200, !8, i64 1232}
+!131 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !132, i64 48, !15, i64 64, !29, i64 72, !8, i64 80, !8, i64 128, !29, i64 176, !29, i64 180}
+!132 = !{!"list_head", !133, i64 0}
+!133 = !{!"list_node", !15, i64 0, !15, i64 8}
+!134 = !{!"", !8, i64 0}
+!135 = !{!"rb_hook_list_struct", !15, i64 0, !29, i64 8, !29, i64 12, !29, i64 16}
+!136 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!137 = !DILocation(line: 0, scope: !58)
+!138 = !DILocation(line: 7, column: 1, scope: !58)
+!139 = !DILocation(line: 12, column: 1, scope: !58)
+!140 = !DILocation(line: 17, column: 1, scope: !58)
+!141 = !DILocation(line: 22, column: 1, scope: !58)
+!142 = !{!143, !29, i64 8}
+!143 = !{!"rb_sorbet_param_struct", !144, i64 0, !29, i64 4, !29, i64 8, !29, i64 12, !29, i64 16, !29, i64 20, !29, i64 24, !29, i64 28, !15, i64 32, !29, i64 40, !29, i64 44, !29, i64 48, !29, i64 52, !15, i64 56}
+!144 = !{!"", !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 1, !29, i64 1}
+!145 = !{!143, !29, i64 4}
+!146 = !{!143, !15, i64 32}
 !147 = distinct !DISubprogram(name: "func_Object#2lt.cold.1", linkageName: "func_Object#2lt.cold.1", scope: null, file: !4, type: !148, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
 !148 = !DISubroutineType(types: !5)
 !149 = distinct !DISubprogram(name: "func_Object#2lt.cold.3", linkageName: "func_Object#2lt.cold.3", scope: null, file: !4, type: !148, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)

--- a/test/testdata/compiler/globalfields.opt.ll.exp
+++ b/test/testdata/compiler/globalfields.opt.ll.exp
@@ -177,8 +177,6 @@ declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
-
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #3
 
@@ -206,43 +204,42 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
 define void @Init_globalfields() local_unnamed_addr #5 {
 entry:
   %positional_table.i.i = alloca i64, align 8, !dbg !10
-  %0 = alloca %struct.rb_calling_info, align 8
   %locals.i19.i = alloca i64, i32 0, align 8
   %locals.i17.i = alloca i64, i32 0, align 8
   %locals.i15.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
-  store i64 %1, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
-  store i64 %2, i64* @rubyIdPrecomputed_new, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #11
-  store i64 %3, i64* @rubyIdPrecomputed_initialize, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
-  store i64 %4, i64* @rubyIdPrecomputed_read, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
-  store i64 %5, i64* @rubyIdPrecomputed_puts, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
-  store i64 %6, i64* @rubyIdPrecomputed_write, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @"str_$f", i64 0, i64 0), i64 noundef 2) #11
-  store i64 %7, i64* @"rubyIdPrecomputed_$f", align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
-  store i64 %8, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_v, i64 0, i64 0), i64 noundef 1) #11
-  store i64 %10, i64* @rubyIdPrecomputed_v, align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
+  store i64 %1, i64* @rubyIdPrecomputed_new, align 8
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #11
+  store i64 %2, i64* @rubyIdPrecomputed_initialize, align 8
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
+  store i64 %3, i64* @rubyIdPrecomputed_read, align 8
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
+  store i64 %5, i64* @rubyIdPrecomputed_write, align 8
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @"str_$f", i64 0, i64 0), i64 noundef 2) #11
+  store i64 %6, i64* @"rubyIdPrecomputed_$f", align 8
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  store i64 %7, i64* @"rubyIdPrecomputed_<class:A>", align 8
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_v, i64 0, i64 0), i64 noundef 1) #11
+  store i64 %9, i64* @rubyIdPrecomputed_v, align 8
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %10) #11
+  store i64 %10, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/globalfields.rb", i64 0, i64 0), i64 noundef 38) #11
   tail call void @rb_gc_register_mark_object(i64 %11) #11
-  store i64 %11, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %12 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/globalfields.rb", i64 0, i64 0), i64 noundef 38) #11
-  tail call void @rb_gc_register_mark_object(i64 %12) #11
-  store i64 %12, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
+  store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 20)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/globalfields.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !17
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
   %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !17
@@ -251,9 +248,9 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !18
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_value, i64 0, i64 0), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %14) #11
-  store i64 %14, i64* @rubyStrFrozen_value, align 8
+  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_value, i64 0, i64 0), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %13) #11
+  store i64 %13, i64* @rubyStrFrozen_value, align 8
   %rubyId_write.i = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !20
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_write, i64 %rubyId_write.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
   %rubyId_read6.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !21
@@ -262,280 +259,235 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
   %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %15) #11
+  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %14) #11
   %rubyId_write.i.i = load i64, i64* @rubyIdPrecomputed_write, align 8
   %"rubyStr_test/testdata/compiler/globalfields.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %rubyId_write.i.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#5write", align 8
-  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %17) #11
+  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_write.i.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#5write", align 8
+  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %16) #11
   %rubyId_read.i.i = load i64, i64* @rubyIdPrecomputed_read, align 8
   %"rubyStr_test/testdata/compiler/globalfields.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %rubyId_read.i.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %19) #11
+  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %rubyId_read.i.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8
+  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %18) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %"rubyStr_test/testdata/compiler/globalfields.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %21 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !24
-  %22 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %21, i64 0, i32 18
-  %23 = load i64, i64* %22, align 8, !tbaa !26
-  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2
-  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !tbaa !36
+  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %20 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !24
+  %21 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %20, i64 0, i32 18
+  %22 = load i64, i64* %21, align 8, !tbaa !26
+  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
+  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !36
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %27, align 8, !tbaa !39
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4
-  %29 = load i64*, i64** %28, align 8, !tbaa !41
-  %30 = load i64, i64* %29, align 8, !tbaa !6
-  %31 = and i64 %30, -33
-  store i64 %31, i64* %29, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %24, %struct.rb_control_frame_struct* %26, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %32, align 8, !dbg !42, !tbaa !24
-  %33 = load i64, i64* @rb_cObject, align 8, !dbg !43
-  %34 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %33) #11, !dbg !43
-  %35 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %34) #11, !dbg !43
-  %36 = bitcast %struct.rb_calling_info* %0 to i8*, !dbg !43
-  call void @llvm.lifetime.start.p0i8(i64 noundef 24, i8* noundef nonnull align 8 dereferenceable(24) %36) #11, !dbg !43
-  %37 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 0, !dbg !43
-  store i64 0, i64* %37, align 8, !dbg !43, !tbaa !44
-  %38 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 3, !dbg !43
-  store i32 0, i32* %38, align 4, !dbg !43, !tbaa !46
-  %39 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 1, !dbg !43
-  store i64 %34, i64* %39, align 8, !dbg !43, !tbaa !47
-  %40 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 2, !dbg !43
-  store i32 0, i32* %40, align 8, !dbg !43, !tbaa !48
-  %41 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %41) #11
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %26, align 8, !tbaa !39
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
+  %28 = load i64*, i64** %27, align 8, !tbaa !41
+  %29 = load i64, i64* %28, align 8, !tbaa !6
+  %30 = and i64 %29, -33
+  store i64 %30, i64* %28, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %23, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %31, align 8, !dbg !42, !tbaa !24
+  %32 = load i64, i64* @rb_cObject, align 8, !dbg !43
+  %33 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %32) #11, !dbg !43
+  %34 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %33) #11, !dbg !43
+  %35 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %42 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %42, i64 0, i32 2
-  %44 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %43, align 8, !tbaa !36
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %45, align 8, !tbaa !39
-  %46 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %44, i64 0, i32 4
-  %47 = load i64*, i64** %46, align 8, !tbaa !41
-  %48 = load i64, i64* %47, align 8, !tbaa !6
-  %49 = and i64 %48, -33
-  store i64 %49, i64* %47, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %42, %struct.rb_control_frame_struct* %44, %struct.rb_iseq_struct* %stackFrame.i.i) #11
-  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %50, align 8, !dbg !49, !tbaa !24
-  %51 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %52 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !50
-  %needTakeSlowPath = icmp ne i64 %51, %52, !dbg !10
-  br i1 %needTakeSlowPath, label %53, label %54, !dbg !10, !prof !51
+  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2
+  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !tbaa !36
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %39, align 8, !tbaa !39
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 4
+  %41 = load i64*, i64** %40, align 8, !tbaa !41
+  %42 = load i64, i64* %41, align 8, !tbaa !6
+  %43 = and i64 %42, -33
+  store i64 %43, i64* %41, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %36, %struct.rb_control_frame_struct* %38, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 0
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %44, align 8, !dbg !44, !tbaa !24
+  %45 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %46 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !45
+  %needTakeSlowPath = icmp ne i64 %45, %46, !dbg !10
+  br i1 %needTakeSlowPath, label %47, label %48, !dbg !10, !prof !46
 
-53:                                               ; preds = %entry
+47:                                               ; preds = %entry
   call void @const_recompute_A(), !dbg !10
-  br label %54, !dbg !10
+  br label %48, !dbg !10
 
-54:                                               ; preds = %entry, %53
-  %55 = load i64, i64* @guarded_const_A, align 8, !dbg !10
-  %56 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %57 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !50
-  %guardUpdated = icmp eq i64 %56, %57, !dbg !10
+48:                                               ; preds = %entry, %47
+  %49 = load i64, i64* @guarded_const_A, align 8, !dbg !10
+  %50 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %51 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !45
+  %guardUpdated = icmp eq i64 %50, %51, !dbg !10
   call void @llvm.assume(i1 %guardUpdated), !dbg !10
   %stackFrame18.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#5write", align 8, !dbg !10
-  %58 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
-  %59 = bitcast i8* %58 to i16*, !dbg !10
-  %60 = load i16, i16* %59, align 8, !dbg !10
-  %61 = and i16 %60, -384, !dbg !10
-  %62 = or i16 %61, 1, !dbg !10
-  store i16 %62, i16* %59, align 8, !dbg !10
-  %63 = getelementptr inbounds i8, i8* %58, i64 8, !dbg !10
-  %64 = bitcast i8* %63 to i32*, !dbg !10
-  store i32 1, i32* %64, align 8, !dbg !10, !tbaa !52
-  %65 = getelementptr inbounds i8, i8* %58, i64 12, !dbg !10
-  %66 = getelementptr inbounds i8, i8* %58, i64 4, !dbg !10
-  %67 = bitcast i8* %66 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %65, i8 0, i64 20, i1 false) #11, !dbg !10
-  store i32 1, i32* %67, align 4, !dbg !10, !tbaa !55
+  %52 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %53 = bitcast i8* %52 to i16*, !dbg !10
+  %54 = load i16, i16* %53, align 8, !dbg !10
+  %55 = and i16 %54, -384, !dbg !10
+  %56 = or i16 %55, 1, !dbg !10
+  store i16 %56, i16* %53, align 8, !dbg !10
+  %57 = getelementptr inbounds i8, i8* %52, i64 8, !dbg !10
+  %58 = bitcast i8* %57 to i32*, !dbg !10
+  store i32 1, i32* %58, align 8, !dbg !10, !tbaa !47
+  %59 = getelementptr inbounds i8, i8* %52, i64 12, !dbg !10
+  %60 = getelementptr inbounds i8, i8* %52, i64 4, !dbg !10
+  %61 = bitcast i8* %60 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %59, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %61, align 4, !dbg !10, !tbaa !50
   %rubyId_v.i.i = load i64, i64* @rubyIdPrecomputed_v, align 8, !dbg !10
   store i64 %rubyId_v.i.i, i64* %positional_table.i.i, align 8, !dbg !10
-  %68 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %68, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %41, i64 noundef 8, i1 noundef false) #11, !dbg !10
-  %69 = getelementptr inbounds i8, i8* %58, i64 32, !dbg !10
-  %70 = bitcast i8* %69 to i8**, !dbg !10
-  store i8* %68, i8** %70, align 8, !dbg !10, !tbaa !56
-  call void @sorbet_vm_define_method(i64 %55, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#5write", i8* nonnull %58, %struct.rb_iseq_struct* %stackFrame18.i.i, i1 noundef zeroext false) #11, !dbg !10
-  %71 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !10, !tbaa !24
-  %72 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 5, !dbg !10
-  %73 = load i32, i32* %72, align 8, !dbg !10, !tbaa !57
-  %74 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 6, !dbg !10
-  %75 = load i32, i32* %74, align 4, !dbg !10, !tbaa !58
-  %76 = xor i32 %75, -1, !dbg !10
-  %77 = and i32 %76, %73, !dbg !10
-  %78 = icmp eq i32 %77, 0, !dbg !10
-  br i1 %78, label %rb_vm_check_ints.exit1.i.i, label %79, !dbg !10, !prof !59
-
-79:                                               ; preds = %54
-  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %71, i64 0, i32 8, !dbg !10
-  %81 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %80, align 8, !dbg !10, !tbaa !60
-  %82 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %81, i32 noundef 0) #11, !dbg !10
-  br label %rb_vm_check_ints.exit1.i.i, !dbg !10
-
-rb_vm_check_ints.exit1.i.i:                       ; preds = %79, %54
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %50, align 8, !dbg !10, !tbaa !24
-  %stackFrame27.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8, !dbg !61
-  %83 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !61
-  %84 = bitcast i8* %83 to i16*, !dbg !61
-  %85 = load i16, i16* %84, align 8, !dbg !61
-  %86 = and i16 %85, -384, !dbg !61
-  store i16 %86, i16* %84, align 8, !dbg !61
-  %87 = getelementptr inbounds i8, i8* %83, i64 4, !dbg !61
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %87, i8 0, i64 28, i1 false) #11, !dbg !61
-  call void @sorbet_vm_define_method(i64 %55, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#4read", i8* nonnull %83, %struct.rb_iseq_struct* %stackFrame27.i.i, i1 noundef zeroext false) #11, !dbg !61
-  %88 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !61, !tbaa !24
-  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %88, i64 0, i32 5, !dbg !61
-  %90 = load i32, i32* %89, align 8, !dbg !61, !tbaa !57
-  %91 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %88, i64 0, i32 6, !dbg !61
-  %92 = load i32, i32* %91, align 4, !dbg !61, !tbaa !58
-  %93 = xor i32 %92, -1, !dbg !61
-  %94 = and i32 %93, %90, !dbg !61
-  %95 = icmp eq i32 %94, 0, !dbg !61
-  br i1 %95, label %"func_A.13<static-init>L62.exit.i", label %96, !dbg !61, !prof !59
-
-96:                                               ; preds = %rb_vm_check_ints.exit1.i.i
-  %97 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %88, i64 0, i32 8, !dbg !61
-  %98 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %97, align 8, !dbg !61, !tbaa !60
-  %99 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %98, i32 noundef 0) #11, !dbg !61
-  br label %"func_A.13<static-init>L62.exit.i", !dbg !61
-
-"func_A.13<static-init>L62.exit.i":               ; preds = %96, %rb_vm_check_ints.exit1.i.i
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %41) #11
+  %62 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %35, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %63 = getelementptr inbounds i8, i8* %52, i64 32, !dbg !10
+  %64 = bitcast i8* %63 to i8**, !dbg !10
+  store i8* %62, i8** %64, align 8, !dbg !10, !tbaa !51
+  call void @sorbet_vm_define_method(i64 %49, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#5write", i8* nonnull %52, %struct.rb_iseq_struct* %stackFrame18.i.i, i1 noundef zeroext false) #11, !dbg !10
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %44, align 8, !dbg !10, !tbaa !24
+  %stackFrame27.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8, !dbg !52
+  %65 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !52
+  %66 = bitcast i8* %65 to i16*, !dbg !52
+  %67 = load i16, i16* %66, align 8, !dbg !52
+  %68 = and i16 %67, -384, !dbg !52
+  store i16 %68, i16* %66, align 8, !dbg !52
+  %69 = getelementptr inbounds i8, i8* %65, i64 4, !dbg !52
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %69, i8 0, i64 28, i1 false) #11, !dbg !52
+  call void @sorbet_vm_define_method(i64 %49, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#4read", i8* nonnull %65, %struct.rb_iseq_struct* %stackFrame27.i.i, i1 noundef zeroext false) #11, !dbg !52
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35) #11
   call void @sorbet_popFrame() #11, !dbg !43
-  call void @llvm.lifetime.end.p0i8(i64 noundef 24, i8* noundef nonnull %36) #11, !dbg !43
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %32, align 8, !dbg !43, !tbaa !24
-  %100 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %55, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !17
-  %101 = icmp eq i64 %100, 52, !dbg !17
-  br i1 %101, label %slowNew.i, label %fastNew.i, !dbg !17
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %31, align 8, !dbg !43, !tbaa !24
+  %70 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %49, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !17
+  %71 = icmp eq i64 %70, 52, !dbg !17
+  br i1 %71, label %slowNew.i, label %fastNew.i, !dbg !17
 
-slowNew.i:                                        ; preds = %"func_A.13<static-init>L62.exit.i"
-  %102 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !17
-  %103 = load i64*, i64** %102, align 8, !dbg !17
-  store i64 %55, i64* %103, align 8, !dbg !17, !tbaa !6
-  %104 = getelementptr inbounds i64, i64* %103, i64 1, !dbg !17
-  store i64* %104, i64** %102, align 8, !dbg !17
-  %105 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !17
+slowNew.i:                                        ; preds = %48
+  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !17
+  %73 = load i64*, i64** %72, align 8, !dbg !17
+  store i64 %49, i64* %73, align 8, !dbg !17, !tbaa !6
+  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !17
+  store i64* %74, i64** %72, align 8, !dbg !17
+  %75 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !17
   br label %"func_<root>.17<static-init>$152.exit", !dbg !17
 
-fastNew.i:                                        ; preds = %"func_A.13<static-init>L62.exit.i"
-  %106 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !17
-  %107 = load i64*, i64** %106, align 8, !dbg !17
-  store i64 %100, i64* %107, align 8, !dbg !17, !tbaa !6
-  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !17
-  store i64* %108, i64** %106, align 8, !dbg !17
-  %109 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !17
+fastNew.i:                                        ; preds = %48
+  %76 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !17
+  %77 = load i64*, i64** %76, align 8, !dbg !17
+  store i64 %70, i64* %77, align 8, !dbg !17, !tbaa !6
+  %78 = getelementptr inbounds i64, i64* %77, i64 1, !dbg !17
+  store i64* %78, i64** %76, align 8, !dbg !17
+  %79 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !17
   br label %"func_<root>.17<static-init>$152.exit", !dbg !17
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %slowNew.i, %fastNew.i
-  %initializedObject.i = phi i64 [ %105, %slowNew.i ], [ %100, %fastNew.i ], !dbg !17
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %32, align 8, !dbg !17, !tbaa !24
-  %110 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !18
-  %111 = load i64*, i64** %110, align 8, !dbg !18
-  store i64 %initializedObject.i, i64* %111, align 8, !dbg !18, !tbaa !6
-  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !18
-  store i64* %112, i64** %110, align 8, !dbg !18
+  %initializedObject.i = phi i64 [ %75, %slowNew.i ], [ %70, %fastNew.i ], !dbg !17
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %31, align 8, !dbg !17, !tbaa !24
+  %80 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !18
+  %81 = load i64*, i64** %80, align 8, !dbg !18
+  store i64 %initializedObject.i, i64* %81, align 8, !dbg !18, !tbaa !6
+  %82 = getelementptr inbounds i64, i64* %81, i64 1, !dbg !18
+  store i64* %82, i64** %80, align 8, !dbg !18
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
-  %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !19
-  %114 = load i64*, i64** %113, align 8, !dbg !19
-  store i64 %23, i64* %114, align 8, !dbg !19, !tbaa !6
-  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !19
-  store i64 %send, i64* %115, align 8, !dbg !19, !tbaa !6
-  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !19
-  store i64* %116, i64** %113, align 8, !dbg !19
+  %83 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !19
+  %84 = load i64*, i64** %83, align 8, !dbg !19
+  store i64 %22, i64* %84, align 8, !dbg !19, !tbaa !6
+  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !19
+  store i64 %send, i64* %85, align 8, !dbg !19, !tbaa !6
+  %86 = getelementptr inbounds i64, i64* %85, i64 1, !dbg !19
+  store i64* %86, i64** %83, align 8, !dbg !19
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %32, align 8, !dbg !19, !tbaa !24
-  %rubyStr_value.i = load i64, i64* @rubyStrFrozen_value, align 8, !dbg !62
-  %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !20
-  %118 = load i64*, i64** %117, align 8, !dbg !20
-  store i64 %initializedObject.i, i64* %118, align 8, !dbg !20, !tbaa !6
-  %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !20
-  store i64 %rubyStr_value.i, i64* %119, align 8, !dbg !20, !tbaa !6
-  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !20
-  store i64* %120, i64** %117, align 8, !dbg !20
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %31, align 8, !dbg !19, !tbaa !24
+  %rubyStr_value.i = load i64, i64* @rubyStrFrozen_value, align 8, !dbg !53
+  %87 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !20
+  %88 = load i64*, i64** %87, align 8, !dbg !20
+  store i64 %initializedObject.i, i64* %88, align 8, !dbg !20, !tbaa !6
+  %89 = getelementptr inbounds i64, i64* %88, i64 1, !dbg !20
+  store i64 %rubyStr_value.i, i64* %89, align 8, !dbg !20, !tbaa !6
+  %90 = getelementptr inbounds i64, i64* %89, i64 1, !dbg !20
+  store i64* %90, i64** %87, align 8, !dbg !20
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !20
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %32, align 8, !dbg !20, !tbaa !24
-  %121 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !21
-  %122 = load i64*, i64** %121, align 8, !dbg !21
-  store i64 %initializedObject.i, i64* %122, align 8, !dbg !21, !tbaa !6
-  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !21
-  store i64* %123, i64** %121, align 8, !dbg !21
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %31, align 8, !dbg !20, !tbaa !24
+  %91 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !21
+  %92 = load i64*, i64** %91, align 8, !dbg !21
+  store i64 %initializedObject.i, i64* %92, align 8, !dbg !21, !tbaa !6
+  %93 = getelementptr inbounds i64, i64* %92, i64 1, !dbg !21
+  store i64* %93, i64** %91, align 8, !dbg !21
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.1, i64 0), !dbg !21
-  %124 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !22
-  %125 = load i64*, i64** %124, align 8, !dbg !22
-  store i64 %23, i64* %125, align 8, !dbg !22, !tbaa !6
-  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !22
-  store i64 %send6, i64* %126, align 8, !dbg !22, !tbaa !6
-  %127 = getelementptr inbounds i64, i64* %126, i64 1, !dbg !22
-  store i64* %127, i64** %124, align 8, !dbg !22
+  %94 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !22
+  %95 = load i64*, i64** %94, align 8, !dbg !22
+  store i64 %22, i64* %95, align 8, !dbg !22, !tbaa !6
+  %96 = getelementptr inbounds i64, i64* %95, i64 1, !dbg !22
+  store i64 %send6, i64* %96, align 8, !dbg !22, !tbaa !6
+  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !22
+  store i64* %97, i64** %94, align 8, !dbg !22
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !22
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %32, align 8, !dbg !22, !tbaa !24
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %31, align 8, !dbg !22, !tbaa !24
   %"rubyId_$f.i" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !23
-  %128 = call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f.i") #11, !dbg !23
-  %129 = call i64 @rb_gvar_get(%struct.rb_global_entry* %128) #11, !dbg !23
-  %130 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !23
-  %131 = load i64*, i64** %130, align 8, !dbg !23
-  store i64 %23, i64* %131, align 8, !dbg !23, !tbaa !6
-  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !23
-  store i64 %129, i64* %132, align 8, !dbg !23, !tbaa !6
-  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !23
-  store i64* %133, i64** %130, align 8, !dbg !23
+  %98 = call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f.i") #11, !dbg !23
+  %99 = call i64 @rb_gvar_get(%struct.rb_global_entry* %98) #11, !dbg !23
+  %100 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !23
+  %101 = load i64*, i64** %100, align 8, !dbg !23
+  store i64 %22, i64* %101, align 8, !dbg !23, !tbaa !6
+  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !23
+  store i64 %99, i64* %102, align 8, !dbg !23, !tbaa !6
+  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !23
+  store i64* %103, i64** %100, align 8, !dbg !23
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !23
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %32, align 8, !dbg !23, !tbaa !24
-  %134 = call i64 @sorbet_setConstant(i64 %33, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_F, i64 0, i64 0), i64 noundef 1, i64 noundef 3) #11, !dbg !63
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %31, align 8, !dbg !23, !tbaa !24
+  %104 = call i64 @sorbet_setConstant(i64 %32, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_F, i64 0, i64 0), i64 noundef 1, i64 noundef 3) #11, !dbg !54
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @"func_A#5write"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !64 {
+define internal i64 @"func_A#5write"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !55 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !24
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !65
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !65
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !65
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !65, !prof !66
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !56
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !56
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !56
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !56, !prof !57
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !65
-  unreachable, !dbg !65
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !56
+  unreachable, !dbg !56
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_v = load i64, i64* %argArray, align 8, !dbg !65
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !67, !tbaa !24
-  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !68
-  %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !68
-  %2 = tail call i64 @rb_gvar_set(%struct.rb_global_entry* %1, i64 %rawArg_v) #11, !dbg !68
-  %"rubyId_$f7" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !69
-  %3 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f7") #11, !dbg !69
-  %4 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %3) #11, !dbg !69
+  %rawArg_v = load i64, i64* %argArray, align 8, !dbg !56
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !58, !tbaa !24
+  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !59
+  %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !59
+  %2 = tail call i64 @rb_gvar_set(%struct.rb_global_entry* %1, i64 %rawArg_v) #11, !dbg !59
+  %"rubyId_$f7" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !60
+  %3 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f7") #11, !dbg !60
+  %4 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %3) #11, !dbg !60
   ret i64 %4
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @"func_A#4read"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !70 {
+define internal i64 @"func_A#4read"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !61 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !tbaa !24
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !71
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !71, !prof !72
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !62
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !62, !prof !63
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !71
-  unreachable, !dbg !71
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !62
+  unreachable, !dbg !62
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !73, !tbaa !24
-  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !74
-  %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !74
-  %2 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %1) #11, !dbg !74
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !64, !tbaa !24
+  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !65
+  %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !65
+  %2 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %1) #11, !dbg !65
   ret i64 %2
 }
 
@@ -549,7 +501,7 @@ declare void @llvm.assume(i1 noundef) #8
 define linkonce void @const_recompute_A() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !50
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !45
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -616,34 +568,25 @@ attributes #13 = { noreturn }
 !41 = !{!40, !25, i64 32}
 !42 = !DILocation(line: 0, scope: !16)
 !43 = !DILocation(line: 5, column: 1, scope: !16)
-!44 = !{!45, !7, i64 0}
-!45 = !{!"rb_calling_info", !7, i64 0, !7, i64 8, !31, i64 16, !31, i64 20}
-!46 = !{!45, !31, i64 20}
-!47 = !{!45, !7, i64 8}
-!48 = !{!45, !31, i64 16}
-!49 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
-!50 = !{!32, !32, i64 0}
-!51 = !{!"branch_weights", i32 1, i32 10000}
-!52 = !{!53, !31, i64 8}
-!53 = !{!"rb_sorbet_param_struct", !54, i64 0, !31, i64 4, !31, i64 8, !31, i64 12, !31, i64 16, !31, i64 20, !31, i64 24, !31, i64 28, !25, i64 32, !31, i64 40, !31, i64 44, !31, i64 48, !31, i64 52, !25, i64 56}
-!54 = !{!"", !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 1, !31, i64 1}
-!55 = !{!53, !31, i64 4}
-!56 = !{!53, !25, i64 32}
-!57 = !{!37, !31, i64 40}
-!58 = !{!37, !31, i64 44}
-!59 = !{!"branch_weights", i32 2000, i32 1}
-!60 = !{!37, !25, i64 56}
-!61 = !DILocation(line: 9, column: 3, scope: !11, inlinedAt: !15)
-!62 = !DILocation(line: 16, column: 9, scope: !16)
-!63 = !DILocation(line: 19, column: 5, scope: !16)
-!64 = distinct !DISubprogram(name: "A#write", linkageName: "func_A#5write", scope: null, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!65 = !DILocation(line: 6, column: 3, scope: !64)
-!66 = !{!"branch_weights", i32 4001, i32 4000000}
-!67 = !DILocation(line: 6, column: 13, scope: !64)
-!68 = !DILocation(line: 7, column: 10, scope: !64)
-!69 = !DILocation(line: 7, column: 5, scope: !64)
-!70 = distinct !DISubprogram(name: "A#read", linkageName: "func_A#4read", scope: null, file: !4, line: 9, type: !12, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!71 = !DILocation(line: 9, column: 3, scope: !70)
-!72 = !{!"branch_weights", i32 1, i32 2000}
-!73 = !DILocation(line: 0, scope: !70)
-!74 = !DILocation(line: 10, column: 5, scope: !70)
+!44 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
+!45 = !{!32, !32, i64 0}
+!46 = !{!"branch_weights", i32 1, i32 10000}
+!47 = !{!48, !31, i64 8}
+!48 = !{!"rb_sorbet_param_struct", !49, i64 0, !31, i64 4, !31, i64 8, !31, i64 12, !31, i64 16, !31, i64 20, !31, i64 24, !31, i64 28, !25, i64 32, !31, i64 40, !31, i64 44, !31, i64 48, !31, i64 52, !25, i64 56}
+!49 = !{!"", !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 0, !31, i64 1, !31, i64 1}
+!50 = !{!48, !31, i64 4}
+!51 = !{!48, !25, i64 32}
+!52 = !DILocation(line: 9, column: 3, scope: !11, inlinedAt: !15)
+!53 = !DILocation(line: 16, column: 9, scope: !16)
+!54 = !DILocation(line: 19, column: 5, scope: !16)
+!55 = distinct !DISubprogram(name: "A#write", linkageName: "func_A#5write", scope: null, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!56 = !DILocation(line: 6, column: 3, scope: !55)
+!57 = !{!"branch_weights", i32 4001, i32 4000000}
+!58 = !DILocation(line: 6, column: 13, scope: !55)
+!59 = !DILocation(line: 7, column: 10, scope: !55)
+!60 = !DILocation(line: 7, column: 5, scope: !55)
+!61 = distinct !DISubprogram(name: "A#read", linkageName: "func_A#4read", scope: null, file: !4, line: 9, type: !12, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!62 = !DILocation(line: 9, column: 3, scope: !61)
+!63 = !{!"branch_weights", i32 1, i32 2000}
+!64 = !DILocation(line: 0, scope: !61)
+!65 = !DILocation(line: 10, column: 5, scope: !61)

--- a/test/testdata/compiler/intrinsics/bang.opt.ll.exp
+++ b/test/testdata/compiler/intrinsics/bang.opt.ll.exp
@@ -160,12 +160,6 @@ declare i64 @rb_define_module(i8*) local_unnamed_addr #1
 
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
-
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
 declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
@@ -175,99 +169,95 @@ declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
 declare i64 @rb_funcallv_with_cc(%struct.rb_call_data*, i64, i64, i32, i64*) local_unnamed_addr #1
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #1
-
 ; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #3
+declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #11
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #11
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: sspreq
-define void @Init_bang() local_unnamed_addr #5 {
+define void @Init_bang() local_unnamed_addr #4 {
 entry:
-  %0 = alloca %struct.rb_calling_info, align 8
-  %1 = alloca %struct.rb_calling_info, align 8
   %locals.i27.i = alloca i64, i32 0, align 8
   %locals.i25.i = alloca i64, i32 0, align 8
   %locals.i23.i = alloca i64, i32 0, align 8
   %locals.i21.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
-  store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #12
-  store i64 %3, i64* @rubyIdPrecomputed_test, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #12
-  store i64 %4, i64* @"rubyIdPrecomputed_!", align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #12
-  store i64 %5, i64* @rubyIdPrecomputed_puts, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Bad>", i64 0, i64 0), i64 noundef 11) #12
-  store i64 %6, i64* @"rubyIdPrecomputed_<class:Bad>", align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #12
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #12
-  store i64 %8, i64* @rubyIdPrecomputed_new, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #12
-  store i64 %9, i64* @rubyIdPrecomputed_initialize, align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #12
-  store i64 %10, i64* @"rubyIdPrecomputed_<module:Main>", align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
-  tail call void @rb_gc_register_mark_object(i64 %11) #12
-  store i64 %11, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %12 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @"str_test/testdata/compiler/intrinsics/bang.rb", i64 0, i64 0), i64 noundef 41) #12
-  tail call void @rb_gc_register_mark_object(i64 %12) #12
-  store i64 %12, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
+  store i64 %1, i64* @rubyIdPrecomputed_test, align 8
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #11
+  store i64 %2, i64* @"rubyIdPrecomputed_!", align 8
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Bad>", i64 0, i64 0), i64 noundef 11) #11
+  store i64 %4, i64* @"rubyIdPrecomputed_<class:Bad>", align 8
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
+  store i64 %6, i64* @rubyIdPrecomputed_new, align 8
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #11
+  store i64 %7, i64* @rubyIdPrecomputed_initialize, align 8
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #11
+  store i64 %8, i64* @"rubyIdPrecomputed_<module:Main>", align 8
+  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %9) #11
+  store i64 %9, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @"str_test/testdata/compiler/intrinsics/bang.rb", i64 0, i64 0), i64 noundef 41) #11
+  tail call void @rb_gc_register_mark_object(i64 %10) #11
+  store i64 %10, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 23)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_test.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !10
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #12
-  call void @rb_gc_register_mark_object(i64 %14) #12
+  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #11
+  call void @rb_gc_register_mark_object(i64 %12) #11
   %"rubyId_!.i.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %"rubyId_!.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i21.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @"str_bad bang overload", i64 0, i64 0), i64 noundef 17) #12
-  call void @rb_gc_register_mark_object(i64 %16) #12
-  store i64 %16, i64* @"rubyStrFrozen_bad bang overload", align 8
+  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %12, i64 %"rubyId_!.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i21.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8
+  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @"str_bad bang overload", i64 0, i64 0), i64 noundef 17) #11
+  call void @rb_gc_register_mark_object(i64 %14) #11
+  store i64 %14, i64* @"rubyStrFrozen_bad bang overload", align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Bad>", i64 0, i64 0), i64 noundef 11) #12
-  call void @rb_gc_register_mark_object(i64 %17) #12
+  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Bad>", i64 0, i64 0), i64 noundef 11) #11
+  call void @rb_gc_register_mark_object(i64 %15) #11
   %"rubyId_<class:Bad>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:Bad>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %"rubyId_<class:Bad>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #12
-  call void @rb_gc_register_mark_object(i64 %19) #12
+  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %"rubyId_<class:Bad>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
+  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %17) #11
   %rubyId_test.i.i = load i64, i64* @rubyIdPrecomputed_test, align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8
+  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8
   %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
   %rubyId_puts5.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts5.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !20
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_hello, i64 0, i64 0), i64 noundef 5) #12
-  call void @rb_gc_register_mark_object(i64 %21) #12
-  store i64 %21, i64* @rubyStrFrozen_hello, align 8
+  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_hello, i64 0, i64 0), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %19) #11
+  store i64 %19, i64* @rubyStrFrozen_hello, align 8
   %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !22
@@ -276,179 +266,135 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
   %rubyId_puts17.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts17.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #12
-  call void @rb_gc_register_mark_object(i64 %22) #12
+  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #11
+  call void @rb_gc_register_mark_object(i64 %20) #11
   %"rubyId_<module:Main>.i.i" = load i64, i64* @"rubyIdPrecomputed_<module:Main>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %"rubyId_<module:Main>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 12, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i27.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
-  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2
-  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !tbaa !26
+  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_<module:Main>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 12, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i27.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
+  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
+  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !26
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %27, align 8, !tbaa !30
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4
-  %29 = load i64*, i64** %28, align 8, !tbaa !32
-  %30 = load i64, i64* %29, align 8, !tbaa !6
-  %31 = and i64 %30, -33
-  store i64 %31, i64* %29, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %24, %struct.rb_control_frame_struct* %26, %struct.rb_iseq_struct* %stackFrame.i) #12
-  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %32, align 8, !dbg !33, !tbaa !24
-  %33 = load i64, i64* @rb_cObject, align 8, !dbg !34
-  %34 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 %33) #12, !dbg !34
-  %35 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %34) #12, !dbg !34
-  %36 = bitcast %struct.rb_calling_info* %0 to i8*, !dbg !34
-  call void @llvm.lifetime.start.p0i8(i64 noundef 24, i8* noundef nonnull align 8 dereferenceable(24) %36) #12, !dbg !34
-  %37 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 0, !dbg !34
-  store i64 0, i64* %37, align 8, !dbg !34, !tbaa !35
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !30
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
+  %27 = load i64*, i64** %26, align 8, !tbaa !32
+  %28 = load i64, i64* %27, align 8, !tbaa !6
+  %29 = and i64 %28, -33
+  store i64 %29, i64* %27, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !33, !tbaa !24
+  %31 = load i64, i64* @rb_cObject, align 8, !dbg !34
+  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 %31) #11, !dbg !34
+  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #11, !dbg !34
   %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
-  %38 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
-  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 2
-  %40 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %39, align 8, !tbaa !26
-  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %41, align 8, !tbaa !30
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 4
-  %43 = load i64*, i64** %42, align 8, !tbaa !32
-  %44 = load i64, i64* %43, align 8, !tbaa !6
-  %45 = and i64 %44, -33
-  store i64 %45, i64* %43, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %38, %struct.rb_control_frame_struct* %40, %struct.rb_iseq_struct* %stackFrame.i1.i) #12
-  %46 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %46, align 8, !dbg !37, !tbaa !24
-  %47 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !40
-  %48 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !40, !tbaa !41
-  %needTakeSlowPath = icmp ne i64 %47, %48, !dbg !40
-  br i1 %needTakeSlowPath, label %49, label %50, !dbg !40, !prof !43
+  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
+  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !26
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !30
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
+  %39 = load i64*, i64** %38, align 8, !tbaa !32
+  %40 = load i64, i64* %39, align 8, !tbaa !6
+  %41 = and i64 %40, -33
+  store i64 %41, i64* %39, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i1.i) #11
+  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !35, !tbaa !24
+  %43 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !38
+  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !39
+  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !38
+  br i1 %needTakeSlowPath, label %45, label %46, !dbg !38, !prof !41
 
-49:                                               ; preds = %entry
-  call void @const_recompute_Bad(), !dbg !40
-  br label %50, !dbg !40
+45:                                               ; preds = %entry
+  call void @const_recompute_Bad(), !dbg !38
+  br label %46, !dbg !38
 
-50:                                               ; preds = %entry, %49
-  %51 = load i64, i64* @guarded_const_Bad, align 8, !dbg !40
-  %52 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !40
-  %53 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !40, !tbaa !41
-  %guardUpdated = icmp eq i64 %52, %53, !dbg !40
-  call void @llvm.assume(i1 %guardUpdated), !dbg !40
-  %stackFrame8.i2.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8, !dbg !40
-  %54 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !40
-  %55 = bitcast i8* %54 to i16*, !dbg !40
-  %56 = load i16, i16* %55, align 8, !dbg !40
-  %57 = and i16 %56, -384, !dbg !40
-  store i16 %57, i16* %55, align 8, !dbg !40
-  %58 = getelementptr inbounds i8, i8* %54, i64 4, !dbg !40
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %58, i8 0, i64 28, i1 false) #12, !dbg !40
-  call void @sorbet_vm_define_method(i64 %51, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Bad#1!", i8* nonnull %54, %struct.rb_iseq_struct* %stackFrame8.i2.i, i1 noundef zeroext false) #12, !dbg !40
-  %59 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !24
-  %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 5, !dbg !40
-  %61 = load i32, i32* %60, align 8, !dbg !40, !tbaa !44
-  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 6, !dbg !40
-  %63 = load i32, i32* %62, align 4, !dbg !40, !tbaa !45
-  %64 = xor i32 %63, -1, !dbg !40
-  %65 = and i32 %64, %61, !dbg !40
-  %66 = icmp eq i32 %65, 0, !dbg !40
-  br i1 %66, label %"func_Bad.13<static-init>L62.exit.i", label %67, !dbg !40, !prof !46
-
-67:                                               ; preds = %50
-  %68 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %59, i64 0, i32 8, !dbg !40
-  %69 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %68, align 8, !dbg !40, !tbaa !47
-  %70 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %69, i32 noundef 0) #12, !dbg !40
-  br label %"func_Bad.13<static-init>L62.exit.i", !dbg !40
-
-"func_Bad.13<static-init>L62.exit.i":             ; preds = %67, %50
-  call void @sorbet_popFrame() #12, !dbg !34
-  call void @llvm.lifetime.end.p0i8(i64 noundef 24, i8* noundef nonnull %36) #12, !dbg !34
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %32, align 8, !dbg !34, !tbaa !24
-  %71 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0)) #12, !dbg !48
-  %72 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %71) #12, !dbg !48
-  %73 = bitcast %struct.rb_calling_info* %1 to i8*, !dbg !48
-  call void @llvm.lifetime.start.p0i8(i64 noundef 24, i8* noundef nonnull align 8 dereferenceable(24) %73) #12, !dbg !48
-  %74 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %1, i64 0, i32 0, !dbg !48
-  store i64 0, i64* %74, align 8, !dbg !48, !tbaa !35
+46:                                               ; preds = %entry, %45
+  %47 = load i64, i64* @guarded_const_Bad, align 8, !dbg !38
+  %48 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !38
+  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !39
+  %guardUpdated = icmp eq i64 %48, %49, !dbg !38
+  call void @llvm.assume(i1 %guardUpdated), !dbg !38
+  %stackFrame8.i2.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8, !dbg !38
+  %50 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !38
+  %51 = bitcast i8* %50 to i16*, !dbg !38
+  %52 = load i16, i16* %51, align 8, !dbg !38
+  %53 = and i16 %52, -384, !dbg !38
+  store i16 %53, i16* %51, align 8, !dbg !38
+  %54 = getelementptr inbounds i8, i8* %50, i64 4, !dbg !38
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %54, i8 0, i64 28, i1 false) #11, !dbg !38
+  call void @sorbet_vm_define_method(i64 %47, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Bad#1!", i8* nonnull %50, %struct.rb_iseq_struct* %stackFrame8.i2.i, i1 noundef zeroext false) #11, !dbg !38
+  call void @sorbet_popFrame() #11, !dbg !34
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %30, align 8, !dbg !34, !tbaa !24
+  %55 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0)) #11, !dbg !42
+  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #11, !dbg !42
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
-  %75 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
-  %76 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %75, i64 0, i32 2
-  %77 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %76, align 8, !tbaa !26
-  %78 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %77, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %78, align 8, !tbaa !30
-  %79 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %77, i64 0, i32 4
-  %80 = load i64*, i64** %79, align 8, !tbaa !32
-  %81 = load i64, i64* %80, align 8, !tbaa !6
-  %82 = and i64 %81, -33
-  store i64 %82, i64* %80, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %75, %struct.rb_control_frame_struct* %77, %struct.rb_iseq_struct* %stackFrame.i.i) #12
-  %83 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %72, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %83, align 8, !dbg !49, !tbaa !24
-  %84 = load i64, i64* @guard_epoch_Main, align 8, !dbg !52
-  %85 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !41
-  %needTakeSlowPath1 = icmp ne i64 %84, %85, !dbg !52
-  br i1 %needTakeSlowPath1, label %86, label %87, !dbg !52, !prof !43
+  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 2
+  %59 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %58, align 8, !tbaa !26
+  %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %59, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %60, align 8, !tbaa !30
+  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %59, i64 0, i32 4
+  %62 = load i64*, i64** %61, align 8, !tbaa !32
+  %63 = load i64, i64* %62, align 8, !tbaa !6
+  %64 = and i64 %63, -33
+  store i64 %64, i64* %62, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %57, %struct.rb_control_frame_struct* %59, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %65 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %65, align 8, !dbg !43, !tbaa !24
+  %66 = load i64, i64* @guard_epoch_Main, align 8, !dbg !46
+  %67 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !39
+  %needTakeSlowPath1 = icmp ne i64 %66, %67, !dbg !46
+  br i1 %needTakeSlowPath1, label %68, label %69, !dbg !46, !prof !41
 
-86:                                               ; preds = %"func_Bad.13<static-init>L62.exit.i"
-  call void @const_recompute_Main(), !dbg !52
-  br label %87, !dbg !52
+68:                                               ; preds = %46
+  call void @const_recompute_Main(), !dbg !46
+  br label %69, !dbg !46
 
-87:                                               ; preds = %"func_Bad.13<static-init>L62.exit.i", %86
-  %88 = load i64, i64* @guarded_const_Main, align 8, !dbg !52
-  %89 = load i64, i64* @guard_epoch_Main, align 8, !dbg !52
-  %90 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !41
-  %guardUpdated2 = icmp eq i64 %89, %90, !dbg !52
-  call void @llvm.assume(i1 %guardUpdated2), !dbg !52
-  %stackFrame8.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8, !dbg !52
-  %91 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !52
-  %92 = bitcast i8* %91 to i16*, !dbg !52
-  %93 = load i16, i16* %92, align 8, !dbg !52
-  %94 = and i16 %93, -384, !dbg !52
-  store i16 %94, i16* %92, align 8, !dbg !52
-  %95 = getelementptr inbounds i8, i8* %91, i64 4, !dbg !52
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %95, i8 0, i64 28, i1 false) #12, !dbg !52
-  call void @sorbet_vm_define_method(i64 %88, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Main.4test, i8* nonnull %91, %struct.rb_iseq_struct* %stackFrame8.i.i, i1 noundef zeroext true) #12, !dbg !52
-  %96 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !24
-  %97 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %96, i64 0, i32 5, !dbg !52
-  %98 = load i32, i32* %97, align 8, !dbg !52, !tbaa !44
-  %99 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %96, i64 0, i32 6, !dbg !52
-  %100 = load i32, i32* %99, align 4, !dbg !52, !tbaa !45
-  %101 = xor i32 %100, -1, !dbg !52
-  %102 = and i32 %101, %98, !dbg !52
-  %103 = icmp eq i32 %102, 0, !dbg !52
-  br i1 %103, label %"func_<root>.17<static-init>$152.exit", label %104, !dbg !52, !prof !46
-
-104:                                              ; preds = %87
-  %105 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %96, i64 0, i32 8, !dbg !52
-  %106 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %105, align 8, !dbg !52, !tbaa !47
-  %107 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %106, i32 noundef 0) #12, !dbg !52
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !52
-
-"func_<root>.17<static-init>$152.exit":           ; preds = %87, %104
-  call void @sorbet_popFrame() #12, !dbg !48
-  call void @llvm.lifetime.end.p0i8(i64 noundef 24, i8* noundef nonnull %73) #12, !dbg !48
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %32, align 8, !dbg !48, !tbaa !24
-  %108 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !10
-  %109 = load i64*, i64** %108, align 8, !dbg !10
-  store i64 %88, i64* %109, align 8, !dbg !10, !tbaa !6
-  %110 = getelementptr inbounds i64, i64* %109, i64 1, !dbg !10
-  store i64* %110, i64** %108, align 8, !dbg !10
+69:                                               ; preds = %46, %68
+  %70 = load i64, i64* @guarded_const_Main, align 8, !dbg !46
+  %71 = load i64, i64* @guard_epoch_Main, align 8, !dbg !46
+  %72 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !39
+  %guardUpdated2 = icmp eq i64 %71, %72, !dbg !46
+  call void @llvm.assume(i1 %guardUpdated2), !dbg !46
+  %stackFrame8.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8, !dbg !46
+  %73 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !46
+  %74 = bitcast i8* %73 to i16*, !dbg !46
+  %75 = load i16, i16* %74, align 8, !dbg !46
+  %76 = and i16 %75, -384, !dbg !46
+  store i16 %76, i16* %74, align 8, !dbg !46
+  %77 = getelementptr inbounds i8, i8* %73, i64 4, !dbg !46
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %77, i8 0, i64 28, i1 false) #11, !dbg !46
+  call void @sorbet_vm_define_method(i64 %70, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Main.4test, i8* nonnull %73, %struct.rb_iseq_struct* %stackFrame8.i.i, i1 noundef zeroext true) #11, !dbg !46
+  call void @sorbet_popFrame() #11, !dbg !42
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %30, align 8, !dbg !42, !tbaa !24
+  %78 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
+  %79 = load i64*, i64** %78, align 8, !dbg !10
+  store i64 %70, i64* %79, align 8, !dbg !10, !tbaa !6
+  %80 = getelementptr inbounds i64, i64* %79, i64 1, !dbg !10
+  store i64* %80, i64** %78, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !10
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal noundef i64 @"func_Bad#1!"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !16 {
+define internal noundef i64 @"func_Bad#1!"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #5 !dbg !16 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !24
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !53
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !53, !prof !54
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !47
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !47, !prof !48
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #14, !dbg !53
-  unreachable, !dbg !53
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !47
+  unreachable, !dbg !47
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !55, !tbaa !24
-  %"rubyStr_bad bang overload" = load i64, i64* @"rubyStrFrozen_bad bang overload", align 8, !dbg !56
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !49, !tbaa !24
+  %"rubyStr_bad bang overload" = load i64, i64* @"rubyStrFrozen_bad bang overload", align 8, !dbg !50
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !15
   %2 = load i64*, i64** %1, align 8, !dbg !15
   store i64 %selfRaw, i64* %2, align 8, !dbg !15, !tbaa !6
@@ -462,20 +408,20 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @func_Main.4test(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !18 {
+define internal i64 @func_Main.4test(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #5 !dbg !18 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !24
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !57
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !57, !prof !54
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !51
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !51, !prof !48
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #14, !dbg !57
-  unreachable, !dbg !57
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !51
+  unreachable, !dbg !51
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !58, !tbaa !24
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !59), !dbg !62
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !52, !tbaa !24
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !53), !dbg !56
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !17
   %2 = load i64*, i64** %1, align 8, !dbg !17
   store i64 %selfRaw, i64* %2, align 8, !dbg !17, !tbaa !6
@@ -485,7 +431,7 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
   store i64* %4, i64** %1, align 8, !dbg !17
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !17
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %0, align 8, !dbg !17, !tbaa !24
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !63), !dbg !66
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !57), !dbg !60
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !19
   %6 = load i64*, i64** %5, align 8, !dbg !19
   store i64 %selfRaw, i64* %6, align 8, !dbg !19, !tbaa !6
@@ -495,7 +441,7 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
   store i64* %8, i64** %5, align 8, !dbg !19
   %send110 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !19
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !dbg !19, !tbaa !24
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !67), !dbg !70
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !61), !dbg !64
   %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !20
   %10 = load i64*, i64** %9, align 8, !dbg !20
   store i64 %selfRaw, i64* %10, align 8, !dbg !20, !tbaa !6
@@ -505,23 +451,23 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
   store i64* %12, i64** %9, align 8, !dbg !20
   %send112 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !20
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !20, !tbaa !24
-  %rubyStr_hello = load i64, i64* @rubyStrFrozen_hello, align 8, !dbg !71
-  %"rubyId_!69" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !72
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !73), !dbg !72
-  %13 = and i64 %rubyStr_hello, -9, !dbg !72
-  %14 = icmp eq i64 %13, 0, !dbg !72
-  br i1 %14, label %sorbet_bang.exit106, label %15, !dbg !72
+  %rubyStr_hello = load i64, i64* @rubyStrFrozen_hello, align 8, !dbg !65
+  %"rubyId_!69" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !66
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !67), !dbg !66
+  %13 = and i64 %rubyStr_hello, -9, !dbg !66
+  %14 = icmp eq i64 %13, 0, !dbg !66
+  br i1 %14, label %sorbet_bang.exit106, label %15, !dbg !66
 
 15:                                               ; preds = %fillRequiredArgs
-  %16 = icmp eq i64 %rubyStr_hello, 20, !dbg !72
-  br i1 %16, label %sorbet_bang.exit106, label %17, !dbg !72
+  %16 = icmp eq i64 %rubyStr_hello, 20, !dbg !66
+  br i1 %16, label %sorbet_bang.exit106, label %17, !dbg !66
 
 17:                                               ; preds = %15
-  %18 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %rubyStr_hello, i64 %"rubyId_!69", i32 noundef 0, i64* noundef null) #12, !dbg !72
-  br label %sorbet_bang.exit106, !dbg !72
+  %18 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %rubyStr_hello, i64 %"rubyId_!69", i32 noundef 0, i64* noundef null) #11, !dbg !66
+  br label %sorbet_bang.exit106, !dbg !66
 
 sorbet_bang.exit106:                              ; preds = %fillRequiredArgs, %15, %17
-  %19 = phi i64 [ %18, %17 ], [ 0, %15 ], [ 20, %fillRequiredArgs ], !dbg !72
+  %19 = phi i64 [ %18, %17 ], [ 0, %15 ], [ 20, %fillRequiredArgs ], !dbg !66
   %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !21
   %21 = load i64*, i64** %20, align 8, !dbg !21
   store i64 %selfRaw, i64* %21, align 8, !dbg !21, !tbaa !6
@@ -532,9 +478,9 @@ sorbet_bang.exit106:                              ; preds = %fillRequiredArgs, %
   %send114 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !21
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %0, align 8, !dbg !21, !tbaa !24
   %24 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !22
-  %25 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !41
+  %25 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !39
   %needTakeSlowPath = icmp ne i64 %24, %25, !dbg !22
-  br i1 %needTakeSlowPath, label %26, label %27, !dbg !22, !prof !43
+  br i1 %needTakeSlowPath, label %26, label %27, !dbg !22, !prof !41
 
 26:                                               ; preds = %sorbet_bang.exit106
   tail call void @const_recompute_Bad(), !dbg !22
@@ -543,7 +489,7 @@ sorbet_bang.exit106:                              ; preds = %fillRequiredArgs, %
 27:                                               ; preds = %sorbet_bang.exit106, %26
   %28 = load i64, i64* @guarded_const_Bad, align 8, !dbg !22
   %29 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !22
-  %30 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !41
+  %30 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !39
   %guardUpdated = icmp eq i64 %29, %30, !dbg !22
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !22
   %31 = tail call i64 @sorbet_maybeAllocateObjectFastPath(i64 %28, %struct.FunctionInlineCache* noundef @ic_new), !dbg !22
@@ -570,22 +516,22 @@ fastNew:                                          ; preds = %27
 
 afterNew:                                         ; preds = %fastNew, %slowNew
   %initializedObject = phi i64 [ %36, %slowNew ], [ %31, %fastNew ], !dbg !22
-  %"rubyId_!86" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !76
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !77), !dbg !76
-  %41 = and i64 %initializedObject, -9, !dbg !76
-  %42 = icmp eq i64 %41, 0, !dbg !76
-  br i1 %42, label %sorbet_bang.exit, label %43, !dbg !76
+  %"rubyId_!86" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !70
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !71), !dbg !70
+  %41 = and i64 %initializedObject, -9, !dbg !70
+  %42 = icmp eq i64 %41, 0, !dbg !70
+  br i1 %42, label %sorbet_bang.exit, label %43, !dbg !70
 
 43:                                               ; preds = %afterNew
-  %44 = icmp eq i64 %initializedObject, 20, !dbg !76
-  br i1 %44, label %sorbet_bang.exit, label %45, !dbg !76
+  %44 = icmp eq i64 %initializedObject, 20, !dbg !70
+  br i1 %44, label %sorbet_bang.exit, label %45, !dbg !70
 
 45:                                               ; preds = %43
-  %46 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %initializedObject, i64 %"rubyId_!86", i32 noundef 0, i64* noundef null) #12, !dbg !76
-  br label %sorbet_bang.exit, !dbg !76
+  %46 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %initializedObject, i64 %"rubyId_!86", i32 noundef 0, i64* noundef null) #11, !dbg !70
+  br label %sorbet_bang.exit, !dbg !70
 
 sorbet_bang.exit:                                 ; preds = %afterNew, %43, %45
-  %47 = phi i64 [ %46, %45 ], [ 0, %43 ], [ 20, %afterNew ], !dbg !76
+  %47 = phi i64 [ %46, %45 ], [ 0, %43 ], [ 20, %afterNew ], !dbg !70
   %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !23
   %49 = load i64*, i64** %48, align 8, !dbg !23
   store i64 %selfRaw, i64* %49, align 8, !dbg !23, !tbaa !6
@@ -598,47 +544,46 @@ sorbet_bang.exit:                                 ; preds = %afterNew, %43, %45
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare void @llvm.experimental.noalias.scope.decl(metadata) #7
+declare void @llvm.experimental.noalias.scope.decl(metadata) #6
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #8
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #7
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #9
+declare void @llvm.assume(i1 noundef) #8
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_Bad() local_unnamed_addr #10 {
+define linkonce void @const_recompute_Bad() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 3)
   store i64 %1, i64* @guarded_const_Bad, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !41
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !39
   store i64 %2, i64* @guard_epoch_Bad, align 8
   ret void
 }
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_Main() local_unnamed_addr #10 {
+define linkonce void @const_recompute_Main() local_unnamed_addr #9 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0), i64 4)
   store i64 %1, i64* @guarded_const_Main, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !41
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !39
   store i64 %2, i64* @guard_epoch_Main, align 8
   ret void
 }
 
 attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { argmemonly nofree nosync nounwind willreturn }
-attributes #3 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #5 = { sspreq }
-attributes #6 = { nounwind sspreq uwtable }
-attributes #7 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #8 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #9 = { nofree nosync nounwind willreturn }
-attributes #10 = { ssp }
-attributes #11 = { noreturn nounwind }
-attributes #12 = { nounwind }
-attributes #13 = { nounwind allocsize(0,1) }
-attributes #14 = { noreturn }
+attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { sspreq }
+attributes #5 = { nounwind sspreq uwtable }
+attributes #6 = { inaccessiblememonly nofree nosync nounwind willreturn }
+attributes #7 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #8 = { nofree nosync nounwind willreturn }
+attributes #9 = { ssp }
+attributes #10 = { noreturn nounwind }
+attributes #11 = { nounwind }
+attributes #12 = { nounwind allocsize(0,1) }
+attributes #13 = { noreturn }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -678,48 +623,42 @@ attributes #14 = { noreturn }
 !32 = !{!31, !25, i64 32}
 !33 = !DILocation(line: 0, scope: !11)
 !34 = !DILocation(line: 5, column: 1, scope: !11)
-!35 = !{!36, !7, i64 0}
-!36 = !{!"rb_calling_info", !7, i64 0, !7, i64 8, !28, i64 16, !28, i64 20}
-!37 = !DILocation(line: 0, scope: !38, inlinedAt: !39)
-!38 = distinct !DISubprogram(name: "Bad.<static-init>", linkageName: "func_Bad.13<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!39 = distinct !DILocation(line: 5, column: 1, scope: !11)
-!40 = !DILocation(line: 6, column: 3, scope: !38, inlinedAt: !39)
-!41 = !{!42, !42, i64 0}
-!42 = !{!"long long", !8, i64 0}
-!43 = !{!"branch_weights", i32 1, i32 10000}
-!44 = !{!27, !28, i64 40}
-!45 = !{!27, !28, i64 44}
-!46 = !{!"branch_weights", i32 2000, i32 1}
-!47 = !{!27, !25, i64 56}
-!48 = !DILocation(line: 12, column: 1, scope: !11)
-!49 = !DILocation(line: 0, scope: !50, inlinedAt: !51)
-!50 = distinct !DISubprogram(name: "Main.<static-init>", linkageName: "func_Main.13<static-init>L129", scope: null, file: !4, line: 12, type: !12, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!51 = distinct !DILocation(line: 12, column: 1, scope: !11)
-!52 = !DILocation(line: 13, column: 3, scope: !50, inlinedAt: !51)
-!53 = !DILocation(line: 6, column: 3, scope: !16)
-!54 = !{!"branch_weights", i32 1, i32 2000}
-!55 = !DILocation(line: 0, scope: !16)
-!56 = !DILocation(line: 7, column: 10, scope: !16)
-!57 = !DILocation(line: 13, column: 3, scope: !18)
-!58 = !DILocation(line: 0, scope: !18)
-!59 = !{!60}
-!60 = distinct !{!60, !61, !"sorbet_bang: argument 0"}
-!61 = distinct !{!61, !"sorbet_bang"}
-!62 = !DILocation(line: 14, column: 10, scope: !18)
-!63 = !{!64}
-!64 = distinct !{!64, !65, !"sorbet_bang: argument 0"}
-!65 = distinct !{!65, !"sorbet_bang"}
-!66 = !DILocation(line: 15, column: 10, scope: !18)
+!35 = !DILocation(line: 0, scope: !36, inlinedAt: !37)
+!36 = distinct !DISubprogram(name: "Bad.<static-init>", linkageName: "func_Bad.13<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!37 = distinct !DILocation(line: 5, column: 1, scope: !11)
+!38 = !DILocation(line: 6, column: 3, scope: !36, inlinedAt: !37)
+!39 = !{!40, !40, i64 0}
+!40 = !{!"long long", !8, i64 0}
+!41 = !{!"branch_weights", i32 1, i32 10000}
+!42 = !DILocation(line: 12, column: 1, scope: !11)
+!43 = !DILocation(line: 0, scope: !44, inlinedAt: !45)
+!44 = distinct !DISubprogram(name: "Main.<static-init>", linkageName: "func_Main.13<static-init>L129", scope: null, file: !4, line: 12, type: !12, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!45 = distinct !DILocation(line: 12, column: 1, scope: !11)
+!46 = !DILocation(line: 13, column: 3, scope: !44, inlinedAt: !45)
+!47 = !DILocation(line: 6, column: 3, scope: !16)
+!48 = !{!"branch_weights", i32 1, i32 2000}
+!49 = !DILocation(line: 0, scope: !16)
+!50 = !DILocation(line: 7, column: 10, scope: !16)
+!51 = !DILocation(line: 13, column: 3, scope: !18)
+!52 = !DILocation(line: 0, scope: !18)
+!53 = !{!54}
+!54 = distinct !{!54, !55, !"sorbet_bang: argument 0"}
+!55 = distinct !{!55, !"sorbet_bang"}
+!56 = !DILocation(line: 14, column: 10, scope: !18)
+!57 = !{!58}
+!58 = distinct !{!58, !59, !"sorbet_bang: argument 0"}
+!59 = distinct !{!59, !"sorbet_bang"}
+!60 = !DILocation(line: 15, column: 10, scope: !18)
+!61 = !{!62}
+!62 = distinct !{!62, !63, !"sorbet_bang: argument 0"}
+!63 = distinct !{!63, !"sorbet_bang"}
+!64 = !DILocation(line: 16, column: 10, scope: !18)
+!65 = !DILocation(line: 17, column: 11, scope: !18)
+!66 = !DILocation(line: 17, column: 10, scope: !18)
 !67 = !{!68}
 !68 = distinct !{!68, !69, !"sorbet_bang: argument 0"}
 !69 = distinct !{!69, !"sorbet_bang"}
-!70 = !DILocation(line: 16, column: 10, scope: !18)
-!71 = !DILocation(line: 17, column: 11, scope: !18)
-!72 = !DILocation(line: 17, column: 10, scope: !18)
-!73 = !{!74}
-!74 = distinct !{!74, !75, !"sorbet_bang: argument 0"}
-!75 = distinct !{!75, !"sorbet_bang"}
-!76 = !DILocation(line: 18, column: 10, scope: !18)
-!77 = !{!78}
-!78 = distinct !{!78, !79, !"sorbet_bang: argument 0"}
-!79 = distinct !{!79, !"sorbet_bang"}
+!70 = !DILocation(line: 18, column: 10, scope: !18)
+!71 = !{!72}
+!72 = distinct !{!72, !73, !"sorbet_bang: argument 0"}
+!73 = distinct !{!73, !"sorbet_bang"}

--- a/test/testdata/compiler/intrinsics/t_must.opt.ll.exp
+++ b/test/testdata/compiler/intrinsics/t_must.opt.ll.exp
@@ -222,115 +222,10 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
   unreachable
 }
 
-; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_Test.13<static-init>L62"(%struct.rb_control_frame_struct* nocapture writeonly %cfp) unnamed_addr #5 !dbg !10 {
-functionEntryInitializers:
-  %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
-  %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !20
-  %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !22
-  %6 = load i64, i64* %5, align 8, !tbaa !6
-  %7 = and i64 %6, -33
-  store i64 %7, i64* %5, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #14
-  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !23, !tbaa !14
-  %9 = load i64, i64* @guard_epoch_Test, align 8, !dbg !24
-  %10 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !25
-  %needTakeSlowPath = icmp ne i64 %9, %10, !dbg !24
-  br i1 %needTakeSlowPath, label %11, label %12, !dbg !24, !prof !27
-
-11:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_Test(), !dbg !24
-  br label %12, !dbg !24
-
-12:                                               ; preds = %functionEntryInitializers, %11
-  %13 = load i64, i64* @guarded_const_Test, align 8, !dbg !24
-  %14 = load i64, i64* @guard_epoch_Test, align 8, !dbg !24
-  %15 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !25
-  %guardUpdated = icmp eq i64 %14, %15, !dbg !24
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !24
-  %stackFrame18 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8, !dbg !24
-  %16 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !24
-  %17 = bitcast i8* %16 to i16*, !dbg !24
-  %18 = load i16, i16* %17, align 8, !dbg !24
-  %19 = and i16 %18, -384, !dbg !24
-  store i16 %19, i16* %17, align 8, !dbg !24
-  %20 = getelementptr inbounds i8, i8* %16, i64 4, !dbg !24
-  %21 = bitcast i8* %20 to i32*, !dbg !24
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %20, i8 0, i64 28, i1 false), !dbg !24
-  tail call void @sorbet_vm_define_method(i64 %13, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_test_known_nil, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.14test_known_nil, i8* nonnull %16, %struct.rb_iseq_struct* %stackFrame18, i1 noundef zeroext true) #14, !dbg !24
-  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !14
-  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 5, !dbg !24
-  %24 = load i32, i32* %23, align 8, !dbg !24, !tbaa !28
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 6, !dbg !24
-  %26 = load i32, i32* %25, align 4, !dbg !24, !tbaa !29
-  %27 = xor i32 %26, -1, !dbg !24
-  %28 = and i32 %27, %24, !dbg !24
-  %29 = icmp eq i32 %28, 0, !dbg !24
-  br i1 %29, label %rb_vm_check_ints.exit1, label %30, !dbg !24, !prof !30
-
-30:                                               ; preds = %12
-  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 8, !dbg !24
-  %32 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %31, align 8, !dbg !24, !tbaa !31
-  %33 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %32, i32 noundef 0) #14, !dbg !24
-  br label %rb_vm_check_ints.exit1, !dbg !24
-
-rb_vm_check_ints.exit1:                           ; preds = %12, %30
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !24, !tbaa !14
-  %stackFrame27 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8, !dbg !32
-  %34 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !32
-  %35 = bitcast i8* %34 to i16*, !dbg !32
-  %36 = load i16, i16* %35, align 8, !dbg !32
-  %37 = and i16 %36, -384, !dbg !32
-  %38 = or i16 %37, 1, !dbg !32
-  store i16 %38, i16* %35, align 8, !dbg !32
-  %39 = getelementptr inbounds i8, i8* %34, i64 8, !dbg !32
-  %40 = bitcast i8* %39 to i32*, !dbg !32
-  store i32 1, i32* %40, align 8, !dbg !32, !tbaa !33
-  %41 = getelementptr inbounds i8, i8* %34, i64 12, !dbg !32
-  %42 = bitcast i8* %41 to i32*, !dbg !32
-  %43 = getelementptr inbounds i8, i8* %34, i64 4, !dbg !32
-  %44 = bitcast i8* %43 to i32*, !dbg !32
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %41, i8 0, i64 20, i1 false), !dbg !32
-  store i32 1, i32* %44, align 4, !dbg !32, !tbaa !36
-  %positional_table = alloca i64, align 8, !dbg !32
-  %rubyId_arg = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !32
-  store i64 %rubyId_arg, i64* %positional_table, align 8, !dbg !32
-  %45 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #15, !dbg !32
-  %46 = bitcast i64* %positional_table to i8*, !dbg !32
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %45, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %46, i64 noundef 8, i1 noundef false) #14, !dbg !32
-  %47 = getelementptr inbounds i8, i8* %34, i64 32, !dbg !32
-  %48 = bitcast i8* %47 to i8**, !dbg !32
-  store i8* %45, i8** %48, align 8, !dbg !32, !tbaa !37
-  tail call void @sorbet_vm_define_method(i64 %13, i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.16test_nilable_arg, i8* nonnull %34, %struct.rb_iseq_struct* %stackFrame27, i1 noundef zeroext true) #14, !dbg !32
-  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !32, !tbaa !14
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 5, !dbg !32
-  %51 = load i32, i32* %50, align 8, !dbg !32, !tbaa !28
-  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 6, !dbg !32
-  %53 = load i32, i32* %52, align 4, !dbg !32, !tbaa !29
-  %54 = xor i32 %53, -1, !dbg !32
-  %55 = and i32 %54, %51, !dbg !32
-  %56 = icmp eq i32 %55, 0, !dbg !32
-  br i1 %56, label %rb_vm_check_ints.exit, label %57, !dbg !32, !prof !30
-
-57:                                               ; preds = %rb_vm_check_ints.exit1
-  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 8, !dbg !32
-  %59 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %58, align 8, !dbg !32, !tbaa !31
-  %60 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %59, i32 noundef 0) #14, !dbg !32
-  br label %rb_vm_check_ints.exit, !dbg !32
-
-rb_vm_check_ints.exit:                            ; preds = %rb_vm_check_ints.exit1, %57
-  ret void
-}
-
 ; Function Attrs: sspreq
-define void @Init_t_must() local_unnamed_addr #6 {
+define void @Init_t_must() local_unnamed_addr #5 {
 entry:
+  %positional_table.i.i = alloca i64, align 8, !dbg !10
   %locals.i32.i = alloca i64, i32 0, align 8
   %locals.i22.i = alloca i64, i32 5, align 8
   %locals.i17.i = alloca i64, i32 4, align 8
@@ -382,14 +277,14 @@ entry:
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
   %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %rubyId_test_known_nil.i = load i64, i64* @rubyIdPrecomputed_test_known_nil, align 8, !dbg !38
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_known_nil, i64 %rubyId_test_known_nil.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !38
-  %rubyId_test_nilable_arg.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !40
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !40
-  %rubyId_test_nilable_arg2.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.1, i64 %rubyId_test_nilable_arg2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !41
-  %rubyId_test_nilable_arg4.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !42
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.2, i64 %rubyId_test_nilable_arg4.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !42
+  %rubyId_test_known_nil.i = load i64, i64* @rubyIdPrecomputed_test_known_nil, align 8, !dbg !17
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_known_nil, i64 %rubyId_test_known_nil.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
+  %rubyId_test_nilable_arg.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !18
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
+  %rubyId_test_nilable_arg2.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.1, i64 %rubyId_test_nilable_arg2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  %rubyId_test_nilable_arg4.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !20
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.2, i64 %rubyId_test_nilable_arg4.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
   %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_test_known_nil, i64 0, i64 0), i64 noundef 14) #14
   call void @rb_gc_register_mark_object(i64 %21) #14
   %22 = bitcast i64* %locals.i17.i to i8*
@@ -426,10 +321,10 @@ entry:
   store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_3", align 8
   %31 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #14
   store i64 %31, i64* @"<retry-singleton>", align 8
-  %"rubyId_is_a?.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !43
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
+  %"rubyId_is_a?.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !21
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
   %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 noundef 16) #14
   call void @rb_gc_register_mark_object(i64 %32) #14
   %33 = bitcast i64* %locals.i22.i to i8*
@@ -470,555 +365,604 @@ entry:
   %43 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_ wasn't nil", i64 0, i64 0), i64 noundef 11) #14
   call void @rb_gc_register_mark_object(i64 %43) #14
   store i64 %43, i64* @"rubyStrFrozen_ wasn't nil", align 8
-  %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
-  %"rubyId_is_a?11.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !50
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?.4", i64 %"rubyId_is_a?11.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !50
-  %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !52
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !52
+  %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
+  %"rubyId_is_a?11.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !28
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?.4", i64 %"rubyId_is_a?11.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
+  %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !30
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
   %44 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Test>", i64 0, i64 0), i64 noundef 13) #14
   call void @rb_gc_register_mark_object(i64 %44) #14
   %"rubyId_<module:Test>.i.i" = load i64, i64* @"rubyIdPrecomputed_<module:Test>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
   %45 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %44, i64 %"rubyId_<module:Test>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i32.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %45, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
-  %46 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %46 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
   %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2
-  %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !tbaa !16
+  %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !tbaa !33
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %49, align 8, !tbaa !20
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %49, align 8, !tbaa !37
   %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 4
-  %51 = load i64*, i64** %50, align 8, !tbaa !22
+  %51 = load i64*, i64** %50, align 8, !tbaa !39
   %52 = load i64, i64* %51, align 8, !tbaa !6
   %53 = and i64 %52, -33
   store i64 %53, i64* %51, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %46, %struct.rb_control_frame_struct* %48, %struct.rb_iseq_struct* %stackFrame.i) #14
   %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %54, align 8, !dbg !53, !tbaa !14
-  %55 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Test, i64 0, i64 0)) #14, !dbg !54
-  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #14, !dbg !54
-  call fastcc void @"func_Test.13<static-init>L62"(%struct.rb_control_frame_struct* nocapture writeonly %56) #14, !dbg !54
-  call void @sorbet_popFrame() #14, !dbg !54
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %54, align 8, !dbg !54, !tbaa !14
-  %57 = load i64, i64* @guard_epoch_Test, align 8, !dbg !38
-  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !25
-  %needTakeSlowPath = icmp ne i64 %57, %58, !dbg !38
-  br i1 %needTakeSlowPath, label %59, label %60, !dbg !38, !prof !27
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %54, align 8, !dbg !40, !tbaa !31
+  %55 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Test, i64 0, i64 0)) #14, !dbg !41
+  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #14, !dbg !41
+  %57 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %57) #14
+  %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
+  %58 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
+  %59 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %58, i64 0, i32 2
+  %60 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %59, align 8, !tbaa !33
+  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %60, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %61, align 8, !tbaa !37
+  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %60, i64 0, i32 4
+  %63 = load i64*, i64** %62, align 8, !tbaa !39
+  %64 = load i64, i64* %63, align 8, !tbaa !6
+  %65 = and i64 %64, -33
+  store i64 %65, i64* %63, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %58, %struct.rb_control_frame_struct* %60, %struct.rb_iseq_struct* %stackFrame.i.i1) #14
+  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %66, align 8, !dbg !42, !tbaa !31
+  %67 = load i64, i64* @guard_epoch_Test, align 8, !dbg !43
+  %68 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %needTakeSlowPath = icmp ne i64 %67, %68, !dbg !43
+  br i1 %needTakeSlowPath, label %69, label %70, !dbg !43, !prof !46
 
-59:                                               ; preds = %entry
-  call void @const_recompute_Test(), !dbg !38
-  br label %60, !dbg !38
+69:                                               ; preds = %entry
+  call void @const_recompute_Test(), !dbg !43
+  br label %70, !dbg !43
 
-60:                                               ; preds = %entry, %59
-  %61 = load i64, i64* @guarded_const_Test, align 8, !dbg !38
-  %62 = load i64, i64* @guard_epoch_Test, align 8, !dbg !38
-  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !25
-  %guardUpdated = icmp eq i64 %62, %63, !dbg !38
-  call void @llvm.assume(i1 %guardUpdated), !dbg !38
-  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !38
-  %65 = load i64*, i64** %64, align 8, !dbg !38
-  store i64 %61, i64* %65, align 8, !dbg !38, !tbaa !6
-  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !38
-  store i64* %66, i64** %64, align 8, !dbg !38
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_known_nil, i64 0), !dbg !38
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %54, align 8, !dbg !38, !tbaa !14
-  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !40
-  %68 = load i64*, i64** %67, align 8, !dbg !40
-  store i64 %61, i64* %68, align 8, !dbg !40, !tbaa !6
-  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !40
-  store i64 21, i64* %69, align 8, !dbg !40, !tbaa !6
-  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !40
-  store i64* %70, i64** %67, align 8, !dbg !40
-  %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg, i64 0), !dbg !40
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %54, align 8, !dbg !40, !tbaa !14
-  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !41
-  %72 = load i64*, i64** %71, align 8, !dbg !41
-  store i64 %61, i64* %72, align 8, !dbg !41, !tbaa !6
-  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !41
-  store i64 0, i64* %73, align 8, !dbg !41, !tbaa !6
-  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !41
-  store i64* %74, i64** %71, align 8, !dbg !41
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.1, i64 0), !dbg !41
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %54, align 8, !dbg !41, !tbaa !14
-  %75 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !42
-  %76 = load i64*, i64** %75, align 8, !dbg !42
-  store i64 %61, i64* %76, align 8, !dbg !42, !tbaa !6
-  %77 = getelementptr inbounds i64, i64* %76, i64 1, !dbg !42
-  store i64 8, i64* %77, align 8, !dbg !42, !tbaa !6
-  %78 = getelementptr inbounds i64, i64* %77, i64 1, !dbg !42
-  store i64* %78, i64** %75, align 8, !dbg !42
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.2, i64 0), !dbg !42
+70:                                               ; preds = %entry, %69
+  %71 = load i64, i64* @guarded_const_Test, align 8, !dbg !43
+  %72 = load i64, i64* @guard_epoch_Test, align 8, !dbg !43
+  %73 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %guardUpdated = icmp eq i64 %72, %73, !dbg !43
+  call void @llvm.assume(i1 %guardUpdated), !dbg !43
+  %stackFrame18.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8, !dbg !43
+  %74 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !43
+  %75 = bitcast i8* %74 to i16*, !dbg !43
+  %76 = load i16, i16* %75, align 8, !dbg !43
+  %77 = and i16 %76, -384, !dbg !43
+  store i16 %77, i16* %75, align 8, !dbg !43
+  %78 = getelementptr inbounds i8, i8* %74, i64 4, !dbg !43
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %78, i8 0, i64 28, i1 false) #14, !dbg !43
+  call void @sorbet_vm_define_method(i64 %71, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_test_known_nil, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.14test_known_nil, i8* nonnull %74, %struct.rb_iseq_struct* %stackFrame18.i.i, i1 noundef zeroext true) #14, !dbg !43
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %66, align 8, !dbg !43, !tbaa !31
+  %stackFrame27.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8, !dbg !10
+  %79 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !10
+  %80 = bitcast i8* %79 to i16*, !dbg !10
+  %81 = load i16, i16* %80, align 8, !dbg !10
+  %82 = and i16 %81, -384, !dbg !10
+  %83 = or i16 %82, 1, !dbg !10
+  store i16 %83, i16* %80, align 8, !dbg !10
+  %84 = getelementptr inbounds i8, i8* %79, i64 8, !dbg !10
+  %85 = bitcast i8* %84 to i32*, !dbg !10
+  store i32 1, i32* %85, align 8, !dbg !10, !tbaa !47
+  %86 = getelementptr inbounds i8, i8* %79, i64 12, !dbg !10
+  %87 = getelementptr inbounds i8, i8* %79, i64 4, !dbg !10
+  %88 = bitcast i8* %87 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %86, i8 0, i64 20, i1 false) #14, !dbg !10
+  store i32 1, i32* %88, align 4, !dbg !10, !tbaa !50
+  %rubyId_arg.i.i2 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !10
+  store i64 %rubyId_arg.i.i2, i64* %positional_table.i.i, align 8, !dbg !10
+  %89 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #15, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %89, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %57, i64 noundef 8, i1 noundef false) #14, !dbg !10
+  %90 = getelementptr inbounds i8, i8* %79, i64 32, !dbg !10
+  %91 = bitcast i8* %90 to i8**, !dbg !10
+  store i8* %89, i8** %91, align 8, !dbg !10, !tbaa !51
+  call void @sorbet_vm_define_method(i64 %71, i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.16test_nilable_arg, i8* nonnull %79, %struct.rb_iseq_struct* %stackFrame27.i.i, i1 noundef zeroext true) #14, !dbg !10
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %57) #14
+  call void @sorbet_popFrame() #14, !dbg !41
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %54, align 8, !dbg !41, !tbaa !31
+  %92 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !17
+  %93 = load i64*, i64** %92, align 8, !dbg !17
+  store i64 %71, i64* %93, align 8, !dbg !17, !tbaa !6
+  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !17
+  store i64* %94, i64** %92, align 8, !dbg !17
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_known_nil, i64 0), !dbg !17
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %54, align 8, !dbg !17, !tbaa !31
+  %95 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !18
+  %96 = load i64*, i64** %95, align 8, !dbg !18
+  store i64 %71, i64* %96, align 8, !dbg !18, !tbaa !6
+  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !18
+  store i64 21, i64* %97, align 8, !dbg !18, !tbaa !6
+  %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !18
+  store i64* %98, i64** %95, align 8, !dbg !18
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg, i64 0), !dbg !18
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %54, align 8, !dbg !18, !tbaa !31
+  %99 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !19
+  %100 = load i64*, i64** %99, align 8, !dbg !19
+  store i64 %71, i64* %100, align 8, !dbg !19, !tbaa !6
+  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !19
+  store i64 0, i64* %101, align 8, !dbg !19, !tbaa !6
+  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !19
+  store i64* %102, i64** %99, align 8, !dbg !19
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.1, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %54, align 8, !dbg !19, !tbaa !31
+  %103 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !20
+  %104 = load i64*, i64** %103, align 8, !dbg !20
+  store i64 %71, i64* %104, align 8, !dbg !20, !tbaa !6
+  %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !20
+  store i64 8, i64* %105, align 8, !dbg !20, !tbaa !6
+  %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !20
+  store i64* %106, i64** %103, align 8, !dbg !20
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.2, i64 0), !dbg !20
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @func_Test.14test_known_nil(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #5 !dbg !45 {
+define internal i64 @func_Test.14test_known_nil(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !23 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !14
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !55
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !55, !prof !56
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !31
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !52
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !52, !prof !53
 
 postProcess:                                      ; preds = %fillRequiredArgs, %exception-continue
-  %"<returnValue>.sroa.0.0" = phi i64 [ %6, %exception-continue ], [ %2, %fillRequiredArgs ], !dbg !57
+  %"<returnValue>.sroa.0.0" = phi i64 [ %6, %exception-continue ], [ %2, %fillRequiredArgs ], !dbg !54
   ret i64 %"<returnValue>.sroa.0.0"
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #16, !dbg !55
-  unreachable, !dbg !55
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #16, !dbg !52
+  unreachable, !dbg !52
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !57, !tbaa !14
-  %1 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !58, !tbaa !14
-  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !58
-  %2 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %1, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_1", i64** nonnull align 8 dereferenceable(8) %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !58
-  %ensureReturnValue = icmp ne i64 %2, 52, !dbg !58
-  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !58
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !54, !tbaa !31
+  %1 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !55, !tbaa !31
+  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !55
+  %2 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %1, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_1", i64** nonnull align 8 dereferenceable(8) %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.14test_known_nil$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !55
+  %ensureReturnValue = icmp ne i64 %2, 52, !dbg !55
+  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !55
 
 exception-continue:                               ; preds = %fillRequiredArgs
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %0, align 8, !tbaa !14
-  %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !59
-  %4 = load i64*, i64** %3, align 8, !dbg !59, !tbaa !22
-  %5 = getelementptr inbounds i64, i64* %4, i64 -5, !dbg !59
-  %6 = load i64, i64* %5, align 8, !dbg !59, !tbaa !6
-  br label %postProcess, !dbg !59
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %0, align 8, !tbaa !31
+  %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !56
+  %4 = load i64*, i64** %3, align 8, !dbg !56, !tbaa !39
+  %5 = getelementptr inbounds i64, i64* %4, i64 -5, !dbg !56
+  %6 = load i64, i64* %5, align 8, !dbg !56, !tbaa !6
+  br label %postProcess, !dbg !56
 }
 
 ; Function Attrs: noreturn nounwind ssp
-define internal i64 @"func_Test.14test_known_nil$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #7 !dbg !60 {
+define internal i64 @"func_Test.14test_known_nil$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #7 !dbg !57 {
 functionEntryInitializers:
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !14
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !61) #17, !dbg !64
-  %0 = load i64, i64* @rb_eTypeError, align 8, !dbg !64, !tbaa !6, !noalias !61
-  tail call void (i64, i8*, ...) @rb_raise(i64 %0, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #13, !dbg !64, !noalias !61
-  unreachable, !dbg !64
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !31
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !58) #17, !dbg !61
+  %0 = load i64, i64* @rb_eTypeError, align 8, !dbg !61, !tbaa !6, !noalias !58
+  tail call void (i64, i8*, ...) @rb_raise(i64 %0, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #13, !dbg !61, !noalias !58
+  unreachable, !dbg !61
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.14test_known_nil$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !44 {
+define internal noundef i64 @"func_Test.14test_known_nil$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !22 {
 vm_get_ep.exit34:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !33
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !65
+  %4 = load i64, i64* %3, align 8, !tbaa !62
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_2", align 8
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #14
-  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
   %6 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %5, i64 0, i32 2
-  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !16
+  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !33
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !tbaa !14
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !43, !tbaa !14
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !43
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !43, !tbaa !16
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !43
-  %13 = load i64*, i64** %12, align 8, !dbg !43
-  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !43
-  %15 = load i64, i64* %14, align 8, !dbg !43, !tbaa !6
-  %16 = and i64 %15, -4, !dbg !43
-  %17 = inttoptr i64 %16 to i64*, !dbg !43
-  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !43
-  %19 = load i64, i64* %18, align 8, !dbg !43, !tbaa !6
-  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !43
-  %21 = tail call i64 @sorbet_vm_isa_p(%struct.FunctionInlineCache* noundef @"ic_is_a?", %struct.rb_control_frame_struct* %11, i64 %19, i64 %20), !dbg !43
-  %22 = and i64 %21, -9, !dbg !43
-  %23 = icmp ne i64 %22, 0, !dbg !43
-  br i1 %23, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !43
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %8, align 8, !tbaa !31
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !21, !tbaa !31
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !21
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !21, !tbaa !33
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !21
+  %13 = load i64*, i64** %12, align 8, !dbg !21
+  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !21
+  %15 = load i64, i64* %14, align 8, !dbg !21, !tbaa !6
+  %16 = and i64 %15, -4, !dbg !21
+  %17 = inttoptr i64 %16 to i64*, !dbg !21
+  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !21
+  %19 = load i64, i64* %18, align 8, !dbg !21, !tbaa !6
+  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !21
+  %21 = tail call i64 @sorbet_vm_isa_p(%struct.FunctionInlineCache* noundef @"ic_is_a?", %struct.rb_control_frame_struct* %11, i64 %19, i64 %20), !dbg !21
+  %22 = and i64 %21, -9, !dbg !21
+  %23 = icmp ne i64 %22, 0, !dbg !21
+  br i1 %23, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !21
 
 blockExit:                                        ; preds = %75, %73, %60, %58
   tail call void @sorbet_popFrame()
   ret i64 52
 
 vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
-  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !14
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2, !dbg !66
-  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !dbg !66, !tbaa !16
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4, !dbg !66
-  %28 = load i64*, i64** %27, align 8, !dbg !66
-  %29 = getelementptr inbounds i64, i64* %28, i64 -1, !dbg !66
-  %30 = load i64, i64* %29, align 8, !dbg !66, !tbaa !6
-  %31 = and i64 %30, -4, !dbg !66
-  %32 = inttoptr i64 %31 to i64*, !dbg !66
-  %33 = load i64, i64* %32, align 8, !dbg !66, !tbaa !6
-  %34 = and i64 %33, 8, !dbg !66
-  %35 = icmp eq i64 %34, 0, !dbg !66
-  br i1 %35, label %36, label %38, !dbg !66, !prof !30
+  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !63, !tbaa !31
+  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2, !dbg !63
+  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !dbg !63, !tbaa !33
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4, !dbg !63
+  %28 = load i64*, i64** %27, align 8, !dbg !63
+  %29 = getelementptr inbounds i64, i64* %28, i64 -1, !dbg !63
+  %30 = load i64, i64* %29, align 8, !dbg !63, !tbaa !6
+  %31 = and i64 %30, -4, !dbg !63
+  %32 = inttoptr i64 %31 to i64*, !dbg !63
+  %33 = load i64, i64* %32, align 8, !dbg !63, !tbaa !6
+  %34 = and i64 %33, 8, !dbg !63
+  %35 = icmp eq i64 %34, 0, !dbg !63
+  br i1 %35, label %36, label %38, !dbg !63, !prof !64
 
 36:                                               ; preds = %vm_get_ep.exit32
-  %37 = getelementptr inbounds i64, i64* %32, i64 -3, !dbg !66
-  store i64 8, i64* %37, align 8, !dbg !66, !tbaa !6
-  br label %vm_get_ep.exit30, !dbg !66
+  %37 = getelementptr inbounds i64, i64* %32, i64 -3, !dbg !63
+  store i64 8, i64* %37, align 8, !dbg !63, !tbaa !6
+  br label %vm_get_ep.exit30, !dbg !63
 
 38:                                               ; preds = %vm_get_ep.exit32
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %32, i32 noundef -3, i64 noundef 8) #14, !dbg !66
-  br label %vm_get_ep.exit30, !dbg !66
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %32, i32 noundef -3, i64 noundef 8) #14, !dbg !63
+  br label %vm_get_ep.exit30, !dbg !63
 
 vm_get_ep.exit30:                                 ; preds = %36, %38
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %8, align 8, !dbg !67, !tbaa !14
-  %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !14
-  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %39, i64 0, i32 2, !dbg !46
-  %41 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %40, align 8, !dbg !46, !tbaa !16
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !46
-  %43 = load i64*, i64** %42, align 8, !dbg !46
-  store i64 %4, i64* %43, align 8, !dbg !46, !tbaa !6
-  %44 = getelementptr inbounds i64, i64* %43, i64 1, !dbg !46
-  store i64 %19, i64* %44, align 8, !dbg !46, !tbaa !6
-  %45 = getelementptr inbounds i64, i64* %44, i64 1, !dbg !46
-  store i64* %45, i64** %42, align 8, !dbg !46
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !46
-  %46 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !46, !tbaa !14
-  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2, !dbg !46
-  %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !dbg !46, !tbaa !16
-  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 4, !dbg !46
-  %50 = load i64*, i64** %49, align 8, !dbg !46
-  %51 = getelementptr inbounds i64, i64* %50, i64 -1, !dbg !46
-  %52 = load i64, i64* %51, align 8, !dbg !46, !tbaa !6
-  %53 = and i64 %52, -4, !dbg !46
-  %54 = inttoptr i64 %53 to i64*, !dbg !46
-  %55 = load i64, i64* %54, align 8, !dbg !46, !tbaa !6
-  %56 = and i64 %55, 8, !dbg !46
-  %57 = icmp eq i64 %56, 0, !dbg !46
-  br i1 %57, label %58, label %60, !dbg !46, !prof !30
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %8, align 8, !dbg !65, !tbaa !31
+  %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !31
+  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %39, i64 0, i32 2, !dbg !24
+  %41 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %40, align 8, !dbg !24, !tbaa !33
+  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !24
+  %43 = load i64*, i64** %42, align 8, !dbg !24
+  store i64 %4, i64* %43, align 8, !dbg !24, !tbaa !6
+  %44 = getelementptr inbounds i64, i64* %43, i64 1, !dbg !24
+  store i64 %19, i64* %44, align 8, !dbg !24, !tbaa !6
+  %45 = getelementptr inbounds i64, i64* %44, i64 1, !dbg !24
+  store i64* %45, i64** %42, align 8, !dbg !24
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !24
+  %46 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !31
+  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2, !dbg !24
+  %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !dbg !24, !tbaa !33
+  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 4, !dbg !24
+  %50 = load i64*, i64** %49, align 8, !dbg !24
+  %51 = getelementptr inbounds i64, i64* %50, i64 -1, !dbg !24
+  %52 = load i64, i64* %51, align 8, !dbg !24, !tbaa !6
+  %53 = and i64 %52, -4, !dbg !24
+  %54 = inttoptr i64 %53 to i64*, !dbg !24
+  %55 = load i64, i64* %54, align 8, !dbg !24, !tbaa !6
+  %56 = and i64 %55, 8, !dbg !24
+  %57 = icmp eq i64 %56, 0, !dbg !24
+  br i1 %57, label %58, label %60, !dbg !24, !prof !64
 
 58:                                               ; preds = %vm_get_ep.exit30
-  %59 = getelementptr inbounds i64, i64* %54, i64 -5, !dbg !46
-  store i64 %send, i64* %59, align 8, !dbg !46, !tbaa !6
-  br label %blockExit, !dbg !46
+  %59 = getelementptr inbounds i64, i64* %54, i64 -5, !dbg !24
+  store i64 %send, i64* %59, align 8, !dbg !24, !tbaa !6
+  br label %blockExit, !dbg !24
 
 60:                                               ; preds = %vm_get_ep.exit30
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %54, i32 noundef -5, i64 %send) #14, !dbg !46
-  br label %blockExit, !dbg !46
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %54, i32 noundef -5, i64 %send) #14, !dbg !24
+  br label %blockExit, !dbg !24
 
 vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !tbaa !14
-  %61 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !68, !tbaa !14
-  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 2, !dbg !68
-  %63 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %62, align 8, !dbg !68, !tbaa !16
-  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %63, i64 0, i32 4, !dbg !68
-  %65 = load i64*, i64** %64, align 8, !dbg !68
-  %66 = getelementptr inbounds i64, i64* %65, i64 -1, !dbg !68
-  %67 = load i64, i64* %66, align 8, !dbg !68, !tbaa !6
-  %68 = and i64 %67, -4, !dbg !68
-  %69 = inttoptr i64 %68 to i64*, !dbg !68
-  %70 = load i64, i64* %69, align 8, !dbg !68, !tbaa !6
-  %71 = and i64 %70, 8, !dbg !68
-  %72 = icmp eq i64 %71, 0, !dbg !68
-  br i1 %72, label %73, label %75, !dbg !68, !prof !30
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !tbaa !31
+  %61 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !31
+  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 2, !dbg !66
+  %63 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %62, align 8, !dbg !66, !tbaa !33
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %63, i64 0, i32 4, !dbg !66
+  %65 = load i64*, i64** %64, align 8, !dbg !66
+  %66 = getelementptr inbounds i64, i64* %65, i64 -1, !dbg !66
+  %67 = load i64, i64* %66, align 8, !dbg !66, !tbaa !6
+  %68 = and i64 %67, -4, !dbg !66
+  %69 = inttoptr i64 %68 to i64*, !dbg !66
+  %70 = load i64, i64* %69, align 8, !dbg !66, !tbaa !6
+  %71 = and i64 %70, 8, !dbg !66
+  %72 = icmp eq i64 %71, 0, !dbg !66
+  br i1 %72, label %73, label %75, !dbg !66, !prof !64
 
 73:                                               ; preds = %vm_get_ep.exit
-  %74 = getelementptr inbounds i64, i64* %69, i64 -6, !dbg !68
-  store i64 20, i64* %74, align 8, !dbg !68, !tbaa !6
-  br label %blockExit, !dbg !68
+  %74 = getelementptr inbounds i64, i64* %69, i64 -6, !dbg !66
+  store i64 20, i64* %74, align 8, !dbg !66, !tbaa !6
+  br label %blockExit, !dbg !66
 
 75:                                               ; preds = %vm_get_ep.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %69, i32 noundef -6, i64 noundef 20) #14, !dbg !68
-  br label %blockExit, !dbg !68
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %69, i32 noundef -6, i64 noundef 20) #14, !dbg !66
+  br label %blockExit, !dbg !66
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.14test_known_nil$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !69 {
+define internal noundef i64 @"func_Test.14test_known_nil$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !67 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_3", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !33
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #14
-  %3 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %3 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
   %4 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %3, i64 0, i32 2
-  %5 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %4, align 8, !tbaa !16
+  %5 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %4, align 8, !tbaa !33
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %6, align 8, !tbaa !14
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %6, align 8, !tbaa !31
   tail call void @sorbet_popFrame()
   ret i64 52
 }
 
 ; Function Attrs: argmemonly nofree norecurse nosync nounwind ssp willreturn writeonly
-define internal noundef i64 @"func_Test.14test_known_nil$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !70 {
+define internal noundef i64 @"func_Test.14test_known_nil$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !68 {
 functionEntryInitializers:
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %pc, align 8, !tbaa !14
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %pc, align 8, !tbaa !31
   ret i64 52
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @func_Test.16test_nilable_arg(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #5 !dbg !49 {
+define internal i64 @func_Test.16test_nilable_arg(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !27 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !tbaa !14
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !71
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !71
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !71
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !71, !prof !72
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !tbaa !31
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !69
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !69
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !69
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !69, !prof !70
 
 postProcess:                                      ; preds = %sorbet_writeLocal.exit, %exception-continue
-  %"<returnValue>.sroa.0.0" = phi i64 [ %13, %exception-continue ], [ %10, %sorbet_writeLocal.exit ], !dbg !73
+  %"<returnValue>.sroa.0.0" = phi i64 [ %13, %exception-continue ], [ %10, %sorbet_writeLocal.exit ], !dbg !71
   ret i64 %"<returnValue>.sroa.0.0"
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #16, !dbg !71
-  unreachable, !dbg !71
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #16, !dbg !69
+  unreachable, !dbg !69
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !71
-  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !71
-  %2 = load i64*, i64** %1, align 8, !dbg !71, !tbaa !22
-  %3 = load i64, i64* %2, align 8, !dbg !71, !tbaa !6
-  %4 = and i64 %3, 8, !dbg !71
-  %5 = icmp eq i64 %4, 0, !dbg !71
-  br i1 %5, label %6, label %8, !dbg !71, !prof !30
+  %rawArg_arg = load i64, i64* %argArray, align 8, !dbg !69
+  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !69
+  %2 = load i64*, i64** %1, align 8, !dbg !69, !tbaa !39
+  %3 = load i64, i64* %2, align 8, !dbg !69, !tbaa !6
+  %4 = and i64 %3, 8, !dbg !69
+  %5 = icmp eq i64 %4, 0, !dbg !69
+  br i1 %5, label %6, label %8, !dbg !69, !prof !64
 
 6:                                                ; preds = %fillRequiredArgs
-  %7 = getelementptr inbounds i64, i64* %2, i64 -4, !dbg !71
-  store i64 %rawArg_arg, i64* %7, align 8, !dbg !71, !tbaa !6
-  br label %sorbet_writeLocal.exit, !dbg !71
+  %7 = getelementptr inbounds i64, i64* %2, i64 -4, !dbg !69
+  store i64 %rawArg_arg, i64* %7, align 8, !dbg !69, !tbaa !6
+  br label %sorbet_writeLocal.exit, !dbg !69
 
 8:                                                ; preds = %fillRequiredArgs
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %2, i32 noundef -4, i64 %rawArg_arg) #14, !dbg !71
-  br label %sorbet_writeLocal.exit, !dbg !71
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %2, i32 noundef -4, i64 %rawArg_arg) #14, !dbg !69
+  br label %sorbet_writeLocal.exit, !dbg !69
 
 sorbet_writeLocal.exit:                           ; preds = %6, %8
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !dbg !73, !tbaa !14
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !74, !tbaa !14
-  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !74
-  %10 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %9, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_1", i64** nonnull %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !74
-  %ensureReturnValue = icmp ne i64 %10, 52, !dbg !74
-  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !74
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !dbg !71, !tbaa !31
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !72, !tbaa !31
+  %"<retry-singleton>" = load i64, i64* @"<retry-singleton>", align 8, !dbg !72
+  %10 = tail call i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct* %9, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_1", i64** nonnull %0, i64 noundef 0, %struct.rb_control_frame_struct* nonnull %cfp, i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_2", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_4", i64 (i64**, i64, %struct.rb_control_frame_struct*)* noundef @"func_Test.16test_nilable_arg$block_3", i64 %"<retry-singleton>", i64 noundef 0, i64 noundef 0), !dbg !72
+  %ensureReturnValue = icmp ne i64 %10, 52, !dbg !72
+  br i1 %ensureReturnValue, label %postProcess, label %exception-continue, !dbg !72
 
 exception-continue:                               ; preds = %sorbet_writeLocal.exit
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %0, align 8, !tbaa !14
-  %11 = load i64*, i64** %1, align 8, !dbg !75, !tbaa !22
-  %12 = getelementptr inbounds i64, i64* %11, i64 -6, !dbg !75
-  %13 = load i64, i64* %12, align 8, !dbg !75, !tbaa !6
-  br label %postProcess, !dbg !75
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %0, align 8, !tbaa !31
+  %11 = load i64*, i64** %1, align 8, !dbg !73, !tbaa !39
+  %12 = getelementptr inbounds i64, i64* %11, i64 -6, !dbg !73
+  %13 = load i64, i64* %12, align 8, !dbg !73, !tbaa !6
+  br label %postProcess, !dbg !73
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.16test_nilable_arg$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(40) %cfp) #8 !dbg !48 {
+define internal noundef i64 @"func_Test.16test_nilable_arg$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(40) %cfp) #8 !dbg !26 {
 functionEntryInitializers:
   %callArgs = alloca [3 x i64], align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !33
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !65
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !tbaa !14
-  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !76
-  %6 = load i64*, i64** %5, align 8, !dbg !76, !tbaa !22
-  %7 = getelementptr inbounds i64, i64* %6, i64 -4, !dbg !76
-  %8 = load i64, i64* %7, align 8, !dbg !76, !tbaa !6
-  %callArgs0Addr = getelementptr [3 x i64], [3 x i64]* %callArgs, i32 0, i64 0, !dbg !76
-  store i64 %8, i64* %callArgs0Addr, align 8, !dbg !76
-  %9 = getelementptr [3 x i64], [3 x i64]* %callArgs, i64 0, i64 0, !dbg !76
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !77), !dbg !76
-  %10 = load i64, i64* %9, align 8, !dbg !76, !tbaa !6, !alias.scope !77
-  %11 = icmp eq i64 %10, 8, !dbg !76
-  br i1 %11, label %12, label %sorbet_T_must.exit, !dbg !76, !prof !56
+  %4 = load i64, i64* %3, align 8, !tbaa !62
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !tbaa !31
+  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !74
+  %6 = load i64*, i64** %5, align 8, !dbg !74, !tbaa !39
+  %7 = getelementptr inbounds i64, i64* %6, i64 -4, !dbg !74
+  %8 = load i64, i64* %7, align 8, !dbg !74, !tbaa !6
+  %callArgs0Addr = getelementptr [3 x i64], [3 x i64]* %callArgs, i32 0, i64 0, !dbg !74
+  store i64 %8, i64* %callArgs0Addr, align 8, !dbg !74
+  %9 = getelementptr [3 x i64], [3 x i64]* %callArgs, i64 0, i64 0, !dbg !74
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !75), !dbg !74
+  %10 = load i64, i64* %9, align 8, !dbg !74, !tbaa !6, !alias.scope !75
+  %11 = icmp eq i64 %10, 8, !dbg !74
+  br i1 %11, label %12, label %sorbet_T_must.exit, !dbg !74, !prof !53
 
 12:                                               ; preds = %functionEntryInitializers
-  %13 = load i64, i64* @rb_eTypeError, align 8, !dbg !76, !tbaa !6, !noalias !77
-  tail call void (i64, i8*, ...) @rb_raise(i64 %13, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #13, !dbg !76, !noalias !77
-  unreachable, !dbg !76
+  %13 = load i64, i64* @rb_eTypeError, align 8, !dbg !74, !tbaa !6, !noalias !75
+  tail call void (i64, i8*, ...) @rb_raise(i64 %13, i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i64 0, i64 0)) #13, !dbg !74, !noalias !75
+  unreachable, !dbg !74
 
 sorbet_T_must.exit:                               ; preds = %functionEntryInitializers
-  %14 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !76, !tbaa !14
-  %15 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 5, !dbg !76
-  %16 = load i32, i32* %15, align 8, !dbg !76, !tbaa !28
-  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 6, !dbg !76
-  %18 = load i32, i32* %17, align 4, !dbg !76, !tbaa !29
-  %19 = xor i32 %18, -1, !dbg !76
-  %20 = and i32 %19, %16, !dbg !76
-  %21 = icmp eq i32 %20, 0, !dbg !76
-  br i1 %21, label %rb_vm_check_ints.exit, label %22, !dbg !76, !prof !30
+  %14 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !74, !tbaa !31
+  %15 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 5, !dbg !74
+  %16 = load i32, i32* %15, align 8, !dbg !74, !tbaa !78
+  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 6, !dbg !74
+  %18 = load i32, i32* %17, align 4, !dbg !74, !tbaa !79
+  %19 = xor i32 %18, -1, !dbg !74
+  %20 = and i32 %19, %16, !dbg !74
+  %21 = icmp eq i32 %20, 0, !dbg !74
+  br i1 %21, label %rb_vm_check_ints.exit, label %22, !dbg !74, !prof !64
 
 22:                                               ; preds = %sorbet_T_must.exit
-  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 8, !dbg !76
-  %24 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %23, align 8, !dbg !76, !tbaa !31
-  %25 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %24, i32 noundef 0) #14, !dbg !76
-  br label %rb_vm_check_ints.exit, !dbg !76
+  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 8, !dbg !74
+  %24 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %23, align 8, !dbg !74, !tbaa !80
+  %25 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %24, i32 noundef 0) #14, !dbg !74
+  br label %rb_vm_check_ints.exit, !dbg !74
 
 rb_vm_check_ints.exit:                            ; preds = %sorbet_T_must.exit, %22
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %pc, align 8, !dbg !76, !tbaa !14
-  %"rubyStr_ wasn't nil" = load i64, i64* @"rubyStrFrozen_ wasn't nil", align 8, !dbg !80
-  %26 = load i64*, i64** %5, align 8, !dbg !81, !tbaa !22
-  %27 = getelementptr inbounds i64, i64* %26, i64 -4, !dbg !81
-  %28 = load i64, i64* %27, align 8, !dbg !81, !tbaa !6
-  store i64 %28, i64* %callArgs0Addr, align 8, !dbg !81
-  %callArgs1Addr = getelementptr [3 x i64], [3 x i64]* %callArgs, i32 0, i64 1, !dbg !81
-  store i64 %"rubyStr_ wasn't nil", i64* %callArgs1Addr, align 8, !dbg !81
-  %"rubyId_<string-interpolate>" = load i64, i64* @"rubyIdPrecomputed_<string-interpolate>", align 8, !dbg !81
-  %rawSendResult13 = call i64 @sorbet_stringInterpolate(i64 noundef 8, i64 %"rubyId_<string-interpolate>", i32 noundef 2, i64* noundef nonnull %9, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0), !dbg !81
-  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !47
-  %30 = load i64*, i64** %29, align 8, !dbg !47
-  store i64 %4, i64* %30, align 8, !dbg !47, !tbaa !6
-  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !47
-  store i64 %rawSendResult13, i64* %31, align 8, !dbg !47, !tbaa !6
-  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !47
-  store i64* %32, i64** %29, align 8, !dbg !47
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !47
-  %33 = load i64*, i64** %5, align 8, !dbg !47, !tbaa !22
-  %34 = load i64, i64* %33, align 8, !dbg !47, !tbaa !6
-  %35 = and i64 %34, 8, !dbg !47
-  %36 = icmp eq i64 %35, 0, !dbg !47
-  br i1 %36, label %37, label %39, !dbg !47, !prof !30
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %pc, align 8, !dbg !74, !tbaa !31
+  %"rubyStr_ wasn't nil" = load i64, i64* @"rubyStrFrozen_ wasn't nil", align 8, !dbg !81
+  %26 = load i64*, i64** %5, align 8, !dbg !82, !tbaa !39
+  %27 = getelementptr inbounds i64, i64* %26, i64 -4, !dbg !82
+  %28 = load i64, i64* %27, align 8, !dbg !82, !tbaa !6
+  store i64 %28, i64* %callArgs0Addr, align 8, !dbg !82
+  %callArgs1Addr = getelementptr [3 x i64], [3 x i64]* %callArgs, i32 0, i64 1, !dbg !82
+  store i64 %"rubyStr_ wasn't nil", i64* %callArgs1Addr, align 8, !dbg !82
+  %"rubyId_<string-interpolate>" = load i64, i64* @"rubyIdPrecomputed_<string-interpolate>", align 8, !dbg !82
+  %rawSendResult13 = call i64 @sorbet_stringInterpolate(i64 noundef 8, i64 %"rubyId_<string-interpolate>", i32 noundef 2, i64* noundef nonnull %9, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0), !dbg !82
+  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !25
+  %30 = load i64*, i64** %29, align 8, !dbg !25
+  store i64 %4, i64* %30, align 8, !dbg !25, !tbaa !6
+  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !25
+  store i64 %rawSendResult13, i64* %31, align 8, !dbg !25, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !25
+  store i64* %32, i64** %29, align 8, !dbg !25
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !25
+  %33 = load i64*, i64** %5, align 8, !dbg !25, !tbaa !39
+  %34 = load i64, i64* %33, align 8, !dbg !25, !tbaa !6
+  %35 = and i64 %34, 8, !dbg !25
+  %36 = icmp eq i64 %35, 0, !dbg !25
+  br i1 %36, label %37, label %39, !dbg !25, !prof !64
 
 37:                                               ; preds = %rb_vm_check_ints.exit
-  %38 = getelementptr inbounds i64, i64* %33, i64 -6, !dbg !47
-  store i64 %send, i64* %38, align 8, !dbg !47, !tbaa !6
-  br label %sorbet_writeLocal.exit, !dbg !47
+  %38 = getelementptr inbounds i64, i64* %33, i64 -6, !dbg !25
+  store i64 %send, i64* %38, align 8, !dbg !25, !tbaa !6
+  br label %sorbet_writeLocal.exit, !dbg !25
 
 39:                                               ; preds = %rb_vm_check_ints.exit
-  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %33, i32 noundef -6, i64 %send) #14, !dbg !47
-  br label %sorbet_writeLocal.exit, !dbg !47
+  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %33, i32 noundef -6, i64 %send) #14, !dbg !25
+  br label %sorbet_writeLocal.exit, !dbg !25
 
 sorbet_writeLocal.exit:                           ; preds = %37, %39
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !dbg !47, !tbaa !14
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !dbg !25, !tbaa !31
   ret i64 52
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.16test_nilable_arg$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !51 {
+define internal noundef i64 @"func_Test.16test_nilable_arg$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !29 {
 vm_get_ep.exit34:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !33
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !65
+  %4 = load i64, i64* %3, align 8, !tbaa !62
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_2", align 8
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #14
-  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
   %6 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %5, i64 0, i32 2
-  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !16
+  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !33
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !tbaa !14
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !50, !tbaa !14
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !50
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !50, !tbaa !16
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !50
-  %13 = load i64*, i64** %12, align 8, !dbg !50
-  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !50
-  %15 = load i64, i64* %14, align 8, !dbg !50, !tbaa !6
-  %16 = and i64 %15, -4, !dbg !50
-  %17 = inttoptr i64 %16 to i64*, !dbg !50
-  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !50
-  %19 = load i64, i64* %18, align 8, !dbg !50, !tbaa !6
-  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !50
-  %21 = tail call i64 @sorbet_vm_isa_p(%struct.FunctionInlineCache* noundef @"ic_is_a?.4", %struct.rb_control_frame_struct* %11, i64 %19, i64 %20), !dbg !50
-  %22 = and i64 %21, -9, !dbg !50
-  %23 = icmp ne i64 %22, 0, !dbg !50
-  br i1 %23, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !50
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !tbaa !31
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !31
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !28
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !28, !tbaa !33
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !28
+  %13 = load i64*, i64** %12, align 8, !dbg !28
+  %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !28
+  %15 = load i64, i64* %14, align 8, !dbg !28, !tbaa !6
+  %16 = and i64 %15, -4, !dbg !28
+  %17 = inttoptr i64 %16 to i64*, !dbg !28
+  %18 = getelementptr inbounds i64, i64* %17, i64 -3, !dbg !28
+  %19 = load i64, i64* %18, align 8, !dbg !28, !tbaa !6
+  %20 = load i64, i64* @rb_eStandardError, align 8, !dbg !28
+  %21 = tail call i64 @sorbet_vm_isa_p(%struct.FunctionInlineCache* noundef @"ic_is_a?.4", %struct.rb_control_frame_struct* %11, i64 %19, i64 %20), !dbg !28
+  %22 = and i64 %21, -9, !dbg !28
+  %23 = icmp ne i64 %22, 0, !dbg !28
+  br i1 %23, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !28
 
 blockExit:                                        ; preds = %75, %73, %60, %58
   tail call void @sorbet_popFrame()
   ret i64 52
 
 vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
-  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !82, !tbaa !14
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2, !dbg !82
-  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !dbg !82, !tbaa !16
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4, !dbg !82
-  %28 = load i64*, i64** %27, align 8, !dbg !82
-  %29 = getelementptr inbounds i64, i64* %28, i64 -1, !dbg !82
-  %30 = load i64, i64* %29, align 8, !dbg !82, !tbaa !6
-  %31 = and i64 %30, -4, !dbg !82
-  %32 = inttoptr i64 %31 to i64*, !dbg !82
-  %33 = load i64, i64* %32, align 8, !dbg !82, !tbaa !6
-  %34 = and i64 %33, 8, !dbg !82
-  %35 = icmp eq i64 %34, 0, !dbg !82
-  br i1 %35, label %36, label %38, !dbg !82, !prof !30
+  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !83, !tbaa !31
+  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2, !dbg !83
+  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !dbg !83, !tbaa !33
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4, !dbg !83
+  %28 = load i64*, i64** %27, align 8, !dbg !83
+  %29 = getelementptr inbounds i64, i64* %28, i64 -1, !dbg !83
+  %30 = load i64, i64* %29, align 8, !dbg !83, !tbaa !6
+  %31 = and i64 %30, -4, !dbg !83
+  %32 = inttoptr i64 %31 to i64*, !dbg !83
+  %33 = load i64, i64* %32, align 8, !dbg !83, !tbaa !6
+  %34 = and i64 %33, 8, !dbg !83
+  %35 = icmp eq i64 %34, 0, !dbg !83
+  br i1 %35, label %36, label %38, !dbg !83, !prof !64
 
 36:                                               ; preds = %vm_get_ep.exit32
-  %37 = getelementptr inbounds i64, i64* %32, i64 -3, !dbg !82
-  store i64 8, i64* %37, align 8, !dbg !82, !tbaa !6
-  br label %vm_get_ep.exit30, !dbg !82
+  %37 = getelementptr inbounds i64, i64* %32, i64 -3, !dbg !83
+  store i64 8, i64* %37, align 8, !dbg !83, !tbaa !6
+  br label %vm_get_ep.exit30, !dbg !83
 
 38:                                               ; preds = %vm_get_ep.exit32
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %32, i32 noundef -3, i64 noundef 8) #14, !dbg !82
-  br label %vm_get_ep.exit30, !dbg !82
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %32, i32 noundef -3, i64 noundef 8) #14, !dbg !83
+  br label %vm_get_ep.exit30, !dbg !83
 
 vm_get_ep.exit30:                                 ; preds = %36, %38
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %8, align 8, !dbg !83, !tbaa !14
-  %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !14
-  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %39, i64 0, i32 2, !dbg !52
-  %41 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %40, align 8, !dbg !52, !tbaa !16
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !52
-  %43 = load i64*, i64** %42, align 8, !dbg !52
-  store i64 %4, i64* %43, align 8, !dbg !52, !tbaa !6
-  %44 = getelementptr inbounds i64, i64* %43, i64 1, !dbg !52
-  store i64 %19, i64* %44, align 8, !dbg !52, !tbaa !6
-  %45 = getelementptr inbounds i64, i64* %44, i64 1, !dbg !52
-  store i64* %45, i64** %42, align 8, !dbg !52
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !52
-  %46 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !14
-  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2, !dbg !52
-  %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !dbg !52, !tbaa !16
-  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 4, !dbg !52
-  %50 = load i64*, i64** %49, align 8, !dbg !52
-  %51 = getelementptr inbounds i64, i64* %50, i64 -1, !dbg !52
-  %52 = load i64, i64* %51, align 8, !dbg !52, !tbaa !6
-  %53 = and i64 %52, -4, !dbg !52
-  %54 = inttoptr i64 %53 to i64*, !dbg !52
-  %55 = load i64, i64* %54, align 8, !dbg !52, !tbaa !6
-  %56 = and i64 %55, 8, !dbg !52
-  %57 = icmp eq i64 %56, 0, !dbg !52
-  br i1 %57, label %58, label %60, !dbg !52, !prof !30
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %8, align 8, !dbg !84, !tbaa !31
+  %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !31
+  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %39, i64 0, i32 2, !dbg !30
+  %41 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %40, align 8, !dbg !30, !tbaa !33
+  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !30
+  %43 = load i64*, i64** %42, align 8, !dbg !30
+  store i64 %4, i64* %43, align 8, !dbg !30, !tbaa !6
+  %44 = getelementptr inbounds i64, i64* %43, i64 1, !dbg !30
+  store i64 %19, i64* %44, align 8, !dbg !30, !tbaa !6
+  %45 = getelementptr inbounds i64, i64* %44, i64 1, !dbg !30
+  store i64* %45, i64** %42, align 8, !dbg !30
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !30
+  %46 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !31
+  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2, !dbg !30
+  %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !dbg !30, !tbaa !33
+  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 4, !dbg !30
+  %50 = load i64*, i64** %49, align 8, !dbg !30
+  %51 = getelementptr inbounds i64, i64* %50, i64 -1, !dbg !30
+  %52 = load i64, i64* %51, align 8, !dbg !30, !tbaa !6
+  %53 = and i64 %52, -4, !dbg !30
+  %54 = inttoptr i64 %53 to i64*, !dbg !30
+  %55 = load i64, i64* %54, align 8, !dbg !30, !tbaa !6
+  %56 = and i64 %55, 8, !dbg !30
+  %57 = icmp eq i64 %56, 0, !dbg !30
+  br i1 %57, label %58, label %60, !dbg !30, !prof !64
 
 58:                                               ; preds = %vm_get_ep.exit30
-  %59 = getelementptr inbounds i64, i64* %54, i64 -6, !dbg !52
-  store i64 %send, i64* %59, align 8, !dbg !52, !tbaa !6
-  br label %blockExit, !dbg !52
+  %59 = getelementptr inbounds i64, i64* %54, i64 -6, !dbg !30
+  store i64 %send, i64* %59, align 8, !dbg !30, !tbaa !6
+  br label %blockExit, !dbg !30
 
 60:                                               ; preds = %vm_get_ep.exit30
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %54, i32 noundef -6, i64 %send) #14, !dbg !52
-  br label %blockExit, !dbg !52
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %54, i32 noundef -6, i64 %send) #14, !dbg !30
+  br label %blockExit, !dbg !30
 
 vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %8, align 8, !tbaa !14
-  %61 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !84, !tbaa !14
-  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 2, !dbg !84
-  %63 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %62, align 8, !dbg !84, !tbaa !16
-  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %63, i64 0, i32 4, !dbg !84
-  %65 = load i64*, i64** %64, align 8, !dbg !84
-  %66 = getelementptr inbounds i64, i64* %65, i64 -1, !dbg !84
-  %67 = load i64, i64* %66, align 8, !dbg !84, !tbaa !6
-  %68 = and i64 %67, -4, !dbg !84
-  %69 = inttoptr i64 %68 to i64*, !dbg !84
-  %70 = load i64, i64* %69, align 8, !dbg !84, !tbaa !6
-  %71 = and i64 %70, 8, !dbg !84
-  %72 = icmp eq i64 %71, 0, !dbg !84
-  br i1 %72, label %73, label %75, !dbg !84, !prof !30
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %8, align 8, !tbaa !31
+  %61 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !85, !tbaa !31
+  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 2, !dbg !85
+  %63 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %62, align 8, !dbg !85, !tbaa !33
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %63, i64 0, i32 4, !dbg !85
+  %65 = load i64*, i64** %64, align 8, !dbg !85
+  %66 = getelementptr inbounds i64, i64* %65, i64 -1, !dbg !85
+  %67 = load i64, i64* %66, align 8, !dbg !85, !tbaa !6
+  %68 = and i64 %67, -4, !dbg !85
+  %69 = inttoptr i64 %68 to i64*, !dbg !85
+  %70 = load i64, i64* %69, align 8, !dbg !85, !tbaa !6
+  %71 = and i64 %70, 8, !dbg !85
+  %72 = icmp eq i64 %71, 0, !dbg !85
+  br i1 %72, label %73, label %75, !dbg !85, !prof !64
 
 73:                                               ; preds = %vm_get_ep.exit
-  %74 = getelementptr inbounds i64, i64* %69, i64 -7, !dbg !84
-  store i64 20, i64* %74, align 8, !dbg !84, !tbaa !6
-  br label %blockExit, !dbg !84
+  %74 = getelementptr inbounds i64, i64* %69, i64 -7, !dbg !85
+  store i64 20, i64* %74, align 8, !dbg !85, !tbaa !6
+  br label %blockExit, !dbg !85
 
 75:                                               ; preds = %vm_get_ep.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %69, i32 noundef -7, i64 noundef 20) #14, !dbg !84
-  br label %blockExit, !dbg !84
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %69, i32 noundef -7, i64 noundef 20) #14, !dbg !85
+  br label %blockExit, !dbg !85
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.16test_nilable_arg$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !85 {
+define internal noundef i64 @"func_Test.16test_nilable_arg$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !86 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3", align 8
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !16
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !33
   tail call void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame) #14
-  %3 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %3 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
   %4 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %3, i64 0, i32 2
-  %5 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %4, align 8, !tbaa !16
+  %5 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %4, align 8, !tbaa !33
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %6, align 8, !tbaa !14
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %6, align 8, !tbaa !31
   tail call void @sorbet_popFrame()
   ret i64 52
 }
 
 ; Function Attrs: argmemonly nofree norecurse nosync nounwind ssp willreturn writeonly
-define internal noundef i64 @"func_Test.16test_nilable_arg$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !86 {
+define internal noundef i64 @"func_Test.16test_nilable_arg$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !87 {
 functionEntryInitializers:
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %pc, align 8, !tbaa !14
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %pc, align 8, !tbaa !31
   ret i64 52
 }
 
@@ -1035,7 +979,7 @@ declare void @llvm.assume(i1 noundef) #12
 define linkonce void @const_recompute_Test() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @str_Test, i64 0, i64 0), i64 4)
   store i64 %1, i64* @guarded_const_Test, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !25
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @guard_epoch_Test, align 8
   ret void
 }
@@ -1045,8 +989,8 @@ attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-preci
 attributes #2 = { argmemonly nofree nosync nounwind willreturn }
 attributes #3 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #5 = { nounwind sspreq uwtable }
-attributes #6 = { sspreq }
+attributes #5 = { sspreq }
+attributes #6 = { nounwind sspreq uwtable }
 attributes #7 = { noreturn nounwind ssp }
 attributes #8 = { ssp }
 attributes #9 = { argmemonly nofree norecurse nosync nounwind ssp willreturn writeonly }
@@ -1072,80 +1016,81 @@ attributes #17 = { willreturn }
 !7 = !{!"long", !8, i64 0}
 !8 = !{!"omnipotent char", !9, i64 0}
 !9 = !{!"Simple C/C++ TBAA"}
-!10 = distinct !DISubprogram(name: "Test.<static-init>", linkageName: "func_Test.13<static-init>L62", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!11 = !DISubroutineType(types: !12)
-!12 = !{!13}
-!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!14 = !{!15, !15, i64 0}
-!15 = !{!"any pointer", !8, i64 0}
-!16 = !{!17, !15, i64 16}
-!17 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !18, i64 40, !18, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !19, i64 152}
-!18 = !{!"int", !8, i64 0}
-!19 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
-!20 = !{!21, !15, i64 16}
-!21 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
-!22 = !{!21, !15, i64 32}
-!23 = !DILocation(line: 0, scope: !10)
-!24 = !DILocation(line: 6, column: 3, scope: !10)
-!25 = !{!26, !26, i64 0}
-!26 = !{!"long long", !8, i64 0}
-!27 = !{!"branch_weights", i32 1, i32 10000}
-!28 = !{!17, !18, i64 40}
-!29 = !{!17, !18, i64 44}
-!30 = !{!"branch_weights", i32 2000, i32 1}
-!31 = !{!17, !15, i64 56}
-!32 = !DILocation(line: 14, column: 3, scope: !10)
-!33 = !{!34, !18, i64 8}
-!34 = !{!"rb_sorbet_param_struct", !35, i64 0, !18, i64 4, !18, i64 8, !18, i64 12, !18, i64 16, !18, i64 20, !18, i64 24, !18, i64 28, !15, i64 32, !18, i64 40, !18, i64 44, !18, i64 48, !18, i64 52, !15, i64 56}
-!35 = !{!"", !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 0, !18, i64 1, !18, i64 1}
-!36 = !{!34, !18, i64 4}
-!37 = !{!34, !15, i64 32}
-!38 = !DILocation(line: 24, column: 1, scope: !39)
-!39 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!40 = !DILocation(line: 25, column: 1, scope: !39)
-!41 = !DILocation(line: 26, column: 1, scope: !39)
-!42 = !DILocation(line: 27, column: 1, scope: !39)
-!43 = !DILocation(line: 9, column: 15, scope: !44)
-!44 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_2", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!45 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil", scope: null, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!46 = !DILocation(line: 10, column: 7, scope: !44)
-!47 = !DILocation(line: 17, column: 7, scope: !48)
-!48 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_1", scope: !49, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!49 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg", scope: null, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!50 = !DILocation(line: 18, column: 15, scope: !51)
-!51 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_2", scope: !49, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!52 = !DILocation(line: 19, column: 7, scope: !51)
-!53 = !DILocation(line: 0, scope: !39)
-!54 = !DILocation(line: 5, column: 1, scope: !39)
-!55 = !DILocation(line: 6, column: 3, scope: !45)
-!56 = !{!"branch_weights", i32 1, i32 2000}
-!57 = !DILocation(line: 0, scope: !45)
-!58 = !DILocation(line: 8, column: 7, scope: !45)
-!59 = !DILocation(line: 12, column: 3, scope: !45)
-!60 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_1", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!61 = !{!62}
-!62 = distinct !{!62, !63, !"sorbet_T_must: argument 0"}
-!63 = distinct !{!63, !"sorbet_T_must"}
-!64 = !DILocation(line: 8, column: 7, scope: !60)
-!65 = !{!21, !7, i64 24}
-!66 = !DILocation(line: 0, scope: !44)
-!67 = !DILocation(line: 9, column: 5, scope: !44)
-!68 = !DILocation(line: 8, column: 7, scope: !44)
-!69 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_3", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!70 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_4", scope: !45, file: !4, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!71 = !DILocation(line: 14, column: 3, scope: !49)
-!72 = !{!"branch_weights", i32 4001, i32 4000000}
-!73 = !DILocation(line: 0, scope: !49)
-!74 = !DILocation(line: 16, column: 7, scope: !49)
-!75 = !DILocation(line: 21, column: 3, scope: !49)
-!76 = !DILocation(line: 16, column: 7, scope: !48)
-!77 = !{!78}
-!78 = distinct !{!78, !79, !"sorbet_T_must: argument 0"}
-!79 = distinct !{!79, !"sorbet_T_must"}
-!80 = !DILocation(line: 17, column: 19, scope: !48)
-!81 = !DILocation(line: 17, column: 12, scope: !48)
-!82 = !DILocation(line: 0, scope: !51)
-!83 = !DILocation(line: 18, column: 5, scope: !51)
-!84 = !DILocation(line: 16, column: 7, scope: !51)
-!85 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_3", scope: !49, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!86 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_4", scope: !49, file: !4, line: 14, type: !11, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!10 = !DILocation(line: 14, column: 3, scope: !11, inlinedAt: !15)
+!11 = distinct !DISubprogram(name: "Test.<static-init>", linkageName: "func_Test.13<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = distinct !DILocation(line: 5, column: 1, scope: !16)
+!16 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!17 = !DILocation(line: 24, column: 1, scope: !16)
+!18 = !DILocation(line: 25, column: 1, scope: !16)
+!19 = !DILocation(line: 26, column: 1, scope: !16)
+!20 = !DILocation(line: 27, column: 1, scope: !16)
+!21 = !DILocation(line: 9, column: 15, scope: !22)
+!22 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_2", scope: !23, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!23 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil", scope: null, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!24 = !DILocation(line: 10, column: 7, scope: !22)
+!25 = !DILocation(line: 17, column: 7, scope: !26)
+!26 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_1", scope: !27, file: !4, line: 14, type: !12, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!27 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg", scope: null, file: !4, line: 14, type: !12, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!28 = !DILocation(line: 18, column: 15, scope: !29)
+!29 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_2", scope: !27, file: !4, line: 14, type: !12, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!30 = !DILocation(line: 19, column: 7, scope: !29)
+!31 = !{!32, !32, i64 0}
+!32 = !{!"any pointer", !8, i64 0}
+!33 = !{!34, !32, i64 16}
+!34 = !{!"rb_execution_context_struct", !32, i64 0, !7, i64 8, !32, i64 16, !32, i64 24, !32, i64 32, !35, i64 40, !35, i64 44, !32, i64 48, !32, i64 56, !32, i64 64, !7, i64 72, !7, i64 80, !32, i64 88, !7, i64 96, !32, i64 104, !32, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !36, i64 152}
+!35 = !{!"int", !8, i64 0}
+!36 = !{!"", !32, i64 0, !32, i64 8, !7, i64 16, !8, i64 24}
+!37 = !{!38, !32, i64 16}
+!38 = !{!"rb_control_frame_struct", !32, i64 0, !32, i64 8, !32, i64 16, !7, i64 24, !32, i64 32, !32, i64 40, !32, i64 48}
+!39 = !{!38, !32, i64 32}
+!40 = !DILocation(line: 0, scope: !16)
+!41 = !DILocation(line: 5, column: 1, scope: !16)
+!42 = !DILocation(line: 0, scope: !11, inlinedAt: !15)
+!43 = !DILocation(line: 6, column: 3, scope: !11, inlinedAt: !15)
+!44 = !{!45, !45, i64 0}
+!45 = !{!"long long", !8, i64 0}
+!46 = !{!"branch_weights", i32 1, i32 10000}
+!47 = !{!48, !35, i64 8}
+!48 = !{!"rb_sorbet_param_struct", !49, i64 0, !35, i64 4, !35, i64 8, !35, i64 12, !35, i64 16, !35, i64 20, !35, i64 24, !35, i64 28, !32, i64 32, !35, i64 40, !35, i64 44, !35, i64 48, !35, i64 52, !32, i64 56}
+!49 = !{!"", !35, i64 0, !35, i64 0, !35, i64 0, !35, i64 0, !35, i64 0, !35, i64 0, !35, i64 0, !35, i64 0, !35, i64 1, !35, i64 1}
+!50 = !{!48, !35, i64 4}
+!51 = !{!48, !32, i64 32}
+!52 = !DILocation(line: 6, column: 3, scope: !23)
+!53 = !{!"branch_weights", i32 1, i32 2000}
+!54 = !DILocation(line: 0, scope: !23)
+!55 = !DILocation(line: 8, column: 7, scope: !23)
+!56 = !DILocation(line: 12, column: 3, scope: !23)
+!57 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_1", scope: !23, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!58 = !{!59}
+!59 = distinct !{!59, !60, !"sorbet_T_must: argument 0"}
+!60 = distinct !{!60, !"sorbet_T_must"}
+!61 = !DILocation(line: 8, column: 7, scope: !57)
+!62 = !{!38, !7, i64 24}
+!63 = !DILocation(line: 0, scope: !22)
+!64 = !{!"branch_weights", i32 2000, i32 1}
+!65 = !DILocation(line: 9, column: 5, scope: !22)
+!66 = !DILocation(line: 8, column: 7, scope: !22)
+!67 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_3", scope: !23, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!68 = distinct !DISubprogram(name: "Test.test_known_nil", linkageName: "func_Test.14test_known_nil$block_4", scope: !23, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!69 = !DILocation(line: 14, column: 3, scope: !27)
+!70 = !{!"branch_weights", i32 4001, i32 4000000}
+!71 = !DILocation(line: 0, scope: !27)
+!72 = !DILocation(line: 16, column: 7, scope: !27)
+!73 = !DILocation(line: 21, column: 3, scope: !27)
+!74 = !DILocation(line: 16, column: 7, scope: !26)
+!75 = !{!76}
+!76 = distinct !{!76, !77, !"sorbet_T_must: argument 0"}
+!77 = distinct !{!77, !"sorbet_T_must"}
+!78 = !{!34, !35, i64 40}
+!79 = !{!34, !35, i64 44}
+!80 = !{!34, !32, i64 56}
+!81 = !DILocation(line: 17, column: 19, scope: !26)
+!82 = !DILocation(line: 17, column: 12, scope: !26)
+!83 = !DILocation(line: 0, scope: !29)
+!84 = !DILocation(line: 18, column: 5, scope: !29)
+!85 = !DILocation(line: 16, column: 7, scope: !29)
+!86 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_3", scope: !27, file: !4, line: 14, type: !12, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!87 = distinct !DISubprogram(name: "Test.test_nilable_arg", linkageName: "func_Test.16test_nilable_arg$block_4", scope: !27, file: !4, line: 14, type: !12, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)

--- a/test/testdata/compiler/repeated_casts.opt.ll.exp
+++ b/test/testdata/compiler/repeated_casts.opt.ll.exp
@@ -154,8 +154,6 @@ declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #3
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #3
-
 ; Function Attrs: allocsize(0,1)
 declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #5
 
@@ -168,14 +166,14 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #12
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #13
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #12
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #13
   unreachable
 }
 
@@ -190,7 +188,7 @@ functionEntryInitializers:
   br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !16, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #13, !dbg !16
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #14, !dbg !16
   unreachable, !dbg !16
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
@@ -232,165 +230,35 @@ typeTestSuccess:                                  ; preds = %4
   ret i64 %send33
 
 codeRepl:                                         ; preds = %4
-  tail call fastcc void @"func_Object#10doubleCast.cold.1"(i64 %rawArg_a) #14, !dbg !19
+  tail call fastcc void @"func_Object#10doubleCast.cold.1"(i64 %rawArg_a) #15, !dbg !19
   unreachable
 }
 
-; Function Attrs: nounwind sspreq uwtable
-define internal fastcc void @"func_<root>.17<static-init>$152"(%struct.rb_control_frame_struct* nocapture writeonly %cfp) unnamed_addr #7 !dbg !25 {
-functionEntryInitializers:
-  %0 = alloca %struct.rb_calling_info, align 8
-  %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %1 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %2 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %1, i64 0, i32 2
-  %3 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %2, align 8, !tbaa !26
-  %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %3, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %4, align 8, !tbaa !30
-  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %3, i64 0, i32 4
-  %6 = load i64*, i64** %5, align 8, !tbaa !32
-  %7 = load i64, i64* %6, align 8, !tbaa !6
-  %8 = and i64 %7, -33
-  store i64 %8, i64* %6, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %1, %struct.rb_control_frame_struct* %3, %struct.rb_iseq_struct* %stackFrame) #15
-  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %9, align 8, !dbg !33, !tbaa !14
-  %10 = load i64, i64* @rb_cObject, align 8, !dbg !34
-  %11 = tail call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %10) #15, !dbg !34
-  %12 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %11) #15, !dbg !34
-  %13 = bitcast %struct.rb_calling_info* %0 to i8*, !dbg !34
-  call void @llvm.lifetime.start.p0i8(i64 noundef 24, i8* noundef nonnull align 8 dereferenceable(24) %13) #15, !dbg !34
-  %14 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 0, !dbg !34
-  store i64 0, i64* %14, align 8, !dbg !34, !tbaa !35
-  %15 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 3, !dbg !34
-  store i32 0, i32* %15, align 4, !dbg !34, !tbaa !37
-  %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2
-  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !26
-  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %19, align 8, !tbaa !30
-  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 4
-  %21 = load i64*, i64** %20, align 8, !tbaa !32
-  %22 = load i64, i64* %21, align 8, !tbaa !6
-  %23 = and i64 %22, -33
-  store i64 %23, i64* %21, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %16, %struct.rb_control_frame_struct* %18, %struct.rb_iseq_struct* %stackFrame.i) #15
-  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %24, align 8, !dbg !38, !tbaa !14
-  %25 = load i64, i64* @guard_epoch_A, align 8, !dbg !41
-  %26 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !20
-  %needTakeSlowPath = icmp ne i64 %25, %26, !dbg !41
-  br i1 %needTakeSlowPath, label %27, label %28, !dbg !41, !prof !22
-
-27:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_A(), !dbg !41
-  br label %28, !dbg !41
-
-28:                                               ; preds = %functionEntryInitializers, %27
-  %29 = load i64, i64* @guarded_const_A, align 8, !dbg !41
-  %30 = load i64, i64* @guard_epoch_A, align 8, !dbg !41
-  %31 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !41, !tbaa !20
-  %guardUpdated = icmp eq i64 %30, %31, !dbg !41
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !41
-  %stackFrame8.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8, !dbg !41
-  %32 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !41
-  %33 = bitcast i8* %32 to i16*, !dbg !41
-  %34 = load i16, i16* %33, align 8, !dbg !41
-  %35 = and i16 %34, -384, !dbg !41
-  store i16 %35, i16* %33, align 8, !dbg !41
-  %36 = getelementptr inbounds i8, i8* %32, i64 4, !dbg !41
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %36, i8 0, i64 28, i1 false) #15, !dbg !41
-  tail call void @sorbet_vm_define_method(i64 %29, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %32, %struct.rb_iseq_struct* %stackFrame8.i, i1 noundef zeroext false) #15, !dbg !41
-  %37 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !41, !tbaa !14
-  %38 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %37, i64 0, i32 5, !dbg !41
-  %39 = load i32, i32* %38, align 8, !dbg !41, !tbaa !42
-  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %37, i64 0, i32 6, !dbg !41
-  %41 = load i32, i32* %40, align 4, !dbg !41, !tbaa !43
-  %42 = xor i32 %41, -1, !dbg !41
-  %43 = and i32 %42, %39, !dbg !41
-  %44 = icmp eq i32 %43, 0, !dbg !41
-  br i1 %44, label %"func_A.13<static-init>L61.exit", label %45, !dbg !41, !prof !23
-
-45:                                               ; preds = %28
-  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %37, i64 0, i32 8, !dbg !41
-  %47 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %46, align 8, !dbg !41, !tbaa !44
-  %48 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %47, i32 noundef 0) #15, !dbg !41
-  br label %"func_A.13<static-init>L61.exit", !dbg !41
-
-"func_A.13<static-init>L61.exit":                 ; preds = %28, %45
-  tail call void @sorbet_popFrame() #15, !dbg !34
-  call void @llvm.lifetime.end.p0i8(i64 noundef 24, i8* noundef nonnull %13) #15, !dbg !34
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %9, align 8, !dbg !34, !tbaa !14
-  %stackFrame20 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#10doubleCast", align 8, !dbg !45
-  %49 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #16, !dbg !45
-  %50 = bitcast i8* %49 to i16*, !dbg !45
-  %51 = load i16, i16* %50, align 8, !dbg !45
-  %52 = and i16 %51, -384, !dbg !45
-  %53 = or i16 %52, 1, !dbg !45
-  store i16 %53, i16* %50, align 8, !dbg !45
-  %54 = getelementptr inbounds i8, i8* %49, i64 8, !dbg !45
-  %55 = bitcast i8* %54 to i32*, !dbg !45
-  store i32 1, i32* %55, align 8, !dbg !45, !tbaa !46
-  %56 = getelementptr inbounds i8, i8* %49, i64 12, !dbg !45
-  %57 = bitcast i8* %56 to i32*, !dbg !45
-  %58 = getelementptr inbounds i8, i8* %49, i64 4, !dbg !45
-  %59 = bitcast i8* %58 to i32*, !dbg !45
-  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %56, i8 0, i64 20, i1 false), !dbg !45
-  store i32 1, i32* %59, align 4, !dbg !45, !tbaa !49
-  %positional_table = alloca i64, align 8, !dbg !45
-  %rubyId_a = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !45
-  store i64 %rubyId_a, i64* %positional_table, align 8, !dbg !45
-  %60 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #16, !dbg !45
-  %61 = bitcast i64* %positional_table to i8*, !dbg !45
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %60, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %61, i64 noundef 8, i1 noundef false) #15, !dbg !45
-  %62 = getelementptr inbounds i8, i8* %49, i64 32, !dbg !45
-  %63 = bitcast i8* %62 to i8**, !dbg !45
-  store i8* %60, i8** %63, align 8, !dbg !45, !tbaa !50
-  tail call void @sorbet_vm_define_method(i64 %10, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#10doubleCast", i8* nonnull %49, %struct.rb_iseq_struct* %stackFrame20, i1 noundef zeroext false) #15, !dbg !45
-  %64 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !45, !tbaa !14
-  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 5, !dbg !45
-  %66 = load i32, i32* %65, align 8, !dbg !45, !tbaa !42
-  %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 6, !dbg !45
-  %68 = load i32, i32* %67, align 4, !dbg !45, !tbaa !43
-  %69 = xor i32 %68, -1, !dbg !45
-  %70 = and i32 %69, %66, !dbg !45
-  %71 = icmp eq i32 %70, 0, !dbg !45
-  br i1 %71, label %rb_vm_check_ints.exit, label %72, !dbg !45, !prof !23
-
-72:                                               ; preds = %"func_A.13<static-init>L61.exit"
-  %73 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %64, i64 0, i32 8, !dbg !45
-  %74 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %73, align 8, !dbg !45, !tbaa !44
-  %75 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %74, i32 noundef 0) #15, !dbg !45
-  br label %rb_vm_check_ints.exit, !dbg !45
-
-rb_vm_check_ints.exit:                            ; preds = %"func_A.13<static-init>L61.exit", %72
-  ret void
-}
-
-; Function Attrs: ssp
+; Function Attrs: sspreq
 define void @Init_repeated_casts() local_unnamed_addr #8 {
 entry:
+  %positional_table.i = alloca i64, align 8, !dbg !25
   %locals.i8.i = alloca i64, i32 0, align 8
   %locals.i6.i = alloca i64, i32 0, align 8
   %locals.i4.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 noundef 10) #15
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 noundef 10) #16
   store i64 %0, i64* @rubyIdPrecomputed_doubleCast, align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #15
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #16
   store i64 %1, i64* @rubyIdPrecomputed_foo, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
   store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #15
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #15
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #16
   store i64 %4, i64* @rubyIdPrecomputed_a, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #15
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #16
   store i64 %5, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 noundef 10) #15
-  tail call void @rb_gc_register_mark_object(i64 %6) #15
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 noundef 10) #16
+  tail call void @rb_gc_register_mark_object(i64 %6) #16
   store i64 %6, i64* @rubyStrFrozen_doubleCast, align 8
-  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([41 x i8], [41 x i8]* @"str_test/testdata/compiler/repeated_casts.rb", i64 0, i64 0), i64 noundef 40) #15
-  tail call void @rb_gc_register_mark_object(i64 %7) #15
+  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([41 x i8], [41 x i8]* @"str_test/testdata/compiler/repeated_casts.rb", i64 0, i64 0), i64 noundef 40) #16
+  tail call void @rb_gc_register_mark_object(i64 %7) #16
   store i64 %7, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 12)
   %rubyId_doubleCast.i.i = load i64, i64* @rubyIdPrecomputed_doubleCast, align 8
@@ -402,45 +270,124 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !19
   %rubyId_foo1.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !24
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo1.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
-  %9 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #15
-  call void @rb_gc_register_mark_object(i64 %9) #15
+  %9 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  call void @rb_gc_register_mark_object(i64 %9) #16
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i3.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
   %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i3.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i4.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #15
-  call void @rb_gc_register_mark_object(i64 %11) #15
+  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #16
+  call void @rb_gc_register_mark_object(i64 %11) #16
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i5.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
   %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i6.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
-  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #15
-  call void @rb_gc_register_mark_object(i64 %13) #15
+  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #16
+  call void @rb_gc_register_mark_object(i64 %13) #16
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i7.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
   %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i7.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
   %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 2
-  %17 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %16, align 8, !tbaa !26
-  call fastcc void @"func_<root>.17<static-init>$152"(%struct.rb_control_frame_struct* nocapture writeonly %17) #15
+  %17 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %16, align 8, !tbaa !27
+  %18 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %18)
+  %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %19, align 8, !tbaa !31
+  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 4
+  %21 = load i64*, i64** %20, align 8, !tbaa !33
+  %22 = load i64, i64* %21, align 8, !tbaa !6
+  %23 = and i64 %22, -33
+  store i64 %23, i64* %21, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %15, %struct.rb_control_frame_struct* %17, %struct.rb_iseq_struct* %stackFrame.i) #16
+  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 0
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %24, align 8, !dbg !34, !tbaa !14
+  %25 = load i64, i64* @rb_cObject, align 8, !dbg !35
+  %26 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %25) #16, !dbg !35
+  %27 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %26) #16, !dbg !35
+  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 2
+  %30 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %29, align 8, !tbaa !27
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %31, align 8, !tbaa !31
+  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 4
+  %33 = load i64*, i64** %32, align 8, !tbaa !33
+  %34 = load i64, i64* %33, align 8, !tbaa !6
+  %35 = and i64 %34, -33
+  store i64 %35, i64* %33, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %28, %struct.rb_control_frame_struct* %30, %struct.rb_iseq_struct* %stackFrame.i.i) #16
+  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 0
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %36, align 8, !dbg !36, !tbaa !14
+  %37 = load i64, i64* @guard_epoch_A, align 8, !dbg !39
+  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !39, !tbaa !20
+  %needTakeSlowPath = icmp ne i64 %37, %38, !dbg !39
+  br i1 %needTakeSlowPath, label %39, label %40, !dbg !39, !prof !22
+
+39:                                               ; preds = %entry
+  call void @const_recompute_A(), !dbg !39
+  br label %40, !dbg !39
+
+40:                                               ; preds = %entry, %39
+  %41 = load i64, i64* @guarded_const_A, align 8, !dbg !39
+  %42 = load i64, i64* @guard_epoch_A, align 8, !dbg !39
+  %43 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !39, !tbaa !20
+  %guardUpdated = icmp eq i64 %42, %43, !dbg !39
+  call void @llvm.assume(i1 %guardUpdated), !dbg !39
+  %stackFrame8.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8, !dbg !39
+  %44 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !39
+  %45 = bitcast i8* %44 to i16*, !dbg !39
+  %46 = load i16, i16* %45, align 8, !dbg !39
+  %47 = and i16 %46, -384, !dbg !39
+  store i16 %47, i16* %45, align 8, !dbg !39
+  %48 = getelementptr inbounds i8, i8* %44, i64 4, !dbg !39
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %48, i8 0, i64 28, i1 false) #16, !dbg !39
+  call void @sorbet_vm_define_method(i64 %41, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %44, %struct.rb_iseq_struct* %stackFrame8.i.i, i1 noundef zeroext false) #16, !dbg !39
+  call void @sorbet_popFrame() #16, !dbg !35
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %24, align 8, !dbg !35, !tbaa !14
+  %stackFrame20.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#10doubleCast", align 8, !dbg !25
+  %49 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !25
+  %50 = bitcast i8* %49 to i16*, !dbg !25
+  %51 = load i16, i16* %50, align 8, !dbg !25
+  %52 = and i16 %51, -384, !dbg !25
+  %53 = or i16 %52, 1, !dbg !25
+  store i16 %53, i16* %50, align 8, !dbg !25
+  %54 = getelementptr inbounds i8, i8* %49, i64 8, !dbg !25
+  %55 = bitcast i8* %54 to i32*, !dbg !25
+  store i32 1, i32* %55, align 8, !dbg !25, !tbaa !40
+  %56 = getelementptr inbounds i8, i8* %49, i64 12, !dbg !25
+  %57 = getelementptr inbounds i8, i8* %49, i64 4, !dbg !25
+  %58 = bitcast i8* %57 to i32*, !dbg !25
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %56, i8 0, i64 20, i1 false) #16, !dbg !25
+  store i32 1, i32* %58, align 4, !dbg !25, !tbaa !43
+  %rubyId_a.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !25
+  store i64 %rubyId_a.i, i64* %positional_table.i, align 8, !dbg !25
+  %59 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !25
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %59, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %18, i64 noundef 8, i1 noundef false) #16, !dbg !25
+  %60 = getelementptr inbounds i8, i8* %49, i64 32, !dbg !25
+  %61 = bitcast i8* %60 to i8**, !dbg !25
+  store i8* %59, i8** %61, align 8, !dbg !25, !tbaa !44
+  call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#10doubleCast", i8* nonnull %49, %struct.rb_iseq_struct* %stackFrame20.i, i1 noundef zeroext false) #16, !dbg !25
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %18)
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal noundef i64 @"func_A#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !51 {
+define internal noundef i64 @"func_A#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !45 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !tbaa !14
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !52
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !52, !prof !53
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !46
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !46, !prof !47
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !52
-  unreachable, !dbg !52
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #14, !dbg !46
+  unreachable, !dbg !46
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !54, !tbaa !14
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !dbg !48, !tbaa !14
   ret i64 8
 }
 
@@ -448,17 +395,17 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #9
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Object#10doubleCast.cold.1"(i64 %rawArg_a) unnamed_addr #10 !dbg !55 {
+define internal fastcc void @"func_Object#10doubleCast.cold.1"(i64 %rawArg_a) unnamed_addr #10 !dbg !49 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_a, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0)) #13, !dbg !57
-  unreachable, !dbg !57
+  tail call void @sorbet_cast_failure(i64 %rawArg_a, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0)) #14, !dbg !51
+  unreachable, !dbg !51
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
 declare void @llvm.assume(i1 noundef) #11
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_A() local_unnamed_addr #8 {
+define linkonce void @const_recompute_A() local_unnamed_addr #12 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !20
@@ -474,15 +421,16 @@ attributes #4 = { argmemonly nofree nosync nounwind willreturn }
 attributes #5 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #6 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #7 = { nounwind sspreq uwtable }
-attributes #8 = { ssp }
+attributes #8 = { sspreq }
 attributes #9 = { argmemonly nofree nosync nounwind willreturn writeonly }
 attributes #10 = { cold minsize noreturn nounwind sspreq uwtable }
 attributes #11 = { nofree nosync nounwind willreturn }
-attributes #12 = { noreturn nounwind }
-attributes #13 = { noreturn }
-attributes #14 = { noinline }
-attributes #15 = { nounwind }
-attributes #16 = { nounwind allocsize(0,1) }
+attributes #12 = { ssp }
+attributes #13 = { noreturn nounwind }
+attributes #14 = { noreturn }
+attributes #15 = { noinline }
+attributes #16 = { nounwind }
+attributes #17 = { nounwind allocsize(0,1) }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -512,36 +460,30 @@ attributes #16 = { nounwind allocsize(0,1) }
 !22 = !{!"branch_weights", i32 1, i32 10000}
 !23 = !{!"branch_weights", i32 2000, i32 1}
 !24 = !DILocation(line: 10, column: 3, scope: !10)
-!25 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!26 = !{!27, !15, i64 16}
-!27 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !28, i64 40, !28, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !29, i64 152}
-!28 = !{!"int", !8, i64 0}
-!29 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
-!30 = !{!31, !15, i64 16}
-!31 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
-!32 = !{!31, !15, i64 32}
-!33 = !DILocation(line: 0, scope: !25)
-!34 = !DILocation(line: 4, column: 1, scope: !25)
-!35 = !{!36, !7, i64 0}
-!36 = !{!"rb_calling_info", !7, i64 0, !7, i64 8, !28, i64 16, !28, i64 20}
-!37 = !{!36, !28, i64 20}
-!38 = !DILocation(line: 0, scope: !39, inlinedAt: !40)
-!39 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.13<static-init>L61", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!40 = distinct !DILocation(line: 4, column: 1, scope: !25)
-!41 = !DILocation(line: 5, column: 3, scope: !39, inlinedAt: !40)
-!42 = !{!27, !28, i64 40}
-!43 = !{!27, !28, i64 44}
-!44 = !{!27, !15, i64 56}
-!45 = !DILocation(line: 8, column: 1, scope: !25)
-!46 = !{!47, !28, i64 8}
-!47 = !{!"rb_sorbet_param_struct", !48, i64 0, !28, i64 4, !28, i64 8, !28, i64 12, !28, i64 16, !28, i64 20, !28, i64 24, !28, i64 28, !15, i64 32, !28, i64 40, !28, i64 44, !28, i64 48, !28, i64 52, !15, i64 56}
-!48 = !{!"", !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 0, !28, i64 1, !28, i64 1}
-!49 = !{!47, !28, i64 4}
-!50 = !{!47, !15, i64 32}
-!51 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#3foo", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!52 = !DILocation(line: 5, column: 3, scope: !51)
-!53 = !{!"branch_weights", i32 1, i32 2000}
-!54 = !DILocation(line: 0, scope: !51)
-!55 = distinct !DISubprogram(name: "func_Object#10doubleCast.cold.1", linkageName: "func_Object#10doubleCast.cold.1", scope: null, file: !4, type: !56, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!56 = !DISubroutineType(types: !5)
-!57 = !DILocation(line: 9, column: 3, scope: !55)
+!25 = !DILocation(line: 8, column: 1, scope: !26)
+!26 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!27 = !{!28, !15, i64 16}
+!28 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !29, i64 40, !29, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !30, i64 152}
+!29 = !{!"int", !8, i64 0}
+!30 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!31 = !{!32, !15, i64 16}
+!32 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!33 = !{!32, !15, i64 32}
+!34 = !DILocation(line: 0, scope: !26)
+!35 = !DILocation(line: 4, column: 1, scope: !26)
+!36 = !DILocation(line: 0, scope: !37, inlinedAt: !38)
+!37 = distinct !DISubprogram(name: "A.<static-init>", linkageName: "func_A.13<static-init>L61", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!38 = distinct !DILocation(line: 4, column: 1, scope: !26)
+!39 = !DILocation(line: 5, column: 3, scope: !37, inlinedAt: !38)
+!40 = !{!41, !29, i64 8}
+!41 = !{!"rb_sorbet_param_struct", !42, i64 0, !29, i64 4, !29, i64 8, !29, i64 12, !29, i64 16, !29, i64 20, !29, i64 24, !29, i64 28, !15, i64 32, !29, i64 40, !29, i64 44, !29, i64 48, !29, i64 52, !15, i64 56}
+!42 = !{!"", !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 1, !29, i64 1}
+!43 = !{!41, !29, i64 4}
+!44 = !{!41, !15, i64 32}
+!45 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#3foo", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!46 = !DILocation(line: 5, column: 3, scope: !45)
+!47 = !{!"branch_weights", i32 1, i32 2000}
+!48 = !DILocation(line: 0, scope: !45)
+!49 = distinct !DISubprogram(name: "func_Object#10doubleCast.cold.1", linkageName: "func_Object#10doubleCast.cold.1", scope: null, file: !4, type: !50, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!50 = !DISubroutineType(types: !5)
+!51 = !DILocation(line: 9, column: 3, scope: !49)

--- a/test/testdata/compiler/sig_rewriter.opt.ll.exp
+++ b/test/testdata/compiler/sig_rewriter.opt.ll.exp
@@ -158,12 +158,6 @@ declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #2
 
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #2
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #3
-
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #3
-
 declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #2
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #2
@@ -171,64 +165,61 @@ declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #2
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
 
-declare i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct*, i32) local_unnamed_addr #2
-
 ; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #4
+declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #3
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #5 {
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #11
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #5 {
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #11
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: sspreq
-define void @Init_sig_rewriter() local_unnamed_addr #6 {
+define void @Init_sig_rewriter() local_unnamed_addr #5 {
 entry:
-  %0 = alloca %struct.rb_calling_info, align 8
   %locals.i12.i = alloca i64, i32 0, align 8
   %locals.i10.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
-  store i64 %1, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #12
-  store i64 %2, i64* @rubyIdPrecomputed_new, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #12
-  store i64 %3, i64* @rubyIdPrecomputed_initialize, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #12
-  store i64 %4, i64* @rubyIdPrecomputed_foo, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #12
-  store i64 %5, i64* @rubyIdPrecomputed_puts, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #12
-  store i64 %6, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #12
-  store i64 %7, i64* @"rubyIdPrecomputed_block in <class:A>", align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #12
-  store i64 %8, i64* @rubyIdPrecomputed_returns, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #12
-  store i64 %9, i64* @rubyIdPrecomputed_extend, align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #12
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
-  tail call void @rb_gc_register_mark_object(i64 %11) #12
-  store i64 %11, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %12 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/sig_rewriter.rb", i64 0, i64 0), i64 noundef 38) #12
-  tail call void @rb_gc_register_mark_object(i64 %12) #12
-  store i64 %12, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
+  store i64 %1, i64* @rubyIdPrecomputed_new, align 8
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #11
+  store i64 %2, i64* @rubyIdPrecomputed_initialize, align 8
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
+  store i64 %3, i64* @rubyIdPrecomputed_foo, align 8
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  store i64 %5, i64* @"rubyIdPrecomputed_<class:A>", align 8
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #11
+  store i64 %6, i64* @"rubyIdPrecomputed_block in <class:A>", align 8
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #11
+  store i64 %7, i64* @rubyIdPrecomputed_returns, align 8
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #11
+  store i64 %8, i64* @rubyIdPrecomputed_extend, align 8
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %10) #11
+  store i64 %10, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/sig_rewriter.rb", i64 0, i64 0), i64 noundef 38) #11
+  tail call void @rb_gc_register_mark_object(i64 %11) #11
+  store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 14)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !10
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !10
@@ -237,228 +228,183 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #12
-  call void @rb_gc_register_mark_object(i64 %14) #12
+  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
+  call void @rb_gc_register_mark_object(i64 %13) #11
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i10.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #12
-  call void @rb_gc_register_mark_object(i64 %16) #12
+  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i10.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
+  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %15) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #12
-  call void @rb_gc_register_mark_object(i64 %18) #12
+  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #11
+  call void @rb_gc_register_mark_object(i64 %17) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
   %"rubyId_block in <class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:A>", align 8
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %"rubyId_block in <class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>$block_1", align 8
+  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %"rubyId_block in <class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>$block_1", align 8
   %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !16
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
   %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %20 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !20
-  %21 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %20, i64 0, i32 18
-  %22 = load i64, i64* %21, align 8, !tbaa !22
-  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
-  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !32
+  %19 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !20
+  %20 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %19, i64 0, i32 18
+  %21 = load i64, i64* %20, align 8, !tbaa !22
+  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
+  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
+  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !32
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %26, align 8, !tbaa !35
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
-  %28 = load i64*, i64** %27, align 8, !tbaa !37
-  %29 = load i64, i64* %28, align 8, !tbaa !6
-  %30 = and i64 %29, -33
-  store i64 %30, i64* %28, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %23, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #12
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %31, align 8, !dbg !38, !tbaa !20
-  %32 = load i64, i64* @rb_cObject, align 8, !dbg !39
-  %33 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %32) #12, !dbg !39
-  %34 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %33) #12, !dbg !39
-  %35 = bitcast %struct.rb_calling_info* %0 to i8*, !dbg !39
-  call void @llvm.lifetime.start.p0i8(i64 noundef 24, i8* noundef nonnull align 8 dereferenceable(24) %35) #12, !dbg !39
-  %36 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 0, !dbg !39
-  store i64 0, i64* %36, align 8, !dbg !39, !tbaa !40
-  %37 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 3, !dbg !39
-  store i32 0, i32* %37, align 4, !dbg !39, !tbaa !42
-  %38 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 1, !dbg !39
-  store i64 %33, i64* %38, align 8, !dbg !39, !tbaa !43
-  %39 = getelementptr inbounds %struct.rb_calling_info, %struct.rb_calling_info* %0, i64 0, i32 2, !dbg !39
-  store i32 0, i32* %39, align 8, !dbg !39, !tbaa !44
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !35
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
+  %27 = load i64*, i64** %26, align 8, !tbaa !37
+  %28 = load i64, i64* %27, align 8, !tbaa !6
+  %29 = and i64 %28, -33
+  store i64 %29, i64* %27, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !38, !tbaa !20
+  %31 = load i64, i64* @rb_cObject, align 8, !dbg !39
+  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %31) #11, !dbg !39
+  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #11, !dbg !39
   %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
-  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 2
-  %42 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %41, align 8, !tbaa !32
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %43, align 8, !tbaa !35
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 4
-  %45 = load i64*, i64** %44, align 8, !tbaa !37
-  %46 = load i64, i64* %45, align 8, !tbaa !6
-  %47 = and i64 %46, -33
-  store i64 %47, i64* %45, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %40, %struct.rb_control_frame_struct* %42, %struct.rb_iseq_struct* %stackFrame.i.i1) #12
-  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %48, align 8, !dbg !45, !tbaa !20
-  %rubyId_foo.i.i2 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !47
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_foo.i.i2) #12, !dbg !47
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %33, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.13<static-init>L62$block_1") #12, !dbg !47
-  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !47, !tbaa !20
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 5, !dbg !47
-  %51 = load i32, i32* %50, align 8, !dbg !47, !tbaa !48
-  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 6, !dbg !47
-  %53 = load i32, i32* %52, align 4, !dbg !47, !tbaa !49
-  %54 = xor i32 %53, -1, !dbg !47
-  %55 = and i32 %54, %51, !dbg !47
-  %56 = icmp eq i32 %55, 0, !dbg !47
-  br i1 %56, label %rb_vm_check_ints.exit1.i.i, label %57, !dbg !47, !prof !50
+  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
+  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
+  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !32
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %37, align 8, !tbaa !35
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
+  %39 = load i64*, i64** %38, align 8, !tbaa !37
+  %40 = load i64, i64* %39, align 8, !tbaa !6
+  %41 = and i64 %40, -33
+  store i64 %41, i64* %39, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
+  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %42, align 8, !dbg !40, !tbaa !20
+  %rubyId_foo.i.i2 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !42
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_foo.i.i2) #11, !dbg !42
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %32, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.13<static-init>L62$block_1") #11, !dbg !42
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !42, !tbaa !20
+  %43 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !43
+  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !43
+  br i1 %needTakeSlowPath, label %45, label %46, !dbg !43, !prof !45
 
-57:                                               ; preds = %entry
-  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 8, !dbg !47
-  %59 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %58, align 8, !dbg !47, !tbaa !51
-  %60 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %59, i32 noundef 0) #12, !dbg !47
-  br label %rb_vm_check_ints.exit1.i.i, !dbg !47
+45:                                               ; preds = %entry
+  call void @"const_recompute_T::Sig"(), !dbg !43
+  br label %46, !dbg !43
 
-rb_vm_check_ints.exit1.i.i:                       ; preds = %57, %entry
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %48, align 8, !dbg !47, !tbaa !20
-  %61 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !52
-  %62 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !53
-  %needTakeSlowPath = icmp ne i64 %61, %62, !dbg !52
-  br i1 %needTakeSlowPath, label %63, label %64, !dbg !52, !prof !54
+46:                                               ; preds = %entry, %45
+  %47 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !43
+  %48 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !43
+  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %guardUpdated = icmp eq i64 %48, %49, !dbg !43
+  call void @llvm.assume(i1 %guardUpdated), !dbg !43
+  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !43
+  %51 = load i64*, i64** %50, align 8, !dbg !43
+  store i64 %32, i64* %51, align 8, !dbg !43, !tbaa !6
+  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !43
+  store i64 %47, i64* %52, align 8, !dbg !43, !tbaa !6
+  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !43
+  store i64* %53, i64** %50, align 8, !dbg !43
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !43
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %42, align 8, !dbg !43, !tbaa !20
+  %54 = load i64, i64* @guard_epoch_A, align 8, !dbg !46
+  %55 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !44
+  %needTakeSlowPath3 = icmp ne i64 %54, %55, !dbg !46
+  br i1 %needTakeSlowPath3, label %56, label %57, !dbg !46, !prof !45
 
-63:                                               ; preds = %rb_vm_check_ints.exit1.i.i
-  call void @"const_recompute_T::Sig"(), !dbg !52
-  br label %64, !dbg !52
+56:                                               ; preds = %46
+  call void @const_recompute_A(), !dbg !46
+  br label %57, !dbg !46
 
-64:                                               ; preds = %rb_vm_check_ints.exit1.i.i, %63
-  %65 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !52
-  %66 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !52
-  %67 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !52, !tbaa !53
-  %guardUpdated = icmp eq i64 %66, %67, !dbg !52
-  call void @llvm.assume(i1 %guardUpdated), !dbg !52
-  %68 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 1, !dbg !52
-  %69 = load i64*, i64** %68, align 8, !dbg !52
-  store i64 %33, i64* %69, align 8, !dbg !52, !tbaa !6
-  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !52
-  store i64 %65, i64* %70, align 8, !dbg !52, !tbaa !6
-  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !52
-  store i64* %71, i64** %68, align 8, !dbg !52
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !52
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %48, align 8, !dbg !52, !tbaa !20
-  %72 = load i64, i64* @guard_epoch_A, align 8, !dbg !55
-  %73 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !55, !tbaa !53
-  %needTakeSlowPath3 = icmp ne i64 %72, %73, !dbg !55
-  br i1 %needTakeSlowPath3, label %74, label %75, !dbg !55, !prof !54
+57:                                               ; preds = %46, %56
+  %58 = load i64, i64* @guarded_const_A, align 8, !dbg !46
+  %59 = load i64, i64* @guard_epoch_A, align 8, !dbg !46
+  %60 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !44
+  %guardUpdated4 = icmp eq i64 %59, %60, !dbg !46
+  call void @llvm.assume(i1 %guardUpdated4), !dbg !46
+  %stackFrame43.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8, !dbg !46
+  %61 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !46
+  %62 = bitcast i8* %61 to i16*, !dbg !46
+  %63 = load i16, i16* %62, align 8, !dbg !46
+  %64 = and i16 %63, -384, !dbg !46
+  store i16 %64, i16* %62, align 8, !dbg !46
+  %65 = getelementptr inbounds i8, i8* %61, i64 4, !dbg !46
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %65, i8 0, i64 28, i1 false) #11, !dbg !46
+  call void @sorbet_vm_define_method(i64 %58, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %61, %struct.rb_iseq_struct* %stackFrame43.i.i, i1 noundef zeroext false) #11, !dbg !46
+  call void @sorbet_popFrame() #11, !dbg !39
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %30, align 8, !dbg !39, !tbaa !20
+  %66 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %58, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !10
+  %67 = icmp eq i64 %66, 52, !dbg !10
+  br i1 %67, label %slowNew.i, label %fastNew.i, !dbg !10
 
-74:                                               ; preds = %64
-  call void @const_recompute_A(), !dbg !55
-  br label %75, !dbg !55
-
-75:                                               ; preds = %64, %74
-  %76 = load i64, i64* @guarded_const_A, align 8, !dbg !55
-  %77 = load i64, i64* @guard_epoch_A, align 8, !dbg !55
-  %78 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !55, !tbaa !53
-  %guardUpdated4 = icmp eq i64 %77, %78, !dbg !55
-  call void @llvm.assume(i1 %guardUpdated4), !dbg !55
-  %stackFrame43.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8, !dbg !55
-  %79 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !55
-  %80 = bitcast i8* %79 to i16*, !dbg !55
-  %81 = load i16, i16* %80, align 8, !dbg !55
-  %82 = and i16 %81, -384, !dbg !55
-  store i16 %82, i16* %80, align 8, !dbg !55
-  %83 = getelementptr inbounds i8, i8* %79, i64 4, !dbg !55
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %83, i8 0, i64 28, i1 false) #12, !dbg !55
-  call void @sorbet_vm_define_method(i64 %76, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %79, %struct.rb_iseq_struct* %stackFrame43.i.i, i1 noundef zeroext false) #12, !dbg !55
-  %84 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !55, !tbaa !20
-  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 5, !dbg !55
-  %86 = load i32, i32* %85, align 8, !dbg !55, !tbaa !48
-  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 6, !dbg !55
-  %88 = load i32, i32* %87, align 4, !dbg !55, !tbaa !49
-  %89 = xor i32 %88, -1, !dbg !55
-  %90 = and i32 %89, %86, !dbg !55
-  %91 = icmp eq i32 %90, 0, !dbg !55
-  br i1 %91, label %"func_A.13<static-init>L62.exit.i", label %92, !dbg !55, !prof !50
-
-92:                                               ; preds = %75
-  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 8, !dbg !55
-  %94 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %93, align 8, !dbg !55, !tbaa !51
-  %95 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #12, !dbg !55
-  br label %"func_A.13<static-init>L62.exit.i", !dbg !55
-
-"func_A.13<static-init>L62.exit.i":               ; preds = %92, %75
-  call void @sorbet_popFrame() #12, !dbg !39
-  call void @llvm.lifetime.end.p0i8(i64 noundef 24, i8* noundef nonnull %35) #12, !dbg !39
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %31, align 8, !dbg !39, !tbaa !20
-  %96 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %76, %struct.FunctionInlineCache* noundef @ic_new) #12, !dbg !10
-  %97 = icmp eq i64 %96, 52, !dbg !10
-  br i1 %97, label %slowNew.i, label %fastNew.i, !dbg !10
-
-slowNew.i:                                        ; preds = %"func_A.13<static-init>L62.exit.i"
-  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !10
-  %99 = load i64*, i64** %98, align 8, !dbg !10
-  store i64 %76, i64* %99, align 8, !dbg !10, !tbaa !6
-  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !10
-  store i64* %100, i64** %98, align 8, !dbg !10
-  %101 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #12, !dbg !10
+slowNew.i:                                        ; preds = %57
+  %68 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
+  %69 = load i64*, i64** %68, align 8, !dbg !10
+  store i64 %58, i64* %69, align 8, !dbg !10, !tbaa !6
+  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !10
+  store i64* %70, i64** %68, align 8, !dbg !10
+  %71 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !10
   br label %"func_<root>.17<static-init>$152.exit", !dbg !10
 
-fastNew.i:                                        ; preds = %"func_A.13<static-init>L62.exit.i"
-  %102 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !10
-  %103 = load i64*, i64** %102, align 8, !dbg !10
-  store i64 %96, i64* %103, align 8, !dbg !10, !tbaa !6
-  %104 = getelementptr inbounds i64, i64* %103, i64 1, !dbg !10
-  store i64* %104, i64** %102, align 8, !dbg !10
-  %105 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #12, !dbg !10
+fastNew.i:                                        ; preds = %57
+  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
+  %73 = load i64*, i64** %72, align 8, !dbg !10
+  store i64 %66, i64* %73, align 8, !dbg !10, !tbaa !6
+  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !10
+  store i64* %74, i64** %72, align 8, !dbg !10
+  %75 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !10
   br label %"func_<root>.17<static-init>$152.exit", !dbg !10
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %slowNew.i, %fastNew.i
-  %initializedObject.i = phi i64 [ %101, %slowNew.i ], [ %96, %fastNew.i ], !dbg !10
-  %106 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !10
-  %107 = load i64*, i64** %106, align 8, !dbg !10
-  store i64 %initializedObject.i, i64* %107, align 8, !dbg !10, !tbaa !6
-  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !10
-  store i64* %108, i64** %106, align 8, !dbg !10
+  %initializedObject.i = phi i64 [ %71, %slowNew.i ], [ %66, %fastNew.i ], !dbg !10
+  %76 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
+  %77 = load i64*, i64** %76, align 8, !dbg !10
+  store i64 %initializedObject.i, i64* %77, align 8, !dbg !10, !tbaa !6
+  %78 = getelementptr inbounds i64, i64* %77, i64 1, !dbg !10
+  store i64* %78, i64** %76, align 8, !dbg !10
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !10
-  %109 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !15
-  %110 = load i64*, i64** %109, align 8, !dbg !15
-  store i64 %22, i64* %110, align 8, !dbg !15, !tbaa !6
-  %111 = getelementptr inbounds i64, i64* %110, i64 1, !dbg !15
-  store i64 %send6, i64* %111, align 8, !dbg !15, !tbaa !6
-  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !15
-  store i64* %112, i64** %109, align 8, !dbg !15
+  %79 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !15
+  %80 = load i64*, i64** %79, align 8, !dbg !15
+  store i64 %21, i64* %80, align 8, !dbg !15, !tbaa !6
+  %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !15
+  store i64 %send6, i64* %81, align 8, !dbg !15, !tbaa !6
+  %82 = getelementptr inbounds i64, i64* %81, i64 1, !dbg !15
+  store i64* %82, i64** %79, align 8, !dbg !15
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal noundef i64 @"func_A#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !56 {
+define internal noundef i64 @"func_A#3foo"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !47 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !20
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !57
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !57, !prof !58
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !48
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !48, !prof !49
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #14, !dbg !57
-  unreachable, !dbg !57
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !48
+  unreachable, !dbg !48
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !59, !tbaa !20
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !50, !tbaa !20
   ret i64 183
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_A.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !17 {
+define internal i64 @"func_A.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #7 !dbg !17 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !32
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !60
+  %4 = load i64, i64* %3, align 8, !tbaa !51
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>$block_1", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
   store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !35
@@ -478,29 +424,29 @@ functionEntryInitializers:
   %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !16
   store i64* %15, i64** %12, align 8, !dbg !16
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !16
-  ret i64 %send, !dbg !61
+  ret i64 %send, !dbg !52
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #9
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #8
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #10
+declare void @llvm.assume(i1 noundef) #9
 
 ; Function Attrs: ssp
-define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #8 {
+define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #7 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !53
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_A() local_unnamed_addr #8 {
+define linkonce void @const_recompute_A() local_unnamed_addr #7 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !53
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @guard_epoch_A, align 8
   ret void
 }
@@ -508,18 +454,17 @@ define linkonce void @const_recompute_A() local_unnamed_addr #8 {
 attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { argmemonly nofree nosync nounwind willreturn }
-attributes #4 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #5 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #6 = { sspreq }
-attributes #7 = { nounwind sspreq uwtable }
-attributes #8 = { ssp }
-attributes #9 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #10 = { nofree nosync nounwind willreturn }
-attributes #11 = { noreturn nounwind }
-attributes #12 = { nounwind }
-attributes #13 = { nounwind allocsize(0,1) }
-attributes #14 = { noreturn }
+attributes #3 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #5 = { sspreq }
+attributes #6 = { nounwind sspreq uwtable }
+attributes #7 = { ssp }
+attributes #8 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #9 = { nofree nosync nounwind willreturn }
+attributes #10 = { noreturn nounwind }
+attributes #11 = { nounwind }
+attributes #12 = { nounwind allocsize(0,1) }
+attributes #13 = { noreturn }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -564,25 +509,16 @@ attributes #14 = { noreturn }
 !37 = !{!36, !21, i64 32}
 !38 = !DILocation(line: 0, scope: !11)
 !39 = !DILocation(line: 5, column: 1, scope: !11)
-!40 = !{!41, !7, i64 0}
-!41 = !{!"rb_calling_info", !7, i64 0, !7, i64 8, !27, i64 16, !27, i64 20}
-!42 = !{!41, !27, i64 20}
-!43 = !{!41, !7, i64 8}
-!44 = !{!41, !27, i64 16}
-!45 = !DILocation(line: 0, scope: !18, inlinedAt: !46)
-!46 = distinct !DILocation(line: 5, column: 1, scope: !11)
-!47 = !DILocation(line: 7, column: 3, scope: !18, inlinedAt: !46)
-!48 = !{!33, !27, i64 40}
-!49 = !{!33, !27, i64 44}
-!50 = !{!"branch_weights", i32 2000, i32 1}
-!51 = !{!33, !21, i64 56}
-!52 = !DILocation(line: 6, column: 3, scope: !18, inlinedAt: !46)
-!53 = !{!28, !28, i64 0}
-!54 = !{!"branch_weights", i32 1, i32 10000}
-!55 = !DILocation(line: 8, column: 3, scope: !18, inlinedAt: !46)
-!56 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#3foo", scope: null, file: !4, line: 8, type: !12, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!57 = !DILocation(line: 8, column: 3, scope: !56)
-!58 = !{!"branch_weights", i32 1, i32 2000}
-!59 = !DILocation(line: 0, scope: !56)
-!60 = !{!36, !7, i64 24}
-!61 = !DILocation(line: 7, column: 3, scope: !17)
+!40 = !DILocation(line: 0, scope: !18, inlinedAt: !41)
+!41 = distinct !DILocation(line: 5, column: 1, scope: !11)
+!42 = !DILocation(line: 7, column: 3, scope: !18, inlinedAt: !41)
+!43 = !DILocation(line: 6, column: 3, scope: !18, inlinedAt: !41)
+!44 = !{!28, !28, i64 0}
+!45 = !{!"branch_weights", i32 1, i32 10000}
+!46 = !DILocation(line: 8, column: 3, scope: !18, inlinedAt: !41)
+!47 = distinct !DISubprogram(name: "A#foo", linkageName: "func_A#3foo", scope: null, file: !4, line: 8, type: !12, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!48 = !DILocation(line: 8, column: 3, scope: !47)
+!49 = !{!"branch_weights", i32 1, i32 2000}
+!50 = !DILocation(line: 0, scope: !47)
+!51 = !{!36, !7, i64 24}
+!52 = !DILocation(line: 7, column: 3, scope: !17)


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have a hook for processing interrupts after an intrinsic because normal Ruby method sends will already check for interrupts, and we found that intrinsics that did C calls directly did not check for interrupts, leading to (IIRC) GC issues.

This is a good plan, but sometimes we don't want to bloat the code...or we know that we don't need to check for interrupts, or can delay emitting the check for interrupts.  This PR introduces a way of enabling `SymbolBasedIntrinsicMethod`s to signal that they don't need this extra processing, and I've added such signaling to what I think are relatively uncontroversial intrinsics: method definition, and various things associated with sigs.

(I noticed this bloating the code for static-init methods; there's a lot of code there to trim down, and this is but one way of addressing that.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
