### PR TITLE
add sigs to T::Props::{ClassMethods,Decorator}#props

### DIFF
--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -17,6 +17,13 @@ module T::Props
   mixes_in_class_methods(T::Props::ClassMethods)
 end
 
+class T::Props::Decorator
+  Rules = T.type_alias {T::Hash[Symbol, T.untyped]}
+  DecoratedInstance = T.type_alias {T.untyped} # Would be T::Props, but that produces circular reference errors in some circumstances
+  PropType = T.type_alias {T::Types::Base}
+  PropTypeOrClass = T.type_alias {T.any(PropType, Module)}
+end
+
 module T::Props::ClassMethods
   sig {params(name: Symbol, cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
   def const(name, cls_or_args, args={}, &blk); end
@@ -26,6 +33,7 @@ module T::Props::ClassMethods
   def decorator_class; end
   def plugin(mod); end
   def plugins; end
+  sig {returns(T::Props::Decorator::Rules)}
   def props; end
   def reload_decorator!; end
   def validate_prop_value(prop, val); end
@@ -47,13 +55,6 @@ module T::Props::GeneratedCodeValidation
 end
 
 class T::Props::Decorator
-  Rules = T.type_alias {T::Hash[Symbol, T.untyped]}
-  DecoratedInstance = T.type_alias {T.untyped} # Would be T::Props, but that produces circular reference errors in some circumstances
-  PropType = T.type_alias {T::Types::Base}
-  PropTypeOrClass = T.type_alias {T.any(PropType, Module)}
-end
-
-class T::Props::Decorator
   def add_prop_definition(prop, rules); end
   def all_props; end
   def decorated_class; end
@@ -70,6 +71,7 @@ class T::Props::Decorator
   def prop_set(instance, prop, value, rules = {}); end
   alias_method :set, :prop_set
   def prop_validate_definition!(name, cls, rules, type); end
+  sig {returns(Rules)}
   def props; end
   def self.method_added(name); end
   def self.singleton_method_added(name); end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is kind of silly, but there are some warm-ish methods that would benefit from the compiler knowing the return type of `props`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
